### PR TITLE
perf: further removal of clones and regex compile

### DIFF
--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -124,7 +124,7 @@ pub async fn save_enrichment_data(
 
                     if records.is_empty() {
                         hour_key =
-                            super::ingestion::get_hour_key(timestamp, vec![], json_record.clone());
+                            super::ingestion::get_hour_key(timestamp, vec![], &json_record);
                     }
                     records.push(value_str);
                 }

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -177,7 +177,7 @@ pub async fn get_stream_alerts<'a>(
 pub fn get_hour_key(
     timestamp: i64,
     partition_keys: Vec<String>,
-    local_val: Map<String, Value>,
+    local_val: &Map<String, Value>,
 ) -> String {
     // get hour file name
     let mut hour_key = Utc
@@ -392,7 +392,7 @@ mod tests {
             get_hour_key(
                 1620000000,
                 vec!["country".to_string(), "sport".to_string()],
-                local_val
+                &local_val
             ),
             "1970_01_01_00_country=USA_sport=basketball"
         );
@@ -403,12 +403,12 @@ mod tests {
         let mut local_val = Map::new();
         local_val.insert("country".to_string(), Value::String("USA".to_string()));
         local_val.insert("sport".to_string(), Value::String("basketball".to_string()));
-        assert_eq!(get_hour_key(1620000000, vec![], local_val), "1970_01_01_00");
+        assert_eq!(get_hour_key(1620000000, vec![], &local_val), "1970_01_01_00");
     }
     #[test]
     fn test_get_hour_key_no_partition_keys_no_local_val() {
         assert_eq!(
-            get_hour_key(1620000000, vec![], Map::new()),
+            get_hour_key(1620000000, vec![], &Map::new()),
             "1970_01_01_00"
         );
     }

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -211,13 +211,13 @@ async fn add_valid_record(
 ) -> Option<Trigger> {
     let mut trigger: Option<Trigger> = None;
     let timestamp: i64 = local_val
-        .get(&CONFIG.common.column_timestamp.clone())
+        .get(&CONFIG.common.column_timestamp)
         .unwrap()
         .as_i64()
         .unwrap();
     // get hour key
     let hour_key =
-        super::ingestion::get_hour_key(timestamp, stream_meta.partition_keys, local_val.clone());
+        super::ingestion::get_hour_key(timestamp, stream_meta.partition_keys, local_val);
     let hour_buf = buf.entry(hour_key.clone()).or_default();
 
     let mut value_str = common::json::to_string(&local_val).unwrap();

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -270,7 +270,7 @@ pub async fn remote_write(
             let hour_key = crate::service::ingestion::get_hour_key(
                 timestamp,
                 partition_keys.clone(),
-                value.as_object().unwrap().clone(),
+                value.as_object().unwrap(),
             );
             let hour_buf = buf.entry(hour_key.clone()).or_default();
             hour_buf.push(value_str);

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -50,8 +50,13 @@ use crate::meta::{
     common::FileMeta, search::Session as SearchSession, sql, stream::StreamParams, StreamType,
 };
 use crate::service::search::sql::Sql;
+use once_cell::sync::Lazy;
 
 const AGGREGATE_UDF_LIST: [&str; 6] = ["min", "max", "count", "avg", "sum", "array_agg"];
+
+static RE_WHERE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i) where (.*)").unwrap());
+static RE_FIELD_FN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(?i)([a-zA-Z0-9_]+)\((['"a-zA-Z0-9_*]+)"#).unwrap());
 
 pub async fn sql(
     session: &SearchSession,
@@ -86,9 +91,7 @@ pub async fn sql(
 
     // get used UDF
     let mut field_fns = vec![];
-
     let mut sql_parts = vec![];
-    let where_regex = Regex::new(r"(?i) where (.*)").unwrap();
 
     for fn_name in crate::common::functions::get_all_transform_keys(&sql.org_id).await {
         if sql.origin_sql.contains(&fn_name) {
@@ -97,7 +100,7 @@ pub async fn sql(
     }
 
     if !field_fns.is_empty() || sql.query_fn.is_some() {
-        if let Some(caps) = where_regex.captures(&sql.origin_sql) {
+        if let Some(caps) = RE_WHERE.captures(&sql.origin_sql) {
             sql_parts.insert(
                 0,
                 sql.origin_sql
@@ -596,7 +599,6 @@ fn merge_rewrite_sql(sql: &str, schema: Arc<Schema>) -> Result<String> {
     }
 
     let mut need_rewrite = false;
-    let re_field_fn = Regex::new(r#"(?i)([a-zA-Z0-9_]+)\((['"a-zA-Z0-9_*]+)"#).unwrap();
     for i in 0..fields.len() {
         let field = fields.get(i).unwrap();
         if !field.contains('(') {
@@ -607,7 +609,7 @@ fn merge_rewrite_sql(sql: &str, schema: Arc<Schema>) -> Result<String> {
             continue;
         }
         need_rewrite = true;
-        let cap = re_field_fn.captures(field).unwrap();
+        let cap = RE_FIELD_FN.captures(field).unwrap();
         let mut fn_name = cap.get(1).unwrap().as_str().to_lowercase();
         if !AGGREGATE_UDF_LIST.contains(&fn_name.as_str()) {
             fields[i] = format!("\"{}\"", schema.field(i).name());
@@ -632,8 +634,7 @@ fn merge_rewrite_sql(sql: &str, schema: Arc<Schema>) -> Result<String> {
     }
 
     // delete where from sql
-    let re_where = Regex::new(r"(?i) where (.*)").unwrap();
-    let mut where_str = match re_where.captures(&sql) {
+    let mut where_str = match RE_WHERE.captures(&sql) {
         Some(caps) => caps[0].to_string(),
         None => "".to_string(),
     };

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -211,7 +211,7 @@ pub async fn handle_trace_request(
                 let mut hour_key = super::ingestion::get_hour_key(
                     timestamp.try_into().unwrap(),
                     partition_keys.clone(),
-                    value.as_object().unwrap().clone(),
+                    value.as_object().unwrap(),
                 );
 
                 if !stream_alerts_map.is_empty() {

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -291,7 +291,7 @@ pub async fn traces_json(
                             let mut hour_key = crate::service::ingestion::get_hour_key(
                                 timestamp.try_into().unwrap(),
                                 partition_keys.clone(),
-                                value.as_object().unwrap().clone(),
+                                value.as_object().unwrap(),
                             );
 
                             if !stream_alerts_map.is_empty() {


### PR DESCRIPTION
Regex::new() invocations have been used in several places, especially on hot paths. Moved them inside static/once_cell lazy object so that we initialize them only once.

https://github.com/rust-lang/regex/blob/master/PERFORMANCE.md#thou-shalt-not-compile-regular-expressions-in-a-loop