### PR TITLE
fix: minor, but highly visible typo correction

### DIFF
--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -344,7 +344,7 @@
     "rtAlert": "Real time alerts",
     "noData": "No Data Ingested",
     "findIngestion": "Find how to ingest logs >>",
-    "ingestionMsg": "Looks like you have not ingested any data to selected organization, there are varoius ways in which data can be ingested like fluentbit.",
+    "ingestionMsg": "Looks like you have not ingested any data to selected organization, there are various ways in which data can be ingested, like fluentbit.",
     "inestedInSearch": "Try Log Search",
     "searchInDemoOrg": "You can explore search capbilities by switching to demo organization, to switch to demo organization, select 'Demo Organization' using organization dropdown on top.We keep ingesting dummy data to Demo Organization."
   },


### PR DESCRIPTION
Correct a minor typo in the first message an English-speaking user sees upon startup.