### PR TITLE
fix: support to open trace details from traces scatter chart 

### DIFF
--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -647,10 +647,11 @@ export default defineComponent({
       }
     }
 
-    const getTraceDetails = (traceId: string) => {
+    const getTraceDetails = (trace: string) => {
+      searchObj.meta.showTraceDetails = true;
       searchObj.data.traceDetails.loading = true;
       searchObj.data.traceDetails.spanList = [];
-      const req = buildTraceSearchQuery(traceId);
+      const req = buildTraceSearchQuery(trace);
       delete req.aggs;
 
       searchService
@@ -667,16 +668,15 @@ export default defineComponent({
         });
     };
 
-    const buildTraceSearchQuery = (traceId: string) => {
+    const buildTraceSearchQuery = (trace: string) => {
       const req = getDefaultRequest();
       req.query.from = 0;
       req.query.size = 1000;
-      var timestamps: any = getConsumableDateTime();
-      req.query.start_time = getISOTimestamp(timestamps.start_time);
-      req.query.end_time = getISOTimestamp(timestamps.end_time);
+      req.query.start_time = trace._timestamp - 30000000;
+      req.query.end_time = trace._timestamp + 30000000;
 
       req.query.sql = b64EncodeUnicode(
-        `SELECT * FROM ${searchObj.data.stream.selectedStream.value} WHERE trace_id = '${traceId}' ORDER BY start_time`
+        `SELECT * FROM ${searchObj.data.stream.selectedStream.value} WHERE trace_id = '${trace.trace_id}' ORDER BY start_time`
       );
 
       return req;
@@ -932,9 +932,10 @@ export default defineComponent({
       var trace1 = {
         x: xData,
         y: yData,
-        name: "Gold",
+        name: "Trace",
         type: "scatter",
         mode: "markers",
+        hovertemplate: "%{x} <br> %{y}", // hovertemplate for custom tooltip
       };
 
       var data = [trace1];

--- a/web/src/plugins/traces/SearchResult.vue
+++ b/web/src/plugins/traces/SearchResult.vue
@@ -25,6 +25,7 @@
         v-show="searchObj.meta.showHistogram"
         :chart="searchObj.data.histogram"
         @updated:chart="onChartUpdate"
+        @click="onChartClick"
       />
 
       <q-virtual-scroll
@@ -78,7 +79,7 @@
               row[store.state.zoConfig.timestamp_column]
             }`"
             :key="'expand_' + index"
-            @click="expandRowDetail(row, index)"
+            @click="expandRowDetail(row)"
             style="cursor: pointer"
             :style="
               row[store.state.zoConfig.timestamp_column] ==
@@ -271,9 +272,9 @@ export default defineComponent({
       // searchObj.meta.resultGrid.pagination.rowsPerPage = val;
     };
 
-    const expandRowDetail = (props: any, index: number) => {
+    const expandRowDetail = (props: any) => {
       searchObj.meta.showTraceDetails = true;
-      emit("get:traceDetails", props.trace_id);
+      emit("get:traceDetails", props);
     };
 
     const getRowIndex = (next: boolean, prev: boolean, oldIndex: number) => {
@@ -308,6 +309,12 @@ export default defineComponent({
       searchObj.data.traceDetails.selectedSpanId = null;
     };
 
+    const onChartClick = (data: any) => {
+      expandRowDetail(
+        searchObj.data.queryResults.hits[data.points[0].pointIndex]
+      );
+    };
+
     return {
       t,
       store,
@@ -326,6 +333,7 @@ export default defineComponent({
       getImageURL,
       showTraceDetails,
       closeTraceDetails,
+      onChartClick,
     };
   },
 });

--- a/web/src/plugins/traces/TraceChart.vue
+++ b/web/src/plugins/traces/TraceChart.vue
@@ -25,7 +25,7 @@ import { defineComponent, onMounted, onUpdated, ref } from "vue";
 
 export default defineComponent({
   name: "TraceChart",
-  emits: ["updated:chart"],
+  emits: ["updated:chart", "click"],
   props: {
     height: {
       type: Number,
@@ -138,6 +138,16 @@ export default defineComponent({
       await Plotly.newPlot(props.id, traces, layout, {
         responsive: true,
         displayModeBar: false,
+      });
+
+      plotref.value.on("plotly_click", (data: any) => {
+        // data contains all the info about the clicked marker
+        emit("click", data);
+      });
+
+      plotref.value.on("plotly_hover", (data: any) => {
+        // Apply the cursor pointer style on hover
+        data.event.target.style.cursor = "pointer";
       });
 
       plotref.value.on("plotly_relayout", onPlotZoom);

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -211,6 +211,17 @@ export default defineComponent({
       else expandedEvents.value[index.toString()] = true;
     };
 
+    const getSpanKind = (id: number) => {
+      const spanKindMapping: { [key: number]: string } = {
+        1: "Server",
+        2: "Client",
+        3: "Producer",
+        4: "Consumer",
+        5: "Internal",
+      };
+      return spanKindMapping[id] || id;
+    };
+
     const getFormattedSpanDetails = () => {
       const spanDetails: { attrs: any; events: any[] } = {
         attrs: {},
@@ -229,6 +240,7 @@ export default defineComponent({
           ),
           "MMM DD, YYYY HH:mm:ss.SSS Z"
         );
+      spanDetails.attrs.span_kind = getSpanKind(spanDetails.attrs.span_kind);
 
       spanDetails.events = JSON.parse(props.span.events).map(
         (event: any) => event


### PR DESCRIPTION
User can open trace details on clicking markers from traces scatter chart