### PR TITLE
perf: optimize the query without where clause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,11 +3497,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ indexmap = { version = "1.9", features = ["serde"] }
 ipnetwork = "0.20"
 lazy_static = "1.4"
 log = "0.4"
-lru = "0.8"
+lru = "0.10"
 memchr = "2.5"
 mimalloc = { version = "0.1", default-features = false, optional = true }
 object_store = { version = "0.5", features = [

--- a/src/handler/grpc/request/metrics.rs
+++ b/src/handler/grpc/request/metrics.rs
@@ -128,7 +128,8 @@ impl Metrics for Querier {
                 }
             }
             if let Ok(body) = get_file_contents(&file) {
-                let name = file.split('/').last().unwrap_or_default();
+                let name = file.replace('\\', "/");
+                let name = name.split('/').last().unwrap_or_default();
                 resp.files.push(MetricsWalFile {
                     name: name.to_string(),
                     body,

--- a/src/handler/grpc/request/search.rs
+++ b/src/handler/grpc/request/search.rs
@@ -38,16 +38,19 @@ impl Search for Searcher {
         });
         tracing::Span::current().set_parent(parent_cx);
 
-        let req = req.get_ref();
-        let org_id = &req.org_id;
-        let stream_type = req.stream_type.as_str();
-        let result = SearchService::grpc::search(req).await.map_err(|err| {
+        let req = req.get_ref().to_owned();
+        let org_id = req.org_id.clone();
+        let stream_type = req.stream_type.clone();
+        let result = tokio::task::spawn(async move { SearchService::grpc::search(&req).await })
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        let result = result.map_err(|err| {
             let time = start.elapsed().as_secs_f64();
             metrics::GRPC_RESPONSE_TIME
-                .with_label_values(&["/_search", "500", org_id, "", stream_type])
+                .with_label_values(&["/_search", "500", &org_id, "", &stream_type])
                 .observe(time);
             metrics::GRPC_INCOMING_REQUESTS
-                .with_label_values(&["/_search", "500", org_id, "", stream_type])
+                .with_label_values(&["/_search", "500", &org_id, "", &stream_type])
                 .inc();
             let message = if let errors::Error::ErrorCode(code) = err {
                 code.to_json()
@@ -59,10 +62,10 @@ impl Search for Searcher {
 
         let time = start.elapsed().as_secs_f64();
         metrics::GRPC_RESPONSE_TIME
-            .with_label_values(&["/_search", "200", org_id, "", stream_type])
+            .with_label_values(&["/_search", "200", &org_id, "", &stream_type])
             .observe(time);
         metrics::GRPC_INCOMING_REQUESTS
-            .with_label_values(&["/_search", "200", org_id, "", stream_type])
+            .with_label_values(&["/_search", "200", &org_id, "", &stream_type])
             .inc();
 
         Ok(Response::new(result))

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -535,19 +535,12 @@ pub async fn values(
     };
 
     for field in &fields {
-        /*  let fn_field = if uses_fn {
-            let mut temp_field = field.replacen('_', "['", 1);
-            temp_field.push_str("']");
-            temp_field
-        } else {
-            field.clone()
-        }; */
         req.aggs.insert(
-            field.clone(),
-            format!(
-                "SELECT {field} AS key, COUNT(*) AS num FROM query GROUP BY key ORDER BY num DESC LIMIT {size}"
-            ),
-        );
+                field.clone(),
+                format!(
+                    "SELECT {field} AS key, COUNT(*) AS num FROM query GROUP BY key ORDER BY num DESC LIMIT {size}"
+                ),
+            );
     }
     let resp_search = match SearchService::search(&org_id, stream_type, &req).await {
         Ok(res) => res,

--- a/src/service/promql/search/grpc/mod.rs
+++ b/src/service/promql/search/grpc/mod.rs
@@ -101,9 +101,7 @@ pub async fn search(
     };
 
     // clear session
-    search::datafusion::storage::file_list::clear(&session_id)
-        .await
-        .unwrap();
+    search::datafusion::storage::file_list::clear(&session_id).await;
     // clear tmpfs
     tmpfs::delete(&format!("/{}/", session_id), true).unwrap();
 

--- a/src/service/promql/search/grpc/mod.rs
+++ b/src/service/promql/search/grpc/mod.rs
@@ -101,7 +101,7 @@ pub async fn search(
     };
 
     // clear session
-    search::datafusion::storage::file_list::clear(&session_id).await;
+    search::datafusion::storage::file_list::clear(&session_id);
     // clear tmpfs
     tmpfs::delete(&format!("/{}/", session_id), true).unwrap();
 

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -114,19 +114,7 @@ pub(crate) async fn create_context(
         storage_type,
     };
 
-    register_table(
-        &session,
-        StreamParams {
-            org_id,
-            stream_name,
-            stream_type,
-        },
-        Some(schema),
-        stream_name,
-        &files,
-        FileType::PARQUET,
-    )
-    .await
+    register_table(&session, schema, stream_name, &files, FileType::PARQUET).await
 }
 
 #[tracing::instrument(name = "promql:search:grpc:storage:get_file_list", skip_all)]

--- a/src/service/promql/search/grpc/wal.rs
+++ b/src/service/promql/search/grpc/wal.rs
@@ -30,7 +30,7 @@ use crate::infra::{
     cluster::{get_cached_online_ingester_nodes, get_internal_grpc_token},
     config::CONFIG,
 };
-use crate::meta::{search::Session as SearchSession, stream::StreamParams, StreamType};
+use crate::meta::{search::Session as SearchSession, StreamType};
 use crate::service::{
     db,
     search::{
@@ -77,19 +77,7 @@ pub(crate) async fn create_context(
         storage_type: StorageType::Tmpfs,
     };
 
-    register_table(
-        &session,
-        StreamParams {
-            org_id,
-            stream_name,
-            stream_type,
-        },
-        Some(schema),
-        stream_name,
-        &[],
-        FileType::JSON,
-    )
-    .await
+    register_table(&session, schema, stream_name, &[], FileType::JSON).await
 }
 
 /// get file list from local cache, no need match_source, each file will be searched

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -357,7 +357,13 @@ async fn get_fast_mode_ctx(
             break;
         }
     }
-    let (mut ctx, schema) = register_table(session, schema, "tbl", &new_files, file_type).await?;
+
+    let fast_sesison = SearchSession {
+        id: format!("{}-fast", session.id),
+        storage_type: session.storage_type.clone(),
+    };
+    let (mut ctx, schema) =
+        register_table(&fast_sesison, schema, "tbl", &new_files, file_type).await?;
 
     // register UDF
     register_udf(&mut ctx, &sql.org_id).await;

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -947,10 +947,10 @@ pub async fn register_table(
     };
 
     let prefix = if session.storage_type.eq(&StorageType::FsMemory) {
-        file_list::set(&session.id, files).await;
+        file_list::set(&session.id, files);
         format!("fsm:///{}/", session.id)
     } else if session.storage_type.eq(&StorageType::FsNoCache) {
-        file_list::set(&session.id, files).await;
+        file_list::set(&session.id, files);
         format!("fsn:///{}/", session.id)
     } else if session.storage_type.eq(&StorageType::Tmpfs) {
         format!("tmpfs:///{}/", session.id)

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -947,10 +947,10 @@ pub async fn register_table(
     };
 
     let prefix = if session.storage_type.eq(&StorageType::FsMemory) {
-        file_list::set(&session.id, files).await.unwrap();
+        file_list::set(&session.id, files).await;
         format!("fsm:///{}/", session.id)
     } else if session.storage_type.eq(&StorageType::FsNoCache) {
-        file_list::set(&session.id, files).await.unwrap();
+        file_list::set(&session.id, files).await;
         format!("fsn:///{}/", session.id)
     } else if session.storage_type.eq(&StorageType::Tmpfs) {
         format!("tmpfs:///{}/", session.id)

--- a/src/service/search/datafusion/storage/file_list.rs
+++ b/src/service/search/datafusion/storage/file_list.rs
@@ -22,7 +22,7 @@ use crate::service::file_list;
 
 pub static FILES: Lazy<RwHashMap<String, Vec<ObjectMeta>>> = Lazy::new(DashMap::default);
 
-pub async fn get(session_id: &str) -> Result<Vec<ObjectMeta>, anyhow::Error> {
+pub fn get(session_id: &str) -> Result<Vec<ObjectMeta>, anyhow::Error> {
     let data = match FILES.get(session_id) {
         Some(data) => data,
         None => return Err(anyhow::anyhow!("session_id not found")),
@@ -30,7 +30,7 @@ pub async fn get(session_id: &str) -> Result<Vec<ObjectMeta>, anyhow::Error> {
     Ok(data.value().clone())
 }
 
-pub async fn set(session_id: &str, files: &[String]) {
+pub fn set(session_id: &str, files: &[String]) {
     let mut values = Vec::with_capacity(files.len());
     for file in files {
         let meta = file_list::get_file_meta(file).unwrap();
@@ -44,7 +44,7 @@ pub async fn set(session_id: &str, files: &[String]) {
     FILES.insert(session_id.to_string(), values);
 }
 
-pub async fn clear(session_id: &str) {
+pub fn clear(session_id: &str) {
     FILES.remove(session_id);
 }
 
@@ -64,12 +64,11 @@ mod tests {
         let file_name = "files/default/logs/olympics/2022/10/03/10/6982652937134804993_1.parquet";
         crate::infra::cache::file_list::set_file_to_cache(file_name, meta).unwrap();
         let session_id = "1234";
+        set(session_id, &[file_name.to_string()]);
 
-        set(session_id, &[file_name.to_string()]).await;
-
-        let get_resp = get(session_id).await;
+        let get_resp = get(session_id);
         assert!(get_resp.unwrap().len() > 0);
 
-        clear(session_id).await;
+        clear(session_id);
     }
 }

--- a/src/service/search/datafusion/storage/file_list.rs
+++ b/src/service/search/datafusion/storage/file_list.rs
@@ -30,7 +30,7 @@ pub async fn get(session_id: &str) -> Result<Vec<ObjectMeta>, anyhow::Error> {
     Ok(data.value().clone())
 }
 
-pub async fn set(session_id: &str, files: &[String]) -> Result<(), anyhow::Error> {
+pub async fn set(session_id: &str, files: &[String]) {
     let mut values = Vec::with_capacity(files.len());
     for file in files {
         let meta = file_list::get_file_meta(file).unwrap();
@@ -42,12 +42,10 @@ pub async fn set(session_id: &str, files: &[String]) -> Result<(), anyhow::Error
         });
     }
     FILES.insert(session_id.to_string(), values);
-    Ok(())
 }
 
-pub async fn clear(session_id: &str) -> Result<(), anyhow::Error> {
+pub async fn clear(session_id: &str) {
     FILES.remove(session_id);
-    Ok(())
 }
 
 #[cfg(test)]
@@ -67,13 +65,11 @@ mod tests {
         crate::infra::cache::file_list::set_file_to_cache(file_name, meta).unwrap();
         let session_id = "1234";
 
-        let res = set(session_id, &[file_name.to_string()]).await;
-        assert!(res.is_ok());
+        set(session_id, &[file_name.to_string()]).await;
 
         let get_resp = get(session_id).await;
         assert!(get_resp.unwrap().len() > 0);
 
-        let resp = clear(session_id).await;
-        assert!(resp.is_ok());
+        clear(session_id).await;
     }
 }

--- a/src/service/search/datafusion/storage/memory.rs
+++ b/src/service/search/datafusion/storage/memory.rs
@@ -133,7 +133,7 @@ impl ObjectStore for FS {
     #[tracing::instrument(name = "datafusion::storage::memory::list", skip_all)]
     async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
         let key = prefix.unwrap().to_string();
-        let objects = super::file_list::get(&key).await.unwrap();
+        let objects = super::file_list::get(&key).unwrap();
         let values = objects
             .iter()
             .map(|file| Ok(file.to_owned()))

--- a/src/service/search/datafusion/storage/mod.rs
+++ b/src/service/search/datafusion/storage/mod.rs
@@ -24,7 +24,6 @@ pub enum StorageType {
     FsMemory,  // fsm
     FsNoCache, // fsn
     Tmpfs,
-    Wal,
 }
 
 /// A specialized `Error` for in-memory object store-related errors

--- a/src/service/search/datafusion/storage/nocache.rs
+++ b/src/service/search/datafusion/storage/nocache.rs
@@ -114,7 +114,7 @@ impl ObjectStore for FS {
     #[tracing::instrument(name = "datafusion::storage::nocache::list", skip_all)]
     async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
         let key = prefix.unwrap().to_string();
-        let objects = super::file_list::get(&key).await.unwrap();
+        let objects = super::file_list::get(&key).unwrap();
         let values = objects
             .iter()
             .map(|file| Ok(file.to_owned()))

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -160,9 +160,9 @@ pub async fn search(
     }
 
     // clear session data
-    datafusion::storage::file_list::clear(&session_id)
-        .await
-        .unwrap();
+    datafusion::storage::file_list::clear(&session_id).await;
+    // clear fast session data
+    datafusion::storage::file_list::clear(&format!("{session_id}-fast")).await;
 
     // final result
     let mut hits_buf = Vec::new();

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -160,9 +160,9 @@ pub async fn search(
     }
 
     // clear session data
-    datafusion::storage::file_list::clear(&session_id).await;
+    datafusion::storage::file_list::clear(&session_id);
     // clear fast session data
-    datafusion::storage::file_list::clear(&format!("{session_id}-fast")).await;
+    datafusion::storage::file_list::clear(&format!("{session_id}-fast"));
 
     // final result
     let mut hits_buf = Vec::new();

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -171,7 +171,7 @@ pub async fn search(
                     &session,
                     stream_type,
                     Some(schema),
-                    diff_fields,
+                    &diff_fields,
                     &sql,
                     &files,
                     FileType::PARQUET,

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -169,8 +169,7 @@ pub async fn search(
             async move {
                 super::datafusion::exec::sql(
                     &session,
-                    stream_type,
-                    Some(schema),
+                    schema,
                     &diff_fields,
                     &sql,
                     &files,

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -96,8 +96,7 @@ pub async fn search(
     };
     let result = match super::datafusion::exec::sql(
         &session,
-        stream_type,
-        Some(schema),
+        schema,
         &HashMap::new(),
         &sql,
         &files,

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -98,7 +98,7 @@ pub async fn search(
         &session,
         stream_type,
         Some(schema),
-        HashMap::new(),
+        &HashMap::new(),
         &sql,
         &files,
         FileType::JSON,

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -178,7 +178,7 @@ async fn get_file_list(sql: &Sql, stream_type: meta::StreamType) -> Result<Vec<S
             .match_source(&source_file, false, true, stream_type)
             .await
         {
-            result.push(format!("{}{local_file}", &CONFIG.common.data_wal_dir));
+            result.push(format!("{}{local_file}", &CONFIG.common.data_wal_dir).replace('\\', "/"));
         }
     }
     Ok(result)

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -52,7 +52,9 @@ pub async fn search(
     req.org_id = org_id.to_string();
     req.stype = cluster_rpc::SearchType::User as i32;
     req.stream_type = stream_type.to_string();
-    search_in_cluster(req).await
+    tokio::task::spawn(async move { search_in_cluster(req).await })
+        .await
+        .map_err(server_internal_error)?
 }
 
 #[inline(always)]

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -125,15 +125,10 @@ impl Sql {
         // 1. no where
         // 2. no aggregation
         // 3. no group by
-        let fast_mode = if meta.selection.is_none()
+        let fast_mode = meta.selection.is_none()
             && meta.group_by.is_empty()
-            && !meta.fields.iter().any(|f| f.contains("("))
-            && !meta.field_alias.iter().any(|f| f.0.contains("("))
-        {
-            true
-        } else {
-            false
-        };
+            && !meta.fields.iter().any(|f| f.contains('('))
+            && !meta.field_alias.iter().any(|f| f.0.contains('('));
 
         // check sql_mode
         let sql_mode: SqlMode = req_query.sql_mode.as_str().into();

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -677,21 +677,16 @@ fn generate_histogram_interval(time_range: Option<(i64, i64)>, num: u16) -> Stri
             "15 second",
         ),
         (
-            Duration::minutes(20).num_microseconds().unwrap(),
+            Duration::minutes(15).num_microseconds().unwrap(),
             "10 second",
         ),
-        (
-            Duration::minutes(10).num_microseconds().unwrap(),
-            "5 second",
-        ),
-        (Duration::minutes(5).num_microseconds().unwrap(), "2 second"),
     ];
     for interval in intervals.iter() {
         if (time_range.1 - time_range.0) >= interval.0 {
             return interval.1.to_string();
         }
     }
-    "1 second".to_string()
+    "10 second".to_string()
 }
 
 fn split_sql_token_unwrap_brace(s: &str) -> Vec<String> {

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -609,19 +609,7 @@ export default defineComponent({
           req.query.start_time = startISOTimestamp;
           req.query.end_time = endISOTimestamp;
 
-          searchObj.meta.resultGrid.chartInterval = "1 second";
-          if (timestamps.end_time - timestamps.start_time >= 1000 * 60 * 5) {
-            searchObj.meta.resultGrid.chartInterval = "3 second";
-            searchObj.meta.resultGrid.chartKeyFormat = "HH:mm:ss";
-          }
-          if (timestamps.end_time - timestamps.start_time >= 1000 * 60 * 10) {
-            searchObj.meta.resultGrid.chartInterval = "5 second";
-            searchObj.meta.resultGrid.chartKeyFormat = "HH:mm:ss";
-          }
-          if (timestamps.end_time - timestamps.start_time >= 1000 * 60 * 20) {
-            searchObj.meta.resultGrid.chartInterval = "10 second";
-            searchObj.meta.resultGrid.chartKeyFormat = "HH:mm:ss";
-          }
+          searchObj.meta.resultGrid.chartInterval = "10 second";
           if (timestamps.end_time - timestamps.start_time >= 1000 * 60 * 30) {
             searchObj.meta.resultGrid.chartInterval = "15 second";
             searchObj.meta.resultGrid.chartKeyFormat = "HH:mm:ss";

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -507,22 +507,10 @@ export default defineComponent({
         timestamps.end_time != "Invalid Date"
       ) {
         const chartSettings = {
-          chartInterval: "1 second",
+          chartInterval: "10 second",
           chartKeyFormat: "HH:mm:ss",
         };
 
-        if (timestamps.end_time - timestamps.start_time >= 1000 * 60 * 5) {
-          chartSettings.chartInterval = "3 second";
-          chartSettings.chartKeyFormat = "HH:mm:ss";
-        }
-        if (timestamps.end_time - timestamps.start_time >= 1000 * 60 * 10) {
-          chartSettings.chartInterval = "5 second";
-          chartSettings.chartKeyFormat = "HH:mm:ss";
-        }
-        if (timestamps.end_time - timestamps.start_time >= 1000 * 60 * 20) {
-          chartSettings.chartInterval = "10 second";
-          chartSettings.chartKeyFormat = "HH:mm:ss";
-        }
         if (timestamps.end_time - timestamps.start_time >= 1000 * 60 * 30) {
           chartSettings.chartInterval = "15 second";
           chartSettings.chartKeyFormat = "HH:mm:ss";


### PR DESCRIPTION
we will only load the latest parquets based on the record num in the time range when there is no where clause, it will be much optimized default query for UI.