### PR TITLE
fix: #978 extra underscore in ingesting records containing array

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,18 +1,18 @@
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-feature=+aes,+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2"]
+rustflags = ["-C", "target-feature=+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2"]
 
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=+sse2,+sse3,+ssse3,+sse4.1,+sse4.2"]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
-rustflags = ["-C", "target-feature=+aes,+crc,+lse,+neon"]
+rustflags = ["-C", "target-feature=+neon"]
 
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "target-feature=+aes,+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2"]
+rustflags = ["-C", "target-feature=+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "target-feature=+aes,+crc,+lse,+neon"]
+rustflags = ["-C", "target-feature=+neon"]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+sse2,+sse3,+ssse3,+sse4.1,+sse4.2"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,16 +2511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flatten-json-object"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9539d6d8c87acbf7c3189fb4d1c8ce926de16369212e97ba1629b62febb3d512"
-dependencies = [
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3955,7 +3945,6 @@ dependencies = [
  "etcd-client",
  "expect-test",
  "flate2",
- "flatten-json-object",
  "float-cmp",
  "futures",
  "get_if_addrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ dotenvy = "0.15"
 env_logger = "0.10"
 etcd-client = { version = "0.10", features = ["tls"] }
 flate2 = { version = "1.0", features = ["zlib"] }
-flatten-json-object = "0.6"
 futures = "0.3"
 get_if_addrs = "0.5"
 glob = "0.3"

--- a/deploy/build/Dockerfile.aarch64
+++ b/deploy/build/Dockerfile.aarch64
@@ -21,8 +21,7 @@ COPY --from=webBuilder /web/dist web/dist
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
   CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
-  CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
-  RUSTFLAGS='-C target-feature=+aes,+crc,+lse,+neon'
+  CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
 RUN --mount=type=cache,target=/root/.cache/sccache du -sh /root/.cache/sccache
 RUN --mount=type=cache,target=/root/.cache/sccache cargo build --release --features mimalloc --target aarch64-unknown-linux-gnu \
   && sccache --show-stats \

--- a/deploy/build/Dockerfile.amd64
+++ b/deploy/build/Dockerfile.amd64
@@ -20,7 +20,7 @@ COPY . /app
 COPY --from=webBuilder /web/dist web/dist
 
 RUN --mount=type=cache,target=/root/.cache/sccache du -sh /root/.cache/sccache
-RUN --mount=type=cache,target=/root/.cache/sccache RUSTFLAGS='-C target-feature=+sse2,+sse3,+ssse3,+sse4.1,+sse4.2' cargo build --release --features mimalloc --target x86_64-unknown-linux-gnu \
+RUN --mount=type=cache,target=/root/.cache/sccache cargo build --release --features mimalloc --target x86_64-unknown-linux-gnu \
   && sccache --show-stats \
   && du -sh /root/.cache/sccache
 RUN mv /app/target/x86_64-unknown-linux-gnu/release/openobserve /app/target/release/openobserve

--- a/deploy/build/Dockerfile.tag-simd.amd64
+++ b/deploy/build/Dockerfile.tag-simd.amd64
@@ -20,7 +20,7 @@ COPY . /app
 COPY --from=webBuilder /web/dist web/dist
 
 # RUN cargo build --release
-RUN RUSTFLAGS='-C target-feature=+aes,+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx512f,+avx512cd,+avx512er,+avx512bw,+avx512dq,+avx512vl' cargo build --release --features mimalloc --target x86_64-unknown-linux-gnu
+RUN RUSTFLAGS='-C target-feature=+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx512f,+avx512cd,+avx512er,+avx512bw,+avx512dq,+avx512vl' cargo build --release --features mimalloc --target x86_64-unknown-linux-gnu
 RUN mv /app/target/x86_64-unknown-linux-gnu/release/openobserve /app/target/release/openobserve
 
 FROM gcr.io/distroless/cc as runtime

--- a/deploy/build/Dockerfile.tag.aarch64
+++ b/deploy/build/Dockerfile.tag.aarch64
@@ -22,8 +22,7 @@ COPY --from=webBuilder /web/dist web/dist
 # RUN cargo build --release
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
   CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
-  CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
-  RUSTFLAGS='-C target-feature=+aes,+crc,+lse,+neon'
+  CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
 RUN cargo build --release --features mimalloc --target aarch64-unknown-linux-gnu
 RUN mv /app/target/aarch64-unknown-linux-gnu/release/openobserve /app/target/release/openobserve
 

--- a/deploy/build/Dockerfile.tag.amd64
+++ b/deploy/build/Dockerfile.tag.amd64
@@ -20,7 +20,7 @@ COPY . /app
 COPY --from=webBuilder /web/dist web/dist
 
 # RUN cargo build --release
-RUN RUSTFLAGS='-C target-feature=+sse2,+sse3,+ssse3,+sse4.1,+sse4.2' cargo build --release --features mimalloc --target x86_64-unknown-linux-gnu
+RUN cargo build --release --features mimalloc --target x86_64-unknown-linux-gnu
 RUN mv /app/target/x86_64-unknown-linux-gnu/release/openobserve /app/target/release/openobserve
 
 FROM gcr.io/distroless/cc as runtime

--- a/src/common/flatten.rs
+++ b/src/common/flatten.rs
@@ -1,0 +1,350 @@
+// Copyright 2022 Zinc Labs Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde_json::value::Map;
+use serde_json::value::Value;
+
+const KEY_SEPARATOR: &str = "_";
+const FORMAT_KEY_ENABLED: bool = true;
+
+/// Flattens the provided JSON object (`current`).
+///
+/// It will return an error if flattening the object would make two keys to be the same,
+/// overwriting a value. It will alre return an error if the JSON value passed it's not an object.
+///
+/// # Errors
+/// Will return `Err` if `to_flatten` it's not an object, or if flattening the object would
+/// result in two or more keys colliding.
+pub fn flatten(to_flatten: &Value) -> Result<Value, anyhow::Error> {
+    let mut flat = Map::<String, Value>::new();
+    flatten_value(to_flatten, "".to_owned(), 0, &mut flat).map(|_x| Value::Object(flat))
+}
+
+/// Flattens the passed JSON value (`current`), whose path is `parent_key` and its 0-based
+/// depth is `depth`.  The result is stored in the JSON object `flattened`.
+fn flatten_value(
+    current: &Value,
+    parent_key: String,
+    depth: u32,
+    flattened: &mut Map<String, Value>,
+) -> Result<(), anyhow::Error> {
+    if depth == 0 {
+        match current {
+            Value::Object(map) => {
+                if map.is_empty() {
+                    return Ok(()); // If the top level input object is empty there is nothing to do
+                }
+            }
+            _ => return Err(anyhow::anyhow!("flatten value must be an object")),
+        }
+    }
+
+    if let Some(current) = current.as_object() {
+        flatten_object(current, &parent_key, depth, flattened)?;
+    } else if let Some(current) = current.as_array() {
+        flatten_array(current, &parent_key, depth, flattened)?;
+    } else {
+        if flattened.contains_key(&parent_key) {
+            return Err(anyhow::anyhow!(
+                "flatten will be overwritten a key {}",
+                parent_key
+            ));
+        }
+        flattened.insert(parent_key, current.clone());
+    }
+    Ok(())
+}
+
+/// Flattens the passed object (`current`), whose path is `parent_key` and its 0-based depth
+/// is `depth`.  The result is stored in the JSON object `flattened`.
+fn flatten_object(
+    current: &Map<String, Value>,
+    parent_key: &str,
+    depth: u32,
+    flattened: &mut Map<String, Value>,
+) -> Result<(), anyhow::Error> {
+    for (k, v) in current.iter() {
+        let k = if FORMAT_KEY_ENABLED {
+            format_key(k)
+        } else {
+            k.to_string()
+        };
+        let parent_key = if depth > 0 {
+            format!("{}{}{}", parent_key, KEY_SEPARATOR, k)
+        } else {
+            k
+        };
+        flatten_value(v, parent_key, depth + 1, flattened)?;
+    }
+    Ok(())
+}
+
+/// Flattens the passed array (`current`), whose path is `parent_key` and its 0-based depth
+/// is `depth`.  The result is stored in the JSON object `flattened`.
+fn flatten_array(
+    current: &[Value],
+    parent_key: &str,
+    depth: u32,
+    flattened: &mut Map<String, Value>,
+) -> Result<(), anyhow::Error> {
+    for (i, obj) in current.iter().enumerate() {
+        let parent_key = format!("{}{}{}", parent_key, KEY_SEPARATOR, i);
+        flatten_value(obj, parent_key, depth + 1, flattened)?;
+    }
+    Ok(())
+}
+
+/// We need every character in the key to be lowercase alphanumeric or underscore
+fn format_key(key: &str) -> String {
+    if key
+        .chars()
+        .all(|c| c.is_lowercase() || c.is_numeric() || c == '_')
+    {
+        return key.to_string();
+    }
+    key.chars()
+        .map(|c| {
+            if c.is_lowercase() || c.is_numeric() || c == '_' {
+                c
+            } else if c.is_uppercase() {
+                c.to_lowercase().next().unwrap()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn object_with_plain_values() {
+        let obj = json!({"int": 1, "float": 2.0, "str": "a", "bool": true, "null": null});
+        assert_eq!(obj, flatten(&obj).unwrap());
+    }
+
+    /// Ensures that when using `ArrayFormatting::Plain` both arrays and objects are formatted
+    /// properly.
+    #[test]
+    fn array_formatting_plain() {
+        let obj = json!({"s": {"a": [1, 2.0, "b", null, true]}});
+        assert_eq!(
+            flatten(&obj).unwrap(),
+            json!({
+                format!("s{k}a{k}0", k = KEY_SEPARATOR): 1,
+                format!("s{k}a{k}1", k = KEY_SEPARATOR): 2.0,
+                format!("s{k}a{k}2", k = KEY_SEPARATOR): "b",
+                format!("s{k}a{k}3", k = KEY_SEPARATOR): null,
+                format!("s{k}a{k}4", k = KEY_SEPARATOR): true,
+            })
+        );
+    }
+
+    #[test]
+    fn nested_single_key_value() {
+        let obj = json!({"key": "value", "nested_key": {"key": "value"}});
+        assert_eq!(
+            flatten(&obj).unwrap(),
+            json!({"key": "value", "nested_key_key": "value"}),
+        );
+    }
+
+    #[test]
+    fn nested_multiple_key_value() {
+        let obj = json!({"key": "value", "nested_key": {"key1": "value1", "key2": "value2"}});
+        assert_eq!(
+            flatten(&obj).unwrap(),
+            json!({"key": "value", "nested_key_key1": "value1", "nested_key_key2": "value2"}),
+        );
+    }
+
+    #[test]
+    fn complex_nested_struct() {
+        let obj = json!({
+            "simple_key": "simple_value",
+            "key": [
+                "value1",
+                {"key": "value2"},
+                {"nested_array": [
+                    "nested1",
+                    "nested2",
+                    ["nested3", "nested4"]
+                ]}
+            ]
+        });
+        assert_eq!(
+            flatten(&obj).unwrap(),
+            json!({"simple_key": "simple_value", "key_0": "value1", "key_1_key": "value2",
+                "key_2_nested_array_0": "nested1", "key_2_nested_array_1": "nested2",
+                "key_2_nested_array_2_0": "nested3", "key_2_nested_array_2_1": "nested4"}),
+        );
+    }
+
+    #[test]
+    fn overlapping_after_flattening_array() {
+        let obj = json!({"key": ["value1", "value2"], "key_0": "Oopsy"});
+        let res = flatten(&obj);
+        assert!(res.is_err());
+        match res {
+            Err(err) => assert!(err.to_string().contains("key_0")),
+            Ok(_) => panic!("This should have failed"),
+        }
+    }
+
+    /// Ensure that empty arrays are not present in the result
+    #[test]
+    fn empty_array() {
+        let obj = json!({"key": []});
+        assert_eq!(flatten(&obj).unwrap(), json!({}));
+    }
+
+    /// Ensure that empty objects are not present in the result
+    #[test]
+    fn empty_object() {
+        let obj = json!({"key": {}});
+        assert_eq!(flatten(&obj).unwrap(), json!({}));
+    }
+
+    #[test]
+    fn empty_top_object() {
+        let obj = json!({});
+        assert_eq!(flatten(&obj).unwrap(), json!({}));
+    }
+
+    /// Ensure that if all the end values of the JSON object are either `[]` or `{}` the flattened
+    /// resulting object it's empty.
+    #[test]
+    fn empty_complex_object() {
+        let obj = json!({"key": {"key2": {}, "key3": [[], {}, {"k": {}, "q": []}]}});
+        assert_eq!(flatten(&obj).unwrap(), json!({}));
+    }
+
+    #[test]
+    fn nested_object_with_empty_array_and_string() {
+        let obj = json!({"key": {"key2": [], "key3": "a"}});
+        assert_eq!(flatten(&obj).unwrap(), json!({"key_key3": "a"}));
+    }
+
+    #[test]
+    fn nested_object_with_empty_object_and_string() {
+        let obj = json!({"key": {"key2": {}, "key3": "a"}});
+        assert_eq!(flatten(&obj).unwrap(), json!({"key_key3": "a"}));
+    }
+
+    #[test]
+    fn empty_string_as_key() {
+        let obj = json!({"key": {"": "a"}});
+        assert_eq!(flatten(&obj).unwrap(), json!({"key_": "a"}));
+    }
+
+    #[test]
+    fn empty_string_as_key_multiple_times() {
+        let obj = json!({"key": {"": {"": {"": "a"}}}});
+        assert_eq!(flatten(&obj).unwrap(), json!({"key___": "a"}));
+    }
+
+    /// Flattening only makes sense for objects. Passing something else must return an informative
+    /// error.
+    #[test]
+    fn first_level_must_be_an_object() {
+        let integer = json!(3);
+        let string = json!("");
+        let boolean = json!(false);
+        let null = json!(null);
+        let array = json!([1, 2, 3]);
+
+        for j in [integer, string, boolean, null, array] {
+            let res = flatten(&j);
+            match res {
+                Err(_) => return, // Good
+                Ok(_) => panic!("This should have failed"),
+            }
+        }
+    }
+
+    #[test]
+    fn complex_array() {
+        let obj = json!({"a": [1, [2, [3, 4], 5], 6]});
+        assert_eq!(
+            flatten(&obj).unwrap(),
+            json!({"a_0": 1, "a_2": 6, "a_1_0": 2, "a_1_1_0": 3, "a_1_1_1": 4, "a_1_2": 5}),
+        );
+    }
+
+    #[test]
+    fn complex_key_format() {
+        let datas = [
+            (
+                json!({"key": "value", "nested_key": {"key": "value", "foo": "bar"}}),
+                json!({"key": "value", "nested_key_key": "value", "nested_key_foo": "bar"}),
+            ),
+            (
+                json!({"key+bar": "value", "@nested_key": {"key": "value", "Foo": "Bar"}}),
+                json!({"key_bar": "value", "_nested_key_key": "value", "_nested_key_foo": "Bar"}),
+            ),
+            (
+                json!({"a": {"A.1": [1, [3, 4], 5], "A_2": 6}}),
+                json!({"a_a_1_0": 1, "a_a_1_1_0": 3, "a_a_1_1_1": 4, "a_a_1_2": 5, "a_a_2": 6}),
+            ),
+        ];
+        for (input, expected) in datas.iter() {
+            assert_eq!(flatten(input).unwrap(), *expected);
+        }
+    }
+
+    #[test]
+    fn test_flatten_json_complex() {
+        let input = json!({
+            "firstName": "John",
+            "lastName": "Doe",
+            "age": 25,
+            "address": {
+                "streetAddress": "123 Main St",
+                "city": "Anytown",
+                "state": "CA",
+                "postalCode": "12345"
+            },
+            "phoneNumbers": [
+                {
+                    "type": "home",
+                    "number": "555-555-1234"
+                },
+                {
+                    "type": "work",
+                    "number": "555-555-5678"
+                }
+            ]
+        });
+
+        let expected_output = json!({
+            "firstname": "John",
+            "lastname": "Doe",
+            "age": 25,
+            "address_streetaddress": "123 Main St",
+            "address_city": "Anytown",
+            "address_state": "CA",
+            "address_postalcode": "12345",
+            "phonenumbers_0_type":"home",
+            "phonenumbers_0_number": "555-555-1234",
+            "phonenumbers_1_type":"work",
+            "phonenumbers_1_number": "555-555-5678"
+        });
+
+        let output = flatten(&input).unwrap();
+        assert_eq!(output, expected_output);
+    }
+}

--- a/src/common/flatten.rs
+++ b/src/common/flatten.rs
@@ -115,7 +115,7 @@ fn format_key(key: &str) -> String {
     }
     key.chars()
         .map(|c| {
-            if c.is_lowercase() || c.is_numeric() || c == '_' {
+            if c.is_lowercase() || c.is_numeric() {
                 c
             } else if c.is_uppercase() {
                 c.to_lowercase().next().unwrap()

--- a/src/common/json.rs
+++ b/src/common/json.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use flatten_json_object::{ArrayFormatting, Flattener};
 pub use serde_json::{from_value, json, to_value, Error, Map, Value};
 
 #[inline(always)]
@@ -85,69 +84,4 @@ where
     T: serde::Deserialize<'a>,
 {
     serde_json::from_slice(v)
-}
-
-#[inline(always)]
-pub fn flatten_json_and_format_field(obj: &Value) -> Value {
-    let obj = flatten_json(obj);
-    if !obj.is_object() {
-        return obj;
-    }
-
-    let map = obj
-        .as_object()
-        .unwrap()
-        .iter()
-        .map(|(key, value)| {
-            let key = key
-                .chars()
-                .map(|c| {
-                    if c.is_alphanumeric() {
-                        c.to_lowercase().next().unwrap()
-                    } else {
-                        '_'
-                    }
-                })
-                .collect::<String>();
-            (key, value.to_owned())
-        })
-        .collect();
-
-    Value::Object(map)
-}
-
-#[inline(always)]
-pub fn flatten_json(obj: &Value) -> Value {
-    Flattener::new()
-        .set_key_separator("_")
-        .set_array_formatting(ArrayFormatting::Surrounded {
-            start: "[".to_string(),
-            end: "]".to_string(),
-        })
-        .set_preserve_empty_arrays(false)
-        .set_preserve_empty_objects(false)
-        .flatten(obj)
-        .unwrap()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_flatten_json() {
-        let datas = [
-            (
-                json!({"key": "value", "nested_key": {"key": "value", "foo": "bar"}}),
-                json!({"key": "value", "nested_key_key": "value", "nested_key_foo": "bar"}),
-            ),
-            (
-                json!({"key+bar": "value", "@nested_key": {"key": "value", "Foo": "Bar"}}),
-                json!({"key_bar": "value", "_nested_key_key": "value", "_nested_key_foo": "Bar"}),
-            ),
-        ];
-        for (input, expected) in datas.iter() {
-            assert_eq!(flatten_json_and_format_field(input), *expected);
-        }
-    }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -15,6 +15,7 @@
 pub mod auth;
 pub mod base64;
 pub mod file;
+pub mod flatten;
 pub mod functions;
 pub mod http;
 pub mod json;

--- a/src/service/logs/json.rs
+++ b/src/service/logs/json.rs
@@ -19,17 +19,14 @@ use datafusion::arrow::datatypes::Schema;
 use std::time::Instant;
 
 use super::StreamMeta;
-use crate::common::flatten;
-use crate::common::json;
-use crate::common::time::parse_timestamp_micro_from_value;
-use crate::infra::config::CONFIG;
-use crate::infra::{cluster, metrics};
-use crate::meta::alert::{Alert, Trigger};
-use crate::meta::ingestion::{IngestionResponse, RecordStatus, StreamStatus};
-use crate::meta::StreamType;
-use crate::service::db;
-use crate::service::ingestion::write_file;
-use crate::service::schema::stream_schema_exists;
+use crate::common::{flatten, json, time::parse_timestamp_micro_from_value};
+use crate::infra::{cluster, config::CONFIG, metrics};
+use crate::meta::{
+    alert::{Alert, Trigger},
+    ingestion::{IngestionResponse, RecordStatus, StreamStatus},
+    StreamType,
+};
+use crate::service::{db, ingestion::write_file, schema::stream_schema_exists};
 
 pub async fn ingest(
     org_id: &str,

--- a/src/service/logs/json.rs
+++ b/src/service/logs/json.rs
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use actix_web::{http, web, HttpResponse};
+use actix_web::{http, web};
 use ahash::AHashMap;
 use chrono::{Duration, Utc};
 use datafusion::arrow::datatypes::Schema;
-use std::io::Error;
 use std::time::Instant;
 
 use super::StreamMeta;
+use crate::common::flatten;
 use crate::common::json;
 use crate::common::time::parse_timestamp_micro_from_value;
 use crate::infra::config::CONFIG;
 use crate::infra::{cluster, metrics};
 use crate::meta::alert::{Alert, Trigger};
-use crate::meta::http::HttpResponse as MetaHttpResponse;
 use crate::meta::ingestion::{IngestionResponse, RecordStatus, StreamStatus};
 use crate::meta::StreamType;
 use crate::service::db;
@@ -37,28 +36,19 @@ pub async fn ingest(
     in_stream_name: &str,
     body: actix_web::web::Bytes,
     thread_id: web::Data<usize>,
-) -> Result<HttpResponse, Error> {
+) -> Result<IngestionResponse, anyhow::Error> {
     let start = Instant::now();
-
     let stream_name = &crate::service::ingestion::format_stream_name(in_stream_name);
 
     if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                "not an ingester".to_string(),
-            )),
-        );
+        return Err(anyhow::anyhow!("not an ingester"));
     }
 
     // check if we are allowed to ingest
     if db::compact::delete::is_deleting_stream(org_id, stream_name, StreamType::Logs, None) {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                format!("stream [{stream_name}] is being deleted"),
-            )),
-        );
+        return Err(anyhow::anyhow!(format!(
+            "stream [{stream_name}] is being deleted"
+        )));
     }
 
     let mut min_ts =
@@ -112,7 +102,7 @@ pub async fn ingest(
     let reader: Vec<json::Value> = json::from_slice(&body)?;
     for item in reader.iter() {
         //JSON Flattening
-        let mut value = json::flatten_json_and_format_field(item);
+        let mut value = flatten::flatten(item)?;
 
         #[cfg(feature = "zo_functions")]
         if !local_trans.is_empty() {
@@ -122,7 +112,7 @@ pub async fn ingest(
                 &stream_vrl_map,
                 stream_name,
                 &mut runtime,
-            );
+            )?;
         }
         #[cfg(feature = "zo_functions")]
         if value.is_null() || !value.is_object() {
@@ -206,8 +196,8 @@ pub async fn ingest(
         ])
         .inc();
 
-    Ok(HttpResponse::Ok().json(IngestionResponse::new(
+    Ok(IngestionResponse::new(
         http::StatusCode::OK.into(),
         vec![stream_status],
-    )))
+    ))
 }

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -22,7 +22,7 @@ use tracing::{info_span, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
-use crate::common::{json, str::find};
+use crate::common::{flatten, json, str::find};
 use crate::handler::grpc::cluster_rpc;
 use crate::infra::{
     cluster,
@@ -370,7 +370,7 @@ async fn search_in_cluster(req: cluster_rpc::SearchRequest) -> Result<search::Re
 
         if sql.uses_zo_fn {
             for source in sources {
-                result.add_hit(&json::flatten_json_and_format_field(&source));
+                result.add_hit(&flatten::flatten(&source).unwrap());
             }
         } else {
             for source in sources {

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -18,18 +18,18 @@ use bytes::{BufMut, BytesMut};
 use chrono::{Duration, Utc};
 use datafusion::arrow::datatypes::Schema;
 use opentelemetry::trace::{SpanId, TraceId};
-use opentelemetry_proto::tonic::common::v1::AnyValue;
 use opentelemetry_proto::tonic::{
     collector::trace::v1::ExportTraceServiceRequest,
-    collector::trace::v1::ExportTraceServiceResponse,
+    collector::trace::v1::ExportTraceServiceResponse, common::v1::AnyValue,
 };
 use prost::Message;
-use std::fs::OpenOptions;
-use std::io::Error;
+use std::{fs::OpenOptions, io::Error};
 
-use crate::common::json::{json, Map, Value};
-use crate::infra::config::CONFIG;
-use crate::infra::wal;
+use crate::common::{
+    flatten,
+    json::{json, Map, Value},
+};
+use crate::infra::{config::CONFIG, wal};
 use crate::meta::alert::{Alert, Evaluate, Trigger};
 use crate::meta::traces::Event;
 use crate::service::schema::stream_schema_exists;
@@ -195,7 +195,7 @@ pub async fn handle_trace_request(
                 let value: json::Value = json::to_value(local_val).unwrap();
 
                 //JSON Flattening
-                let mut value = json::flatten_json_and_format_field(&value);
+                let mut value = flatten::flatten(&value).unwrap();
 
                 // get json object
                 let val_map = value.as_object_mut().unwrap();


### PR DESCRIPTION
- [x] fix sperater eror
- [x] improve flatten speed

Ingest data:
```json
[
  {
    "user": "prabhat",
    "access": [
      {
        "type": "read",
        "path": "/home/prabhat"
      },
      {
        "type": "write",
        "path": "/home/prabhat",
        "groups": [
          "admin",
          "dev"
        ]
      }
    ]
  }
]
```

the result is: 
```json
{
  "_timestamp": 1686964366295822,
  "access_0__path": "/home/prabhat",
  "access_0__type": "read",
  "access_1__groups_0_": "admin",
  "access_1__groups_1_": "dev",
  "access_1__path": "/home/prabhat",
  "access_1__type": "write",
  "user": "prabhat"
}
```

now is:
```json
{
  "_timestamp": 1687147762824047,
  "access_0_path": "/home/prabhat",
  "access_0_type": "read",
  "access_1_groups_0": "admin",
  "access_1_groups_1": "dev",
  "access_1_path": "/home/prabhat",
  "access_1_type": "write",
  "user": "prabhat"
}
```


## Improve flatten speed

- Earlier we convert every key to lowercase, it need copy every key once.
- Now we check if the key is already lowercase and without special characters, skip copy. actually, in most case the key is lowercase letters, so it can improve flattening speed.