### PR TITLE
fix: in some case we can't use key as alias

### DIFF
--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -538,7 +538,7 @@ pub async fn values(
         req.aggs.insert(
                 field.clone(),
                 format!(
-                    "SELECT {field} AS key, COUNT(*) AS num FROM query GROUP BY key ORDER BY num DESC LIMIT {size}"
+                    "SELECT {field} AS zo_sql_key, COUNT(*) AS zo_sql_num FROM query GROUP BY zo_sql_key ORDER BY zo_sql_num DESC LIMIT {size}"
                 ),
             );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,7 +243,6 @@ fn init_grpc_server() -> Result<(), anyhow::Error> {
 }
 
 fn enable_tracing() -> Result<(), anyhow::Error> {
-    let service_name = format!("zo-{}", CONFIG.common.instance_name);
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
     let mut headers = HashMap::new();
     headers.insert(
@@ -259,7 +258,7 @@ fn enable_tracing() -> Result<(), anyhow::Error> {
                 .with_headers(headers),
         )
         .with_trace_config(sdktrace::config().with_resource(Resource::new(vec![
-            KeyValue::new("service.name", service_name),
+            KeyValue::new("instance_name", CONFIG.common.instance_name.as_str()),
             KeyValue::new("deployment_type", "k8s"),
         ])))
         .install_batch(opentelemetry::runtime::Tokio)?;

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -936,7 +936,7 @@ mod tests {
                 true, 0, (1679202494333000, 1679203394333000),
             ),
             (
-                "select histogram(_timestamp, '5 second') AS key, count(*) AS num from table1 GROUP BY key ORDER BY key",
+                "select histogram(_timestamp, '5 second') AS zo_sql_key, count(*) AS zo_sql_num from table1 GROUP BY zo_sql_key ORDER BY zo_sql_key",
                 true, 0, (0,0),
             ),
             (


### PR DESCRIPTION
for api: `/api/:org/:stream/_values`

We rename:

- key -> zo_sql_key
- num -> zo_sql_num