### PR TITLE
feat: initial structure of promql vector bin ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3973,6 +3984,7 @@ dependencies = [
  "pyroscope",
  "pyroscope_pprofrs",
  "rand",
+ "rayon",
  "regex",
  "regex-syntax 0.6.29",
  "reqwest",
@@ -4784,6 +4796,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ async_once = "0.2"
 async-recursion = "1.0"
 awc = "3.1"
 base64 = "0.21"
-blake3 = "1.3"
+blake3 = "1.4"
 bytes = "1.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4.1", default-features = false, features = [
@@ -119,6 +119,7 @@ prost = "0.11"
 pyroscope = { version = "0.5.6", optional = true }
 pyroscope_pprofrs = { version = "0.2.5", optional = true }
 rand = "0.8"
+rayon = "1.7.0"
 regex = "1.7"
 regex-syntax = "0.6"
 reqwest = { version = "0.11", default-features = false, features = [
@@ -155,7 +156,6 @@ vrl = { git = "https://github.com/zinclabs/vrl", rev = "2bbe6728fc0a9d0c20b6ee86
 walkdir = "2"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zstd = "0.12"
-
 
 [build-dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/src/service/promql/binaries/mod.rs
+++ b/src/service/promql/binaries/mod.rs
@@ -1,4 +1,4 @@
 mod scalar_operations;
 mod vector_operations;
 pub(crate) use scalar_operations::scalar_binary_operations;
-pub(crate) use vector_operations::vector_scalar_bin_op;
+pub(crate) use vector_operations::{vector_bin_op, vector_scalar_bin_op};

--- a/src/service/promql/binaries/vector_operations.rs
+++ b/src/service/promql/binaries/vector_operations.rs
@@ -1,10 +1,12 @@
-use datafusion::error::Result;
+use ahash::{HashMap, HashSet};
 
 use crate::service::promql::{
     binaries::scalar_binary_operations,
-    value::{InstantValue, Sample, Value},
+    value::{signature, InstantValue, Sample, Signature, Value},
 };
-use promql_parser::parser::BinaryExpr;
+use datafusion::error::{DataFusionError, Result};
+use promql_parser::parser::{token, BinaryExpr, VectorMatchCardinality};
+use rayon::prelude::*;
 
 /// Implement the operation between a vector and a float.
 ///
@@ -17,7 +19,7 @@ pub async fn vector_scalar_bin_op(
     let is_comparison_operator = expr.op.is_comparison_operator();
 
     let output: Vec<InstantValue> = left
-        .iter()
+        .par_iter()
         .map(|instant| {
             let value =
                 scalar_binary_operations(expr.op.id(), instant.sample.value, right).unwrap();
@@ -37,4 +39,189 @@ pub async fn vector_scalar_bin_op(
         })
         .collect();
     Ok(Value::Vector(output))
+}
+
+/// vector1 or vector2 results in a vector that contains all original elements (label sets + values)
+/// of vector1 and additionally all elements of vector2 which do not have matching label sets in vector1.
+///
+/// https://prometheus.io/docs/prometheus/latest/querying/operators/#logical-set-binary-operators
+fn vector_or(expr: &BinaryExpr, left: &[InstantValue], right: &[InstantValue]) -> Result<Value> {
+    if expr.modifier.as_ref().unwrap().card != VectorMatchCardinality::ManyToMany {
+        return Err(DataFusionError::NotImplemented(
+            "set operations must only use many-to-many matching".to_string(),
+        ));
+    }
+
+    if left.is_empty() {
+        return Ok(Value::Vector(right.to_vec()));
+    }
+
+    if right.is_empty() {
+        return Ok(Value::Vector(left.to_vec()));
+    }
+
+    let lhs_sig: HashSet<Signature> = left
+        .par_iter()
+        .map(|item| signature(&item.labels))
+        .collect();
+
+    // Add all right-hand side elements which have not been added from the left-hand side.
+    let right_instants: Vec<InstantValue> = right
+        .par_iter()
+        .filter(|item| {
+            let right_sig = signature(&item.labels);
+            !lhs_sig.contains(&right_sig)
+        })
+        .map(|item| item.clone())
+        .collect();
+
+    let output = [left, &right_instants].concat();
+    Ok(Value::Vector(output))
+}
+
+/// vector1 unless vector2 results in a vector consisting of the elements of vector1
+/// for which there are no elements in vector2 with exactly matching label sets.
+/// All matching elements in both vectors are dropped.
+///
+/// https://prometheus.io/docs/prometheus/latest/querying/operators/#logical-set-binary-operators
+fn vector_unless(
+    expr: &BinaryExpr,
+    left: &[InstantValue],
+    right: &[InstantValue],
+) -> Result<Value> {
+    if expr.modifier.as_ref().unwrap().card != VectorMatchCardinality::ManyToMany {
+        return Err(DataFusionError::NotImplemented(
+            "set operations must only use many-to-many matching".to_string(),
+        ));
+    }
+
+    // If right is empty, we simply return the left
+    // if left is empty we will return it anyway.
+    if left.is_empty() || right.is_empty() {
+        return Ok(Value::Vector(left.to_vec()));
+    }
+    // Generate all the signatures from the right hand.
+    let rhs_sig: HashSet<Signature> = right
+        .par_iter()
+        .map(|item| signature(&item.labels))
+        .collect();
+
+    // Now filter out all the matching labels from left.
+    let output: Vec<InstantValue> = left
+        .par_iter()
+        .filter(|item| {
+            let left_sig = signature(&item.labels);
+            !rhs_sig.contains(&left_sig)
+        })
+        .map(|val| val.clone())
+        .collect();
+    Ok(Value::Vector(output))
+}
+
+/// vector1 and vector2 results in a vector consisting of the elements of vector1 for which there
+/// are elements in vector2 with exactly matching label sets.
+/// Other elements are dropped. The metric name and values are carried over from the left-hand side vector.
+///
+/// https://prometheus.io/docs/prometheus/latest/querying/operators/#logical-set-binary-operators
+fn vector_and(expr: &BinaryExpr, left: &[InstantValue], right: &[InstantValue]) -> Result<Value> {
+    if expr.modifier.as_ref().unwrap().card != VectorMatchCardinality::ManyToMany {
+        return Err(DataFusionError::NotImplemented(
+            "set operations must only use many-to-many matching".to_string(),
+        ));
+    }
+
+    if left.is_empty() || right.is_empty() {
+        return Err(DataFusionError::NotImplemented(
+            "Either left or right operand is empty.".to_string(),
+        ));
+    }
+
+    let rhs_sig: HashSet<Signature> = right
+        .par_iter()
+        .map(|item| signature(&item.labels))
+        .collect();
+
+    // Now include all the matching ones from the right
+    let output: Vec<InstantValue> = left
+        .par_iter()
+        .filter(|item| {
+            let left_sig = signature(&item.labels);
+            rhs_sig.contains(&left_sig)
+        })
+        .map(|val| val.clone())
+        .collect();
+
+    Ok(Value::Vector(output))
+}
+
+fn vector_arithmatic_operators(
+    expr: &BinaryExpr,
+    left: &[InstantValue],
+    right: &[InstantValue],
+) -> Result<Value> {
+    let operator = expr.op.id();
+    // Get the hash for the labels on the right
+    let rhs_sig: HashMap<Signature, Sample> = right
+        .par_iter()
+        .map(|item| (signature(&item.labels), item.sample))
+        .collect();
+
+    // Iterate over left and pick up the corresponding instance from rhs
+    let output: Vec<InstantValue> = left
+        .par_iter()
+        .flat_map(|item| {
+            let left_sig = signature(&item.labels);
+            if rhs_sig.contains_key(&left_sig) {
+                Some((item, rhs_sig.get(&left_sig).unwrap()))
+            } else {
+                None
+            }
+        })
+        .map(|(lhs_instant, rhs_sample)| {
+            let value =
+                scalar_binary_operations(operator, lhs_instant.sample.value, rhs_sample.value)
+                    .unwrap();
+            InstantValue {
+                labels: lhs_instant.labels.clone(),
+                sample: Sample {
+                    timestamp: lhs_instant.sample.timestamp,
+                    value,
+                },
+            }
+        })
+        .collect();
+
+    Ok(Value::Vector(output))
+}
+
+/// Implement binary operations between two vectors
+///
+/// https://prometheus.io/docs/prometheus/latest/querying/operators/#comparison-binary-operators
+///
+/// Between two instant vectors, a binary arithmetic operator is applied to each entry in the
+/// left-hand side vector and its matching element in the right-hand vector. The result is
+/// propagated into the result vector with the grouping labels becoming the output label set.
+/// The metric name is dropped. Entries for which no matching entry in the right-hand vector
+/// can be found are not part of the result.
+///
+///
+/// Between two instant vectors, comparison binary operators behave as a filter by default,
+/// applied to matching entries. Vector elements for which the expression is not true or which
+/// do not find a match on the other side of the expression get dropped from the result, while
+/// the others are propagated into a result vector with the grouping labels becoming the output
+/// label set. If the bool modifier is provided, vector elements that would have been dropped
+/// instead have the value 0 and vector elements that would be kept have the value 1, with the
+/// grouping labels again becoming the output label set. The metric name is dropped if the bool
+/// modifier is provided.
+pub fn vector_bin_op(
+    expr: &BinaryExpr,
+    left: &[InstantValue],
+    right: &[InstantValue],
+) -> Result<Value> {
+    match expr.op.id() {
+        token::T_LAND => vector_and(expr, left, right),
+        token::T_LOR => vector_or(expr, left, right),
+        token::T_LUNLESS => vector_unless(expr, left, right),
+        _ => vector_arithmatic_operators(expr, left, right),
+    }
 }

--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -82,11 +82,8 @@ impl Engine {
                         let value = binaries::scalar_binary_operations(token, left, right)?;
                         Value::Float(value)
                     }
-                    (Value::Vector(_left), Value::Vector(_right)) => {
-                        return Err(DataFusionError::NotImplemented(format!(
-                            "Unsupported binary operation between two vectors. {:?} {:?}",
-                            &lhs, &rhs
-                        )))
+                    (Value::Vector(left), Value::Vector(right)) => {
+                        binaries::vector_bin_op(expr, &left, &right)?
                     }
                     (Value::Vector(left), Value::Float(right)) => {
                         binaries::vector_scalar_bin_op(expr, &left, right).await?


### PR DESCRIPTION
For binary operation between two vectors we support `and`, `or` and `unless` operations in this PR.

This also contains the vector arithmatic operators.