### PR TITLE
fix: change provider of s3

### DIFF
--- a/src/infra/config.rs
+++ b/src/infra/config.rs
@@ -580,18 +580,8 @@ fn check_s3_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         }
     }
     cfg.s3.provider = cfg.s3.provider.to_lowercase();
-    match cfg.s3.provider.as_str() {
-        "oss" => {
-            cfg.s3.feature_force_path_style = true;
-        }
-        "minio" => {
-            cfg.s3.feature_force_path_style = true;
-        }
-        "swift" => {
-            cfg.s3.feature_force_path_style = true;
-            std::env::set_var("AWS_EC2_METADATA_DISABLED", "true");
-        }
-        _ => {}
+    if cfg.s3.provider.eq("swift") {
+        std::env::set_var("AWS_EC2_METADATA_DISABLED", "true");
     }
     Ok(())
 }


### PR DESCRIPTION
Now we only has three provider for object storage:

## ZO_S3_PROVIDER
- s3
- gcp
- azure

All platform compatible s3, you can use `s3` or just skip this value because default is `s3`.

## ZO_S3_FEATURE_FORCE_PATH_STYLE

For s3 compatible platform, maybe you need `ZO_S3_FEATURE_FORCE_PATH_STYLE=true`, this config option default value is `false`.