### PR TITLE
fix: promql vector ops supporting boolean cases.

### DIFF
--- a/src/service/promql/binaries/vector_operations.rs
+++ b/src/service/promql/binaries/vector_operations.rs
@@ -33,6 +33,7 @@ pub async fn vector_scalar_bin_op(
 ) -> Result<Value> {
     let is_comparison_operator = expr.op.is_comparison_operator();
     let return_bool = expr.return_bool();
+
     let output: Vec<InstantValue> = left
         .par_iter()
         .flat_map(|instant| {
@@ -57,7 +58,10 @@ pub async fn vector_scalar_bin_op(
                     } else {
                         instant.labels.clone()
                     };
-                    let final_value = if is_comparison_operator && swapped_lhs_rhs {
+
+                    let final_value = if is_comparison_operator && swapped_lhs_rhs && return_bool {
+                        value
+                    } else if is_comparison_operator && swapped_lhs_rhs {
                         instant.sample.value
                     } else {
                         value
@@ -75,6 +79,7 @@ pub async fn vector_scalar_bin_op(
             }
         })
         .collect();
+
     Ok(Value::Vector(output))
 }
 
@@ -208,6 +213,7 @@ fn vector_arithmatic_operators(
 
     let return_bool = expr.return_bool();
     let comparison_operator = expr.op.is_comparison_operator();
+
     // Iterate over left and pick up the corresponding instance from rhs
     let output: Vec<InstantValue> = left
         .par_iter()

--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -109,6 +109,7 @@ impl Engine {
                 let token = expr.op.id();
                 let return_bool = expr.return_bool();
                 let op = expr.op.is_comparison_operator();
+
                 match (lhs.clone(), rhs.clone()) {
                     (Value::Float(left), Value::Float(right)) => {
                         let value = binaries::scalar_binary_operations(

--- a/src/service/promql/functions/rate.rs
+++ b/src/service/promql/functions/rate.rs
@@ -17,7 +17,7 @@ use datafusion::error::Result;
 use crate::service::promql::value::{extrapolated_rate, ExtrapolationKind, RangeValue, Value};
 
 pub(crate) fn rate(data: &Value) -> Result<Value> {
-    super::eval_idelta(data, "rate", exec, true)
+    super::eval_idelta(data, "rate", exec, false)
 }
 
 fn exec(series: &RangeValue) -> Option<f64> {


### PR DESCRIPTION
This is the third installment of scalar <-> vector ops
where we support queries like following, which include bool.

```
1 < bool some-vector-metric
```