### PR TITLE
fix: optimize some query cases

### DIFF
--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -39,6 +39,7 @@ impl Event for Eventer {
 
         let req = req.get_ref();
         for file in req.items.iter() {
+            log::info!("received event:file {:?}", file);
             if let Err(e) = file_list::progress(
                 &file.key,
                 FileMeta::from(file.meta.as_ref().unwrap()),

--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -39,7 +39,7 @@ impl Event for Eventer {
 
         let req = req.get_ref();
         for file in req.items.iter() {
-            log::info!("received event:file {:?}", file);
+            // log::info!("received event:file {:?}", file);
             if let Err(e) = file_list::progress(
                 &file.key,
                 FileMeta::from(file.meta.as_ref().unwrap()),

--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -44,6 +44,7 @@ impl Event for Eventer {
                 &file.key,
                 FileMeta::from(file.meta.as_ref().unwrap()),
                 file.deleted,
+                true,
             )
             .await
             {

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -112,10 +112,11 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
         json::json!({"stream_num": stream_num, "mem_size": mem_size}),
     );
 
+    let file_num = cache::file_data::len();
     let (max_size, cur_size) = cache::file_data::stats();
     stats.insert(
         "FILE_DATA",
-        json::json!({"memory_limit":max_size,"mem_size": cur_size}),
+        json::json!({"cache_files":file_num, "memory_limit":max_size,"mem_size": cur_size}),
     );
 
     let (file_list_num, files_num, mem_size) = cache::file_list::get_file_num().unwrap();

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -239,7 +239,7 @@ pub async fn merge_by_stream(
                 let mut cache_success = true;
                 for event in &events {
                     if let Err(e) =
-                        db::file_list::progress(&event.key, event.meta, event.deleted).await
+                        db::file_list::progress(&event.key, event.meta, event.deleted, false).await
                     {
                         cache_success = false;
                         log::error!("[COMPACT] set local cache failed, retrying: {}", e);

--- a/src/service/compact/retention.rs
+++ b/src/service/compact/retention.rs
@@ -292,7 +292,8 @@ async fn delete_from_file_list(
             // set to local cache
             let mut cache_success = true;
             for event in &items {
-                if let Err(e) = db::file_list::progress(&event.key, event.meta, event.deleted).await
+                if let Err(e) =
+                    db::file_list::progress(&event.key, event.meta, event.deleted, false).await
                 {
                     cache_success = false;
                     log::error!(

--- a/src/service/db/file_list/local.rs
+++ b/src/service/db/file_list/local.rs
@@ -49,7 +49,8 @@ pub async fn set(key: &str, meta: FileMeta, deleted: bool) -> Result<(), anyhow:
     file.write(write_buf.as_ref());
 
     super::progress(key, meta, deleted).await?;
-    super::broadcast::send(&[file_data]).await
+    tokio::task::spawn(async move { super::broadcast::send(&[file_data]).await });
+    Ok(())
 }
 
 pub async fn get_all() -> Result<Vec<FileKey>, anyhow::Error> {

--- a/src/service/db/file_list/local.rs
+++ b/src/service/db/file_list/local.rs
@@ -48,7 +48,7 @@ pub async fn set(key: &str, meta: FileMeta, deleted: bool) -> Result<(), anyhow:
     let file = wal::get_or_create(0, "", "", StreamType::Filelist, &hour_key, false);
     file.write(write_buf.as_ref());
 
-    super::progress(key, meta, deleted).await?;
+    super::progress(key, meta, deleted, true).await?;
     tokio::task::spawn(async move { super::broadcast::send(&[file_data]).await });
     Ok(())
 }
@@ -92,7 +92,7 @@ pub async fn cache() -> Result<(), anyhow::Error> {
             super::DELETED_FILES.insert(item.key, item.meta.to_owned());
             continue;
         }
-        super::progress(&item.key, item.meta, item.deleted).await?;
+        super::progress(&item.key, item.meta, item.deleted, false).await?;
     }
     Ok(())
 }

--- a/src/service/db/file_list/mod.rs
+++ b/src/service/db/file_list/mod.rs
@@ -77,12 +77,8 @@ pub async fn progress(key: &str, data: FileMeta, delete: bool) -> Result<(), any
             if CONFIG.memory_cache.cache_latest_files
                 && cluster::is_querier(&cluster::LOCAL_NODE_ROLE)
             {
-                match cache::file_data::download(key).await {
-                    Ok(_) => {}
-                    Err(e) => {
-                        log::error!("service:db:file_list: add {}, download error: {}", key, e);
-                    }
-                }
+                // maybe load already merged file, no need report error
+                _ = cache::file_data::download(key).await;
             }
             if old_data.is_ok() {
                 return Ok(()); // already exists, skip increase stats

--- a/src/service/db/file_list/mod.rs
+++ b/src/service/db/file_list/mod.rs
@@ -31,7 +31,6 @@ pub static DELETED_FILES: Lazy<RwHashMap<String, FileMeta>> =
 pub static BLOCKED_ORGS: Lazy<Vec<&str>> =
     Lazy::new(|| CONFIG.compact.blocked_orgs.split(',').collect());
 
-#[inline]
 pub async fn progress(
     key: &str,
     data: FileMeta,

--- a/src/service/db/file_list/mod.rs
+++ b/src/service/db/file_list/mod.rs
@@ -32,7 +32,12 @@ pub static BLOCKED_ORGS: Lazy<Vec<&str>> =
     Lazy::new(|| CONFIG.compact.blocked_orgs.split(',').collect());
 
 #[inline]
-pub async fn progress(key: &str, data: FileMeta, delete: bool) -> Result<(), anyhow::Error> {
+pub async fn progress(
+    key: &str,
+    data: FileMeta,
+    delete: bool,
+    download: bool,
+) -> Result<(), anyhow::Error> {
     let old_data = cache::file_list::get_file_from_cache(key);
     match delete {
         true => {
@@ -74,7 +79,8 @@ pub async fn progress(key: &str, data: FileMeta, delete: bool) -> Result<(), any
                     );
                 }
             }
-            if CONFIG.memory_cache.cache_latest_files
+            if download
+                && CONFIG.memory_cache.cache_latest_files
                 && cluster::is_querier(&cluster::LOCAL_NODE_ROLE)
             {
                 // maybe load already merged file, no need report error

--- a/src/service/db/file_list/remote.rs
+++ b/src/service/db/file_list/remote.rs
@@ -93,7 +93,12 @@ pub async fn cache(prefix: &str) -> Result<(), anyhow::Error> {
 
 async fn process_file(file: &str) -> Result<usize, anyhow::Error> {
     // download file list from storage
-    let data = storage::get(file).await?;
+    let data = match storage::get(file).await {
+        Ok(data) => data,
+        Err(_) => {
+            return Ok(0);
+        }
+    };
     // uncompress file
     let uncompress = zstd::decode_all(data.reader())?;
     let uncompress_reader = BufReader::new(uncompress.reader());

--- a/src/service/db/file_list/remote.rs
+++ b/src/service/db/file_list/remote.rs
@@ -72,7 +72,7 @@ pub async fn cache(prefix: &str) -> Result<(), anyhow::Error> {
 
     // delete files
     for item in super::DELETED_FILES.iter() {
-        super::progress(item.key(), item.value().to_owned(), true).await?;
+        super::progress(item.key(), item.value().to_owned(), true, false).await?;
     }
 
     log::info!(
@@ -120,7 +120,7 @@ async fn process_file(file: &str) -> Result<usize, anyhow::Error> {
             super::DELETED_FILES.insert(item.key, item.meta.to_owned());
             continue;
         }
-        super::progress(&item.key, item.meta, item.deleted).await?;
+        super::progress(&item.key, item.meta, item.deleted, false).await?;
     }
     Ok(count)
 }

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -98,7 +98,7 @@ pub async fn delete_parquet_file(key: &str) -> Result<(), anyhow::Error> {
     buf.write_all(&write_buf)?;
     let compressed_bytes = buf.finish().unwrap();
     storage::put(&new_file_list_key, compressed_bytes.into()).await?;
-    db::file_list::progress(key, meta, deleted).await?;
+    db::file_list::progress(key, meta, deleted, false).await?;
     db::file_list::broadcast::send(&[file_data]).await?;
 
     // delete the parquet whaterever the file is exists or not

--- a/src/service/promql/functions/time_operations.rs
+++ b/src/service/promql/functions/time_operations.rs
@@ -93,10 +93,8 @@ pub(crate) fn days_in_month(data: &Value) -> Result<Value> {
 }
 
 fn exec(data: &Value, op: &TimeOperationType) -> Result<Value> {
-
     let instant_values = match data {
-        Value::Vector(v) => {v
-        }
+        Value::Vector(v) => v,
         _ => {
             return Err(DataFusionError::NotImplemented(format!(
                 "Invalid input for minute value: {:?}",

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -187,7 +187,7 @@ async fn cache_parquet_files(files: &[String]) -> Result<Vec<String>> {
         let file = file.clone();
         let permit = semaphore.clone().acquire_owned().await.unwrap();
         let task: tokio::task::JoinHandle<Option<String>> = tokio::task::spawn(async move {
-            if !file_data::exist(&file).unwrap_or_default() {
+            if !file_data::exist(&file) {
                 if let Err(e) = file_data::download(&file).await {
                     log::info!("promql->search->storage: download file err: {}", e);
                     if e.to_string().to_lowercase().contains("not found") {

--- a/src/service/schema.rs
+++ b/src/service/schema.rs
@@ -350,9 +350,7 @@ async fn handle_existing_schema(
     stream_schema_map: &mut AHashMap<String, Schema>,
 ) -> Option<SchemaEvolution> {
     if !CONFIG.common.local_mode {
-        let mut lock = etcd::Locker::new(&format!(
-            "/schema/lock/{org_id}/{stream_type}/{stream_name}"
-        ));
+        let mut lock = etcd::Locker::new(&format!("schema/{org_id}/{stream_type}/{stream_name}"));
         lock.lock(0).await.map_err(server_internal_error).unwrap();
         let schema = db::schema::get_from_db(org_id, stream_name, stream_type)
             .await
@@ -491,9 +489,8 @@ async fn handle_new_schema(
         stream_schema_map.insert(stream_name.to_string(), final_schema.clone());
 
         if !CONFIG.common.local_mode {
-            let mut lock = etcd::Locker::new(&format!(
-                "/schema/lock/{org_id}/{stream_type}/{stream_name}"
-            ));
+            let mut lock =
+                etcd::Locker::new(&format!("schema/{org_id}/{stream_type}/{stream_name}"));
             lock.lock(0).await.map_err(server_internal_error).unwrap();
             log::info!("Aquired lock for stream {} as schema is empty", stream_name);
 

--- a/src/service/search/datafusion/storage/nocache.rs
+++ b/src/service/search/datafusion/storage/nocache.rs
@@ -42,17 +42,11 @@ impl FS {
         path.into()
     }
 
-    async fn get_cache(&self, location: &Path) -> Result<Bytes> {
+    async fn get_cache(&self, location: &Path) -> Option<Bytes> {
         let path = location.to_string();
         let data = file_data::get(&path);
         tokio::task::yield_now().await;
-        match data {
-            Ok(data) => Ok(data),
-            Err(err) => Err(object_store::Error::NotFound {
-                path,
-                source: err.into(),
-            }),
-        }
+        data
     }
 }
 
@@ -67,8 +61,8 @@ impl ObjectStore for FS {
     async fn get(&self, location: &Path) -> Result<GetResult> {
         let location = &self.format_location(location);
         let data = match self.get_cache(location).await {
-            Ok(data) => data,
-            Err(_) => return storage::DEFAULT.get(location).await,
+            Some(data) => data,
+            None => return storage::DEFAULT.get(location).await,
         };
         Ok(GetResult::Stream(
             futures::stream::once(async move { Ok(data) }).boxed(),
@@ -78,8 +72,8 @@ impl ObjectStore for FS {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let location = &self.format_location(location);
         let data = match self.get_cache(location).await {
-            Ok(data) => data,
-            Err(_) => return storage::DEFAULT.get_opts(location, options).await,
+            Some(data) => data,
+            None => return storage::DEFAULT.get_opts(location, options).await,
         };
         Ok(GetResult::Stream(
             futures::stream::once(async move { Ok(data) }).boxed(),
@@ -89,8 +83,8 @@ impl ObjectStore for FS {
     async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
         let location = &self.format_location(location);
         let data = match self.get_cache(location).await {
-            Ok(data) => data,
-            Err(_) => return storage::DEFAULT.get_range(location, range).await,
+            Some(data) => data,
+            None => return storage::DEFAULT.get_range(location, range).await,
         };
         if range.end > data.len() {
             return Err(super::Error::OutOfRange(location.to_string()).into());
@@ -104,8 +98,8 @@ impl ObjectStore for FS {
     async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
         let location = &self.format_location(location);
         let data = match self.get_cache(location).await {
-            Ok(data) => data,
-            Err(_) => return storage::DEFAULT.get_ranges(location, ranges).await,
+            Some(data) => data,
+            None => return storage::DEFAULT.get_ranges(location, ranges).await,
         };
         ranges
             .iter()
@@ -124,8 +118,8 @@ impl ObjectStore for FS {
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         let location = &self.format_location(location);
         let data = match self.get_cache(location).await {
-            Ok(data) => data,
-            Err(_) => return storage::DEFAULT.head(location).await,
+            Some(data) => data,
+            None => return storage::DEFAULT.head(location).await,
         };
         Ok(ObjectMeta {
             location: location.clone(),

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -252,7 +252,7 @@ async fn cache_parquet_files(files: &[String]) -> Result<Vec<String>, Error> {
         let file = file.clone();
         let permit = semaphore.clone().acquire_owned().await.unwrap();
         let task: tokio::task::JoinHandle<Option<String>> = tokio::task::spawn(async move {
-            if !file_data::exist(&file).unwrap_or_default() {
+            if !file_data::exist(&file) {
                 if let Err(e) = file_data::download(&file).await {
                     log::info!("search->storage: download file err: {}", e);
                     if e.to_string().to_lowercase().contains("not found") {


### PR DESCRIPTION
- [x] let broadcast async to accelerate delete wal file
- [x] maybe load already merged file, no need report error
- [x] optimize file cache
- [x] don't cache parquet file when loading file list
- [x] maybe try to download a deleted file_list file, just return zero