### PR TITLE
fix: histogram ingestion for json api

### DIFF
--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -433,9 +433,35 @@ pub(crate) async fn get_metadata(
                 "failed to get metrics' stream schemas: {error}"
             )))
         }
-        Ok(stream_schemas) => {
+        Ok(mut stream_schemas) => {
+            stream_schemas.sort_by(|a, b| a.stream_name.cmp(&b.stream_name));
+            let histogram_summary = stream_schemas
+                .iter()
+                .filter_map(|v| match super::get_prom_metadata_from_schema(&v.schema) {
+                    None => None,
+                    Some(v) => {
+                        if v.metric_type == prom::MetricType::Histogram
+                            || v.metric_type == prom::MetricType::Summary
+                        {
+                            Some(v.metric_family_name)
+                        } else {
+                            None
+                        }
+                    }
+                })
+                .collect::<Vec<_>>();
+            let mut histogram_summary_sub = Vec::with_capacity(histogram_summary.len() * 3);
+            for name in histogram_summary.iter() {
+                histogram_summary_sub.push(format!("{}_bucket", name));
+                histogram_summary_sub.push(format!("{}_count", name));
+                histogram_summary_sub.push(format!("{}_sum", name));
+            }
             let metric_names = stream_schemas.into_iter().filter_map(|schema| {
-                get_metadata_object(&schema.schema).map(|meta| (schema.stream_name, vec![meta]))
+                if histogram_summary_sub.contains(&schema.stream_name) {
+                    None
+                } else {
+                    get_metadata_object(&schema.schema).map(|meta| (schema.stream_name, vec![meta]))
+                }
             });
             Ok(match req.limit {
                 None => metric_names.collect(),
@@ -608,7 +634,7 @@ pub(crate) async fn get_label_values(
         // This special case doesn't require any SQL to be executed. All we have
         // to do is to collect stream names that satisfy selection criteria
         // (i.e., `selector` and `start`/`end`) and return them.
-        let stream_schemas = db::schema::list(org_id, Some(stream_type), false)
+        let stream_schemas = db::schema::list(org_id, Some(stream_type), true)
             .await
             .unwrap_or_default();
         let mut label_values = Vec::with_capacity(stream_schemas.len());
@@ -620,7 +646,22 @@ pub(crate) async fn get_label_values(
                     continue;
                 }
             }
-            let stats = stats::get_stream_stats(org_id, &schema.stream_name, stream_type);
+            let stats = match super::get_prom_metadata_from_schema(&schema.schema) {
+                None => stats::get_stream_stats(org_id, &schema.stream_name, stream_type),
+                Some(metadata) => {
+                    if metadata.metric_type == prom::MetricType::Histogram
+                        || metadata.metric_type == prom::MetricType::Summary
+                    {
+                        stats::get_stream_stats(
+                            org_id,
+                            &format!("{}_sum", schema.stream_name),
+                            stream_type,
+                        )
+                    } else {
+                        stats::get_stream_stats(org_id, &schema.stream_name, stream_type)
+                    }
+                }
+            };
             if stats.time_range_intersects(start, end) {
                 label_values.push(schema.stream_name.clone())
             }


### PR DESCRIPTION

## Examples

### Counter

```json
[
    {
        "__name__": "zo_incoming_requests",
        "__type__": "counter",
        "endpoint": "/api/config",
        "method": "get",
		"status": "200",
		"instance": "zo1-openobserve-router-5d9f7d67c6-296wj",
        "_timestamp": 1690129406888,
        "value": 6.0
    }
]
```

### Gauge

```json
[
    {
        "__name__": "ingest_wal_used_bytes",
        "__type__": "gauge",
        "organization": "default",
        "stream_type": "logs",
		"stream": "default",
		"instance": "zo1-openobserve-router-5d9f7d67c6-296wj",
        "_timestamp": 1690129406888,
        "value": 180567.1
    }
]
```

### Histogram

Histogram is a complex metrics type, need 4 types data values.

1. The `Histogram` type row of the metrics name.
1. The `Counter` type rows of the `_bucket` values.
1. The `Counter` type row of the `_count` value.
1. The `Counter` type row of the `_sum` value.

```json
[
	{"__name__": "http_response_time", "__type__": "histogram"},
    {"__name__": "http_response_time_bucket", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "le": "0.001", "_timestamp": 1690129406888, "value": 18.0},
    {"__name__": "http_response_time_bucket", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "le": "0.01", "_timestamp": 1690129406888, "value": 18.0},
    {"__name__": "http_response_time_bucket", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "le": "0.1", "_timestamp": 1690129406888, "value": 18.0},
    {"__name__": "http_response_time_bucket", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "le": "+Inf", "_timestamp": 1690129406888, "value": 18.0},
    {"__name__": "http_response_time_count", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "_timestamp": 1690129406888, "value": 18.0},
    {"__name__": "http_response_time_sum", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "_timestamp": 1690129406888, "value": 0.003}
]
```

### Summary

Summary is a complex metrics type, need 4 types data values.

1. The `Summary` type row of the metrics name.
1. The `Counter` type rows of the metrics values.
1. The `Counter` type row of the `_count` value.
1. The `Counter` type row of the `_sum` value.

```json
[
    {"__name__": "http_request_time", "__type__": "summary"},
    {"__name__": "http_request_time", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "quantile": "0.001", "_timestamp": 1690129406888, "value": 18.0},
    {"__name__": "http_request_time", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "quantile": "0.01", "_timestamp": 1690129406888, "value": 18.0},
    {"__name__": "http_request_time", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "quantile": "0.1", "_timestamp": 1690129406888, "value": 18.0},
    {"__name__": "http_request_time", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "quantile": "+Inf", "_timestamp": 1690129406888, "value": 18.0},
    {"__name__": "http_request_time_count", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "_timestamp": 1690129406888, "value": 18.0},
    {"__name__": "http_request_time_sum", "__type__": "counter", "endpoint": "/api/default/default/_json", "method": "get", "_timestamp": 1690129406888, "value": 0.003}
]
```
