### PR TITLE
fix: pass the range param to the matrix data-selector

### DIFF
--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -256,7 +256,7 @@ impl Engine {
         let metrics_name = selector.name.as_ref().unwrap();
         let cache_exists = { self.ctx.data_cache.read().await.contains_key(metrics_name) };
         if !cache_exists {
-            self.selector_load_data(selector, None).await?;
+            self.selector_load_data(selector, Some(range)).await?;
         }
         let metrics_cache = self.ctx.data_cache.read().await;
         let metrics_cache = match metrics_cache.get(metrics_name) {


### PR DESCRIPTION
`range` param was missing while loading the raw data in the cache and was being passed as `None`. Thus, fixing this should improve the promql compliance.

```
================================================================================
General query tweaks:
*  Openobserve is sometimes off by 1ms when parsing floating point start/end timestamps.
*  Openobserve fractional tolerance amount for <agg>_over_time queries
================================================================================
Total: 486 / 548 (88.69%) passed, 0 unsupported
```