### PR TITLE
feat: promql subquery impl and small improvements

### DIFF
--- a/src/service/promql/functions/histogram.rs
+++ b/src/service/promql/functions/histogram.rs
@@ -61,7 +61,7 @@ pub(crate) fn histogram_quantile(sample_time: i64, phi: f64, data: Value) -> Res
         // without such a label are silently ignored.*
         let upper_bound: f64 = match labels
             .iter()
-            .find(|v| v.name == "le")
+            .find(|v| v.name == LE_LABEL)
             .map(|s| s.value.parse())
         {
             Some(Ok(u)) => u,

--- a/src/service/promql/functions/mod.rs
+++ b/src/service/promql/functions/mod.rs
@@ -146,9 +146,10 @@ pub(crate) fn eval_idelta(
     let data = match data {
         Value::Matrix(v) => v,
         Value::None => return Ok(Value::None),
-        _ => {
+        v => {
             return Err(DataFusionError::Plan(format!(
-                "{fn_name}: matrix argument expected"
+                "{fn_name}: matrix argument expected but got {}",
+                v.get_type()
             )))
         }
     };

--- a/src/service/promql/functions/predict_linear.rs
+++ b/src/service/promql/functions/predict_linear.rs
@@ -22,7 +22,6 @@ pub(crate) fn predict_linear(data: &Value, duration: f64) -> Result<Value> {
     exec(data, duration)
 }
 
-// fn exec(data: &RangeValue, duration:f64) -> Option<f64> {
 fn exec(data: &Value, duration: f64) -> Result<Value> {
     let data = match data {
         Value::Matrix(v) => v,

--- a/src/service/promql/value.rs
+++ b/src/service/promql/value.rs
@@ -411,6 +411,14 @@ impl Value {
         }
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn get_vector(&self) -> Option<&Vec<InstantValue>> {
+        match self {
+            Value::Vector(values) => Some(values),
+            _ => None,
+        }
+    }
+
     pub(crate) fn get_string(&self) -> Option<String> {
         match self {
             Value::String(v) => Some(v.into()),
@@ -637,5 +645,32 @@ mod tests {
     #[test]
     fn test_invalid_label_name() {
         assert!(!Label::is_valid_label_name("~invalid-label-name"));
+    }
+
+    #[test]
+    fn test_get_value() {
+        let mut labels: Labels = Default::default();
+        labels.push(Arc::new(Label {
+            name: "a".to_owned(),
+            value: "1".to_owned(),
+        }));
+        labels.push(Arc::new(Label {
+            name: "b".to_owned(),
+            value: "2".to_owned(),
+        }));
+        labels.push(Arc::new(Label {
+            name: "c".to_owned(),
+            value: "3".to_owned(),
+        }));
+        labels.push(Arc::new(Label {
+            name: "d".to_owned(),
+            value: "4".to_owned(),
+        }));
+
+        let value = labels.get_value("a");
+        assert!(value == "1");
+
+        let value = labels.get_value("non-existant-label");
+        assert!(value == "");
     }
 }


### PR DESCRIPTION
- Now supporting queries like:
```
sum by(instance, type) (demo_memory_usage_bytes) + on(instance, type) group_left(job) demo_memory_usage_bytes
```
- Implemented a subquery parser, i.e. supporting queries like
```
avg_over_time(rate(demo_cpu_usage_seconds_total[1m])[2m:10s])
```
- Fixed a small bug in queries for time-like functions for e.g. `minute()`, `hour()`, ..etc. where the timestamp of the sample was being evaluated, rather than the actual value of the sample.

Running the compliance on this PR, generates the following results:
```
================================================================================
General query tweaks:
*  Openobserve is sometimes off by 1ms when parsing floating point start/end timestamps.
*  Openobserve fractional tolerance amount for <agg>_over_time queries
================================================================================
Total: 523 / 548 (95.44%) passed, 0 unsupported
```