### PR TITLE
feat: promql count_values support

### DIFF
--- a/src/service/promql/aggregations/count_values.rs
+++ b/src/service/promql/aggregations/count_values.rs
@@ -1,0 +1,59 @@
+// Copyright 2022 Zinc Labs Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::Engine;
+use datafusion::error::DataFusionError;
+use datafusion::error::Result;
+use promql_parser::parser::Expr as PromExpr;
+use promql_parser::parser::LabelModifier;
+
+use crate::service::promql::value::{InstantValue, Label, Sample, Value};
+
+pub async fn count_values(
+    ctx: &mut Engine,
+    timestamp: i64,
+    param: Box<PromExpr>,
+    modifier: &Option<LabelModifier>,
+    data: &Value,
+) -> Result<Value> {
+    let param = ctx.exec_expr(&param).await?;
+    let label_name = match param {
+        Value::String(v) => v,
+        _ => {
+            return Err(DataFusionError::Plan(format!(
+                "[label_name] param must be a String"
+            )))
+        }
+    };
+    if !Label::is_valid_label_name(&label_name) {
+        return Err(DataFusionError::Plan(format!(
+                "[label_name] param invalid. Check https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels"
+            )));
+    }
+    let score_values = super::eval_count_values(modifier, data, "count_values", &label_name)?;
+    if score_values.is_none() {
+        return Ok(Value::None);
+    }
+
+    let values = score_values
+        .unwrap()
+        .values()
+        .map(|it| InstantValue {
+            labels: it.labels.clone(),
+            sample: Sample::new(timestamp, it.count as f64),
+        })
+        .collect();
+
+    Ok(Value::Vector(values))
+}

--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -502,7 +502,16 @@ impl Engine {
             token::T_BOTTOMK => {
                 aggregations::bottomk(self, param.clone().unwrap(), modifier, &input).await?
             }
-            token::T_COUNT_VALUES => Value::None,
+            token::T_COUNT_VALUES => {
+                aggregations::count_values(
+                    self,
+                    sample_time,
+                    param.clone().unwrap(),
+                    modifier,
+                    &input,
+                )
+                .await?
+            }
             token::T_QUANTILE => {
                 aggregations::quantile(self, sample_time, param.clone().unwrap(), &input).await?
             }

--- a/src/service/promql/value.rs
+++ b/src/service/promql/value.rs
@@ -57,6 +57,12 @@ pub trait LabelsExt {
     /// delete the labels as described by the `labels` vector
     /// and keep the remaining
     fn delete(&self, labels: &[String]) -> Labels;
+
+    /// Sort the labels by name
+    fn sort(&mut self);
+
+    /// Set a new label -> value to this label
+    fn set(&mut self, name: &str, value: &str);
 }
 
 impl LabelsExt for Labels {
@@ -105,6 +111,17 @@ impl LabelsExt for Labels {
                 }
             })
             .collect()
+    }
+
+    fn sort(&mut self) {
+        self.sort_by(|a, b| a.name.cmp(&b.name))
+    }
+
+    fn set(&mut self, name: &str, value: &str) {
+        self.push(Arc::new(Label {
+            name: name.to_string(),
+            value: value.to_string(),
+        }))
     }
 }
 


### PR DESCRIPTION
Now supporting queries like:
```
count_values("value", demo_api_request_duration_seconds_bucket)
```