### PR TITLE
fix: incorrect labels in aggregations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,6 +1355,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "constant_time_eq",
  "digest",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ awc = "3.1"
 aws-config = "0.55.3"
 aws-sdk-dynamodb = "0.28.0"
 base64 = "0.21"
-blake3 = "1.4"
+blake3 = { version = "1.4", features = ["rayon"] }
 bytes = "1.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4.1", default-features = false, features = [

--- a/src/service/promql/aggregations/mod.rs
+++ b/src/service/promql/aggregations/mod.rs
@@ -83,7 +83,7 @@ pub fn labels_to_include(
     actual_labels
         .iter()
         .flat_map(|label| {
-            if include_labels.contains(&label.name) && label.name != NAME_LABEL {
+            if include_labels.contains(&label.name) {
                 Some(label.clone())
             } else {
                 None

--- a/src/service/promql/binaries/vector_operations.rs
+++ b/src/service/promql/binaries/vector_operations.rs
@@ -2,9 +2,12 @@ use std::sync::Arc;
 
 use ahash::{HashMap, HashSet};
 
-use crate::service::promql::{
-    binaries::scalar_binary_operations,
-    value::{signature, InstantValue, Label, LabelsExt, Sample, Signature, Value},
+use crate::{
+    common::meta::prom::NAME_LABEL,
+    service::promql::{
+        binaries::scalar_binary_operations,
+        value::{signature, InstantValue, Label, LabelsExt, Sample, Signature, Value},
+    },
 };
 use datafusion::error::{DataFusionError, Result};
 use promql_parser::parser::{token, BinaryExpr, VectorMatchCardinality};
@@ -221,6 +224,7 @@ fn vector_arithmatic_operators(
             labels_to_include_set.sort();
         } else {
             labels_to_exclude_set = modifier.matching.as_ref().unwrap().labels().labels.clone();
+            labels_to_exclude_set.push(NAME_LABEL.to_string());
             labels_to_exclude_set.sort();
         }
     }

--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -136,17 +136,11 @@ impl Engine {
                     (Value::Float(left), Value::Vector(right)) => {
                         binaries::vector_scalar_bin_op(expr, &right, left, true).await?
                     }
-                    (Value::None, _) | (_, Value::None) => {
-                        return Err(DataFusionError::NotImplemented(format!(
-                            "No data found for the operation lhs: {:?} rhs: {:?}",
-                            &lhs, &rhs
-                        )))
-                    }
                     _ => {
-                        return Err(DataFusionError::NotImplemented(format!(
-                            "Unsupported binary operation between two operands. {:?} {:?}",
-                            &lhs, &rhs
-                        )))
+                        log::info!(
+                            "[PromExpr::Binary] either lhs or rhs vector is found to be empty"
+                        );
+                        Value::Vector(vec![])
                     }
                 }
             }

--- a/src/service/promql/value.rs
+++ b/src/service/promql/value.rs
@@ -545,8 +545,8 @@ pub fn signature_without_labels(labels: &Labels, exclude_names: &[&str]) -> Sign
         .iter()
         .filter(|item| !exclude_names.contains(&item.name.as_str()))
         .for_each(|item| {
-            hasher.update(item.name.as_bytes());
-            hasher.update(item.value.as_bytes());
+            hasher.update_rayon(item.name.as_bytes());
+            hasher.update_rayon(item.value.as_bytes());
         });
     Signature(hasher.finalize().into())
 }


### PR DESCRIPTION
In case of `by` queries, the labels_to_include() was also including the MetricName, this is incorrect, thus fixing it.