### PR TITLE
fix: fixes #1313

### DIFF
--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -249,6 +249,7 @@ impl Engine {
         }
 
         let metrics_name = selector.name.as_ref().expect("Missing selector name");
+
         let cache_exists = { self.ctx.data_cache.read().await.contains_key(metrics_name) };
         if !cache_exists {
             self.selector_load_data(&selector, None).await?;


### PR DESCRIPTION
Due to a mismatch on the label which was used to generate signatures for matching `lhs` with `rhs` metrics was being computed in a wrong way.

Also refactored code a bit to simply `signature` creation and added bunch of tests.