### PR TITLE
feat: promql aggregations parallelized

### DIFF
--- a/src/service/promql/aggregations/avg.rs
+++ b/src/service/promql/aggregations/avg.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::service::promql::value::{InstantValue, Sample, Value};
 use datafusion::error::Result;
 use promql_parser::parser::LabelModifier;
-
-use crate::service::promql::value::{InstantValue, Sample, Value};
+use rayon::prelude::*;
 
 pub fn avg(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Result<Value> {
     let score_values = super::eval_arithmetic(param, data, "avg", |total, val| total + val)?;
@@ -24,10 +24,10 @@ pub fn avg(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
     }
     let values = score_values
         .unwrap()
-        .values()
+        .par_iter()
         .map(|v| InstantValue {
-            labels: v.labels.clone(),
-            sample: Sample::new(timestamp, v.value / v.num as f64),
+            labels: v.1.labels.clone(),
+            sample: Sample::new(timestamp, v.1.value / v.1.num as f64),
         })
         .collect();
     Ok(Value::Vector(values))

--- a/src/service/promql/aggregations/count.rs
+++ b/src/service/promql/aggregations/count.rs
@@ -14,6 +14,7 @@
 
 use datafusion::error::Result;
 use promql_parser::parser::LabelModifier;
+use rayon::prelude::*;
 
 use crate::service::promql::value::{InstantValue, Sample, Value};
 
@@ -24,10 +25,10 @@ pub fn count(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Res
     }
     let values = score_values
         .unwrap()
-        .values()
+        .par_iter()
         .map(|it| InstantValue {
-            labels: it.labels.clone(),
-            sample: Sample::new(timestamp, it.num as _),
+            labels: it.1.labels.clone(),
+            sample: Sample::new(timestamp, it.1.num as _),
         })
         .collect();
     Ok(Value::Vector(values))

--- a/src/service/promql/aggregations/count_values.rs
+++ b/src/service/promql/aggregations/count_values.rs
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 use super::Engine;
+use crate::service::promql::value::{InstantValue, Label, Sample, Value};
 use datafusion::error::DataFusionError;
 use datafusion::error::Result;
 use promql_parser::parser::Expr as PromExpr;
 use promql_parser::parser::LabelModifier;
-
-use crate::service::promql::value::{InstantValue, Label, Sample, Value};
 
 pub async fn count_values(
     ctx: &mut Engine,

--- a/src/service/promql/aggregations/group.rs
+++ b/src/service/promql/aggregations/group.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::service::promql::value::{InstantValue, Sample, Value};
 use datafusion::error::Result;
 use promql_parser::parser::LabelModifier;
-
-use crate::service::promql::value::{InstantValue, Sample, Value};
+use rayon::prelude::*;
 
 /// https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
 pub fn group(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Result<Value> {
@@ -25,10 +25,10 @@ pub fn group(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Res
     }
     let values = score_values
         .unwrap()
-        .values()
+        .par_iter()
         .map(|v| InstantValue {
-            labels: v.labels.clone(),
-            sample: Sample::new(timestamp, v.value),
+            labels: v.1.labels.clone(),
+            sample: Sample::new(timestamp, v.1.value),
         })
         .collect();
     Ok(Value::Vector(values))

--- a/src/service/promql/aggregations/max.rs
+++ b/src/service/promql/aggregations/max.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::service::promql::value::{InstantValue, Sample, Value};
 use datafusion::error::Result;
 use promql_parser::parser::LabelModifier;
-
-use crate::service::promql::value::{InstantValue, Sample, Value};
+use rayon::prelude::*;
 
 pub fn max(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Result<Value> {
     let score_values =
@@ -36,10 +36,10 @@ pub fn max(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
     }
     let values = score_values
         .unwrap()
-        .values()
+        .par_iter()
         .map(|it| InstantValue {
-            labels: it.labels.clone(),
-            sample: Sample::new(timestamp, it.value),
+            labels: it.1.labels.clone(),
+            sample: Sample::new(timestamp, it.1.value),
         })
         .collect();
     Ok(Value::Vector(values))

--- a/src/service/promql/aggregations/min.rs
+++ b/src/service/promql/aggregations/min.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::service::promql::value::{InstantValue, Sample, Value};
 use datafusion::error::Result;
 use promql_parser::parser::LabelModifier;
-
-use crate::service::promql::value::{InstantValue, Sample, Value};
+use rayon::prelude::*;
 
 pub fn min(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Result<Value> {
     let score_values = super::eval_arithmetic(param, data, "min", |prev, val| {
@@ -30,10 +30,10 @@ pub fn min(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
     }
     let values = score_values
         .unwrap()
-        .values()
+        .par_iter()
         .map(|it| InstantValue {
-            labels: it.labels.clone(),
-            sample: Sample::new(timestamp, it.value),
+            labels: it.1.labels.clone(),
+            sample: Sample::new(timestamp, it.1.value),
         })
         .collect();
     Ok(Value::Vector(values))

--- a/src/service/promql/aggregations/quantile.rs
+++ b/src/service/promql/aggregations/quantile.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use datafusion::error::{DataFusionError, Result};
-use promql_parser::parser::Expr as PromExpr;
-
 use super::Engine;
 use crate::service::promql::common::quantile as calculate_quantile;
 use crate::service::promql::value::Labels;
 use crate::service::promql::value::{InstantValue, Sample, Value};
+use datafusion::error::{DataFusionError, Result};
+use promql_parser::parser::Expr as PromExpr;
+use rayon::prelude::*;
 
 pub async fn quantile(
     ctx: &mut Engine,
@@ -58,7 +58,7 @@ pub async fn quantile(
         return prepare_vector(timestamp, f64::NAN);
     }
 
-    let values: Vec<f64> = data.iter().map(|item| item.sample.value).collect();
+    let values: Vec<f64> = data.par_iter().map(|item| item.sample.value).collect();
 
     let quantile_value = calculate_quantile(&values, qtile).unwrap();
     prepare_vector(timestamp, quantile_value)

--- a/src/service/promql/aggregations/stdvar.rs
+++ b/src/service/promql/aggregations/stdvar.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use datafusion::error::Result;
-use promql_parser::parser::LabelModifier;
-
 use crate::service::promql::common::std_variance2;
 use crate::service::promql::value::{InstantValue, Sample, Value};
+use datafusion::error::Result;
+use promql_parser::parser::LabelModifier;
+use rayon::prelude::*;
 
 pub fn stdvar(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Result<Value> {
     let score_values = super::eval_std_dev_var(param, data, "stdvar")?;
@@ -25,11 +25,12 @@ pub fn stdvar(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Re
     }
     let values = score_values
         .unwrap()
-        .values()
+        .par_iter()
         .map(|it| {
-            let std_var = std_variance2(&it.values, it.current_mean, it.current_count).unwrap();
+            let std_var =
+                std_variance2(&it.1.values, it.1.current_mean, it.1.current_count).unwrap();
             InstantValue {
-                labels: it.labels.clone(),
+                labels: it.1.labels.clone(),
                 sample: Sample::new(timestamp, std_var),
             }
         })

--- a/src/service/promql/aggregations/sum.rs
+++ b/src/service/promql/aggregations/sum.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::service::promql::value::{InstantValue, Sample, Value};
 use datafusion::error::Result;
 use promql_parser::parser::LabelModifier;
-
-use crate::service::promql::value::{InstantValue, Sample, Value};
+use rayon::prelude::*;
 
 pub fn sum(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Result<Value> {
     let score_values = super::eval_arithmetic(param, data, "sum", |total, val| total + val)?;
@@ -24,10 +24,10 @@ pub fn sum(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
     }
     let values = score_values
         .unwrap()
-        .values()
+        .par_iter()
         .map(|it| InstantValue {
-            labels: it.labels.clone(),
-            sample: Sample::new(timestamp, it.value),
+            labels: it.1.labels.clone(),
+            sample: Sample::new(timestamp, it.1.value),
         })
         .collect();
     Ok(Value::Vector(values))


### PR DESCRIPTION
Aggregations use several `map` operation after the initial `.iter()` over the raw data. This is required to ensure that we have the entries in the ordered manner.

After this it is safe to parallelize the aggregation value, thus implemented.