### PR TITLE
feat: disable dictionary for log fields

### DIFF
--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -64,7 +64,14 @@ pub static SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA: Lazy<Vec<String>> = Lazy::new(|| {
             .common
             .feature_fulltext_extra_fields
             .split(',')
-            .map(|s| s.to_string()),
+            .filter_map(|s| {
+                let s = s.trim();
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s.to_string())
+                }
+            }),
     )
     .collect()
 });

--- a/src/common/utils/stream.rs
+++ b/src/common/utils/stream.rs
@@ -22,8 +22,6 @@ use crate::common::infra::config::{CONFIG, FILE_EXT_JSON};
 use crate::common::meta::{common::FileMeta, StreamType};
 use crate::common::utils::json;
 
-pub const SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 5] = ["log", "message", "msg", "content", "data"];
-
 #[inline(always)]
 pub fn stream_type_query_param_error() -> Result<HttpResponse, Error> {
     /*  return Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -19,13 +19,11 @@ use serde::Serialize;
 use std::io::Error;
 use utoipa::ToSchema;
 
-use crate::common::infra::{
-    cache, cluster,
-    config::{self, CONFIG, INSTANCE_ID, SYSLOG_ENABLED},
-    file_list,
+use crate::common::{
+    infra::{cache, cluster, config::*, file_list},
+    meta::functions::ZoFunction,
+    utils::json,
 };
-use crate::common::meta::functions::ZoFunction;
-use crate::common::utils::json;
 use crate::service::{db, search::datafusion::DEFAULT_FUNCTIONS};
 
 #[derive(Serialize, ToSchema)]
@@ -68,13 +66,13 @@ pub async fn healthz() -> Result<HttpResponse, Error> {
 #[get("")]
 pub async fn zo_config() -> Result<HttpResponse, Error> {
     Ok(HttpResponse::Ok().json(ConfigResponse {
-        version: config::VERSION.to_string(),
+        version: VERSION.to_string(),
         instance: INSTANCE_ID.get("instance_id").unwrap().to_string(),
-        commit_hash: config::COMMIT_HASH.to_string(),
-        build_date: config::BUILD_DATE.to_string(),
-        functions_enabled: config::HAS_FUNCTIONS,
+        commit_hash: COMMIT_HASH.to_string(),
+        build_date: BUILD_DATE.to_string(),
+        functions_enabled: HAS_FUNCTIONS,
         telemetry_enabled: CONFIG.common.telemetry_enabled,
-        default_fts_keys: crate::common::utils::stream::SQL_FULL_TEXT_SEARCH_FIELDS
+        default_fts_keys: SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA
             .iter()
             .map(|s| s.to_string())
             .collect(),
@@ -94,14 +92,8 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
         "LOCAL_NODE_UUID",
         json::json!(cluster::LOCAL_NODE_UUID.clone()),
     );
-    stats.insert(
-        "LOCAL_NODE_NAME",
-        json::json!(&config::CONFIG.common.instance_name),
-    );
-    stats.insert(
-        "LOCAL_NODE_ROLE",
-        json::json!(&config::CONFIG.common.node_role),
-    );
+    stats.insert("LOCAL_NODE_NAME", json::json!(&CONFIG.common.instance_name));
+    stats.insert("LOCAL_NODE_ROLE", json::json!(&CONFIG.common.node_role));
 
     let (stream_num, stream_schema_num, mem_size) = get_stream_schema_status();
     stats.insert("STREAM_SCHEMA", json::json!({"stream_num": stream_num,"stream_schema_num": stream_schema_num, "mem_size": mem_size}));
@@ -139,7 +131,7 @@ fn get_stream_schema_status() -> (usize, usize, usize) {
     let mut stream_num = 0;
     let mut stream_schema_num = 0;
     let mut mem_size = 0;
-    for item in config::STREAM_SCHEMAS.iter() {
+    for item in STREAM_SCHEMAS.iter() {
         stream_num += 1;
         mem_size += std::mem::size_of::<Vec<Schema>>();
         mem_size += item.key().len();

--- a/src/service/search/datafusion/mod.rs
+++ b/src/service/search/datafusion/mod.rs
@@ -94,10 +94,6 @@ pub fn new_parquet_writer<'a>(
         writer_props = writer_props
             .set_column_dictionary_enabled(ColumnPath::from(vec![field.to_string()]), false);
     }
-    println!(
-        "dictionary fields: {:?}",
-        SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA.clone()
-    );
     if let Some(fields) = bf_fields {
         for field in fields {
             writer_props = writer_props

--- a/src/service/search/datafusion/mod.rs
+++ b/src/service/search/datafusion/mod.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use crate::common::{
     infra::config::{
         get_parquet_compression, CONFIG, PARQUET_BATCH_SIZE, PARQUET_MAX_ROW_GROUP_SIZE,
-        PARQUET_PAGE_SIZE,
+        PARQUET_PAGE_SIZE, SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA,
     },
     meta::functions::ZoFunction,
 };
@@ -86,9 +86,18 @@ pub fn new_parquet_writer<'a>(
         .set_write_batch_size(PARQUET_BATCH_SIZE)
         .set_data_page_size_limit(PARQUET_PAGE_SIZE)
         .set_max_row_group_size(PARQUET_MAX_ROW_GROUP_SIZE)
+        .set_dictionary_enabled(true)
         .set_sorting_columns(Some(
             [SortingColumn::new(sort_column_id as i32, true, false)].to_vec(),
         ));
+    for field in SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA.iter() {
+        writer_props = writer_props
+            .set_column_dictionary_enabled(ColumnPath::from(vec![field.to_string()]), false);
+    }
+    println!(
+        "dictionary fields: {:?}",
+        SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA.clone()
+    );
     if let Some(fields) = bf_fields {
         for field in fields {
             writer_props = writer_props

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -23,14 +23,13 @@ use std::{
     fmt::{Display, Formatter},
 };
 
-use crate::common::meta::{sql::Sql as MetaSql, stream::StreamParams, StreamType};
-use crate::common::utils::str::find;
 use crate::common::{
     infra::{
-        config::CONFIG,
+        config::{CONFIG, SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA},
         errors::{Error, ErrorCodes},
     },
-    meta::common::FileKey,
+    meta::{common::FileKey, sql::Sql as MetaSql, stream::StreamParams, StreamType},
+    utils::str::find,
 };
 use crate::handler::grpc::cluster_rpc;
 use crate::service::{db, search::match_source, stream::get_stream_setting_fts_fields};
@@ -366,7 +365,7 @@ impl Sql {
         let match_all_fields = if !fts_fields.is_empty() {
             fts_fields.iter().map(|v| v.to_lowercase()).collect()
         } else {
-            crate::common::utils::stream::SQL_FULL_TEXT_SEARCH_FIELDS
+            SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA
                 .iter()
                 .map(|v| v.to_string())
                 .collect::<String>()


### PR DESCRIPTION
New environment:

```
ZO_FEATURE_FULLTEXT_EXTRA_FIELDS=""
```

Default we use `log`, `message`, `msg`, `content`, `data` as `full text search` fields, you can use `match_all` to search it.

If you want set additional fields as global full text search fields, you can set it like this:

```
ZO_FEATURE_FULLTEXT_EXTRA_FIELDS="fielda,fieldb,fieldc"
```
