### PR TITLE
fix: allow query file list with empty time range

### DIFF
--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -55,7 +55,8 @@ pub const FILE_EXT_JSON: &str = ".json";
 pub const FILE_EXT_PARQUET: &str = ".parquet";
 pub const COLUMN_TRACE_ID: &str = "trace_id";
 
-const SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 5] = ["log", "message", "msg", "content", "data"];
+const SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 7] =
+    ["log", "message", "msg", "content", "data", "events", "json"];
 
 pub static SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA: Lazy<Vec<String>> = Lazy::new(|| {
     chain(

--- a/src/common/infra/file_list/dynamo.rs
+++ b/src/common/infra/file_list/dynamo.rs
@@ -32,6 +32,7 @@ use crate::common::{
         stream::{PartitionTimeLevel, StreamStats},
         StreamType,
     },
+    utils::time::BASE_TIME,
 };
 
 pub struct DynamoFileList {
@@ -188,11 +189,9 @@ impl super::FileList for DynamoFileList {
         time_level: PartitionTimeLevel,
         time_range: (i64, i64),
     ) -> Result<Vec<(String, FileMeta)>> {
-        let (time_start, mut time_end) = time_range;
+        let (mut time_start, mut time_end) = time_range;
         if time_start == 0 {
-            return Err(Error::Message(
-                "Disallow empty time range query".to_string(),
-            ));
+            time_start = BASE_TIME.timestamp_micros();
         }
         if time_end == 0 {
             time_end = Utc::now().timestamp_micros();

--- a/src/common/infra/file_list/postgres.rs
+++ b/src/common/infra/file_list/postgres.rs
@@ -208,11 +208,6 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         time_range: (i64, i64),
     ) -> Result<Vec<(String, FileMeta)>> {
         let (time_start, mut time_end) = time_range;
-        if time_start == 0 {
-            return Err(Error::Message(
-                "Disallow empty time range query".to_string(),
-            ));
-        }
         if time_end == 0 {
             time_end = Utc::now().timestamp_micros();
         }

--- a/src/common/infra/file_list/sqlite.rs
+++ b/src/common/infra/file_list/sqlite.rs
@@ -212,11 +212,6 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         time_range: (i64, i64),
     ) -> Result<Vec<(String, FileMeta)>> {
         let (time_start, mut time_end) = time_range;
-        if time_start == 0 {
-            return Err(Error::Message(
-                "Disallow empty time range query".to_string(),
-            ));
-        }
         if time_end == 0 {
             time_end = Utc::now().timestamp_micros();
         }


### PR DESCRIPTION
Delete stream use empty time_range, it can't work now.