### PR TITLE
fix: 1471 Increase the precision of the duration field to nanoseconds

### DIFF
--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -197,7 +197,7 @@ pub async fn handle_trace_request(
                     operation_name: span.name.clone(),
                     start_time,
                     end_time,
-                    duration: (end_time - start_time) / 1000000,
+                    duration: end_time - start_time,
                     reference: span_ref,
                     service_name: service_name.clone(),
                     attributes: span_att_map,

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -269,7 +269,7 @@ pub async fn traces_json(
                         operation_name: span.get("name").unwrap().as_str().unwrap().to_string(),
                         start_time,
                         end_time,
-                        duration: (end_time - start_time) / 1000000,
+                        duration: end_time - start_time,
                         reference: span_ref,
                         service_name: service_name.clone(),
                         attributes: span_att_map,


### PR DESCRIPTION
Fixes https://github.com/openobserve/openobserve/issues/1471