### PR TITLE
fix: cancel datafusion execution when it timeout

### DIFF
--- a/proto/cluster/metrics.proto
+++ b/proto/cluster/metrics.proto
@@ -19,6 +19,7 @@ message MetricsQueryRequest {
     SearchType                stype = 3;
     bool                   need_wal = 4;
     MetricsQueryStmt          query = 5;
+    int64                   timeout = 8;
 }
 
 message MetricsQueryStmt {

--- a/proto/cluster/search.proto
+++ b/proto/cluster/search.proto
@@ -37,6 +37,7 @@ message SearchRequest {
     SearchQuery              query = 5;
     repeated FileKey     file_list = 6;
     repeated SearchAggRequest aggs = 7;
+    int64                  timeout = 8;
 }
 
 // The response message containing the greetings

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -176,8 +176,6 @@ pub struct Grpc {
     pub port: u16,
     #[env_config(name = "ZO_GRPC_ADDR", default = "")]
     pub addr: String,
-    #[env_config(name = "ZO_GRPC_TIMEOUT", default = 600)]
-    pub timeout: u64,
     #[env_config(name = "ZO_GRPC_ORG_HEADER_KEY", default = "zinc-org-id")]
     pub org_header_key: String,
     #[env_config(name = "ZO_INTERNAL_GRPC_TOKEN", default = "")]
@@ -306,6 +304,8 @@ pub struct Limit {
     pub file_move_thread_num: usize,
     #[env_config(name = "ZO_QUERY_THREAD_NUM", default = 0)]
     pub query_thread_num: usize,
+    #[env_config(name = "ZO_QUERY_TIMEOUT", default = 600)]
+    pub query_timeout: u64,
     #[env_config(name = "ZO_INGEST_ALLOWED_UPTO", default = 5)] // in hours - in past
     pub ingest_allowed_upto: i64,
     #[env_config(name = "ZO_LOGS_FILE_RETENTION", default = "hourly")]

--- a/src/common/meta/search.rs
+++ b/src/common/meta/search.rs
@@ -34,6 +34,8 @@ pub struct Request {
     pub aggs: HashMap<String, String>,
     #[serde(default)]
     pub encoding: RequestEncoding,
+    #[serde(default)]
+    pub timeout: i64,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]

--- a/src/handler/grpc/mod.rs
+++ b/src/handler/grpc/mod.rs
@@ -62,6 +62,7 @@ impl From<meta::search::Request> for cluster_rpc::SearchRequest {
             aggs,
             file_list: vec![],
             stream_type: "".to_string(),
+            timeout: req.timeout,
         }
     }
 }
@@ -132,6 +133,7 @@ impl From<promql::MetricsQueryRequest> for cluster_rpc::MetricsQueryRequest {
             stype: cluster_rpc::SearchType::User.into(),
             need_wal: false,
             query: Some(req_query),
+            timeout: 0,
         }
     }
 }
@@ -239,6 +241,7 @@ mod test {
             },
             aggs: HashMap::new(),
             encoding: "base64".into(),
+            timeout: 0,
         };
         req.aggs
             .insert("test".to_string(), "SELECT * FROM test".to_string());

--- a/src/service/alert_manager.rs
+++ b/src/service/alert_manager.rs
@@ -105,6 +105,7 @@ async fn handle_trigger(alert_key: &str, frequency: i64) {
                         query,
                         aggs: HashMap::new(),
                         encoding: meta::search::RequestEncoding::Empty,
+                        timeout: 0,
                     };
                     // do search
                     match SearchService::search(&trigger.org, alert.stream_type.unwrap(), &req)

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -106,6 +106,7 @@ pub async fn save_alert(
             query: alert.clone().query.unwrap(),
             aggs: HashMap::new(),
             encoding: meta::search::RequestEncoding::Empty,
+            timeout: 0,
         };
         let req: cluster_rpc::SearchRequest = meta_req.into();
         let sql = Sql::new(&req).await;

--- a/src/service/db/enrichment_table.rs
+++ b/src/service/db/enrichment_table.rs
@@ -41,6 +41,7 @@ pub async fn get(org_id: &str, name: &str) -> Result<Vec<vrl::value::Value>, any
         query,
         aggs: HashMap::new(),
         encoding: meta::search::RequestEncoding::Empty,
+        timeout: 0,
     };
     // do search
     match SearchService::search(org_id, meta::StreamType::EnrichmentTables, &req).await {

--- a/src/service/db/file_list/remote.rs
+++ b/src/service/db/file_list/remote.rs
@@ -135,7 +135,6 @@ pub async fn cache(prefix: &str, force: bool) -> Result<(), anyhow::Error> {
 }
 
 pub async fn cache_stats() -> Result<(), anyhow::Error> {
-    let start = std::time::Instant::now();
     let orgs = db::schema::list_organizations_from_cache();
     for org_id in orgs {
         let ret = infra_file_list::get_stream_stats(&org_id, None, None).await;
@@ -152,7 +151,6 @@ pub async fn cache_stats() -> Result<(), anyhow::Error> {
         }
         time::sleep(time::Duration::from_millis(100)).await;
     }
-    log::info!("Load stream stats in {}s", start.elapsed().as_secs());
     Ok(())
 }
 

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -32,7 +32,7 @@ use crate::common::{
 };
 use crate::service::schema::check_for_schema;
 
-use super::ingestion::{get_wal_time_key, get_value};
+use super::ingestion::{get_value, get_wal_time_key};
 
 pub mod bulk;
 pub mod gcs_pub_sub;

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -580,6 +580,7 @@ pub(crate) async fn get_series(
         },
         aggs: HashMap::new(),
         encoding: meta::search::RequestEncoding::Empty,
+        timeout: 0,
     };
     let series = match search_service::search(org_id, StreamType::Metrics, &req).await {
         Err(err) => {
@@ -721,6 +722,7 @@ pub(crate) async fn get_label_values(
         },
         aggs: HashMap::new(),
         encoding: meta::search::RequestEncoding::Empty,
+        timeout: 0,
     };
     let mut label_values = match search_service::search(org_id, stream_type, &req).await {
         Ok(resp) => resp

--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -417,12 +417,9 @@ impl Engine {
         let mut tasks = Vec::new();
         for (ctx, schema, scan_stats) in ctxs {
             let selector = selector.clone();
-            let task = tokio::time::timeout(
-                Duration::from_secs(CONFIG.limit.query_timeout),
-                async move {
-                    selector_load_data_from_datafusion(ctx, schema, selector, start, end).await
-                },
-            );
+            let task = tokio::time::timeout(Duration::from_secs(self.ctx.timeout), async move {
+                selector_load_data_from_datafusion(ctx, schema, selector, start, end).await
+            });
             tasks.push(task);
             // update stats
             let mut ctx_scan_stats = self.ctx.scan_stats.write().await;

--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -417,9 +417,12 @@ impl Engine {
         let mut tasks = Vec::new();
         for (ctx, schema, scan_stats) in ctxs {
             let selector = selector.clone();
-            let task = tokio::task::spawn(async move {
-                selector_load_data_from_datafusion(ctx, schema, selector, start, end).await
-            });
+            let task = tokio::time::timeout(
+                Duration::from_secs(CONFIG.limit.query_timeout),
+                async move {
+                    selector_load_data_from_datafusion(ctx, schema, selector, start, end).await
+                },
+            );
             tasks.push(task);
             // update stats
             let mut ctx_scan_stats = self.ctx.scan_stats.write().await;

--- a/src/service/promql/exec.rs
+++ b/src/service/promql/exec.rs
@@ -41,10 +41,11 @@ pub struct Query {
     /// key — metric name; value — time series data
     pub data_cache: Arc<RwLock<HashMap<String, Value>>>,
     pub scan_stats: Arc<RwLock<ScanStats>>,
+    pub timeout: u64, // seconds, query timeout
 }
 
 impl Query {
-    pub fn new<P>(org_id: &str, provider: P) -> Self
+    pub fn new<P>(org_id: &str, provider: P, timeout: u64) -> Self
     where
         P: TableProvider,
     {
@@ -59,6 +60,7 @@ impl Query {
             lookback_delta: five_min,
             data_cache: Arc::new(RwLock::new(HashMap::default())),
             scan_stats: Arc::new(RwLock::new(ScanStats::default())),
+            timeout,
         }
     }
 

--- a/src/service/promql/search/grpc/wal.rs
+++ b/src/service/promql/search/grpc/wal.rs
@@ -19,7 +19,7 @@ use datafusion::{
     prelude::SessionContext,
 };
 use futures::future::try_join_all;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 use tonic::{codec::CompressionEncoding, metadata::MetadataValue, transport::Channel, Request};
 use tracing::{info_span, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -126,7 +126,7 @@ async fn get_file_list(
                     .parse()
                     .map_err(|_| DataFusionError::Execution("invalid org_id".to_string()))?;
                 let mut request = tonic::Request::new(req);
-                request.set_timeout(Duration::from_secs(CONFIG.grpc.timeout));
+                // request.set_timeout(Duration::from_secs(CONFIG.grpc.timeout));
 
                 opentelemetry::global::get_text_map_propagator(|propagator| {
                     propagator.inject_context(

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -17,7 +17,6 @@ use futures::future::try_join_all;
 use std::{
     cmp::{max, min},
     sync::Arc,
-    time::Duration,
 };
 use tonic::{codec::CompressionEncoding, metadata::MetadataValue, transport::Channel, Request};
 use tracing::{info_span, Instrument};
@@ -146,7 +145,7 @@ async fn search_in_cluster(req: cluster_rpc::MetricsQueryRequest) -> Result<Valu
                     .parse()
                     .map_err(|_| Error::Message(format!("invalid org_id: {}", req.org_id)))?;
                 let mut request = tonic::Request::new(req);
-                request.set_timeout(Duration::from_secs(CONFIG.grpc.timeout));
+                // request.set_timeout(Duration::from_secs(CONFIG.grpc.timeout));
 
                 opentelemetry::global::get_text_map_propagator(|propagator| {
                     propagator.inject_context(

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -47,10 +47,11 @@ use crate::{
 pub mod grpc;
 
 #[tracing::instrument(skip_all, fields(org_id = org_id))]
-pub async fn search(org_id: &str, req: &MetricsQueryRequest) -> Result<Value> {
+pub async fn search(org_id: &str, req: &MetricsQueryRequest, timeout: i64) -> Result<Value> {
     let mut req: cluster_rpc::MetricsQueryRequest = req.to_owned().into();
     req.org_id = org_id.to_string();
     req.stype = cluster_rpc::SearchType::User as _;
+    req.timeout = timeout;
     search_in_cluster(req).await
 }
 

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -47,6 +47,7 @@ pub async fn search(
     sql: Arc<Sql>,
     file_list: &[FileKey],
     stream_type: meta::StreamType,
+    timeout: u64,
 ) -> super::SearchResult {
     // fetch all schema versions, group files by version
     let schema_versions =
@@ -181,7 +182,7 @@ pub async fn search(
         }
         let datafusion_span = info_span!("service:search:grpc:storage:datafusion", org_id = sql.org_id,stream_name = sql.stream_name, stream_type = ?stream_type);
         let task = tokio::time::timeout(
-            Duration::from_secs(CONFIG.limit.query_timeout),
+            Duration::from_secs(timeout),
             async move {
                 exec::sql(
                     &session,

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -14,19 +14,22 @@
 
 use ahash::AHashMap as HashMap;
 use datafusion::{arrow::record_batch::RecordBatch, common::FileType};
+use futures::future::try_join_all;
 use std::sync::Arc;
-use tokio::sync::Semaphore;
+use tokio::{sync::Semaphore, time::Duration};
 use tracing::{info_span, Instrument};
 
-use crate::common::infra::{
-    cache::file_data,
-    config::{is_local_disk_storage, CONFIG},
-    errors::{Error, ErrorCodes},
-};
-use crate::common::meta::{
-    self,
-    common::FileKey,
-    stream::{PartitionTimeLevel, ScanStats},
+use crate::common::{
+    infra::{
+        cache::file_data,
+        config::{is_local_disk_storage, CONFIG},
+        errors::{Error, ErrorCodes},
+    },
+    meta::{
+        self,
+        common::FileKey,
+        stream::{PartitionTimeLevel, ScanStats},
+    },
 };
 use crate::service::{
     db, file_list,
@@ -177,7 +180,8 @@ pub async fn search(
             }
         }
         let datafusion_span = info_span!("service:search:grpc:storage:datafusion", org_id = sql.org_id,stream_name = sql.stream_name, stream_type = ?stream_type);
-        let task = tokio::task::spawn(
+        let task = tokio::time::timeout(
+            Duration::from_secs(CONFIG.limit.query_timeout),
             async move {
                 exec::sql(
                     &session,
@@ -195,24 +199,20 @@ pub async fn search(
     }
 
     let mut results: HashMap<String, Vec<RecordBatch>> = HashMap::new();
-    for task in tasks {
-        match task.await {
-            Ok(ret) => match ret {
-                Ok(ret) => {
-                    for (k, v) in ret {
-                        let group = results.entry(k).or_insert_with(Vec::new);
-                        group.extend(v);
-                    }
+    let task_results = try_join_all(tasks)
+        .await
+        .map_err(|e| Error::ErrorCode(ErrorCodes::ServerInternalError(e.to_string())))?;
+    for ret in task_results {
+        match ret {
+            Ok(ret) => {
+                for (k, v) in ret {
+                    let group = results.entry(k).or_insert_with(Vec::new);
+                    group.extend(v);
                 }
-                Err(err) => {
-                    log::error!("datafusion execute error: {}", err);
-                    return Err(super::handle_datafusion_error(err));
-                }
-            },
+            }
             Err(err) => {
-                return Err(Error::ErrorCode(ErrorCodes::ServerInternalError(
-                    err.to_string(),
-                )));
+                log::error!("datafusion execute error: {}", err);
+                return Err(super::handle_datafusion_error(err));
             }
         };
     }

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -17,17 +17,21 @@ use datafusion::{
     arrow::{datatypes::Schema, json::reader::infer_json_schema, record_batch::RecordBatch},
     common::FileType,
 };
+use futures::future::try_join_all;
 use std::{io::BufReader, path::Path, sync::Arc, time::UNIX_EPOCH};
+use tokio::time::Duration;
 use tracing::{info_span, Instrument};
 
-use crate::common::infra::{
-    cache::tmpfs,
-    config::CONFIG,
-    errors::{Error, ErrorCodes},
-    wal,
+use crate::common::{
+    infra::{
+        cache::tmpfs,
+        config::CONFIG,
+        errors::{Error, ErrorCodes},
+        wal,
+    },
+    meta::{self, common::FileKey, stream::ScanStats},
+    utils::file::{get_file_contents, get_file_meta, scan_files},
 };
-use crate::common::meta::{self, common::FileKey, stream::ScanStats};
-use crate::common::utils::file::{get_file_contents, get_file_meta, scan_files};
 use crate::service::{
     db,
     search::{
@@ -184,7 +188,8 @@ pub async fn search(
             stream_type = ?stream_type
         );
         let task =
-            tokio::task::spawn(
+            tokio::time::timeout(
+                Duration::from_secs(CONFIG.limit.query_timeout),
                 async move {
                     exec::sql(&session, schema, &diff_fields, &sql, &files, FileType::JSON).await
                 }
@@ -194,24 +199,20 @@ pub async fn search(
     }
 
     let mut results: HashMap<String, Vec<RecordBatch>> = HashMap::new();
-    for task in tasks {
-        match task.await {
-            Ok(ret) => match ret {
-                Ok(ret) => {
-                    for (k, v) in ret {
-                        let group = results.entry(k).or_insert_with(Vec::new);
-                        group.extend(v);
-                    }
+    let task_results = try_join_all(tasks)
+        .await
+        .map_err(|e| Error::ErrorCode(ErrorCodes::ServerInternalError(e.to_string())))?;
+    for ret in task_results {
+        match ret {
+            Ok(ret) => {
+                for (k, v) in ret {
+                    let group = results.entry(k).or_insert_with(Vec::new);
+                    group.extend(v);
                 }
-                Err(err) => {
-                    log::error!("datafusion execute error: {}", err);
-                    return Err(super::handle_datafusion_error(err));
-                }
-            },
+            }
             Err(err) => {
-                return Err(Error::ErrorCode(ErrorCodes::ServerInternalError(
-                    err.to_string(),
-                )));
+                log::error!("datafusion execute error: {}", err);
+                return Err(super::handle_datafusion_error(err));
             }
         };
     }

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -46,6 +46,7 @@ pub async fn search(
     session_id: &str,
     sql: Arc<Sql>,
     stream_type: meta::StreamType,
+    timeout: u64,
 ) -> super::SearchResult {
     // get file list
     let mut files = get_file_list(&sql, stream_type).await?;
@@ -189,7 +190,7 @@ pub async fn search(
         );
         let task =
             tokio::time::timeout(
-                Duration::from_secs(CONFIG.limit.query_timeout),
+                Duration::from_secs(timeout),
                 async move {
                     exec::sql(&session, schema, &diff_fields, &sql, &files, FileType::JSON).await
                 }

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -15,7 +15,7 @@
 use ::datafusion::arrow::{datatypes::Schema, ipc, json as arrow_json, record_batch::RecordBatch};
 use ahash::AHashMap as HashMap;
 use once_cell::sync::Lazy;
-use std::{cmp::min, io::Cursor, sync::Arc, time::Duration};
+use std::{cmp::min, io::Cursor, sync::Arc};
 use tokio::sync::Mutex;
 use tonic::{codec::CompressionEncoding, metadata::MetadataValue, transport::Channel, Request};
 use tracing::{info_span, Instrument};
@@ -200,7 +200,7 @@ async fn search_in_cluster(req: cluster_rpc::SearchRequest) -> Result<search::Re
                     .parse()
                     .map_err(|_| Error::Message("invalid org_id".to_string()))?;
                 let mut request = tonic::Request::new(req);
-                request.set_timeout(Duration::from_secs(CONFIG.grpc.timeout));
+                // request.set_timeout(Duration::from_secs(CONFIG.grpc.timeout));
 
                 opentelemetry::global::get_text_map_propagator(|propagator| {
                     propagator.inject_context(

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -809,6 +809,7 @@ mod tests {
             query,
             aggs: HashMap::new(),
             encoding: crate::common::meta::search::RequestEncoding::Empty,
+            timeout: 0,
         };
 
         let mut rpc_req: cluster_rpc::SearchRequest = req.to_owned().into();
@@ -892,6 +893,7 @@ mod tests {
                 query: query.clone(),
                 aggs: HashMap::new(),
                 encoding: crate::common::meta::search::RequestEncoding::Empty,
+                timeout: 0,
             };
             let mut rpc_req: cluster_rpc::SearchRequest = req.to_owned().into();
             rpc_req.org_id = org_id.to_string();
@@ -979,6 +981,7 @@ mod tests {
                 query: query.clone(),
                 aggs: HashMap::new(),
                 encoding: crate::common::meta::search::RequestEncoding::Empty,
+                timeout: 0,
             };
             let mut rpc_req: cluster_rpc::SearchRequest = req.to_owned().into();
             rpc_req.org_id = org_id.to_string();

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -389,6 +389,7 @@ async fn get_stream_stats(
         query,
         aggs: HashMap::new(),
         encoding: meta::search::RequestEncoding::Empty,
+        timeout: 0,
     };
     match SearchService::search(&CONFIG.common.usage_org, meta::StreamType::Logs, &req).await {
         Ok(res) => {

--- a/src/service/usage/stats.rs
+++ b/src/service/usage/stats.rs
@@ -77,6 +77,7 @@ pub async fn publish_stats() -> Result<(), anyhow::Error> {
             query,
             aggs: HashMap::new(),
             encoding: meta::search::RequestEncoding::Empty,
+            timeout: 0,
         };
         // do search
         match SearchService::search(&CONFIG.common.usage_org, meta::StreamType::Logs, &req).await {
@@ -142,6 +143,7 @@ async fn get_last_stats(
         query,
         aggs: HashMap::new(),
         encoding: meta::search::RequestEncoding::Empty,
+        timeout: 0,
     };
     match SearchService::search(&CONFIG.common.usage_org, meta::StreamType::Logs, &req).await {
         Ok(res) => Ok(res.hits),


### PR DESCRIPTION
impl #1429 

Add `timeout` parameter for each query API, like `/_search` API, you can provide `timeout` like this:

```
{
  "query": {},
  "aggs": {},
  "timeout": 2
}
```

the `timeout` unit is `seconds`.

Add a new environment

```
ZO_QUERY_TIMEOUT=600
```

Deleted an old environment:

```
ZO_GRPC_TIMEOUT=600
```

Now the timeout progress will be:

1. Nginx proxy has a timeout, default is 60s
2. OpenObserve router has a timeout, default is `ZO_ROUTE_TIMEOUT=600`, 600s
3. OpenObserve query engine has a timeout, default is `ZO_QUERY_TIMEOUT=600`, 600s， but you can pass a parameter to change it for each query API.

If the `proxy` timeout, the query will continue work until the `query` timeout.

If the `query` timeout, the engine will cancel the job then the CPU usage will lower down.
