### PR TITLE
fix: wal file retention

### DIFF
--- a/src/common/meta/stream.rs
+++ b/src/common/meta/stream.rs
@@ -274,8 +274,8 @@ impl PartitionTimeLevel {
     pub fn duration(self) -> i64 {
         match self {
             PartitionTimeLevel::Unset => 0,
-            PartitionTimeLevel::Hourly => 3600000,
-            PartitionTimeLevel::Daily => 86400000,
+            PartitionTimeLevel::Hourly => 0,
+            PartitionTimeLevel::Daily => 3600, // seconds, 1 hour
         }
     }
 }

--- a/src/common/meta/stream.rs
+++ b/src/common/meta/stream.rs
@@ -274,8 +274,8 @@ impl PartitionTimeLevel {
     pub fn duration(self) -> i64 {
         match self {
             PartitionTimeLevel::Unset => 0,
-            PartitionTimeLevel::Hourly => 0,
-            PartitionTimeLevel::Daily => 3600, // seconds, 1 hour
+            PartitionTimeLevel::Hourly => 3600, // seconds, 1 hour
+            PartitionTimeLevel::Daily => 86400, // seconds, 24 hour
         }
     }
 }


### PR DESCRIPTION
First, the duration unit is `second`.

Second, we will use 1 hour expired duration for hourly wal files, and 24 hours expired duration for daily wal files.

And now we have a default file partition level for each stream type and you can change it:

### Global settings:

```
ZO_LOGS_FILE_RETENTION=hourly
ZO_TRACES_FILE_RETENTION=hourly
ZO_METRICS_FILE_RETENTION=daily
```

### API settings:

```
POST /api/:org/:stream/settings
{
  "data_retention": 0,
  "partition_time_level": "hourly / daily"
}
```

if you found there is many very small files in an hour, you can try to change `hourly` to `daily`, it means we will merge files by day, it should reduce 24x small files.
