### PR TITLE
fix: wal time retention

### DIFF
--- a/src/common/infra/wal.rs
+++ b/src/common/infra/wal.rs
@@ -337,9 +337,9 @@ impl RwFile {
             (Some(RwLock::new(f)), None)
         };
 
+        let time_now: DateTime<Utc> = Utc::now();
         let level_duration = partition_time_level.unwrap_or_default().duration();
         let ttl = if level_duration > 0 {
-            let time_now: DateTime<Utc> = Utc::now();
             let time_end_day = Utc
                 .with_ymd_and_hms(
                     time_now.year(),
@@ -359,7 +359,7 @@ impl RwFile {
                 expired
             }
         } else {
-            Utc::now().timestamp() + CONFIG.limit.max_file_retention_time as i64
+            time_now.timestamp() + CONFIG.limit.max_file_retention_time as i64
         };
 
         RwFile {

--- a/src/common/infra/wal.rs
+++ b/src/common/infra/wal.rs
@@ -14,6 +14,7 @@
 
 use ahash::HashMap;
 use bytes::{Bytes, BytesMut};
+use chrono::{DateTime, Datelike, TimeZone, Utc};
 use itertools::chain;
 use once_cell::sync::Lazy;
 use std::{
@@ -191,7 +192,7 @@ impl Manager {
 
         // check size & ttl
         if file.size() >= (CONFIG.limit.max_file_size_on_disk as i64)
-            || file.expired() <= chrono::Utc::now().timestamp()
+            || file.expired() <= Utc::now().timestamp()
         {
             let mut manager = self.data.get(thread_id).unwrap().write().unwrap();
             manager.remove(&full_key);
@@ -338,9 +339,27 @@ impl RwFile {
 
         let level_duration = partition_time_level.unwrap_or_default().duration();
         let ttl = if level_duration > 0 {
-            chrono::Utc::now().timestamp() + level_duration
+            let time_now: DateTime<Utc> = Utc::now();
+            let time_end_day = Utc
+                .with_ymd_and_hms(
+                    time_now.year(),
+                    time_now.month(),
+                    time_now.day(),
+                    23,
+                    59,
+                    59,
+                )
+                .unwrap()
+                .timestamp();
+            let expired = time_now.timestamp() + level_duration;
+            if expired > time_end_day {
+                // if the file expired time is tomorrow, it should be deleted at 23:59:59 + 10min
+                time_end_day + CONFIG.limit.max_file_retention_time as i64
+            } else {
+                expired
+            }
         } else {
-            chrono::Utc::now().timestamp() + CONFIG.limit.max_file_retention_time as i64
+            Utc::now().timestamp() + CONFIG.limit.max_file_retention_time as i64
         };
 
         RwFile {


### PR DESCRIPTION
Earlier if the WAL file is daily and it is created at 23:00, it will move to storage at tomorrow 23:00, but actually, after 1 hour we will create a new file and this file will never be written again in tomorrow. so we should move it faster no need wait 24 hours.