### PR TITLE
fix: dynamo migration

### DIFF
--- a/src/common/migration/file_list.rs
+++ b/src/common/migration/file_list.rs
@@ -42,12 +42,12 @@ pub async fn run_for_dynamo() -> Result<(), anyhow::Error> {
     let start_time = BASE_TIME.timestamp_micros();
     let end_time = chrono::Utc::now().timestamp_micros();
     let orgs = db::schema::list_organizations_from_cache();
-    for org_id in &orgs {
+    for org_id in orgs.iter() {
         for stream_type in stream_types {
             let streams = db::schema::list_streams_from_cache(org_id, stream_type);
             for stream_name in streams.iter() {
                 let files = infra_file_list::query(
-                    &org_id,
+                    org_id,
                     stream_type,
                     stream_name,
                     PartitionTimeLevel::Unset,

--- a/src/common/migration/file_list.rs
+++ b/src/common/migration/file_list.rs
@@ -12,14 +12,62 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::service::db;
+use crate::common::{
+    infra::file_list as infra_file_list,
+    meta::{common::FileKey, stream::PartitionTimeLevel, StreamType},
+    utils::time::BASE_TIME,
+};
+use crate::service::{compact::stats::update_stats_from_file_list, db};
 
-pub async fn load(prefix: &str) -> Result<(), anyhow::Error> {
+pub async fn run(prefix: &str) -> Result<(), anyhow::Error> {
+    // load stream list
+    db::schema::cache().await?;
+    // load file list to db
     db::file_list::remote::cache(prefix, false)
         .await
         .expect("file list migration failed");
-    db::file_list::remote::cache_stats()
+    // update stream stats
+    update_stats_from_file_list()
         .await
-        .expect("file list migration stream stats failed");
+        .expect("file list migration stats failed");
+    Ok(())
+}
+
+/// Run the file list migration for DynamoDB to add new fields `created_at` and `org`.
+pub async fn run_for_dynamo() -> Result<(), anyhow::Error> {
+    // load stream list
+    db::schema::cache().await?;
+    // load file list from DynamoDB
+    let stream_types = [StreamType::Logs, StreamType::Metrics, StreamType::Traces];
+    let start_time = BASE_TIME.timestamp_micros();
+    let end_time = chrono::Utc::now().timestamp_micros();
+    let orgs = db::schema::list_organizations_from_cache();
+    for org_id in &orgs {
+        for stream_type in stream_types {
+            let streams = db::schema::list_streams_from_cache(org_id, stream_type);
+            for stream_name in streams.iter() {
+                let files = infra_file_list::query(
+                    &org_id,
+                    stream_type,
+                    stream_name,
+                    PartitionTimeLevel::Unset,
+                    (start_time, end_time),
+                )
+                .await
+                .expect("file list get failed");
+                let put_items = files
+                    .into_iter()
+                    .map(|(file_key, file_meta)| FileKey::new(&file_key, file_meta, false))
+                    .collect::<Vec<_>>();
+                infra_file_list::batch_add(&put_items)
+                    .await
+                    .expect("file list put failed");
+            }
+        }
+    }
+    // create secondary index
+    infra_file_list::dynamo::create_table_file_list_org_crated_at_index()
+        .await
+        .expect("file list migration create index failed");
     Ok(())
 }

--- a/src/common/migration/meta.rs
+++ b/src/common/migration/meta.rs
@@ -23,7 +23,7 @@ const ITEM_PREFIXES: [&str; 11] = [
     "/kv",
 ];
 
-pub async fn load() -> Result<(), anyhow::Error> {
+pub async fn run() -> Result<(), anyhow::Error> {
     println!("local mode is {}", CONFIG.common.local_mode);
     if CONFIG.common.local_mode {
         load_meta_from_sled().await

--- a/src/handler/grpc/request/logs.rs
+++ b/src/handler/grpc/request/logs.rs
@@ -45,19 +45,18 @@ impl LogsService for LogsServer {
             return Err(Status::invalid_argument(msg));
         }
 
-        let resp = crate::service::logs::otlp_grpc::handle_grpc_request(
+        match crate::service::logs::otlp_grpc::handle_grpc_request(
             org_id.unwrap().to_str().unwrap(),
             0,
             in_req,
             true,
         )
-        .await;
-        if resp.is_ok() {
-            return Ok(Response::new(ExportLogsServiceResponse {
+        .await
+        {
+            Ok(_) => Ok(Response::new(ExportLogsServiceResponse {
                 partial_success: None,
-            }));
-        } else {
-            Err(Status::internal(resp.err().unwrap().to_string()))
+            })),
+            Err(e) => Err(Status::internal(e.to_string())),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,16 +339,18 @@ async fn cli() -> Result<bool, anyhow::Error> {
                         .long("component")
                         .help("view data of the component: version, user"),
                 ),
-            clap::Command::new("migrate-file-list")
-                .about("migrate file-list from s3 to dynamo db")
-                .arg(
-                    clap::Arg::new("prefix")
-                        .short('p')
-                        .long("prefix")
-                        .value_name("prefix")
-                        .required(false)
-                        .help("only migrate specified prefix, default is all"),
-                ),
+                clap::Command::new("migrate-file-list")
+                    .about("migrate file-list from s3 to dynamo db")
+                    .arg(
+                        clap::Arg::new("prefix")
+                            .short('p')
+                            .long("prefix")
+                            .value_name("prefix")
+                            .required(false)
+                            .help("only migrate specified prefix, default is all"),
+                    ),
+                    clap::Command::new("migrate-file-list-from-dynamo")
+                        .about("migrate file-list from dynamo to dynamo db"),
             clap::Command::new("migrate-meta").about("migrate meta"),
             clap::Command::new("delete-parquet")
                 .about("delete parquet files from s3 and file_list")
@@ -440,11 +442,15 @@ async fn cli() -> Result<bool, anyhow::Error> {
                 None => "".to_string(),
             };
             println!("Running migration with prefix: {}", prefix);
-            migration::file_list::load(&prefix).await?
+            migration::file_list::run(&prefix).await?
+        }
+        "migrate-file-list-from-dynamo" => {
+            println!("Running migration from DynamoDB");
+            migration::file_list::run_for_dynamo().await?
         }
         "migrate-meta" => {
             println!("Running migration");
-            migration::meta::load().await?
+            migration::meta::run().await?
         }
         "delete-parquet" => {
             let file = command.get_one::<String>("file").unwrap();

--- a/src/service/promql/exec.rs
+++ b/src/service/promql/exec.rs
@@ -107,7 +107,6 @@ impl Query {
             let time = self.start + (self.interval * i);
             let mut engine = super::Engine::new(ctx.clone(), time);
             let expr = expr.clone();
-            // let task = tokio::task::spawn(async move { (time, engine.exec(&expr).await) });
             let task = (time, engine.exec(&expr).await);
             tasks.push(task);
         }

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -55,9 +55,7 @@ pub async fn search(
     req.org_id = org_id.to_string();
     req.stype = cluster_rpc::SearchType::User as i32;
     req.stream_type = stream_type.to_string();
-    tokio::task::spawn(async move { search_in_cluster(req).await })
-        .await
-        .map_err(server_internal_error)?
+    search_in_cluster(req).await
 }
 
 async fn get_times(sql: &sql::Sql, stream_type: StreamType) -> (i64, i64) {


### PR DESCRIPTION
## Migration for DynamoDB

1. run `./openobserve migrate-file-list-from-dynamo`
    it will upgrade records for the old `file-list` table and create the secondary index for `file-list` table.
3. run `./openobserve reset -c stream-stats` , **after the secondary index for `file-list` table is successfully created**
    it will rebuild the stream stats, but need run this command after `10m` or you will got empty stream stats.
