### PR TITLE
fix: migration for local mode with s3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4334,7 +4334,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openobserve"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "actix-cors",
  "actix-multipart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = [
 license = "Apache-2.0"
 name = "openobserve"
 repository = "https://github.com/openobserve/openobserve/"
-version = "0.6.0"
+version = "0.6.1"
 publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/common/migration/file_list.rs
+++ b/src/common/migration/file_list.rs
@@ -36,11 +36,6 @@ pub async fn run(prefix: &str) -> Result<(), anyhow::Error> {
         log::error!("Error moving disk files to remote: {}", e);
     }
 
-    if get_file_meta(&CONFIG.common.data_stream_dir).is_err() {
-        // there is no local stream files, no need upgrade
-        return Ok(());
-    }
-
     // load stream list
     db::schema::cache().await?;
     // load file list to db

--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -26,7 +26,7 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
     }
     log::info!("Upgrading from {} to {}", old_ver, new_ver);
     match (old_ver, new_ver) {
-        (_, "v0.5.3") | (_, "v0.6.0") | (_, "v0.6.1") => upgrade_052_053().await,
+        (_, "v0.6.0") | (_, "v0.6.1") => upgrade_052_053().await,
         _ => Ok(()),
     }
 }

--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -21,9 +21,12 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
     if !CONFIG.common.local_mode || old_ver >= new_ver {
         return Ok(());
     }
+    if old_ver >= "v0.5.3" {
+        return Ok(());
+    }
     log::info!("Upgrading from {} to {}", old_ver, new_ver);
     match (old_ver, new_ver) {
-        (_, "v0.5.3") | (_, "v0.6.0") => upgrade_052_053().await,
+        (_, "v0.5.3") | (_, "v0.6.0") | (_, "v0.6.1") => upgrade_052_053().await,
         _ => Ok(()),
     }
 }


### PR DESCRIPTION
We checked if there is `data/stream/` directory, and will skip migration when the directory does not exist. but when the user uses local mode with s3, it has data but there is no `stream` directory.

If the user use `local_mode` + `s3` they need to create an empty `data/openobserve/stream` directory at the same level as `wal` directory. then run the new version, which will upgrade success.