### PR TITLE
fix: Syslog ingestion message values are 'cut off' #1514

### DIFF
--- a/src/handler/tcp_udp/mod.rs
+++ b/src/handler/tcp_udp/mod.rs
@@ -23,7 +23,7 @@ use crate::{job::syslog_server::BROADCASTER, service::logs::syslog};
 pub static STOP_SRV: &str = "ZO_STOP_TCP_UDP";
 
 pub async fn udp_server(socket: UdpSocket) {
-    let mut buf_udp = vec![0u8; 1024];
+    let mut buf_udp = vec![0u8; 1472];
     let sender = BROADCASTER.read().await;
     let mut udp_receiver_rx = sender.subscribe();
     loop {
@@ -46,7 +46,7 @@ pub async fn udp_server(socket: UdpSocket) {
 pub async fn tcp_server(listener: TcpListener) {
     let sender = BROADCASTER.read().await;
     let mut tcp_receiver_rx = sender.subscribe();
-    let mut buf_tcp = vec![0u8; 1024];
+    let mut buf_tcp = vec![0u8; 1460];
     loop {
         let (mut stream, _) = listener.accept().await.unwrap();
 


### PR DESCRIPTION
Before the fix supported length in bytes by both TCP & UDP was limited to 1024 bytes, which resulted in values being cut off.

We had two options as fix : 

- Support max size in line with standard [IEEE 802.3](https://en.wikipedia.org/wiki/IEEE_802.3) , which limits 1500 bytes of payload , with this we can support 1472 bytes (1500 - 20 (IP header ) -8 (UDP header) ) for UDP & 1460 bytes(1500 - 20 (IP header ) -20 (TCP header) )  for TCP 
- JUMBO frames - Ruled out  because :  for jumbo frames , frame size used by an end-to-end connection is typically limited by the lowest frame size in intermediate links ,not only sender & receiver has to enable jumbo frames but all intermediate links will have to support it.

Fixes #1514

**Summary : we will support max 1472 bytes  for UDP & 1460 bytes for TCP**