### PR TITLE
fix: sqlite metadata panic

### DIFF
--- a/src/common/infra/db/mod.rs
+++ b/src/common/infra/db/mod.rs
@@ -140,12 +140,12 @@ pub fn parse_key(mut key: &str) -> (String, String, String) {
 
 pub fn build_key(module: &str, key1: &str, key2: &str) -> String {
     if key1.is_empty() {
-        return module.to_string();
+        format!("/{module}/")
+    } else if key2.is_empty() {
+        format!("/{module}/{key1}")
+    } else {
+        format!("/{module}/{key1}/{key2}")
     }
-    if key2.is_empty() {
-        return format!("/{}/{}", module, key1);
-    }
-    format!("/{}/{}/{}", module, key1, key2)
 }
 
 #[derive(Debug, Default)]

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -22,7 +22,7 @@ use opentelemetry_proto::tonic::collector::logs::v1::{
 };
 use prost::Message;
 
-use crate::{common::{
+use crate::common::{
     infra::{cluster, config::CONFIG, metrics},
     meta::{
         alert::{Alert, Trigger},
@@ -33,10 +33,10 @@ use crate::{common::{
         StreamType,
     },
     utils::{flatten, json},
-}, service::format_stream_name};
+};
 use crate::handler::http::request::CONTENT_TYPE_JSON;
 use crate::service::{
-    db,
+    db, format_stream_name,
     ingestion::{grpc::get_val_for_attr, write_file},
     schema::stream_schema_exists,
     usage::report_request_usage_stats,


### PR DESCRIPTION
Error:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', github.com/zinclabs/openobserve/src/service/db/metrics.rs:99:55
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```