### PR TITLE
fix: all labels to have string values 

### DIFF
--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -19,7 +19,7 @@ use datafusion::arrow::{datatypes::Schema, json::reader::infer_json_schema};
 use std::{collections::HashMap, io::BufReader};
 use vrl::compiler::runtime::Runtime;
 
-use crate::common::{
+use crate::{common::{
     infra::{cluster, config::CONFIG, metrics},
     meta::{
         ingestion::{IngestionResponse, StreamStatus},
@@ -29,7 +29,7 @@ use crate::common::{
         StreamType,
     },
     utils::{flatten, json, time},
-};
+}, service::format_stream_name};
 use crate::service::{
     db, ingestion::get_wal_time_key, ingestion::write_file, stream::unwrap_partition_time_level,
     usage::report_request_usage_stats,
@@ -59,7 +59,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes, thread_id: usize) -> Result<
         // check data type
         let record = record.as_object_mut().unwrap();
         let stream_name = match record.get(NAME_LABEL).ok_or(anyhow!("missing __name__"))? {
-            json::Value::String(s) => s.clone(),
+            json::Value::String(s) => format_stream_name(s),
             _ => {
                 return Err(anyhow::anyhow!("invalid __name__, need to be string"));
             }

--- a/src/service/metrics/mod.rs
+++ b/src/service/metrics/mod.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use datafusion::arrow::datatypes::Schema;
+use once_cell::sync::Lazy;
+use regex::{self, Regex};
 
 use crate::common;
 use crate::common::infra::config::CONFIG;
@@ -24,6 +26,8 @@ pub mod otlp_http;
 pub mod prom;
 
 const EXCLUDE_LABELS: [&str; 5] = [VALUE_LABEL, "start_time", "is_monotonic", "exemplars", "le"];
+
+static RE_CORRECT_LABEL_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^a-zA-Z0-9_]+").unwrap());
 
 pub fn get_prom_metadata_from_schema(schema: &Schema) -> Option<Metadata> {
     let metadata = schema.metadata.get(METADATA_LABEL)?;
@@ -65,4 +69,9 @@ fn get_exclude_labels() -> Vec<&'static str> {
     let mut vec: Vec<&str> = EXCLUDE_LABELS.to_vec();
     vec.push(&CONFIG.common.column_timestamp);
     vec
+}
+
+// format stream name
+pub fn format_label_name(label: &str) -> String {
+    RE_CORRECT_LABEL_NAME.replace_all(label, "_").to_string()
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use once_cell::sync::Lazy;
+use regex::{self, Regex};
+
 pub mod alert_manager;
 pub mod alerts;
 pub mod compact;
@@ -39,6 +42,8 @@ pub mod users;
 
 const MAX_KEY_LENGTH: usize = 100;
 
+static RE_CORRECT_STREAM_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^a-zA-Z0-9_:]+").unwrap());
+
 // format partition key
 pub fn format_partition_key(input: &str) -> String {
     let mut output = String::with_capacity(std::cmp::min(input.len(), MAX_KEY_LENGTH));
@@ -53,7 +58,9 @@ pub fn format_partition_key(input: &str) -> String {
     output
 }
 
-// format straeam name
+// format stream name
 pub fn format_stream_name(stream_name: &str) -> String {
-    stream_name.replace('/', "_").replace('=', "-")
+    RE_CORRECT_STREAM_NAME
+        .replace_all(stream_name, "_")
+        .to_string()
 }


### PR DESCRIPTION
- [x] As part of OTLP ingestion, some labels like "is_monotonic" were having non-string values , which was creating issue for promql query ,fixed these to have to string value
- [x] Metric names were invalid , containing "." , "-" etc , fixed these to have only a-zA-Z0-9_: 
- [x] Labels to have only a-zA-Z0-9_ 