### PR TITLE
fix: where keyword in sql mode to avoid syntax error

### DIFF
--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -767,9 +767,20 @@ export default defineComponent({
           this.searchObj.data.query = currentQuery.join("| ");
         } else {
           if (currentQuery != "") {
-            currentQuery += " and " + filter;
+            if (
+              this.searchObj.meta.sqlMode == true &&
+              currentQuery.toString().toLowerCase().indexOf("where") == -1
+            ) {
+              currentQuery += " where " + filter;
+            } else {
+              currentQuery += " and " + filter;
+            }
           } else {
-            currentQuery = filter;
+            if (this.searchObj.meta.sqlMode == true) {
+              currentQuery = "where " + filter;
+            } else {
+              currentQuery = filter;
+            }
           }
           this.searchObj.data.query = currentQuery;
         }


### PR DESCRIPTION
This PR contains the fix for the syntax error issue in SQL Mode.

issue #1054 
Solution: An additional condition was added to check sql mode is enabled or not and check for the "where" keyword exists in the query while adding a new condition to the query editor.