### PR TITLE
fix: calendar datatime reset issue fix

### DIFF
--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -152,6 +152,9 @@
                       filled
                       mask="time"
                       :rules="['time']"
+                      @blur="
+                        resetTime(selectedTime.startTime, selectedTime.endTime)
+                      "
                     >
                       <template #append>
                         <q-icon name="access_time" class="cursor-pointer">
@@ -181,6 +184,9 @@
                       filled
                       mask="time"
                       :rules="['time']"
+                      @blur="
+                        resetTime(selectedTime.startTime, selectedTime.endTime)
+                      "
                     >
                       <template #append>
                         <q-icon name="access_time" class="cursor-pointer">
@@ -302,6 +308,7 @@ export default defineComponent({
     onMounted(() => {
       // updateDisplayValue();
       try {
+        resetTime("", "");
         selectedType.value = props.defaultType;
         setAbsoluteTime(
           props.defaultAbsoluteTime?.startTime,
@@ -383,13 +390,24 @@ export default defineComponent({
       }
     };
 
+    const resetTime = (startTime, endTime) => {
+      if (!startTime || !endTime) {
+        var dateString = new Date().toLocaleDateString("en-ZA");
+        selectedDate.value.from = dateString;
+        selectedDate.value.to = dateString;
+        if (!startTime) selectedTime.value.startTime = "00:00";
+
+        if (!endTime) selectedTime.value.endTime = "23:59";
+        return;
+      }
+      return;
+    };
+
     const setAbsoluteTime = (startTime, endTime) => {
       if (!startTime || !endTime) {
         var dateString = new Date().toLocaleDateString("en-ZA");
         selectedDate.value.from = dateString;
         selectedDate.value.to = dateString;
-        selectedTime.value.startTime = "00:00";
-        selectedTime.value.endTime = "23:59";
         return;
       }
 
@@ -544,6 +562,7 @@ export default defineComponent({
       displayValue,
       refresh,
       dateLocale,
+      resetTime,
     };
   },
 });

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -375,6 +375,10 @@ const useLogs = () => {
         timestamps.startTime != "Invalid Date" &&
         timestamps.endTime != "Invalid Date"
       ) {
+        if (timestamps.startTime > timestamps.endTime) {
+          showErrorNotification("Start time cannot be greater than end time");
+          return false;
+        }
         searchObj.meta.resultGrid.chartKeyFormat = "HH:mm:ss";
 
         req.query.start_time = timestamps.startTime;

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -558,6 +558,13 @@ const useLogs = () => {
 
         if (queryReq != null) {
           if (
+            searchObj.meta.refreshInterval > 0 &&
+            router.currentRoute.value.name == "logs"
+          ) {
+            queryReq.query.from = 0;
+          }
+
+          if (
             searchObj.data.tempFunctionContent != "" &&
             searchObj.meta.toggleFunction
           ) {
@@ -570,10 +577,16 @@ const useLogs = () => {
 
           if (!isPagination) initialQueryPayload.value = cloneDeep(queryReq);
           else {
-            queryReq.query.start_time =
-              initialQueryPayload.value?.query?.start_time;
-            queryReq.query.end_time =
-              initialQueryPayload.value?.query?.end_time;
+            if (
+              searchObj.meta.refreshInterval == 0 &&
+              router.currentRoute.value.name == "logs" &&
+              searchObj.data.queryResults.hasOwnProperty("hits")
+            ) {
+              queryReq.query.start_time =
+                initialQueryPayload.value?.query?.start_time;
+              queryReq.query.end_time =
+                initialQueryPayload.value?.query?.end_time;
+            }
           }
 
           searchObj.data.errorCode = 0;
@@ -592,7 +605,35 @@ const useLogs = () => {
                 searchObj.data.queryResults.hits.push(...res.data.hits);
               } else {
                 resetFieldValues();
-                searchObj.data.queryResults = res.data;
+                if (
+                  searchObj.meta.refreshInterval > 0 &&
+                  router.currentRoute.value.name == "logs" &&
+                  searchObj.data.queryResults.hasOwnProperty("hits")
+                ) {
+                  searchObj.data.queryResults.from = res.data.from;
+                  searchObj.data.queryResults.scan_size = res.data.scan_size;
+                  searchObj.data.queryResults.took = res.data.took;
+                  searchObj.data.queryResults.aggs = res.data.aggs;
+                  const lastRecordTimeStamp = parseInt(
+                    searchObj.data.queryResults.hits[0]._timestamp
+                  );
+                  // searchObj.data.queryResults.hits = res.data.hits;
+                  for (let i = 0; i < res.data.hits.length; i++) {
+                    if (
+                      lastRecordTimeStamp <
+                      parseInt(res.data.hits[i]._timestamp)
+                    ) {
+                      searchObj.data.queryResults.hits.unshift(
+                        res.data.hits[i]
+                      );
+                    }
+                  }
+
+                  searchObj.data.queryResults.hits = searchObj.data.queryResults.hits.splice(0, 150);
+
+                } else {
+                  searchObj.data.queryResults = res.data;
+                }
               }
 
               updateFieldValues();
@@ -966,8 +1007,11 @@ const useLogs = () => {
     ) {
       clearInterval(refreshIntervalID);
       refreshIntervalID = setInterval(async () => {
-        searchObj.loading = true;
-        await getQueryData();
+        // searchObj.loading = true;
+        await getQueryData(true);
+        generateHistogramData();
+        updateGridColumns();
+        searchObj.meta.histogramDirtyFlag = true;
       }, searchObj.meta.refreshInterval * 1000);
       $q.notify({
         message: `Live mode is enabled. Only top ${searchObj.meta.resultGrid.rowsPerPage} results are shown.`,

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -509,6 +509,9 @@ export default defineComponent({
     fullSQLMode() {
       return this.searchObj.meta.sqlMode;
     },
+    refreshHistogram() {
+      return this.searchObj.meta.histogramDirtyFlag;
+    },
   },
   watch: {
     showFields() {
@@ -580,6 +583,10 @@ export default defineComponent({
     },
     fullSQLMode(newVal) {
       this.setQuery(newVal);
+    },
+    refreshHistogram() {
+      this.searchObj.meta.histogramDirtyFlag = false;
+      this.refreshHistogramChart();
     },
   },
 });


### PR DESCRIPTION
This PR contains a fix for the calendar time selection issue.
Problem: When a user attempts to set the "start time" in the absolute tab and subsequently clears the entire "end time" field, it inadvertently resets the "start time."

Solution: When a user is setting up the time no need to reset it. I have moved out that when users move out from calendar control. If the user tries to click the "Run Query" button without selecting the time user will get an error message.