### PR TITLE
fix: default folder rename issue

### DIFF
--- a/src/handler/http/request/dashboards/folders.rs
+++ b/src/handler/http/request/dashboards/folders.rs
@@ -48,7 +48,7 @@ pub async fn create_folder(
     folder: web::Json<Folder>,
 ) -> Result<HttpResponse, Error> {
     let org_id = path.into_inner();
-    folders::save_folder(&org_id, folder.into_inner()).await
+    folders::save_folder(&org_id, folder.into_inner(), false).await
 }
 
 /** UpdateFolder */

--- a/src/service/dashboards/folders.rs
+++ b/src/service/dashboards/folders.rs
@@ -26,7 +26,19 @@ use crate::common::meta::{
 use crate::service::db;
 
 #[tracing::instrument(skip(folder))]
-pub async fn save_folder(org_id: &str, mut folder: Folder) -> Result<HttpResponse, Error> {
+pub async fn save_folder(
+    org_id: &str,
+    mut folder: Folder,
+    is_internal: bool,
+) -> Result<HttpResponse, Error> {
+    if !is_internal && folder.folder_id == DEFAULT_FOLDER {
+        return Ok(
+            HttpResponse::InternalServerError().json(MetaHttpResponse::message(
+                http::StatusCode::BAD_REQUEST.into(),
+                "can't update default folder".to_string(),
+            )),
+        );
+    }
     if folder.folder_id != DEFAULT_FOLDER {
         folder.folder_id = crate::common::infra::ider::generate();
     }

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -44,7 +44,7 @@ pub async fn create_dashboard(
                     name: DEFAULT_FOLDER.to_string(),
                     description: DEFAULT_FOLDER.to_string(),
                 };
-                folders::save_folder(org_id, folder).await?;
+                folders::save_folder(org_id, folder, true).await?;
                 let dashboard_id = crate::common::infra::ider::generate();
                 save_dashboard(org_id, &dashboard_id, folder_id, body).await
             } else {


### PR DESCRIPTION
We create default folder , when we first receive call to create a dashboard in default folder. If an API call tries to create a default folder , it should not be allowed