### PR TITLE
fix: optimize file list broadcast

### DIFF
--- a/src/common/infra/cluster.rs
+++ b/src/common/infra/cluster.rs
@@ -365,12 +365,9 @@ async fn watch_node_list() -> Result<()> {
                 log::info!("[CLUSTER] join {:?}", item_value.clone());
                 NODES.insert(item_key.to_string(), item_value.clone());
                 // The ingester need broadcast local file list to the new node
-                // -- 1. broadcast to the node prepare
-                // -- 2. broadcast to the node online (only itself)
                 if is_ingester(&LOCAL_NODE_ROLE)
                     && (item_value.status.eq(&NodeStatus::Prepare)
-                        || (item_value.status.eq(&NodeStatus::Online)
-                            && item_key.eq(LOCAL_NODE_UUID.as_str())))
+                        || item_value.status.eq(&NodeStatus::Online))
                 {
                     log::info!("[CLUSTER] broadcast file_list to new node: {}", item_key);
                     let notice_uuid = if item_key.eq(LOCAL_NODE_UUID.as_str()) {

--- a/src/common/infra/cluster.rs
+++ b/src/common/infra/cluster.rs
@@ -47,6 +47,8 @@ pub struct Node {
     pub role: Vec<Role>,
     pub cpu_num: u64,
     pub status: NodeStatus,
+    #[serde(default)]
+    pub broadcasted: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -198,6 +200,7 @@ pub async fn register() -> Result<()> {
         role: LOCAL_NODE_ROLE.clone(),
         cpu_num: CONFIG.limit.cpu_num as u64,
         status: NodeStatus::Prepare,
+        broadcasted: false,
     };
     // cache local node
     NODES.insert(LOCAL_NODE_UUID.clone(), val.clone());
@@ -245,6 +248,7 @@ pub async fn set_online() -> Result<()> {
             role: LOCAL_NODE_ROLE.clone(),
             cpu_num: CONFIG.limit.cpu_num as u64,
             status: NodeStatus::Online,
+            broadcasted: false,
         },
     };
 
@@ -361,31 +365,39 @@ async fn watch_node_list() -> Result<()> {
         match ev {
             Event::Put(ev) => {
                 let item_key = ev.key.strip_prefix(key).unwrap();
-                let item_value: Node = json::from_slice(&ev.value.unwrap()).unwrap();
+                let mut item_value: Node = json::from_slice(&ev.value.unwrap()).unwrap();
                 log::info!("[CLUSTER] join {:?}", item_value.clone());
-                NODES.insert(item_key.to_string(), item_value.clone());
-                // The ingester need broadcast local file list to the new node
-                if is_ingester(&LOCAL_NODE_ROLE)
-                    && (item_value.status.eq(&NodeStatus::Prepare)
-                        || item_value.status.eq(&NodeStatus::Online))
-                {
-                    log::info!("[CLUSTER] broadcast file_list to new node: {}", item_key);
-                    let notice_uuid = if item_key.eq(LOCAL_NODE_UUID.as_str()) {
-                        None
-                    } else {
-                        Some(item_key.to_string())
-                    };
-                    tokio::task::spawn(async move {
-                        if let Err(e) = db::file_list::local::broadcast_cache(notice_uuid).await {
-                            log::error!("[CLUSTER] broadcast file_list error: {}", e);
-                        }
-                    });
+                let broadcasted = match NODES.clone().get(item_key) {
+                    Some(v) => v.broadcasted,
+                    None => false,
+                };
+                if !broadcasted {
+                    // The ingester need broadcast local file list to the new node
+                    if is_ingester(&LOCAL_NODE_ROLE)
+                        && (item_value.status.eq(&NodeStatus::Prepare)
+                            || item_value.status.eq(&NodeStatus::Online))
+                    {
+                        log::info!("[CLUSTER] broadcast file_list to new node: {}", item_key);
+                        let notice_uuid = if item_key.eq(LOCAL_NODE_UUID.as_str()) {
+                            None
+                        } else {
+                            Some(item_key.to_string())
+                        };
+                        tokio::task::spawn(async move {
+                            if let Err(e) = db::file_list::local::broadcast_cache(notice_uuid).await
+                            {
+                                log::error!("[CLUSTER] broadcast file_list error: {}", e);
+                            }
+                        });
+                    }
                 }
+                item_value.broadcasted = true;
+                NODES.insert(item_key.to_string(), item_value);
             }
             Event::Delete(ev) => {
                 let item_key = ev.key.strip_prefix(key).unwrap();
                 let item_value = NODES.get(item_key).unwrap().clone();
-                log::info!("[CLUSTER] leave {:?}", item_value.clone());
+                log::info!("[CLUSTER] leave {:?}", item_value);
                 NODES.remove(item_key);
             }
             Event::Empty => {}
@@ -406,6 +418,7 @@ pub fn load_local_mode_node() -> Node {
         role: [Role::All].to_vec(),
         cpu_num: CONFIG.limit.cpu_num as u64,
         status: NodeStatus::Online,
+        broadcasted: false,
     }
 }
 

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use dashmap::{DashMap, DashSet};
 use datafusion::arrow::datatypes::Schema;
 use dotenv_config::EnvConfig;
@@ -42,6 +42,7 @@ pub type FxIndexSet<K> = indexmap::IndexSet<K, ahash::RandomState>;
 pub type RwHashMap<K, V> = DashMap<K, V, ahash::RandomState>;
 pub type RwHashSet<K> = DashSet<K, ahash::RandomState>;
 pub type RwAHashMap<K, V> = tokio::sync::RwLock<AHashMap<K, V>>;
+pub type RwAHashSet<K> = tokio::sync::RwLock<AHashSet<K>>;
 
 pub static VERSION: &str = env!("GIT_VERSION");
 pub static COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -120,7 +120,11 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
     );
 
     let file_list_num = file_list::len().await;
-    stats.insert("FILE_LIST", json::json!({"num":file_list_num}));
+    let file_list_max_id = file_list::get_max_pk_value().await.unwrap_or_default();
+    stats.insert(
+        "FILE_LIST",
+        json::json!({"num":file_list_num,"max_id": file_list_max_id}),
+    );
 
     let tmpfs_mem_size = cache::tmpfs::stats().unwrap();
     stats.insert("TMPFS", json::json!({ "mem_size": tmpfs_mem_size }));

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -130,16 +130,22 @@ pub async fn init() -> Result<(), anyhow::Error> {
         .expect("syslog settings cache failed");
 
     // cache file list
-    if !CONFIG.common.meta_store_external
-        && (cluster::is_querier(&cluster::LOCAL_NODE_ROLE)
-            || cluster::is_compactor(&cluster::LOCAL_NODE_ROLE))
-    {
-        db::file_list::remote::cache("", false)
-            .await
-            .expect("file list remote cache failed");
-        update_stats_from_file_list()
-            .await
-            .expect("file list remote calculate stats failed");
+    if !CONFIG.common.meta_store_external {
+        if cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+            // load the wal file_list into memory
+            db::file_list::local::load_wal_in_cache()
+                .await
+                .expect("load wal file list failed");
+        } else if cluster::is_querier(&cluster::LOCAL_NODE_ROLE)
+            || cluster::is_compactor(&cluster::LOCAL_NODE_ROLE)
+        {
+            db::file_list::remote::cache("", false)
+                .await
+                .expect("file list remote cache failed");
+            update_stats_from_file_list()
+                .await
+                .expect("file list remote calculate stats failed");
+        }
     }
     infra_file_list::create_table_index().await?;
     infra_file_list::set_initialised().await?;


### PR DESCRIPTION
The latest 10-minute data mayn't be queried when we redeploy the whole cluster, because of the ingester can't broadcast the data in WAL.

## Solution

Load the file list in WAL into `cache` when it start, and then we will have data to send broadcast.