### PR TITLE
fix: change the log::info -> debug for missing vector

### DIFF
--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -36,13 +36,13 @@ use super::ingestion::{get_value, get_wal_time_key};
 
 pub mod bulk;
 pub mod gcs_pub_sub;
+pub mod ingest;
 pub mod json;
 pub mod kinesis_firehose;
 pub mod multi;
 pub mod otlp_grpc;
 pub mod otlp_http;
 pub mod syslog;
-pub mod ingest;
 
 static BULK_OPERATORS: [&str; 3] = ["create", "index", "update"];
 

--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -137,7 +137,7 @@ impl Engine {
                         binaries::vector_scalar_bin_op(expr, &right, left, true).await?
                     }
                     _ => {
-                        log::info!(
+                        log::debug!(
                             "[PromExpr::Binary] either lhs or rhs vector is found to be empty"
                         );
                         Value::Vector(vec![])


### PR DESCRIPTION
In promql we were reporting as info logs, in case one of the lhs/rhs of a binary-operation was missing, now we just report it as `debug`.