### PR TITLE
fix: dashboard tooltips for single item only

### DIFF
--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -356,6 +356,7 @@ const getPropsByChartTypeForSeries = (type: string) => {
         emphasis: { focus: "series" },
         smooth: true,
         areaStyle: {},
+        symbolSize:1,
         // showSymbol: false,
       };
     case "stacked":
@@ -370,6 +371,7 @@ const getPropsByChartTypeForSeries = (type: string) => {
         stack: "Total",
         areaStyle: {},
         // showSymbol: false,
+        symbolSize:1,
         emphasis: {
           focus: "series",
         },

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -77,25 +77,19 @@ export const convertPromQLData = (
     },
     tooltip: {
       show: true,
-      trigger: "axis",
+      trigger: "item",
       textStyle: {
         fontSize: 12,
       },
       formatter: function (name: any) {
-        if (name.length == 0) return "";
-
-        const date = new Date(name[0].data[0]);
-
-        let hoverText = name.map((it: any) => {
-          return `${it.marker} ${it.seriesName} : ${formatUnitValue(
-            getUnitValue(
-              it.data[1],
-              panelSchema.config?.unit,
-              panelSchema.config?.unit_custom
-            )
-          )}`;
-        });
-        return `${formatDate(date)} <br/> ${hoverText.join("<br/>")}`;
+        const date = new Date(name.value[0]);
+        return `${formatDate(date)} <br/> ${name?.marker} ${name?.seriesName} : ${formatUnitValue(
+              getUnitValue(
+                name?.value[1],
+                panelSchema.config?.unit,
+                panelSchema.config?.unit_custom
+              )
+            )}`;
       },
       axisPointer: {
         show: true,
@@ -331,7 +325,8 @@ const getPropsByChartTypeForSeries = (type: string) => {
         type: "line",
         emphasis: { focus: "series" },
         smooth: true,
-        showSymbol: false,
+        // showSymbol: false,
+        symbolSize:1
       };
     case "scatter":
       return {
@@ -361,7 +356,7 @@ const getPropsByChartTypeForSeries = (type: string) => {
         emphasis: { focus: "series" },
         smooth: true,
         areaStyle: {},
-        showSymbol: false,
+        // showSymbol: false,
       };
     case "stacked":
       return {
@@ -374,7 +369,7 @@ const getPropsByChartTypeForSeries = (type: string) => {
         smooth: true,
         stack: "Total",
         areaStyle: {},
-        showSymbol: false,
+        // showSymbol: false,
         emphasis: {
           focus: "series",
         },

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -134,7 +134,7 @@ export const convertSQLData = (
       bottom: "40",
     },
     tooltip: {
-      trigger: "axis",
+      trigger: "item",
       textStyle: {
         fontSize: 12,
       },
@@ -188,18 +188,13 @@ export const convertSQLData = (
         },
       },
       formatter: function (name: any) {
-        if (name.length == 0) return "";
-
-        let hoverText = name.map((it: any) => {
-          return `${it.marker} ${it.seriesName} : ${formatUnitValue(
-            getUnitValue(
-              it.value,
-              panelSchema.config?.unit,
-              panelSchema.config?.unit_custom
-            )
-          )}`;
-        });
-        return `${name[0].name} <br/> ${hoverText.join("<br/>")}`;
+        return `${name.name} <br/> ${name.marker} ${name.seriesName} : ${formatUnitValue(
+              getUnitValue(
+                name.value,
+                panelSchema.config?.unit,
+                panelSchema.config?.unit_custom
+              )
+        )}`;
       },
     },
     xAxis: xAxisKeys
@@ -392,20 +387,15 @@ export const convertSQLData = (
       }
       else{
         options.tooltip.formatter = function (name: any) {
-          //reduce to each name
-          const hoverText = name.reduce((text: any, it: any) => {
-            return (text += `<br/> ${it.marker} ${
-              it.seriesName
-            } : ${formatUnitValue(
-              getUnitValue(
-                it.value[1],
-                panelSchema.config?.unit,
-                panelSchema.config?.unit_custom
-              )
-            )}`);
-          }, "");
-          //x axis name + hovertext
-          return `${name[0].name} ${hoverText}`;
+          return `${name.name} <br/> ${name.marker} ${
+                name.seriesName
+              } : ${formatUnitValue(
+                getUnitValue(
+                  name.value[1],
+                  panelSchema.config?.unit,
+                  panelSchema.config?.unit_custom
+                )
+          )}`;
         };
         options.series = yAxisKeys?.map((key: any) => {
           const seriesObj = {
@@ -796,6 +786,8 @@ export const convertSQLData = (
     //if x axis has time series
     if (field) {
       options.series.map((seriesObj: any) => {
+        seriesObj.showSymbol= true;
+        seriesObj.symbolSize = 1;
         seriesObj.data = seriesObj.data.map((it: any, index: any) => [
           Number.isInteger(options.xAxis[0].data[index]) ? options.xAxis[0].data[index] : new Date(options.xAxis[0].data[index]+ "Z").getTime(),
           it,
@@ -804,20 +796,14 @@ export const convertSQLData = (
       options.xAxis[0].type = "time";
       options.xAxis[0].data = [];
       options.tooltip.formatter = function (name: any) {
-        if (name.length == 0) return "";
-  
-        const date = new Date(name[0].data[0]);
-  
-        let hoverText = name.map((it: any) => {
-          return `${it.marker} ${it.seriesName} : ${formatUnitValue(
-            getUnitValue(
-              it.data[1],
-              panelSchema.config?.unit,
-              panelSchema.config?.unit_custom
-            )
-          )}`;
-        });
-        return `${formatDate(date)} <br/> ${hoverText.join("<br/>")}`;
+        const date = new Date(name.value[0]);
+        return `${formatDate(date)} <br/> ${name.marker} ${name.seriesName} : ${formatUnitValue(
+              getUnitValue(
+                name.value[1],
+                panelSchema.config?.unit,
+                panelSchema.config?.unit_custom
+              )
+        )}`;
       };
       options.tooltip.axisPointer = {
         type: "cross",
@@ -832,7 +818,7 @@ export const convertSQLData = (
                   panelSchema.config?.unit_custom
                 )
               );
-            return formatDate(new Date(params.seriesData[0].data[0])).toString();
+            return formatDate(new Date(params.value)).toString();
           },
         },
         formatter: function (params: any) {
@@ -862,6 +848,8 @@ export const convertSQLData = (
     });
     if (isTimeSeries) {
       options.series.map((seriesObj: any) => {
+        seriesObj.showSymbol= true;
+        seriesObj.symbolSize = 1;
         seriesObj.data = seriesObj?.data?.map((it: any, index: any) => [
           new Date(options.xAxis[0].data[index] + "Z").getTime(),
           it,
@@ -869,7 +857,16 @@ export const convertSQLData = (
       });
       options.xAxis[0].type = "time";
       options.xAxis[0].data = [];
-      options.tooltip.formatter = null;
+      options.tooltip.formatter = function (name: any) {  
+        const date = new Date(name.value[0]);
+        return `${formatDate(date)} <br/> ${name.marker} ${name.seriesName} : ${formatUnitValue(
+              getUnitValue(
+                name.value[1],
+                panelSchema.config?.unit,
+                panelSchema.config?.unit_custom
+              )
+        )}`;
+      };
       options.tooltip.axisPointer = {
         type: "cross",
         label: {
@@ -883,7 +880,7 @@ export const convertSQLData = (
                   panelSchema.config?.unit_custom
                 )
               );
-            return formatDate(new Date(params?.seriesData[0]?.data[0])).toString();
+            return formatDate(new Date(params?.value)).toString();
           },
         },
         formatter: function (params: any) {


### PR DESCRIPTION
Show single item value only instead of showing all the items in the tooltip when a single element is hovered

![image](https://github.com/openobserve/openobserve/assets/124270523/94470415-906c-437e-89cb-9e271acf50db)
