### PR TITLE
feat: add schedule for cluster node

### DIFF
--- a/src/service/db/file_list/broadcast.rs
+++ b/src/service/db/file_list/broadcast.rs
@@ -35,8 +35,9 @@ pub async fn send(items: &[FileKey], node_uuid: Option<String>) -> Result<(), an
     }
     let nodes = if node_uuid.is_none() {
         cluster::get_cached_nodes(|node| {
-            (node.status == cluster::NodeStatus::Prepare
-                || node.status == cluster::NodeStatus::Online)
+            node.scheduled
+                && (node.status == cluster::NodeStatus::Prepare
+                    || node.status == cluster::NodeStatus::Online)
                 && (cluster::is_querier(&node.role) || cluster::is_compactor(&node.role))
         })
         .unwrap()


### PR DESCRIPTION
Sometimes we want to set a node to`NoSchedule`, like we want offline an ingester but there are some WAL files in the node, we need `NoSchedule` the node and wait for some time to let the WAL files move to storage.

With this PR we can use etcd to set the node attribute `scheduled: false` then it will never be scheduled. 