### PR TITLE
fix: "Search around" button remains disabled

### DIFF
--- a/web/src/enterprise/components/users/User.vue
+++ b/web/src/enterprise/components/users/User.vue
@@ -306,8 +306,8 @@ export default defineComponent({
     const inviteUser = () => {
       const emailArray = userEmail.value
         .split(";")
-        .split(",")
-        .filter((email: any) => email)
+        .flatMap((email: any) => email.split(","))
+        .filter((email: any) => email.trim().length > 0)
         .map((email: any) => email.trim());
       const validationArray = emailArray.map((email: any) =>
         validateEmail(email)

--- a/web/src/plugins/logs/DetailTable.vue
+++ b/web/src/plugins/logs/DetailTable.vue
@@ -14,7 +14,10 @@
 -->
 
 <template>
-  <q-card class="column full-height no-wrap searchdetaildialog" data-test="dialog-box">
+  <q-card
+    class="column full-height no-wrap searchdetaildialog"
+    data-test="dialog-box"
+  >
     <q-card-section class="q-pa-md q-pb-md">
       <div class="row items-center no-wrap">
         <div class="col">
@@ -23,7 +26,13 @@
           </div>
         </div>
         <div class="col-auto">
-          <q-btn v-close-popup round flat icon="cancel" data-test="close-dialog"/>
+          <q-btn
+            v-close-popup
+            round
+            flat
+            icon="cancel"
+            data-test="close-dialog"
+          />
         </div>
       </div>
     </q-card-section>
@@ -219,7 +228,6 @@
               class="text-bold"
               text-color="light-text"
               no-caps
-              :disabled="currentIndex >= totalLength - 1"
               outline
               label="Search Around"
               @click="searchTimeBoxed(rowData, Number(selectedRelativeValue))"


### PR DESCRIPTION
1. The "Search around" button remains disabled
- There was an unwanted condition to disable the button which was not required. Removed that condition from the button.