### PR TITLE
fix: read cpu & memory limits from cgroup

### DIFF
--- a/src/common/utils/cgroup.rs
+++ b/src/common/utils/cgroup.rs
@@ -20,7 +20,6 @@ pub fn get_cpu_limit() -> usize {
         if !val.is_empty() && !val.to_lowercase().starts_with("max") {
             let columns = val.split(' ').collect::<Vec<&str>>();
             let val = columns[0].parse::<usize>().unwrap_or_default();
-            println!("cpu.max: {}", val);
             if val > 0 {
                 if val < 100000 {
                     1 // maybe the limit less than 1 core
@@ -50,7 +49,6 @@ pub fn get_cpu_limit() -> usize {
 pub fn get_memory_limit() -> usize {
     let mem_size = if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
         if !val.is_empty() && !val.to_lowercase().starts_with("max") {
-            println!("memory.max: {}", val);
             val.trim_end().parse::<usize>().unwrap_or_default()
         } else {
             read_memory_cgroup_v1()
@@ -71,7 +69,6 @@ pub fn get_memory_limit() -> usize {
 fn read_cpu_cgroup_v1() -> usize {
     if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") {
         let ret_val = val.trim().to_string().parse::<usize>().unwrap_or_default();
-        println!("cpu.cfs_quota_us: {}", ret_val);
         if ret_val > 0 && ret_val < 100000 {
             1 // maybe the limit less than 1 core
         } else {
@@ -84,7 +81,6 @@ fn read_cpu_cgroup_v1() -> usize {
 
 fn read_memory_cgroup_v1() -> usize {
     if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
-        println!("memory.limit_in_bytes: {}", val);
         val.trim_end().parse::<usize>().unwrap_or_default()
     } else {
         0

--- a/src/common/utils/cgroup.rs
+++ b/src/common/utils/cgroup.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use sysinfo::SystemExt;
 
 /// Get cpu limit by cgroup or return the node cpu cores
@@ -20,7 +22,7 @@ pub fn get_cpu_limit() -> usize {
         if !val.is_empty() && !val.to_lowercase().starts_with("max") {
             let columns = val.split(' ').collect::<Vec<&str>>();
             let val = columns[0].parse::<usize>().unwrap_or_default();
-            log::info!("cpu.max: {}", val);
+            println!("cpu.max: {}", val);
             if val > 0 {
                 if val < 100000 {
                     1 // maybe the limit less than 1 core
@@ -50,7 +52,7 @@ pub fn get_cpu_limit() -> usize {
 pub fn get_memory_limit() -> usize {
     let mem_size = if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
         if !val.is_empty() && !val.to_lowercase().starts_with("max") {
-            log::info!("memory.max: {}", val);
+            println!("memory.max: {}", val);
             val.trim_end().parse::<usize>().unwrap_or_default()
         } else {
             read_memory_cgroup_v1()
@@ -69,10 +71,23 @@ pub fn get_memory_limit() -> usize {
 }
 
 fn read_cpu_cgroup_v1() -> usize {
+    if Path::new("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").is_file() {
+        println!("/sys/fs/cgroup/cpu/cpu.cfs_quota_us is a file!");
+    } else {
+        println!("/sys/fs/cgroup/cpu/cpu.cfs_quota_us is not a file or doesn't exist");
+    }
+
+    if Path::new("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us").is_file() {
+        println!("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us is a file!");
+    } else {
+        println!("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us is not a file or doesn't exist");
+    }
+
     if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") {
+        println!("cpu.cfs_quota_us read: {}", val);
         let columns = val.split(' ').collect::<Vec<&str>>();
         let val = columns[0].parse::<usize>().unwrap_or_default();
-        log::info!("cpu.cfs_quota_us: {}", val);
+        println!("cpu.cfs_quota_us: {}", val);
         if val > 0 && val < 100000 {
             1 // maybe the limit less than 1 core
         } else {
@@ -85,7 +100,7 @@ fn read_cpu_cgroup_v1() -> usize {
 
 fn read_memory_cgroup_v1() -> usize {
     if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
-        log::info!("memory.limit_in_bytes: {}", val);
+        println!("memory.limit_in_bytes: {}", val);
         val.trim_end().parse::<usize>().unwrap_or_default()
     } else {
         0

--- a/src/common/utils/cgroup.rs
+++ b/src/common/utils/cgroup.rs
@@ -69,7 +69,7 @@ pub fn get_memory_limit() -> usize {
 }
 
 fn read_cpu_cgroup_v1() -> usize {
-    if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us") {
+    if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") {
         let columns = val.split(' ').collect::<Vec<&str>>();
         let val = columns[0].parse::<usize>().unwrap_or_default();
         log::info!("cpu.cfs_quota_us: {}", val);

--- a/src/common/utils/cgroup.rs
+++ b/src/common/utils/cgroup.rs
@@ -69,7 +69,7 @@ pub fn get_memory_limit() -> usize {
 }
 
 fn read_cpu_cgroup_v1() -> usize {
-    if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") {
+    if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us") {
         let columns = val.split(' ').collect::<Vec<&str>>();
         let val = columns[0].parse::<usize>().unwrap_or_default();
         log::info!("cpu.cfs_quota_us: {}", val);
@@ -86,7 +86,7 @@ fn read_cpu_cgroup_v1() -> usize {
 fn read_memory_cgroup_v1() -> usize {
     if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
         log::info!("memory.limit_in_bytes: {}", val);
-        val.trim_end().parse::<usize>().unwrap_or_default() / 1048576
+        val.trim_end().parse::<usize>().unwrap_or_default()
     } else {
         0
     }

--- a/src/common/utils/cgroup.rs
+++ b/src/common/utils/cgroup.rs
@@ -17,27 +17,24 @@ use sysinfo::SystemExt;
 /// Get cpu limit by cgroup or return the node cpu cores
 pub fn get_cpu_limit() -> usize {
     let cpu_num = if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu.max") {
-        if !val.to_lowercase().starts_with("max") {
+        if !val.is_empty() && !val.to_lowercase().starts_with("max") {
             let columns = val.split(' ').collect::<Vec<&str>>();
             let val = columns[0].parse::<usize>().unwrap_or_default();
-            if val < 100000 {
-                1 // maybe the limit less than 1 core
+            log::info!("cpu.max: {}", val);
+            if val > 0 {
+                if val < 100000 {
+                    1 // maybe the limit less than 1 core
+                } else {
+                    val / 100000
+                }
             } else {
-                val / 100000
+                read_cpu_cgroup_v1()
             }
         } else {
-            0
-        }
-    } else if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") {
-        let columns = val.split(' ').collect::<Vec<&str>>();
-        let val = columns[0].parse::<usize>().unwrap_or_default();
-        if val < 100000 {
-            1 // maybe the limit less than 1 core
-        } else {
-            val / 100000
+            read_cpu_cgroup_v1()
         }
     } else {
-        0
+        read_cpu_cgroup_v1()
     };
 
     if cpu_num > 0 {
@@ -52,21 +49,45 @@ pub fn get_cpu_limit() -> usize {
 /// Get memory limit by cgroup or return the node memory size
 pub fn get_memory_limit() -> usize {
     let mem_size = if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
-        if !val.to_lowercase().starts_with("max") {
+        if !val.is_empty() && !val.to_lowercase().starts_with("max") {
+            log::info!("memory.max: {}", val);
             val.trim_end().parse::<usize>().unwrap_or_default()
         } else {
-            0
+            read_memory_cgroup_v1()
         }
-    } else if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
-        val.trim_end().parse::<usize>().unwrap_or_default() / 1048576
     } else {
-        0
+        read_memory_cgroup_v1()
     };
+
     if mem_size > 0 {
         mem_size
     } else {
         let mut system = sysinfo::System::new();
         system.refresh_memory();
         system.total_memory() as usize
+    }
+}
+
+fn read_cpu_cgroup_v1() -> usize {
+    if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") {
+        let columns = val.split(' ').collect::<Vec<&str>>();
+        let val = columns[0].parse::<usize>().unwrap_or_default();
+        log::info!("cpu.cfs_quota_us: {}", val);
+        if val > 0 && val < 100000 {
+            1 // maybe the limit less than 1 core
+        } else {
+            val / 100000
+        }
+    } else {
+        0
+    }
+}
+
+fn read_memory_cgroup_v1() -> usize {
+    if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
+        log::info!("memory.limit_in_bytes: {}", val);
+        val.trim_end().parse::<usize>().unwrap_or_default() / 1048576
+    } else {
+        0
     }
 }

--- a/src/common/utils/cgroup.rs
+++ b/src/common/utils/cgroup.rs
@@ -70,12 +70,12 @@ pub fn get_memory_limit() -> usize {
 
 fn read_cpu_cgroup_v1() -> usize {
     if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") {
-        let val = val.parse::<usize>().unwrap_or_default();
-        println!("cpu.cfs_quota_us: {}", val);
-        if val > 0 && val < 100000 {
+        let ret_val = val.trim().to_string().parse::<usize>().unwrap_or_default();
+        println!("cpu.cfs_quota_us: {}", ret_val);
+        if ret_val > 0 && ret_val < 100000 {
             1 // maybe the limit less than 1 core
         } else {
-            val / 100000
+            ret_val / 100000
         }
     } else {
         0

--- a/src/common/utils/cgroup.rs
+++ b/src/common/utils/cgroup.rs
@@ -28,9 +28,18 @@ pub fn get_cpu_limit() -> usize {
         } else {
             0
         }
+    } else if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") {
+        let columns = val.split(' ').collect::<Vec<&str>>();
+        let val = columns[0].parse::<usize>().unwrap_or_default();
+        if val < 100000 {
+            1 // maybe the limit less than 1 core
+        } else {
+            val / 100000
+        }
     } else {
         0
     };
+
     if cpu_num > 0 {
         cpu_num
     } else {
@@ -48,6 +57,8 @@ pub fn get_memory_limit() -> usize {
         } else {
             0
         }
+    } else if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
+        val.trim_end().parse::<usize>().unwrap_or_default() / 1048576
     } else {
         0
     };

--- a/src/common/utils/cgroup.rs
+++ b/src/common/utils/cgroup.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
-
 use sysinfo::SystemExt;
 
 /// Get cpu limit by cgroup or return the node cpu cores
@@ -71,22 +69,8 @@ pub fn get_memory_limit() -> usize {
 }
 
 fn read_cpu_cgroup_v1() -> usize {
-    if Path::new("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").is_file() {
-        println!("/sys/fs/cgroup/cpu/cpu.cfs_quota_us is a file!");
-    } else {
-        println!("/sys/fs/cgroup/cpu/cpu.cfs_quota_us is not a file or doesn't exist");
-    }
-
-    if Path::new("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us").is_file() {
-        println!("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us is a file!");
-    } else {
-        println!("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us is not a file or doesn't exist");
-    }
-
     if let Ok(val) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") {
-        println!("cpu.cfs_quota_us read: {}", val);
-        let columns = val.split(' ').collect::<Vec<&str>>();
-        let val = columns[0].parse::<usize>().unwrap_or_default();
+        let val = val.parse::<usize>().unwrap_or_default();
         println!("cpu.cfs_quota_us: {}", val);
         if val > 0 && val < 100000 {
             1 // maybe the limit less than 1 core


### PR DESCRIPTION
based on cgroup version limits are part of different files:

- v1 
  memory - /sys/fs/cgroup/memory/memory.limit_in_bytes
  cpu - sys/fs/cgroup/cpu/cpu.cfs_quota_us 

- v2
  memory - /sys/fs/cgroup/memory.max
 cpu - /sys/fs/cgroup/cpu.max