### PR TITLE
fix: function name with invalid chars issue

### DIFF
--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -554,11 +554,13 @@ impl Sql {
                     crate::common::utils::functions::get_all_transform_keys(&org_id).await
                 {
                     let str_re = format!(r"(?i){}[ ]*\(.*\)", fn_name);
-                    let re1 = Regex::new(&str_re).unwrap();
-                    let cap = re1.captures(&origin_sql);
-                    if cap.is_some() {
-                        for _ in 0..cap.unwrap().len() {
-                            used_fns.push(fn_name.clone());
+
+                    if let Ok(re1) = Regex::new(&str_re) {
+                        let cap = re1.captures(&origin_sql);
+                        if cap.is_some() {
+                            for _ in 0..cap.unwrap().len() {
+                                used_fns.push(fn_name.clone());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
When function with name like "{name}" is created (UI doesn't allow , however API allows creation) , any search results in failure with error:
[2023-10-16T04:56:03Z INFO  openobserve::service::search::sql] service:search:sql:new; org_id="default"
thread 'actix-server worker 0' panicked at 'called `Result::unwrap()` on an `Err` value: Syntax(
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
regex parse error:
    (?i){name}[ ]*\(.*\)
        ^
error: repetition operator missing expression
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

The PR handles these cases to ignore such functions.