### PR TITLE
feat: improve parquet writing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             file_ext: .tar.gz
           - arch: x86_64-pc-windows-msvc
             os: windows-2022-16-cores
-            features: ""
+            features: "--features mimalloc"
             file_name: openobserve-${{ github.ref_name }}-windows-amd64
             file_ext: .zip
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Run cargo build
         if: contains(matrix.file_name, '-simd') == false
-        run: cargo build ${{ matrix.features }} --profile release-prod --target ${{ matrix.arch }}rustc --print cfg
+        run: cargo build ${{ matrix.features }} --profile release-prod --target ${{ matrix.arch }}
 
       - name: Run cargo build
         if: contains(matrix.file_name, '-simd')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,9 +126,12 @@ jobs:
       - name: Output package versions
         run: protoc --version ; cargo version ; rustc --version ; gcc --version ; g++ --version
 
+      - name: Print rustc cfg
+        run: rustc --print cfg
+
       - name: Run cargo build
         if: contains(matrix.file_name, '-simd') == false
-        run: cargo build ${{ matrix.features }} --profile release-prod --target ${{ matrix.arch }}
+        run: cargo build ${{ matrix.features }} --profile release-prod --target ${{ matrix.arch }}rustc --print cfg
 
       - name: Run cargo build
         if: contains(matrix.file_name, '-simd')

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -233,8 +233,6 @@ pub struct Common {
     pub wal_memory_mode_enabled: bool,
     #[env_config(name = "ZO_WAL_LINE_MODE_ENABLED", default = true)]
     pub wal_line_mode_enabled: bool,
-    #[env_config(name = "ZO_PARQUET_COMPRESSION", default = "zstd")]
-    pub parquet_compression: String,
     #[env_config(name = "ZO_COLUMN_TIMESTAMP", default = "_timestamp")]
     pub column_timestamp: String,
     #[env_config(name = "ZO_WIDENING_SCHEMA_EVOLUTION", default = true)]
@@ -861,18 +859,6 @@ fn check_dynamo_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
 }
 
 #[inline]
-pub fn get_parquet_compression() -> parquet::basic::Compression {
-    match CONFIG.common.parquet_compression.to_lowercase().as_str() {
-        "snappy" => parquet::basic::Compression::SNAPPY,
-        "gzip" => parquet::basic::Compression::GZIP(Default::default()),
-        "brotli" => parquet::basic::Compression::BROTLI(Default::default()),
-        "lz4" => parquet::basic::Compression::LZ4_RAW,
-        "zstd" => parquet::basic::Compression::ZSTD(Default::default()),
-        _ => parquet::basic::Compression::ZSTD(Default::default()),
-    }
-}
-
-#[inline]
 pub fn is_local_disk_storage() -> bool {
     CONFIG.common.local_mode && CONFIG.common.local_mode_storage.eq("disk")
 }
@@ -902,12 +888,6 @@ mod tests {
         check_memory_cache_config(&mut cfg).unwrap();
         assert_eq!(cfg.memory_cache.max_size, 1024 * 1024 * 1024);
         assert_eq!(cfg.memory_cache.release_size, 1024 * 1024 * 1024);
-
-        cfg.common.parquet_compression = "zstd".to_string();
-        assert_eq!(
-            get_parquet_compression(),
-            parquet::basic::Compression::ZSTD(Default::default())
-        );
 
         cfg.limit.file_push_interval = 0;
         cfg.limit.req_cols_per_record_limit = 0;

--- a/src/service/search/datafusion/storage/memory.rs
+++ b/src/service/search/datafusion/storage/memory.rs
@@ -43,9 +43,9 @@ impl FS {
         path.into()
     }
 
-    async fn get_cache(&self, location: &Path) -> Option<Bytes> {
+    async fn get_cache(&self, location: &Path, range: Option<Range<usize>>) -> Option<Bytes> {
         let path = location.to_string();
-        let data = file_data::memory::get(&path).await;
+        let data = file_data::memory::get(&path, range).await;
         tokio::task::yield_now().await;
         data
     }
@@ -61,7 +61,7 @@ impl std::fmt::Display for FS {
 impl ObjectStore for FS {
     async fn get(&self, location: &Path) -> Result<GetResult> {
         let location = &self.format_location(location);
-        match self.get_cache(location).await {
+        match self.get_cache(location, None).await {
             Some(data) => {
                 let meta = ObjectMeta {
                     location: location.clone(),
@@ -90,7 +90,7 @@ impl ObjectStore for FS {
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let location = &self.format_location(location);
-        match self.get_cache(location).await {
+        match self.get_cache(location, None).await {
             Some(data) => {
                 let meta = ObjectMeta {
                     location: location.clone(),
@@ -131,15 +131,15 @@ impl ObjectStore for FS {
 
     async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
         let location = &self.format_location(location);
-        match self.get_cache(location).await {
+        match self.get_cache(location, Some(range.clone())).await {
             Some(data) => {
-                if range.end > data.len() {
-                    return Err(super::Error::OutOfRange(location.to_string()).into());
-                }
                 if range.start > range.end {
                     return Err(super::Error::BadRange(location.to_string()).into());
                 }
-                Ok(data.slice(range))
+                if range.end - range.start != data.len() {
+                    return Err(super::Error::BadRange(location.to_string()).into());
+                }
+                Ok(data)
             }
             None => match storage::LOCAL_CACHE
                 .get_range(location, range.clone())
@@ -152,18 +152,29 @@ impl ObjectStore for FS {
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
+        if ranges.is_empty() {
+            return Ok(vec![]);
+        }
         let location = &self.format_location(location);
-        match self.get_cache(location).await {
+        let merged_range = Range {
+            start: ranges[0].start,
+            end: ranges[ranges.len() - 1].end,
+        };
+        let merged_range_start = merged_range.start;
+        match self.get_cache(location, Some(merged_range)).await {
             Some(data) => ranges
                 .iter()
                 .map(|range| {
-                    if range.end > data.len() {
-                        return Err(super::Error::OutOfRange(location.to_string()).into());
-                    }
                     if range.start > range.end {
                         return Err(super::Error::BadRange(location.to_string()).into());
                     }
-                    Ok(data.slice(range.clone()))
+                    if range.end - merged_range_start > data.len() {
+                        return Err(super::Error::OutOfRange(location.to_string()).into());
+                    }
+                    Ok(data.slice(Range {
+                        start: range.start - merged_range_start,
+                        end: range.end - merged_range_start,
+                    }))
                 })
                 .collect(),
             None => match storage::LOCAL_CACHE.get_ranges(location, ranges).await {
@@ -175,7 +186,7 @@ impl ObjectStore for FS {
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         let location = &self.format_location(location);
-        match self.get_cache(location).await {
+        match self.get_cache(location, None).await {
             Some(data) => Ok(ObjectMeta {
                 location: location.clone(),
                 last_modified: *BASE_TIME,

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -285,7 +285,7 @@ impl Sql {
                         let pos_start = origin_sql.find(where_str.as_str()).unwrap();
                         let pos_end = pos_start + where_str.len();
                         origin_sql = format!(
-                            "{}{} AND {}{}",
+                            "{}{} AND ({}){}",
                             &origin_sql[0..pos_start],
                             time_range_sql,
                             where_str,


### PR DESCRIPTION
- [x] perf: add range get from memory cache
- [x] feat: improve parquet writing, use [Delta Encoding](https://parquet.apache.org/docs/file-format/data-pages/encodings/#a-namedeltaencadelta-encoding-delta_binary_packed--5) for `_timestamp` 
- [x] fix: https://github.com/openobserve/openobserve/issues/1657
- [x] ci: print rustc cfg