### PR TITLE
fix: #1647

### DIFF
--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -38,7 +38,7 @@ use crate::common::{
     utils::{flatten, json, str::find},
 };
 use crate::handler::grpc::cluster_rpc;
-use crate::service::{db, file_list, format_partition_key, format_stream_name, stream};
+use crate::service::{db, file_list, format_partition_key, stream};
 
 pub(crate) mod datafusion;
 pub(crate) mod grpc;
@@ -523,8 +523,6 @@ pub async fn match_source(
 
 fn filter_source_by_partition_key(source: &str, filters: &[(&str, &str)]) -> bool {
     !filters.iter().any(|(k, v)| {
-        let k = format_stream_name(k);
-        let v = format_stream_name(v);
         let field = format_partition_key(&format!("{k}="));
         let value = format_partition_key(&format!("{k}={v}"));
         find(source, &format!("/{field}")) && !find(source, &format!("/{value}/"))


### PR DESCRIPTION
fix #1647 It is because we changed the rule for `stream name` and the partition key filter was used the pattern. 

The partition key value like this `ab-cd` we replace the `-` to `_` in the stream name. but partition key wasn't so cause the problem.