### PR TITLE
feat: added vrl functions to otlp endpoints & syslogs

### DIFF
--- a/src/common/meta/functions.rs
+++ b/src/common/meta/functions.rs
@@ -130,6 +130,11 @@ pub struct VRLRuntimeConfig {
     pub fields: Vec<String>,
 }
 
+pub struct VRLResultResolver {
+    pub program: Program,
+    pub fields: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -23,7 +23,7 @@ use crate::common::{
     infra::{cluster, config::CONFIG, metrics},
     meta::{
         alert::{Alert, Trigger},
-        functions::{StreamTransform, VRLRuntimeConfig},
+        functions::{StreamTransform, VRLResultResolver},
         ingestion::{
             BulkResponse, BulkResponseError, BulkResponseItem, BulkStreamData, RecordStatus,
             StreamSchemaChk,
@@ -68,7 +68,7 @@ pub async fn ingest(
 
     let mut runtime = crate::service::ingestion::init_functions_runtime();
 
-    let mut stream_vrl_map: AHashMap<String, VRLRuntimeConfig> = AHashMap::new();
+    let mut stream_vrl_map: AHashMap<String, VRLResultResolver> = AHashMap::new();
     let mut stream_schema_map: AHashMap<String, Schema> = AHashMap::new();
     let mut stream_data_map = AHashMap::new();
 

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -24,7 +24,7 @@ use vrl::compiler::runtime::Runtime;
 
 use super::StreamMeta;
 use crate::common::infra::{config::CONFIG, metrics};
-use crate::common::meta::functions::{StreamTransform, VRLRuntimeConfig};
+use crate::common::meta::functions::{StreamTransform, VRLResultResolver};
 use crate::common::meta::ingestion::{
     AWSRecordType, GCPIngestionResponse, IngestionData, IngestionDataIter, IngestionError,
     IngestionRequest, KinesisFHData, KinesisFHIngestionResponse,
@@ -231,7 +231,7 @@ pub async fn ingest(
 fn apply_functions<'a>(
     item: &'a json::Value,
     local_trans: &Vec<StreamTransform>,
-    stream_vrl_map: &'a AHashMap<String, VRLRuntimeConfig>,
+    stream_vrl_map: &'a AHashMap<String, VRLResultResolver>,
     stream_name: &'a str,
     runtime: &mut Runtime,
 ) -> Result<json::Value, anyhow::Error> {

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -94,6 +94,7 @@ pub async fn metrics_json_handler(
     }
 
     let start = std::time::Instant::now();
+    let mut runtime = crate::service::ingestion::init_functions_runtime();
     let mut metric_data_map: AHashMap<String, AHashMap<String, Vec<String>>> = AHashMap::new();
     let mut metric_schema_map: AHashMap<String, Schema> = AHashMap::new();
     let mut stream_alerts_map: AHashMap<String, Vec<Alert>> = AHashMap::new();
@@ -193,6 +194,15 @@ pub async fn metrics_json_handler(
                     crate::service::ingestion::get_stream_alerts(key, &mut stream_alerts_map).await;
                     // End get stream alert
 
+                    // Start Register Transforms for stream
+                    let (local_trans, stream_vrl_map) =
+                        crate::service::ingestion::register_stream_transforms(
+                            org_id,
+                            StreamType::Metrics,
+                            metric_name,
+                        );
+                    // End Register Transforms for stream
+
                     let buf = metric_data_map.entry(metric_name.to_owned()).or_default();
                     let mut rec = json::json!({});
 
@@ -279,6 +289,18 @@ pub async fn metrics_json_handler(
                         // flattening
                         rec = flatten::flatten(&rec).expect("failed to flatten");
                         // get json object
+
+                        if !local_trans.is_empty() {
+                            rec = crate::service::ingestion::apply_stream_transform(
+                                &local_trans,
+                                &rec,
+                                &stream_vrl_map,
+                                metric_name,
+                                &mut runtime,
+                            )
+                            .unwrap_or(rec);
+                        }
+
                         let val_map: &mut serde_json::Map<String, serde_json::Value> =
                             rec.as_object_mut().unwrap();
 

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -49,6 +49,7 @@ use crate::common::{
     },
     meta::{
         common::{FileKey, FileMeta},
+        functions::VRLResultResolver,
         search::Session as SearchSession,
         sql, StreamType,
     },
@@ -1105,7 +1106,10 @@ fn apply_query_fn(
                 .filter_map(|hit| {
                     let ret_val = crate::service::ingestion::apply_vrl_fn(
                         &mut runtime,
-                        &program,
+                        &VRLResultResolver {
+                            program: program.program.clone(),
+                            fields: program.fields.clone(),
+                        },
                         &json::Value::Object(hit.clone()),
                     );
                     (!ret_val.is_null()).then_some(flatten::flatten(&ret_val).unwrap_or(ret_val))


### PR DESCRIPTION
We were not supporting vrl functions during data ingestion for otlp & syslog endpoints , added support for it.

- [x] OTLP - Logs
- [x] OTLP - Metrics
- [x] OTLP - Traces
- [x] Syslog