### PR TITLE
fix: reordering to put related charts together in add panel page

### DIFF
--- a/web/src/components/dashboards/addPanel/ChartSelection.vue
+++ b/web/src/components/dashboards/addPanel/ChartSelection.vue
@@ -73,6 +73,11 @@ export default defineComponent({
         id: "area-stacked",
       },
       {
+        image: "img:" + getImageURL("images/dashboard/charts/line-chart.png"),
+        title: "Line",
+        id: "line",
+      },
+      {
         image: "img:" + getImageURL("images/dashboard/charts/bar-chart.png"),
         title: "Bar",
         id: "bar",
@@ -101,11 +106,6 @@ export default defineComponent({
         image: "img:" + getImageURL("images/dashboard/charts/h-stacked.png"),
         title: "H-Stacked",
         id: "h-stacked",
-      },
-      {
-        image: "img:" + getImageURL("images/dashboard/charts/line-chart.png"),
-        title: "Line",
-        id: "line",
       },
       {
         image: "img:" + getImageURL("images/dashboard/charts/pie-chart.png"),


### PR DESCRIPTION
Reordering charts to show related charts together, like lines and area charts.

![image](https://github.com/openobserve/openobserve/assets/124270523/6d399c53-b23a-47ac-adc9-8cff53cc1e6d)
