### PR TITLE
fix: dashboard metric text, tooltip dark mode, table loading indicators

### DIFF
--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -92,8 +92,6 @@ export default defineComponent({
           panelData.value = convertPanelData(panelSchema.value, data.value, store);
           errorDetail.value = "";
         } catch (error: any) {
-          console.log("error", error);
-          
           errorDetail.value = error.message;
         }
       }

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -92,6 +92,8 @@ export default defineComponent({
           panelData.value = convertPanelData(panelSchema.value, data.value, store);
           errorDetail.value = "";
         } catch (error: any) {
+          console.log("error", error);
+          
           errorDetail.value = error.message;
         }
       }

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -34,9 +34,9 @@
     <div
       v-if="loading"
       class="row"
-      style="position: absolute; top: 0px; width: 100%"
+      style="position: absolute; top: 0px; width: 100%; z-index: 999;"
     >
-      <q-spinner-dots color="primary" size="40px" style="margin: 0 auto" />
+      <q-spinner-dots color="primary" size="40px" style="margin: 0 auto; z-index: 999;" />
     </div>
   </div>
 </template>

--- a/web/src/components/dashboards/panels/ChartRenderer.vue
+++ b/web/src/components/dashboards/panels/ChartRenderer.vue
@@ -96,6 +96,10 @@ export default defineComponent({
           chart?.dispose();  
           chart = echarts.init(chartRef.value, theme);
           const options = props.data.options || {}
+
+          // change color and background color of tooltip
+          options.tooltip && options.tooltip.textStyle && (options.tooltip.textStyle.color = theme === 'dark' ? '#fff' : '#000');
+          options.tooltip && (options.tooltip.backgroundColor = theme === 'dark' ? "rgba(0,0,0,1)" : "rgba(255,255,255,1)");
           options.animation = false
           chart?.setOption(options, true);
           chart?.setOption({animation: true});

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -62,7 +62,6 @@ export const convertPromQLData = (
       textStyle: {
         fontSize: 12,
       },
-      backgroundColor: "rgba(255,255,255,0.8)",
     },
     textStyle: {
       width: 150,
@@ -108,9 +107,11 @@ export const convertPromQLData = (
       show: true,
       trigger: "axis",
       textStyle: {
+        color: store.state.theme === "dark" ? "#fff" : "#000",
         fontSize: 12,
       },
       enterable: true,
+      backgroundColor: store.state.theme === "dark" ? "rgba(0,0,0,1)" : "rgba(255,255,255,1)",
       extraCssText: "max-height: 200px; overflow: auto;",
       formatter: function (name: any) {
         if (name.length == 0) return "";

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -107,7 +107,6 @@ export const convertSQLData = (
       textStyle: {
         fontSize: 12,
       },
-      backgroundColor: "rgba(255,255,255,0.8)",
     },
     textStyle: {
       width: 100,
@@ -160,9 +159,11 @@ export const convertSQLData = (
     tooltip: {
       trigger: "axis",
       textStyle: {
+        color: store.state.theme === "dark" ? "#fff" : "#000",
         fontSize: 12,
       },
       enterable: true,
+      backgroundColor: store.state.theme === "dark" ? "rgba(0,0,0,1)" : "rgba(255,255,255,1)",
       extraCssText: "max-height: 200px; overflow: auto;",
       axisPointer: {
         type: "cross",
@@ -551,8 +552,10 @@ export const convertSQLData = (
       options.tooltip = {
         trigger: "item",
         textStyle: {
+          color: store.state.theme === "dark" ? "#fff" : "#000",
           fontSize: 12,
         },
+        backgroundColor: store.state.theme === "dark" ? "rgba(0,0,0,1)" : "rgba(255,255,255,1)",
         formatter: function (name: any) {
           return `${name.marker} ${name.name} : <b>${formatUnitValue(
             getUnitValue(
@@ -588,8 +591,10 @@ export const convertSQLData = (
       options.tooltip = {
         trigger: "item",
         textStyle: {
+          color: store.state.theme === "dark" ? "#fff" : "#000",
           fontSize: 12,
         },
+        backgroundColor: store.state.theme === "dark" ? "rgba(0,0,0,1)" : "rgba(255,255,255,1)",
         formatter: function (name: any) {
           return `${name.marker} ${name.name} : <b>${formatUnitValue(
             getUnitValue(
@@ -744,8 +749,10 @@ export const convertSQLData = (
       (options.tooltip = {
         position: "top",
         textStyle: {
+        color: store.state.theme === "dark" ? "#fff" : "#000",
           fontSize: 12,
         },
+        backgroundColor: store.state.theme === "dark" ? "rgba(0,0,0,1)" : "rgba(255,255,255,1)",
         formatter: (params: any) => {
           // we have value[1] which return yaxis index
           // it is used to get y axis data

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -872,7 +872,13 @@ export const convertSQLData = (
   }
 
   // auto SQL: if x axis has time series
-  if(panelSchema.type != "h-bar"&& panelSchema.type != "h-stacked" && panelSchema.type != "heatmap" && panelSchema?.queries[0]?.customQuery == false){
+  if(panelSchema.type != "h-bar" &&
+    panelSchema.type != "h-stacked" &&
+    panelSchema.type != "heatmap" &&
+    panelSchema.type != "metric" &&
+    panelSchema.type != "pie" &&
+    panelSchema.type != "donut" &&
+    panelSchema?.queries[0]?.customQuery == false){
     // auto SQL: if x axis has time series(aggregation function is histogram)
     const field = panelSchema.queries[0].fields?.x.find(
       (it: any) =>
@@ -959,7 +965,10 @@ export const convertSQLData = (
   if (
     panelSchema.type != "h-bar" &&
     panelSchema.type != "h-stacked" &&
-    panelSchema.type != "heatmap" &&
+    panelSchema.type != "heatmap" && 
+    panelSchema.type != "metric" &&
+    panelSchema.type != "pie" &&
+    panelSchema.type != "donut" &&
     panelSchema?.queries[0]?.customQuery == true &&
     options.xAxis.length > 0 &&
     options.xAxis[0].data.length > 0
@@ -1049,11 +1058,14 @@ export const convertSQLData = (
   }
 
   //check if is there any data else filter out axis or series data
-  options.series = options.series.filter((it: any) => it.data?.length);
-  if(panelSchema.type == "h-bar" || panelSchema.type == "h-stacked"){
-    options.xAxis = options.series.length ? options.xAxis : {};
-  }else{
-    options.yAxis = options.series.length ? options.yAxis : {};
+  // for metric we does not have data field
+  if(panelSchema.type != "metric"){
+    options.series = options.series.filter((it: any) => it.data?.length);
+    if(panelSchema.type == "h-bar" || panelSchema.type == "h-stacked"){
+      options.xAxis = options.series.length ? options.xAxis : {};
+    }else{
+      options.yAxis = options.series.length ? options.yAxis : {};
+    }
   }
   
   

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -1049,7 +1049,7 @@ export const convertSQLData = (
   }
 
   //check if is there any data else filter out axis or series data
-  options.series = options.series.filter((it: any) => it.data.length);
+  options.series = options.series.filter((it: any) => it.data?.length);
   if(panelSchema.type == "h-bar" || panelSchema.type == "h-stacked"){
     options.xAxis = options.series.length ? options.xAxis : {};
   }else{

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -128,7 +128,6 @@ export default defineComponent({
         route.query.dashboard,
         route.query.folder ?? "default"
       )
-      currentDashboardData.data = data;
 
       // if variables data is null, set it to empty list
       if(!(currentDashboardData.data?.variables && currentDashboardData.data?.variables?.list.length)) {


### PR DESCRIPTION
- Fixed metric text throwing error / not visible
- Tooltip dark mode (#1693)
- Table loading dots are hidden behind the rendered table