### PR TITLE
fix: dashboard chart default horizontal zoom enabled

### DIFF
--- a/web/src/components/dashboards/panels/ChartRenderer.vue
+++ b/web/src/components/dashboards/panels/ChartRenderer.vue
@@ -106,6 +106,9 @@ export default defineComponent({
           chart?.on("mouseover", mouseHoverEffectFn);
           chart?.on("globalout", () => {mouseHoverEffectFn({})});
           chart?.on("legendselectchanged",legendSelectChangedFn);
+
+          // we need that toolbox datazoom button initally selected
+          chart.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
         });
 
         onMounted(async () => {
@@ -144,6 +147,9 @@ export default defineComponent({
                 emit("click", params);
             });
             window.addEventListener("resize", windowResizeEventCallback);
+
+            // we need that toolbox datazoom button initally selected
+            chart.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
         });
         onUnmounted(() => {
             window.removeEventListener("resize", windowResizeEventCallback);
@@ -152,12 +158,20 @@ export default defineComponent({
         //need to resize chart on activated
         onActivated(()=>{
             windowResizeEventCallback();
+
+            // we need that toolbox datazoom button initally selected
+            chart.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
         })
         
         watch(() => props.data.options, async () => {
             await nextTick();
             chart?.resize();
             chart?.setOption(props?.data?.options || {}, true);
+            // we need that toolbox datazoom button initally selected
+            // for that we required to dispatch an event
+            // while dispatching an event we need to pass a datazoomselectactive as true
+            // this action is available in the echarts docs in list of brush actions
+            chart.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
         }, { deep: true });
         return { chartRef };
     },

--- a/web/src/components/dashboards/panels/ChartRenderer.vue
+++ b/web/src/components/dashboards/panels/ChartRenderer.vue
@@ -108,7 +108,7 @@ export default defineComponent({
           chart?.on("legendselectchanged",legendSelectChangedFn);
 
           // we need that toolbox datazoom button initally selected
-          chart.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
+          chart?.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
         });
 
         onMounted(async () => {
@@ -149,7 +149,7 @@ export default defineComponent({
             window.addEventListener("resize", windowResizeEventCallback);
 
             // we need that toolbox datazoom button initally selected
-            chart.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
+            chart?.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
         });
         onUnmounted(() => {
             window.removeEventListener("resize", windowResizeEventCallback);
@@ -160,7 +160,7 @@ export default defineComponent({
             windowResizeEventCallback();
 
             // we need that toolbox datazoom button initally selected
-            chart.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
+            chart?.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
         })
         
         watch(() => props.data.options, async () => {
@@ -171,7 +171,7 @@ export default defineComponent({
             // for that we required to dispatch an event
             // while dispatching an event we need to pass a datazoomselectactive as true
             // this action is available in the echarts docs in list of brush actions
-            chart.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
+            chart?.dispatchAction({ type: 'takeGlobalCursor', key: 'dataZoomSelect', dataZoomSelectActive:true });
         }, { deep: true });
         return { chartRef };
     },

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -28,10 +28,7 @@ import {
 export const convertSQLData = (
   panelSchema: any,
   searchQueryData: any,
-  store: any,
-  params: any = {
-    timezone: "UTC",
-  }
+  store: any
 ) => {
   // if no data than return it
   if (

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -173,7 +173,7 @@ export default defineComponent({
       }
     };
 
-    const addSettingsData = () => {
+    const openSettingsDialog = () => {
       showDashboardSettingsDialog.value = true;
     };
 
@@ -311,6 +311,7 @@ export default defineComponent({
       variablesData,
       variablesDataUpdated,
       showDashboardSettingsDialog,
+      openSettingsDialog,
       loadDashboard,
       getQueryParamsForDuration,
     };


### PR DESCRIPTION
On dashboard panels, with echarts default horizontal zooming was not On. So enabled it so users can click and select horizontal area to zoom in.

This affects the logs page as well.