### PR TITLE
fix: use a const to represent the org-setting-key

### DIFF
--- a/src/handler/http/request/organization/settings.rs
+++ b/src/handler/http/request/organization/settings.rs
@@ -15,7 +15,7 @@
 use crate::common::meta::http::HttpResponse as MetaHttpResponse;
 use crate::common::meta::organization::OrganizationSettingResponse;
 use crate::common::utils::json;
-use crate::service::db::organization::get_org_setting;
+use crate::service::db::organization::{get_org_setting, ORG_SETTINGS_KEY_PREFIX};
 use crate::{
     common::meta::organization::OrganizationSetting, service::db::organization::set_org_setting,
 };
@@ -80,7 +80,10 @@ async fn get(path: web::Path<String>) -> Result<HttpResponse, Error> {
         Ok(s) => s,
         Err(e) => {
             let err = e.to_string();
-            let expected_err = format!("DbError# key /organization/{org_id} does not exist");
+            let expected_err = format!(
+                "DbError# key {}/{} does not exist",
+                ORG_SETTINGS_KEY_PREFIX, org_id
+            );
             if err.contains(&expected_err) {
                 let setting = OrganizationSetting::default();
                 if let Ok(()) = set_org_setting(&org_id, &setting).await {

--- a/src/service/db/organization.rs
+++ b/src/service/db/organization.rs
@@ -20,12 +20,15 @@ use crate::common::{
 use bytes::Bytes;
 use std::sync::Arc;
 
+// DBKey to set settings for an org
+pub const ORG_SETTINGS_KEY_PREFIX: &str = "/organization/setting";
+
 pub async fn set_org_setting(
     org_name: &str,
     setting: &OrganizationSetting,
 ) -> Result<(), anyhow::Error> {
     let db = &infra_db::DEFAULT;
-    let key = format!("/organization/setting/{}", org_name);
+    let key = format!("{}/{}", ORG_SETTINGS_KEY_PREFIX, org_name);
     db.put(
         &key,
         json::to_vec(&setting).unwrap().into(),
@@ -44,7 +47,7 @@ pub async fn set_org_setting(
 
 pub async fn get_org_setting(org_name: &str) -> Result<Bytes, anyhow::Error> {
     let db = &infra_db::DEFAULT;
-    let key = format!("/organization/setting/{}", org_name);
+    let key = format!("{}/{}", ORG_SETTINGS_KEY_PREFIX, org_name);
 
     match ORGANIZATION_SETTING.clone().read().await.get(&key) {
         Some(v) => Ok(json::to_vec(v).unwrap().into()),
@@ -54,7 +57,7 @@ pub async fn get_org_setting(org_name: &str) -> Result<Bytes, anyhow::Error> {
 
 /// Cache the existing org settings in the beginning
 pub async fn cache() -> Result<(), anyhow::Error> {
-    let prefix = "/organization/setting";
+    let prefix = ORG_SETTINGS_KEY_PREFIX;
     let ret = infra_db::DEFAULT.list(prefix).await?;
     for (key, item_value) in ret {
         let json_val: OrganizationSetting = json::from_slice(&item_value).unwrap();
@@ -69,7 +72,7 @@ pub async fn cache() -> Result<(), anyhow::Error> {
 }
 
 pub async fn watch() -> Result<(), anyhow::Error> {
-    let key = "/organization/setting";
+    let key = ORG_SETTINGS_KEY_PREFIX;
     let db = &infra_db::CLUSTER_COORDINATOR;
     let mut events = db.watch(key).await?;
     let events = Arc::get_mut(&mut events).unwrap();


### PR DESCRIPTION
A small fix to ensure that the prefix for organization setting is consistent everywhere, we use it.