### PR TITLE
feat: add new configure for control query queue

### DIFF
--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -259,6 +259,8 @@ pub struct Common {
     pub feature_fulltext_extra_fields: String,
     #[env_config(name = "ZO_FEATURE_FILELIST_DEDUP_ENABLED", default = false)]
     pub feature_filelist_dedup_enabled: bool,
+    #[env_config(name = "ZO_FEATURE_QUERY_QUEUE_ENABLED", default = true)]
+    pub feature_query_queue_enabled: bool,
     #[env_config(name = "ZO_UI_ENABLED", default = true)]
     pub ui_enabled: bool,
     #[env_config(name = "ZO_UI_SQL_BASE64_ENABLED", default = false)]
@@ -336,7 +338,7 @@ pub struct Limit {
     pub max_file_size_on_disk: u64,
     #[env_config(name = "ZO_MAX_FILE_RETENTION_TIME", default = 600)] // seconds
     pub max_file_retention_time: u64,
-    #[env_config(name = "ZO_FILE_PUSH_INTERVAL", default = 60)] // seconds
+    #[env_config(name = "ZO_FILE_PUSH_INTERVAL", default = 10)] // seconds
     pub file_push_interval: u64,
     #[env_config(name = "ZO_FILE_MOVE_THREAD_NUM", default = 0)]
     pub file_move_thread_num: usize,
@@ -462,7 +464,7 @@ pub struct Etcd {
     pub prefix: String,
     #[env_config(name = "ZO_ETCD_CONNECT_TIMEOUT", default = 5)]
     pub connect_timeout: u64,
-    #[env_config(name = "ZO_ETCD_COMMAND_TIMEOUT", default = 10)]
+    #[env_config(name = "ZO_ETCD_COMMAND_TIMEOUT", default = 5)]
     pub command_timeout: u64,
     #[env_config(name = "ZO_ETCD_LOCK_WAIT_TIMEOUT", default = 3600)]
     pub lock_wait_timeout: u64,

--- a/src/common/infra/dist_lock.rs
+++ b/src/common/infra/dist_lock.rs
@@ -17,7 +17,7 @@ use crate::common::infra::{config::CONFIG, db::etcd, errors::Result};
 /// lock key in etcd, wait_ttl is 0 means wait forever
 #[inline(always)]
 pub async fn lock(key: &str, wait_ttl: u64) -> Result<Option<etcd::Locker>> {
-    if CONFIG.common.local_mode {
+    if CONFIG.common.local_mode || !CONFIG.common.feature_query_queue_enabled {
         return Ok(None);
     }
     let mut lock = etcd::Locker::new(key);

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -137,7 +137,10 @@ pub async fn search(
 
     // get a local search queue lock
     let locker = SearchService::QUEUE_LOCKER.clone();
-    let _locker = locker.lock().await;
+    let locker = locker.lock().await;
+    if !CONFIG.common.feature_query_queue_enabled {
+        drop(locker);
+    }
     let took_wait = start.elapsed().as_millis() as usize;
 
     // do search


### PR DESCRIPTION
```
ZO_FEATURE_QUERY_QUEUE_ENABLED = true
```

You can disable the global query queue by setting it to `false`.

We still need a better solution for controlling the query queue.