### PR TITLE
fix: chart loading indicator does not go away if the value of the dependent variables is not present

### DIFF
--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -184,7 +184,7 @@ export const usePanelDataLoader = (
 
     isDirty.value = false;
     const controller = new AbortController();
-    state.loading = true;
+    // state.loading = true;
 
     if (isQueryDependentOnTheVariables() && !canRunQueryBasedOnVariables()) {
 


### PR DESCRIPTION
Chat shows loading even if the API call is not made with the chart waiting for the dependent variable's values. The below issue is fixed:

![image](https://github.com/openobserve/openobserve/assets/124270523/2385cf15-ce2f-41c0-93f3-6db1e62e7aa6)
