### PR TITLE
feat: implement distinct_values

### DIFF
--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -61,12 +61,13 @@ pub const FILE_EXT_JSON: &str = ".json";
 pub const FILE_EXT_PARQUET: &str = ".parquet";
 pub const COLUMN_TRACE_ID: &str = "trace_id";
 
-const SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 7] =
+const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 7] =
     ["log", "message", "msg", "content", "data", "events", "json"];
-
-pub static SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA: Lazy<Vec<String>> = Lazy::new(|| {
+pub static SQL_FULL_TEXT_SEARCH_FIELDS: Lazy<Vec<String>> = Lazy::new(|| {
     chain(
-        SQL_FULL_TEXT_SEARCH_FIELDS.iter().map(|s| s.to_string()),
+        _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS
+            .iter()
+            .map(|s| s.to_string()),
         CONFIG
             .common
             .feature_fulltext_extra_fields
@@ -83,10 +84,10 @@ pub static SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA: Lazy<Vec<String>> = Lazy::new(|| {
     .collect()
 });
 
-const DISTINCT_FIELDS: [&str; 2] = ["service_name", "operation_name"];
-pub static DISTINCT_FIELDS_EXTRA: Lazy<Vec<String>> = Lazy::new(|| {
+const _DEFAULT_DISTINCT_FIELDS: [&str; 2] = ["service_name", "operation_name"];
+pub static DISTINCT_FIELDS: Lazy<Vec<String>> = Lazy::new(|| {
     chain(
-        DISTINCT_FIELDS.iter().map(|s| s.to_string()),
+        _DEFAULT_DISTINCT_FIELDS.iter().map(|s| s.to_string()),
         CONFIG
             .common
             .feature_distinct_extra_fields

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -89,7 +89,7 @@ pub static DISTINCT_FIELDS_EXTRA: Lazy<Vec<String>> = Lazy::new(|| {
         DISTINCT_FIELDS.iter().map(|s| s.to_string()),
         CONFIG
             .common
-            .feature_distinct_fields
+            .feature_distinct_extra_fields
             .split(',')
             .filter_map(|s| {
                 let s = s.trim();
@@ -277,8 +277,8 @@ pub struct Common {
     pub feature_fulltext_on_all_fields: bool,
     #[env_config(name = "ZO_FEATURE_FULLTEXT_EXTRA_FIELDS", default = "")]
     pub feature_fulltext_extra_fields: String,
-    #[env_config(name = "ZO_FEATURE_DISTINCT_FIELDS", default = "")]
-    pub feature_distinct_fields: String,
+    #[env_config(name = "ZO_FEATURE_DISTINCT_EXTRA_FIELDS", default = "")]
+    pub feature_distinct_extra_fields: String,
     #[env_config(name = "ZO_FEATURE_FILELIST_DEDUP_ENABLED", default = false)]
     pub feature_filelist_dedup_enabled: bool,
     #[env_config(name = "ZO_FEATURE_QUERY_QUEUE_ENABLED", default = true)]

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -83,6 +83,26 @@ pub static SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA: Lazy<Vec<String>> = Lazy::new(|| {
     .collect()
 });
 
+const DISTINCT_FIELDS: [&str; 2] = ["service_name", "operation_name"];
+pub static DISTINCT_FIELDS_EXTRA: Lazy<Vec<String>> = Lazy::new(|| {
+    chain(
+        DISTINCT_FIELDS.iter().map(|s| s.to_string()),
+        CONFIG
+            .common
+            .feature_distinct_fields
+            .split(',')
+            .filter_map(|s| {
+                let s = s.trim();
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s.to_string())
+                }
+            }),
+    )
+    .collect()
+});
+
 pub static CONFIG: Lazy<Config> = Lazy::new(init);
 pub static INSTANCE_ID: Lazy<RwHashMap<String, String>> = Lazy::new(Default::default);
 
@@ -257,6 +277,8 @@ pub struct Common {
     pub feature_fulltext_on_all_fields: bool,
     #[env_config(name = "ZO_FEATURE_FULLTEXT_EXTRA_FIELDS", default = "")]
     pub feature_fulltext_extra_fields: String,
+    #[env_config(name = "ZO_FEATURE_DISTINCT_FIELDS", default = "")]
+    pub feature_distinct_fields: String,
     #[env_config(name = "ZO_FEATURE_FILELIST_DEDUP_ENABLED", default = false)]
     pub feature_filelist_dedup_enabled: bool,
     #[env_config(name = "ZO_FEATURE_QUERY_QUEUE_ENABLED", default = true)]

--- a/src/common/infra/errors.rs
+++ b/src/common/infra/errors.rs
@@ -52,6 +52,8 @@ pub enum Error {
     Unknown,
 }
 
+unsafe impl Send for Error {}
+
 #[derive(ThisError, Debug)]
 pub enum DbError {
     #[error("key {0} does not exist")]

--- a/src/common/meta/mod.rs
+++ b/src/common/meta/mod.rs
@@ -47,6 +47,7 @@ pub enum StreamType {
     EnrichmentTables,
     #[serde(rename = "file_list")]
     Filelist,
+    Metadata,
 }
 
 impl From<&str> for StreamType {
@@ -57,6 +58,7 @@ impl From<&str> for StreamType {
             "traces" => StreamType::Traces,
             "enrichment_tables" => StreamType::EnrichmentTables,
             "file_list" => StreamType::Filelist,
+            "metadata" => StreamType::Metadata,
             _ => StreamType::Logs,
         }
     }
@@ -70,6 +72,7 @@ impl std::fmt::Display for StreamType {
             StreamType::Traces => write!(f, "traces"),
             StreamType::EnrichmentTables => write!(f, "enrichment_tables"),
             StreamType::Filelist => write!(f, "file_list"),
+            StreamType::Metadata => write!(f, "metadata"),
         }
     }
 }

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -19,7 +19,7 @@ use chrono::Duration;
 use std::collections::HashMap;
 use std::io::Error;
 
-use crate::common::infra::config::CONFIG;
+use crate::common::infra::config::{CONFIG, DISTINCT_FIELDS_EXTRA};
 use crate::common::infra::{errors, metrics};
 use crate::common::meta::http::HttpResponse as MetaHttpResponse;
 use crate::common::meta::usage::{RequestStats, UsageType};
@@ -521,8 +521,6 @@ pub async fn values(
     path: web::Path<(String, String)>,
     in_req: HttpRequest,
 ) -> Result<HttpResponse, Error> {
-    let start = std::time::Instant::now();
-    let mut uses_fn = false;
     let (org_id, stream_name) = path.into_inner();
     let query = web::Query::<AHashMap<String, String>>::from_query(in_req.query_string()).unwrap();
     let stream_type = match get_stream_type_from_request(&query) {
@@ -530,6 +528,53 @@ pub async fn values(
         Err(e) => return Ok(meta::http::HttpResponse::bad_request(e)),
     };
 
+    let fields = match query.get("fields") {
+        Some(v) => v.split(',').map(|s| s.to_string()).collect::<Vec<_>>(),
+        None => return Ok(MetaHttpResponse::bad_request("fields is empty")),
+    };
+
+    let query_context = match query.get("sql") {
+        None => "".to_string(),
+        Some(v) => base64::decode(v).unwrap_or("".to_string()),
+    };
+
+    if fields.len() == 1
+        && DISTINCT_FIELDS_EXTRA.contains(&fields[0])
+        && !query_context.to_lowercase().contains(" WHERE ")
+    {
+        if let Some(v) = query.get("filter") {
+            if !v.is_empty() {
+                let column = v.splitn(2, '=').collect::<Vec<_>>();
+                if DISTINCT_FIELDS_EXTRA.contains(&column[0].to_string()) {
+                    // has filter and the filter can be used to distinct_values
+                    return values_v2(
+                        &org_id,
+                        stream_type,
+                        &stream_name,
+                        &fields[0],
+                        Some((column[0], column[1])),
+                        &query,
+                    )
+                    .await;
+                }
+            }
+        } else {
+            // no filter
+            return values_v2(&org_id, stream_type, &stream_name, &fields[0], None, &query).await;
+        }
+    }
+    values_v1(&org_id, stream_type, &stream_name, &query).await
+}
+
+/// search in original data
+async fn values_v1(
+    org_id: &str,
+    stream_type: StreamType,
+    stream_name: &str,
+    query: &web::Query<AHashMap<String, String>>,
+) -> Result<HttpResponse, Error> {
+    let start = std::time::Instant::now();
+    let mut uses_fn = false;
     let fields = match query.get("fields") {
         Some(v) => v.split(',').map(|s| s.to_string()).collect::<Vec<_>>(),
         None => return Ok(MetaHttpResponse::bad_request("fields is empty")),
@@ -558,7 +603,7 @@ pub async fn values(
         Some(v) => match base64::decode(v) {
             Err(_) => None,
             Ok(v) => {
-                uses_fn = functions::get_all_transform_keys(&org_id)
+                uses_fn = functions::get_all_transform_keys(org_id)
                     .await
                     .iter()
                     .any(|fn_name| v.contains(&format!("{}(", fn_name)));
@@ -624,25 +669,25 @@ pub async fn values(
                 ),
             );
     }
-    let resp_search = match SearchService::search(&org_id, stream_type, &req).await {
+    let resp_search = match SearchService::search(org_id, stream_type, &req).await {
         Ok(res) => res,
         Err(err) => {
             let time = start.elapsed().as_secs_f64();
             metrics::HTTP_RESPONSE_TIME
                 .with_label_values(&[
-                    "/api/org/_values",
+                    "/api/org/_values/v1",
                     "500",
-                    &org_id,
-                    &stream_name,
+                    org_id,
+                    stream_name,
                     stream_type.to_string().as_str(),
                 ])
                 .observe(time);
             metrics::HTTP_INCOMING_REQUESTS
                 .with_label_values(&[
-                    "/api/org/_values",
+                    "/api/org/_values/v1",
                     "500",
-                    &org_id,
-                    &stream_name,
+                    org_id,
+                    stream_name,
                     stream_type.to_string().as_str(),
                 ])
                 .inc();
@@ -660,10 +705,10 @@ pub async fn values(
 
     let mut resp = meta::search::Response::default();
     let mut hit_values: Vec<json::Value> = Vec::new();
-    for (key, values) in resp_search.aggs {
+    for (key, val) in resp_search.aggs {
         let mut field_value: json::Map<String, json::Value> = json::Map::new();
         field_value.insert("field".to_string(), json::Value::String(key));
-        field_value.insert("values".to_string(), json::Value::Array(values));
+        field_value.insert("values".to_string(), json::Value::Array(val));
         hit_values.push(json::Value::Object(field_value));
     }
     resp.total = fields.len();
@@ -675,19 +720,19 @@ pub async fn values(
     let time = start.elapsed().as_secs_f64();
     metrics::HTTP_RESPONSE_TIME
         .with_label_values(&[
-            "/api/org/_values",
+            "/api/org/_values/v1",
             "200",
-            &org_id,
-            &stream_name,
+            org_id,
+            stream_name,
             stream_type.to_string().as_str(),
         ])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
         .with_label_values(&[
-            "/api/org/_values",
+            "/api/org/_values/v1",
             "200",
-            &org_id,
-            &stream_name,
+            org_id,
+            stream_name,
             stream_type.to_string().as_str(),
         ])
         .inc();
@@ -702,8 +747,154 @@ pub async fn values(
     let num_fn = req.query.query_fn.is_some() as u16;
     report_request_usage_stats(
         req_stats,
-        &org_id,
-        &stream_name,
+        org_id,
+        stream_name,
+        StreamType::Logs,
+        UsageType::SearchTopNValues,
+        num_fn,
+    )
+    .await;
+
+    Ok(HttpResponse::Ok().json(resp))
+}
+
+/// search in distinct data
+async fn values_v2(
+    org_id: &str,
+    stream_type: StreamType,
+    stream_name: &str,
+    field: &str,
+    filter: Option<(&str, &str)>,
+    query: &web::Query<AHashMap<String, String>>,
+) -> Result<HttpResponse, Error> {
+    let start = std::time::Instant::now();
+    let mut query_sql =  format!("SELECT field_value AS zo_sql_key, SUM(count) as zo_sql_num FROM distinct_values WHERE stream_type='{}' AND stream_name='{}' AND field_name='{}'", stream_type,stream_name,field);
+    if let Some((key, val)) = filter {
+        query_sql = format!(
+            "{} AND filter_name ='{}' AND filter_value='{}'",
+            query_sql, key, val
+        );
+    }
+
+    let size = query
+        .get("size")
+        .map_or(10, |v| v.parse::<usize>().unwrap_or(0));
+    let start_time = query
+        .get("start_time")
+        .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
+    if start_time == 0 {
+        return Ok(MetaHttpResponse::bad_request("start_time is empty"));
+    }
+    let mut end_time = query
+        .get("end_time")
+        .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
+    if end_time == 0 {
+        end_time = chrono::Utc::now().timestamp_micros();
+    }
+
+    let timeout = query
+        .get("timeout")
+        .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
+
+    // search
+    let req = meta::search::Request {
+        query: meta::search::Query {
+            sql: format!("{query_sql} GROUP BY zo_sql_key ORDER BY zo_sql_num DESC LIMIT {size}"),
+            from: 0,
+            size: 0,
+            start_time,
+            end_time,
+            sort_by: None,
+            sql_mode: "full".to_string(),
+            query_type: "".to_string(),
+            track_total_hits: false,
+            query_context: None,
+            uses_zo_fn: false,
+            query_fn: None,
+        },
+        aggs: HashMap::new(),
+        encoding: meta::search::RequestEncoding::Empty,
+        timeout,
+    };
+    let resp_search = match SearchService::search(org_id, StreamType::Metadata, &req).await {
+        Ok(res) => res,
+        Err(err) => {
+            let time = start.elapsed().as_secs_f64();
+            metrics::HTTP_RESPONSE_TIME
+                .with_label_values(&[
+                    "/api/org/_values/v2",
+                    "500",
+                    org_id,
+                    stream_name,
+                    stream_type.to_string().as_str(),
+                ])
+                .observe(time);
+            metrics::HTTP_INCOMING_REQUESTS
+                .with_label_values(&[
+                    "/api/org/_values/v2",
+                    "500",
+                    org_id,
+                    stream_name,
+                    stream_type.to_string().as_str(),
+                ])
+                .inc();
+            log::error!("search values error: {:?}", err);
+            return Ok(match err {
+                errors::Error::ErrorCode(code) => HttpResponse::InternalServerError()
+                    .json(meta::http::HttpResponse::error_code(code)),
+                _ => HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
+                    StatusCode::INTERNAL_SERVER_ERROR.into(),
+                    err.to_string(),
+                )),
+            });
+        }
+    };
+
+    let mut resp = meta::search::Response::default();
+    let mut hit_values: Vec<json::Value> = Vec::new();
+    let mut field_value: json::Map<String, json::Value> = json::Map::new();
+    field_value.insert("field".to_string(), json::Value::String(field.to_string()));
+    field_value.insert("values".to_string(), json::Value::Array(resp_search.hits));
+    hit_values.push(json::Value::Object(field_value));
+
+    resp.total = 1;
+    resp.hits = hit_values;
+    resp.size = size;
+    resp.scan_size = resp_search.scan_size;
+    resp.took = start.elapsed().as_millis() as usize;
+
+    let time = start.elapsed().as_secs_f64();
+    metrics::HTTP_RESPONSE_TIME
+        .with_label_values(&[
+            "/api/org/_values/v2",
+            "200",
+            org_id,
+            stream_name,
+            stream_type.to_string().as_str(),
+        ])
+        .observe(time);
+    metrics::HTTP_INCOMING_REQUESTS
+        .with_label_values(&[
+            "/api/org/_values/v2",
+            "200",
+            org_id,
+            stream_name,
+            stream_type.to_string().as_str(),
+        ])
+        .inc();
+
+    let req_stats = RequestStats {
+        records: resp.hits.len() as i64,
+        response_time: time,
+        size: resp.scan_size as f64,
+        request_body: Some(req.query.sql),
+        ..Default::default()
+    };
+    let num_fn = req.query.query_fn.is_some() as u16;
+    report_request_usage_stats(
+        req_stats,
+        org_id,
+        stream_name,
         StreamType::Logs,
         UsageType::SearchTopNValues,
         num_fn,

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -540,7 +540,7 @@ pub async fn values(
 
     if fields.len() == 1
         && DISTINCT_FIELDS_EXTRA.contains(&fields[0])
-        && !query_context.to_lowercase().contains(" WHERE ")
+        && !query_context.to_lowercase().contains(" where ")
     {
         if let Some(v) = query.get("filter") {
             if !v.is_empty() {

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -12,24 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use actix_web::http::StatusCode;
-use actix_web::{get, post, web, HttpRequest, HttpResponse};
+use actix_web::{get, http::StatusCode, post, web, HttpRequest, HttpResponse};
 use ahash::AHashMap;
 use chrono::Duration;
-use std::collections::HashMap;
-use std::io::Error;
+use std::{collections::HashMap, io::Error};
 
-use crate::common::infra::config::{CONFIG, DISTINCT_FIELDS_EXTRA};
-use crate::common::infra::{errors, metrics};
-use crate::common::meta::http::HttpResponse as MetaHttpResponse;
-use crate::common::meta::usage::{RequestStats, UsageType};
-use crate::common::meta::{self, StreamType};
-use crate::common::utils::base64;
-use crate::common::utils::functions;
-use crate::common::utils::http::get_stream_type_from_request;
-use crate::common::utils::json;
-use crate::service::search as SearchService;
-use crate::service::usage::report_request_usage_stats;
+use crate::common::{
+    infra::{
+        config::{CONFIG, DISTINCT_FIELDS},
+        errors, metrics,
+    },
+    meta::{
+        self,
+        http::HttpResponse as MetaHttpResponse,
+        usage::{RequestStats, UsageType},
+        StreamType,
+    },
+    utils::{base64, functions, http::get_stream_type_from_request, json},
+};
+use crate::service::{search as SearchService, usage::report_request_usage_stats};
 
 /** SearchStreamData*/
 #[utoipa::path(
@@ -539,13 +540,13 @@ pub async fn values(
     };
 
     if fields.len() == 1
-        && DISTINCT_FIELDS_EXTRA.contains(&fields[0])
+        && DISTINCT_FIELDS.contains(&fields[0])
         && !query_context.to_lowercase().contains(" where ")
     {
         if let Some(v) = query.get("filter") {
             if !v.is_empty() {
                 let column = v.splitn(2, '=').collect::<Vec<_>>();
-                if DISTINCT_FIELDS_EXTRA.contains(&column[0].to_string()) {
+                if DISTINCT_FIELDS.contains(&column[0].to_string()) {
                     // has filter and the filter can be used to distinct_values
                     return values_v2(
                         &org_id,

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -72,7 +72,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         build_date: BUILD_DATE.to_string(),
         functions_enabled: HAS_FUNCTIONS,
         telemetry_enabled: CONFIG.common.telemetry_enabled,
-        default_fts_keys: SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA
+        default_fts_keys: SQL_FULL_TEXT_SEARCH_FIELDS
             .iter()
             .map(|s| s.to_string())
             .collect(),

--- a/src/job/files/disk.rs
+++ b/src/job/files/disk.rs
@@ -77,7 +77,7 @@ pub async fn move_files_to_storage() -> Result<(), anyhow::Error> {
         let columns = file_path.splitn(5, '/').collect::<Vec<&str>>();
 
         // eg: files/default/logs/olympics/0/2023/08/21/08/8b8a5451bbe1c44b/7099303408192061440f3XQ2p.json
-        // eg: files/default/traces/default/0/2023/09/04/05/default/service_name=ingestter/7104328279989026816guOA4t.json
+        // eg: files/default/traces/default/0/2023/09/04/05/default/service_name=ingester/7104328279989026816guOA4t.json
         // let _ = columns[0].to_string(); // files/
         let org_id = columns[1].to_string();
         let stream_type: StreamType = StreamType::from(columns[2]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ use openobserve::{
         http::router::*,
     },
     job,
-    service::{compact, db, file_list, router, users},
+    service::{compact, db, distinct_values, file_list, router, users},
 };
 
 #[cfg(feature = "profiling")]
@@ -269,6 +269,10 @@ async fn main() -> Result<(), anyhow::Error> {
     // flush db
     if let Err(e) = infra::db::DEFAULT.close().await {
         log::error!("waiting for db close failed, error: {}", e);
+    }
+    // flush distinct values
+    if let Err(e) = distinct_values::close().await {
+        log::error!("waiting for distinct_values close failed, error: {}", e);
     }
 
     log::info!("server stopped");

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,21 +259,15 @@ async fn main() -> Result<(), anyhow::Error> {
         .event("OpenObserve - Server stopped", None, false)
         .await;
     // leave the cluster
-    let _ = cluster::leave().await;
+    _ = cluster::leave().await;
     // flush WAL cache to disk
     infra::wal::flush_all_to_disk().await;
     // flush compact offset cache to disk disk
-    if let Err(e) = db::compact::files::sync_cache_to_db().await {
-        log::error!("sync compact offset cache to db failed, error: {}", e);
-    }
+    _ = db::compact::files::sync_cache_to_db().await;
     // flush db
-    if let Err(e) = infra::db::DEFAULT.close().await {
-        log::error!("waiting for db close failed, error: {}", e);
-    }
+    _ = infra::db::DEFAULT.close().await;
     // flush distinct values
-    if let Err(e) = distinct_values::close().await {
-        log::error!("waiting for distinct_values close failed, error: {}", e);
-    }
+    _ = distinct_values::close().await;
 
     log::info!("server stopped");
 

--- a/src/service/distinct_values.rs
+++ b/src/service/distinct_values.rs
@@ -1,0 +1,228 @@
+// Copyright 2023 Zinc Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ahash::AHashMap;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use tokio::{
+    sync::{mpsc, RwLock},
+    time,
+};
+
+use crate::common::{
+    infra::{
+        config::{FxIndexMap, CONFIG},
+        errors::{Error, Result},
+    },
+    meta::{stream::StreamParams, StreamType},
+    utils::json,
+};
+use crate::service::{ingestion, stream::unwrap_partition_time_level};
+
+const CHANNEL_SIZE: usize = 10240;
+const STREAM_NAME: &str = "distinct_values";
+
+static CHANNEL: Lazy<DistinctValues> = Lazy::new(DistinctValues::new);
+
+type MemTable = FxIndexMap<String, FxIndexMap<DvItem, u32>>;
+
+pub struct DistinctValues {
+    channel: Arc<mpsc::Sender<DvEvent>>,
+    shutdown: Arc<AtomicBool>,
+    mem_table: Arc<RwLock<MemTable>>,
+}
+
+#[derive(Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DvItem {
+    pub stream_type: StreamType,
+    pub stream_name: String,
+    pub field_name: String,
+    pub field_value: String,
+    pub filter_name: String,
+    pub filter_value: String,
+}
+
+#[derive(Debug)]
+enum DvEventType {
+    Add,
+    Shutudown,
+}
+
+#[derive(Debug)]
+struct DvEvent {
+    org_id: String,
+    item: DvItem,
+    count: u32,
+    ev_type: DvEventType,
+}
+
+impl DvEvent {
+    pub fn new(org_id: &str, item: DvItem, count: u32) -> Self {
+        Self {
+            org_id: org_id.to_string(),
+            item,
+            count,
+            ev_type: DvEventType::Add,
+        }
+    }
+    pub fn shutdown() -> Self {
+        Self {
+            org_id: String::from(""),
+            item: DvItem::default(),
+            count: 0,
+            ev_type: DvEventType::Shutudown,
+        }
+    }
+}
+
+impl Default for DistinctValues {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DistinctValues {
+    pub fn new() -> Self {
+        tokio::task::spawn(async move { run_flush().await });
+        Self {
+            channel: handle_channel(),
+            shutdown: Arc::new(AtomicBool::new(false)),
+            mem_table: Arc::new(RwLock::new(FxIndexMap::default())),
+        }
+    }
+
+    async fn write(&self, org_id: &str, data: Vec<DvItem>) -> Result<()> {
+        let mut group_items: FxIndexMap<DvItem, u32> = FxIndexMap::default();
+        for item in data {
+            let count = group_items.entry(item).or_insert(0);
+            *count += 1;
+        }
+        for (item, count) in group_items {
+            self.channel
+                .send(DvEvent::new(org_id, item, count))
+                .await
+                .map_err(|v| Error::Message(v.to_string()))?;
+        }
+        Ok(())
+    }
+
+    async fn flush(&self) -> Result<()> {
+        let mut mem_table = self.mem_table.write().await;
+        let mut new_table: MemTable = FxIndexMap::default();
+        std::mem::swap(&mut new_table, &mut *mem_table);
+        drop(mem_table);
+
+        // write to wal
+        let timestamp = chrono::Utc::now().timestamp_micros();
+        let mut stream_file_name = "".to_string();
+        for (org, items) in new_table {
+            if items.is_empty() {
+                continue;
+            }
+            let stream_params = StreamParams {
+                org_id: org.into(),
+                stream_name: STREAM_NAME.into(),
+                stream_type: StreamType::Metadata,
+            };
+            let mut buf: AHashMap<String, Vec<String>> = AHashMap::new();
+            for (item, count) in items {
+                let mut data = json::to_value(item).unwrap();
+                let data = data.as_object_mut().unwrap();
+                data.insert("count".to_string(), json::Value::Number(count.into()));
+                data.insert(
+                    CONFIG.common.column_timestamp.clone(),
+                    json::Value::Number(timestamp.into()),
+                );
+                let hour_key = ingestion::get_wal_time_key(
+                    timestamp,
+                    &vec![],
+                    unwrap_partition_time_level(None, StreamType::Logs),
+                    data,
+                    None,
+                );
+                let line_str = json::to_string(&data).unwrap();
+                let hour_buf = buf.entry(hour_key).or_default();
+                hour_buf.push(line_str);
+            }
+            _ = ingestion::write_file(&buf, 0, &stream_params, &mut stream_file_name, None).await;
+        }
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        let tx = CHANNEL.channel.clone();
+        tx.send(DvEvent::shutdown())
+            .await
+            .map_err(|e| Error::Message(e.to_string()))?;
+        loop {
+            if self.shutdown.load(Ordering::Relaxed) {
+                break;
+            }
+            time::sleep(time::Duration::from_secs(1)).await;
+        }
+        Ok(())
+    }
+}
+
+fn handle_channel() -> Arc<mpsc::Sender<DvEvent>> {
+    let (tx, mut rx) = mpsc::channel::<DvEvent>(CHANNEL_SIZE);
+    tokio::task::spawn(async move {
+        loop {
+            let event = match rx.recv().await {
+                Some(v) => v,
+                None => {
+                    log::info!("[distinct_values] event channel closed");
+                    break;
+                }
+            };
+            if let DvEventType::Shutudown = event.ev_type {
+                if let Err(e) = CHANNEL.flush().await {
+                    log::error!("flush error: {}", e);
+                }
+                CHANNEL.shutdown.store(true, Ordering::Relaxed);
+                break;
+            }
+            let mut mem_table = CHANNEL.mem_table.write().await;
+            let entry = mem_table.entry(event.org_id).or_default();
+            let field_entry = entry.entry(event.item).or_insert(0);
+            *field_entry += event.count;
+        }
+        log::info!("[distinct_values] event loop exit");
+    });
+    Arc::new(tx)
+}
+
+async fn run_flush() {
+    let mut interval = time::interval(time::Duration::from_secs(10));
+    interval.tick().await; // trigger the first run
+    loop {
+        interval.tick().await;
+        if let Err(e) = CHANNEL.flush().await {
+            log::error!("[distinct_values] errot flush data to wal: {}", e);
+        }
+    }
+}
+
+pub async fn write(org_id: &str, data: Vec<DvItem>) -> Result<()> {
+    CHANNEL.write(org_id, data).await
+}
+
+pub async fn close() -> Result<()> {
+    CHANNEL.stop().await?;
+    Ok(())
+}

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -345,6 +345,13 @@ pub async fn ingest(
         super::evaluate_trigger(Some(entry.clone()), &stream_alerts_map).await;
     }
 
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
+
     metrics::HTTP_RESPONSE_TIME
         .with_label_values(&[
             "/api/org/ingest/logs/_bulk",

--- a/src/service/logs/gcs_pub_sub.rs
+++ b/src/service/logs/gcs_pub_sub.rs
@@ -188,6 +188,13 @@ pub async fn process(
     // only one trigger per request, as it updates etcd
     super::evaluate_trigger(trigger, &stream_alerts_map).await;
 
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
+
     metrics::HTTP_RESPONSE_TIME
         .with_label_values(&[
             "/api/org/ingest/logs/_gcs",

--- a/src/service/logs/gcs_pub_sub.rs
+++ b/src/service/logs/gcs_pub_sub.rs
@@ -4,7 +4,11 @@ use datafusion::arrow::datatypes::Schema;
 
 use super::{ingest::decode_and_decompress, StreamMeta};
 use crate::common::{
-    infra::{cluster, config::CONFIG, metrics},
+    infra::{
+        cluster,
+        config::{CONFIG, DISTINCT_FIELDS},
+        metrics,
+    },
     meta::{
         alert::{Alert, Trigger},
         ingestion::{GCPIngestionRequest, GCPIngestionResponse, RecordStatus, StreamStatus},
@@ -15,7 +19,8 @@ use crate::common::{
     utils::{flatten, json, time::parse_timestamp_micro_from_value},
 };
 use crate::service::{
-    db, get_formatted_stream_name, ingestion::write_file, usage::report_request_usage_stats,
+    db, distinct_values, get_formatted_stream_name, ingestion::write_file,
+    usage::report_request_usage_stats,
 };
 
 pub async fn process(
@@ -27,6 +32,7 @@ pub async fn process(
     let start = std::time::Instant::now();
 
     let mut stream_schema_map: AHashMap<String, Schema> = AHashMap::new();
+    let mut distinct_values = Vec::with_capacity(16);
     let mut stream_params = StreamParams::new(org_id, in_stream_name, StreamType::Logs);
     let stream_name = &get_formatted_stream_name(&mut stream_params, &mut stream_schema_map).await;
     //stream_params.stream_name = stream_name.to_string().into();
@@ -140,6 +146,22 @@ pub async fn process(
 
             if local_trigger.is_some() {
                 trigger = Some(local_trigger.unwrap());
+            }
+
+            // get distinct_value item
+            for field in DISTINCT_FIELDS.iter() {
+                if let Some(val) = local_val.get(field) {
+                    if !val.is_null() {
+                        distinct_values.push(distinct_values::DvItem {
+                            stream_type: StreamType::Logs,
+                            stream_name: stream_name.to_string(),
+                            field_name: field.to_string(),
+                            field_value: val.as_str().unwrap().to_string(),
+                            filter_name: "".to_string(),
+                            filter_value: "".to_string(),
+                        });
+                    }
+                }
             }
         }
         Err(err) => {

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -24,7 +24,7 @@ use vrl::compiler::runtime::Runtime;
 use super::StreamMeta;
 use crate::common::{
     infra::{
-        config::{CONFIG, DISTINCT_FIELDS_EXTRA},
+        config::{CONFIG, DISTINCT_FIELDS},
         metrics,
     },
     meta::{
@@ -156,7 +156,7 @@ pub async fn ingest(
                         .await;
 
                         // get distinct_value item
-                        for field in DISTINCT_FIELDS_EXTRA.iter() {
+                        for field in DISTINCT_FIELDS.iter() {
                             if let Some(val) = local_val.get(field) {
                                 if !val.is_null() {
                                     distinct_values.push(distinct_values::DvItem {

--- a/src/service/logs/json.rs
+++ b/src/service/logs/json.rs
@@ -20,7 +20,7 @@ use datafusion::arrow::datatypes::Schema;
 use super::StreamMeta;
 use crate::common::{
     infra::{
-        config::{CONFIG, DISTINCT_FIELDS_EXTRA},
+        config::{CONFIG, DISTINCT_FIELDS},
         metrics,
     },
     meta::{
@@ -151,7 +151,7 @@ pub async fn ingest(
         .await;
 
         // get distinct_value item
-        for field in DISTINCT_FIELDS_EXTRA.iter() {
+        for field in DISTINCT_FIELDS.iter() {
             if let Some(val) = local_val.get(field) {
                 if !val.is_null() {
                     distinct_values.push(distinct_values::DvItem {

--- a/src/service/logs/json.rs
+++ b/src/service/logs/json.rs
@@ -19,7 +19,10 @@ use datafusion::arrow::datatypes::Schema;
 
 use super::StreamMeta;
 use crate::common::{
-    infra::{config::CONFIG, metrics},
+    infra::{
+        config::{CONFIG, DISTINCT_FIELDS_EXTRA},
+        metrics,
+    },
     meta::{
         alert::{Alert, Trigger},
         ingestion::{IngestionResponse, StreamStatus},
@@ -30,8 +33,8 @@ use crate::common::{
     utils::{flatten, json, time::parse_timestamp_micro_from_value},
 };
 use crate::service::{
-    get_formatted_stream_name, ingestion::is_ingestion_allowed, ingestion::write_file,
-    usage::report_request_usage_stats,
+    distinct_values, get_formatted_stream_name, ingestion::is_ingestion_allowed,
+    ingestion::write_file, usage::report_request_usage_stats,
 };
 
 pub async fn ingest(
@@ -42,6 +45,7 @@ pub async fn ingest(
 ) -> Result<IngestionResponse, anyhow::Error> {
     let start = std::time::Instant::now();
     let mut stream_schema_map: AHashMap<String, Schema> = AHashMap::new();
+    let mut distinct_values = Vec::with_capacity(16);
     let mut stream_params = StreamParams::new(org_id, in_stream_name, StreamType::Logs);
     let stream_name = &get_formatted_stream_name(&mut stream_params, &mut stream_schema_map).await;
 
@@ -146,6 +150,22 @@ pub async fn ingest(
         )
         .await;
 
+        // get distinct_value item
+        for field in DISTINCT_FIELDS_EXTRA.iter() {
+            if let Some(val) = local_val.get(field) {
+                if !val.is_null() {
+                    distinct_values.push(distinct_values::DvItem {
+                        stream_type: StreamType::Logs,
+                        stream_name: stream_name.to_string(),
+                        field_name: field.to_string(),
+                        field_value: val.as_str().unwrap().to_string(),
+                        filter_name: "".to_string(),
+                        filter_value: "".to_string(),
+                    });
+                }
+            }
+        }
+
         if local_trigger.is_some() {
             trigger = Some(local_trigger.unwrap());
         }
@@ -176,6 +196,13 @@ pub async fn ingest(
 
     // only one trigger per request, as it updates etcd
     super::evaluate_trigger(trigger, &stream_alerts_map).await;
+
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
 
     let time = start.elapsed().as_secs_f64();
     metrics::HTTP_RESPONSE_TIME

--- a/src/service/logs/kinesis_firehose.rs
+++ b/src/service/logs/kinesis_firehose.rs
@@ -255,6 +255,13 @@ pub async fn process(
     // only one trigger per request, as it updates etcd
     super::evaluate_trigger(trigger, &stream_alerts_map).await;
 
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
+
     req_stats.response_time = start.elapsed().as_secs_f64();
     //metric + data usage
     report_request_usage_stats(

--- a/src/service/logs/multi.rs
+++ b/src/service/logs/multi.rs
@@ -20,7 +20,7 @@ use std::io::{BufRead, BufReader};
 
 use crate::common::{
     infra::{
-        config::{CONFIG, DISTINCT_FIELDS_EXTRA},
+        config::{CONFIG, DISTINCT_FIELDS},
         metrics,
     },
     meta::{
@@ -205,7 +205,7 @@ async fn ingest_inner(
         .await;
 
         // get distinct_value item
-        for field in DISTINCT_FIELDS_EXTRA.iter() {
+        for field in DISTINCT_FIELDS.iter() {
             if let Some(val) = local_val.get(field) {
                 if !val.is_null() {
                     distinct_values.push(distinct_values::DvItem {

--- a/src/service/logs/multi.rs
+++ b/src/service/logs/multi.rs
@@ -19,7 +19,10 @@ use datafusion::arrow::datatypes::Schema;
 use std::io::{BufRead, BufReader};
 
 use crate::common::{
-    infra::{config::CONFIG, metrics},
+    infra::{
+        config::{CONFIG, DISTINCT_FIELDS_EXTRA},
+        metrics,
+    },
     meta::{
         alert::{Alert, Trigger},
         ingestion::{IngestionResponse, StreamStatus},
@@ -30,8 +33,8 @@ use crate::common::{
     utils::{flatten, json, time::parse_timestamp_micro_from_value},
 };
 use crate::service::{
-    get_formatted_stream_name, ingestion::is_ingestion_allowed, ingestion::write_file,
-    logs::StreamMeta, usage::report_request_usage_stats,
+    distinct_values, get_formatted_stream_name, ingestion::is_ingestion_allowed,
+    ingestion::write_file, logs::StreamMeta, usage::report_request_usage_stats,
 };
 
 /// Ingest a multiline json body but add extra keys to each json row
@@ -87,6 +90,7 @@ async fn ingest_inner(
     let start = std::time::Instant::now();
 
     let mut stream_schema_map: AHashMap<String, Schema> = AHashMap::new();
+    let mut distinct_values = Vec::with_capacity(16);
     let mut stream_params = StreamParams::new(org_id, in_stream_name, StreamType::Logs);
     let stream_name = &get_formatted_stream_name(&mut stream_params, &mut stream_schema_map).await;
 
@@ -103,7 +107,6 @@ async fn ingest_inner(
     let mut trigger: Option<Trigger> = None;
 
     // Start Register Transforms for stream
-
     let (local_trans, stream_vrl_map) = crate::service::ingestion::register_stream_transforms(
         org_id,
         StreamType::Logs,
@@ -201,6 +204,22 @@ async fn ingest_inner(
         )
         .await;
 
+        // get distinct_value item
+        for field in DISTINCT_FIELDS_EXTRA.iter() {
+            if let Some(val) = local_val.get(field) {
+                if !val.is_null() {
+                    distinct_values.push(distinct_values::DvItem {
+                        stream_type: StreamType::Logs,
+                        stream_name: stream_name.to_string(),
+                        field_name: field.to_string(),
+                        field_value: val.as_str().unwrap().to_string(),
+                        filter_name: "".to_string(),
+                        filter_value: "".to_string(),
+                    });
+                }
+            }
+        }
+
         if local_trigger.is_some() {
             trigger = Some(local_trigger.unwrap());
         }
@@ -227,6 +246,13 @@ async fn ingest_inner(
 
     // only one trigger per request, as it updates etcd
     super::evaluate_trigger(trigger, &stream_alerts_map).await;
+
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
 
     req_stats.response_time = start.elapsed().as_secs_f64();
     //metric + data usage

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -185,6 +185,13 @@ pub async fn usage_ingest(
     // only one trigger per request, as it updates etcd
     super::evaluate_trigger(trigger, &stream_alerts_map).await;
 
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
+
     let time = start.elapsed().as_secs_f64();
     metrics::HTTP_RESPONSE_TIME
         .with_label_values(&[
@@ -421,6 +428,13 @@ pub async fn handle_grpc_request(
 
     // only one trigger per request, as it updates etcd
     super::evaluate_trigger(trigger, &stream_alerts_map).await;
+
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
 
     let ep = if is_grpc {
         "grpc/export/logs"

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -25,7 +25,11 @@ use prost::Message;
 
 use super::StreamMeta;
 use crate::common::{
-    infra::{cluster, config::CONFIG, metrics},
+    infra::{
+        cluster,
+        config::{CONFIG, DISTINCT_FIELDS},
+        metrics,
+    },
     meta::{
         alert::{Alert, Trigger},
         http::HttpResponse as MetaHttpResponse,
@@ -37,7 +41,7 @@ use crate::common::{
     utils::{flatten, json, time::parse_timestamp_micro_from_value},
 };
 use crate::service::{
-    db, get_formatted_stream_name,
+    db, distinct_values, get_formatted_stream_name,
     ingestion::{grpc::get_val, write_file},
     schema::stream_schema_exists,
     usage::report_request_usage_stats,
@@ -51,6 +55,7 @@ pub async fn usage_ingest(
 ) -> Result<IngestionResponse, anyhow::Error> {
     let start = std::time::Instant::now();
     let mut stream_schema_map: AHashMap<String, Schema> = AHashMap::new();
+    let mut distinct_values = Vec::with_capacity(16);
     let stream_name = &get_formatted_stream_name(
         &mut StreamParams::new(org_id, in_stream_name, StreamType::Logs),
         &mut stream_schema_map,
@@ -140,6 +145,22 @@ pub async fn usage_ingest(
 
         if local_trigger.is_some() {
             trigger = Some(local_trigger.unwrap());
+        }
+
+        // get distinct_value item
+        for field in DISTINCT_FIELDS.iter() {
+            if let Some(val) = local_val.get(field) {
+                if !val.is_null() {
+                    distinct_values.push(distinct_values::DvItem {
+                        stream_type: StreamType::Logs,
+                        stream_name: stream_name.to_string(),
+                        field_name: field.to_string(),
+                        field_value: val.as_str().unwrap().to_string(),
+                        filter_name: "".to_string(),
+                        filter_value: "".to_string(),
+                    });
+                }
+            }
         }
     }
 
@@ -235,6 +256,7 @@ pub async fn handle_grpc_request(
     let mut runtime = crate::service::ingestion::init_functions_runtime();
     let mut stream_alerts_map: AHashMap<String, Vec<Alert>> = AHashMap::new();
     let mut stream_status = StreamStatus::new(stream_name);
+    let mut distinct_values = Vec::with_capacity(16);
 
     let partition_det =
         crate::service::ingestion::get_stream_partition_keys(stream_name, &stream_schema_map).await;
@@ -365,6 +387,22 @@ pub async fn handle_grpc_request(
 
                 if local_trigger.is_some() {
                     trigger = Some(local_trigger.unwrap());
+                }
+
+                // get distinct_value item
+                for field in DISTINCT_FIELDS.iter() {
+                    if let Some(val) = local_val.get(field) {
+                        if !val.is_null() {
+                            distinct_values.push(distinct_values::DvItem {
+                                stream_type: StreamType::Logs,
+                                stream_name: stream_name.to_string(),
+                                field_name: field.to_string(),
+                                field_value: val.as_str().unwrap().to_string(),
+                                filter_name: "".to_string(),
+                                filter_value: "".to_string(),
+                            });
+                        }
+                    }
                 }
             }
         }

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -349,6 +349,13 @@ pub async fn logs_json_handler(
     // only one trigger per request, as it updates etcd
     super::evaluate_trigger(trigger, &stream_alerts_map).await;
 
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
+
     let time = start.elapsed().as_secs_f64();
     metrics::HTTP_RESPONSE_TIME
         .with_label_values(&[

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -190,6 +190,13 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse, anyhow:
     // only one trigger per request, as it updates etcd
     super::evaluate_trigger(trigger, &stream_alerts_map).await;
 
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
+
     let time = start.elapsed().as_secs_f64();
     metrics::HTTP_RESPONSE_TIME
         .with_label_values(&[

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -23,7 +23,7 @@ use super::StreamMeta;
 use crate::common::{
     infra::{
         cluster,
-        config::{CONFIG, SYSLOG_ROUTES},
+        config::{CONFIG, DISTINCT_FIELDS, SYSLOG_ROUTES},
         metrics,
     },
     meta::{
@@ -36,7 +36,7 @@ use crate::common::{
     },
     utils::{flatten, json, time::parse_timestamp_micro_from_value},
 };
-use crate::service::{db, get_formatted_stream_name, ingestion::write_file};
+use crate::service::{db, distinct_values, get_formatted_stream_name, ingestion::write_file};
 
 pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse, anyhow::Error> {
     let start = std::time::Instant::now();
@@ -84,6 +84,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse, anyhow:
 
     let mut stream_alerts_map: AHashMap<String, Vec<Alert>> = AHashMap::new();
     let mut stream_status = StreamStatus::new(stream_name);
+    let mut distinct_values = Vec::with_capacity(16);
 
     let mut trigger: Option<Trigger> = None;
 
@@ -166,6 +167,23 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse, anyhow:
     if local_trigger.is_some() {
         trigger = Some(local_trigger.unwrap());
     }
+
+    // get distinct_value item
+    for field in DISTINCT_FIELDS.iter() {
+        if let Some(val) = local_val.get(field) {
+            if !val.is_null() {
+                distinct_values.push(distinct_values::DvItem {
+                    stream_type: StreamType::Logs,
+                    stream_name: stream_name.to_string(),
+                    field_name: field.to_string(),
+                    field_value: val.as_str().unwrap().to_string(),
+                    filter_name: "".to_string(),
+                    filter_value: "".to_string(),
+                });
+            }
+        }
+    }
+
     let mut stream_file_name = "".to_string();
     write_file(&buf, thread_id, &stream_params, &mut stream_file_name, None).await;
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -24,6 +24,7 @@ pub mod alerts;
 pub mod compact;
 pub mod dashboards;
 pub mod db;
+pub mod distinct_values;
 pub mod enrichment;
 pub mod enrichment_table;
 pub mod file_list;

--- a/src/service/search/datafusion/mod.rs
+++ b/src/service/search/datafusion/mod.rs
@@ -25,7 +25,7 @@ use std::{str::FromStr, sync::Arc};
 use crate::common::{
     infra::config::{
         CONFIG, PARQUET_BATCH_SIZE, PARQUET_MAX_ROW_GROUP_SIZE, PARQUET_PAGE_SIZE,
-        SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA,
+        SQL_FULL_TEXT_SEARCH_FIELDS,
     },
     meta::functions::ZoFunction,
 };
@@ -121,7 +121,7 @@ pub fn new_parquet_writer<'a>(
             ColumnPath::from(vec![CONFIG.common.column_timestamp.to_string()]),
             Encoding::DELTA_BINARY_PACKED,
         );
-    for field in SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA.iter() {
+    for field in SQL_FULL_TEXT_SEARCH_FIELDS.iter() {
         writer_props = writer_props
             .set_column_dictionary_enabled(ColumnPath::from(vec![field.to_string()]), false);
     }

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -25,7 +25,7 @@ use std::{
 
 use crate::common::{
     infra::{
-        config::{CONFIG, SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA},
+        config::{CONFIG, SQL_FULL_TEXT_SEARCH_FIELDS},
         errors::{Error, ErrorCodes},
     },
     meta::{common::FileKey, sql::Sql as MetaSql, stream::StreamParams, StreamType},
@@ -370,7 +370,7 @@ impl Sql {
         let match_all_fields = if !fts_fields.is_empty() {
             fts_fields.iter().map(|v| v.to_lowercase()).collect()
         } else {
-            SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA
+            SQL_FULL_TEXT_SEARCH_FIELDS
                 .iter()
                 .map(|v| v.to_string())
                 .collect::<String>()

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -20,8 +20,7 @@ use crate::common::{
     infra::{
         cache::stats,
         config::{
-            is_local_disk_storage, CONFIG, SIZE_IN_MB, SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA,
-            STREAM_SCHEMAS,
+            is_local_disk_storage, CONFIG, SIZE_IN_MB, SQL_FULL_TEXT_SEARCH_FIELDS, STREAM_SCHEMAS,
         },
     },
     meta::{
@@ -172,7 +171,7 @@ pub async fn save_stream_settings(
     }
 
     for key in setting.partition_keys.iter() {
-        if SQL_FULL_TEXT_SEARCH_FIELDS_EXTRA.contains(key) {
+        if SQL_FULL_TEXT_SEARCH_FIELDS.contains(key) {
             return Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(
                 http::StatusCode::BAD_REQUEST.into(),
                 format!("field [{key}] can't be used for partition key"),

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -28,7 +28,7 @@ use std::{fs::OpenOptions, io::Error};
 use crate::common::{
     infra::{
         cluster,
-        config::{CONFIG, DISTINCT_FIELDS_EXTRA},
+        config::{CONFIG, DISTINCT_FIELDS},
         metrics,
     },
     meta::{
@@ -254,7 +254,7 @@ pub async fn handle_trace_request(
                 );
 
                 // get distinct_value item
-                for field in DISTINCT_FIELDS_EXTRA.iter() {
+                for field in DISTINCT_FIELDS.iter() {
                     if let Some(val) = val_map.get(field) {
                         if !val.is_null() {
                             let (filter_name, filter_value) = if field == "operation_name" {

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -38,7 +38,7 @@ use crate::common::{
     utils::{flatten, json},
 };
 use crate::service::{
-    db, format_partition_key, format_stream_name,
+    db, distinct_values, format_partition_key, format_stream_name,
     ingestion::{grpc::get_val, write_file},
     schema::{add_stream_schema, stream_schema_exists},
     stream::unwrap_partition_time_level,
@@ -87,8 +87,9 @@ pub async fn handle_trace_request(
     let mut runtime = crate::service::ingestion::init_functions_runtime();
     let mut trace_meta_coll: AHashMap<String, Vec<json::Map<String, json::Value>>> =
         AHashMap::new();
-    let mut traces_schema_map: AHashMap<String, Schema> = AHashMap::new();
     let mut stream_alerts_map: AHashMap<String, Vec<Alert>> = AHashMap::new();
+    let mut traces_schema_map: AHashMap<String, Schema> = AHashMap::new();
+    let mut distinct_values = Vec::with_capacity(16);
 
     let stream_schema = stream_schema_exists(
         org_id,
@@ -248,6 +249,21 @@ pub async fn handle_trace_request(
                     json::Value::Number(timestamp.into()),
                 );
 
+                // get distinct_value item
+                distinct_values.push(distinct_values::DvItem {
+                    stream_type: StreamType::Traces,
+                    stream_name: traces_stream_name.to_string(),
+                    field_name: "operation_name".to_string(),
+                    field_value: val_map
+                        .get("operation_name")
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        .to_string(),
+                    filter_name: "service_name".to_string(),
+                    filter_value: service_name.clone(),
+                });
+
                 let value_str = crate::common::utils::json::to_string(&val_map).unwrap();
 
                 // get hour key
@@ -322,6 +338,13 @@ pub async fn handle_trace_request(
     .await;
     let time = start.elapsed().as_secs_f64();
     req_stats.response_time = time;
+
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
 
     let ep = if is_grpc {
         "grpc/export/traces"

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -23,7 +23,7 @@ use std::{fs::OpenOptions, io::Error};
 use crate::common::{
     infra::{
         cluster,
-        config::{CONFIG, DISTINCT_FIELDS_EXTRA},
+        config::{CONFIG, DISTINCT_FIELDS},
         metrics,
     },
     meta::{
@@ -316,7 +316,7 @@ pub async fn traces_json(
                     );
 
                     // get distinct_value item
-                    for field in DISTINCT_FIELDS_EXTRA.iter() {
+                    for field in DISTINCT_FIELDS.iter() {
                         if let Some(val) = val_map.get(field) {
                             if !val.is_null() {
                                 let (filter_name, filter_value) = if field == "operation_name" {

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -21,7 +21,7 @@ use prost::Message;
 use std::{fs::OpenOptions, io::Error};
 
 use crate::service::{
-    db, format_partition_key, format_stream_name,
+    db, distinct_values, format_partition_key, format_stream_name,
     ingestion::write_file,
     schema::{add_stream_schema, stream_schema_exists},
     stream::unwrap_partition_time_level,
@@ -94,6 +94,7 @@ pub async fn traces_json(
         AHashMap::new();
     let mut stream_alerts_map: AHashMap<String, Vec<Alert>> = AHashMap::new();
     let mut traces_schema_map: AHashMap<String, Schema> = AHashMap::new();
+    let mut distinct_values = Vec::with_capacity(16);
 
     let mut min_ts =
         (Utc::now() + Duration::hours(CONFIG.limit.ingest_allowed_upto)).timestamp_micros();
@@ -313,6 +314,21 @@ pub async fn traces_json(
                         json::Value::Number(timestamp.into()),
                     );
 
+                    // get distinct_value item
+                    distinct_values.push(distinct_values::DvItem {
+                        stream_type: StreamType::Traces,
+                        stream_name: traces_stream_name.to_string(),
+                        field_name: "operation_name".to_string(),
+                        field_value: val_map
+                            .get("operation_name")
+                            .unwrap()
+                            .as_str()
+                            .unwrap()
+                            .to_string(),
+                        filter_name: "service_name".to_string(),
+                        filter_value: service_name.clone(),
+                    });
+
                     let value_str = crate::common::utils::json::to_string(&val_map).unwrap();
                     // get hour key
                     let mut hour_key = crate::service::ingestion::get_wal_time_key(
@@ -385,6 +401,13 @@ pub async fn traces_json(
     .await;
     let time = start.elapsed().as_secs_f64();
     req_stats.response_time = time;
+
+    // send distinct_values
+    if !distinct_values.is_empty() {
+        if let Err(e) = distinct_values::write(org_id, distinct_values).await {
+            log::error!("Error while writing distinct values: {}", e);
+        }
+    }
 
     metrics::HTTP_RESPONSE_TIME
         .with_label_values(&[


### PR DESCRIPTION
impl #1290 

We add a new stream `distinct_values` and the stream type is `metadata`, this stream will collect the distinct values from ingestion based on the fields settings.

Then we can use this stream to accelerate the top N value query.

We enable `distinct_values` for fields `service_name` and `operation_name` as default, you can set the extra default field by environment `ZO_FEATURE_DISTINCT_EXTRA_FIELDS`, like:

```
ZO_FEATURE_DISTINCT_EXTRA_FIELDS = "fielda, fieldb"
```