### PR TITLE
fix: resource/span attributes retain data types

### DIFF
--- a/src/service/ingestion/grpc.rs
+++ b/src/service/ingestion/grpc.rs
@@ -14,7 +14,7 @@
 
 use crate::common::utils::json;
 use opentelemetry_proto::tonic::{
-    common::v1::AnyValue,
+    common::v1::{any_value::Value, AnyValue},
     metrics::v1::{exemplar, number_data_point},
 };
 
@@ -24,35 +24,29 @@ pub fn get_val(attr_val: &Option<AnyValue>) -> json::Value {
     match attr_val {
         Some(local_val) => match &local_val.value {
             Some(val) => match val {
-                opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
-                    inner_val,
-                ) => json::json!(inner_val.as_str()),
-                opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(inner_val) => {
+                Value::StringValue(inner_val) => json::json!(inner_val.as_str()),
+                Value::BoolValue(inner_val) => {
                     json::json!(inner_val.to_string())
                 }
-                opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(inner_val) => {
+                Value::IntValue(inner_val) => {
                     json::json!(inner_val.to_string())
                 }
-                opentelemetry_proto::tonic::common::v1::any_value::Value::DoubleValue(
-                    inner_val,
-                ) => json::json!(inner_val.to_string()),
-                opentelemetry_proto::tonic::common::v1::any_value::Value::ArrayValue(inner_val) => {
+                Value::DoubleValue(inner_val) => json::json!(inner_val.to_string()),
+                Value::ArrayValue(inner_val) => {
                     let mut vals = vec![];
                     for item in inner_val.values.iter().cloned() {
                         vals.push(get_val(&Some(item)))
                     }
                     json::json!(vals)
                 }
-                opentelemetry_proto::tonic::common::v1::any_value::Value::KvlistValue(
-                    inner_val,
-                ) => {
+                Value::KvlistValue(inner_val) => {
                     let mut vals = json::Map::new();
                     for item in inner_val.values.iter().cloned() {
                         vals.insert(item.key, get_val(&item.value));
                     }
                     json::json!(vals)
                 }
-                opentelemetry_proto::tonic::common::v1::any_value::Value::BytesValue(inner_val) => {
+                Value::BytesValue(inner_val) => {
                     json::json!(inner_val)
                 }
             },
@@ -122,6 +116,46 @@ pub fn get_val_for_attr(attr_val: json::Value) -> json::Value {
     ().into()
 }
 
+pub fn get_val_with_type_retained(attr_val: &Option<AnyValue>) -> json::Value {
+    match attr_val {
+        Some(local_val) => match &local_val.value {
+            Some(val) => match val {
+                Value::StringValue(val) => {
+                    json::json!(val)
+                }
+                Value::BoolValue(val) => {
+                    json::json!(val)
+                }
+                Value::IntValue(val) => {
+                    json::json!(val)
+                }
+                Value::DoubleValue(val) => {
+                    json::json!(val)
+                }
+                Value::ArrayValue(val) => {
+                    let mut vals = vec![];
+                    for item in val.values.iter().cloned() {
+                        vals.push(get_val(&Some(item)))
+                    }
+                    json::json!(vals)
+                }
+                Value::KvlistValue(val) => {
+                    let mut vals = json::Map::new();
+                    for item in val.values.iter().cloned() {
+                        vals.insert(item.key, get_val(&item.value));
+                    }
+                    json::json!(vals)
+                }
+                Value::BytesValue(val) => {
+                    json::json!(val)
+                }
+            },
+            None => json::Value::Null,
+        },
+        None => json::Value::Null,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use opentelemetry_proto::tonic::common::v1::AnyValue;
@@ -132,68 +166,55 @@ mod tests {
     fn test_get_val() {
         let in_str = "Test".to_string();
         let str_val = AnyValue {
-            value: Some(
-                opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
-                    in_str.clone(),
-                ),
-            ),
+            value: Some(Value::StringValue(in_str.clone())),
         };
         let resp = get_val(&Some(str_val));
         assert_eq!(resp.as_str().unwrap(), in_str);
 
         let in_bool = false;
         let bool_val = AnyValue {
-            value: Some(
-                opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(in_bool),
-            ),
+            value: Some(Value::BoolValue(in_bool)),
         };
         let resp = get_val(&Some(bool_val));
         assert_eq!(resp.as_str().unwrap(), in_bool.to_string());
 
         let in_int = 20;
         let int_val = AnyValue {
-            value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(in_int)),
+            value: Some(Value::IntValue(in_int)),
         };
         let resp = get_val(&Some(int_val.clone()));
         assert_eq!(resp.as_str().unwrap(), in_int.to_string());
 
         let in_double = 20.00;
         let double_val = AnyValue {
-            value: Some(
-                opentelemetry_proto::tonic::common::v1::any_value::Value::DoubleValue(in_double),
-            ),
+            value: Some(Value::DoubleValue(in_double)),
         };
         let resp = get_val(&Some(double_val));
         assert_eq!(resp.as_str().unwrap(), in_double.to_string());
 
         let in_arr = vec![int_val.clone()];
         let arr_val = AnyValue {
-            value: Some(
-                opentelemetry_proto::tonic::common::v1::any_value::Value::ArrayValue(
-                    opentelemetry_proto::tonic::common::v1::ArrayValue { values: in_arr },
-                ),
-            ),
+            value: Some(Value::ArrayValue(
+                opentelemetry_proto::tonic::common::v1::ArrayValue { values: in_arr },
+            )),
         };
         let resp = get_val(&Some(arr_val));
         assert!(!resp.as_array().unwrap().is_empty());
 
         let kv_val = AnyValue {
-            value: Some(
-                opentelemetry_proto::tonic::common::v1::any_value::Value::KvlistValue(
-                    opentelemetry_proto::tonic::common::v1::KeyValueList {
-                        values: vec![opentelemetry_proto::tonic::common::v1::KeyValue {
-                            key: in_str.clone(),
-                            value: Some(int_val.clone()),
-                        }],
-                    },
-                ),
-            ),
+            value: Some(Value::KvlistValue(
+                opentelemetry_proto::tonic::common::v1::KeyValueList {
+                    values: vec![opentelemetry_proto::tonic::common::v1::KeyValue {
+                        key: in_str.clone(),
+                        value: Some(int_val.clone()),
+                    }],
+                },
+            )),
         };
         let resp = get_val(&Some(kv_val));
         assert!(resp.as_object().unwrap().contains_key(&in_str));
 
-        let in_byte =
-            opentelemetry_proto::tonic::common::v1::any_value::Value::BytesValue(vec![8u8]);
+        let in_byte = Value::BytesValue(vec![8u8]);
 
         let byte_val = AnyValue {
             value: Some(in_byte),

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -24,30 +24,27 @@ use opentelemetry_proto::tonic::collector::logs::v1::{
 use prost::Message;
 
 use super::StreamMeta;
+use crate::common::{
+    infra::{
+        cluster,
+        config::{CONFIG, DISTINCT_FIELDS},
+        metrics,
+    },
+    meta::{
+        alert::{Alert, Trigger},
+        http::HttpResponse as MetaHttpResponse,
+        ingestion::{IngestionResponse, StreamStatus},
+        stream::StreamParams,
+        usage::UsageType,
+        StreamType,
+    },
+    utils::{flatten, json, time::parse_timestamp_micro_from_value},
+};
 use crate::service::{
     db, distinct_values, get_formatted_stream_name,
-    ingestion::{grpc::get_val, write_file},
+    ingestion::{grpc::get_val, grpc::get_val_with_type_retained, write_file},
     schema::stream_schema_exists,
     usage::report_request_usage_stats,
-};
-use crate::{
-    common::{
-        infra::{
-            cluster,
-            config::{CONFIG, DISTINCT_FIELDS},
-            metrics,
-        },
-        meta::{
-            alert::{Alert, Trigger},
-            http::HttpResponse as MetaHttpResponse,
-            ingestion::{IngestionResponse, StreamStatus},
-            stream::StreamParams,
-            usage::UsageType,
-            StreamType,
-        },
-        utils::{flatten, json, time::parse_timestamp_micro_from_value},
-    },
-    service::ingestion::grpc::get_val_with_type_retained,
 };
 
 pub async fn usage_ingest(

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -25,6 +25,7 @@ use opentelemetry_proto::tonic::{
 use prost::Message;
 use std::{fs::OpenOptions, io::Error};
 
+use super::ingestion::grpc::get_val_with_type_retained;
 use crate::common::{
     infra::{
         cluster,
@@ -152,7 +153,7 @@ pub async fn handle_trace_request(
             } else {
                 service_att_map.insert(
                     format!("{}.{}", SERVICE, res_attr.key),
-                    get_val(&res_attr.value),
+                    get_val_with_type_retained(&res_attr.value),
                 );
             }
         }
@@ -193,7 +194,7 @@ pub async fn handle_trace_request(
                 let end_time: u64 = span.end_time_unix_nano;
                 let mut span_att_map: AHashMap<String, json::Value> = AHashMap::new();
                 for span_att in span.attributes {
-                    span_att_map.insert(span_att.key, get_val(&span_att.value));
+                    span_att_map.insert(span_att.key, get_val_with_type_retained(&span_att.value));
                 }
 
                 let mut events = vec![];

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -25,7 +25,6 @@ use opentelemetry_proto::tonic::{
 use prost::Message;
 use std::{fs::OpenOptions, io::Error};
 
-use super::ingestion::grpc::get_val_with_type_retained;
 use crate::common::{
     infra::{
         cluster,
@@ -44,7 +43,7 @@ use crate::common::{
 };
 use crate::service::{
     db, distinct_values, format_partition_key, format_stream_name,
-    ingestion::{grpc::get_val, write_file},
+    ingestion::{grpc::get_val, grpc::get_val_with_type_retained, write_file},
     schema::{add_stream_schema, stream_schema_exists},
     stream::unwrap_partition_time_level,
     usage::report_request_usage_stats,


### PR DESCRIPTION
For GRPC ingestion resource attributes , span attributes  values are currently being stored as string , the PR fixes these to retain data types.