### PR TITLE
fix: invalidate the local cache with rumtoken

### DIFF
--- a/src/service/db/user.rs
+++ b/src/service/db/user.rs
@@ -166,6 +166,8 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                     }
                     USERS.insert(format!("{}/{}", user.org, item_key), user);
                 }
+                // Invalidate the entire RUM-TOKEN-CACHE
+                USERS_RUM_TOKEN.clear();
             }
             infra_db::Event::Delete(ev) => {
                 let item_key = ev.key.strip_prefix(key).unwrap();
@@ -175,6 +177,8 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                         break;
                     }
                 }
+                // Invalidate the entire RUM-TOKEN-CACHE
+                USERS_RUM_TOKEN.clear();
             }
             infra_db::Event::Empty => {}
         }

--- a/src/service/users.rs
+++ b/src/service/users.rs
@@ -297,10 +297,20 @@ pub async fn get_user_by_token(org_id: &str, token: &str) -> Option<User> {
     let user = USERS_RUM_TOKEN.get(&key);
     match user {
         Some(loc_user) => Some(loc_user.value().clone()),
-        None => db::user::get_by_token(Some(org_id), token)
-            .await
-            .ok()
-            .flatten(),
+        None => {
+            if let Some(user) = db::user::get_by_token(Some(org_id), token)
+                .await
+                .ok()
+                .flatten()
+            {
+                USERS_RUM_TOKEN
+                    .clone()
+                    .insert(format!("{}/{}", org_id, token), user.clone());
+                Some(user)
+            } else {
+                None
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Ensure the local-cache is invalidated in case of an update operation. Also ensure that the operation is supported in distributed mode