### PR TITLE
fix: wrong timestamps in add panel page values API

### DIFF
--- a/web/src/composables/useDashboardPanel.ts
+++ b/web/src/composables/useDashboardPanel.ts
@@ -550,8 +550,8 @@ const removeQuery = (index: number) => {
       .fieldValues({
         org_identifier: store.state.selectedOrganization.identifier,
         stream_name: dashboardPanelData.data.queries[dashboardPanelData.layout.currentQueryIndex].fields.stream,
-        start_time:  new Date(dashboardPanelData.meta.dateTime["start_time"].toISOString()).getTime() * 1000,
-        end_time:  new Date(dashboardPanelData.meta.dateTime["end_time"].toISOString()).getTime() * 1000,
+        start_time:  new Date(dashboardPanelData.meta.dateTime["start_time"].toISOString()).getTime() ,
+        end_time:  new Date(dashboardPanelData.meta.dateTime["end_time"].toISOString()).getTime() ,
         fields: [name],
         size: 10,
         type: dashboardPanelData.data.queries[dashboardPanelData.layout.currentQueryIndex].fields.stream_type
@@ -588,8 +588,8 @@ const loadFilterItem = (name:any)=>{
       .fieldValues({
         org_identifier: store.state.selectedOrganization.identifier,
         stream_name: dashboardPanelData.data.queries[dashboardPanelData.layout.currentQueryIndex].fields.stream,
-        start_time:  new Date(dashboardPanelData.meta.dateTime["start_time"].toISOString()).getTime() * 1000,
-        end_time:  new Date(dashboardPanelData.meta.dateTime["end_time"].toISOString()).getTime() * 1000,
+        start_time:  new Date(dashboardPanelData.meta.dateTime["start_time"].toISOString()).getTime() ,
+        end_time:  new Date(dashboardPanelData.meta.dateTime["end_time"].toISOString()).getTime() ,
         fields: [name],
         size: 10,
         type: dashboardPanelData.data.queries[dashboardPanelData.layout.currentQueryIndex].fields.stream_type


### PR DESCRIPTION
Values API fetched values with the wrong timestamp after changing the date time picker. This issue has been fixed with this PR.