### PR TITLE
fix: Swagger was missing a rum-model

### DIFF
--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -174,6 +174,8 @@ use crate::handler::http::request;
             meta::organization::PasscodeResponse,
             meta::organization::OrganizationSetting,
             meta::organization::OrganizationSettingResponse,
+            meta::organization::RumIngestionResponse,
+            meta::organization::RumIngestionToken,
             request::status::HealthzResponse,
             meta::ingestion::BulkResponse,
             meta::ingestion::BulkResponseItem,


### PR DESCRIPTION
Added the `RumIngestionResponse` and `RumIngestionToken` models to the swagger-ui