### PR TITLE
feat: support sidecar querier for ingester

### DIFF
--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -250,6 +250,8 @@ pub struct Common {
     pub cluster_name: String,
     #[env_config(name = "ZO_INSTANCE_NAME", default = "")]
     pub instance_name: String,
+    #[env_config(name = "ZO_INGESTER_SIDE_QUERIER", default = false)]
+    pub ingester_side_querier: bool,
     #[env_config(name = "ZO_DATA_DIR", default = "./data/openobserve/")]
     pub data_dir: String,
     #[env_config(name = "ZO_DATA_WAL_DIR", default = "")] // ./data/openobserve/wal/

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -250,8 +250,10 @@ pub struct Common {
     pub cluster_name: String,
     #[env_config(name = "ZO_INSTANCE_NAME", default = "")]
     pub instance_name: String,
-    #[env_config(name = "ZO_INGESTER_SIDE_QUERIER", default = false)]
-    pub ingester_side_querier: bool,
+    #[env_config(name = "ZO_INGESTER_SIDECAR_ENABLED", default = false)]
+    pub ingester_sidecar_enabled: bool,
+    #[env_config(name = "ZO_INGESTER_SIDECAR_QUERIER", default = false)]
+    pub ingester_sidecar_querier: bool,
     #[env_config(name = "ZO_DATA_DIR", default = "./data/openobserve/")]
     pub data_dir: String,
     #[env_config(name = "ZO_DATA_WAL_DIR", default = "")] // ./data/openobserve/wal/

--- a/src/job/file_list.rs
+++ b/src/job/file_list.rs
@@ -34,7 +34,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
 }
 
 pub async fn run_move_file_to_s3() -> Result<(), anyhow::Error> {
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) || CONFIG.common.ingester_side_querier {
         return Ok(()); // not an ingester, no need to init job
     }
 

--- a/src/job/file_list.rs
+++ b/src/job/file_list.rs
@@ -34,7 +34,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
 }
 
 pub async fn run_move_file_to_s3() -> Result<(), anyhow::Error> {
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) || CONFIG.common.ingester_side_querier {
+    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) || CONFIG.common.ingester_sidecar_querier {
         return Ok(()); // not an ingester, no need to init job
     }
 

--- a/src/job/files/disk.rs
+++ b/src/job/files/disk.rs
@@ -255,8 +255,10 @@ async fn upload_file(
             .build(json_reader)
             .unwrap();
         for batch in json {
-            let batch_write = batch.unwrap();
-            batches.push(batch_write);
+            match batch {
+                Ok(batch) => batches.push(batch),
+                Err(err) => log::error!("[JOB] Failed to parse record: error: {}", err),
+            }
         }
     } else {
         let mut json = vec![];

--- a/src/job/files/mod.rs
+++ b/src/job/files/mod.rs
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 use crate::common::{
-    infra::{cluster, config::FILE_EXT_PARQUET, ider},
+    infra::{
+        cluster,
+        config::{CONFIG, FILE_EXT_PARQUET},
+        ider,
+    },
     meta::StreamType,
 };
 
@@ -22,7 +26,7 @@ pub mod disk;
 pub mod memory;
 
 pub async fn run() -> Result<(), anyhow::Error> {
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) || CONFIG.common.ingester_side_querier {
         return Ok(()); // not an ingester, no need to init job
     }
 

--- a/src/job/files/mod.rs
+++ b/src/job/files/mod.rs
@@ -26,7 +26,7 @@ pub mod disk;
 pub mod memory;
 
 pub async fn run() -> Result<(), anyhow::Error> {
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) || CONFIG.common.ingester_side_querier {
+    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) || CONFIG.common.ingester_sidecar_querier {
         return Ok(()); // not an ingester, no need to init job
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,10 +182,16 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // HTTP server
     let thread_id = Arc::new(AtomicU16::new(0));
+    let http_port =
+        if CONFIG.common.ingester_sidecar_enabled && CONFIG.common.ingester_sidecar_querier {
+            50800 // a fake port
+        } else {
+            CONFIG.http.port
+        };
     let haddr: SocketAddr = if CONFIG.http.ipv6_enabled {
-        format!("[::]:{}", CONFIG.http.port).parse()?
+        format!("[::]:{}", http_port).parse()?
     } else {
-        format!("0.0.0.0:{}", CONFIG.http.port).parse()?
+        format!("0.0.0.0:{}", http_port).parse()?
     };
     meta::telemetry::Telemetry::new()
         .event("OpenObserve - Starting server", None, false)
@@ -282,7 +288,12 @@ async fn main() -> Result<(), anyhow::Error> {
 }
 
 fn init_grpc_server() -> Result<(), anyhow::Error> {
-    let gaddr: SocketAddr = format!("0.0.0.0:{}", CONFIG.grpc.port).parse()?;
+    let gaddr: SocketAddr =
+        if CONFIG.common.ingester_sidecar_enabled && !CONFIG.common.ingester_sidecar_querier {
+            "0.0.0.0:50810".parse()? // a fake port
+        } else {
+            format!("0.0.0.0:{}", CONFIG.grpc.port).parse()?
+        };
     let event_svc = EventServer::new(Eventer)
         .send_compressed(CompressionEncoding::Gzip)
         .accept_compressed(CompressionEncoding::Gzip);


### PR DESCRIPTION
We added two environments to control sidecar pod for the ingester:

```
ZO_INGESTER_SIDECAR_ENABLED = false
ZO_INGESTER_SIDECAR_QUERIER = false
```

You can enable these envs when you deploy a sidecar querier for ingester.

Key points:

- Both containers need to set `ZO_INGESTER_SIDECAR_ENABLED = true`
- The ingester needs to set  `ZO_INGESTER_SIDECAR_QUERIER = false`
- The querier needs to set `ZO_INGESTER_SIDECAR_QUERIER = true`
- The ingester listens on HTTP `5080` for receive HTTP ingrestion
- The querier listens on gRPC `5081` for receive gRPC searching

You can deploy a side querier for ingester like this:

```
# Source: openobserve/templates/ingester-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: zo1-openobserve-ingester
  namespace: "ziox-dev"
  labels:
    helm.sh/chart: openobserve-0.5.30
    app.kubernetes.io/name: openobserve
    app.kubernetes.io/instance: zo1
    app.kubernetes.io/version: "v0.6.5"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: openobserve
      app.kubernetes.io/instance: zo1
      role: ingester
  serviceName: zo1-openobserve
  template:
    metadata:
      labels:
        app.kubernetes.io/name: openobserve
        app.kubernetes.io/instance: zo1
        role: ingester
    spec:
      serviceAccountName: zo1-openobserve
      securityContext:
        fsGroup: 0
        runAsGroup: 0
        runAsUser: 0
        runAsNonRoot: false
      containers:
        - name: openobserve-ingester
          securityContext:
            {}
          image: "public.ecr.aws/zinclabs/openobserve-dev:v0.6.4-3ca57d1-amd64"
          imagePullPolicy: IfNotPresent
          ports:
            - containerPort: 5080
              name: http
          # livenessProbe:
          #   httpGet:
          #     path: /
          #     port: http
          # readinessProbe:
          #   httpGet:
          #     path: /
          #     port: http
          resources:
            limits:
              cpu: "4"
              memory: 8Gi
            requests:
              cpu: "2"
              memory: 4Gi
          envFrom:
            - secretRef:
                name: zo1-openobserve
            - configMapRef:
                name: zo1-openobserve
          env:
            - name: ZO_NODE_ROLE
              value: "ingester"
            - name: ZO_INGESTER_SIDECAR_ENABLED
              value: "true"
            - name: ZO_INGESTER_SIDECAR_QUERIER
              value: "false"
          volumeMounts:
            - name: data
              mountPath: /data
        - name: openobserve-querier
          securityContext:
            {}
          image: "public.ecr.aws/zinclabs/openobserve-dev:v0.6.4-3ca57d1-amd64"
          imagePullPolicy: IfNotPresent
          ports:
            - containerPort: 5081
              name: grpc
          # livenessProbe:
          #   httpGet:
          #     path: /
          #     port: http
          # readinessProbe:
          #   httpGet:
          #     path: /
          #     port: http
          resources:
            limits:
              cpu: "4"
              memory: 8Gi
            requests:
              cpu: "2"
              memory: 4Gi
          envFrom:
            - secretRef:
                name: zo1-openobserve
            - configMapRef:
                name: zo1-openobserve
          env:
            - name: ZO_NODE_ROLE
              value: "ingester"
            - name: ZO_INGESTER_SIDECAR_ENABLED
              value: "true"
            - name: ZO_INGESTER_SIDECAR_QUERIER
              value: "true"
          volumeMounts:
            - name: data
              mountPath: /data
      tolerations:
        - effect: NoSchedule
          key: oo
          operator: Equal
          value: "yes"
  volumeClaimTemplates:
  - metadata:
      name: data
    spec:
      accessModes:
        - "ReadWriteOnce"
      storageClassName:
      resources:
        requests:
          storage: "100Gi"
```