### PR TITLE
fix: data type conflict for traces

### DIFF
--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -123,6 +123,7 @@ pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
                     srv.call(req).map(move |res| {
                         if path.starts_with("src/")
                             || path.starts_with("assets/")
+                            || path.starts_with("monacoeditorwork/")
                             || path.eq("favicon.ico")
                         {
                             res

--- a/src/handler/http/router/ui.rs
+++ b/src/handler/http/router/ui.rs
@@ -26,7 +26,11 @@ struct WebAssets;
 pub async fn serve(path: web::Path<String>) -> EmbedResponse<EmbedableFileResponse> {
     let mut path = path.as_str();
 
-    if !path.starts_with("src/") && !path.starts_with("assets/") && !path.eq("favicon.ico") {
+    if !path.starts_with("src/")
+        && !path.starts_with("assets/")
+        && !path.starts_with("monacoeditorwork/")
+        && !path.eq("favicon.ico")
+    {
         path = "index.html";
     }
 

--- a/src/job/files/disk.rs
+++ b/src/job/files/disk.rs
@@ -239,7 +239,10 @@ async fn upload_file(
                     }
                 }
                 if res_records.is_empty() {
-                    return Err(anyhow::anyhow!("file has corrupt json data: {}", path_str));
+                    return Err(anyhow::anyhow!(
+                        "[JOB] File has corrupt json data: {}",
+                        path_str
+                    ));
                 }
                 let value_iter = res_records.iter().map(Ok);
                 infer_json_schema_from_iterator(value_iter, stream_type).unwrap()
@@ -257,7 +260,14 @@ async fn upload_file(
         for batch in json {
             match batch {
                 Ok(batch) => batches.push(batch),
-                Err(err) => log::error!("[JOB] Failed to parse record: error: {}", err),
+                Err(err) => {
+                    tokio::fs::remove_file(path_str).await?;
+                    return Err(anyhow::anyhow!(
+                        "[JOB] File has corrupt data: {}, err: {}",
+                        path_str,
+                        err
+                    ));
+                }
             }
         }
     } else {

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -295,7 +295,8 @@ pub async fn handle_grpc_request(
                 match &resource_log.resource {
                     Some(res) => {
                         for item in &res.attributes {
-                            rec[item.key.as_str()] = get_val_with_type_retained(&item.value);
+                            rec[item.key.as_str()] =
+                                get_val_with_type_retained(&item.value.as_ref());
                         }
                     }
                     None => {}
@@ -335,9 +336,9 @@ pub async fn handle_grpc_request(
                 rec[CONFIG.common.column_timestamp.clone()] = ts.into();
                 rec["severity"] = log_record.severity_text.to_owned().into();
                 //rec["name"] = log_record.name.to_owned().into();
-                rec["body"] = get_val(&log_record.body);
+                rec["body"] = get_val(&log_record.body.as_ref());
                 for item in &log_record.attributes {
-                    rec[item.key.as_str()] = get_val_with_type_retained(&item.value);
+                    rec[item.key.as_str()] = get_val_with_type_retained(&item.value.as_ref());
                 }
                 rec["dropped_attributes_count"] = log_record.dropped_attributes_count.into();
                 match TraceId::from_bytes(

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -126,7 +126,8 @@ pub async fn handle_grpc_request(
                 match &resource_metric.resource {
                     Some(res) => {
                         for item in &res.attributes {
-                            rec[format_label_name(item.key.as_str())] = get_val(&item.value);
+                            rec[format_label_name(item.key.as_str())] =
+                                get_val(&item.value.as_ref());
                         }
                     }
                     None => {}
@@ -513,7 +514,7 @@ fn process_summary(
 
 fn process_data_point(rec: &mut json::Value, data_point: &NumberDataPoint) {
     for attr in &data_point.attributes {
-        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value);
+        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
     }
     rec[VALUE_LABEL] = get_metric_val(&data_point.value);
     rec[&CONFIG.common.column_timestamp] = (data_point.time_unix_nano / 1000).into();
@@ -534,7 +535,7 @@ fn process_hist_data_point(
     let mut bucket_recs = vec![];
 
     for attr in &data_point.attributes {
-        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value);
+        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
     }
     rec[&CONFIG.common.column_timestamp] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
@@ -582,7 +583,7 @@ fn process_exp_hist_data_point(
     let mut bucket_recs = vec![];
 
     for attr in &data_point.attributes {
-        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value);
+        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
     }
     rec[&CONFIG.common.column_timestamp] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
@@ -643,7 +644,7 @@ fn process_summary_data_point(
     let mut bucket_recs = vec![];
 
     for attr in &data_point.attributes {
-        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value);
+        rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
     }
     rec[&CONFIG.common.column_timestamp] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
@@ -680,7 +681,7 @@ fn process_exemplars(rec: &mut json::Value, exemplars: &Vec<Exemplar>) {
     for exemplar in exemplars {
         let mut exemplar_rec = json::json!({});
         for attr in &exemplar.filtered_attributes {
-            exemplar_rec[attr.key.as_str()] = get_val(&attr.value);
+            exemplar_rec[attr.key.as_str()] = get_val(&attr.value.as_ref());
         }
         exemplar_rec[VALUE_LABEL] = get_exemplar_val(&exemplar.value);
         exemplar_rec[&CONFIG.common.column_timestamp] = (exemplar.time_unix_nano / 1000).into();

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -144,7 +144,7 @@ pub async fn handle_trace_request(
 
         for res_attr in resource.attributes {
             if res_attr.key.eq(SERVICE_NAME) {
-                let loc_service_name = get_val(&res_attr.value);
+                let loc_service_name = get_val(&res_attr.value.as_ref());
                 if !loc_service_name.eq(&json::Value::Null) {
                     service_name = loc_service_name.as_str().unwrap().to_string();
                     service_att_map.insert(res_attr.key, loc_service_name);
@@ -152,7 +152,7 @@ pub async fn handle_trace_request(
             } else {
                 service_att_map.insert(
                     format!("{}.{}", SERVICE, res_attr.key),
-                    get_val(&res_attr.value),
+                    get_val(&res_attr.value.as_ref()),
                 );
             }
         }
@@ -193,14 +193,14 @@ pub async fn handle_trace_request(
                 let end_time: u64 = span.end_time_unix_nano;
                 let mut span_att_map: AHashMap<String, json::Value> = AHashMap::new();
                 for span_att in span.attributes {
-                    span_att_map.insert(span_att.key, get_val(&span_att.value));
+                    span_att_map.insert(span_att.key, get_val(&span_att.value.as_ref()));
                 }
 
                 let mut events = vec![];
                 let mut event_att_map: AHashMap<String, json::Value> = AHashMap::new();
                 for event in span.events {
                     for event_att in event.attributes {
-                        event_att_map.insert(event_att.key, get_val(&event_att.value));
+                        event_att_map.insert(event_att.key, get_val(&event_att.value.as_ref()));
                     }
                     events.push(Event {
                         name: event.name,


### PR DESCRIPTION
Fixed:

- [x] data type conflict for traces, the error like this: 
```
'tokio-runtime-worker' panicked at /app/src/job/files/disk.rs:257:37:
called 'Result:unwrap()' on an Err value: JsonError("whilst decoding field 'net_peer_port': expected string got 38910")
```
- [x] web/monacoeditorwork/editor.worker.bundle.js was blocked because of a disallowed MIME type ("text/html")