### PR TITLE
fix: k8s events stream name

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6301,18 +6301,22 @@
       }
     },
     "node_modules/browserify-sign": {
-      "version": "4.2.1",
-      "license": "ISC",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+      "integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
       "dependencies": {
-        "bn.js": "^5.1.1",
-        "browserify-rsa": "^4.0.1",
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.4",
         "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "parse-asn1": "^5.1.6",
+        "readable-stream": "^3.6.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/browserify-sign/node_modules/readable-stream": {

--- a/web/src/components/ingestion/Custom.vue
+++ b/web/src/components/ingestion/Custom.vue
@@ -15,68 +15,65 @@
 
 <!-- eslint-disable vue/x-invalid-end-tag -->
 <template>
-
-    <q-splitter
-      v-model="splitterModel"
-      unit="px"
-      style="min-height: calc(100vh - 130px)"
-    >
-      <template v-slot:before>
-        <q-tabs
-          v-model="tabs"
-          indicator-color="transparent"
+  <q-splitter
+    v-model="splitterModel"
+    unit="px"
+    style="min-height: calc(100vh - 130px)"
+  >
+    <template v-slot:before>
+      <q-tabs
+        v-model="tabs"
+        indicator-color="transparent"
         inline-label
         vertical
-        >
-          <q-route-tab
-            default
-            name="ingestLogs"
-            :to="{
-              name: 'ingestLogs',
-              query: {
-                org_identifier: store.state.selectedOrganization.identifier,
-              },
-            }"
-            :label="t('ingestion.logsLabel')"
-            content-class="tab_content"
-          />
-          <q-route-tab
-            name="ingestMetrics"
-            :to="{
-              name: 'ingestMetrics',
-              query: {
-                org_identifier: store.state.selectedOrganization.identifier,
-              },
-            }"
-            :label="t('ingestion.metricsLabel')"
-            label="Metrics"
-            content-class="tab_content"
-          />
-          <q-route-tab
-            name="ingestTraces"
-            :to="{
-              name: 'ingestTraces',
-              query: {
-                org_identifier: store.state.selectedOrganization.identifier,
-              },
-            }"
-            :label="t('ingestion.tracesLabel')"
-            label="Traces"
-            content-class="tab_content"
-          />
-        </q-tabs>
-      </template>
+      >
+        <q-route-tab
+          default
+          name="ingestLogs"
+          :to="{
+            name: 'ingestLogs',
+            query: {
+              org_identifier: store.state.selectedOrganization.identifier,
+            },
+          }"
+          :label="t('ingestion.logsLabel')"
+          content-class="tab_content"
+        />
+        <q-route-tab
+          name="ingestMetrics"
+          :to="{
+            name: 'ingestMetrics',
+            query: {
+              org_identifier: store.state.selectedOrganization.identifier,
+            },
+          }"
+          :label="t('ingestion.metricsLabel')"
+          content-class="tab_content"
+        />
+        <q-route-tab
+          name="ingestTraces"
+          :to="{
+            name: 'ingestTraces',
+            query: {
+              org_identifier: store.state.selectedOrganization.identifier,
+            },
+          }"
+          :label="t('ingestion.tracesLabel')"
+          content-class="tab_content"
+        />
+      </q-tabs>
+    </template>
 
-      <template v-slot:after>
-        <router-view
-          :title="tabs"
-          :currOrgIdentifier="currOrgIdentifier"
-          :currUserEmail="currentUserEmail"
-          @copy-to-clipboard-fn="copyToClipboardFn"
-        >
-        </router-view>
-      </template>
-    </q-splitter>
+    <template v-slot:after>
+      <router-view
+        :title="tabs"
+        :currOrgIdentifier="currOrgIdentifier"
+        :currUserEmail="currentUserEmail"
+        @copy-to-clipboard-fn="copyToClipboardFn"
+      >
+      </router-view>
+    </template>
+  </q-splitter>
 </template>
 
 <script lang="ts">

--- a/web/src/components/ingestion/metrics/PrometheusConfig.vue
+++ b/web/src/components/ingestion/metrics/PrometheusConfig.vue
@@ -14,39 +14,42 @@
 -->
 
 <template>
-  <div class="tabContent q-ma-md">
-    <div class="tabContent__head">
-      <div class="copy_action">
-        <q-btn
-          data-test="traces-copy-btn"
-          flat
-          round
-          size="0.5rem"
-          padding="0.6rem"
-          color="grey"
-          icon="content_copy"
-          @click="$emit('copy-to-clipboard-fn', copyTracesContent)"
-        />
+  <div>
+    <div class="tabContent q-ma-md">
+      <div class="tabContent__head">
+        <div class="copy_action">
+          <q-btn
+            data-test="traces-copy-btn"
+            flat
+            round
+            size="0.5rem"
+            padding="0.6rem"
+            color="grey"
+            icon="content_copy"
+            @click="$emit('copy-to-clipboard-fn', copyTracesContent)"
+          />
+        </div>
       </div>
-    </div>
-    <pre ref="copyTracesContent" data-test="traces-content-text">
+      <pre ref="copyTracesContent" data-test="traces-content-text">
 remote_write:
   - url: {{ endpoint.url }}/api/{{ currOrgIdentifier }}/prometheus/api/v1/write
     basic_auth:
       username: {{ currUserEmail }}
-      password: {{ store.state.organizationData.organizationPasscode }}</pre>
-  </div>
-  <div>
-    <a
-      href="https://openobserve.ai/blog/send-metrics-using-kube-prometheus-stack-to-openobserve"
-      class="q-ml-lg text-bold"
-      style="padding-right: 2px"
-      target="_blank"
-      title="Send Kubernetes Metrics Using Prometheus to OpenObserve"
-    >
-      Click here</a
-    >
-    to learn how to ingest metrics using Prometheus
+      password: {{ store.state.organizationData.organizationPasscode }}</pre
+      >
+    </div>
+    <div>
+      <a
+        href="https://openobserve.ai/blog/send-metrics-using-kube-prometheus-stack-to-openobserve"
+        class="q-ml-lg text-bold"
+        style="padding-right: 2px"
+        target="_blank"
+        title="Send Kubernetes Metrics Using Prometheus to OpenObserve"
+      >
+        Click here</a
+      >
+      to learn how to ingest metrics using Prometheus
+    </div>
   </div>
 </template>
 

--- a/web/src/components/ingestion/recommended/KubernetesConfig.vue
+++ b/web/src/components/ingestion/recommended/KubernetesConfig.vue
@@ -15,7 +15,7 @@
       content="kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml"
     />
 
-    <div class="text-subtitle1 q-pl-xs q-mt-md">Wait for 2 minutes</div>
+    <div class="text-subtitle1 q-pl-xs q-mt-md">Wait for 2 minutes after installing cert-manger for the webhook to be ready before installing OpenTelemetry operator.</div>
     <div class="text-subtitle1 q-pl-xs q-mt-md">Update helm repo</div>
     <ContentCopy
       class="q-mt-sm"

--- a/web/src/components/ingestion/recommended/KubernetesConfig.vue
+++ b/web/src/components/ingestion/recommended/KubernetesConfig.vue
@@ -15,7 +15,10 @@
       content="kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml"
     />
 
-    <div class="text-subtitle1 q-pl-xs q-mt-md">Wait for 2 minutes after installing cert-manger for the webhook to be ready before installing OpenTelemetry operator.</div>
+    <div class="text-subtitle1 q-pl-xs q-mt-md">
+      Wait for 2 minutes after installing cert-manger for the webhook to be
+      ready before installing OpenTelemetry operator.
+    </div>
     <div class="text-subtitle1 q-pl-xs q-mt-md">Update helm repo</div>
     <ContentCopy
       class="q-mt-sm"

--- a/web/src/components/ingestion/recommended/OtelConfig.vue
+++ b/web/src/components/ingestion/recommended/OtelConfig.vue
@@ -67,7 +67,7 @@ const getOtelGrpcConfig = computed(() => {
       headers:
         Authorization: "Basic ${accessKey.value}"
         organization: ${props.currOrgIdentifier}
-        stream-name: default
+        stream-name: k8s_events
       tls:
         insecure: true`;
 });

--- a/web/src/components/ingestion/recommended/OtelConfig.vue
+++ b/web/src/components/ingestion/recommended/OtelConfig.vue
@@ -1,12 +1,16 @@
 <template>
-  <div class="q-pa-md">
-    <div class="text-subtitle1 text-bold q-mt-md q-pl-xs">OTLP HTTP</div>
-    <ContentCopy class="q-mt-sm" :content="getOtelHttpConfig" />
-  </div>
-  <div class="q-pa-md">
-    <div class="text-subtitle1 text-bold q-mt-md q-pl-xs">OTLP gRPC</div>
-    <div class="title" data-test="vector-title-text"><b>Note:</b> Not supported in clustered installation of OpenObserve yet.</div>
-    <ContentCopy class="q-mt-sm" :content="getOtelGrpcConfig" />
+  <div>
+    <div class="q-pa-md">
+      <div class="text-subtitle1 text-bold q-mt-md q-pl-xs">OTLP HTTP</div>
+      <ContentCopy class="q-mt-sm" :content="getOtelHttpConfig" />
+    </div>
+    <div class="q-pa-md">
+      <div class="text-subtitle1 text-bold q-mt-md q-pl-xs">OTLP gRPC</div>
+      <div class="title" data-test="vector-title-text">
+        <b>Note:</b> Not supported in clustered installation of OpenObserve yet.
+      </div>
+      <ContentCopy class="q-mt-sm" :content="getOtelGrpcConfig" />
+    </div>
   </div>
 </template>
 

--- a/web/src/components/ingestion/traces/OpenTelemetry.vue
+++ b/web/src/components/ingestion/traces/OpenTelemetry.vue
@@ -14,47 +14,56 @@
 -->
 
 <template>
-  <div class="title q-pl-md q-pt-md" data-test="vector-title-text"><b>OTLP HTTP</b></div>
-  <div class="tabContent q-ma-md">
-    <div class="tabContent__head">
-      <div class="copy_action">
-        <q-btn
-          data-test="traces-copy-btn"
-          flat
-          round
-          color="grey"
-          icon="content_copy"
-          @click="$emit('copy-to-clipboard-fn', copyHTTPTracesContent)"
-        />
-      </div>
+  <div>
+    <div class="title q-pl-md q-pt-md" data-test="vector-title-text">
+      <b>OTLP HTTP</b>
     </div>
-    <pre ref="copyHTTPTracesContent" data-test="traces-http-content-text">
+    <div class="tabContent q-ma-md">
+      <div class="tabContent__head">
+        <div class="copy_action">
+          <q-btn
+            data-test="traces-copy-btn"
+            flat
+            round
+            color="grey"
+            icon="content_copy"
+            @click="$emit('copy-to-clipboard-fn', copyHTTPTracesContent)"
+          />
+        </div>
+      </div>
+      <pre ref="copyHTTPTracesContent" data-test="traces-http-content-text">
 HTTP Endpoint: {{ endpoint.url }}/api/{{ currOrgIdentifier }}/traces
-Authorization: Basic {{ accessKey }}</pre>
-  </div>
-
-  <div class="title q-pl-md q-pt-md" data-test="vector-title-text"><b>OTLP gRPC</b> <br />(<b>Note:</b> Only available for single node. Not supported in distributed mode.)</div>
-  <div class="tabContent q-ma-md">
-    <div class="tabContent__head">
-      <div class="copy_action">
-        <q-btn
-          data-test="traces-copy-btn"
-          flat
-          round
-          color="grey"
-          icon="content_copy"
-          @click="$emit('copy-to-clipboard-fn', copyGRPCTracesContent)"
-        />
-      </div>
+Authorization: Basic {{ accessKey }}</pre
+      >
     </div>
-    <pre ref="copyGRPCTracesContent" data-test="traces-grpc-content-text">
+
+    <div class="title q-pl-md q-pt-md" data-test="vector-title-text">
+      <b>OTLP gRPC</b> <br /><b>Note:</b> Not supported in clustered
+      installation of OpenObserve yet.
+    </div>
+    <div class="tabContent q-ma-md">
+      <div class="tabContent__head">
+        <div class="copy_action">
+          <q-btn
+            data-test="traces-copy-btn"
+            flat
+            round
+            color="grey"
+            icon="content_copy"
+            @click="$emit('copy-to-clipboard-fn', copyGRPCTracesContent)"
+          />
+        </div>
+      </div>
+      <pre ref="copyGRPCTracesContent" data-test="traces-grpc-content-text">
 endpoint: {{ endpoint.host }}
 headers: 
   Authorization: "Basic {{ accessKey }}"
   organization: {{ currOrgIdentifier }}
   stream-name: default
 tls:
-  insecure: {{endpoint.protocol == "https" ? false : true}}</pre>
+  insecure: {{ endpoint.protocol == "https" ? false : true }}</pre
+      >
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
otel-collector is supposed to send all k8s events to a stream named `k8s_events` for for better analysis. It was being sent to `default` for otlp/grpc