### PR TITLE
feat: add musl release binary for arm64 architecture

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,9 @@ rustflags = ["-C", "target-feature=+sse2,+ssse3,+sse4.1,+sse4.2"]
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=+sse2,+ssse3,+sse4.1,+sse4.2"]
 
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+neon"]
+
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 rustflags = ["-C", "target-feature=+neon"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
             features: "--features mimalloc"
             file_name: openobserve-${{ github.ref_name }}-linux-amd64-musl
             file_ext: .tar.gz
+          - arch: aarch64-unknown-linux-musl
+            os: ubuntu-2004-8-cores
+            features: "--features mimalloc"
+            file_name: openobserve-${{ github.ref_name }}-linux-arm64-musl
+            file_ext: .tar.gz
           - arch: aarch64-unknown-linux-gnu
             os: ubuntu-2004-8-cores
             features: "--features mimalloc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,13 @@ jobs:
           brew install protobuf
 
       - name: Install dependencies for linux
-        if: contains(matrix.arch, 'linux')
+        if: contains(matrix.arch, 'linux-gnu')
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install libssl-dev pkg-config g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+      
+      - name: Install dependencies for linux
+        if: contains(matrix.arch, 'linux-musl')
         run: |
           sudo apt-get -y update
           sudo apt-get -y install libssl-dev pkg-config g++-aarch64-linux-gnu gcc-aarch64-linux-gnu musl-dev musl-tools


### PR DESCRIPTION
Add musl binary for arm64 architecture to generate a binary with no dependencies. https://github.com/openobserve/openobserve/issues/1890