### PR TITLE
feat: set pushdown_filters only for normal query

### DIFF
--- a/src/common/meta/search.rs
+++ b/src/common/meta/search.rs
@@ -23,6 +23,13 @@ use crate::service::search::datafusion::storage::StorageType;
 pub struct Session {
     pub id: String,
     pub storage_type: StorageType,
+    pub search_type: SearchType,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SearchType {
+    Normal,
+    Aggregation,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -28,7 +28,7 @@ use crate::common::{
     },
     meta::{
         common::FileKey,
-        search::Session as SearchSession,
+        search::{SearchType, Session as SearchSession},
         stream::{PartitionTimeLevel, ScanStats, StreamParams},
         StreamType,
     },
@@ -130,6 +130,7 @@ pub(crate) async fn create_context(
     let session = SearchSession {
         id: session_id.to_string(),
         storage_type: StorageType::Memory,
+        search_type: SearchType::Normal,
     };
 
     let ctx = register_table(

--- a/src/service/promql/search/grpc/wal.rs
+++ b/src/service/promql/search/grpc/wal.rs
@@ -24,12 +24,18 @@ use tonic::{codec::CompressionEncoding, metadata::MetadataValue, transport::Chan
 use tracing::{info_span, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::common::infra::{
-    cache::tmpfs,
-    cluster::{get_cached_online_ingester_nodes, get_internal_grpc_token},
-    config::CONFIG,
+use crate::common::{
+    infra::{
+        cache::tmpfs,
+        cluster::{get_cached_online_ingester_nodes, get_internal_grpc_token},
+        config::CONFIG,
+    },
+    meta::{
+        search::{SearchType, Session as SearchSession},
+        stream::ScanStats,
+        StreamType,
+    },
 };
-use crate::common::meta::{search::Session as SearchSession, stream::ScanStats, StreamType};
 use crate::handler::grpc::cluster_rpc;
 use crate::service::{
     db,
@@ -88,6 +94,7 @@ pub(crate) async fn create_context(
     let session = SearchSession {
         id: session_id.to_string(),
         storage_type: StorageType::Tmpfs,
+        search_type: SearchType::Normal,
     };
 
     let ctx = register_table(&session, schema.clone(), stream_name, &[], FileType::JSON).await?;

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -28,6 +28,7 @@ use crate::common::{
     meta::{
         self,
         common::FileKey,
+        search::SearchType,
         stream::{PartitionTimeLevel, ScanStats},
     },
 };
@@ -168,6 +169,11 @@ pub async fn search(
         let session = meta::search::Session {
             id: format!("{session_id}-{ver}"),
             storage_type: StorageType::Memory,
+            search_type: if !sql.meta.group_by.is_empty() {
+                SearchType::Aggregation
+            } else {
+                SearchType::Normal
+            },
         };
         // cacluate the diff between latest schema and group schema
         let mut diff_fields = HashMap::new();

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -29,7 +29,7 @@ use crate::common::{
         errors::{Error, ErrorCodes},
         wal,
     },
-    meta::{self, common::FileKey, stream::ScanStats},
+    meta::{self, common::FileKey, search::SearchType, stream::ScanStats},
     utils::{
         file::{get_file_contents, get_file_meta, scan_files},
         schema::infer_json_schema,
@@ -188,6 +188,11 @@ pub async fn search(
             meta::search::Session {
                 id: session_id.to_string(),
                 storage_type: StorageType::Tmpfs,
+                search_type: if !sql.meta.group_by.is_empty() {
+                    SearchType::Aggregation
+                } else {
+                    SearchType::Normal
+                },
             }
         } else {
             let id = format!("{session_id}-{ver}");
@@ -204,6 +209,11 @@ pub async fn search(
             meta::search::Session {
                 id,
                 storage_type: StorageType::Tmpfs,
+                search_type: if !sql.meta.group_by.is_empty() {
+                    SearchType::Aggregation
+                } else {
+                    SearchType::Normal
+                },
             }
         };
         let datafusion_span = info_span!(


### PR DESCRIPTION
This is an optimized option `DATAFUSION_EXECUTION_PARQUET_PUSHDOWN_FILTERS`, we found it can improve normal query speed like `select * from t where a=b`, but it will slow the aggregation query `select a, count(*) from t group by a`.

So, we only auto enable this option for normal query.

After this change we also support use `datafusion evironments` to control it, like set an environment like this:

```
DATAFUSION_EXECUTION_PARQUET_PUSHDOWN_FILTERS = true
```