### PR TITLE
fix: alert deletion & notification panic

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,11 +12,11 @@ rustflags = ["-C", "target-feature=+neon"]
 linker = "aarch64-linux-gnu-gcc"
 rustflags = ["-C", "target-feature=+neon"]
 
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "target-feature=+sse2,+ssse3,+sse4.1,+sse4.2"]
-
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "target-feature=+neon"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "target-feature=+sse2,+ssse3,+sse4.1,+sse4.2"]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+sse2,+ssse3,+sse4.1,+sse4.2"]

--- a/src/common/meta/alert.rs
+++ b/src/common/meta/alert.rs
@@ -159,6 +159,8 @@ pub struct Trigger {
     pub is_ingest_time: bool,
     #[serde(default)]
     pub stream_type: StreamType,
+    #[serde(default)]
+    pub parent_alert_deleted: bool,
 }
 
 impl Default for Trigger {
@@ -173,6 +175,7 @@ impl Default for Trigger {
             count: 0,
             stream_type: StreamType::Logs,
             is_ingest_time: false,
+            parent_alert_deleted: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,7 +296,6 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
         if CONFIG.common.feature_per_thread_lock {
             thread_id.fetch_add(1, Ordering::SeqCst);
         }
-
         log::info!(
             "starting HTTP server at: {}, thread_id: {}",
             haddr,

--- a/src/service/alert_manager.rs
+++ b/src/service/alert_manager.rs
@@ -26,7 +26,7 @@ use crate::service::triggers;
 
 pub async fn run() -> Result<(), anyhow::Error> {
     for trigger in TRIGGERS.iter() {
-        if !trigger.is_ingest_time {
+        if !trigger.is_ingest_time && !trigger.parent_alert_deleted {
             let trigger = trigger.clone();
             tokio::task::spawn(async move { handle_triggers(trigger).await });
         }
@@ -89,7 +89,7 @@ async fn handle_trigger(alert_key: &str, frequency: i64) {
                 break;
             }
         };
-        if TRIGGERS_IN_PROCESS.clone().contains_key(alert_key) {
+        if !trigger.parent_alert_deleted && TRIGGERS_IN_PROCESS.clone().contains_key(alert_key) {
             let alert_resp = super::db::alerts::get(
                 &trigger.org,
                 &trigger.stream,

--- a/src/service/alert_manager.rs
+++ b/src/service/alert_manager.rs
@@ -43,7 +43,12 @@ pub async fn handle_triggers(trigger: Trigger) {
     )
     .await
     {
-        Err(_) => log::error!("[ALERT MANAGER] Error fetching alert"),
+        Err(_) => {
+            let trigger_key = format!("{}/{}", &trigger.org, &trigger.alert_name);
+            let mut local_trigger = trigger;
+            local_trigger.parent_alert_deleted = true;
+            let _ = crate::service::db::triggers::set(&trigger_key, &local_trigger).await;
+        }
         Ok(result) => {
             let key = format!("{}/{}", &trigger.org, &trigger.alert_name);
             if let Some(alert) = result {

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -133,6 +133,7 @@ pub async fn save_alert(
             last_sent_at: 0,
             count: 0,
             is_ingest_time: false,
+            parent_alert_deleted: false,
         };
         let _ = triggers::save_trigger(&trigger.alert_name, &trigger).await;
     }
@@ -223,6 +224,7 @@ pub async fn trigger_alert(
                 count: 0,
                 is_ingest_time: alert.is_real_time,
                 stream_type,
+                parent_alert_deleted: false,
             };
             let _ = send_notification(&alert, &trigger).await;
             Ok(HttpResponse::Ok().json(MetaHttpResponse::message(

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -297,6 +297,7 @@ async fn add_valid_record(
                                     last_sent_at: 0,
                                     count: 0,
                                     is_ingest_time: true,
+                                    parent_alert_deleted: false,
                                 });
                             }
                         }

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -254,6 +254,7 @@ pub async fn handle_grpc_request(
                                                 last_sent_at: 0,
                                                 count: 0,
                                                 is_ingest_time: true,
+                                                parent_alert_deleted: false,
                                             },
                                         );
                                     }

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -357,6 +357,7 @@ pub async fn metrics_json_handler(
                                                     last_sent_at: 0,
                                                     count: 0,
                                                     is_ingest_time: true,
+                                                    parent_alert_deleted: false,
                                                 },
                                             );
                                         }

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -324,6 +324,7 @@ pub async fn remote_write(
                                         last_sent_at: 0,
                                         count: 0,
                                         is_ingest_time: true,
+                                        parent_alert_deleted: false,
                                     },
                                 );
                             }

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -304,6 +304,7 @@ pub async fn handle_trace_request(
                                         last_sent_at: 0,
                                         count: 0,
                                         is_ingest_time: true,
+                                        parent_alert_deleted: false,
                                     });
                                 }
                             }

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -368,6 +368,7 @@ pub async fn traces_json(
                                             last_sent_at: 0,
                                             count: 0,
                                             is_ingest_time: true,
+                                            parent_alert_deleted: false,
                                         });
                                     }
                                 }

--- a/src/service/triggers.rs
+++ b/src/service/triggers.rs
@@ -69,6 +69,7 @@ mod tests {
                 stream_type: crate::common::meta::StreamType::Logs,
                 count: 0,
                 is_ingest_time: false,
+                parent_alert_deleted: false,
             },
         )
         .await;


### PR DESCRIPTION
fixes below mentioned issues: 

- [x] https://github.com/openobserve/openobserve/issues/1925
- [x] If destination url cant be parsed , application panics
- [x] Update trigger for deleted alert (for old versions of openobserve)