### PR TITLE
fix: change instrumenter to per language

### DIFF
--- a/web/src/components/ingestion/recommended/KubernetesConfig.vue
+++ b/web/src/components/ingestion/recommended/KubernetesConfig.vue
@@ -53,26 +53,26 @@
           <ol>
             <li>
               <b>Java:</b> instrumentation.opentelemetry.io/inject-java:
-              "openobserve-collector/openobserve"
+              "openobserve-collector/openobserve-java"
             </li>
             <li>
               <b>DotNet:</b> instrumentation.opentelemetry.io/inject-dotnet:
-              "openobserve-collector/openobserve"
+              "openobserve-collector/openobserve-dotnet"
             </li>
             <li>
               <b>NodeJS:</b> instrumentation.opentelemetry.io/inject-nodejs:
-              "openobserve-collector/openobserve"
+              "openobserve-collector/openobserve-nodejs"
             </li>
             <li>
               <b>Python:</b> instrumentation.opentelemetry.io/inject-python:
-              "openobserve-collector/openobserve"
+              "openobserve-collector/openobserve-python"
             </li>
             <li>
               <b>Go (Uses eBPF):</b>
               <ul>
                 <li>
                   instrumentation.opentelemetry.io/inject-go:
-                  "openobserve-collector/openobserve"
+                  "openobserve-collector/openobserve-go"
                 </li>
                 <li>
                   instrumentation.opentelemetry.io/otel-go-auto-target-exe:


### PR DESCRIPTION
Automatic instrumentation for each language is now done by a sperate instrumenter. This allows for upgrade of helm chart of openobserve collector without making any changes to OpenObserve ingestion page when changes to individual languages are done.