### PR TITLE
docs: defaultPrivacyLevel added for RUM

### DIFF
--- a/web/src/components/ingestion/recommended/FrontendRumConfig.vue
+++ b/web/src/components/ingestion/recommended/FrontendRumConfig.vue
@@ -96,6 +96,7 @@ openobserveRum.init({
   trackUserInteractions: true,
   apiVersion: options.apiVersion,
   insecureHTTP: options.insecureHTTP,
+  defaultPrivacyLevel: 'allow' // 'allow' or 'mask-user-input' or 'mask'. Use one of the 3 values.
 });
 
 openobserveLogs.init({


### PR DESCRIPTION
Added defaultPrivacyLevel guidance which allows configuration of masking session replay data.