### PR TITLE
fix: partiton_key for traces should have consistent behavior

### DIFF
--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -314,8 +314,7 @@ pub async fn handle_trace_request(
                 }
 
                 if partition_keys.is_empty() {
-                    let partition_key =
-                        format!("service_name={}", format_stream_name(&service_name));
+                    let partition_key = format!("service_name={}", service_name);
                     hour_key.push_str(&format!("/{}", format_partition_key(&partition_key)));
                 }
 

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -378,8 +378,7 @@ pub async fn traces_json(
                     }
 
                     if partition_keys.is_empty() {
-                        let partition_key =
-                            format!("service_name={}", format_stream_name(&service_name));
+                        let partition_key = format!("service_name={}", service_name);
                         hour_key.push_str(&format!("/{}", format_partition_key(&partition_key)));
                     }
 


### PR DESCRIPTION
If we ingest data with `service_name=id-map` then it will create a wal file with `service_name=id_map`, because we replace `-` to `_`.

But after the stream is created then the ingested file will be `service_name=id-map`, because the second time we don't format stream_name, we use the function `format_partiton_key`.