### PR TITLE
fix: run the mmdb downloader everywhere

### DIFF
--- a/src/job/mmdb_downloader.rs
+++ b/src/job/mmdb_downloader.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::common::infra::cluster::is_ingester;
 use crate::common::infra::config::{CONFIG, MAXMIND_DB_CLIENT};
 use crate::common::meta::maxmind::MaxmindClient;
 use futures::stream::StreamExt;
@@ -23,6 +22,24 @@ use std::path::Path;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use tokio::time;
+
+pub const MMDB_FILE_NAME: &str = "GeoLite2-City.mmdb";
+
+/// Update the global maxdb client object
+pub async fn update_global_maxmind_client(fname: &str) {
+    match MaxmindClient::new_with_path(fname) {
+        Ok(maxminddb_client) => {
+            let mut client = MAXMIND_DB_CLIENT.write().await;
+            *client = Some(maxminddb_client);
+            log::info!("Successfully updated MaxmindClient");
+        }
+        Err(e) => log::warn!(
+            "Failed to create MaxmindClient with path: {}, {}",
+            fname,
+            e.to_string()
+        ),
+    }
+}
 
 pub async fn is_digest_different(
     local_file_path: &str,
@@ -67,7 +84,7 @@ pub async fn download_file(client: &Client, url: &str, path: &str) -> Result<(),
 async fn run_download_files() {
     // send request and await response
     let client = reqwest::ClientBuilder::default().build().unwrap();
-    let fname = format!("{}/GeoLite2-City.mmdb", &CONFIG.common.mmdb_data_dir);
+    let fname = format!("{}/{}", &CONFIG.common.mmdb_data_dir, MMDB_FILE_NAME);
 
     let download_files =
         match is_digest_different(&fname, &CONFIG.common.mmdb_geolite_citydb_sha256_url).await {
@@ -81,10 +98,7 @@ async fn run_download_files() {
     if download_files {
         match download_file(&client, &CONFIG.common.mmdb_geolite_citydb_url, &fname).await {
             Ok(()) => {
-                let maxminddb_client = MaxmindClient::new_with_path(fname);
-                let mut client = MAXMIND_DB_CLIENT.write().await;
-                *client = maxminddb_client.ok();
-                log::info!("Updated geo-json data")
+                update_global_maxmind_client(&fname).await;
             }
             Err(e) => log::error!("failed to download the files {}", e),
         }
@@ -93,15 +107,15 @@ async fn run_download_files() {
 
 pub async fn run() -> Result<(), anyhow::Error> {
     log::info!("spawned");
-    if !is_ingester(&super::cluster::LOCAL_NODE_ROLE) {
-        return Ok(());
-    }
-
     std::fs::create_dir_all(&CONFIG.common.mmdb_data_dir)?;
     // should run it every 24 hours
     let mut interval = time::interval(time::Duration::from_secs(
         CONFIG.common.mmdb_update_duration,
     ));
+
+    // Try to load the existing file, in the beginning.
+    let fname = format!("{}/{}", &CONFIG.common.mmdb_data_dir, MMDB_FILE_NAME);
+    update_global_maxmind_client(&fname).await;
 
     loop {
         interval.tick().await;


### PR DESCRIPTION
- mmdb-downloader wasn't enabled on ingestor, enabled that.
- mmdb-client wasn't initialized on the first run ( in case the file
  already existed ), so enabled that