### PR TITLE
Update install command for sccache

### DIFF
--- a/deploy/build/Dockerfile.sccache.aarch64
+++ b/deploy/build/Dockerfile.sccache.aarch64
@@ -4,7 +4,7 @@ RUN rustup toolchain install nightly-2023-10-24
 RUN rustup default nightly-2023-10-24
 RUN rustup target add aarch64-unknown-linux-gnu
 RUN rustup component add rustfmt clippy llvm-tools
-RUN cargo install sccache
+RUN cargo install sccache --locked
 ENV SCCACHE_IDLE_TIMEOUT=1800
 ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
 

--- a/deploy/build/Dockerfile.sccache.amd64
+++ b/deploy/build/Dockerfile.sccache.amd64
@@ -4,7 +4,7 @@ RUN rustup toolchain install nightly-2023-10-24
 RUN rustup default nightly-2023-10-24
 RUN rustup target add x86_64-unknown-linux-gnu
 RUN rustup component add rustfmt clippy llvm-tools
-RUN cargo install sccache
+RUN cargo install sccache --locked
 ENV SCCACHE_IDLE_TIMEOUT=1800
 ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
 


### PR DESCRIPTION
Update the install command for `sccache` to follow guidelines from `mozilla/sccache` developers.

Related: https://github.com/mozilla/sccache/issues/1989
Fixes #2061 