### PR TITLE
fix: rum browser sdk sends keys with updated o2 prefix

### DIFF
--- a/src/handler/http/auth/mod.rs
+++ b/src/handler/http/auth/mod.rs
@@ -293,7 +293,8 @@ pub async fn validator_rum(
         web::Query::<std::collections::HashMap<String, String>>::from_query(req.query_string())
             .unwrap();
 
-    match query.get("oo-api-key") {
+    let token = query.get("oo-api-key").or_else(|| query.get("o2-api-key"));
+    match token {
         Some(token) => match validate_token(token, org_id_end_point[0]).await {
             Ok(res) => {
                 if res {


### PR DESCRIPTION
We have updated the prefix of the keys from `oo` -> `o2` in rum-browser sdk. This change is to support both the versions of keys in the payload