### PR TITLE
fix: removed newline

### DIFF
--- a/web/src/components/ingestion/recommended/LinuxConfig.vue
+++ b/web/src/components/ingestion/recommended/LinuxConfig.vue
@@ -58,8 +58,7 @@ const accessKey = computed(() => {
 });
 
 const getCommand = computed(() => {
-  return `curl -O https://raw.githubusercontent.com/openobserve/agents/main/linux/install.sh \\      
-    && chmod +x install.sh && sudo ./install.sh ${endpoint.value.url}/api/${props.currOrgIdentifier}/ ${accessKey.value}`;
+  return `curl -O https://raw.githubusercontent.com/openobserve/agents/main/linux/install.sh && chmod +x install.sh && sudo ./install.sh ${endpoint.value.url}/api/${props.currOrgIdentifier}/ ${accessKey.value}`;
 });
 </script>
 


### PR DESCRIPTION
Removed newline. Directly copy pasting the linux ingestion command was throwing error 

```
curl: (3) URL using bad/illegal format or missing URL
-bash: syntax error near unexpected token `&&'
```