### PR TITLE
feat: remove requirement of powershell6+

### DIFF
--- a/web/src/components/ingestion/recommended/WindowsConfig.vue
+++ b/web/src/components/ingestion/recommended/WindowsConfig.vue
@@ -1,31 +1,5 @@
 <template>
   <div class="q-pa-md">
-    <div class="text-subtitle1 q-pb-sm">
-      You need minimum PowerShell 6 to run the install script, you can check
-      your PowerShell version by running
-      <code class="q-px-xs q-py-xs text-subtitle1" style="border-radius: 4px"
-        >$PSVersionTable.PSVersion</code
-      >
-      in your terminal.
-    </div>
-    <div class="text-subtitle1">You should see something like this:</div>
-    <pre
-      class="notranslate q-px-md q-py-md text-body"
-    >PS C:\<span class="pl-k">&gt;</span> <span class="pl-c1">$PSVersionTable<span class="pl-smi">.PSVersion</span></span>
-
-Major  Minor  Patch  PreReleaseLabel BuildLabel
-<span class="pl-k">-----</span>  <span class="pl-k">-----</span>  <span class="pl-k">-----</span>  <span class="pl-k">---------------</span> <span class="pl-k">----------</span>
-<span class="pl-c1">7</span>      <span class="pl-c1">3</span>      <span class="pl-c1">7</span></pre>
-    <div class="text-subtitle1">Major should be at least 6.</div>
-    <div class="text-subtitle1 q-pt-sm">
-      You can download and install the latest version of powershell from
-      <a
-        target="_blank"
-        href="https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.3"
-        >here</a
-      >
-    </div>
-
     <div class="text-subtitle1 q-pl-xs q-mt-md">
       Run the powershell terminal as administrator and execute the following
       command:


### PR DESCRIPTION
At least powershell 6 was required to execute the openobserve-collector installation script on windows. By deafult powershell 5.1 is available in most machines. 

This modification allows installation of openobserve-collector without upgrading powershell.