### PR TITLE
fix: add keyword search for values API

### DIFF
--- a/src/service/distinct_values.rs
+++ b/src/service/distinct_values.rs
@@ -155,7 +155,7 @@ impl DistinctValues {
                 let hour_key = ingestion::get_wal_time_key(
                     timestamp,
                     &vec![],
-                    unwrap_partition_time_level(None, StreamType::Logs),
+                    unwrap_partition_time_level(None, StreamType::Metadata),
                     data,
                     None,
                 );


### PR DESCRIPTION
Now, you can set url parameter `keyword=abc` to search the values. and use parameter `filter=service_name=a,b,c` to filter multiple values.