### PR TITLE
fix: zoom issue for non timeseries charts

### DIFF
--- a/web/src/components/dashboards/viewPanel/ViewPanel.vue
+++ b/web/src/components/dashboards/viewPanel/ViewPanel.vue
@@ -67,7 +67,10 @@
               <VariablesValueSelector
                 :variablesConfig="currentDashboardData.data?.variables"
                 :selectedTimeDate="dashboardPanelData.meta.dateTime"
-                :initialVariableValues="initialVariableValues"
+                :initialVariableValues="initialVariableValues?.values?.reduce((initialObj: any, variable: any) => {
+                  initialObj[variable?.name] = variable?.value;
+                  return initialObj;
+                }, {})"
                 @variablesData="variablesDataUpdated"
               />
               <div style="flex: 1">
@@ -180,6 +183,8 @@ export default defineComponent({
 
     // array of histogram fields
     let histogramFields: any = ref([]);
+
+    console.log(props.initialVariableValues, "initialVariableValues");
 
     watch(
       () => histogramInterval.value,

--- a/web/src/components/dashboards/viewPanel/ViewPanel.vue
+++ b/web/src/components/dashboards/viewPanel/ViewPanel.vue
@@ -184,8 +184,6 @@ export default defineComponent({
     // array of histogram fields
     let histogramFields: any = ref([]);
 
-    console.log(props.initialVariableValues, "initialVariableValues");
-
     watch(
       () => histogramInterval.value,
       () => {

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -125,7 +125,11 @@ export const convertPromQLData = (
       extraCssText: "max-height: 200px; overflow: auto; max-width: 500px",
       formatter: function (name: any) {
         // show tooltip for hovered panel only for other we only need axis so just return empty string
-        if (hoveredSeriesState?.value?.panelId != panelSchema.id) return "";
+        if (
+          hoveredSeriesState?.value &&
+          hoveredSeriesState?.value?.panelId != panelSchema.id
+        )
+          return "";
         if (name.length == 0) return "";
 
         const date = new Date(name[0].data[0]);
@@ -213,10 +217,10 @@ export const convertPromQLData = (
       tooltip: {
         show: false,
       },
-      itemSize:0,
-      itemGap:0,
+      itemSize: 0,
+      itemGap: 0,
       // it is used to hide toolbox buttons
-      bottom:"100%",
+      bottom: "100%",
       feature: {
         dataZoom: {
           filterMode: "none",

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -493,7 +493,10 @@ export const convertPromQLData = (
 
   options.series = options.series.flat();
 
-  // promql query will be always timeseries
+  // allowed to zoom, only if timeseries
+  options.toolbox.show = options.toolbox.show && isTimeSeriesFlag;
+
+  // promql query will be always timeseries except gauge and metric text chart.
   return {
     options,
     extras: { panelId: panelSchema?.id, isTimeSeries: isTimeSeriesFlag },

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -235,7 +235,11 @@ export const convertSQLData = (
       },
       formatter: function (name: any) {
         // show tooltip for hovered panel only for other we only need axis so just return empty string
-        if (hoveredSeriesState?.value?.panelId != panelSchema.id) return "";
+        if (
+          hoveredSeriesState?.value &&
+          hoveredSeriesState?.value?.panelId != panelSchema.id
+        )
+          return "";
         if (name.length == 0) return "";
 
         // get the current series index from name
@@ -375,10 +379,10 @@ export const convertSQLData = (
       tooltip: {
         show: false,
       },
-      itemSize:0,
-      itemGap:0,
+      itemSize: 0,
+      itemGap: 0,
       // it is used to hide toolbox buttons
-      bottom:"100%",
+      bottom: "100%",
       feature: {
         dataZoom: {
           yAxisIndex: "none",
@@ -488,7 +492,11 @@ export const convertSQLData = (
       } else {
         options.tooltip.formatter = function (name: any) {
           // show tooltip for hovered panel only for other we only need axis so just return empty string
-          if (hoveredSeriesState?.value?.panelId != panelSchema.id) return "";
+          if (
+            hoveredSeriesState?.value &&
+            hoveredSeriesState?.value?.panelId != panelSchema.id
+          )
+            return "";
           if (name.length == 0) return "";
 
           // get the current series index from name
@@ -610,7 +618,11 @@ export const convertSQLData = (
             : "rgba(255,255,255,1)",
         formatter: function (name: any) {
           // show tooltip for hovered panel only for other we only need axis so just return empty string
-          if (hoveredSeriesState?.value?.panelId != panelSchema.id) return "";
+          if (
+            hoveredSeriesState?.value &&
+            hoveredSeriesState?.value?.panelId != panelSchema.id
+          )
+            return "";
           return `${name.marker} ${name.name} : <b>${formatUnitValue(
             getUnitValue(
               name.value,
@@ -654,7 +666,11 @@ export const convertSQLData = (
             : "rgba(255,255,255,1)",
         formatter: function (name: any) {
           // show tooltip for hovered panel only for other we only need axis so just return empty string
-          if (hoveredSeriesState?.value?.panelId != panelSchema.id) return "";
+          if (
+            hoveredSeriesState?.value &&
+            hoveredSeriesState?.value?.panelId != panelSchema.id
+          )
+            return "";
           return `${name.marker} ${name.name} : <b>${formatUnitValue(
             getUnitValue(
               name.value,
@@ -817,7 +833,11 @@ export const convertSQLData = (
             : "rgba(255,255,255,1)",
         formatter: (params: any) => {
           // show tooltip for hovered panel only for other we only need axis so just return empty string
-          if (hoveredSeriesState?.value?.panelId != panelSchema.id) return "";
+          if (
+            hoveredSeriesState?.value &&
+            hoveredSeriesState?.value?.panelId != panelSchema.id
+          )
+            return "";
           // we have value[1] which return yaxis index
           // it is used to get y axis data
           return `${
@@ -1171,7 +1191,11 @@ export const convertSQLData = (
       options.xAxis[0].data = [];
       options.tooltip.formatter = function (name: any) {
         // show tooltip for hovered panel only for other we only need axis so just return empty string
-        if (hoveredSeriesState?.value?.panelId != panelSchema.id) return "";
+        if (
+          hoveredSeriesState?.value &&
+          hoveredSeriesState?.value?.panelId != panelSchema.id
+        )
+          return "";
         if (name.length == 0) return "";
 
         const date = new Date(name[0].data[0]);
@@ -1287,7 +1311,11 @@ export const convertSQLData = (
       options.xAxis[0].data = [];
       options.tooltip.formatter = function (name: any) {
         // show tooltip for hovered panel only for other we only need axis so just return empty string
-        if (hoveredSeriesState?.value?.panelId != panelSchema.id) return "";
+        if (
+          hoveredSeriesState?.value &&
+          hoveredSeriesState?.value?.panelId != panelSchema.id
+        )
+          return "";
         if (name.length == 0) return "";
 
         const date = new Date(name[0].data[0]);

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -1390,6 +1390,9 @@ export const convertSQLData = (
     }
   }
 
+  // allowed to zoom, only if timeseries
+  options.toolbox.show = options.toolbox.show && isTimeSeriesFlag;
+
   return {
     options,
     extras: { panelId: panelSchema?.id, isTimeSeries: isTimeSeriesFlag },

--- a/web/src/views/Dashboards/RenderDashboardCharts.vue
+++ b/web/src/views/Dashboards/RenderDashboardCharts.vue
@@ -79,7 +79,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <ViewPanel
           :panelId="viewPanelId"
           :currentTimeObj="currentTimeObj"
-          :initialVariableValues="initialVariableValues"
+          :initialVariableValues="variablesData"
           @close-panel="() => (showViewPanel = false)"
           :class="store.state.theme == 'dark' ? 'dark-mode' : 'bg-white'"
         />


### PR DESCRIPTION
- fix: Tooltip does not working in Add/Edit panel.
- fix: Should not allowed to zoom for non timeseries charts.
- fix: maximize panel initial variable issue.