### PR TITLE
feat: support structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,6 +4508,7 @@ dependencies = [
  "tonic 0.8.3",
  "tonic-build 0.8.4",
  "tracing",
+ "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uaparser",
@@ -7269,6 +7270,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7336,6 +7349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7345,12 +7368,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,9 +157,9 @@ tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 tonic = { version = "0.8", features = ["prost", "gzip"] }
-tracing = { version = "0.1.37", features = ["attributes"] }
+tracing = { version = "0.1.40", features = ["attributes"] }
 tracing-opentelemetry = "0.18"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uaparser = "0.6.1"
 url = "2.2"
 utoipa = { version = "4", features = ["actix_extras", "openapi_extensions"] }
@@ -171,6 +171,7 @@ walkdir = "2"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zstd = "0.13"
 memory-stats = "1.1.0"
+tracing-appender = "0.2.3"
 
 [build-dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -386,9 +386,6 @@ pub struct Common {
     #[env_config(name = "ZO_DEFAULT_SCRAPE_INTERVAL", default = 15)]
     // Default scrape_interval value 15s
     pub default_scrape_interval: u32,
-    // logger timestamp local setup, eg: %Y-%m-%dT%H:%M:%S
-    #[env_config(name = "ZO_LOG_LOCAL_TIME_FORMAT", default = "")]
-    pub log_local_time_format: String,
     #[env_config(name = "ZO_CIRCUIT_BREAKER_ENABLE", default = false)]
     pub memory_circuit_breaker_enable: bool,
     #[env_config(name = "ZO_CIRCUIT_BREAKER_RATIO", default = 100)]
@@ -513,10 +510,13 @@ pub struct DiskCache {
 pub struct Log {
     #[env_config(name = "RUST_LOG", default = "info")]
     pub level: String,
-
+    #[env_config(name = "ZO_LOG_JSON_FORMAT", default = false)]
+    pub json_format: bool,
     #[env_config(name = "ZO_LOG_FILE_DIR", default = "")]
-    pub log_file_dir: String,
-
+    pub file_dir: String,
+    // logger timestamp local setup, eg: %Y-%m-%dT%H:%M:%SZ
+    #[env_config(name = "ZO_LOG_LOCAL_TIME_FORMAT", default = "")]
+    pub local_time_format: String,
     #[env_config(name = "ZO_EVENTS_ENABLED", default = false)]
     pub events_enabled: bool,
     #[env_config(

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -513,8 +513,10 @@ pub struct DiskCache {
 pub struct Log {
     #[env_config(name = "RUST_LOG", default = "info")]
     pub level: String,
-    #[env_config(name = "ZO_LOG_FILE", default = "")]
-    pub file: String,
+
+    #[env_config(name = "ZO_LOG_FILE_DIR", default = "")]
+    pub log_file_dir: String,
+
     #[env_config(name = "ZO_EVENTS_ENABLED", default = false)]
     pub events_enabled: bool,
     #[env_config(


### PR DESCRIPTION
    
The idea behind this PR is to generate logs in a structured-json
format, such that we can use automated tooling to parse and debug
O2 logs as well.

If logs are to be written and analysed in files, one can enable:
`ZO_LOG_FILE_DIR=/tmp/openobserve`
The output file will be of format - `/tmp/openobserve/o2.log.2023-12-18-10`
and it will be rotated daily.

And add a new environment `ZO_LOG_JSON_FORMAT=false`, set to `true` to enable json format.
