### PR TITLE
fix: add/edit panel zoom, tooltip highlight and histogram field should use ASC as a default in sort by field issue

### DIFF
--- a/web/src/composables/useDashboardPanel.ts
+++ b/web/src/composables/useDashboardPanel.ts
@@ -286,6 +286,8 @@ const useDashboardPanelData = () => {
           row.name == store.state.zoConfig.timestamp_column
             ? "histogram"
             : null,
+        sortBy:
+          row.name == store.state.zoConfig.timestamp_column ? "ASC" : null,
       });
     }
 

--- a/web/src/views/Dashboards/addPanel/AddPanel.vue
+++ b/web/src/views/Dashboards/addPanel/AddPanel.vue
@@ -276,6 +276,7 @@ import PanelSchemaRenderer from "../../../components/dashboards/PanelSchemaRende
 import { useLoading } from "@/composables/useLoading";
 import _ from "lodash-es";
 import QueryInspector from "@/components/dashboards/QueryInspector.vue";
+import { provide } from "vue";
 
 export default defineComponent({
   name: "AddPanel",
@@ -1102,6 +1103,32 @@ export default defineComponent({
       // set it as a absolute time
       dateTimePickerRef?.value?.setCustomDate("absolute", selectedDateObj);
     };
+
+    const hoveredSeriesState = ref({
+      hoveredSeriesName: "",
+      panelId: -1,
+      dataIndex: -1,
+      seriesIndex: -1,
+      hoveredTime: null,
+      setHoveredSeriesName: function (name: string) {
+        hoveredSeriesState.value.hoveredSeriesName = name ?? "";
+      },
+      setIndex: function (
+        dataIndex: number,
+        seriesIndex: number,
+        panelId: any,
+        hoveredTime?: any
+      ) {
+        hoveredSeriesState.value.dataIndex = dataIndex ?? -1;
+        hoveredSeriesState.value.seriesIndex = seriesIndex ?? -1;
+        hoveredSeriesState.value.panelId = panelId ?? -1;
+        hoveredSeriesState.value.hoveredTime = hoveredTime ?? null;
+      },
+    });
+
+    // used provide and inject to share data between components
+    // it is currently used in panelschemarendered, chartrenderer, convertpromqldata(via panelschemarenderer), and convertsqldata
+    provide("hoveredSeriesState", hoveredSeriesState);
 
     return {
       t,

--- a/web/src/views/Dashboards/addPanel/AddPanel.vue
+++ b/web/src/views/Dashboards/addPanel/AddPanel.vue
@@ -190,6 +190,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           :variablesData="variablesData"
                           :width="6"
                           @error="handleChartApiError"
+                          @updated:data-zoom="onDataZoom"
                         />
                         <q-dialog v-model="showViewPanel">
                           <QueryInspector
@@ -1082,6 +1083,26 @@ export default defineComponent({
       errorList.splice(0);
       errorList.push(errorMessage);
     };
+
+    const onDataZoom = (event: any) => {
+      const selectedDateObj = {
+        start: new Date(event.start),
+        end: new Date(event.end),
+      };
+      // Truncate seconds and milliseconds from the dates
+      selectedDateObj.start.setSeconds(0, 0);
+      selectedDateObj.end.setSeconds(0, 0);
+
+      // Compare the truncated dates
+      if (selectedDateObj.start.getTime() === selectedDateObj.end.getTime()) {
+        // Increment the end date by 1 minute
+        selectedDateObj.end.setMinutes(selectedDateObj.end.getMinutes() + 1);
+      }
+
+      // set it as a absolute time
+      dateTimePickerRef?.value?.setCustomDate("absolute", selectedDateObj);
+    };
+
     return {
       t,
       updateDateTime,
@@ -1111,6 +1132,7 @@ export default defineComponent({
       metaDataValue,
       metaData,
       panelTitle,
+      onDataZoom,
     };
   },
   methods: {


### PR DESCRIPTION
- fix: zoom issue in add/edit panel.
- fix: tooltip highlight issue in add/edit panel.
- fix: by default, histogram field should use 'ASC' in sort by field.