### PR TITLE
fix: RUM session replay issues

### DIFF
--- a/web/src/components/rum/VideoPlayer.vue
+++ b/web/src/components/rum/VideoPlayer.vue
@@ -341,11 +341,22 @@ const setupSession = async () => {
   //   lastEventTime = currentTime;
   // });
 
-  let playerWidth = playerContainerRef.value?.clientWidth || 0;
-  let playerHeight =
-    (session.value[0].data.height / session.value[0].data.width) * playerWidth;
+  let sessionWidth: number = 0;
+  let sessionHeight: number = 0;
 
-  if (!session.value[0].data.height) {
+  session.value.every((segment: any) => {
+    if (segment.data.height && segment.data.width) {
+      sessionWidth = segment.data.width;
+      sessionHeight = segment.data.height;
+      return false;
+    }
+    return true;
+  });
+
+  let playerWidth = playerContainerRef.value?.clientWidth || 0;
+  let playerHeight = (sessionHeight / sessionWidth) * playerWidth;
+
+  if (!sessionHeight) {
     playerHeight = playerWidth * 0.5625;
   }
 
@@ -354,9 +365,7 @@ const setupSession = async () => {
     playerHeight > playerContainerRef.value?.clientHeight - 90
   ) {
     playerHeight = playerContainerRef.value?.clientHeight - 90 || 0;
-    playerWidth =
-      (session.value[0].data.width / session.value[0].data.height) *
-      playerHeight;
+    playerWidth = (sessionWidth / sessionHeight) * playerHeight;
   }
 
   if (playerRef.value) {

--- a/web/src/views/RUM/AppSessions.vue
+++ b/web/src/views/RUM/AppSessions.vue
@@ -163,6 +163,9 @@ import QueryEditor from "@/components/QueryEditor.vue";
 import DateTime from "@/components/DateTime.vue";
 import SyntaxGuide from "@/plugins/traces/SyntaxGuide.vue";
 import SessionLocationColumn from "@/components/rum/sessionReplay/SessionLocationColumn.vue";
+import { getConsumableRelativeTime } from "@/utils/date";
+import { cloneDeep } from "lodash-es";
+import { f } from "msw/lib/SetupApi-8ab693f7";
 
 interface Session {
   timestamp: string;
@@ -536,6 +539,17 @@ const getFormattedDate = (timestamp: number) =>
 const runQuery = () => {
   sessionState.data.resultGrid.currentPage = 0;
   sessionState.data.sessions = {};
+  if (dateTime.value.valueType === "relative") {
+    const newDate = getConsumableRelativeTime(
+      dateTime.value.relativeTimePeriod
+    );
+
+    if (newDate?.startTime && newDate?.endTime) {
+      dateTime.value.startTime = newDate?.startTime;
+      dateTime.value.endTime = newDate?.endTime;
+    }
+  }
+
   getSessions();
 };
 


### PR DESCRIPTION
1. Session video frame was overlapping the video display area.
2. Updated the start and end time of relative date selected on clicking
run query.