### PR TITLE
feat: bump dotenv_config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,9 +2676,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenv_config"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c42ee79502f8625682f381c05afbd2c0b65115aef83c219f49183f6c4adb1a"
+checksum = "d0125338c5beff100e677d4ffc02848574b602718435c5a47e647737bd88e62d"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ arrow = { version = "49", features = ["simd", "ipc_compression"] }
 arrow-schema = { version = "49", features = ["serde"] }
 parquet = { version = "49", features = ["arrow", "async"] }
 object_store = { version = "0.8", features = ["aws", "azure", "gcp"] }
-dotenv_config = "0.1.7"
+dotenv_config = "0.1.8"
 dotenvy = "0.15"
 env_logger = "0.10"
 etcd-client = { version = "0.12", features = ["tls"] }

--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     common::{
         infra,
-        infra::config::{CONFIG, USERS},
+        infra::config::{render_help, CONFIG, USERS},
         meta, migration,
         utils::file::set_permission,
     },
@@ -46,6 +46,8 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                 .about("import openobserve data").args(args()),
             clap::Command::new("export")
                 .about("export openobserve data").args(args()),
+            clap::Command::new("print-env-info")
+                .about("print all the supported environment variables supported by O2"),
             clap::Command::new("view")
                 .about("view openobserve data")
                 .arg(
@@ -158,6 +160,10 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                     return Err(anyhow::anyhow!("unsupport reset component: {}", component));
                 }
             }
+        }
+        "print-env-info" => {
+            render_help();
+            return Ok(true);
         }
         "view" => {
             let component = command.get_one::<String>("component").unwrap();

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -217,7 +217,12 @@ pub fn render_help() {
         if k.is_empty() {
             continue;
         }
-        println!("{:<38}: {} [DEFAULT: {}]", k, v.1.as_deref().unwrap_or(""), &v.0,);
+        println!(
+            "{:<38}: {} [DEFAULT: {}]",
+            k,
+            v.1.as_deref().unwrap_or(""),
+            &v.0,
+        );
     }
 }
 
@@ -239,29 +244,57 @@ pub struct Pyroscope {
 
 #[derive(EnvConfig)]
 pub struct Auth {
-    #[env_config(name = "ZO_ROOT_USER_EMAIL")]
+    #[env_config(name = "ZO_ROOT_USER_EMAIL", help = "Email of first/super admin user")]
     pub root_user_email: String,
-    #[env_config(name = "ZO_ROOT_USER_PASSWORD")]
+    #[env_config(
+        name = "ZO_ROOT_USER_PASSWORD",
+        help = "Password for first/super admin user"
+    )]
     pub root_user_password: String,
 }
 
 #[derive(EnvConfig)]
 pub struct Http {
-    #[env_config(name = "ZO_HTTP_PORT", default = 5080)]
+    #[env_config(
+        name = "ZO_HTTP_PORT",
+        default = 5080,
+        help = "openobserve server listen HTTP port"
+    )]
     pub port: u16,
-    #[env_config(name = "ZO_HTTP_ADDR", default = "")]
+    #[env_config(
+        name = "ZO_HTTP_ADDR",
+        default = "",
+        help = "openobserve server listen HTTP ip address"
+    )]
     pub addr: String,
-    #[env_config(name = "ZO_HTTP_IPV6_ENABLED", default = false)]
+    #[env_config(
+        name = "ZO_HTTP_IPV6_ENABLED",
+        default = false,
+        help = "enable ipv6 support for HTTP"
+    )]
     pub ipv6_enabled: bool,
 }
 
 #[derive(EnvConfig)]
 pub struct Grpc {
-    #[env_config(name = "ZO_GRPC_PORT", default = 5081)]
+    #[env_config(
+        name = "ZO_GRPC_PORT",
+        default = 5081,
+        help = "openobserve server listen gRPC port"
+    )]
     pub port: u16,
-    #[env_config(name = "ZO_GRPC_ADDR", default = "")]
+    #[env_config(
+        name = "ZO_GRPC_ADDR",
+        default = "",
+        help = "openobserve server listen gRPC ip address"
+    )]
     pub addr: String,
-    #[env_config(name = "ZO_GRPC_ORG_HEADER_KEY", default = "organization")]
+    #[env_config(
+        name = "ZO_GRPC_ORG_HEADER_KEY",
+        default = "organization",
+        help = "header key for sending organization 
+    information for traces using OTLP over grpc"
+    )]
     pub org_header_key: String,
     #[env_config(name = "ZO_GRPC_STREAM_HEADER_KEY", default = "stream-name")]
     pub stream_header_key: String,
@@ -279,7 +312,11 @@ pub struct TCP {
 
 #[derive(EnvConfig)]
 pub struct Route {
-    #[env_config(name = "ZO_ROUTE_TIMEOUT", default = 600)]
+    #[env_config(
+        name = "ZO_ROUTE_TIMEOUT",
+        default = 600,
+        help = "timeout for router node."
+    )]
     pub timeout: u64,
     // zo1-openobserve-ingester.ziox-dev.svc.cluster.local
     #[env_config(name = "ZO_INGESTER_SERVICE_URL", default = "")]
@@ -290,10 +327,21 @@ pub struct Route {
 pub struct Common {
     #[env_config(name = "ZO_APP_NAME", default = "openobserve")]
     pub app_name: String,
-    #[env_config(name = "ZO_LOCAL_MODE", default = true)]
+    #[env_config(
+        name = "ZO_LOCAL_MODE",
+        default = true,
+        help = "If local mode is set to true ,OpenObserve becomes single node deployment, 
+        false indicates cluster mode deployment which supports multiple nodes with different roles. 
+        For local mode one needs to configure sled db, for cluster mode one needs to config etcd."
+    )]
     pub local_mode: bool,
     // ZO_LOCAL_MODE_STORAGE is ignored when ZO_LOCAL_MODE is set to false
-    #[env_config(name = "ZO_LOCAL_MODE_STORAGE", default = "disk")]
+    #[env_config(
+        name = "ZO_LOCAL_MODE_STORAGE",
+        default = "disk",
+        help = "disk or s3, Applicable only for local mode , by default local disk is used as 
+        storage, we also support s3 in local mode."
+    )]
     pub local_mode_storage: String,
     #[env_config(name = "ZO_META_STORE", default = "")]
     pub meta_store: String,
@@ -302,23 +350,49 @@ pub struct Common {
     pub meta_postgres_dsn: String, // postgres://postgres:12345678@localhost:5432/openobserve
     #[env_config(name = "ZO_META_MYSQL_DSN", default = "")]
     pub meta_mysql_dsn: String, // mysql://root:12345678@localhost:3306/openobserve
-    #[env_config(name = "ZO_NODE_ROLE", default = "all")]
+    #[env_config(
+        name = "ZO_NODE_ROLE",
+        default = "all",
+        help = "Possible values are : all, ingester, querier, router, compactor, alertmanager, 
+        A single node can have multiple roles id desired. Specify roles separated by comma. e.g. compactor,alertmanager"
+    )]
     pub node_role: String,
     #[env_config(name = "ZO_CLUSTER_NAME", default = "zo1")]
     pub cluster_name: String,
-    #[env_config(name = "ZO_INSTANCE_NAME", default = "")]
+    #[env_config(
+        name = "ZO_INSTANCE_NAME",
+        default = "",
+        help = "in the cluster mode, each node has a instance name, 
+    default is instance hostname."
+    )]
     pub instance_name: String,
     #[env_config(name = "ZO_INGESTER_SIDECAR_ENABLED", default = false)]
     pub ingester_sidecar_enabled: bool,
     #[env_config(name = "ZO_INGESTER_SIDECAR_QUERIER", default = false)]
     pub ingester_sidecar_querier: bool,
-    #[env_config(name = "ZO_DATA_DIR", default = "./data/openobserve/")]
+    #[env_config(
+        name = "ZO_DATA_DIR",
+        default = "./data/openobserve/",
+        help = "On-disk data directory, where openobserve stores everything."
+    )]
     pub data_dir: String,
-    #[env_config(name = "ZO_DATA_WAL_DIR", default = "")] // ./data/openobserve/wal/
+    #[env_config(
+        name = "ZO_DATA_WAL_DIR",
+        default = "",
+        help = "local WAL data directory."
+    )] // ./data/openobserve/wal/
     pub data_wal_dir: String,
-    #[env_config(name = "ZO_DATA_STREAM_DIR", default = "")] // ./data/openobserve/stream/
+    #[env_config(
+        name = "ZO_DATA_STREAM_DIR",
+        default = "",
+        help = "streams local data storage directory ,applicable only for local mode."
+    )] // ./data/openobserve/stream/
     pub data_stream_dir: String,
-    #[env_config(name = "ZO_DATA_DB_DIR", default = "")] // ./data/openobserve/db/
+    #[env_config(
+        name = "ZO_DATA_DB_DIR",
+        default = "",
+        help = "metadata database local storage directory."
+    )] // ./data/openobserve/db/
     pub data_db_dir: String,
     #[env_config(name = "ZO_DATA_CACHE_DIR", default = "")] // ./data/openobserve/cache/
     pub data_cache_dir: String,

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -343,10 +343,20 @@ pub struct Common {
         storage, we also support s3 in local mode."
     )]
     pub local_mode_storage: String,
-    #[env_config(name = "ZO_META_STORE", default = "")]
+    #[env_config(
+        name = "ZO_META_STORE",
+        default = "",
+        help = "Default is sqlite for local mode, etcd for cluster mode. 
+    and supported values are: sqlite, etcd, postgres, dynamodb, the sqlite only support for local mode."
+    )]
     pub meta_store: String,
     pub meta_store_external: bool, // external storage no need sync file_list to s3
-    #[env_config(name = "ZO_META_POSTGRES_DSN", default = "")]
+    #[env_config(
+        name = "ZO_META_POSTGRES_DSN",
+        default = "",
+        help = "If you enable postgres as meta store, you need configure the database source address, 
+        like this: postgres://postgres:12345678@localhost:5432/openobserve"
+    )]
     pub meta_postgres_dsn: String, // postgres://postgres:12345678@localhost:5432/openobserve
     #[env_config(name = "ZO_META_MYSQL_DSN", default = "")]
     pub meta_mysql_dsn: String, // mysql://root:12345678@localhost:3306/openobserve
@@ -394,25 +404,73 @@ pub struct Common {
         help = "metadata database local storage directory."
     )] // ./data/openobserve/db/
     pub data_db_dir: String,
-    #[env_config(name = "ZO_DATA_CACHE_DIR", default = "")] // ./data/openobserve/cache/
+    #[env_config(
+        name = "ZO_DATA_CACHE_DIR",
+        default = "",
+        help = "local query cache storage directory, applicable only for cluster mode."
+    )] // ./data/openobserve/cache/
     pub data_cache_dir: String,
-    #[env_config(name = "ZO_BASE_URI", default = "")]
+    #[env_config(
+        name = "ZO_BASE_URI",
+        default = "",
+        help = "if you set OpenObserve with a prefix in k8s nginx ingress, you can set the prefix path."
+    )]
     pub base_uri: String,
-    #[env_config(name = "ZO_WAL_MEMORY_MODE_ENABLED", default = false)]
+    #[env_config(
+        name = "ZO_WAL_MEMORY_MODE_ENABLED",
+        default = false,
+        help = "For performance, we can write WAL file into memory instead of write into disk, this will increase 
+        ingestion performance, but it has dast lose risk when the system crashed."
+    )]
     pub wal_memory_mode_enabled: bool,
-    #[env_config(name = "ZO_WAL_LINE_MODE_ENABLED", default = true)]
+    #[env_config(
+        name = "ZO_WAL_LINE_MODE_ENABLED",
+        default = true,
+        help = "Default we write WAL file line by line, it is a bit slow but it safety, you can disable it to increase 
+        a bit performance, but it increase WAL file incorrect risk."
+    )]
     pub wal_line_mode_enabled: bool,
-    #[env_config(name = "ZO_COLUMN_TIMESTAMP", default = "_timestamp")]
+    #[env_config(
+        name = "ZO_COLUMN_TIMESTAMP",
+        default = "_timestamp",
+        help = "for each log line, if not present with this key , we add a 
+    timestamp with this key, used for queries with time range."
+    )]
     pub column_timestamp: String,
-    #[env_config(name = "ZO_WIDENING_SCHEMA_EVOLUTION", default = true)]
+    #[env_config(
+        name = "ZO_WIDENING_SCHEMA_EVOLUTION",
+        default = true,
+        help = "if set to false user can add new columns to data being ingested 
+    but changes to existing data for data type are not supported "
+    )]
     pub widening_schema_evolution: bool,
-    #[env_config(name = "ZO_SKIP_SCHEMA_VALIDATION", default = false)]
+    #[env_config(
+        name = "ZO_SKIP_SCHEMA_VALIDATION",
+        default = false,
+        help = "Default we check ingested every record for schema validation, but if your schema is fixed, you can skip it, 
+    this will increase 2x ingestion performance."
+    )]
     pub skip_schema_validation: bool,
-    #[env_config(name = "ZO_FEATURE_PER_THREAD_LOCK", default = false)]
+    #[env_config(
+        name = "ZO_FEATURE_PER_THREAD_LOCK",
+        default = false,
+        help = "Default we check ingested every record for schema validation, but if your schema is fixed, you can skip it, 
+    this will increase 2x ingestion performance."
+    )]
     pub feature_per_thread_lock: bool,
-    #[env_config(name = "ZO_FEATURE_FULLTEXT_ON_ALL_FIELDS", default = false)]
+    #[env_config(
+        name = "ZO_FEATURE_FULLTEXT_ON_ALL_FIELDS",
+        default = false,
+        help = "default full text search uses log, message, msg, content, data, events, json or selected stream fields. 
+        Enabling this option will perform full text search on each field, may hamper full text search performance"
+    )]
     pub feature_fulltext_on_all_fields: bool,
-    #[env_config(name = "ZO_FEATURE_FULLTEXT_EXTRA_FIELDS", default = "")]
+    #[env_config(
+        name = "ZO_FEATURE_FULLTEXT_EXTRA_FIELDS",
+        default = "",
+        help = "default full text search uses log, message, msg, content, data, events, json as global setting, 
+        but you can add more fields as global full text search fields. eg: field1,field2"
+    )]
     pub feature_fulltext_extra_fields: String,
     #[env_config(name = "ZO_FEATURE_DISTINCT_EXTRA_FIELDS", default = "")]
     pub feature_distinct_extra_fields: String,
@@ -420,9 +478,17 @@ pub struct Common {
     pub feature_filelist_dedup_enabled: bool,
     #[env_config(name = "ZO_FEATURE_QUERY_QUEUE_ENABLED", default = true)]
     pub feature_query_queue_enabled: bool,
-    #[env_config(name = "ZO_UI_ENABLED", default = true)]
+    #[env_config(
+        name = "ZO_UI_ENABLED",
+        default = true,
+        help = "default we enable embed UI, one can disable it."
+    )]
     pub ui_enabled: bool,
-    #[env_config(name = "ZO_UI_SQL_BASE64_ENABLED", default = false)]
+    #[env_config(
+        name = "ZO_UI_SQL_BASE64_ENABLED",
+        default = false,
+        help = "Enable base64 encoding for SQL in UI."
+    )]
     pub ui_sql_base64_enabled: bool,
     #[env_config(name = "ZO_METRICS_DEDUP_ENABLED", default = true)]
     pub metrics_dedup_enabled: bool,
@@ -694,7 +760,12 @@ pub struct Sled {
 
 #[derive(EnvConfig)]
 pub struct Dynamo {
-    #[env_config(name = "ZO_META_DYNAMO_PREFIX", default = "")] // default set to s3 bucket name
+    #[env_config(
+        name = "ZO_META_DYNAMO_PREFIX",
+        default = "",
+        help = "If you enable dynamodb as meta store, you need configure DynamoDB 
+    table prefix, default use s3 bucket name."
+    )] // default set to s3 bucket name
     pub prefix: String,
     pub file_list_table: String,
     pub file_list_deleted_table: String,

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -209,14 +209,31 @@ pub struct Config {
     pub profiling: Pyroscope,
 }
 
+/// Render the help string and default value for all the available
+/// environment variables in O2.
+pub fn render_help() {
+    let fields = Config::get_help();
+    for (k, v) in fields.iter() {
+        if k.is_empty() {
+            continue;
+        }
+        println!("{:<38}: {} [DEFAULT: {}]", k, v.1.as_deref().unwrap_or(""), &v.0,);
+    }
+}
+
 #[derive(EnvConfig)]
 pub struct Pyroscope {
     #[env_config(
         name = "ZO_PROF_PYROSCOPE_SERVER_URL",
-        default = "http://localhost:4040"
+        default = "http://localhost:4040",
+        help = "Default pyroscope server url"
     )]
     pub pyroscope_server_url: String,
-    #[env_config(name = "ZO_PROF_PYROSCOPE_PROJECT_NAME", default = "openobserve")]
+    #[env_config(
+        name = "ZO_PROF_PYROSCOPE_PROJECT_NAME",
+        default = "openobserve",
+        help = "A uniquely identifiable pyroscope project name"
+    )]
     pub pyroscope_project_name: String,
 }
 

--- a/src/service/enrichment_table/geoip.rs
+++ b/src/service/enrichment_table/geoip.rs
@@ -100,7 +100,7 @@ impl Default for GeoipConfig {
 }
 
 impl GeoipConfig {
-   pub fn new(name: &str) -> self::GeoipConfig {
+    pub fn new(name: &str) -> self::GeoipConfig {
         GeoipConfig {
             path: format!("{}{}", &CONFIG.common.mmdb_data_dir, name),
             locale: default_locale(),


### PR DESCRIPTION
The new version exposes a `::get_help()` functionality on top of `EnvConfig`d struct and we have incorporated it in the `openobserve` binary with a new cli-config.

```
$ ./target/debug/openobserve --help
OpenObserve is an observability platform that allows you to capture, search, and analyze your logs, metrics, and traces.

Usage: openobserve [COMMAND]

Commands:
  ...
  print-env-info                 print all the supported environment variables supported by O2
```

```
$ ./target/debug/openobserve print-env-info | grep ZO_PROF_PYROSCOPE_PROJECT_NAME

ZO_PROF_PYROSCOPE_PROJECT_NAME:  A uniquely identifiable pyroscope project name [DEFAULT: openobserve]
```