### PR TITLE
feat: control redirection of a user to ingestions

### DIFF
--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -390,6 +390,13 @@ pub struct Common {
     pub memory_circuit_breaker_enable: bool,
     #[env_config(name = "ZO_CIRCUIT_BREAKER_RATIO", default = 100)]
     pub memory_circuit_breaker_ratio: usize,
+
+    #[env_config(
+        name = "ZO_RESTRICTED_ROUTES_ON_EMPTY_DATA",
+        default = true,
+        help = "Control the redirection of a user to ingestion page in case there is no stream found."
+    )]
+    pub restricted_routes_on_empty_data: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -50,6 +50,7 @@ struct ConfigResponse<'a> {
     timestamp_column: String,
     syslog_enabled: bool,
     data_retention_days: i64,
+    restricted_routes_on_empty_data: bool,
 }
 
 /// Healthz
@@ -86,6 +87,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         timestamp_column: CONFIG.common.column_timestamp.clone(),
         syslog_enabled: *SYSLOG_ENABLED.read(),
         data_retention_days: CONFIG.compact.data_retention_days,
+        restricted_routes_on_empty_data: CONFIG.common.restricted_routes_on_empty_data,
     }))
 }
 


### PR DESCRIPTION
Control redirection of a user to ingestions page in case no data This is an extension to #2173, just that user can now control this behavior.

```
ZO_RESTRICTED_ROUTES_ON_EMPTY_DATA=false cargo run
curl -s -u user:pass -k http://localhost:5080/config | jq .restricted_routes_on_empty_data
```