### PR TITLE
chore: Bump Node.js to v18.19.0

### DIFF
--- a/deploy/build/Dockerfile
+++ b/deploy/build/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.12.1-bullseye as webBuilder
+FROM public.ecr.aws/docker/library/node:18.19.0-bullseye as webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.aarch64
+++ b/deploy/build/Dockerfile.aarch64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.12.1-bullseye as webBuilder
+FROM public.ecr.aws/docker/library/node:18.19.0-bullseye as webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.amd64
+++ b/deploy/build/Dockerfile.amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.12.1-bullseye as webBuilder
+FROM public.ecr.aws/docker/library/node:18.19.0-bullseye as webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tag-debug.aarch64
+++ b/deploy/build/Dockerfile.tag-debug.aarch64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.12.1-bullseye as webBuilder
+FROM public.ecr.aws/docker/library/node:18.19.0-bullseye as webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tag-debug.amd64
+++ b/deploy/build/Dockerfile.tag-debug.amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.12.1-bullseye as webBuilder
+FROM public.ecr.aws/docker/library/node:18.19.0-bullseye as webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tag-simd.amd64
+++ b/deploy/build/Dockerfile.tag-simd.amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.12.1-bullseye as webBuilder
+FROM public.ecr.aws/docker/library/node:18.19.0-bullseye as webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tag.aarch64
+++ b/deploy/build/Dockerfile.tag.aarch64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.12.1-bullseye as webBuilder
+FROM public.ecr.aws/docker/library/node:18.19.0-bullseye as webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tag.amd64
+++ b/deploy/build/Dockerfile.tag.amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.12.1-bullseye as webBuilder
+FROM public.ecr.aws/docker/library/node:18.19.0-bullseye as webBuilder
 WORKDIR /web
 COPY ./web /web/
 


### PR DESCRIPTION
Bump Node.js to latest v18 release: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.19.0