### PR TITLE
fix: logs chart y-axis overlapping issue in logs page

### DIFF
--- a/web/src/utils/logs/convertLogData.ts
+++ b/web/src/utils/logs/convertLogData.ts
@@ -60,6 +60,8 @@ export const convertLogData = (
       axisLine: {
         show: true,
       },
+      // yaxis interval(it will show three values: 0, mid, max value)
+      interval: Math.max(...y) / 2,
     },
     toolbox: {
       orient: "vertical",


### PR DESCRIPTION
![image](https://github.com/openobserve/openobserve/assets/141122205/4334dbbb-5732-45ca-9997-552eb8a61209)
