### PR TITLE
fix: logs chart decimal point issue in yaxis and show grid lines

### DIFF
--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -192,6 +192,9 @@ export const convertPromQLData = (
     },
     xAxis: {
       type: "time",
+      splitLine: {
+        show: true,
+      },
     },
     yAxis: {
       type: "value",
@@ -207,6 +210,9 @@ export const convertPromQLData = (
         },
       },
       axisLine: {
+        show: true,
+      },
+      splitLine: {
         show: true,
       },
     },

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -318,7 +318,7 @@ export const convertSQLData = (
             margin: 18 * (xAxisKeys.length - index - 1) + 5,
           },
           splitLine: {
-            show: false,
+            show: true,
           },
           axisTick: {
             show: xAxisKeys.length == 1 ? false : true,
@@ -371,7 +371,7 @@ export const convertSQLData = (
         },
       },
       splitLine: {
-        show: false,
+        show: true,
       },
       axisLine: {
         show: true,

--- a/web/src/utils/logs/convertLogData.ts
+++ b/web/src/utils/logs/convertLogData.ts
@@ -60,14 +60,19 @@ export const convertLogData = (
       axisLine: {
         show: true,
       },
+      axisPointer: {
+        label: {
+          precision: 0,
+        },
+      },
       // yaxis interval(it will show three values: 0, mid, max value)
       interval: Math.max(...y) / 2,
       axisLabel: {
         formatter: function (value: any) {
           // Format the Y-axis label to show values without decimal points
           return Math.round(value);
-        }
-      }
+        },
+      },
     },
     toolbox: {
       orient: "vertical",
@@ -76,10 +81,10 @@ export const convertLogData = (
       tooltip: {
         show: false,
       },
-      itemSize:0,
-      itemGap:0,
+      itemSize: 0,
+      itemGap: 0,
       // it is used to hide toolbox buttons
-      bottom:"100%",
+      bottom: "100%",
       feature: {
         dataZoom: {
           show: true,

--- a/web/src/utils/logs/convertLogData.ts
+++ b/web/src/utils/logs/convertLogData.ts
@@ -62,6 +62,12 @@ export const convertLogData = (
       },
       // yaxis interval(it will show three values: 0, mid, max value)
       interval: Math.max(...y) / 2,
+      axisLabel: {
+        formatter: function (value: any) {
+          // Format the Y-axis label to show values without decimal points
+          return Math.round(value);
+        }
+      }
     },
     toolbox: {
       orient: "vertical",


### PR DESCRIPTION
- fix: logs chart decimal point issue in yaxis
![image](https://github.com/openobserve/openobserve/assets/141122205/0b8bad5f-b5ea-444f-80c8-8a50dc60cb47)

- add: showing split line in charts.
![image](https://github.com/openobserve/openobserve/assets/141122205/bcd304c5-6564-4cc5-93f8-1502de084837)
