### PR TITLE
fix: RSS reduction due to lazily loading ua-parser

### DIFF
--- a/src/common/meta/middleware_data.rs
+++ b/src/common/meta/middleware_data.rs
@@ -13,20 +13,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::net::IpAddr;
+use std::{net::IpAddr, sync::Arc};
 
 use actix_web::{
     body::MessageBody,
     dev::{ServiceRequest, ServiceResponse},
-    web, Error as ActixErr, FromRequest, HttpMessage,
+    web, Error as ActixErr, HttpMessage,
 };
 use actix_web_lab::middleware::Next;
 use ahash::AHashMap;
 use maxminddb::geoip2::city::Location;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use uaparser::{Parser, UserAgentParser};
 
-use crate::common::infra::config::MAXMIND_DB_CLIENT;
+use crate::{common::infra::config::MAXMIND_DB_CLIENT, USER_AGENT_REGEX_FILE};
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct GeoInfoData<'a> {
@@ -34,6 +35,16 @@ pub struct GeoInfoData<'a> {
     pub country: Option<&'a str>,
     pub country_iso_code: Option<&'a str>,
     pub location: Option<Location<'a>>,
+}
+
+/// This is a global cache for user agent parser. This is lazily initialized only when
+/// the first request comes in.
+static UA_PARSER: Lazy<Arc<UserAgentParser>> = Lazy::new(|| Arc::new(initialize_ua_parser()));
+
+pub fn initialize_ua_parser() -> UserAgentParser {
+    UserAgentParser::builder()
+        .build_from_bytes(USER_AGENT_REGEX_FILE)
+        .expect("User Agent Parser creation failed")
 }
 
 /// This is the custom data which is provided by `browser-sdk`
@@ -139,9 +150,7 @@ impl RumExtraData {
                 .map(|v| v.to_str().unwrap_or(""))
                 .unwrap_or_default();
 
-            let ua_parser = web::Data::<UserAgentParser>::extract(req.request())
-                .await
-                .unwrap();
+            let ua_parser = UA_PARSER.clone();
             let parsed_user_agent = ua_parser.parse(user_agent);
 
             user_agent_hashmap.insert(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,8 @@ pub mod handler;
 pub mod job;
 pub mod router;
 pub mod service;
+
+pub(crate) static USER_AGENT_REGEX_FILE: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/ua_regex/regexes.yaml"
+));

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,6 @@ use tokio::sync::oneshot;
 use tonic::codec::CompressionEncoding;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::Registry;
-use uaparser::UserAgentParser;
 
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
@@ -85,11 +84,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-static USER_AGENT_REGEX_FILE: &[u8] = include_bytes!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/ua_regex/regexes.yaml"
-));
 
 use tracing_subscriber::{
     self, filter::LevelFilter as TracingLevelFilter, fmt::Layer, prelude::*, EnvFilter,
@@ -316,13 +310,6 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
     // metrics
     let prometheus = config::metrics::create_prometheus_handler();
 
-    // ua parser
-    let ua_parser = web::Data::new(
-        UserAgentParser::builder()
-            .build_from_bytes(USER_AGENT_REGEX_FILE)
-            .expect("User Agent Parser creation failed"),
-    );
-
     let thread_id = Arc::new(AtomicU16::new(0));
     let haddr: SocketAddr = if CONFIG.http.ipv6_enabled {
         format!("[::]:{}", CONFIG.http.port).parse()?
@@ -372,7 +359,6 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
         app.app_data(web::JsonConfig::default().limit(CONFIG.limit.req_json_limit))
             .app_data(web::PayloadConfig::new(CONFIG.limit.req_payload_limit)) // size is in bytes
             .app_data(web::Data::new(local_id))
-            .app_data(ua_parser.clone())
             .wrap(middleware::Compress::default())
             .wrap(middleware::Logger::new(
                 r#"%a "%r" %s %b "%{Content-Length}i" "%{Referer}i" "%{User-Agent}i" %T"#,


### PR DESCRIPTION
UserAgent parser is currently used exclusively in RUM related middleware. Loading it lazily when RUM data is ingested results in significant RSS reduction at the startup of O2.