### PR TITLE
feat: Logs page pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.12.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae697f3928e8c89ae6f4dcf788059f49fd01a76dc53e63628f5a33881f5715e"
+checksum = "f5231ad671c74ee5dc02753a0a9c855fe6e90de2a07acb2582f8a702470e04d1"
 dependencies = [
  "http",
  "prost 0.12.3",
@@ -5450,9 +5450,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "platforms"
-version = "3.3.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 
 [[package]]
 name = "poly1305"
@@ -6161,9 +6161,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.2.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f"
+checksum = "810294a8a4a0853d4118e3b94bb079905f2107c7fe979d8f0faae98765eb6378"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -6214,9 +6214,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.2.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16"
+checksum = "bfc144a1273124a67b8c1d7cd19f5695d1878b31569c0512f6086f0f4676604e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6228,9 +6228,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.2.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665"
+checksum = "816ccd4875431253d6bb54b804bcff4369cbde9bae33defde25fdf6c2ef91d40"
 dependencies = [
  "sha2",
  "walkdir",
@@ -6885,13 +6885,13 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
+checksum = "3e9c2e1dde0efa87003e7923d94a90f46e3274ad1649f51de96812be561f041f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7976,9 +7976,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utoipa"
-version = "4.2.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272ebdfbc99111033031d2f10e018836056e4d2c8e2acda76450ec7974269fa7"
+checksum = "0ff05e3bac2c9428f57ade702667753ca3f5cf085e2011fe697de5bfd49aa72d"
 dependencies = [
  "indexmap 2.1.0",
  "serde",
@@ -7988,9 +7988,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.2.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c9f4d08338c1bfa70dde39412a040a884c6f318b3d09aaaf3437a1e52027fc"
+checksum = "5f0b6f4667edd64be0e820d6631a60433a269710b6ee89ac39525b872b76d61d"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -155,6 +155,7 @@ const defaultObject = {
     tempFunctionContent: "",
     tempFunctionLoading: false,
     savedViews: <any>[],
+    customDownloadQueryObj: <any>{},
   },
 };
 
@@ -648,6 +649,7 @@ const useLogs = () => {
           searchObj.data.errorCode = 0;
           const histogramQueryReq = JSON.parse(JSON.stringify(queryReq));
           delete queryReq.aggs;
+          searchObj.data.customDownloadQueryObj = queryReq;
           searchService
             .search({
               org_identifier: searchObj.organizationIdetifier,
@@ -1385,6 +1387,7 @@ const useLogs = () => {
     getSavedViews,
     onStreamChange,
     generateURLQuery,
+    buildSearch,
   };
 };
 

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -54,6 +54,7 @@ const defaultObject = {
   runQuery: false,
   loading: true,
   config: {
+    recordsPerPage: 250,
     splitterModel: 20,
     lastSplitterPosition: 0,
     splitterLimit: [0, 40],

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -54,7 +54,6 @@ const defaultObject = {
   runQuery: false,
   loading: true,
   config: {
-    recordsPerPage: 250,
     splitterModel: 20,
     lastSplitterPosition: 0,
     splitterLimit: [0, 40],

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -53,6 +53,7 @@ const defaultObject = {
   runQuery: false,
   loading: true,
   config: {
+    recordsPerPage: 250,
     splitterModel: 20,
     lastSplitterPosition: 0,
     splitterLimit: [0, 40],
@@ -394,11 +395,10 @@ const useLogs = () => {
           sql: 'select *[QUERY_FUNCTIONS] from "[INDEX_NAME]" [WHERE_CLAUSE]',
           start_time: (new Date().getTime() - 900000) * 1000,
           end_time: new Date().getTime() * 1000,
-          from: searchObj.data.queryResults?.hits?.length || 0,
-          size: parseInt(
-            (searchObj.data.queryResults?.hits?.length || 0) + 150,
-            10
-          ),
+          from:
+            searchObj.config.recordsPerPage *
+              searchObj.data.resultGrid.currentPage || 0,
+          size: searchObj.config.recordsPerPage,
         },
         aggs: {
           histogram:
@@ -660,7 +660,8 @@ const useLogs = () => {
                 searchObj.data.queryResults.from = res.data.from;
                 searchObj.data.queryResults.scan_size += res.data.scan_size;
                 searchObj.data.queryResults.took += res.data.took;
-                searchObj.data.queryResults.hits.push(...res.data.hits);
+                // searchObj.data.queryResults.hits.push(...res.data.hits);
+                searchObj.data.queryResults.hits = res.data.hits;
               } else {
                 resetFieldValues();
                 if (
@@ -971,7 +972,10 @@ const useLogs = () => {
   function getHistogramTitle() {
     const title =
       "Showing " +
-      searchObj.data.queryResults.hits.length.toLocaleString() +
+      searchObj.data.resultGrid.currentPage * searchObj.config.recordsPerPage +
+      " to " +
+      (searchObj.data.resultGrid.currentPage * searchObj.config.recordsPerPage +
+        searchObj.config.recordsPerPage) +
       " out of " +
       searchObj.data.queryResults.total.toLocaleString() +
       " hits in " +

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -693,8 +693,8 @@ const useLogs = () => {
                     }
                   }
 
-                  searchObj.data.queryResults.hits =
-                    searchObj.data.queryResults.hits.splice(0, 150);
+                  // searchObj.data.queryResults.hits =
+                  //   searchObj.data.queryResults.hits.splice(0, 150);
                 } else {
                   searchObj.data.queryResults = res.data;
                 }
@@ -764,10 +764,11 @@ const useLogs = () => {
           })
           .then((res) => {
             dismiss();
+            searchObj.data.errorMsg = "";
             searchObj.data.queryResults.aggs = res.data.aggs;
             searchObj.data.queryResults.total = res.data.total;
             generateHistogramData();
-            searchObj.data.histogram.chartParams.title = getHistogramTitle();
+            // searchObj.data.histogram.chartParams.title = getHistogramTitle();
 
             searchObj.loading = false;
             resolve(true);
@@ -999,7 +1000,10 @@ const useLogs = () => {
       const xData: number[] = [];
       const yData: number[] = [];
 
-      if (searchObj.data.queryResults.aggs) {
+      if (
+        searchObj.data.queryResults.hasOwnProperty("aggs") &&
+        searchObj.data.queryResults.aggs
+      ) {
         searchObj.data.queryResults.aggs.histogram.map(
           (bucket: {
             zo_sql_key: string | number | Date;
@@ -1142,7 +1146,7 @@ const useLogs = () => {
           const customMessage = logsErrorMessage(err.response.data.code);
           searchObj.data.errorCode = err.response.data.code;
           if (customMessage != "") {
-            searchObj.data.errorMsg = t(customMessage);
+            searchObj.data.errorMsg = customMessage;
           }
         })
         .finally(() => (searchObj.loading = false));
@@ -1160,7 +1164,7 @@ const useLogs = () => {
       clearInterval(store.state.refreshIntervalID);
       const refreshIntervalID = setInterval(async () => {
         // searchObj.loading = true;
-        await getQueryData(true);
+        await getQueryData(false);
         generateHistogramData();
         updateGridColumns();
         searchObj.meta.histogramDirtyFlag = true;

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -86,7 +86,13 @@
     "savedViewAction": "Create/Update Saved View",
     "savedViewDropdownLabel": "Saved Views",
     "savedViewName": "View Name",
-    "shareLink": "Share Link"
+    "shareLink": "Share Link",
+    "downloadTable": "Download Table",
+    "customRange": "Custom Range",
+    "initialNumber": "Initial Number",
+    "range": "No of Records",
+    "btnDownload": "Download",
+    "customDownloadMessage": "Enter the initial number and select the range for downloading data."
   },
   "menu": {
     "home": "Home",

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -184,6 +184,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       :expandedLogs="expandedLogs"
                       @update:datetime="setHistogramDate"
                       @update:scroll="getMoreData"
+                      @update:scroll-up="getLessData"
                       @expandlog="toggleExpandLog"
                     />
                   </div>
@@ -272,11 +273,13 @@ export default defineComponent({
           this.searchObj.data.queryResults.size +
             this.searchObj.data.queryResults.from
       ) {
+        // this.searchObj.data.resultGrid.currentPage =
+        //   ((this.searchObj.data.queryResults?.hits?.length || 0) +
+        //     ((this.searchObj.data.queryResults?.hits?.length || 0) + 150)) /
+        //     150 -
+        //   1;
         this.searchObj.data.resultGrid.currentPage =
-          ((this.searchObj.data.queryResults?.hits?.length || 0) +
-            ((this.searchObj.data.queryResults?.hits?.length || 0) + 150)) /
-            150 -
-          1;
+          this.searchObj.data.resultGrid.currentPage + 1;
 
         await this.getQueryData(true);
         this.refreshHistogramChart();
@@ -292,6 +295,40 @@ export default defineComponent({
         }
       }
     },
+    async getLessData() {
+      if (
+        this.searchObj.meta.sqlMode == false &&
+        this.searchObj.meta.refreshInterval == 0 &&
+        this.searchObj.data.queryResults.total >
+          this.searchObj.data.queryResults.from &&
+        this.searchObj.data.queryResults.total >
+          this.searchObj.data.queryResults.size &&
+        this.searchObj.data.queryResults.total >
+          this.searchObj.data.queryResults.size +
+            this.searchObj.data.queryResults.from
+      ) {
+        // this.searchObj.data.resultGrid.currentPage =
+        //   ((this.searchObj.data.queryResults?.hits?.length || 0) +
+        //     ((this.searchObj.data.queryResults?.hits?.length || 0) + 150)) /
+        //     150 -
+        //   1;
+        this.searchObj.data.resultGrid.currentPage =
+          this.searchObj.data.resultGrid.currentPage - 1;
+
+        await this.getQueryData(true);
+        this.refreshHistogramChart();
+
+        if (config.isCloud == "true") {
+          segment.track("Button Click", {
+            button: "Get Less Data",
+            user_org: this.store.state.selectedOrganization.identifier,
+            user_id: this.store.state.userInfo.email,
+            stream_name: this.searchObj.data.stream.selectedStream.value,
+            page: "Search Logs",
+          });
+        }
+      }
+    }
   },
   setup() {
     const store = useStore();

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -184,7 +184,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       :expandedLogs="expandedLogs"
                       @update:datetime="setHistogramDate"
                       @update:scroll="getMoreData"
-                      @update:scroll-up="getLessData"
                       @expandlog="toggleExpandLog"
                     />
                   </div>

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -184,7 +184,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       :expandedLogs="expandedLogs"
                       @update:datetime="setHistogramDate"
                       @update:scroll="getMoreData"
-                      @update:scroll-up="getLessData"
                       @expandlog="toggleExpandLog"
                     />
                   </div>
@@ -278,8 +277,8 @@ export default defineComponent({
         //     ((this.searchObj.data.queryResults?.hits?.length || 0) + 150)) /
         //     150 -
         //   1;
-        this.searchObj.data.resultGrid.currentPage =
-          this.searchObj.data.resultGrid.currentPage + 1;
+        // this.searchObj.data.resultGrid.currentPage =
+        //   this.searchObj.data.resultGrid.currentPage + 1;
 
         await this.getQueryData(true);
         this.refreshHistogramChart();

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -184,6 +184,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       :expandedLogs="expandedLogs"
                       @update:datetime="setHistogramDate"
                       @update:scroll="getMoreData"
+                      @update:scroll-up="getLessData"
                       @expandlog="toggleExpandLog"
                     />
                   </div>

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -144,24 +144,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </th>
             </tr>
           </thead>
-          <tbody class="tbody-sticky">
-            <tr
-              v-if="
-                scrollPosition <= 10 &&
-                searchObj.data.resultGrid.currentPage > 0
-              "
-            >
-              <th :colspan="searchObj.data.resultGrid.columns.length">
-                <q-btn
-                  size="xs"
-                  class="q-text-bold"
-                  color="primary"
-                  @click="onLoadLessData"
-                  >Load less data...</q-btn
-                >
-              </th>
-            </tr>
-          </tbody>
         </template>
         <template v-slot="{ item: row, index }">
           <q-tr
@@ -287,21 +269,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </td>
           </q-tr>
         </template>
-        <template v-slot:after>
-          <tbody class="tfoot-sticky">
-            <tr v-if="scrollPosition >= searchObj.config.recordsPerPage - 10">
-              <th :colspan="searchObj.data.resultGrid.columns.length">
-                <q-btn
-                  size="xs"
-                  class="q-text-bold"
-                  color="primary"
-                  @click="onLoadMoreData"
-                  >Load more data...</q-btn
-                >
-              </th>
-            </tr>
-          </tbody>
-        </template>
       </q-virtual-scroll>
       <q-dialog
         data-test="logs-search-result-detail-dialog"
@@ -364,7 +331,6 @@ export default defineComponent({
   },
   emits: [
     "update:scroll",
-    "update:scroll-up",
     "update:datetime",
     "remove:searchTerm",
     "search:timeboxed",

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -144,6 +144,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </th>
             </tr>
           </thead>
+          <tbody class="tbody-sticky">
+            <tr
+              v-if="
+                scrollPosition <= 10 &&
+                searchObj.data.resultGrid.currentPage > 0
+              "
+            >
+              <th :colspan="searchObj.data.resultGrid.columns.length">
+                <q-btn
+                  size="xs"
+                  class="q-text-bold"
+                  color="primary"
+                  @click="onLoadLessData"
+                  >Load less data...</q-btn
+                >
+              </th>
+            </tr>
+          </tbody>
         </template>
         <template v-slot="{ item: row, index }">
           <q-tr
@@ -269,6 +287,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </td>
           </q-tr>
         </template>
+        <template v-slot:after>
+          <tbody class="tfoot-sticky">
+            <tr v-if="scrollPosition >= searchObj.config.recordsPerPage - 10">
+              <th :colspan="searchObj.data.resultGrid.columns.length">
+                <q-btn
+                  size="xs"
+                  class="q-text-bold"
+                  color="primary"
+                  @click="onLoadMoreData"
+                  >Load more data...</q-btn
+                >
+              </th>
+            </tr>
+          </tbody>
+        </template>
       </q-virtual-scroll>
       <q-dialog
         data-test="logs-search-result-detail-dialog"
@@ -331,6 +364,7 @@ export default defineComponent({
   },
   emits: [
     "update:scroll",
+    "update:scroll-up",
     "update:datetime",
     "remove:searchTerm",
     "search:timeboxed",

--- a/web/src/utils/logs/convertLogData.ts
+++ b/web/src/utils/logs/convertLogData.ts
@@ -17,7 +17,7 @@ export const convertLogData = (
       containLabel: true,
       left: "20",
       right: "20",
-      top: "30",
+      top: "5",
       bottom: "0",
     },
     tooltip: {


### PR DESCRIPTION
**Problem Statement:**
The Logs page experienced excessive memory consumption, exceeding 2-3 GB. This issue was attributed to the highlight feature on the table grid data, compounded by the rendering of a large volume of data on the grid.

**Solution:**
Removed the highlight feature.
Implemented pagination on the Logs page.

**Enhancements:**
Improved the download feature.
Users now have the option to download:
- Entire table data.
- Custom data, specifying the starting number and the desired number of records.

This pull request addresses the memory consumption issue and introduces optimizations for better performance.