### PR TITLE
fix: Memory leak pagination test

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -185,8 +185,10 @@ const useLogs = () => {
       yData: [],
       chartParams: {},
     };
+    searchObj.data.tempFunctionContent = "";
     searchObj.data.query = "";
     searchObj.meta.sqlMode = false;
+    searchObj.runQuery = false;
   };
 
   const updatedLocalLogFilterField = (): void => {
@@ -710,10 +712,13 @@ const useLogs = () => {
 
               //update grid columns
               updateGridColumns();
-              searchObj.loading = false;
-              if (histogramQueryReq.hasOwnProperty("aggs")) {
+              if (
+                res.data.hits.length > 0 &&
+                histogramQueryReq.hasOwnProperty("aggs")
+              ) {
                 getHistogramQueryData(histogramQueryReq);
               }
+              searchObj.loading = false;
               resolve(true);
             })
             .catch((err) => {
@@ -766,7 +771,6 @@ const useLogs = () => {
             searchObj.data.queryResults.total = res.data.total;
             generateHistogramData();
             // searchObj.data.histogram.chartParams.title = getHistogramTitle();
-
             searchObj.loading = false;
             resolve(true);
           })
@@ -1368,6 +1372,7 @@ const useLogs = () => {
     searchObj,
     getStreams,
     resetSearchObj,
+    resetStreamData,
     updatedLocalLogFilterField,
     getFunctions,
     getStreamList,

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -185,7 +185,6 @@ const useLogs = () => {
       yData: [],
       chartParams: {},
     };
-    searchObj.data.tempFunctionContent = "";
     searchObj.data.query = "";
     searchObj.meta.sqlMode = false;
     searchObj.runQuery = false;

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -187,7 +187,6 @@ const useLogs = () => {
     };
     searchObj.data.query = "";
     searchObj.meta.sqlMode = false;
-    searchObj.runQuery = false;
   };
 
   const updatedLocalLogFilterField = (): void => {

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -172,6 +172,8 @@ const useLogs = () => {
   const fieldValues = ref();
   const initialQueryPayload: Ref<LogsQueryPayload | null> = ref(null);
 
+  searchObj.organizationIdetifier = store.state.selectedOrganization.identifier;
+
   const resetSearchObj = () => {
     // searchObj = reactive(Object.assign({}, defaultObject));
     searchObj.data.errorMsg = "No stream found in selected organization!";

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -54,6 +54,7 @@ const defaultObject = {
   runQuery: false,
   loading: true,
   config: {
+    recordsPerPage: 250,
     splitterModel: 20,
     lastSplitterPosition: 0,
     splitterLimit: [0, 40],

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -706,8 +706,7 @@ const useLogs = () => {
               //extract fields from query response
               extractFields();
 
-              if (!isPagination) generateHistogramData();
-              else {
+              if (isPagination){
                 searchObj.data.histogram.chartParams.title =
                   getHistogramTitle();
               }
@@ -979,7 +978,7 @@ const useLogs = () => {
   };
 
   function getHistogramTitle() {
-    const currentPage = searchObj.data.resultGrid.currentPage - 1;
+    const currentPage = searchObj.data.resultGrid.currentPage - 1 || 0;
     const startCount = currentPage * searchObj.meta.resultGrid.rowsPerPage + 1;
     const endCount = startCount + searchObj.data.queryResults.hits.length - 1;
     const title =

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -54,7 +54,6 @@ const defaultObject = {
   runQuery: false,
   loading: true,
   config: {
-    recordsPerPage: 250,
     splitterModel: 20,
     lastSplitterPosition: 0,
     splitterLimit: [0, 40],

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -159,9 +159,8 @@ const defaultObject = {
   },
 };
 
-const searchObj = reactive(Object.assign({}, defaultObject));
-
 const useLogs = () => {
+  const searchObj = reactive(Object.assign({}, defaultObject));
   const store = useStore();
   const { t } = useI18n();
   const $q = useQuasar();

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -56,7 +56,7 @@ const getConfig = async () => {
   await configService.get_config().then((res: any) => {
     store.dispatch("setConfig", res.data);
     config.enableAnalytics = res.data.telemetry_enabled.toString();
-    if (res.data.telemetry_enabled == true && config.isCloud == "true") {
+    if (res.data.telemetry_enabled == true && config.isCloud == "true" && 1==0) {
       Sentry.init({
         app,
         dsn: config.sentryDSN,

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -56,7 +56,7 @@ const getConfig = async () => {
   await configService.get_config().then((res: any) => {
     store.dispatch("setConfig", res.data);
     config.enableAnalytics = res.data.telemetry_enabled.toString();
-    if (res.data.telemetry_enabled == true && config.isCloud == "true" && 1==0) {
+    if (res.data.telemetry_enabled == true && config.isCloud == "true") {
       Sentry.init({
         app,
         dsn: config.sentryDSN,

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -328,7 +328,7 @@ export default defineComponent({
           });
         }
       }
-    }
+    },
   },
   setup() {
     const store = useStore();
@@ -388,11 +388,25 @@ export default defineComponent({
     // }
 
     onDeactivated(() => {
-      resetStreamData();
+      // resetStreamData();
+      searchObj.data.queryResults = {};
+      searchObj.data.sortedQueryResults = [];
+      searchObj.data.histogram = {
+        xData: [],
+        yData: [],
+        chartParams: {},
+      };
     });
     onUnmounted(() => {
-      resetSearchObj();
-      resetStreamData();
+      searchObj.data.queryResults = {};
+      searchObj.data.sortedQueryResults = [];
+      searchObj.data.histogram = {
+        xData: [],
+        yData: [],
+        chartParams: {},
+      };
+      // resetSearchObj();
+      // resetStreamData();
     });
 
     onActivated(async () => {

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -184,7 +184,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       :expandedLogs="expandedLogs"
                       @update:datetime="setHistogramDate"
                       @update:scroll="getMoreData"
-                      @update:scroll-up="getLessData"
                       @expandlog="toggleExpandLog"
                     />
                   </div>

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -210,6 +210,7 @@ import {
   onBeforeMount,
   onBeforeUnmount,
   watch,
+  onUnmounted,
 } from "vue";
 import { useQuasar } from "quasar";
 import { useStore } from "vuex";
@@ -385,10 +386,13 @@ export default defineComponent({
     // }
 
     onDeactivated(() => {
-      // resetSearchObj();
+      resetSearchObj();
       // searchBarRef.value.resetFunctionContent();
       // setQuery("");
       // clearInterval(refreshIntervalID);
+    });
+    onUnmounted(() => {
+      resetSearchObj();
     });
 
     onActivated(async () => {

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -184,6 +184,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       :expandedLogs="expandedLogs"
                       @update:datetime="setHistogramDate"
                       @update:scroll="getMoreData"
+                      @update:scroll-up="getLessData"
                       @expandlog="toggleExpandLog"
                     />
                   </div>

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -328,7 +328,7 @@ export default defineComponent({
           });
         }
       }
-    },
+    }
   },
   setup() {
     const store = useStore();
@@ -388,25 +388,11 @@ export default defineComponent({
     // }
 
     onDeactivated(() => {
-      // resetStreamData();
-      searchObj.data.queryResults = {};
-      searchObj.data.sortedQueryResults = [];
-      searchObj.data.histogram = {
-        xData: [],
-        yData: [],
-        chartParams: {},
-      };
+      resetStreamData();
     });
     onUnmounted(() => {
-      searchObj.data.queryResults = {};
-      searchObj.data.sortedQueryResults = [];
-      searchObj.data.histogram = {
-        xData: [],
-        yData: [],
-        chartParams: {},
-      };
-      // resetSearchObj();
-      // resetStreamData();
+      resetSearchObj();
+      resetStreamData();
     });
 
     onActivated(async () => {

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -346,6 +346,8 @@ export default defineComponent({
       restoreUrlQueryParams,
       handleRunQuery,
       generateHistogramData,
+      resetStreamData,
+      resetSearchObj,
     } = useLogs();
     const searchResultRef = ref(null);
     const searchBarRef = ref(null);
@@ -386,13 +388,11 @@ export default defineComponent({
     // }
 
     onDeactivated(() => {
-      resetSearchObj();
-      // searchBarRef.value.resetFunctionContent();
-      // setQuery("");
-      // clearInterval(refreshIntervalID);
+      resetStreamData();
     });
     onUnmounted(() => {
       resetSearchObj();
+      resetStreamData();
     });
 
     onActivated(async () => {

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -367,15 +367,21 @@ clickable v-close-popup>
 
         <q-card-actions align="right">
           <q-btn
+            unelevated
+            no-caps
+            class="q-mr-sm text-bold"
             data-test="logs-search-bar-confirm-dialog-cancel-btn"
             :label="t('confirmDialog.cancel')"
-            color="primary"
+            color="secondary"
             v-close-popup
           />
           <q-btn
+          unelevated
+            no-caps
+            class="q-mr-sm text-bold"
             data-test="logs-search-bar-confirm-dialog-ok-btn"
             :label="t('search.btnDownload')"
-            color="positive"
+            color="primary"
             @click="downloadRangeData"
           />
         </q-card-actions>

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -144,24 +144,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </th>
             </tr>
           </thead>
-          <tbody class="tbody-sticky">
-            <tr
-              v-if="
-                scrollPosition <= 10 &&
-                searchObj.data.resultGrid.currentPage > 0
-              "
-            >
-              <th :colspan="searchObj.data.resultGrid.columns.length">
-                <q-btn
-                  size="xs"
-                  class="q-text-bold"
-                  color="primary"
-                  @click="onLoadLessData"
-                  >Load less data...</q-btn
-                >
-              </th>
-            </tr>
-          </tbody>
         </template>
         <template v-slot="{ item: row, index }">
           <q-tr
@@ -287,21 +269,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </td>
           </q-tr>
         </template>
-        <template v-slot:after>
-          <tbody class="tfoot-sticky">
-            <tr v-if="scrollPosition >= searchObj.config.recordsPerPage - 10">
-              <th :colspan="searchObj.data.resultGrid.columns.length">
-                <q-btn
-                  size="xs"
-                  class="q-text-bold"
-                  color="primary"
-                  @click="onLoadMoreData"
-                  >Load more data...</q-btn
-                >
-              </th>
-            </tr>
-          </tbody>
-        </template>
       </q-virtual-scroll>
       <q-dialog
         data-test="logs-search-result-detail-dialog"
@@ -364,7 +331,6 @@ export default defineComponent({
   },
   emits: [
     "update:scroll",
-    "update:scroll-up",
     "update:datetime",
     "remove:searchTerm",
     "search:timeboxed",

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -31,9 +31,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <q-pagination
             v-model="pageNumberInput"
             :max="
-              Math.round(
-                searchObj.data.queryResults.total /
-                  searchObj.meta.resultGrid.rowsPerPage
+              Math.max(
+                1,
+                Math.round(
+                  searchObj.data.queryResults.total /
+                    searchObj.meta.resultGrid.rowsPerPage
+                )
               )
             "
             input
@@ -346,30 +349,39 @@ export default defineComponent({
   methods: {
     getPageData(actionType: string) {
       if (actionType == "prev") {
-        if (this.searchObj.data.resultGrid.currentPage > 1) {
+        if (parseInt(this.searchObj.data.resultGrid.currentPage) > 1) {
           this.searchObj.data.resultGrid.currentPage =
-            this.searchObj.data.resultGrid.currentPage - 1;
-          this.pageNumberInput = this.searchObj.data.resultGrid.currentPage;
+            parseInt(this.searchObj.data.resultGrid.currentPage) - 1;
+          this.pageNumberInput = Math.max(
+            1,
+            parseInt(this.searchObj.data.resultGrid.currentPage)
+          );
           this.$emit("update:scroll");
           this.searchTableRef.scrollTo(0);
         }
       } else if (actionType == "next") {
         if (
-          this.searchObj.data.resultGrid.currentPage <=
+          parseInt(this.searchObj.data.resultGrid.currentPage) <=
           Math.round(
             this.searchObj.data.queryResults.total /
               this.searchObj.meta.resultGrid.rowsPerPage
           )
         ) {
           this.searchObj.data.resultGrid.currentPage =
-            this.searchObj.data.resultGrid.currentPage + 1;
-          this.pageNumberInput = this.searchObj.data.resultGrid.currentPage;
+            parseInt(this.searchObj.data.resultGrid.currentPage) + 1;
+          this.pageNumberInput = Math.max(
+            1,
+            parseInt(this.searchObj.data.resultGrid.currentPage)
+          );
           this.$emit("update:scroll");
           this.searchTableRef.scrollTo(0);
         }
       } else if (actionType == "recordsPerPage") {
         this.searchObj.data.resultGrid.currentPage = 1;
-        this.pageNumberInput = this.searchObj.data.resultGrid.currentPage;
+        this.pageNumberInput = Math.max(
+          1,
+          parseInt(this.searchObj.data.resultGrid.currentPage)
+        );
         this.$emit("update:scroll");
         this.searchTableRef.scrollTo(0);
       } else if (actionType == "pageChange") {
@@ -386,7 +398,10 @@ export default defineComponent({
               "Page number is out of range. Please provide valid page number.",
             timeout: 1000,
           });
-          this.pageNumberInput = this.searchObj.data.resultGrid.currentPage;
+          this.pageNumberInput = Math.max(
+            1,
+            parseInt(this.searchObj.data.resultGrid.currentPage)
+          );
           return false;
         }
 

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -111,8 +111,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           wordBreak: 'break-word',
           height:
             !searchObj.meta.showHistogram || searchObj.meta.sqlMode
-              ? 'calc(100% - 0px)'
-              : 'calc(100% - 120px)',
+              ? 'calc(100% - 40px)'
+              : 'calc(100% - 140px)',
         }"
       >
         <template v-slot:before>

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -144,6 +144,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </th>
             </tr>
           </thead>
+          <tbody class="tbody-sticky">
+            <tr
+              v-if="
+                scrollPosition <= 10 &&
+                searchObj.data.resultGrid.currentPage > 0
+              "
+            >
+              <th :colspan="searchObj.data.resultGrid.columns.length">
+                <q-btn
+                  size="xs"
+                  class="q-text-bold"
+                  color="primary"
+                  @click="onLoadLessData"
+                  >Load less data...</q-btn
+                >
+              </th>
+            </tr>
+          </tbody>
         </template>
         <template v-slot="{ item: row, index }">
           <q-tr
@@ -269,6 +287,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </td>
           </q-tr>
         </template>
+        <template v-slot:after>
+          <tbody class="tfoot-sticky">
+            <tr v-if="scrollPosition >= searchObj.config.recordsPerPage - 10">
+              <th :colspan="searchObj.data.resultGrid.columns.length">
+                <q-btn
+                  size="xs"
+                  class="q-text-bold"
+                  color="primary"
+                  @click="onLoadMoreData"
+                  >Load more data...</q-btn
+                >
+              </th>
+            </tr>
+          </tbody>
+        </template>
       </q-virtual-scroll>
       <q-dialog
         data-test="logs-search-result-detail-dialog"
@@ -331,6 +364,7 @@ export default defineComponent({
   },
   emits: [
     "update:scroll",
+    "update:scroll-up",
     "update:datetime",
     "remove:searchTerm",
     "search:timeboxed",

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -164,6 +164,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <q-td
               v-for="column in searchObj.data.resultGrid.columns"
               :key="index + '-' + column.name"
+              :data-test="'log-table-column-' + index + '-' + column.name"
               class="field_list"
               style="cursor: pointer"
             >

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -30,6 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div class="col-6 text-right q-pr-md q-gutter-xs pagination-block">
           <q-pagination
             v-model="pageNumberInput"
+            :key="searchObj.data.queryResults.total + '-' + searchObj.data.resultGrid.currentPage"
             :max="
               Math.max(
                 1,
@@ -307,7 +308,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, onMounted } from "vue";
+import { computed, defineComponent, ref, onMounted, onUpdated } from "vue";
 import { copyToClipboard, useQuasar } from "quasar";
 import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
@@ -349,39 +350,28 @@ export default defineComponent({
   methods: {
     getPageData(actionType: string) {
       if (actionType == "prev") {
-        if (parseInt(this.searchObj.data.resultGrid.currentPage) > 1) {
-          this.searchObj.data.resultGrid.currentPage =
-            parseInt(this.searchObj.data.resultGrid.currentPage) - 1;
-          this.pageNumberInput = Math.max(
-            1,
-            parseInt(this.searchObj.data.resultGrid.currentPage)
-          );
+        if (this.searchObj.data.resultGrid.currentPage > 1) {
+          this.searchObj.data.resultGrid.currentPage = this.searchObj.data.resultGrid.currentPage - 1;
+          this.pageNumberInput = this.searchObj.data.resultGrid.currentPage;
           this.$emit("update:scroll");
           this.searchTableRef.scrollTo(0);
         }
       } else if (actionType == "next") {
         if (
-          parseInt(this.searchObj.data.resultGrid.currentPage) <=
+          this.searchObj.data.resultGrid.currentPage <=
           Math.round(
             this.searchObj.data.queryResults.total /
               this.searchObj.meta.resultGrid.rowsPerPage
           )
         ) {
-          this.searchObj.data.resultGrid.currentPage =
-            parseInt(this.searchObj.data.resultGrid.currentPage) + 1;
-          this.pageNumberInput = Math.max(
-            1,
-            parseInt(this.searchObj.data.resultGrid.currentPage)
-          );
+          this.searchObj.data.resultGrid.currentPage = this.searchObj.data.resultGrid.currentPage + 1;
+          this.pageNumberInput = this.searchObj.data.resultGrid.currentPage;
           this.$emit("update:scroll");
           this.searchTableRef.scrollTo(0);
         }
       } else if (actionType == "recordsPerPage") {
         this.searchObj.data.resultGrid.currentPage = 1;
-        this.pageNumberInput = Math.max(
-          1,
-          parseInt(this.searchObj.data.resultGrid.currentPage)
-        );
+        this.pageNumberInput = this.searchObj.data.resultGrid.currentPage;
         this.$emit("update:scroll");
         this.searchTableRef.scrollTo(0);
       } else if (actionType == "pageChange") {
@@ -398,10 +388,7 @@ export default defineComponent({
               "Page number is out of range. Please provide valid page number.",
             timeout: 1000,
           });
-          this.pageNumberInput = Math.max(
-            1,
-            parseInt(this.searchObj.data.resultGrid.currentPage)
-          );
+          this.pageNumberInput = this.searchObj.data.resultGrid.currentPage;
           return false;
         }
 
@@ -444,8 +431,7 @@ export default defineComponent({
     const noOfRecordsTitle = ref("");
     const scrollPosition = ref(0);
     const rowsPerPageOptions = [10, 25, 50, 100, 250, 500, 1000];
-    const pageNumberInput = ref(1);
-
+    
     const {
       searchObj,
       updatedLocalLogFilterField,
@@ -453,6 +439,7 @@ export default defineComponent({
       extractFTSFields,
       evaluateWrapContentFlag,
     } = useLogs();
+    const pageNumberInput = ref(1);
     const totalHeight = ref(0);
 
     const searchTableRef: any = ref(null);
@@ -461,6 +448,10 @@ export default defineComponent({
 
     onMounted(() => {
       reDrawChart();
+    });
+
+    onUpdated(() => {
+      pageNumberInput.value = searchObj.data.resultGrid.currentPage;
     });
 
     const reDrawChart = () => {


### PR DESCRIPTION
PR contains changes related to memory issue on logs page.
- to avoid memory leak, cleaning up the data from the composable variable. So user navigates away from the logs page all data will be removed to free up memory. Once user come back to logs page data will be pulled again.
- fixed function editor content issue which was wiped out once user navigate back to logs page.