### PR TITLE
feat: migrate from any to any

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -60,7 +60,7 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                         .help("init this path as data root dir"),
                 ),
             clap::Command::new("migrate-file-list")
-                .about("migrate file-list from s3 to dynamo db")
+                .about("migrate file-list")
                 .args([
                     clap::Arg::new("prefix")
                         .short('p')
@@ -73,13 +73,13 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                         .long("from")
                         .value_name("from")
                         .required(true)
-                        .help("migrate from"),
+                        .help("migrate from: sled, sqlite, etcd, mysql, postgresql"),
                     clap::Arg::new("to")
                         .short('t')
                         .long("to")
                         .value_name("to")
                         .required(true)
-                        .help("migrate to"),
+                        .help("migrate to: sqlite, mysql, postgresql"),
                 ]),
             clap::Command::new("migrate-meta")
                 .about("migrate meta")
@@ -89,13 +89,13 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                         .long("from")
                         .value_name("from")
                         .required(true)
-                        .help("migrate from"),
+                        .help("migrate from: sled, sqlite, etcd, mysql, postgresql"),
                     clap::Arg::new("to")
                         .short('t')
                         .long("to")
                         .value_name("to")
                         .required(true)
-                        .help("migrate to"),
+                        .help("migrate to: sqlite, etcd, mysql, postgresql"),
                 ]),
             clap::Command::new("migrate-dashboards").about("migrate-dashboards"),
             clap::Command::new("delete-parquet")

--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -218,8 +218,6 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                 from, to, prefix
             );
             migration::file_list::run(&prefix, &from, &to).await?;
-            println!("Running migration file_list_deleted");
-            migration::file_list::run_for_deleted(&from, &to).await?;
         }
         "migrate-meta" => {
             let from = match command.get_one::<String>("from") {

--- a/src/common/infra/db/dynamo.rs
+++ b/src/common/infra/db/dynamo.rs
@@ -519,6 +519,7 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
     };
 
     let mut parts = local_key.split('/').collect::<Vec<&str>>();
+    let empty_str = "";
     let entity = parts[0];
 
     if db_key.starts_with("/user") {
@@ -552,8 +553,8 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
         "function" | "templates" | "destinations" | "kv" | "metrics_members" | "metrics_leader"
         | "trigger" | "folders" => match operation {
             DbOperation::Get | DbOperation::Put | DbOperation::Delete => DynamoTableDetails {
-                pk_value: parts[1].to_string(),
-                rk_value: format!("{}/{}", parts[0], parts[2]),
+                pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
+                rk_value: format!("{}/{}", parts[0], parts.get(2).unwrap_or(&empty_str)),
                 name: CONFIG.dynamo.org_meta_table.clone(),
                 pk: "org".to_string(),
                 rk: "key".to_string(),
@@ -561,9 +562,9 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
                 entity: entity.to_string(),
             },
             DbOperation::List => {
-                if parts.len() == 1 || parts[1].is_empty() {
+                if parts.len() == 1 || parts.get(1).unwrap_or(&empty_str).is_empty() {
                     DynamoTableDetails {
-                        pk_value: parts[1].to_string(),
+                        pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
                         rk_value: parts[0].to_string(),
                         name: CONFIG.dynamo.org_meta_table.clone(),
                         pk: "org".to_string(),
@@ -573,7 +574,7 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
                     }
                 } else {
                     DynamoTableDetails {
-                        pk_value: parts[1].to_string(),
+                        pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
                         rk_value: parts[0].to_string(),
                         name: CONFIG.dynamo.org_meta_table.clone(),
                         pk: "org".to_string(),
@@ -587,8 +588,14 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
 
         "alerts" => match operation {
             DbOperation::Get | DbOperation::Put | DbOperation::Delete => DynamoTableDetails {
-                pk_value: parts[1].to_string(),
-                rk_value: format!("{}/{}/{}/{}", parts[0], parts[2], parts[3], parts[4]),
+                pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
+                rk_value: format!(
+                    "{}/{}/{}/{}",
+                    parts[0],
+                    parts.get(2).unwrap_or(&empty_str),
+                    parts.get(3).unwrap_or(&empty_str),
+                    parts.get(4).unwrap_or(&empty_str)
+                ),
                 name: CONFIG.dynamo.org_meta_table.clone(),
                 pk: "org".to_string(),
                 rk: "key".to_string(),
@@ -596,9 +603,9 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
                 entity: entity.to_string(),
             },
             DbOperation::List => {
-                if parts.len() == 1 || parts[1].is_empty() {
+                if parts.len() == 1 || parts.get(1).unwrap_or(&empty_str).is_empty() {
                     DynamoTableDetails {
-                        pk_value: parts[1].to_string(),
+                        pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
                         rk_value: parts[0].to_string(),
                         name: CONFIG.dynamo.org_meta_table.clone(),
                         pk: "org".to_string(),
@@ -608,7 +615,7 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
                     }
                 } else {
                     DynamoTableDetails {
-                        pk_value: parts[1].to_string(),
+                        pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
                         rk_value: parts[0].to_string(),
                         name: CONFIG.dynamo.org_meta_table.clone(),
                         pk: "org".to_string(),
@@ -621,8 +628,13 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
         },
         "schema" => match operation {
             DbOperation::Get | DbOperation::Put | DbOperation::Delete => DynamoTableDetails {
-                pk_value: parts[1].to_string(),
-                rk_value: format!("{}/{}/{}", parts[0], parts[2], parts[3]),
+                pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
+                rk_value: format!(
+                    "{}/{}/{}",
+                    parts[0],
+                    parts.get(2).unwrap_or(&empty_str),
+                    parts.get(3).unwrap_or(&empty_str)
+                ),
                 name: CONFIG.dynamo.schema_table.clone(),
                 pk: "org".to_string(),
                 rk: "key".to_string(),
@@ -630,9 +642,9 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
                 entity: entity.to_string(),
             },
             DbOperation::List => {
-                if parts.len() == 1 || parts[1].is_empty() {
+                if parts.len() == 1 || parts.get(1).unwrap_or(&empty_str).is_empty() {
                     DynamoTableDetails {
-                        pk_value: parts[1].to_string(),
+                        pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
                         rk_value: parts[0].to_string(),
                         name: CONFIG.dynamo.schema_table.clone(),
                         pk: "org".to_string(),
@@ -642,7 +654,7 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
                     }
                 } else {
                     DynamoTableDetails {
-                        pk_value: parts[1].to_string(),
+                        pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
                         rk_value: parts[0].to_string(),
                         name: CONFIG.dynamo.schema_table.clone(),
                         pk: "org".to_string(),
@@ -655,8 +667,13 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
         },
         "dashboard" => match operation {
             DbOperation::Get | DbOperation::Put | DbOperation::Delete => DynamoTableDetails {
-                pk_value: parts[1].to_string(),
-                rk_value: format!("{}/{}/{}", parts[0], parts[2], parts[3]),
+                pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
+                rk_value: format!(
+                    "{}/{}/{}",
+                    parts[0],
+                    parts.get(2).unwrap_or(&empty_str),
+                    parts.get(3).unwrap_or(&empty_str)
+                ),
                 name: CONFIG.dynamo.org_meta_table.clone(),
                 pk: "org".to_string(),
                 rk: "key".to_string(),
@@ -664,9 +681,9 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
                 entity: entity.to_string(),
             },
             DbOperation::List => {
-                if parts.len() == 1 || parts[1].is_empty() {
+                if parts.len() == 1 || parts.get(1).unwrap_or(&empty_str).is_empty() {
                     DynamoTableDetails {
-                        pk_value: parts[1].to_string(),
+                        pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
                         rk_value: parts[0].to_string(),
                         name: CONFIG.dynamo.org_meta_table.clone(),
                         pk: "org".to_string(),
@@ -676,8 +693,8 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
                     }
                 } else {
                     DynamoTableDetails {
-                        pk_value: parts[1].to_string(),
-                        rk_value: format!("{}/{}", parts[0], parts[2]),
+                        pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
+                        rk_value: format!("{}/{}", parts[0], parts.get(2).unwrap_or(&empty_str)),
                         name: CONFIG.dynamo.org_meta_table.clone(),
                         pk: "org".to_string(),
                         rk: "key".to_string(),
@@ -691,18 +708,27 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
             DbOperation::Get | DbOperation::Put | DbOperation::Delete => {
                 parts.swap(1, 2);
                 let rk_value = if local_key.starts_with("compact/organization/") {
-                    format!("{}/{}", parts[0], parts[2])
+                    format!("{}/{}", parts[0], parts.get(2).unwrap_or(&empty_str))
                 } else if local_key.starts_with("compact/delete/") {
                     format!(
                         "{}/{}/{}/{}/{}",
-                        parts[0], parts[2], parts[3], parts[4], parts[5]
+                        parts[0],
+                        parts.get(2).unwrap_or(&empty_str),
+                        parts.get(3).unwrap_or(&empty_str),
+                        parts.get(4).unwrap_or(&empty_str),
+                        parts.get(5).unwrap_or(&empty_str)
                     )
                 } else {
-                    format!("{}/{}/{}", parts[0], parts[2], parts[3])
+                    format!(
+                        "{}/{}/{}",
+                        parts[0],
+                        parts.get(2).unwrap_or(&empty_str),
+                        parts.get(3).unwrap_or(&empty_str)
+                    )
                 };
 
                 DynamoTableDetails {
-                    pk_value: parts[1].to_string(),
+                    pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
                     rk_value,
                     name: CONFIG.dynamo.compact_table.clone(),
                     pk: "org".to_string(),
@@ -717,9 +743,12 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
                 } else {
                     parts[0].to_string()
                 };
-                if parts.len() == 1 || parts[1].is_empty() || local_key.eq("compact/delete/") {
+                if parts.len() == 1
+                    || parts.get(1).unwrap_or(&empty_str).is_empty()
+                    || local_key.eq("compact/delete/")
+                {
                     DynamoTableDetails {
-                        pk_value: parts[1].to_string(),
+                        pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
                         rk_value,
                         name: CONFIG.dynamo.compact_table.clone(),
                         pk: "org".to_string(),
@@ -729,7 +758,7 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
                     }
                 } else {
                     DynamoTableDetails {
-                        pk_value: parts[1].to_string(),
+                        pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
                         rk_value: parts[0].to_string(),
                         name: CONFIG.dynamo.compact_table.clone(),
                         pk: "org".to_string(),
@@ -742,7 +771,7 @@ pub fn get_dynamo_key(db_key: &str, operation: DbOperation) -> DynamoTableDetail
         },
 
         _ => DynamoTableDetails {
-            pk_value: parts[1].to_string(),
+            pk_value: parts.get(1).unwrap_or(&empty_str).to_string(),
             rk_value: parts[0].to_string(),
             name: CONFIG.dynamo.org_meta_table.clone(),
             pk: "org".to_string(),

--- a/src/common/migration/file_list.rs
+++ b/src/common/migration/file_list.rs
@@ -21,7 +21,7 @@ use crate::{
     service::{compact::stats::update_stats_from_file_list, db},
 };
 
-pub async fn run(prefix: &str) -> Result<(), anyhow::Error> {
+pub async fn run(prefix: &str, from: &str, to: &str) -> Result<(), anyhow::Error> {
     if get_file_meta(&CONFIG.common.data_wal_dir).is_err() {
         // there is no local wal files, no need upgrade
         return Ok(());
@@ -56,7 +56,7 @@ pub async fn run(prefix: &str) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-pub async fn run_for_deleted() -> Result<(), anyhow::Error> {
+pub async fn run_for_deleted(from: &str, to: &str) -> Result<(), anyhow::Error> {
     if get_file_meta(&CONFIG.common.data_wal_dir).is_err() {
         // there is no local wal files, no need upgrade
         return Ok(());

--- a/src/common/migration/file_list.rs
+++ b/src/common/migration/file_list.rs
@@ -13,10 +13,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::CONFIG;
+use config::{
+    meta::stream::{FileKey, StreamType},
+    CONFIG,
+};
 
 use crate::{
-    common::{infra::file_list as infra_file_list, utils::file::get_file_meta},
+    common::{
+        infra::file_list as infra_file_list,
+        meta::stream::PartitionTimeLevel,
+        utils::{file::get_file_meta, time::BASE_TIME},
+    },
     job::{file_list, files},
     service::{compact::stats::update_stats_from_file_list, db},
 };
@@ -27,6 +34,32 @@ pub async fn run(prefix: &str, from: &str, to: &str) -> Result<(), anyhow::Error
         return Ok(());
     }
 
+    // load stream list
+    let mut from_storage = false;
+    let src: Box<dyn infra_file_list::FileList> = match from.to_lowercase().as_str().trim() {
+        "local" | "s3" | "sled" | "etcd" => {
+            // load file list to db
+            db::file_list::remote::cache(prefix, false)
+                .await
+                .expect("file list migration failed");
+            from_storage = true;
+            Box::<infra_file_list::sqlite::SqliteFileList>::default()
+        }
+        "sqlite" => Box::<infra_file_list::sqlite::SqliteFileList>::default(),
+        "mysql" => Box::<infra_file_list::mysql::MysqlFileList>::default(),
+        "postgres" | "postgresql" => Box::<infra_file_list::postgres::PostgresFileList>::default(),
+        _ => panic!("invalid source"),
+    };
+
+    let dest: Box<dyn infra_file_list::FileList> = match to.to_lowercase().as_str().trim() {
+        "sqlite" => Box::<infra_file_list::sqlite::SqliteFileList>::default(),
+        "mysql" => Box::<infra_file_list::mysql::MysqlFileList>::default(),
+        "postgres" | "postgresql" => Box::<infra_file_list::postgres::PostgresFileList>::default(),
+        _ => panic!("invalid destination"),
+    };
+    dest.create_table().await?;
+    db::schema::cache().await?;
+
     // move files from wal for disk
     if let Err(e) = files::json::move_files_to_storage().await {
         log::error!("Error moving disk json files to remote: {}", e);
@@ -41,11 +74,68 @@ pub async fn run(prefix: &str, from: &str, to: &str) -> Result<(), anyhow::Error
     }
 
     // load stream list
-    db::schema::cache().await?;
-    // load file list to db
-    db::file_list::remote::cache(prefix, false)
-        .await
-        .expect("file list migration failed");
+    let stream_types = [
+        StreamType::Logs,
+        StreamType::Metrics,
+        StreamType::Traces,
+        StreamType::EnrichmentTables,
+        StreamType::Metadata,
+    ];
+    let start_time = BASE_TIME.timestamp_micros();
+    let end_time = chrono::Utc::now().timestamp_micros();
+    let orgs = db::schema::list_organizations_from_cache();
+    for org_id in orgs.iter() {
+        for stream_type in stream_types {
+            let streams = db::schema::list_streams_from_cache(org_id, stream_type);
+            for stream_name in streams.iter() {
+                // load file_list from source
+                let files = src
+                    .query(
+                        org_id,
+                        stream_type,
+                        stream_name,
+                        PartitionTimeLevel::Unset,
+                        (start_time, end_time),
+                    )
+                    .await
+                    .expect("load file_list failed");
+                let put_items = files
+                    .into_iter()
+                    .map(|(file_key, file_meta)| FileKey::new(&file_key, file_meta, false))
+                    .collect::<Vec<_>>();
+                dest.batch_add(&put_items)
+                    .await
+                    .expect("load list_list into db failed");
+            }
+        }
+
+        // load file_list_deleted from storage
+        if from_storage {
+            let files =
+                crate::service::compact::file_list_deleted::load_prefix_from_s3(org_id).await?;
+            if !files.is_empty() {
+                let files = files
+                    .values()
+                    .flatten()
+                    .map(|file| file.to_owned())
+                    .collect::<Vec<_>>();
+                if let Err(e) = dest.batch_add_deleted(org_id, end_time, &files).await {
+                    log::error!("load file_list_deleted into db err: {}", e);
+                }
+            }
+        }
+
+        // load file_list_deleted from source
+        let files = src
+            .query_deleted(org_id, end_time, 1_000_000)
+            .await
+            .expect("load file_list_deleted failed");
+        if let Err(e) = dest.batch_add_deleted(org_id, end_time, &files).await {
+            log::error!("load file_list_deleted into db err: {}", e);
+            continue;
+        }
+    }
+
     infra_file_list::set_initialised()
         .await
         .expect("file list migration set initialised failed");
@@ -53,46 +143,5 @@ pub async fn run(prefix: &str, from: &str, to: &str) -> Result<(), anyhow::Error
     update_stats_from_file_list()
         .await
         .expect("file list migration stats failed");
-    Ok(())
-}
-
-pub async fn run_for_deleted(from: &str, to: &str) -> Result<(), anyhow::Error> {
-    if get_file_meta(&CONFIG.common.data_wal_dir).is_err() {
-        // there is no local wal files, no need upgrade
-        return Ok(());
-    }
-
-    // move files from wal for disk
-    if let Err(e) = files::json::move_files_to_storage().await {
-        log::error!("Error moving disk json files to remote: {}", e);
-    }
-    if let Err(e) = files::parquet::move_files_to_storage().await {
-        log::error!("Error moving disk parquet files to remote: {}", e);
-    }
-
-    // move file_list from wal for disk
-    if let Err(e) = file_list::move_file_list_to_storage(false).await {
-        log::error!("Error moving disk files to remote: {}", e);
-    }
-
-    // load stream list
-    db::schema::cache().await?;
-    let max_time = chrono::Utc::now().timestamp_micros();
-    let orgs = db::schema::list_organizations_from_cache();
-    for org_id in orgs.iter() {
-        let files = crate::service::compact::file_list_deleted::load_prefix_from_s3(org_id).await?;
-        if files.is_empty() {
-            continue;
-        }
-        let files = files
-            .values()
-            .flatten()
-            .map(|file| file.to_owned())
-            .collect::<Vec<_>>();
-        if let Err(e) = infra_file_list::batch_add_deleted(org_id, max_time, &files).await {
-            log::error!("load file_list_deleted into db err: {}", e);
-            continue;
-        }
-    }
     Ok(())
 }

--- a/src/common/migration/meta.rs
+++ b/src/common/migration/meta.rs
@@ -44,7 +44,6 @@ pub async fn run(from: &str, to: &str) -> Result<(), anyhow::Error> {
         _ => panic!("invalid source"),
     };
     let dest: Box<dyn infra_db::Db> = match to.to_lowercase().as_str().trim() {
-        "sled" => Box::<infra_db::sled::SledDb>::default(),
         "sqlite" => Box::<infra_db::sqlite::SqliteDb>::default(),
         "etcd" => Box::<infra_db::etcd::Etcd>::default(),
         "mysql" => Box::<infra_db::mysql::MysqlDb>::default(),

--- a/src/common/migration/meta.rs
+++ b/src/common/migration/meta.rs
@@ -14,12 +14,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use chrono::Utc;
-use config::CONFIG;
 
-use crate::common::{
-    infra::db::{self, Db},
-    utils::file::get_file_meta,
-};
+use crate::common::infra::db as infra_db;
 
 const ITEM_PREFIXES: [&str; 13] = [
     "/user",
@@ -37,94 +33,42 @@ const ITEM_PREFIXES: [&str; 13] = [
     "/kv",
 ];
 
-pub async fn run() -> Result<(), anyhow::Error> {
-    if CONFIG.common.local_mode {
-        load_meta_from_sled().await
-    } else {
-        load_meta_from_etcd().await
-    }
-}
-
-pub async fn load_meta_from_sled() -> Result<(), anyhow::Error> {
-    if get_file_meta(&format!("{}db", CONFIG.sled.data_dir)).is_err() {
-        // there is no local db, no need upgrade
-        return Ok(());
-    }
-    let (src, dest) = if CONFIG.common.local_mode {
-        (Box::<db::sled::SledDb>::default(), db::get_db().await)
-    } else {
-        panic!("enable local mode to migrate from sled");
+pub async fn run(from: &str, to: &str) -> Result<(), anyhow::Error> {
+    println!("load meta from {}", from);
+    let src: Box<dyn infra_db::Db> = match from.to_lowercase().as_str().trim() {
+        "sled" => Box::<infra_db::sled::SledDb>::default(),
+        "sqlite" => Box::<infra_db::sqlite::SqliteDb>::default(),
+        "etcd" => Box::<infra_db::etcd::Etcd>::default(),
+        "mysql" => Box::<infra_db::mysql::MysqlDb>::default(),
+        "postgres" | "postgresql" => Box::<infra_db::postgres::PostgresDb>::default(),
+        _ => panic!("invalid source"),
     };
-    for item in ITEM_PREFIXES {
-        let time = std::time::Instant::now();
-        let res = src.list(item).await?;
-        println!(
-            "resources length for prefix {} from sled is {}",
-            item,
-            res.len()
-        );
-
-        for (key, value) in res.iter() {
-            // let final_key;
-            // let key = if key.starts_with("/trigger") {
-            //     let local_val: Trigger = json::from_slice(value).unwrap();
-            //     final_key = format!("/trigger/{}/{}", local_val.org,
-            // local_val.alert_name);     &final_key
-            // } else {
-            //     key
-            // };
-            match dest.put(key, value.clone(), false).await {
-                Ok(_) => {}
-                Err(e) => {
-                    println!(
-                        "error while migrating key {} from sled to sqlite {}",
-                        key, e
-                    );
-                }
-            }
-        }
-        println!(
-            "migrated  prefix {} from sled , took {} secs",
-            item,
-            time.elapsed().as_secs()
-        );
-    }
-
-    Ok(())
-}
-
-pub async fn load_meta_from_etcd() -> Result<(), anyhow::Error> {
-    println!("load meta from etcd");
-    let (src, dest) = if !CONFIG.common.local_mode {
-        (Box::<db::etcd::Etcd>::default(), db::get_db().await)
-    } else {
-        panic!("disable local mode to migrate from etcd");
+    let dest: Box<dyn infra_db::Db> = match to.to_lowercase().as_str().trim() {
+        "sled" => Box::<infra_db::sled::SledDb>::default(),
+        "sqlite" => Box::<infra_db::sqlite::SqliteDb>::default(),
+        "etcd" => Box::<infra_db::etcd::Etcd>::default(),
+        "mysql" => Box::<infra_db::mysql::MysqlDb>::default(),
+        "postgres" | "postgresql" => Box::<infra_db::postgres::PostgresDb>::default(),
+        _ => panic!("invalid destination"),
     };
+    dest.create_table().await?;
 
     for item in ITEM_PREFIXES {
         let time = std::time::Instant::now();
         let res = src.list(item).await?;
         println!(
-            "resources length for prefix {} from etcd is {}",
+            "resources length for prefix {} from source is {}",
             item,
             res.len()
         );
         let mut count = 0;
         for (key, value) in res.iter() {
-            // let final_key;
-            // let key = if key.starts_with("/trigger") {
-            //     let local_val: Trigger = json::from_slice(value).unwrap();
-            //     final_key = format!("/trigger/{}/{}", local_val.org,
-            // local_val.alert_name);     &final_key
-            // } else {
-            //     key
-            // };
             match dest.put(key, value.clone(), false).await {
                 Ok(_) => {
                     count += 1;
                 }
                 Err(e) => {
-                    println!("error while migrating key {} from etcd {}", key, e);
+                    println!("error while migrating key {} from source {}", key, e);
                 }
             }
             if count % 100 == 0 {
@@ -137,7 +81,7 @@ pub async fn load_meta_from_etcd() -> Result<(), anyhow::Error> {
             }
         }
         println!(
-            "migrated  prefix {} from etcd , took {} secs",
+            "migrated prefix {} from source, took {} secs",
             item,
             time.elapsed().as_secs()
         );

--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -35,10 +35,10 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
 
 async fn upgrade_052_053() -> Result<(), anyhow::Error> {
     // migration for metadata
-    meta::run().await?;
+    meta::run("sled", "sqlite").await?;
 
     // migration for file_list
-    file_list::run("").await?;
+    file_list::run("", "sled", "sqlite").await?;
 
     Ok(())
 }


### PR DESCRIPTION
impl #2469 

## migrate meta

```
./openobserve migrate-meta --help
migrate meta

Usage: openobserve migrate-meta --from <from> --to <to>

Options:
  -f, --from <from>  migrate from: sled, sqlite, etcd, mysql, postgresql
  -t, --to <to>      migrate to: sqlite, etcd, mysql, postgresql
  -h, --help         Print help
```

## migrate file-list

```
./openobserve migrate-file-list --help
migrate file-list

Usage: openobserve migrate-file-list [OPTIONS] --from <from> --to <to>

Options:
  -p, --prefix <prefix>  only migrate specified prefix, default is all
  -f, --from <from>      migrate from: sled, sqlite, etcd, mysql, postgresql
  -t, --to <to>          migrate to: sqlite, mysql, postgresql
  -h, --help             Print help
```