### PR TITLE
feat: add alert_url variable for alerts

### DIFF
--- a/src/common/infra/cluster.rs
+++ b/src/common/infra/cluster.rs
@@ -247,6 +247,14 @@ pub async fn leave() -> Result<()> {
     Ok(())
 }
 
+pub async fn update_node(uuid: &str, node: &Node) -> Result<()> {
+    let mut client = etcd::get_etcd_client().await.clone();
+    let key = format!("{}nodes/{}", &CONFIG.etcd.prefix, uuid);
+    let val = json::to_string(node).unwrap();
+    let _resp = client.put(key, val, None).await?;
+    Ok(())
+}
+
 pub fn get_cached_nodes(cond: fn(&Node) -> bool) -> Option<Vec<Node>> {
     if NODES.is_empty() {
         return None;

--- a/src/common/utils/base64.rs
+++ b/src/common/utils/base64.rs
@@ -48,6 +48,10 @@ pub(crate) fn decode_raw(s: &str) -> Result<Vec<u8>, Error> {
         .map_err(|e| Error::new(ErrorKind::InvalidData, format!("base64 decode error: {e}")))
 }
 
+pub(crate) fn encode(s: &str) -> String {
+    base64::engine::general_purpose::STANDARD.encode(s.as_bytes())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -230,6 +230,10 @@ pub struct Common {
     pub cluster_name: String,
     #[env_config(name = "ZO_INSTANCE_NAME", default = "")]
     pub instance_name: String,
+    #[env_config(name = "ZO_WEB_URL", default = "")] // http://localhost:5080
+    pub web_url: String,
+    #[env_config(name = "ZO_BASE_URI", default = "")] // /abc
+    pub base_uri: String,
     #[env_config(name = "ZO_INGESTER_SIDECAR_ENABLED", default = false)]
     pub ingester_sidecar_enabled: bool,
     #[env_config(name = "ZO_INGESTER_SIDECAR_QUERIER", default = false)]
@@ -244,8 +248,6 @@ pub struct Common {
     pub data_db_dir: String,
     #[env_config(name = "ZO_DATA_CACHE_DIR", default = "")] // ./data/openobserve/cache/
     pub data_cache_dir: String,
-    #[env_config(name = "ZO_BASE_URI", default = "")]
-    pub base_uri: String,
     #[env_config(name = "ZO_WAL_MEMORY_MODE_ENABLED", default = false)]
     pub wal_memory_mode_enabled: bool,
     #[env_config(name = "ZO_WAL_LINE_MODE_ENABLED", default = true)]
@@ -756,6 +758,14 @@ fn check_common_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
 }
 
 fn check_path_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
+    // for web
+    if cfg.common.web_url.ends_with('/') {
+        cfg.common.web_url = cfg.common.web_url.trim_end_matches('/').to_string();
+    }
+    if cfg.common.base_uri.ends_with('/') {
+        cfg.common.base_uri = cfg.common.base_uri.trim_end_matches('/').to_string();
+    }
+    // for data
     if cfg.common.data_dir.is_empty() {
         cfg.common.data_dir = "./data/openobserve/".to_string();
     }
@@ -785,9 +795,6 @@ fn check_path_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
     if !cfg.common.data_cache_dir.ends_with('/') {
         cfg.common.data_cache_dir = format!("{}/", cfg.common.data_cache_dir);
-    }
-    if cfg.common.base_uri.ends_with('/') {
-        cfg.common.base_uri = cfg.common.base_uri.trim_end_matches('/').to_string();
     }
     if cfg.sled.data_dir.is_empty() {
         cfg.sled.data_dir = format!("{}db/", cfg.common.data_dir);

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -201,6 +201,8 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
             ))
             .wrap(cors.clone())
             .service(status::cache_status)
+            .service(status::enable_node)
+            .service(status::flush_node)
             .service(users::list)
             .service(users::save)
             .service(users::delete)

--- a/src/ingester/src/lib.rs
+++ b/src/ingester/src/lib.rs
@@ -25,7 +25,7 @@ mod writer;
 
 pub use entry::Entry;
 pub use immutable::read_from_immutable;
-pub use writer::{check_memtable_size, get_writer, read_from_memtable, Writer};
+pub use writer::{check_memtable_size, flush_all, get_writer, read_from_memtable, Writer};
 
 pub async fn init() -> errors::Result<()> {
     // check uncompleted parquet files, need delete those files

--- a/src/service/alerts/alert_manager.rs
+++ b/src/service/alerts/alert_manager.rs
@@ -142,8 +142,8 @@ pub async fn handle_triggers(
     }
 
     // send notification
-    if let Some(ret) = ret {
-        alert.send_notification(&ret).await?;
+    if let Some((sql, data)) = ret {
+        alert.send_notification(&sql, &data).await?;
     }
 
     // update trigger

--- a/src/service/alerts/alert_manager.rs
+++ b/src/service/alerts/alert_manager.rs
@@ -142,8 +142,8 @@ pub async fn handle_triggers(
     }
 
     // send notification
-    if let Some((sql, data)) = ret {
-        alert.send_notification(&sql, &data).await?;
+    if let Some(data) = ret {
+        alert.send_notification(&data).await?;
     }
 
     // update trigger

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -947,6 +947,14 @@ async fn process_dest_template(
         "scheduled"
     };
 
+    // Hack time range for alert url
+    if alert_start_time == alert_end_time {
+        alert_start_time = alert_end_time
+            - Duration::minutes(alert.trigger_condition.period)
+                .num_microseconds()
+                .unwrap();
+    }
+
     let mut alert_query = String::new();
     let alert_url = if alert.query_condition.query_type == QueryType::PromQL {
         if let Some(promql) = &alert.query_condition.promql {

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -792,6 +792,8 @@ fn process_row_template(tpl: &String, alert: &Alert, rows: &[Map<String, Value>]
         for (key, value) in row.iter() {
             let value = if value.is_string() {
                 value.as_str().unwrap_or_default().to_string()
+            } else if value.is_f64() {
+                format!("{:.2}", value.as_f64().unwrap_or_default())
             } else {
                 value.to_string()
             };
@@ -886,6 +888,8 @@ async fn process_dest_template(
         for (key, value) in row.iter() {
             let value = if value.is_string() {
                 value.as_str().unwrap_or_default().to_string()
+            } else if value.is_f64() {
+                format!("{:.2}", value.as_f64().unwrap_or_default())
             } else {
                 value.to_string()
             };

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -332,7 +332,7 @@ impl QueryCondition {
                             &Operator::EqualTo => "==".to_string(),
                             _ => condition.operator.to_string(),
                         },
-                        condition.value.as_f64().unwrap_or_default()
+                        to_float(&condition.value)
                     ),
                     start,
                     end,
@@ -958,7 +958,7 @@ async fn process_dest_template(
                     Operator::EqualTo => "==".to_string(),
                     _ => condition.operator.to_string(),
                 },
-                condition.value.as_f64().unwrap_or_default()
+                to_float(&condition.value)
             );
         }
         // http://localhost:5080/web/metrics?stream=zo_http_response_time_bucket&from=1705248000000000&to=1705334340000000&query=em9faHR0cF9yZXNwb25zZV90aW1lX2J1Y2tldHt9&org_identifier=default
@@ -1038,4 +1038,12 @@ fn format_variable_value(val: &str) -> String {
     val.replace('\n', "\\\\n")
         .replace('\r', "\\\\r")
         .replace('\"', "\\\\\\\"")
+}
+
+fn to_float(val: &Value) -> f64 {
+    if val.is_number() {
+        val.as_f64().unwrap_or_default()
+    } else {
+        val.as_str().unwrap_or_default().parse().unwrap_or_default()
+    }
 }

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -50,7 +50,7 @@ use crate::{
 
 pub mod grpc;
 
-pub type TriggerAlertData = Vec<(Alert, (String, Vec<Map<String, Value>>))>;
+pub type TriggerAlertData = Vec<(Alert, Vec<Map<String, Value>>)>;
 
 pub fn compile_vrl_function(func: &str, org_id: &str) -> Result<VRLRuntimeConfig, std::io::Error> {
     if func.contains("get_env_var") {
@@ -181,8 +181,8 @@ pub async fn evaluate_trigger(trigger: Option<TriggerAlertData>) {
         return;
     }
     let trigger = trigger.unwrap();
-    for (alert, (sql, val)) in trigger.iter() {
-        if let Err(e) = alert.send_notification(sql, val).await {
+    for (alert, val) in trigger.iter() {
+        if let Err(e) = alert.send_notification(val).await {
             log::error!("Failed to send notification: {}", e)
         }
     }

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -50,7 +50,7 @@ use crate::{
 
 pub mod grpc;
 
-pub type TriggerAlertData = Option<Vec<(Alert, Vec<Map<String, Value>>)>>;
+pub type TriggerAlertData = Vec<(Alert, (String, Vec<Map<String, Value>>))>;
 
 pub fn compile_vrl_function(func: &str, org_id: &str) -> Result<VRLRuntimeConfig, std::io::Error> {
     if func.contains("get_env_var") {
@@ -176,13 +176,13 @@ pub async fn get_stream_alerts(
     stream_alerts_map.insert(key, alerts);
 }
 
-pub async fn evaluate_trigger(trigger: TriggerAlertData) {
+pub async fn evaluate_trigger(trigger: Option<TriggerAlertData>) {
     if trigger.is_none() {
         return;
     }
     let trigger = trigger.unwrap();
-    for (alert, val) in trigger.iter() {
-        if let Err(e) = alert.send_notification(val).await {
+    for (alert, (sql, val)) in trigger.iter() {
+        if let Err(e) = alert.send_notification(sql, val).await {
             log::error!("Failed to send notification: {}", e)
         }
     }

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -95,7 +95,7 @@ pub async fn ingest(
     let mut action = String::from("");
     let mut stream_name = String::from("");
     let mut doc_id = String::from("");
-    let mut stream_trigger_map: HashMap<String, TriggerAlertData> = HashMap::new();
+    let mut stream_trigger_map: HashMap<String, Option<TriggerAlertData>> = HashMap::new();
 
     let mut next_line_is_data = false;
     let reader = BufReader::new(body.as_ref());

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -98,7 +98,7 @@ pub async fn ingest(
 
     let mut stream_status = StreamStatus::new(stream_name);
     let mut distinct_values = Vec::with_capacity(16);
-    let mut trigger: TriggerAlertData = None;
+    let mut trigger: Option<TriggerAlertData> = None;
 
     let partition_det =
         crate::service::ingestion::get_stream_partition_keys(stream_name, &stream_schema_map).await;

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -151,8 +151,8 @@ async fn add_valid_record(
     write_buf: &mut HashMap<String, SchemaRecords>,
     record_val: &mut Map<String, Value>,
     need_trigger: bool,
-) -> Result<TriggerAlertData, anyhow::Error> {
-    let mut trigger: Vec<(Alert, Vec<Map<String, Value>>)> = Vec::new();
+) -> Result<Option<TriggerAlertData>, anyhow::Error> {
+    let mut trigger: TriggerAlertData = Vec::new();
     let timestamp: i64 = record_val
         .get(&CONFIG.common.column_timestamp)
         .unwrap()

--- a/src/service/logs/multi.rs
+++ b/src/service/logs/multi.rs
@@ -84,7 +84,7 @@ async fn ingest_inner(
 
     let mut stream_alerts_map: HashMap<String, Vec<Alert>> = HashMap::new();
     let mut stream_status = StreamStatus::new(stream_name);
-    let mut trigger: TriggerAlertData = None;
+    let mut trigger: Option<TriggerAlertData> = None;
 
     // Start Register Transforms for stream
     let (local_trans, stream_vrl_map) = crate::service::ingestion::register_stream_transforms(

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -84,7 +84,7 @@ pub async fn usage_ingest(
     let mut stream_alerts_map: HashMap<String, Vec<Alert>> = HashMap::new();
     let mut stream_status = StreamStatus::new(stream_name);
 
-    let mut trigger: TriggerAlertData = None;
+    let mut trigger: Option<TriggerAlertData> = None;
 
     let partition_det =
         crate::service::ingestion::get_stream_partition_keys(stream_name, &stream_schema_map).await;
@@ -301,7 +301,7 @@ pub async fn handle_grpc_request(
     );
     // End Register Transforms for stream
 
-    let mut trigger: TriggerAlertData = None;
+    let mut trigger: Option<TriggerAlertData> = None;
 
     let mut data_buf: HashMap<String, SchemaRecords> = HashMap::new();
 

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -134,7 +134,7 @@ pub async fn logs_json_handler(
     let mut stream_alerts_map: HashMap<String, Vec<Alert>> = HashMap::new();
     let mut distinct_values = Vec::with_capacity(16);
     let mut stream_status = StreamStatus::new(stream_name);
-    let mut trigger: TriggerAlertData = None;
+    let mut trigger: Option<TriggerAlertData> = None;
 
     let min_ts =
         (Utc::now() - Duration::hours(CONFIG.limit.ingest_allowed_upto)).timestamp_micros();

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -89,7 +89,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse, anyhow:
     let mut stream_status = StreamStatus::new(stream_name);
     let mut distinct_values = Vec::with_capacity(16);
 
-    let mut trigger: TriggerAlertData = None;
+    let mut trigger: Option<TriggerAlertData> = None;
 
     let partition_det =
         crate::service::ingestion::get_stream_partition_keys(stream_name, &stream_schema_map).await;

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -31,7 +31,7 @@ use crate::{
     common::{
         infra::cluster,
         meta::{
-            alerts::{self, Alert},
+            alerts,
             http::HttpResponse as MetaHttpResponse,
             prom::*,
             stream::{PartitioningDetails, SchemaRecords},
@@ -91,7 +91,7 @@ pub async fn handle_grpc_request(
     let mut metric_schema_map: HashMap<String, Schema> = HashMap::new();
     let mut schema_evoluted: HashMap<String, bool> = HashMap::new();
     let mut stream_alerts_map: HashMap<String, Vec<alerts::Alert>> = HashMap::new();
-    let mut stream_trigger_map: HashMap<String, TriggerAlertData> = HashMap::new();
+    let mut stream_trigger_map: HashMap<String, Option<TriggerAlertData>> = HashMap::new();
     let mut stream_partitioning_map: HashMap<String, PartitioningDetails> = HashMap::new();
 
     for resource_metric in &request.resource_metrics {
@@ -336,10 +336,7 @@ pub async fn handle_grpc_request(
                             local_metric_name.clone()
                         );
                         if let Some(alerts) = stream_alerts_map.get(&key) {
-                            let mut trigger_alerts: Vec<(
-                                Alert,
-                                Vec<json::Map<String, json::Value>>,
-                            )> = Vec::new();
+                            let mut trigger_alerts: TriggerAlertData = Vec::new();
                             for alert in alerts {
                                 if let Ok(Some(v)) = alert.evaluate(Some(val_map)).await {
                                     trigger_alerts.push((alert.clone(), v));

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -113,7 +113,7 @@ pub async fn metrics_json_handler(
     let mut metric_schema_map: HashMap<String, Schema> = HashMap::new();
     let mut schema_evoluted: HashMap<String, bool> = HashMap::new();
     let mut stream_alerts_map: HashMap<String, Vec<Alert>> = HashMap::new();
-    let mut stream_trigger_map: HashMap<String, TriggerAlertData> = HashMap::new();
+    let mut stream_trigger_map: HashMap<String, Option<TriggerAlertData>> = HashMap::new();
     let mut stream_partitioning_map: HashMap<String, PartitioningDetails> = HashMap::new();
 
     let body: json::Value = match json::from_slice(body.as_ref()) {
@@ -435,10 +435,7 @@ pub async fn metrics_json_handler(
                                 local_metric_name
                             );
                             if let Some(alerts) = stream_alerts_map.get(&key) {
-                                let mut trigger_alerts: Vec<(
-                                    Alert,
-                                    Vec<json::Map<String, json::Value>>,
-                                )> = Vec::new();
+                                let mut trigger_alerts: TriggerAlertData = Vec::new();
                                 for alert in alerts {
                                     if let Ok(Some(v)) = alert.evaluate(Some(val_map)).await {
                                         trigger_alerts.push((alert.clone(), v));

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -31,7 +31,7 @@ use crate::{
             errors::{Error, Result},
         },
         meta::{
-            alerts::{self, Alert},
+            alerts,
             functions::StreamTransform,
             prom::*,
             search,
@@ -86,7 +86,7 @@ pub async fn remote_write(
     let mut metric_schema_map: HashMap<String, Schema> = HashMap::new();
     let mut schema_evoluted: HashMap<String, bool> = HashMap::new();
     let mut stream_alerts_map: HashMap<String, Vec<alerts::Alert>> = HashMap::new();
-    let mut stream_trigger_map: HashMap<String, TriggerAlertData> = HashMap::new();
+    let mut stream_trigger_map: HashMap<String, Option<TriggerAlertData>> = HashMap::new();
     let mut stream_transform_map: HashMap<String, Vec<StreamTransform>> = HashMap::new();
     let mut stream_partitioning_map: HashMap<String, PartitioningDetails> = HashMap::new();
 
@@ -373,8 +373,7 @@ pub async fn remote_write(
                     metric_name.clone()
                 );
                 if let Some(alerts) = stream_alerts_map.get(&key) {
-                    let mut trigger_alerts: Vec<(Alert, Vec<json::Map<String, json::Value>>)> =
-                        Vec::new();
+                    let mut trigger_alerts: TriggerAlertData = Vec::new();
                     for alert in alerts {
                         if let Ok(Some(v)) = alert.evaluate(Some(val_map)).await {
                             trigger_alerts.push((alert.clone(), v));

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -147,7 +147,7 @@ pub async fn handle_trace_request(
     );
     // End Register Transforms for stream
 
-    let mut trigger: TriggerAlertData = None;
+    let mut trigger: Option<TriggerAlertData> = None;
 
     let min_ts =
         (Utc::now() - Duration::hours(CONFIG.limit.ingest_allowed_upto)).timestamp_micros();
@@ -309,8 +309,7 @@ pub async fn handle_trace_request(
                     // Start check for alert trigger
                     let key = format!("{}/{}/{}", &org_id, StreamType::Traces, traces_stream_name);
                     if let Some(alerts) = stream_alerts_map.get(&key) {
-                        let mut trigger_alerts: Vec<(Alert, Vec<json::Map<String, json::Value>>)> =
-                            Vec::new();
+                        let mut trigger_alerts: TriggerAlertData = Vec::new();
                         for alert in alerts {
                             if let Ok(Some(v)) = alert.evaluate(Some(record_val)).await {
                                 trigger_alerts.push((alert.clone(), v));

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -152,7 +152,7 @@ pub async fn traces_json(
     );
     // End Register Transforms for stream
 
-    let mut trigger: TriggerAlertData = None;
+    let mut trigger: Option<TriggerAlertData> = None;
 
     let mut service_name: String = traces_stream_name.to_string();
     // let export_req: ExportTraceServiceRequest =
@@ -374,10 +374,7 @@ pub async fn traces_json(
                         let key =
                             format!("{}/{}/{}", &org_id, StreamType::Traces, traces_stream_name);
                         if let Some(alerts) = stream_alerts_map.get(&key) {
-                            let mut trigger_alerts: Vec<(
-                                Alert,
-                                Vec<json::Map<String, json::Value>>,
-                            )> = Vec::new();
+                            let mut trigger_alerts: TriggerAlertData = Vec::new();
                             for alert in alerts {
                                 if let Ok(Some(v)) = alert.evaluate(Some(record_val)).await {
                                     trigger_alerts.push((alert.clone(), v));

--- a/web/src/components/alerts/AddTemplate.vue
+++ b/web/src/components/alerts/AddTemplate.vue
@@ -121,7 +121,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div>alert_name, alert_type</div>
             <div>alert_period, alert_operator, alert_threshold</div>
             <div>alert_count, alert_agg_value</div>
-            <div>alert_start_time, alert_end_time</div>
+            <div>alert_start_time, alert_end_time, alert_url</div>
             <div><b>rows</b> multiple lines of row template</div>
             <div><b>All of the stream fields are variables.</b></div>
           </div>


### PR DESCRIPTION
- [x] Add node status api, then you can safely reduce an ingester:
    1. PUT `/api/node/enable?value=false` let the node leave from cluster
    2. PUT `/api/node/flush` let the node flush all memory data into disk
    3. Waiting for 30 minutes, let everything move to s3
    4. You can use command `find /data/wal/ -name '*.parquet' to confirm there is no parquet files.
    5. Remove the pod
- [x] Add alert_url variable for alerts
    Add a new ENV for it: `ZO_WEB_URL=http://log.zinc.dev`
<img width="628" alt="image" src="https://github.com/openobserve/openobserve/assets/1628250/2101c39c-4b4a-4f01-99b6-65fc5a20cc9b">

