### PR TITLE
fix: ensure correct commit-id is fetched during a PR build

### DIFF
--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -28,7 +28,9 @@ jobs:
         - name: Clone the current repo
           uses: actions/checkout@v4
           with:
+            ref: ${{ github.event.pull_request.head.ref || github.ref }}
             fetch-depth: 0
+            fetch-tags: true
   
         - name: Setup Rust Toolchain
           uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
More information in this - https://github.com/actions/checkout/issues/237