### PR TITLE
refactor: avoid record_val clone operation when inferring schemas

### DIFF
--- a/src/common/utils/json.rs
+++ b/src/common/utils/json.rs
@@ -34,7 +34,7 @@ pub fn estimate_json_bytes(val: &Value) -> usize {
         }
         Value::Array(arr) => {
             // []=>2 [?]=>2 [?,?] extra 1+n
-            size += std::cmp::min(arr.len(), 1) + 1;
+            size += std::cmp::max(arr.len(), 1) + 1;
             for v in arr {
                 size += estimate_json_bytes(v);
             }

--- a/src/common/utils/json.rs
+++ b/src/common/utils/json.rs
@@ -16,3 +16,43 @@
 pub use serde_json::{
     from_slice, from_str, from_value, json, to_string, to_value, to_vec, Error, Map, Number, Value,
 };
+
+pub fn estimate_json_bytes(val: &Value) -> usize {
+    let mut size = 0;
+    match val {
+        Value::Object(map) => {
+            // {?} extra 2
+            size += 2;
+            for (k, v) in map {
+                // "key":?, extra 4 bytes
+                size += k.len() + estimate_json_bytes(v) + 4;
+            }
+            // remove ',' for last item
+            if !map.is_empty() {
+                size -= 1;
+            }
+        }
+        Value::Array(arr) => {
+            // []=>2 [?]=>2 [?,?] extra 1+n
+            size += std::cmp::min(arr.len(), 1) + 1;
+            for v in arr {
+                size += estimate_json_bytes(v);
+            }
+        }
+        Value::String(s) => {
+            // "?"=>2
+            size += s.len() + 2;
+        }
+        Value::Number(n) => {
+            size += n.to_string().len();
+        }
+        Value::Bool(b) => {
+            // true for 4 bytes, false for 5 bytes
+            size += if *b { 4 } else { 5 };
+        }
+        Value::Null => {
+            size += 4;
+        }
+    }
+    size
+}

--- a/src/config/src/utils/schema.rs
+++ b/src/config/src/utils/schema.rs
@@ -47,7 +47,10 @@ pub fn infer_json_schema_from_map<I, V>(
     value_iter: I,
     stream_type: impl Into<StreamType>,
 ) -> Result<Schema, ArrowError>
-where I: Iterator<Item=V>, V: Borrow<Map<String, Value>> {
+where
+    I: Iterator<Item = V>,
+    V: Borrow<Map<String, Value>>,
+{
     let mut fields = None;
     for value in value_iter {
         if fields.is_none() {

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -143,13 +143,13 @@ pub async fn save_enrichment_data(
 
                 // check for schema evolution
                 if !schema_evoluted {
-                    let record_val = json::Value::Object(json_record.to_owned());
+                    let record_val = &json_record;
                     if check_for_schema(
                         org_id,
                         stream_name,
                         StreamType::EnrichmentTables,
                         &mut stream_schema_map,
-                        &record_val,
+                        record_val,
                         timestamp,
                     )
                     .await

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -139,7 +139,7 @@ pub async fn save_enrichment_data(
                     CONFIG.common.column_timestamp.clone(),
                     json::Value::Number(timestamp.into()),
                 );
-                let value_str = json::to_string(&json_record).unwrap();
+
 
                 // check for schema evolution
                 if !schema_evoluted {
@@ -170,8 +170,10 @@ pub async fn save_enrichment_data(
                         Some(&schema_key),
                     );
                 }
-                records.push(Arc::new(json::Value::Object(json_record)));
-                records_size += value_str.len();
+                let record = json::Value::Object(json_record);
+                let record_size = json::estimate_json_bytes(&record);
+                records.push(Arc::new(record));
+                records_size += record_size;
             }
         }
     }

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -27,7 +27,7 @@ use crate::{
             ingestion::RecordStatus,
             stream::{PartitionTimeLevel, SchemaRecords},
         },
-        utils::json::{self, Map, Value},
+        utils::json::{Map, Value},
     },
     service::{
         ingestion::get_wal_time_key, schema::check_for_schema, stream::unwrap_partition_time_level,
@@ -165,7 +165,7 @@ async fn add_valid_record(
         &stream_meta.stream_name,
         StreamType::Logs,
         stream_schema_map,
-        &Value::Object(record_val.clone()),
+        record_val,
         timestamp,
     )
     .await?;
@@ -182,11 +182,12 @@ async fn add_valid_record(
     );
 
     if schema_evolution.schema_compatible {
-        let valid_record = if schema_evolution.types_delta.is_some() {
-            let delta = schema_evolution.types_delta.unwrap();
-            let ret_val = if !CONFIG.common.widening_schema_evolution {
+        let valid_record = if let Some(delta) = schema_evolution.types_delta {
+            let ret_val = if !CONFIG.common.widening_schema_evolution
+                || !schema_evolution.is_schema_changed
+            {
                 cast_to_type(record_val, delta)
-            } else if schema_evolution.is_schema_changed {
+            } else {
                 let local_delta = delta
                     .into_iter()
                     .filter(|x| x.metadata().contains_key("zo_cast"))
@@ -196,8 +197,6 @@ async fn add_valid_record(
                 } else {
                     Ok(())
                 }
-            } else {
-                cast_to_type(record_val, delta)
             };
             match ret_val {
                 Ok(_) => true,
@@ -240,7 +239,7 @@ async fn add_valid_record(
                 }
             });
             let record_val = Value::Object(record_val.clone());
-            let record_size = json::to_vec(&record_val).unwrap_or_default().len();
+            let record_size = estimate_bytes(&record_val);
             hour_buf.records.push(Arc::new(record_val));
             hour_buf.records_size += record_size;
             status.successful += 1;
@@ -253,6 +252,28 @@ async fn add_valid_record(
     } else {
         Ok(Some(trigger))
     }
+}
+
+fn estimate_bytes(val: &Value) -> usize {
+    let mut size = 0;
+    match val {
+        Value::Object(map) => {
+            for (k, v) in map {
+                size += k.len() + estimate_bytes(v);
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                size += estimate_bytes(v);
+            }
+        }
+        Value::String(s) => {
+            size += s.len();
+        },
+        // for convience, we treat all numbers/bool/null as 8 bytes
+        _ => size += 8
+    }
+    size
 }
 
 fn set_parsing_error(parse_error: &mut String, field: &Field) {

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -270,7 +270,7 @@ fn estimate_bytes(val: &Value) -> usize {
         Value::String(s) => {
             size += s.len();
         },
-        // for convience, we treat all numbers/bool/null as 8 bytes
+        // for convenience, we treat all numbers/bool/null as 8 bytes
         _ => size += 8
     }
     size

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -213,13 +213,13 @@ pub async fn ingest(org_id: &str, body: web::Bytes, thread_id: usize) -> Result<
         }
 
         // check for schema evolution
-        let record_val = json::Value::Object(record.to_owned());
+        let record_val = &record;
         let _ = check_for_schema(
             org_id,
             &stream_name,
             StreamType::Metrics,
             &mut stream_schema_map,
-            &record_val,
+            record_val,
             timestamp,
         )
         .await;

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -285,13 +285,13 @@ pub async fn handle_grpc_request(
 
                     // check for schema evolution
                     if schema_evoluted.get(local_metric_name).is_none() {
-                        let record_val = json::Value::Object(val_map.to_owned());
+                        let record_val = &val_map;
                         if check_for_schema(
                             org_id,
                             local_metric_name,
                             StreamType::Metrics,
                             &mut metric_schema_map,
-                            &record_val,
+                            record_val,
                             timestamp,
                         )
                         .await

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -379,13 +379,13 @@ pub async fn metrics_json_handler(
 
                         // check for schema evolution
                         if schema_evoluted.get(local_metric_name).is_none() {
-                            let record_val = json::Value::Object(val_map.to_owned());
+                            let record_val = &val_map;
                             if check_for_schema(
                                 org_id,
                                 local_metric_name,
                                 StreamType::Metrics,
                                 &mut metric_schema_map,
-                                &record_val,
+                                record_val,
                                 timestamp,
                             )
                             .await

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -320,13 +320,13 @@ pub async fn remote_write(
 
             // check for schema evolution
             if schema_evoluted.get(&metric_name).is_none() {
-                let record_val = json::Value::Object(val_map.to_owned());
+                let record_val = &val_map;
                 if check_for_schema(
                     org_id,
                     &metric_name,
                     StreamType::Metrics,
                     &mut metric_schema_map,
-                    &record_val,
+                    record_val,
                     timestamp,
                 )
                 .await

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -348,7 +348,7 @@ pub async fn handle_trace_request(
                 });
                 let record_val = record_val.to_owned();
                 let record_val = json::Value::Object(record_val);
-                let record_size = json::to_vec(&record_val).unwrap_or_default().len();
+                let record_size = json::estimate_json_bytes(&record_val);
                 hour_buf.records.push(Arc::new(record_val));
                 hour_buf.records_size += record_size;
 

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -300,7 +300,7 @@ pub async fn handle_trace_request(
                     traces_stream_name,
                     StreamType::Traces,
                     &mut traces_schema_map,
-                    &json::Value::Object(record_val.clone()),
+                    record_val,
                     timestamp.try_into().unwrap(),
                 )
                 .await;

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -413,7 +413,7 @@ pub async fn traces_json(
                     });
                     let record_val = record_val.to_owned();
                     let record_val = json::Value::Object(record_val);
-                    let record_size = json::to_vec(&record_val).unwrap_or_default().len();
+                    let record_size = json::estimate_json_bytes(&record_val);
                     hour_buf.records.push(Arc::new(record_val));
                     hour_buf.records_size += record_size;
                 }

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -364,7 +364,7 @@ pub async fn traces_json(
                         traces_stream_name,
                         StreamType::Traces,
                         &mut traces_schema_map,
-                        &json::Value::Object(record_val.clone()),
+                        record_val,
                         timestamp.try_into().unwrap(),
                     )
                     .await;


### PR DESCRIPTION
1. avoid record_val clone operation when inferring schemas in writing/reading procedure.
2. use estimate_bytes for json size calculating instead of serializing it.
3. match snippet optimizes.