### PR TITLE
fix: Replace src with s_src in SyslogNg.vue

### DIFF
--- a/web/src/components/ingestion/logs/SyslogNg.vue
+++ b/web/src/components/ingestion/logs/SyslogNg.vue
@@ -75,7 +75,7 @@ export default defineComponent({
 
 
 log {
-    source(src);
+    source(s_src);
     destination(d_openobserve_http);
     flags(flow-control);
 };`;


### PR DESCRIPTION
source should be "s_src" as defined in syslog-ng.conf, otherwise syslog-ng will fail to start, displaying:

>  Error resolving reference; content='source', name='src', location='/etc/syslog-ng/conf.d/openobserve.conf:13:5