### PR TITLE
feat: search queue

### DIFF
--- a/deploy/build/Dockerfile
+++ b/deploy/build/Dockerfile
@@ -15,8 +15,8 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache as builder
 # RUN diff -u <(rustc --print cfg) <(rustc -C target-cpu=native --print cfg)
 RUN rustc --version && sccache --version
 
-WORKDIR /app
-COPY . /app
+WORKDIR /openobserve
+COPY . /openobserve
 COPY --from=webBuilder /web/dist web/dist
 
 RUN cargo build --release
@@ -26,6 +26,6 @@ FROM public.ecr.aws/debian/debian:bookworm-slim as runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools
 RUN update-ca-certificates
-COPY --from=builder /app/target/release/openobserve /
+COPY --from=builder /openobserve/target/release/openobserve /
 RUN ["/openobserve", "init-dir", "-p", "/data/"]
 CMD ["/openobserve"]

--- a/deploy/build/Dockerfile.aarch64
+++ b/deploy/build/Dockerfile.aarch64
@@ -19,23 +19,23 @@ ARG AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
 
 RUN rustc --version && sccache --version
 
-WORKDIR /app
-COPY . /app
+WORKDIR /openobserve
+COPY . /openobserve
 COPY --from=webBuilder /web/dist web/dist
-RUN mkdir -p /app/target/release/
+RUN mkdir -p /openobserve/target/release/
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
   CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
   CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
 RUN --mount=type=cache,target=/root/.cache/sccache cargo build --release --features mimalloc --target aarch64-unknown-linux-gnu \
   && sccache --show-stats
-RUN mv /app/target/aarch64-unknown-linux-gnu/release/openobserve /app/target/release/openobserve
+RUN mv /openobserve/target/aarch64-unknown-linux-gnu/release/openobserve /openobserve/target/release/openobserve
 
 # FROM gcr.io/distroless/cc:latest-arm64 as runtime
 FROM public.ecr.aws/debian/debian:bookworm-slim as runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools sqlite3
 RUN update-ca-certificates
-COPY --from=builder /app/target/release/openobserve /
+COPY --from=builder /openobserve/target/release/openobserve /
 RUN ["/openobserve", "init-dir", "-p", "/data/"]
 CMD ["/openobserve"]

--- a/deploy/build/Dockerfile.amd64
+++ b/deploy/build/Dockerfile.amd64
@@ -19,20 +19,20 @@ ARG AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
 
 RUN rustc --version && sccache --version
 
-WORKDIR /app
-COPY . /app
+WORKDIR /openobserve
+COPY . /openobserve
 COPY --from=webBuilder /web/dist web/dist
-RUN mkdir -p /app/target/release/
+RUN mkdir -p /openobserve/target/release/
 
 RUN --mount=type=cache,target=/root/.cache/sccache cargo build --release --features mimalloc --target x86_64-unknown-linux-gnu \
   && sccache --show-stats
-RUN mv /app/target/x86_64-unknown-linux-gnu/release/openobserve /app/target/release/openobserve
+RUN mv /openobserve/target/x86_64-unknown-linux-gnu/release/openobserve /openobserve/target/release/openobserve
 
 # FROM gcr.io/distroless/cc as runtime
 FROM public.ecr.aws/debian/debian:bookworm-slim as runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools sqlite3
 RUN update-ca-certificates
-COPY --from=builder /app/target/release/openobserve /
+COPY --from=builder /openobserve/target/release/openobserve /
 RUN ["/openobserve", "init-dir", "-p", "/data/"]
 CMD ["/openobserve"]

--- a/deploy/build/Dockerfile.tag-debug.aarch64
+++ b/deploy/build/Dockerfile.tag-debug.aarch64
@@ -16,23 +16,23 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache as builder
 # RUN rustup default nightly-2023-12-24
 # RUN rustup target add aarch64-unknown-linux-gnu
 
-WORKDIR /app
-COPY . /app
+WORKDIR /openobserve
+COPY . /openobserve
 COPY --from=webBuilder /web/dist web/dist
-RUN mkdir -p /app/target/release/
+RUN mkdir -p /openobserve/target/release/
 
 # RUN cargo build --release
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
   CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
   CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
 RUN cargo build --profile release-prod --features mimalloc --target aarch64-unknown-linux-gnu
-RUN mv /app/target/aarch64-unknown-linux-gnu/release-prod/openobserve /app/target/release/openobserve
+RUN mv /openobserve/target/aarch64-unknown-linux-gnu/release-prod/openobserve /openobserve/target/release/openobserve
 
 FROM public.ecr.aws/debian/debian:bookworm-slim as runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools sqlite3
 RUN update-ca-certificates
-COPY --from=builder /app/target/release/openobserve /
+COPY --from=builder /openobserve/target/release/openobserve /
 COPY --from=builder /lib/aarch64-linux-gnu/liblzma.so.5 /lib/aarch64-linux-gnu/liblzma.so.5
 COPY --from=builder /lib/aarch64-linux-gnu/libz.so.1 /lib/aarch64-linux-gnu/libz.so.1
 RUN ["/openobserve", "init-dir", "-p", "/data/"]

--- a/deploy/build/Dockerfile.tag-debug.amd64
+++ b/deploy/build/Dockerfile.tag-debug.amd64
@@ -16,20 +16,20 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache as builder
 # RUN rustup default nightly-2023-12-24
 # RUN rustup target add x86_64-unknown-linux-gnu
 
-WORKDIR /app
-COPY . /app
+WORKDIR /openobserve
+COPY . /openobserve
 COPY --from=webBuilder /web/dist web/dist
-RUN mkdir -p /app/target/release/
+RUN mkdir -p /openobserve/target/release/
 
 # RUN cargo build --release
 RUN cargo build --profile release-prod --features mimalloc --target x86_64-unknown-linux-gnu
-RUN mv /app/target/x86_64-unknown-linux-gnu/release-prod/openobserve /app/target/release/openobserve
+RUN mv /openobserve/target/x86_64-unknown-linux-gnu/release-prod/openobserve /openobserve/target/release/openobserve
 
 FROM public.ecr.aws/debian/debian:bookworm-slim as runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools sqlite3
 RUN update-ca-certificates
-COPY --from=builder /app/target/release/openobserve /
+COPY --from=builder /openobserve/target/release/openobserve /
 COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so.5 /lib/x86_64-linux-gnu/liblzma.so.5
 COPY --from=builder /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
 RUN ["/openobserve", "init-dir", "-p", "/data/"]

--- a/deploy/build/Dockerfile.tag-simd.amd64
+++ b/deploy/build/Dockerfile.tag-simd.amd64
@@ -16,17 +16,17 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache as builder
 # RUN rustup default nightly-2023-12-24
 # RUN rustup target add x86_64-unknown-linux-gnu
 
-WORKDIR /app
-COPY . /app
+WORKDIR /openobserve
+COPY . /openobserve
 COPY --from=webBuilder /web/dist web/dist
-RUN mkdir -p /app/target/release/
+RUN mkdir -p /openobserve/target/release/
 
 # RUN cargo build --release
 RUN RUSTFLAGS='-C target-feature=+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx512f,+avx512cd,+avx512er,+avx512bw,+avx512dq,+avx512vl' cargo build --profile release-prod --features mimalloc --target x86_64-unknown-linux-gnu
-RUN mv /app/target/x86_64-unknown-linux-gnu/release-prod/openobserve /app/target/release/openobserve
+RUN mv /openobserve/target/x86_64-unknown-linux-gnu/release-prod/openobserve /openobserve/target/release/openobserve
 
 FROM gcr.io/distroless/cc-debian12 as runtime
-COPY --from=builder /app/target/release/openobserve /
+COPY --from=builder /openobserve/target/release/openobserve /
 COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so.5 /lib/x86_64-linux-gnu/liblzma.so.5
 COPY --from=builder /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
 RUN ["/openobserve", "init-dir", "-p", "/data/"]

--- a/deploy/build/Dockerfile.tag.aarch64
+++ b/deploy/build/Dockerfile.tag.aarch64
@@ -16,20 +16,20 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache as builder
 # RUN rustup default nightly-2023-12-24
 # RUN rustup target add aarch64-unknown-linux-gnu
 
-WORKDIR /app
-COPY . /app
+WORKDIR /openobserve
+COPY . /openobserve
 COPY --from=webBuilder /web/dist web/dist
-RUN mkdir -p /app/target/release/
+RUN mkdir -p /openobserve/target/release/
 
 # RUN cargo build --release
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
   CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
   CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
 RUN cargo build --profile release-prod --features mimalloc --target aarch64-unknown-linux-gnu
-RUN mv /app/target/aarch64-unknown-linux-gnu/release-prod/openobserve /app/target/release/openobserve
+RUN mv /openobserve/target/aarch64-unknown-linux-gnu/release-prod/openobserve /openobserve/target/release/openobserve
 
 FROM gcr.io/distroless/cc-debian12:latest-arm64 as runtime
-COPY --from=builder /app/target/release/openobserve /
+COPY --from=builder /openobserve/target/release/openobserve /
 COPY --from=builder /lib/aarch64-linux-gnu/liblzma.so.5 /lib/aarch64-linux-gnu/liblzma.so.5
 COPY --from=builder /lib/aarch64-linux-gnu/libz.so.1 /lib/aarch64-linux-gnu/libz.so.1
 RUN ["/openobserve", "init-dir", "-p", "/data/"]

--- a/deploy/build/Dockerfile.tag.amd64
+++ b/deploy/build/Dockerfile.tag.amd64
@@ -16,17 +16,17 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache as builder
 # RUN rustup default nightly-2023-12-24
 # RUN rustup target add x86_64-unknown-linux-gnu
 
-WORKDIR /app
-COPY . /app
+WORKDIR /openobserve
+COPY . /openobserve
 COPY --from=webBuilder /web/dist web/dist
-RUN mkdir -p /app/target/release/
+RUN mkdir -p /openobserve/target/release/
 
 # RUN cargo build --release
 RUN cargo build --profile release-prod --features mimalloc --target x86_64-unknown-linux-gnu
-RUN mv /app/target/x86_64-unknown-linux-gnu/release-prod/openobserve /app/target/release/openobserve
+RUN mv /openobserve/target/x86_64-unknown-linux-gnu/release-prod/openobserve /openobserve/target/release/openobserve
 
 FROM gcr.io/distroless/cc-debian12 as runtime
-COPY --from=builder /app/target/release/openobserve /
+COPY --from=builder /openobserve/target/release/openobserve /
 COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so.5 /lib/x86_64-linux-gnu/liblzma.so.5
 COPY --from=builder /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
 RUN ["/openobserve", "init-dir", "-p", "/data/"]

--- a/proto/cluster/search.proto
+++ b/proto/cluster/search.proto
@@ -38,6 +38,7 @@ message SearchRequest {
     repeated FileKey     file_list = 6;
     repeated SearchAggRequest aggs = 7;
     int64                  timeout = 8;
+    string              work_group = 9;
 }
 
 // The response message containing the greetings

--- a/src/common/meta/search.rs
+++ b/src/common/meta/search.rs
@@ -26,6 +26,7 @@ pub struct Session {
     pub id: String,
     pub storage_type: StorageType,
     pub search_type: SearchType,
+    pub work_group: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/handler/grpc/mod.rs
+++ b/src/handler/grpc/mod.rs
@@ -66,6 +66,7 @@ impl From<meta::search::Request> for cluster_rpc::SearchRequest {
             file_list: vec![],
             stream_type: "".to_string(),
             timeout: req.timeout,
+            work_group: "".to_string(),
         }
     }
 }

--- a/src/handler/http/request/authz/fga.rs
+++ b/src/handler/http/request/authz/fga.rs
@@ -69,7 +69,7 @@ pub async fn update_role(
 ) -> Result<HttpResponse, Error> {
     let (_org_id, role_id) = path.into_inner();
     let update_role = update_role.into_inner();
-    
+
     match o2_enterprise::enterprise::openfga::authorizer::update_role(
         &role_id,
         update_role.add,

--- a/src/ingester/src/immutable.rs
+++ b/src/ingester/src/immutable.rs
@@ -139,7 +139,7 @@ pub(crate) async fn persist() -> Result<()> {
     for task in tasks {
         if let Some((path, json_size, arrow_size)) = task? {
             log::info!(
-                "[INGESTER:WAL] done persist file: {}, json_size: {}, arrow_size: {}",
+                "[INGESTER:WAL] done  persist file: {}, json_size: {}, arrow_size: {}",
                 path.to_string_lossy(),
                 json_size,
                 arrow_size

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -134,6 +134,7 @@ pub(crate) async fn create_context(
         id: session_id.to_string(),
         storage_type: StorageType::Memory,
         search_type: SearchType::Normal,
+        work_group: None,
     };
 
     let ctx = register_table(

--- a/src/service/promql/search/grpc/wal.rs
+++ b/src/service/promql/search/grpc/wal.rs
@@ -133,7 +133,7 @@ pub(crate) async fn create_context(
         })?;
     for (_, (mut arrow_schema, record_batches)) in record_batches_meta {
         if !record_batches.is_empty() {
-            let ctx = prepare_datafusion_context(&SearchType::Normal)?;
+            let ctx = prepare_datafusion_context(None, &SearchType::Normal)?;
             // calulate schema diff
             let mut diff_fields = HashMap::new();
             let group_fields = arrow_schema.fields();
@@ -177,6 +177,7 @@ pub(crate) async fn create_context(
         id: session_id.to_string(),
         storage_type: StorageType::Tmpfs,
         search_type: SearchType::Normal,
+        work_group: None,
     };
 
     let ctx = register_table(

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -49,6 +49,7 @@ pub async fn search(
     sql: Arc<Sql>,
     file_list: &[FileKey],
     stream_type: StreamType,
+    work_group: &str,
     timeout: u64,
 ) -> super::SearchResult {
     // fetch all schema versions, group files by version
@@ -182,6 +183,7 @@ pub async fn search(
             } else {
                 SearchType::Normal
             },
+            work_group: Some(work_group.to_string()),
         };
         // cacluate the diff between latest schema and group schema
         let mut diff_fields = HashMap::new();

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -59,6 +59,7 @@ pub async fn search_parquet(
     session_id: &str,
     sql: Arc<Sql>,
     stream_type: StreamType,
+    work_group: &str,
     timeout: u64,
 ) -> super::SearchResult {
     let schema_latest = db::schema::get(&sql.org_id, &sql.stream_name, stream_type)
@@ -206,6 +207,7 @@ pub async fn search_parquet(
                 } else {
                     SearchType::Normal
                 },
+                work_group: Some(work_group.to_string()),
             }
         } else {
             let id = format!("{session_id}-parquet-{ver}");
@@ -227,6 +229,7 @@ pub async fn search_parquet(
                 } else {
                     SearchType::Normal
                 },
+                work_group: Some(work_group.to_string()),
             }
         };
         let datafusion_span = info_span!(
@@ -295,6 +298,7 @@ pub async fn search_memtable(
     session_id: &str,
     sql: Arc<Sql>,
     stream_type: StreamType,
+    work_group: &str,
     timeout: u64,
 ) -> super::SearchResult {
     let schema_latest = db::schema::get(&sql.org_id, &sql.stream_name, stream_type)
@@ -398,6 +402,7 @@ pub async fn search_memtable(
             } else {
                 SearchType::Normal
             },
+            work_group: Some(work_group.to_string()),
         };
 
         let datafusion_span = info_span!(


### PR DESCRIPTION
Impl #2506 

## Version 1 (enterprise version):

Implemented global search work groups:

- long query group
  - O2_SEARCH_GROUP_LONG_MAX_CPU = 80%
  - O2_SEARCH_GROUP_LONG_MAX_MEMORY = 80%
  - O2_SEARCH_GROUP_LONG_MAX_CONCURRENCY = 2
- short query group
  - O2_SEARCH_GROUP_LONG_MAX_CPU = 20%
  - O2_SEARCH_GROUP_LONG_MAX_MEMORY = 20%
  - O2_SEARCH_GROUP_LONG_MAX_CONCURRENCY = 4

## Enterprise Version
Enterprise version will default enable two search queue. 1 for long term query, 1 for short query. when you are running a long term query, if you fire another small query it sill can be quickly response. but more than `MAX_CONCURRENCY` of the group still need to wait in a queue.

## Open Source Version
Open source version still only has a global search queue, default is enabled. it means only support 1 QPS for query. Also you can disable it by `ZO_FEATURE_QUERY_QUEUE_ENABLED=false`. After that, You can fire multiple search query but there is no control, it maybe cause OOM if you fire multiple concurrency search request.