### PR TITLE
feat: dashboard drilldown to another dashboard

### DIFF
--- a/src/common/meta/dashboards/v3/mod.rs
+++ b/src/common/meta/dashboards/v3/mod.rs
@@ -207,6 +207,8 @@ pub struct DrillDownData {
     #[serde(skip_serializing_if = "Option::is_none")]
     tab: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pass_all_variables: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     variables: Option<Vec<DrillDownVariables>>,
 }
 

--- a/src/common/meta/dashboards/v3/mod.rs
+++ b/src/common/meta/dashboards/v3/mod.rs
@@ -176,6 +176,43 @@ pub struct PanelConfig {
     legend_width: Option<LegendWidth>,
     base_map: Option<BaseMap>,
     map_view: Option<MapView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    drilldown: Vec<DrillDown>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DrillDown {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_blank: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    find_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<DrillDownData>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct DrillDownData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    folder: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dashboard: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tab: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    variables: Option<Vec<DrillDownVariables>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct DrillDownVariables {
+    name: Option<String>,
+    value: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]

--- a/src/common/meta/dashboards/v3/mod.rs
+++ b/src/common/meta/dashboards/v3/mod.rs
@@ -197,6 +197,7 @@ pub struct DrillDown {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct DrillDownData {
     #[serde(skip_serializing_if = "Option::is_none")]
     url: Option<String>,

--- a/src/common/meta/dashboards/v3/mod.rs
+++ b/src/common/meta/dashboards/v3/mod.rs
@@ -177,7 +177,7 @@ pub struct PanelConfig {
     base_map: Option<BaseMap>,
     map_view: Option<MapView>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    drilldown: Vec<DrillDown>,
+    drilldown: Option<Vec<DrillDown>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -186,7 +186,8 @@ pub struct DrillDown {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    type: Option<String>,
+    #[serde(rename = "type")]
+    type_field: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_blank: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/web/src/components/dashboards/PanelContainer.vue
+++ b/web/src/components/dashboards/PanelContainer.vue
@@ -177,7 +177,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :variablesData="props.variablesData"
       @metadata-update="metaDataValue"
       @updated:data-zoom="$emit('updated:data-zoom', $event)"
-      @chartClick="(...args: any) => $emit('chartClick', ...args)"
+      @refresh="$emit('refresh')"
       ref="PanleSchemaRendererRef"
     ></PanelSchemaRenderer>
     <q-dialog v-model="showViewPanel">
@@ -222,7 +222,6 @@ export default defineComponent({
     "onDeletePanel",
     "onViewPanel",
     "updated:data-zoom",
-    "chartClick",
     "onMovePanel",
     "refresh",
   ],

--- a/web/src/components/dashboards/PanelContainer.vue
+++ b/web/src/components/dashboards/PanelContainer.vue
@@ -177,7 +177,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :variablesData="props.variablesData"
       @metadata-update="metaDataValue"
       @updated:data-zoom="$emit('updated:data-zoom', $event)"
-      @chart-click="$emit('chartClick', $event)"
+      @chartClick="(...args: any) => $emit('chartClick', ...args)"
       ref="PanleSchemaRendererRef"
     ></PanelSchemaRenderer>
     <q-dialog v-model="showViewPanel">
@@ -221,7 +221,8 @@ export default defineComponent({
   emits: [
     "onDeletePanel",
     "onViewPanel",
-    "updated:data-zoom", "chartClick",
+    "updated:data-zoom",
+    "chartClick",
     "onMovePanel",
     "refresh",
   ],

--- a/web/src/components/dashboards/PanelContainer.vue
+++ b/web/src/components/dashboards/PanelContainer.vue
@@ -177,6 +177,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :variablesData="props.variablesData"
       @metadata-update="metaDataValue"
       @updated:data-zoom="$emit('updated:data-zoom', $event)"
+      @chart-click="$emit('chartClick', $event)"
       ref="PanleSchemaRendererRef"
     ></PanelSchemaRenderer>
     <q-dialog v-model="showViewPanel">
@@ -220,7 +221,7 @@ export default defineComponent({
   emits: [
     "onDeletePanel",
     "onViewPanel",
-    "updated:data-zoom",
+    "updated:data-zoom", "chartClick",
     "onMovePanel",
     "refresh",
   ],

--- a/web/src/components/dashboards/PanelContainer.vue
+++ b/web/src/components/dashboards/PanelContainer.vue
@@ -177,7 +177,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :variablesData="props.variablesData"
       @metadata-update="metaDataValue"
       @updated:data-zoom="$emit('updated:data-zoom', $event)"
-      @refresh="$emit('refresh')"
+      @update:initial-variable-values="
+        (...args) => $emit('update:initial-variable-values', ...args)
+      "
       ref="PanleSchemaRendererRef"
     ></PanelSchemaRenderer>
     <q-dialog v-model="showViewPanel">
@@ -224,6 +226,7 @@ export default defineComponent({
     "updated:data-zoom",
     "onMovePanel",
     "refresh",
+    "update:initial-variable-values",
   ],
   props: [
     "data",

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -109,39 +109,40 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           style="margin: 0 auto; z-index: 999"
         />
       </div>
-    </div>
-    <div
-      style="
-        border: 1px solid gray;
-        border-radius: 4px;
-        padding: 3px;
-        position: absolute;
-        top: 0px;
-        left: 0px;
-        display: none;
-        text-wrap: nowrap;
-      "
-      :class="store.state.theme === 'dark' ? 'bg-dark' : 'bg-white'"
-      ref="drilldownPopUpRef"
-      @mouseleave="() => (drilldownPopUpRef.style.display = 'none')"
-    >
       <div
-        v-for="(drilldown, index) in drilldownArray"
-        :key="JSON.stringify(drilldown)"
-        class="drilldown-item q-px-sm q-py-xs"
         style="
-          display: flex;
-          flex-direction: row;
-          align-items: center;
-          position: relative;
+          border: 1px solid gray;
+          border-radius: 4px;
+          padding: 3px;
+          position: absolute;
+          top: 0px;
+          left: 0px;
+          display: none;
+          text-wrap: nowrap;
+          z-index: 9999999;
         "
+        :class="store.state.theme === 'dark' ? 'bg-dark' : 'bg-white'"
+        ref="drilldownPopUpRef"
+        @mouseleave="() => (drilldownPopUpRef.style.display = 'none')"
       >
         <div
-          @click="openDrilldown(index)"
-          style="cursor: pointer; display: flex; align-items: center"
+          v-for="(drilldown, index) in drilldownArray"
+          :key="JSON.stringify(drilldown)"
+          class="drilldown-item q-px-sm q-py-xs"
+          style="
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            position: relative;
+          "
         >
-          <q-icon class="q-mr-xs q-mt-xs" size="16px" name="link" />
-          <span>{{ drilldown.name }}</span>
+          <div
+            @click="openDrilldown(index)"
+            style="cursor: pointer; display: flex; align-items: center"
+          >
+            <q-icon class="q-mr-xs q-mt-xs" size="16px" name="link" />
+            <span>{{ drilldown.name }}</span>
+          </div>
         </div>
       </div>
     </div>
@@ -382,7 +383,7 @@ export default defineComponent({
           if (value && part in value) {
             value = value[part];
           } else {
-            return "${" + part + "}";
+            return "${" + key + "}";
           }
         }
         return value;
@@ -449,7 +450,7 @@ export default defineComponent({
       }
 
       // 24 px takes panel header height
-      drilldownPopUpRef.value.style.top = offSetValues?.top + 24 + "px";
+      drilldownPopUpRef.value.style.top = offSetValues?.top + 5 + "px";
       drilldownPopUpRef.value.style.left = offSetValues?.left + 5 + "px";
 
       // if drilldownArray has at least one element then only show the drilldown pop up
@@ -500,6 +501,23 @@ export default defineComponent({
             field: fields,
             index: drilldownParams[1][1],
           };
+        } else if (panelSchema.value.type == "sankey") {
+          // if dataType is node then set node data
+          // else set edge data
+          if (drilldownParams[0].dataType == "node") {
+            // set node data
+            drilldownVariables.node = {
+              __name: drilldownParams[0]?.name ?? "",
+              __value: drilldownParams[0]?.value ?? "",
+            };
+          } else {
+            // set edge data
+            drilldownVariables.edge = {
+              __source: drilldownParams[0]?.data?.source ?? "",
+              __target: drilldownParams[0]?.data?.target ?? "",
+              __value: drilldownParams[0]?.data?.value ?? "",
+            };
+          }
         } else {
           // we have an series object
           drilldownVariables.series = {

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -143,7 +143,12 @@ export default defineComponent({
       type: Object,
     },
   },
-  emits: ["updated:data-zoom", "error", "metadata-update", "refresh"],
+  emits: [
+    "updated:data-zoom",
+    "error",
+    "metadata-update",
+    "update:initialVariableValues",
+  ],
   setup(props, { emit }) {
     const store = useStore();
     const route = useRoute();
@@ -504,8 +509,18 @@ export default defineComponent({
               },
             });
 
-            // reload dashboard because it will be in same path
-            emit("refresh");
+            // ======= [START] default variable values
+
+            const initialVariableValues: any = {};
+            Object.keys(route.query).forEach((key) => {
+              if (key.startsWith("var-")) {
+                const newKey = key.slice(4);
+                initialVariableValues[newKey] = route.query[key];
+              }
+            });
+            // ======= [END] default variable values
+
+            emit("update:initialVariableValues", initialVariableValues);
           }
         }
       }

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -128,7 +128,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div
         v-for="(drilldown, index) in drilldownArray"
         :key="JSON.stringify(drilldown)"
-        class="drilldown-item"
+        class="drilldown-item q-px-sm q-py-xs"
         style="
           display: flex;
           flex-direction: row;

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -121,21 +121,36 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         display: none;
         text-wrap: nowrap;
       "
+      :class="store.state.theme === 'dark' ? 'bg-dark' : 'bg-white'"
       ref="drilldownPopUpRef"
       @mouseleave="() => (drilldownPopUpRef.style.display = 'none')"
     >
       <div
         v-for="(drilldown, index) in drilldownArray"
         :key="JSON.stringify(drilldown)"
-        style="display: flex; flex-direction: row"
+        style="
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          position: relative;
+        "
       >
-        <q-icon class="q-mr-xs q-mt-xs" size="16px" name="link" />
         <div
           @click="openDrilldown(index)"
-          style="cursor: pointer; text-decoration: underline"
+          style="cursor: pointer; display: flex; align-items: center"
         >
-          {{ drilldown.name }}
+          <q-icon class="q-mr-xs q-mt-xs" size="16px" name="link" />
+          <span>{{ drilldown.name }}</span>
         </div>
+        <div
+          style="
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            border-bottom: 1px solid gray;
+          "
+        ></div>
       </div>
     </div>
   </div>

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -405,6 +405,14 @@ export default defineComponent({
     let drilldownParams: any = [];
 
     const onChartClick = async (params: any, ...args: any) => {
+      // check if drilldown data exists
+      if (
+        !panelSchema.value.config.drilldown ||
+        panelSchema.value.config.drilldown.length == 0
+      ) {
+        return;
+      }
+
       drilldownParams = [params, args];
 
       // drilldownarrayref offset values

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -69,6 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         "
         @updated:data-zoom="$emit('updated:data-zoom', $event)"
         @error="errorDetail = $event"
+        @click="$emit('chartClick', $event)"
       />
     </div>
     <div v-if="!errorDetail" class="noData" data-test="no-data">
@@ -139,7 +140,7 @@ export default defineComponent({
       type: Object,
     },
   },
-  emits: ["updated:data-zoom", "error", "metadata-update"],
+  emits: ["updated:data-zoom", "error", "metadata-update", "chartClick"],
   setup(props, { emit }) {
     const store = useStore();
 

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -36,7 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               ? panelData
               : { options: { backgroundColor: 'transparent' } }
           "
-          @click="onChartClick"
+          @row-click="onChartClick"
           ref="tableRendererRef"
         />
         <div

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -69,7 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         "
         @updated:data-zoom="$emit('updated:data-zoom', $event)"
         @error="errorDetail = $event"
-        @click="$emit('chartClick', $event)"
+        @click="(...args) => $emit('chartClick', ...args)"
       />
     </div>
     <div v-if="!errorDetail" class="noData" data-test="no-data">

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -128,6 +128,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div
         v-for="(drilldown, index) in drilldownArray"
         :key="JSON.stringify(drilldown)"
+        class="drilldown-item"
         style="
           display: flex;
           flex-direction: row;
@@ -142,15 +143,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <q-icon class="q-mr-xs q-mt-xs" size="16px" name="link" />
           <span>{{ drilldown.name }}</span>
         </div>
-        <div
-          style="
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            border-bottom: 1px solid gray;
-          "
-        ></div>
       </div>
     </div>
   </div>
@@ -676,6 +668,9 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+.drilldown-item:hover {
+  background-color: rgba(202, 201, 201, 0.908);
+}
 .errorMessage {
   position: absolute;
   top: 20%;

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -330,7 +330,7 @@ export default defineComponent({
       });
     };
 
-    const onChartClick = async (params: any, panelId: any) => {
+    const onChartClick = async (params: any) => {
       // if panelSchema exists
       if (panelSchema.value) {
         // check if drilldown data exists

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -119,6 +119,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         top: 0px;
         left: 0px;
         display: none;
+        text-wrap: nowrap;
       "
       ref="drilldownPopUpRef"
       @mouseleave="() => (drilldownPopUpRef.style.display = 'none')"
@@ -375,17 +376,13 @@ export default defineComponent({
 
     // get offset from parent
     function getOffsetFromParent(parent: any, child: any) {
-      let offsetLeft = 0;
-      let offsetTop = 0;
+      const parentRect = parent.getBoundingClientRect();
+      const childRect = child.getBoundingClientRect();
 
-      let currentElement = child;
-      while (currentElement && currentElement !== parent) {
-        offsetLeft += currentElement.offsetLeft;
-        offsetTop += currentElement.offsetTop;
-        currentElement = currentElement.offsetParent;
-      }
-
-      return { left: offsetLeft, top: offsetTop };
+      return {
+        left: childRect.left - parentRect.left,
+        top: childRect.top - parentRect.top,
+      };
     }
 
     // need to save click event params, to open drilldown

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -424,7 +424,7 @@ export default defineComponent({
       }
 
       // set drilldown array, to show list of drilldowns
-      drilldownArray.value = panelSchema.value.config.drilldown;
+      drilldownArray.value = panelSchema.value.config.drilldown ?? [];
 
       // temporarily show the popup to calculate its dimensions
       drilldownPopUpRef.value.style.display = "block";

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -345,11 +345,15 @@ export default defineComponent({
         const drilldownData = panelSchema.value.config.drilldown[0];
 
         // need to change dynamic variables to it's value using current variables, current chart data(params)
+        // if pie, donut or heatmap then series name will come in name field
+        // also, if value is an array, then last value will be taken
         const drilldownVariables: any = {
           series: {
-            __name: params.seriesName,
+            __name: ["pie", "donut", "heatmap"].includes(panelSchema.value.type)
+              ? params.name
+              : params.seriesName,
             __value: Array.isArray(params.value)
-              ? params.value[1]
+              ? params.value[params.value.length - 1]
               : params.value,
           },
         };
@@ -411,8 +415,6 @@ export default defineComponent({
           // if targetBlank is true then create new url
           // else made changes in current router only
           if (drilldownData.targetBlank) {
-            console.log(route);
-
             // get current origin
             const pos = window.location.pathname.indexOf("/web/");
             let currentUrl: any =

--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -127,14 +127,14 @@ export default defineComponent({
       values: [],
     });
 
-    onMounted(() => {
-      getVariablesData();
+    onMounted(async () => {
+      await getVariablesData();
     });
     // you may need to query the data if the variable configs or the data/time changes
     watch(
       () => [props.variablesConfig, props.selectedTimeDate],
-      () => {
-        getVariablesData();
+      async () => {
+        await getVariablesData();
       }
     );
     watch(
@@ -150,14 +150,24 @@ export default defineComponent({
       emit("variablesData", JSON.parse(JSON.stringify(variablesData)));
     };
 
+    const changeInitialVariableValues = async (newInitialVariableValues: any) => {
+      // reset the values
+      variablesData.values = [];
+      variablesData.isVariablesLoading = false;
+
+      props.initialVariableValues.value = newInitialVariableValues;
+    };
+
     const getVariablesData = async () => {
-       if(isInvalidDate(props.selectedTimeDate?.start_time) || isInvalidDate(props.selectedTimeDate?.end_time)){
-        return
-       }
+      if (
+        isInvalidDate(props.selectedTimeDate?.start_time) ||
+        isInvalidDate(props.selectedTimeDate?.end_time)
+      ) {
+        return;
+      }
 
       // do we have variables & date?
-      if (!props.variablesConfig?.list || !props.selectedTimeDate?.start_time)
-      {
+      if (!props.variablesConfig?.list || !props.selectedTimeDate?.start_time) {
         variablesData.values = [];
         variablesData.isVariablesLoading = false;
         emitVariablesData();
@@ -183,14 +193,16 @@ export default defineComponent({
           variablesConfigList
             ?.filter((it: any) => it.type == "dynamic_filters")
             ?.map((it: any) => it.name) || [];
-        oldVariableValue = Object.keys(props?.initialVariableValues ?? []).map(
-          (key: any) => ({
-            name: key,
-            value: dynamicVariables.includes(key)
-              ? JSON.parse(decodeURIComponent(props.initialVariableValues[key]))
-              : props.initialVariableValues[key],
-          })
-        );
+        oldVariableValue = Object.keys(
+          props?.initialVariableValues?.value ?? []
+        ).map((key: any) => ({
+          name: key,
+          value: dynamicVariables.includes(key)
+            ? JSON.parse(
+                decodeURIComponent(props.initialVariableValues?.value[key])
+              )
+            : props.initialVariableValues?.value[key],
+        }));
       }
 
       // continue as we have variables
@@ -423,6 +435,7 @@ export default defineComponent({
     return {
       props,
       variablesData,
+      changeInitialVariableValues,
     };
   },
 });

--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -150,11 +150,15 @@ export default defineComponent({
       emit("variablesData", JSON.parse(JSON.stringify(variablesData)));
     };
 
-    const changeInitialVariableValues = async (newInitialVariableValues: any) => {
+    // it is used to change/update initial variables values from outside the component
+    const changeInitialVariableValues = async (
+      newInitialVariableValues: any
+    ) => {
       // reset the values
       variablesData.values = [];
       variablesData.isVariablesLoading = false;
 
+      // set initial variables values
       props.initialVariableValues.value = newInitialVariableValues;
     };
 

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -570,10 +570,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       />
 
       <div class="space"></div>
-
-      <Drilldown />
-
-      <div class="space"></div>
+      <Drilldown
+        v-if="!['html', 'markdown'].includes(dashboardPanelData.data.type)"
+      />
     </div>
   </div>
 </template>

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -572,7 +572,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div class="space"></div>
       <Drilldown
         v-if="
-          !['html', 'markdown', 'geomap', 'geojson'].includes(
+          !['html', 'markdown', 'geomap', 'maps'].includes(
             dashboardPanelData.data.type
           )
         "

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -570,7 +570,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       />
 
       <div class="space"></div>
+
       <Drilldown />
+
+      <div class="space"></div>
     </div>
   </div>
 </template>

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -549,6 +549,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       >
       </q-input>
 
+      <Drilldown/>
+
       <div class="space"></div>
 
       <q-toggle
@@ -573,8 +575,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import useDashboardPanelData from "@/composables/useDashboardPanel";
 import { computed, defineComponent, watch, onBeforeMount } from "vue";
 import { useI18n } from "vue-i18n";
+import Drilldown from "./Drilldown.vue";
 
 export default defineComponent({
+  components: { Drilldown },
   setup() {
     const { dashboardPanelData, promqlMode } = useDashboardPanelData();
     const { t } = useI18n();

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -571,7 +571,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       <div class="space"></div>
       <Drilldown
-        v-if="!['html', 'markdown'].includes(dashboardPanelData.data.type)"
+        v-if="
+          !['html', 'markdown', 'geomap', 'geojson'].includes(
+            dashboardPanelData.data.type
+          )
+        "
       />
     </div>
   </div>

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -17,7 +17,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <template>
   <div>
     <div class="" style="max-width: 300px">
-      <div class="q-mb-sm">{{ t("dashboard.description") }}</div>
+      <div class="q-mb-sm" style="font-weight: 600">
+        {{ t("dashboard.description") }}
+      </div>
       <q-input
         outlined
         v-model="dashboardPanelData.data.description"
@@ -286,6 +288,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div
         v-if="promqlMode || dashboardPanelData.data.type == 'geomap'"
         class="q-py-md showLabelOnTop"
+        style="font-weight: 600"
       >
         Query
         <q-tabs
@@ -549,8 +552,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       >
       </q-input>
 
-      <Drilldown />
-
       <div class="space"></div>
 
       <q-toggle
@@ -567,6 +568,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :label="t('dashboard.showBorder')"
         data-test="dashboard-config-axis-border"
       />
+
+      <div class="space"></div>
+      <Drilldown />
     </div>
   </div>
 </template>

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -549,7 +549,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       >
       </q-input>
 
-      <Drilldown></Drilldown>
+      <Drilldown />
 
       <div class="space"></div>
 

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -549,7 +549,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       >
       </q-input>
 
-      <Drilldown/>
+      <Drilldown></Drilldown>
 
       <div class="space"></div>
 

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -16,7 +16,20 @@
 <!-- eslint-disable vue/no-unused-components -->
 <template>
   <div>
-    <div class="q-mb-sm" style="font-weight: 600">Drilldown</div>
+    <div class="q-mb-sm" style="font-weight: 600">
+      <span>Drilldown</span>
+      <q-btn no-caps padding="xs" class="" size="sm" flat icon="info_outline">
+        <q-tooltip
+          class="bg-grey-8"
+          anchor="bottom middle"
+          self="top middle"
+          max-width="250px"
+        >
+          Navigate to a another dashboard or specified URL, carrying over all
+          current variables for seamless data exploration.
+        </q-tooltip>
+      </q-btn>
+    </div>
     <div
       v-for="(data, index) in dashboardPanelData.data.config.drilldown"
       :key="JSON.stringify(data) + index"

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -58,6 +58,7 @@
       <drilldown-pop-up
         @close="() => (showDrilldownPopUp = false)"
         :class="store.state.theme == 'dark' ? 'dark-mode' : 'bg-white'"
+        :drilldown-data="drilldownData"
       />
     </q-dialog>
   </div>
@@ -86,6 +87,25 @@ export default defineComponent({
         name: "Drill down 3",
       },
     ]);
+    const drilldownData: any = ref({
+      name: "",
+      type: "",
+      targetBlank: false,
+      findBy: "name",
+      data: {
+        url: "",
+        folder: "",
+        dashboard: "",
+        tab: "",
+        queryParams: [
+          {
+            name: "",
+            value: "",
+          },
+        ],
+      },
+    });
+
 
     const onDataLinkClick = () => {
       console.log("onDataLinkClick");
@@ -103,6 +123,7 @@ export default defineComponent({
       onDataLinkClick,
       showDrilldownPopUp,
       removeDataLink,
+      drilldownData,
     };
   },
 });

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -1,0 +1,98 @@
+<!-- Copyright 2023 Zinc Labs Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http:www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License. 
+-->
+
+<!-- eslint-disable vue/no-unused-components -->
+<template>
+  <div>
+    <div style="font-size: 14px; padding-bottom: 5px;">Data Link :</div>
+    <div v-for="data in dataLink" :key="JSON.stringify(data)">
+      <div
+        style="
+          display: flex;
+          justify-content: space-between;
+          margin-bottom: 5px;
+        "
+      >
+        <div
+          :onclick="onDataLinkClick"
+          style="
+            cursor: pointer;
+            text-decoration: underline;
+            padding-left: 20px;
+            width: 250px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          "
+        >
+          {{ data.name }}
+        </div>
+        <q-icon
+          class="q-mr-xs"
+          size="20px"
+          name="close"
+          style="cursor: pointer"
+        />
+      </div>
+    </div>
+    <q-dialog v-model="showDrilldownPopUp">
+      <drilldown-pop-up
+        @close="() => (showDrilldownPopUp = false)"
+        :class="store.state.theme == 'dark' ? 'dark-mode' : 'bg-white'"
+      />
+    </q-dialog>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from "vue";
+import DrilldownPopUp from "./DrilldownPopUp.vue";
+import { useStore } from "vuex";
+
+export default defineComponent({
+  name: "Drilldown",
+  components: { DrilldownPopUp },
+  props: {},
+  setup(props, { emit }) {
+    const store = useStore();
+    const showDrilldownPopUp = ref(false);
+    const dataLink: any = ref([
+      {
+        name: "Drill down 1 asfdhk dfashsj ewfjklsda;lkewfsd",
+      },
+      {
+        name: "Drill down 2",
+      },
+      {
+        name: "Drill down 3",
+      },
+    ]);
+
+    const onDataLinkClick = () => {
+      console.log("onDataLinkClick");
+
+      showDrilldownPopUp.value = true;
+    };
+    return {
+      store,
+      dataLink,
+      onDataLinkClick,
+      showDrilldownPopUp,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -16,8 +16,8 @@
 <!-- eslint-disable vue/no-unused-components -->
 <template>
   <div>
-    <div style="font-size: 14px; padding-bottom: 5px;">Data Link :</div>
-    <div v-for="data in dataLink" :key="JSON.stringify(data)">
+    <div style="font-size: 14px; padding-bottom: 5px">Data Link :</div>
+    <div v-for="(data, index) in dataLink" :key="JSON.stringify(data)">
       <div
         style="
           display: flex;
@@ -44,9 +44,16 @@
           size="20px"
           name="close"
           style="cursor: pointer"
+          @click="removeDataLink(index)"
         />
       </div>
     </div>
+    <q-btn
+      @click="onDataLinkClick"
+      style="cursor: pointer; padding: 0px 5px"
+      label="+ Add link"
+      no-caps
+    />
     <q-dialog v-model="showDrilldownPopUp">
       <drilldown-pop-up
         @close="() => (showDrilldownPopUp = false)"
@@ -85,11 +92,17 @@ export default defineComponent({
 
       showDrilldownPopUp.value = true;
     };
+
+    const removeDataLink = (index: any) => {
+      dataLink.value.splice(index, 1);
+    };
+
     return {
       store,
       dataLink,
       onDataLinkClick,
       showDrilldownPopUp,
+      removeDataLink,
     };
   },
 });

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -16,7 +16,7 @@
 <!-- eslint-disable vue/no-unused-components -->
 <template>
   <div>
-    <div style="font-size: 14px; padding-bottom: 5px">Drilldown:</div>
+    <div class="q-mb-sm" style="font-weight: 600">Drilldown</div>
     <div
       v-for="(data, index) in dashboardPanelData.data.config.drilldown"
       :key="JSON.stringify(data) + index"

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -32,15 +32,14 @@
           @click="onDataLinkClick(index)"
           style="
             cursor: pointer;
-            text-decoration: underline;
-            padding-left: 20px;
+            padding-left: 10px;
             width: 250px;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
           "
         >
-          {{ data.name }}
+          {{ index + 1 }}. {{ data.name }}
         </div>
         <q-icon
           class="q-mr-xs"

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -18,7 +18,15 @@
   <div>
     <div class="q-mb-sm" style="font-weight: 600">
       <span>Drilldown</span>
-      <q-btn no-caps padding="xs" class="" size="sm" flat icon="info_outline">
+      <q-btn
+        no-caps
+        padding="xs"
+        class=""
+        size="sm"
+        flat
+        icon="info_outline"
+        data-test="dashboard-addpanel-config-drilldown-info"
+      >
         <q-tooltip
           class="bg-grey-8"
           anchor="bottom middle"
@@ -51,6 +59,7 @@
             overflow: hidden;
             text-overflow: ellipsis;
           "
+          :data-test="`dashboard-addpanel-config-drilldown-name-${index}`"
         >
           {{ index + 1 }}. {{ data.name }}
         </div>
@@ -60,6 +69,7 @@
           name="close"
           style="cursor: pointer"
           @click="removeDrilldownByIndex(index)"
+          :data-test="`dashboard-addpanel-config-drilldown-remove-${index}`"
         />
       </div>
     </div>
@@ -68,6 +78,7 @@
       style="cursor: pointer; padding: 0px 5px"
       label="+ Add"
       no-caps
+      data-test="dashboard-addpanel-config-drilldown-add-btn"
     />
     <q-dialog v-model="showDrilldownPopUp">
       <drilldown-pop-up

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -96,7 +96,8 @@ export default defineComponent({
         folder: "",
         dashboard: "",
         tab: "",
-        queryParams: [
+        passAllVariables: true,
+        variables: [
           {
             name: "",
             value: "",

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -29,7 +29,7 @@
         "
       >
         <div
-          :onclick="onDataLinkClick(index)"
+          @click="onDataLinkClick(index)"
           style="
             cursor: pointer;
             text-decoration: underline;
@@ -87,8 +87,8 @@ export default defineComponent({
 
     onBeforeMount(() => {
       // Ensure that the drilldown is initialized
-      if (!dashboardPanelData.data.drilldown) {
-        dashboardPanelData.data.drilldown = [];
+      if (!dashboardPanelData.data.config.drilldown) {
+        dashboardPanelData.data.config.drilldown = [];
       }
     });
 
@@ -100,6 +100,7 @@ export default defineComponent({
 
     const addDataLink = () => {
       isDrilldownEditMode.value = false;
+      selectedDrilldownIndexToEdit.value = null;
       showDrilldownPopUp.value = true;
     };
 
@@ -108,9 +109,9 @@ export default defineComponent({
     };
 
     const saveDrilldownData = () => {
+      showDrilldownPopUp.value = false;
       selectedDrilldownIndexToEdit.value = null;
       isDrilldownEditMode.value = false;
-      showDrilldownPopUp.value = false;
     };
 
     return {

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -29,7 +29,7 @@
         "
       >
         <div
-          @click="onDataLinkClick(index)"
+          @click="onDrilldownClick(index)"
           style="
             cursor: pointer;
             padding-left: 10px;
@@ -46,12 +46,12 @@
           size="15px"
           name="close"
           style="cursor: pointer"
-          @click="removeDataLink(index)"
+          @click="removeDrilldownByIndex(index)"
         />
       </div>
     </div>
     <q-btn
-      @click="addDataLink"
+      @click="addNewDrilldown"
       style="cursor: pointer; padding: 0px 5px"
       label="+ Add"
       no-caps
@@ -85,25 +85,25 @@ export default defineComponent({
     const { dashboardPanelData } = useDashboardPanelData();
 
     onBeforeMount(() => {
-      // Ensure that the drilldown is initialized
+      // Ensure that the drilldown object is initialized in config
       if (!dashboardPanelData.data.config.drilldown) {
         dashboardPanelData.data.config.drilldown = [];
       }
     });
 
-    const onDataLinkClick = (index: any) => {
+    const onDrilldownClick = (index: any) => {
       selectedDrilldownIndexToEdit.value = index;
       isDrilldownEditMode.value = true;
       showDrilldownPopUp.value = true;
     };
 
-    const addDataLink = () => {
+    const addNewDrilldown = () => {
       isDrilldownEditMode.value = false;
       selectedDrilldownIndexToEdit.value = null;
       showDrilldownPopUp.value = true;
     };
 
-    const removeDataLink = (index: any) => {
+    const removeDrilldownByIndex = (index: any) => {
       dashboardPanelData.data.config.drilldown.splice(index, 1);
     };
 
@@ -116,12 +116,12 @@ export default defineComponent({
     return {
       store,
       dashboardPanelData,
-      onDataLinkClick,
+      onDrilldownClick,
       showDrilldownPopUp,
-      removeDataLink,
+      removeDrilldownByIndex,
       selectedDrilldownIndexToEdit,
       saveDrilldownData,
-      addDataLink,
+      addNewDrilldown,
       isDrilldownEditMode,
     };
   },

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -72,8 +72,7 @@ import { useStore } from "vuex";
 export default defineComponent({
   name: "Drilldown",
   components: { DrilldownPopUp },
-  props: {},
-  setup(props, { emit }) {
+  setup() {
     const store = useStore();
     const showDrilldownPopUp = ref(false);
     const dataLink: any = ref([

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -16,7 +16,7 @@
 <!-- eslint-disable vue/no-unused-components -->
 <template>
   <div>
-    <div style="font-size: 14px; padding-bottom: 5px">Data Link :</div>
+    <div style="font-size: 14px; padding-bottom: 5px">Drilldown:</div>
     <div
       v-for="(data, index) in dashboardPanelData.data.config.drilldown"
       :key="JSON.stringify(data) + index"
@@ -54,7 +54,7 @@
     <q-btn
       @click="addDataLink"
       style="cursor: pointer; padding: 0px 5px"
-      label="+ Add link"
+      label="+ Add"
       no-caps
     />
     <q-dialog v-model="showDrilldownPopUp">

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -43,7 +43,7 @@
         </div>
         <q-icon
           class="q-mr-xs"
-          size="20px"
+          size="15px"
           name="close"
           style="cursor: pointer"
           @click="removeDataLink(index)"

--- a/web/src/components/dashboards/addPanel/Drilldown.vue
+++ b/web/src/components/dashboards/addPanel/Drilldown.vue
@@ -17,7 +17,10 @@
 <template>
   <div>
     <div style="font-size: 14px; padding-bottom: 5px">Data Link :</div>
-    <div v-for="(data, index) in dataLink" :key="JSON.stringify(data)">
+    <div
+      v-for="(data, index) in dashboardPanelData.data.config.drilldown"
+      :key="JSON.stringify(data) + index"
+    >
       <div
         style="
           display: flex;
@@ -26,7 +29,7 @@
         "
       >
         <div
-          :onclick="onDataLinkClick"
+          :onclick="onDataLinkClick(index)"
           style="
             cursor: pointer;
             text-decoration: underline;
@@ -49,16 +52,17 @@
       </div>
     </div>
     <q-btn
-      @click="onDataLinkClick"
+      @click="addDataLink"
       style="cursor: pointer; padding: 0px 5px"
       label="+ Add link"
       no-caps
     />
     <q-dialog v-model="showDrilldownPopUp">
       <drilldown-pop-up
-        @close="() => (showDrilldownPopUp = false)"
+        :drilldown-data-index="selectedDrilldownIndexToEdit"
+        :is-edit-mode="isDrilldownEditMode"
+        @close="saveDrilldownData"
         :class="store.state.theme == 'dark' ? 'dark-mode' : 'bg-white'"
-        :drilldown-data="drilldownData"
       />
     </q-dialog>
   </div>
@@ -68,6 +72,8 @@
 import { defineComponent, ref } from "vue";
 import DrilldownPopUp from "./DrilldownPopUp.vue";
 import { useStore } from "vuex";
+import useDashboardPanelData from "../../../composables/useDashboardPanel";
+import { onBeforeMount } from "vue";
 
 export default defineComponent({
   name: "Drilldown",
@@ -75,55 +81,48 @@ export default defineComponent({
   setup() {
     const store = useStore();
     const showDrilldownPopUp = ref(false);
-    const dataLink: any = ref([
-      {
-        name: "Drill down 1 asfdhk dfashsj ewfjklsda;lkewfsd",
-      },
-      {
-        name: "Drill down 2",
-      },
-      {
-        name: "Drill down 3",
-      },
-    ]);
-    const drilldownData: any = ref({
-      name: "",
-      type: "",
-      targetBlank: false,
-      findBy: "name",
-      data: {
-        url: "",
-        folder: "",
-        dashboard: "",
-        tab: "",
-        passAllVariables: true,
-        variables: [
-          {
-            name: "",
-            value: "",
-          },
-        ],
-      },
+    const isDrilldownEditMode = ref(false);
+    const selectedDrilldownIndexToEdit: any = ref(null);
+    const { dashboardPanelData } = useDashboardPanelData();
+
+    onBeforeMount(() => {
+      // Ensure that the drilldown is initialized
+      if (!dashboardPanelData.data.drilldown) {
+        dashboardPanelData.data.drilldown = [];
+      }
     });
 
+    const onDataLinkClick = (index: any) => {
+      selectedDrilldownIndexToEdit.value = index;
+      isDrilldownEditMode.value = true;
+      showDrilldownPopUp.value = true;
+    };
 
-    const onDataLinkClick = () => {
-      console.log("onDataLinkClick");
-
+    const addDataLink = () => {
+      isDrilldownEditMode.value = false;
       showDrilldownPopUp.value = true;
     };
 
     const removeDataLink = (index: any) => {
-      dataLink.value.splice(index, 1);
+      dashboardPanelData.data.config.drilldown.splice(index, 1);
+    };
+
+    const saveDrilldownData = () => {
+      selectedDrilldownIndexToEdit.value = null;
+      isDrilldownEditMode.value = false;
+      showDrilldownPopUp.value = false;
     };
 
     return {
       store,
-      dataLink,
+      dashboardPanelData,
       onDataLinkClick,
       showDrilldownPopUp,
       removeDataLink,
-      drilldownData,
+      selectedDrilldownIndexToEdit,
+      saveDrilldownData,
+      addDataLink,
+      isDrilldownEditMode,
     };
   },
 });

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -248,6 +248,27 @@ export default defineComponent({
       }
     });
 
+    // on folder change, reset dashboard and tab values
+    watch(
+      () => drilldownData.value.data.folder,
+      (newVal, oldVal) => {
+        if (newVal !== oldVal) {
+          drilldownData.value.data.dashboard = "";
+          drilldownData.value.data.tab = "";
+        }
+      }
+    );
+
+    // on dashboard change, reset tab value
+    watch(
+      () => drilldownData.value.data.dashboard,
+      (newVal, oldVal) => {
+        if (newVal !== oldVal) {
+          drilldownData.value.data.tab = "";
+        }
+      }
+    );
+
     const folderList = computed(() => {
       if (!store.state.organizationData.folders) {
         return [];

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -117,8 +117,8 @@
                   No folders available
                 </q-item-section>
               </q-item>
-            </template></q-select
-          >
+            </template>
+          </q-select>
         </div>
         <div class="dropdownDiv" v-if="drilldownData.data.folder">
           <q-select
@@ -137,13 +137,15 @@
           >
             <!-- template when on options -->
             <template v-slot:no-option>
-              <q-item data-test="dashboard-tab-move-select-no-option">
+              <q-item
+                data-test="dashboard-drilldown-no-dashboard-available-option"
+              >
                 <q-item-section class="text-italic text-grey">
                   No dashboards available
                 </q-item-section>
               </q-item>
-            </template></q-select
-          >
+            </template>
+          </q-select>
         </div>
         <div class="dropdownDiv" v-if="drilldownData.data.dashboard">
           <q-select
@@ -162,7 +164,7 @@
           >
             <!-- template when on options -->
             <template v-slot:no-option>
-              <q-item data-test="dashboard-tab-move-select-no-option">
+              <q-item data-test="dashboard-drilldown-no-tab-available-option">
                 <q-item-section class="text-italic text-grey">
                   No tab Available
                 </q-item-section>
@@ -338,8 +340,8 @@ export default defineComponent({
           )
         : getDefaultDrilldownData()
     );
-    const dashboardList = ref([]);
-    const tabList = ref([]);
+    const dashboardList: any = ref([]);
+    const tabList: any = ref([]);
 
     onMounted(async () => {
       if (
@@ -357,10 +359,13 @@ export default defineComponent({
     // on folder change, reset dashboard and tab values
     watch(
       () => drilldownData.value.data.folder,
-      (newVal, oldVal) => {
+      async (newVal, oldVal) => {
+        await getDashboardList();
         if (newVal !== oldVal) {
-          drilldownData.value.data.dashboard = "";
-          drilldownData.value.data.tab = "";
+          // take first value from new options list
+          drilldownData.value.data.dashboard =
+            dashboardList?.value[0]?.value ?? "";
+          drilldownData.value.data.tab = tabList?.value[0]?.value ?? "";
         }
       }
     );
@@ -368,9 +373,11 @@ export default defineComponent({
     // on dashboard change, reset tab value
     watch(
       () => drilldownData.value.data.dashboard,
-      (newVal, oldVal) => {
+      async (newVal, oldVal) => {
+        await getTabList();
         if (newVal !== oldVal) {
-          drilldownData.value.data.tab = "";
+          // take first value from new options list
+          drilldownData.value.data.tab = tabList?.value[0]?.value ?? "";
         }
       }
     );
@@ -453,20 +460,6 @@ export default defineComponent({
           };
         }) ?? [];
     };
-
-    watch(
-      () => drilldownData.value.data.folder,
-      async () => {
-        await getDashboardList();
-      }
-    );
-
-    watch(
-      () => drilldownData.value.data.dashboard,
-      async () => {
-        await getTabList();
-      }
-    );
 
     const isFormValid = computed(() => {
       // if name is empty

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -136,6 +136,8 @@
             <q-btn
               icon="add"
               color="primary"
+              size="sm"
+              padding="sm"
               @click="
                 () => drilldownData.data.variables.push({ name: '', value: '' })
               "

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -250,7 +250,6 @@
 
     <q-card-actions class="confirmActions">
       <q-btn
-        v-close-popup="true"
         unelevated
         no-caps
         class="q-mr-sm"
@@ -260,13 +259,11 @@
         {{ t("confirmDialog.cancel") }}
       </q-btn>
       <q-btn
-        v-close-popup="true"
         unelevated
         no-caps
         class="no-border"
         color="primary"
-        @click="saveDrilldown.execute()"
-        :loading="saveDrilldown.isLoading.value"
+        @click="saveDrilldown"
         style="min-width: 60px"
         data-test="confirm-button"
         :disable="isFormValid"
@@ -309,6 +306,7 @@ export default defineComponent({
       default: -1,
     },
   },
+  emits: ["close"],
   setup(props, { emit }) {
     const { t } = useI18n();
     const store = useStore();
@@ -336,9 +334,7 @@ export default defineComponent({
       props.isEditMode
         ? JSON.parse(
             JSON.stringify(
-              dashboardPanelData.data.config.drilldowns[
-                props.drilldownDataIndex
-              ]
+              dashboardPanelData.data.config.drilldown[props.drilldownDataIndex]
             )
           )
         : getDefaultDrilldownData()
@@ -438,7 +434,8 @@ export default defineComponent({
 
         // get dashboard data
         const dashboardData = allDashboardList?.find(
-          (dashboard: any) => dashboard.title === drilldownData.value.data.dashboard
+          (dashboard: any) =>
+            dashboard.title === drilldownData.value.data.dashboard
         );
 
         if (!dashboardData) {
@@ -470,7 +467,7 @@ export default defineComponent({
 
       // if action is by url
       if (drilldownData.value.type == "byUrl") {
-        if (drilldownData.value.url.trim()) {
+        if (drilldownData.value.data.url.trim()) {
           return false;
         }
       } else {
@@ -485,17 +482,17 @@ export default defineComponent({
       return true;
     });
 
-    const saveDrilldown = useLoading(async () => {
+    const saveDrilldown = () => {
       // if editmode then made changes
-      // else add new
+      // else add new drilldown
       if (props.isEditMode) {
-        dashboardPanelData.data.config.drilldowns[props.drilldownDataIndex] =
+        dashboardPanelData.data.config.drilldown[props.drilldownDataIndex] =
           drilldownData.value;
       } else {
-        dashboardPanelData.data.config.drilldowns.push(drilldownData.value);
+        dashboardPanelData.data.config.drilldown.push(drilldownData.value);
       }
       emit("close");
-    });
+    };
 
     return {
       t,

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -54,6 +54,7 @@
           :class="drilldownData.type == 'byDashboard' ? 'selected' : ''"
           size="sm"
           @click="changeTypeOfDrilldown('byDashboard')"
+          data-test="dashboard-drilldown-by-dashboard-btn"
           ><q-icon
             class="q-mr-xs"
             :name="outlinedDashboard"
@@ -64,6 +65,7 @@
           :class="drilldownData.type === 'byUrl' ? 'selected' : ''"
           size="sm"
           @click="changeTypeOfDrilldown('byUrl')"
+          data-test="dashboard-drilldown-by-url-btn"
           ><q-icon
             class="q-mr-xs"
             name="link"
@@ -80,10 +82,12 @@
           style="min-width: 100%; max-width: 100%; resize: vertical"
           v-model="drilldownData.data.url"
           :class="store.state.theme == 'dark' ? 'dark-mode' : 'bg-white'"
+          data-test="dashboard-drilldown-url"
         ></textarea>
         <div
           style="color: red; font-size: 12px"
           v-if="!isFormURLValid && drilldownData.data.url.trim()"
+          data-test="dashboard-drilldown-url-error-message"
         >
           Invalid URL
         </div>
@@ -106,6 +110,7 @@
             filled
             dense
             style="width: 100%"
+            data-test="dashboard-drilldown-folder-select"
           >
             <!-- template when on options -->
             <template v-slot:no-option>
@@ -131,6 +136,7 @@
             filled
             dense
             style="width: 100%"
+            data-test="dashboard-drilldown-dashboard-select"
           >
             <!-- template when on options -->
             <template v-slot:no-option>
@@ -158,6 +164,7 @@
             filled
             dense
             style="width: 100%"
+            data-test="dashboard-drilldown-tab-select"
           >
             <!-- template when on options -->
             <template v-slot:no-option>
@@ -193,6 +200,7 @@
                     value: '',
                   })
               "
+              data-test="dashboard-drilldown-add-variable"
               >Add</q-btn
             >
           </div>
@@ -208,6 +216,7 @@
                 outlined
                 filled
                 dense
+                :data-test="`dashboard-drilldown-variable-name-${index}`"
               />
               <q-input
                 v-model="variable.value"
@@ -216,6 +225,7 @@
                 outlined
                 filled
                 dense
+                :data-test="`dashboard-drilldown-variable-value-${index}`"
               />
               <q-icon
                 class="q-mr-xs"
@@ -223,6 +233,7 @@
                 name="close"
                 style="cursor: pointer; height: 35px; display: flex !important"
                 @click="() => drilldownData.data.variables.splice(index, 1)"
+                :data-test="`dashboard-drilldown-variable-remove-${index}`"
               />
             </div>
           </div>
@@ -234,6 +245,7 @@
           :label="`Pass all current variables : `"
           left-label
           v-model="drilldownData.data.passAllVariables"
+          data-test="dashboard-drilldown-pass-all-variables"
         />
       </div>
     </div>
@@ -244,6 +256,7 @@
         :label="`Open in new tab : `"
         left-label
         v-model="drilldownData.targetBlank"
+        data-test="dashboard-drilldown-open-in-new-tab"
       />
     </div>
 

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -61,11 +61,7 @@
         <q-btn
           :class="drilldownData.type == 'byDashboard' ? 'selected' : ''"
           size="sm"
-          @click="
-            () => {
-              drilldownData.type = 'byDashboard';
-            }
-          "
+          @click="changeTypeOfDrilldown('byDashboard')"
           ><q-icon
             class="q-mr-xs"
             :name="outlinedDashboard"
@@ -75,11 +71,7 @@
         <q-btn
           :class="drilldownData.type === 'byUrl' ? 'selected' : ''"
           size="sm"
-          @click="
-            () => {
-              drilldownData.type = 'byUrl';
-            }
-          "
+          @click="changeTypeOfDrilldown('byUrl')"
           ><q-icon
             class="q-mr-xs"
             name="link"
@@ -357,14 +349,18 @@ export default defineComponent({
     const tabList: any = ref([]);
 
     onMounted(async () => {
+      // if no folders in organization, get folders
       if (
         !store.state.organizationData.folders ||
         (Array.isArray(store.state.organizationData.folders) &&
           store.state.organizationData.folders.length === 0)
       ) {
+        // get folders(will be api call)
         await getFoldersList(store);
       }
 
+      // get dashboard list
+      // get tab list
       await getDashboardList();
       await getTabList();
     });
@@ -396,10 +392,11 @@ export default defineComponent({
     );
 
     const folderList = computed(() => {
+      // if no folders in organization, return []
       if (!store.state.organizationData.folders) {
         return [];
       }
-
+      // make list of options from folders list
       return (
         store.state.organizationData.folders?.map((folder: any) => {
           return {
@@ -412,10 +409,12 @@ export default defineComponent({
 
     const getDashboardList = async () => {
       // get folder data
+      // by using folder name, find folder data
       const folderData = store.state.organizationData.folders?.find(
         (folder: any) => folder.name === drilldownData.value.data.folder
       );
 
+      // if no folder with same forder name found, return
       if (!folderData) {
         dashboardList.value = [];
         return;
@@ -439,26 +438,31 @@ export default defineComponent({
 
     const getTabList = async () => {
       // get folder data
+      // by using folder name, find folder data
       const folderData = store.state.organizationData.folders?.find(
         (folder: any) => folder.name === drilldownData.value.data.folder
       );
 
+      // if no folder with same forder name found, return
       if (!folderData) {
         dashboardList.value = [];
         return;
       }
 
+      // get all dashboards from folder
       const allDashboardList = await getAllDashboardsByFolderId(
         store,
         folderData?.folderId
       );
 
       // get dashboard data
+      // by using dashboard name, find dashboard data
       const dashboardData = allDashboardList?.find(
         (dashboard: any) =>
           dashboard.title === drilldownData.value.data.dashboard
       );
 
+      // if no dashboard with same dashboard name found, return
       if (!dashboardData) {
         dashboardList.value = [];
         return;
@@ -475,6 +479,7 @@ export default defineComponent({
     };
 
     const isFormURLValid = computed(() => {
+      // check if url is valid with protocol only(will check only protocol)
       const urlRegex = /^(http|https|ftp|file|mailto|telnet|data|ws|wss):\/\//;
       return urlRegex.test(drilldownData.value.data.url.trim());
     });
@@ -520,6 +525,11 @@ export default defineComponent({
       emit("close");
     };
 
+    // change type of drilldown
+    const changeTypeOfDrilldown = (type: string) => {
+      drilldownData.value.type = type;
+    };
+
     return {
       t,
       outlinedDashboard,
@@ -533,6 +543,7 @@ export default defineComponent({
       isFormValid,
       saveDrilldown,
       isFormURLValid,
+      changeTypeOfDrilldown,
     };
   },
 });

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -21,23 +21,27 @@
       style="border-bottom: 2px solid gray; margin-bottom: 5px"
     >
       <div class="flex items-center q-table__title q-mr-md">
-        <span data-test="dashboard-viewpanel-title" v-if="isEditMode"
+        <span data-test="dashboard-drilldown-title" v-if="isEditMode"
           >Edit Drilldown
         </span>
-        <span data-test="dashboard-viewpanel-title" v-else
+        <span data-test="dashboard-drilldown-title" v-else
           >Create Drilldown</span
         >
       </div>
-      <div class="flex q-gutter-sm items-center">
+      <div class="flex q-gutter-sm items-center" style="position: relative">
         <q-btn
           no-caps
-          @click="$emit('close')"
+          @click=""
           padding="xs"
           class="q-ml-md"
           flat
-          icon="close"
-          data-test="dashboard-viewpanel-close-btn"
-        />
+          icon="help"
+          data-test="dashboard-drilldown-help-btn"
+        >
+          <q-tooltip class="bg-grey-8" anchor="top middle" self="bottom middle">
+            User Guide
+          </q-tooltip>
+        </q-btn>
       </div>
     </div>
     <q-input
@@ -274,9 +278,8 @@
         style="min-width: 60px"
         data-test="confirm-button"
         :disable="isFormValid"
-      >
-        Add
-      </q-btn>
+        :label="isEditMode ? 'Update' : 'Add'"
+      />
     </q-card-actions>
   </div>
 </template>

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -21,7 +21,12 @@
       style="border-bottom: 2px solid gray; margin-bottom: 5px"
     >
       <div class="flex items-center q-table__title q-mr-md">
-        <span data-test="dashboard-viewpanel-title"> Create Drilldown </span>
+        <span data-test="dashboard-viewpanel-title" v-if="isEditMode"
+          >Edit Drilldown
+        </span>
+        <span data-test="dashboard-viewpanel-title" v-else
+          >Create Drilldown</span
+        >
       </div>
       <div class="flex q-gutter-sm items-center">
         <q-btn
@@ -231,7 +236,7 @@
               <q-icon
                 class="q-mr-xs"
                 size="20px"
-                :name="outlinedDelete"
+                name="close"
                 style="cursor: pointer; height: 35px; display: flex !important"
                 @click="() => drilldownData.data.variables.splice(index, 1)"
               />
@@ -278,7 +283,7 @@
         data-test="confirm-button"
         :disable="isFormValid"
       >
-        {{ t("confirmDialog.ok") }}
+        Add
       </q-btn>
     </q-card-actions>
   </div>

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -181,7 +181,7 @@
               align-items: center;
             "
           >
-            <div>Query Params:</div>
+            <div>Variables:</div>
             <q-btn
               icon="add"
               color="primary"
@@ -189,38 +189,60 @@
               padding="sm"
               @click="
                 () =>
-                  drilldownData.data.queryParams.push({
+                  drilldownData.data.variables.push({
                     name: '',
                     value: '',
                   })
               "
-              >Add Query</q-btn
+              >Add</q-btn
             >
           </div>
           <div
-            v-for="(variable, index) in drilldownData.data.queryParams"
+            v-for="(variable, index) in drilldownData.data.variables"
             :key="index"
           >
             <div style="display: flex; gap: 10px; margin-bottom: 10px">
-              <q-input v-model="variable.name" placeholder="Name" />
-              <q-input v-model="variable.value" placeholder="Value" />
+              <q-input
+                v-model="variable.name"
+                placeholder="Name"
+                stack-label
+                outlined
+                filled
+                dense
+              />
+              <q-input
+                v-model="variable.value"
+                placeholder="Value"
+                stack-label
+                outlined
+                filled
+                dense
+              />
               <q-icon
                 class="q-mr-xs"
                 size="20px"
                 :name="outlinedDelete"
                 style="cursor: pointer; height: 35px; display: flex !important"
-                @click="() => drilldownData.data.queryParams.splice(index, 1)"
+                @click="() => drilldownData.data.variables.splice(index, 1)"
               />
             </div>
           </div>
         </div>
+      </div>
+      <!-- radio button for new tab -->
+      <div style="margin-top: 10px">
+        <q-toggle
+          :label="`Pass all current variables: `"
+          left-label
+          v-model="drilldownData.data.passAllVariables"
+        />
       </div>
     </div>
 
     <!-- radio button for new tab -->
     <div style="margin-top: 10px">
       <q-toggle
-        :label="`New Tab: `"
+        :label="`Open in new tab: `"
         left-label
         v-model="drilldownData.targetBlank"
       />

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -209,7 +209,7 @@
 
     <q-card-actions class="confirmActions">
       <q-btn
-        v-close-popup
+        v-close-popup="true"
         unelevated
         no-caps
         class="q-mr-sm"
@@ -219,7 +219,7 @@
         {{ t("confirmDialog.cancel") }}
       </q-btn>
       <q-btn
-        v-close-popup
+        v-close-popup="true"
         unelevated
         no-caps
         class="no-border"

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -138,7 +138,7 @@
             v-model="drilldownData.data.dashboard"
             :options="dashboardList"
             emit-value
-            label="Select Dashboard*:"
+            label="Select Dashboard * :"
             color="input-border"
             bg-color="input-bg"
             class="q-py-sm showLabelOnTop no-case"
@@ -165,7 +165,7 @@
             v-model="drilldownData.data.tab"
             :options="tabList"
             emit-value
-            label="Select Tab*:"
+            label="Select Tab * :"
             color="input-border"
             bg-color="input-bg"
             class="q-py-sm showLabelOnTop no-case"

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -28,20 +28,8 @@
           >Create Drilldown</span
         >
       </div>
-      <div class="flex q-gutter-sm items-center" style="position: relative">
-        <q-btn
-          no-caps
-          @click=""
-          padding="xs"
-          class="q-ml-md"
-          flat
-          icon="help"
-          data-test="dashboard-drilldown-help-btn"
-        >
-          <q-tooltip class="bg-grey-8" anchor="top middle" self="bottom middle">
-            User Guide
-          </q-tooltip>
-        </q-btn>
+      <div class="flex q-gutter-sm items-center">
+        <DrilldownUserGuide />
       </div>
     </div>
     <q-input
@@ -301,10 +289,13 @@ import {
 } from "../../../utils/commons";
 import { onMounted } from "vue";
 import useDashboardPanelData from "../../../composables/useDashboardPanel";
+import DrilldownUserGuide from "@/components/dashboards/addPanel/DrilldownUserGuide.vue";
 
 export default defineComponent({
   name: "DrilldownPopUp",
-  components: {},
+  components: {
+    DrilldownUserGuide,
+  },
   props: {
     isEditMode: {
       type: Boolean,

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -1,0 +1,154 @@
+<!-- Copyright 2023 Zinc Labs Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http:www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License. 
+-->
+
+<!-- eslint-disable vue/no-unused-components -->
+<template>
+  <div style="padding: 10px; min-width: 40%" class="scroll o2-input">
+    <div
+      class="flex justify-between items-center q-pa-md"
+      style="border-bottom: 2px solid gray; margin-bottom: 5px"
+    >
+      <div class="flex items-center q-table__title q-mr-md">
+        <span data-test="dashboard-viewpanel-title"> Create Drilldown </span>
+      </div>
+      <div class="flex q-gutter-sm items-center">
+        <q-btn
+          no-caps
+          @click="$emit('close')"
+          padding="xs"
+          class="q-ml-md"
+          flat
+          icon="close"
+          data-test="dashboard-viewpanel-close-btn"
+        />
+      </div>
+    </div>
+    <q-input
+      v-model="drilldownData.name"
+      :label="t('dashboard.nameOfVariable') + '*'"
+      color="input-border"
+      bg-color="input-bg"
+      class="q-py-md showLabelOnTop"
+      stack-label
+      outlined
+      filled
+      dense
+      :rules="[(val) => !!val.trim() || t('dashboard.nameRequired')]"
+      :lazy-rules="true"
+      style="width: 400px"
+    />
+    Action:
+    <div style="display: flex; flex-direction: row; gap: 10px">
+      <q-btn
+        :class="drilldownData.type == 'byDashboard' ? 'selected' : ''"
+        size="sm"
+        @click="
+          () => {
+            drilldownData.type = 'byDashboard';
+          }
+        "
+        style="max-width: 100px; height: 80px"
+        ><q-icon
+          class="q-mr-xs"
+          size="20px"
+          :name="outlinedDashboard"
+          style="cursor: pointer; height: 40px"
+        />Go to Dashboard</q-btn
+      >
+      <q-btn
+        :class="drilldownData.type === 'byUrl' ? 'selected' : ''"
+        size="sm"
+        @click="
+          () => {
+            drilldownData.type = 'byUrl';
+          }
+        "
+        style="max-width: 100px; height: 80px"
+        ><q-icon
+          class="q-mr-xs"
+          size="20px"
+          name="link"
+          style="cursor: pointer"
+        />Go to URL</q-btn
+      >
+    </div>
+
+    <div v-if="drilldownData.type == 'byUrl'">
+      <q-input
+        outlined
+        v-model="drilldownData.data.url"
+        filled
+        autogrow
+        class="showLabelOnTop"
+        label="Enter URL:"
+      />
+    </div>
+
+    <q-card-actions class="confirmActions">
+      <q-btn
+        v-close-popup
+        unelevated
+        no-caps
+        class="q-mr-sm"
+        @click="$emit('close')"
+        data-test="cancel-button"
+      >
+        {{ t("confirmDialog.cancel") }}
+      </q-btn>
+      <q-btn
+        v-close-popup
+        unelevated
+        no-caps
+        class="no-border"
+        color="primary"
+        @click="() => {}"
+        style="min-width: 60px"
+        data-test="confirm-button"
+      >
+        {{ t("confirmDialog.ok") }}
+      </q-btn>
+    </q-card-actions>
+  </div>
+</template>
+
+<script lang="ts">
+import { ref } from "vue";
+import { defineComponent } from "vue";
+import { useI18n } from "vue-i18n";
+import { outlinedDashboard } from "@quasar/extras/material-icons-outlined";
+
+export default defineComponent({
+  name: "DrilldownPopUp",
+  components: {},
+  props: {},
+  setup(props, { emit }) {
+    const { t } = useI18n();
+    const drilldownData: any = ref({
+      name: "",
+      type: "",
+      data: {
+        url: "",
+      },
+    });
+    return {
+      t,
+      drilldownData,
+      outlinedDashboard,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -37,7 +37,7 @@
     </div>
     <q-input
       v-model="drilldownData.name"
-      :label="t('dashboard.nameOfVariable') + '*'"
+      :label="t('dashboard.nameOfVariable') + ' * ' + ' : '"
       color="input-border"
       bg-color="input-bg"
       class="q-py-md showLabelOnTop"
@@ -51,7 +51,7 @@
     <div
       style="display: flex; flex-direction: row; gap: 10px; align-items: center"
     >
-      Go to:
+      Go to :
       <q-btn-group class="">
         <q-btn
           :class="drilldownData.type == 'byDashboard' ? 'selected' : ''"
@@ -108,7 +108,7 @@
             v-model="drilldownData.data.folder"
             :options="folderList"
             emit-value
-            label="Select Folder*:"
+            label="Select Folder * :"
             color="input-border"
             bg-color="input-bg"
             class="q-py-sm showLabelOnTop no-case"
@@ -191,7 +191,7 @@
               align-items: center;
             "
           >
-            <div>Variables:</div>
+            <div>Variables :</div>
             <q-btn
               icon="add"
               color="primary"
@@ -242,7 +242,7 @@
       <!-- radio button for new tab -->
       <div style="margin-top: 10px">
         <q-toggle
-          :label="`Pass all current variables: `"
+          :label="`Pass all current variables : `"
           left-label
           v-model="drilldownData.data.passAllVariables"
         />
@@ -252,7 +252,7 @@
     <!-- radio button for new tab -->
     <div style="margin-top: 10px">
       <q-toggle
-        :label="`Open in new tab: `"
+        :label="`Open in new tab : `"
         left-label
         v-model="drilldownData.targetBlank"
       />
@@ -534,6 +534,11 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+.selected {
+  background-color: var(--q-primary) !important;
+  font-weight: bold;
+  color: white;
+}
 .dropdownDiv {
   display: flex;
   align-items: center;

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -52,34 +52,36 @@
       style="display: flex; flex-direction: row; gap: 10px; align-items: center"
     >
       Go to:
-      <q-btn
-        :class="drilldownData.type == 'byDashboard' ? 'selected' : ''"
-        size="sm"
-        @click="
-          () => {
-            drilldownData.type = 'byDashboard';
-          }
-        "
-        ><q-icon
-          class="q-mr-xs"
-          :name="outlinedDashboard"
-          style="cursor: pointer; height: 25px"
-        />Dashboard</q-btn
-      >
-      <q-btn
-        :class="drilldownData.type === 'byUrl' ? 'selected' : ''"
-        size="sm"
-        @click="
-          () => {
-            drilldownData.type = 'byUrl';
-          }
-        "
-        ><q-icon
-          class="q-mr-xs"
-          name="link"
-          style="cursor: pointer; height: 25px; display: flex !important"
-        />URL</q-btn
-      >
+      <q-btn-group class="">
+        <q-btn
+          :class="drilldownData.type == 'byDashboard' ? 'selected' : ''"
+          size="sm"
+          @click="
+            () => {
+              drilldownData.type = 'byDashboard';
+            }
+          "
+          ><q-icon
+            class="q-mr-xs"
+            :name="outlinedDashboard"
+            style="cursor: pointer; height: 25px"
+          />Dashboard</q-btn
+        >
+        <q-btn
+          :class="drilldownData.type === 'byUrl' ? 'selected' : ''"
+          size="sm"
+          @click="
+            () => {
+              drilldownData.type = 'byUrl';
+            }
+          "
+          ><q-icon
+            class="q-mr-xs"
+            name="link"
+            style="cursor: pointer; height: 25px; display: flex !important"
+          />URL</q-btn
+        >
+      </q-btn-group>
     </div>
 
     <div v-if="drilldownData.type == 'byUrl'">
@@ -90,6 +92,12 @@
           v-model="drilldownData.data.url"
           :class="store.state.theme == 'dark' ? 'dark-mode' : 'bg-white'"
         ></textarea>
+        <div
+          style="color: red; font-size: 12px"
+          v-if="!isFormURLValid && drilldownData.data.url.trim()"
+        >
+          Invalid URL
+        </div>
       </div>
     </div>
 
@@ -461,6 +469,11 @@ export default defineComponent({
         }) ?? [];
     };
 
+    const isFormURLValid = computed(() => {
+      const urlRegex = /^(http|https|ftp|file|mailto|telnet|data|ws|wss):\/\//;
+      return urlRegex.test(drilldownData.value.data.url.trim());
+    });
+
     const isFormValid = computed(() => {
       // if name is empty
       if (!drilldownData.value.name.trim()) {
@@ -475,7 +488,8 @@ export default defineComponent({
       // if action is by url
       if (drilldownData.value.type == "byUrl") {
         if (drilldownData.value.data.url.trim()) {
-          return false;
+          // check if url is valid with protocol
+          return !isFormURLValid.value;
         }
       } else {
         if (
@@ -513,6 +527,7 @@ export default defineComponent({
       tabList,
       isFormValid,
       saveDrilldown,
+      isFormURLValid,
     };
   },
 });

--- a/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownPopUp.vue
@@ -51,7 +51,7 @@
     <div
       style="display: flex; flex-direction: row; gap: 10px; align-items: center"
     >
-      Action*:
+      Go to:
       <q-btn
         :class="drilldownData.type == 'byDashboard' ? 'selected' : ''"
         size="sm"
@@ -62,10 +62,9 @@
         "
         ><q-icon
           class="q-mr-xs"
-          size="20px"
           :name="outlinedDashboard"
           style="cursor: pointer; height: 25px"
-        />Go to Dashboard</q-btn
+        />Dashboard</q-btn
       >
       <q-btn
         :class="drilldownData.type === 'byUrl' ? 'selected' : ''"
@@ -77,10 +76,9 @@
         "
         ><q-icon
           class="q-mr-xs"
-          size="20px"
           name="link"
           style="cursor: pointer; height: 25px; display: flex !important"
-        />Go to URL</q-btn
+        />URL</q-btn
       >
     </div>
 
@@ -98,12 +96,19 @@
     <div v-if="drilldownData.type == 'byDashboard'">
       <div style="margin-top: 10px">
         <div class="dropdownDiv">
-          <div class="dropdownLabel">Select Folder*:</div>
           <q-select
             v-model="drilldownData.data.folder"
             :options="folderList"
-            class="dropdown"
             emit-value
+            label="Select Folder*:"
+            color="input-border"
+            bg-color="input-bg"
+            class="q-py-sm showLabelOnTop"
+            stack-label
+            outlined
+            filled
+            dense
+            style="width: 100%"
           >
             <!-- template when on options -->
             <template v-slot:no-option>
@@ -116,12 +121,19 @@
           >
         </div>
         <div class="dropdownDiv" v-if="drilldownData.data.folder">
-          <div class="dropdownLabel">Select Dashboard*:</div>
           <q-select
             v-model="drilldownData.data.dashboard"
             :options="dashboardList"
-            class="dropdown"
             emit-value
+            label="Select Dashboard*:"
+            color="input-border"
+            bg-color="input-bg"
+            class="q-py-sm showLabelOnTop"
+            stack-label
+            outlined
+            filled
+            dense
+            style="width: 100%"
           >
             <!-- template when on options -->
             <template v-slot:no-option>
@@ -134,12 +146,19 @@
           >
         </div>
         <div class="dropdownDiv" v-if="drilldownData.data.dashboard">
-          <div class="dropdownLabel">Select Tab*:</div>
           <q-select
             v-model="drilldownData.data.tab"
             :options="tabList"
-            class="dropdown"
             emit-value
+            label="Select Tab*:"
+            color="input-border"
+            bg-color="input-bg"
+            class="q-py-sm showLabelOnTop"
+            stack-label
+            outlined
+            filled
+            dense
+            style="width: 100%"
           >
             <!-- template when on options -->
             <template v-slot:no-option>
@@ -433,6 +452,7 @@ export default defineComponent({
   display: flex;
   align-items: center;
   margin: 10px 0px;
+  width: 100%;
 }
 
 .dropdownLabel {
@@ -440,6 +460,6 @@ export default defineComponent({
 }
 
 .dropdown {
-  min-width: 250px;
+  min-width: 100%;
 }
 </style>

--- a/web/src/components/dashboards/addPanel/DrilldownUserGuide.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownUserGuide.vue
@@ -6,7 +6,7 @@
       padding="xs"
       class="q-ml-md"
       flat
-      icon="help"
+      icon="help_outline"
       data-test="dashboard-drilldown-help-btn"
     >
       <q-tooltip class="bg-grey-8" anchor="bottom middle" self="top middle">
@@ -41,7 +41,12 @@
     <div class="header">Use current dashboard's variable</div>
     <p>You can reference a variable with the following format:</p>
     <ul>
-      <li><span class="bg-highlight">${var-variable_name}</span></li>
+      <li>
+        <span class="bg-highlight">${var-variable_name}</span>
+        <br />
+        (For Example, if your variable name is "test", you can use
+        <span class="bg-highlight">${var-test}</span>)
+      </li>
     </ul>
 
     <div class="header">Use Series name and value</div>
@@ -62,6 +67,10 @@
         <span class="bg-highlight"
           >${row.field["field_label"]} or ${row.field.field_label}</span
         >
+        <br />
+        (For Example, if your want to use "test" column's value of clicked row,
+        you can use <span class="bg-highlight">${row.field.test} </span> or
+        <span class="bg-highlight">${row.field["test"]}</span>)
       </li>
       <li><span class="bg-highlight">${row.index}</span></li>
     </ul>

--- a/web/src/components/dashboards/addPanel/DrilldownUserGuide.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownUserGuide.vue
@@ -143,7 +143,6 @@ ul,
 li,
 p,
 div {
-  // padding-top: 0;
   margin: 0;
 }
 

--- a/web/src/components/dashboards/addPanel/DrilldownUserGuide.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownUserGuide.vue
@@ -93,7 +93,7 @@ import { useStore } from "vuex";
 
 export default {
   name: "DrilldownUserGuide",
-  setup(props, { emit }) {
+  setup() {
     const store = useStore();
     const showUserGuide = ref(false);
 

--- a/web/src/components/dashboards/addPanel/DrilldownUserGuide.vue
+++ b/web/src/components/dashboards/addPanel/DrilldownUserGuide.vue
@@ -1,0 +1,148 @@
+<template>
+  <div ref="userGuideBtnRef">
+    <q-btn
+      no-caps
+      @click="onUserGuideClick"
+      padding="xs"
+      class="q-ml-md"
+      flat
+      icon="help"
+      data-test="dashboard-drilldown-help-btn"
+    >
+      <q-tooltip class="bg-grey-8" anchor="bottom middle" self="top middle">
+        User Guide
+      </q-tooltip>
+    </q-btn>
+  </div>
+  <div
+    class="user-guide scroll o2-input"
+    v-show="showUserGuide"
+    style="
+      position: absolute;
+      z-index: 1;
+      width: 500px;
+      max-height: 300px;
+      border: 1px solid gray;
+      border-radius: 5px;
+    "
+    @mouseleave="showUserGuide = false"
+    :class="
+      store.state.theme == 'dark'
+        ? 'theme-dark bg-dark'
+        : 'theme-light bg-white'
+    "
+    ref="userGuideDivRef"
+  >
+    <p>
+      In URL or while drilldown to another dashboard, you can use the following
+      dynamic variables:
+    </p>
+
+    <div class="header">Use current dashboard's variable</div>
+    <p>You can reference a variable with the following format:</p>
+    <ul>
+      <li><span class="bg-highlight">${var-variable_name}</span></li>
+    </ul>
+
+    <div class="header">Use Series name and value</div>
+    <p>
+      You can reference the series name and value with the following variables:
+    </p>
+    <ul>
+      <li><span class="bg-highlight">${series.__name}</span></li>
+      <li><span class="bg-highlight">${series.__value}</span></li>
+    </ul>
+
+    <div class="header">For table chart drilldown</div>
+    <p>
+      You can reference the row field and index with the following variables:
+    </p>
+    <ul>
+      <li>
+        <span class="bg-highlight"
+          >${row.field["field_label"]} or ${row.field.field_label}</span
+        >
+      </li>
+      <li><span class="bg-highlight">${row.index}</span></li>
+    </ul>
+
+    <div class="header">For Sankey chart drilldown</div>
+    <p>
+      You can reference the edge source, target, and value, as well as the node
+      name and value, with the following variables:
+    </p>
+    <ul>
+      <li class="header">Edge</li>
+      <ul>
+        <li><span class="bg-highlight">${edge.__source}</span></li>
+        <li><span class="bg-highlight">${edge.__target}</span></li>
+        <li><span class="bg-highlight">${edge.__value}</span></li>
+      </ul>
+      <li class="header">Node</li>
+      <ul>
+        <li><span class="bg-highlight">${node.__name}</span></li>
+        <li><span class="bg-highlight">${node.__value}</span></li>
+      </ul>
+    </ul>
+  </div>
+</template>
+
+<script lang="ts">
+import { ref } from "vue";
+import { useStore } from "vuex";
+
+export default {
+  name: "DrilldownUserGuide",
+  setup(props, { emit }) {
+    const store = useStore();
+    const showUserGuide = ref(false);
+
+    const userGuideBtnRef: any = ref(null);
+    const userGuideDivRef: any = ref(null);
+
+    const onUserGuideClick = () => {
+      if (userGuideBtnRef.value && userGuideDivRef.value) {
+        userGuideDivRef.value.style.top =
+          userGuideBtnRef.value.getBoundingClientRect().top + 32 + "px";
+
+        userGuideDivRef.value.style.left =
+          userGuideBtnRef.value.getBoundingClientRect().left + 48 + "px";
+        showUserGuide.value = !showUserGuide.value;
+      }
+    };
+
+    return {
+      store,
+      onUserGuideClick,
+      showUserGuide,
+      userGuideBtnRef,
+      userGuideDivRef,
+    };
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.user-guide {
+  padding: 10px;
+}
+.header {
+  font-weight: bold;
+}
+
+ul,
+li,
+p,
+div {
+  // padding-top: 0;
+  margin: 0;
+}
+
+.theme-dark .bg-highlight {
+  background-color: #747474;
+}
+
+.theme-light .bg-highlight {
+  background-color: #e7e6e6;
+}
+</style>

--- a/web/src/components/dashboards/panels/ChartRenderer.vue
+++ b/web/src/components/dashboards/panels/ChartRenderer.vue
@@ -244,7 +244,7 @@ export default defineComponent({
         }
       });
       chart?.on("click", function (params: any) {
-        return emit("click", params, props.data.extras?.panelId);
+        emit("click", params);
       });
       window.addEventListener("resize", windowResizeEventCallback);
 

--- a/web/src/components/dashboards/panels/ChartRenderer.vue
+++ b/web/src/components/dashboards/panels/ChartRenderer.vue
@@ -244,7 +244,7 @@ export default defineComponent({
         }
       });
       chart?.on("click", function (params: any) {
-        emit("click", params);
+        return emit("click", params, props.data.extras?.panelId);
       });
       window.addEventListener("resize", windowResizeEventCallback);
 

--- a/web/src/components/dashboards/panels/TableRenderer.vue
+++ b/web/src/components/dashboards/panels/TableRenderer.vue
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     row-key="id"
     ref="tableRef"
     data-test="dashboard-panel-table"
+    @row-click="(...args) => $emit('click', ...args)"
   >
   </q-table>
 </template>
@@ -44,6 +45,7 @@ export default defineComponent({
       default: () => ({ rows: [], columns: {} }),
     },
   },
+  emits: ["click"],
   setup(props: any) {
     const $q = useQuasar();
     const tableRef: any = ref(null);

--- a/web/src/components/dashboards/panels/TableRenderer.vue
+++ b/web/src/components/dashboards/panels/TableRenderer.vue
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     row-key="id"
     ref="tableRef"
     data-test="dashboard-panel-table"
-    @row-click="(...args) => $emit('click', ...args)"
+    @row-click="(...args) => $emit('row-click', ...args)"
   >
   </q-table>
 </template>
@@ -45,7 +45,7 @@ export default defineComponent({
       default: () => ({ rows: [], columns: {} }),
     },
   },
-  emits: ["click"],
+  emits: ["row-click"],
   setup(props: any) {
     const $q = useQuasar();
     const tableRef: any = ref(null);

--- a/web/src/components/dashboards/viewPanel/ViewPanel.vue
+++ b/web/src/components/dashboards/viewPanel/ViewPanel.vue
@@ -408,7 +408,8 @@ export default defineComponent({
           variableObj[`${variable.name}`] = variable.value;
         }
       });
-      return variableObj;
+      // pass initial variable values in value property
+      return { value: variableObj };
     };
 
     return {

--- a/web/src/composables/useDashboardPanel.ts
+++ b/web/src/composables/useDashboardPanel.ts
@@ -60,6 +60,7 @@ const getDefaultDashboardPanelData: any = () => ({
         lat: 0,
         lng: 0,
       },
+      drilldown: [],
     },
     htmlContent: "",
     markdownContent: "",

--- a/web/src/views/Dashboards/RenderDashboardCharts.vue
+++ b/web/src/views/Dashboards/RenderDashboardCharts.vue
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :selectedTimeDate="currentTimeObj"
       :initialVariableValues="initialVariableValues"
       @variablesData="variablesDataUpdated"
+      ref="variablesValueSelectorRef"
     />
     <TabList
       v-if="showTabs && selectedTabId !== null"
@@ -78,6 +79,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               @updated:data-zoom="$emit('updated:data-zoom', $event)"
               @onMovePanel="onMovePanel"
               @refresh="refreshDashboard"
+              @update:initial-variable-values="updateInitialVariableValues"
             >
             </PanelContainer>
           </div>
@@ -136,7 +138,7 @@ export default defineComponent({
     viewOnly: {},
     dashboardData: {},
     currentTimeObj: {},
-    initialVariableValues: {},
+    initialVariableValues: { value: {} },
     selectedDateForViewPanel: {},
     showTabs: {
       type: Boolean,
@@ -160,6 +162,7 @@ export default defineComponent({
     const store = useStore();
     const $q = useQuasar();
     const gridLayoutRef = ref(null);
+    const variablesValueSelectorRef = ref(null);
 
     const showViewPanel = ref(false);
     // holds the view panel id
@@ -324,6 +327,13 @@ export default defineComponent({
       }
     };
 
+    const updateInitialVariableValues = async (...args: any) => {
+      refreshDashboard();
+      await variablesValueSelectorRef.value.changeInitialVariableValues(
+        ...args
+      );
+    };
+
     return {
       store,
       addPanelData,
@@ -344,6 +354,8 @@ export default defineComponent({
       panels,
       refreshDashboard,
       onMovePanel,
+      variablesValueSelectorRef,
+      updateInitialVariableValues,
     };
   },
   methods: {

--- a/web/src/views/Dashboards/RenderDashboardCharts.vue
+++ b/web/src/views/Dashboards/RenderDashboardCharts.vue
@@ -76,6 +76,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :width="getPanelLayout(item, 'w')"
               :height="getPanelLayout(item, 'h')"
               @updated:data-zoom="$emit('updated:data-zoom', $event)"
+              @chart-click="$emit('chartClick', $event)"
               @onMovePanel="onMovePanel"
               @refresh="refreshDashboard"
             >
@@ -131,6 +132,7 @@ export default defineComponent({
     "updated:data-zoom",
     "refresh",
     "onMovePanel",
+    "chartClick",
   ],
   props: {
     viewOnly: {},

--- a/web/src/views/Dashboards/RenderDashboardCharts.vue
+++ b/web/src/views/Dashboards/RenderDashboardCharts.vue
@@ -76,7 +76,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :width="getPanelLayout(item, 'w')"
               :height="getPanelLayout(item, 'h')"
               @updated:data-zoom="$emit('updated:data-zoom', $event)"
-              @chartClick="(...args) => $emit('chartClick', ...args)"
               @onMovePanel="onMovePanel"
               @refresh="refreshDashboard"
             >
@@ -132,7 +131,6 @@ export default defineComponent({
     "updated:data-zoom",
     "refresh",
     "onMovePanel",
-    "chartClick",
   ],
   props: {
     viewOnly: {},

--- a/web/src/views/Dashboards/RenderDashboardCharts.vue
+++ b/web/src/views/Dashboards/RenderDashboardCharts.vue
@@ -76,7 +76,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :width="getPanelLayout(item, 'w')"
               :height="getPanelLayout(item, 'h')"
               @updated:data-zoom="$emit('updated:data-zoom', $event)"
-              @chart-click="$emit('chartClick', $event)"
+              @chartClick="(...args) => $emit('chartClick', ...args)"
               @onMovePanel="onMovePanel"
               @refresh="refreshDashboard"
             >

--- a/web/src/views/Dashboards/RenderDashboardCharts.vue
+++ b/web/src/views/Dashboards/RenderDashboardCharts.vue
@@ -327,8 +327,11 @@ export default defineComponent({
       }
     };
 
+    // update initial variable values using the variable value selector ref
     const updateInitialVariableValues = async (...args: any) => {
+      // first, refresh the dashboard
       refreshDashboard();
+      // then, update the initial variable values
       await variablesValueSelectorRef.value.changeInitialVariableValues(
         ...args
       );

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -144,7 +144,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         @updated:data-zoom="onDataZoom"
         @refresh="loadDashboard"
         :showTabs="true"
-        @chart-click="onChartClick"
       />
 
       <q-dialog
@@ -550,124 +549,6 @@ export default defineComponent({
       isFullscreen.value = false;
     });
 
-    const onChartClick = async (params: any, panelId: any) => {
-      // current tabId
-      const tabId = route.query.tab ?? "default";
-
-      // find clicked panel data
-      const panelData = currentDashboardData.data.tabs
-        .find((tab: any) => tab.tabId == tabId)
-        .panels.find((panel: any) => panel.id == panelId);
-
-      // if paneldata exists
-      if (panelData) {
-        // find drilldown data
-        const drilldownData = panelData.config.drilldown[0];
-
-        // if drilldown by url
-        if (drilldownData.type == "byUrl") {
-          // open url
-          return window.open(
-            new URL(drilldownData.data.url),
-            drilldownData.targetBlank ? "_blank" : "_self"
-          );
-        } else if (drilldownData.type == "byDashboard") {
-          // we have folder, dashboard and tabs name
-          // so we have to get id of folder, dashboard and tab
-
-          // get folder id
-          if (
-            !store.state.organizationData.folders ||
-            (Array.isArray(store.state.organizationData.folders) &&
-              store.state.organizationData.folders.length === 0)
-          ) {
-            await getFoldersList(store);
-          }
-          const folderId = store.state.organizationData.folders.find(
-            (folder: any) => folder.name == drilldownData.data.folder
-          )?.folderId;
-
-          if (!folderId) {
-            return;
-          }
-
-          // get dashboard id
-          const allDashboardData = await getAllDashboardsByFolderId(
-            store,
-            folderId
-          );
-          const dashboardData = allDashboardData.find(
-            (dashboard: any) => dashboard.title == drilldownData.data.dashboard
-          );
-
-          if (!dashboardData) {
-            return;
-          }
-
-          // get tab id
-          const tabId =
-            dashboardData.tabs.find(
-              (tab: any) => tab.name == drilldownData.data.tab
-            )?.tabId ?? "default";
-
-          // if targetBlank is true then create new url
-          // else made changes in current router only
-          if (drilldownData.targetBlank) {
-            let currentUrl = window.location.origin;
-
-            // if pass all variables in url
-            currentUrl += drilldownData.data.passAllVariables
-              ? route.fullPath
-              : route.path;
-
-            const url = new URL(currentUrl);
-
-            // set variables provided by user
-            drilldownData.data.variables.forEach((variable: any) => {
-              if (variable?.name?.trim() && variable?.value?.trim()) {
-                url.searchParams.set(variable.name, variable.value);
-              }
-            });
-
-            url.searchParams.set("dashboard", dashboardData.dashboardId);
-            url.searchParams.set("folder", folderId);
-            url.searchParams.set("tab", tabId);
-            currentUrl = url.toString();
-
-            window.open(currentUrl, "_blank");
-          } else {
-            let oldParams = [];
-            // if pass all variables is true
-            if (drilldownData.data.passAllVariables) {
-              // get current query params
-              oldParams = route.query;
-            }
-
-            drilldownData.data.variables.forEach((variable: any) => {
-              if (variable?.name?.trim() && variable?.value?.trim()) {
-                oldParams[variable.name] = variable.value;
-              }
-            });
-
-            // make changes in router
-            await router.push({
-              path: "/dashboards/view",
-              query: {
-                ...oldParams,
-                org_identifier: store.state.selectedOrganization.identifier,
-                dashboard: dashboardData.dashboardId,
-                folder: folderId,
-                tab: tabId,
-              },
-            });
-
-            // reload dashboard because it will be in same path
-            await loadDashboard();
-          }
-        }
-      }
-    };
-
     return {
       currentDashboardData,
       toggleFullscreen,
@@ -697,7 +578,6 @@ export default defineComponent({
       shareLink,
       selectedTabId,
       onMovePanel,
-      onChartClick,
     };
   },
 });

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -144,6 +144,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         @updated:data-zoom="onDataZoom"
         @refresh="loadDashboard"
         :showTabs="true"
+        @chart-click="onChartClick"
       />
 
       <q-dialog
@@ -187,7 +188,7 @@ import { onUnmounted } from "vue";
 
 export default defineComponent({
   name: "ViewDashboard",
-  emits: ["onDeletePanel"],
+  emits: ["onDeletePanel", "chartClick"],
   components: {
     DateTimePickerDashboard,
     AutoRefreshInterval,
@@ -544,6 +545,10 @@ export default defineComponent({
       isFullscreen.value = false;
     });
 
+    const onChartClick = () => {
+      window.open("https://google.com", "_blank");
+    };
+
     return {
       currentDashboardData,
       toggleFullscreen,
@@ -573,6 +578,7 @@ export default defineComponent({
       shareLink,
       selectedTabId,
       onMovePanel,
+      onChartClick,
     };
   },
 });

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -172,12 +172,7 @@ import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
 import DateTimePickerDashboard from "@/components/DateTimePickerDashboard.vue";
 import { useRouter } from "vue-router";
-import {
-  getAllDashboardsByFolderId,
-  getDashboard,
-  getFoldersList,
-  movePanelToAnotherTab,
-} from "../../utils/commons.ts";
+import { getDashboard, movePanelToAnotherTab } from "../../utils/commons.ts";
 import { parseDuration, generateDurationLabel } from "../../utils/date";
 import { toRaw, unref, reactive } from "vue";
 import { useRoute } from "vue-router";
@@ -192,7 +187,7 @@ import { onUnmounted } from "vue";
 
 export default defineComponent({
   name: "ViewDashboard",
-  emits: ["onDeletePanel", "chartClick"],
+  emits: ["onDeletePanel"],
   components: {
     DateTimePickerDashboard,
     AutoRefreshInterval,

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -250,11 +250,11 @@ export default defineComponent({
 
     // ======= [START] default variable values
 
-    const initialVariableValues = {};
+    const initialVariableValues = { value: {} };
     Object.keys(route.query).forEach((key) => {
       if (key.startsWith("var-")) {
         const newKey = key.slice(4);
-        initialVariableValues[newKey] = route.query[key];
+        initialVariableValues.value[newKey] = route.query[key];
       }
     });
     // ======= [END] default variable values


### PR DESCRIPTION
# Drilldown Feature: Seamless Navigation for Enhanced Data Exploration

Drilldown, which allows users to navigate seamlessly between dashboards or specified URLs, carrying over all current variables.

## Adding a Drilldown

To add a Drilldown, follow these steps:

1. Edit the panel where you wish to add or modify a Drilldown.
2. Navigate to the configuration panel. Here, you'll find an option for Drilldown.
3. You'll see a list of existing Drilldowns.
4. From here, you can add a new Drilldown or edit an existing one by clicking on the Drilldown name.

![image](https://github.com/openobserve/openobserve/assets/141122205/9bb5824a-ee1a-4c17-a109-78a464f64792)

## Configuring a Drilldown

When adding or editing a Drilldown, you have two options:

1. **Drilldown to another dashboard:** Specify the target folder, dashboard, and tab. You can also pass variables to the target dashboard.

![image](https://github.com/openobserve/openobserve/assets/141122205/41795437-d151-43f0-bd69-4d1e29c39c1a)


2. **Drilldown to a specified URL:** Provide the URL where you want the Drilldown to navigate to. Here too, you can pass variables to the target URL.


![image](https://github.com/openobserve/openobserve/assets/141122205/ce1b4361-d13e-483f-a3dd-b52e485dae6a)

