### PR TITLE
feat: add unstable inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 description = "OpenObserve is an observability platform that allows you to capture, search, and analyze your logs, metrics, and traces."
 edition = "2021"

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "config"
 version.workspace = true

--- a/src/infra/Cargo.toml
+++ b/src/infra/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "infra"
 version.workspace = true

--- a/src/ingester/Cargo.toml
+++ b/src/ingester/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "ingester"
 version.workspace = true

--- a/src/wal/Cargo.toml
+++ b/src/wal/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "wal"
 version.workspace = true


### PR DESCRIPTION
This adds unstable inheritance to the package which allows generating sbom by running command like:

```
$ cargo-cyclonedx cyclonedx
```
and remove errors like below

```
The package requires the Cargo feature called `workspace-inheritance`, but that feature is not stabilized in this version of Cargo (1.63.0).
       Consider adding `cargo-features = ["workspace-inheritance"]` to the top of Cargo.toml (above the [package] table) to tell Cargo you are opting in to use this unstable feature.
       See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#workspace-inheritance for more information about the status of this feature.
```