### PR TITLE
fix: dashboard streams not loaded when switched between chart types like HTML and Markdown

### DIFF
--- a/web/src/components/dashboards/addPanel/FieldList.vue
+++ b/web/src/components/dashboards/addPanel/FieldList.vue
@@ -662,6 +662,14 @@ export default defineComponent({
     const getStreamList = async (stream_type: any) => {
       await getStreams(stream_type, false).then((res: any) => {
         data.schemaList = res.list;
+
+        // below line required for pass by reference
+        // if we don't set blank, then same object from cache is being set
+        // and that doesn't call the watchers,
+        // so it will not be updated when we switch to different chart types
+        // which doesn't have field list and coming back to field list
+        dashboardPanelData.meta.stream.streamResults = [] 
+
         dashboardPanelData.meta.stream.streamResults = res.list;
       });
     };


### PR DESCRIPTION
- dashboard streams not loaded when switched between chart types like HTML and Markdown and back to any chart type that has field list