### PR TITLE
fix: can't create same name alerts

### DIFF
--- a/src/handler/http/request/alerts/destinations.rs
+++ b/src/handler/http/request/alerts/destinations.rs
@@ -46,7 +46,7 @@ pub async fn save_destination(
 ) -> Result<HttpResponse, Error> {
     let org_id = path.into_inner();
     let dest = dest.into_inner();
-    match destinations::save(&org_id, "", dest).await {
+    match destinations::save(&org_id, "", dest, true).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert destination saved")),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }
@@ -78,7 +78,7 @@ pub async fn update_destination(
     let (org_id, name) = path.into_inner();
     let dest = dest.into_inner();
     let name = name.trim();
-    match destinations::save(&org_id, name, dest).await {
+    match destinations::save(&org_id, name, dest, false).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert destination saved")),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }

--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -65,7 +65,7 @@ pub async fn save_alert(
     let mut alert = alert.into_inner();
     alert.trigger_condition.frequency *= 60;
 
-    match alerts::save(&org_id, stream_type, &stream_name, "", alert).await {
+    match alerts::save(&org_id, stream_type, &stream_name, "", alert, true).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert saved")),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }
@@ -110,7 +110,7 @@ pub async fn update_alert(
     alert.trigger_condition.frequency *= 60;
 
     let name = name.trim();
-    match alerts::save(&org_id, stream_type, &stream_name, name, alert).await {
+    match alerts::save(&org_id, stream_type, &stream_name, name, alert, false).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert Updated")),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }

--- a/src/handler/http/request/alerts/templates.rs
+++ b/src/handler/http/request/alerts/templates.rs
@@ -47,7 +47,7 @@ pub async fn save_template(
     let org_id = path.into_inner();
     let tmpl = tmpl.into_inner();
     // let name = name.trim();
-    match templates::save(&org_id, "", tmpl).await {
+    match templates::save(&org_id, "", tmpl, true).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert template saved")),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }
@@ -79,7 +79,7 @@ pub async fn update_template(
     let (org_id, name) = path.into_inner();
     let tmpl = tmpl.into_inner();
     let name = name.trim();
-    match templates::save(&org_id, name, tmpl).await {
+    match templates::save(&org_id, name, tmpl, false).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert template updated")),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -55,6 +55,7 @@ pub async fn save(
     stream_name: &str,
     name: &str,
     mut alert: Alert,
+    create: bool,
 ) -> Result<(), anyhow::Error> {
     if !name.is_empty() {
         alert.name = name.trim().to_string();
@@ -63,6 +64,22 @@ pub async fn save(
     alert.stream_type = stream_type;
     alert.stream_name = stream_name.to_string();
     alert.row_template = alert.row_template.trim().to_string();
+
+    match db::alerts::get(org_id, stream_type, stream_name, &alert.name).await {
+        Ok(Some(_)) => {
+            if create {
+                return Err(anyhow::anyhow!("Alert already exists"));
+            }
+        }
+        Ok(None) => {
+            if !create {
+                return Err(anyhow::anyhow!("Alert not found"));
+            }
+        }
+        Err(e) => {
+            return Err(e);
+        }
+    }
 
     // default frequency is 60 seconds
     if alert.trigger_condition.frequency == 0 {
@@ -1147,7 +1164,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_alert_save() {
+    async fn test_alert_create() {
         let org_id = "default";
         let stream_type = StreamType::Logs;
         let stream_name = "default";
@@ -1156,7 +1173,7 @@ mod tests {
             name: alert_name.to_string(),
             ..Default::default()
         };
-        let ret = save(org_id, stream_type, stream_name, alert_name, alert).await;
+        let ret = save(org_id, stream_type, stream_name, alert_name, alert, true).await;
         // alert name should not contain /
         assert!(ret.is_err());
     }

--- a/src/service/db/alerts/mod.rs
+++ b/src/service/db/alerts/mod.rs
@@ -49,11 +49,7 @@ pub async fn get(
             Err(_) => None,
         }
     };
-    if value.is_none() {
-        Err(anyhow::anyhow!("Alert not found"))
-    } else {
-        Ok(value)
-    }
+    if value.is_none() { Ok(None) } else { Ok(value) }
 }
 
 pub async fn set(


### PR DESCRIPTION
- [x] Can't create same name alerts
- [x] Can't create same name destination
- [x] Can't create same name template