### PR TITLE
fix: change ZO_RESTRICTED_ROUTES_ON_EMPTY_DATA default to false

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -360,7 +360,7 @@ pub struct Common {
     pub memory_circuit_breaker_ratio: usize,
     #[env_config(
         name = "ZO_RESTRICTED_ROUTES_ON_EMPTY_DATA",
-        default = true,
+        default = false,
         help = "Control the redirection of a user to ingestion page in case there is no stream found."
     )]
     pub restricted_routes_on_empty_data: bool,


### PR DESCRIPTION
change ZO_RESTRICTED_ROUTES_ON_EMPTY_DATA to false. This will not restrict self hosted users from visiting all the pages unless data is ingested.