### PR TITLE
perf: add a new configure to enable infer schema in datafusion

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -336,6 +336,13 @@ pub struct Common {
     pub feature_query_queue_enabled: bool,
     #[env_config(name = "ZO_FEATURE_QUERY_PARTITION_STRATEGY", default = "file_num")]
     pub feature_query_partition_strategy: String,
+    #[env_config(name = "ZO_FEATURE_QUERY_INFER_SCHEMA", default = false)]
+    pub feature_query_infer_schema: bool,
+    #[env_config(
+        name = "ZO_FEATURE_QUERY_INFER_SCHEMA_IF_FIELDS_MORE_THAN",
+        default = 0
+    )]
+    pub feature_query_infer_schema_if_fields_more_than: usize,
     #[env_config(name = "ZO_UI_ENABLED", default = true)]
     pub ui_enabled: bool,
     #[env_config(name = "ZO_UI_SQL_BASE64_ENABLED", default = false)]


### PR DESCRIPTION
```
ZO_FEATURE_QUERY_INFER_SCHEMA=false
```
- By default, this is set to `false`. In this case, the latest schema we have created is used by Datafusion, reducing the need to infer the schema from the files.
- When set to `true`, our own schema is ignored, allowing Datafusion to infer the schema from all the Parquet files and merge the resulting schema.

An alternative solution:

```
ZO_FEATURE_QUERY_INFER_SCHEMA_IF_FIELDS_MORE_THAN=0
```
- This value can be set to a larger number, such as `1000`. If the number of fields in the latest schema exceeds this value, our schema will be skipped and the schema will be inferred from the Parquet files being searched.