### PR TITLE
feat: introduce alert emails in backend

### DIFF
--- a/src/common/meta/alerts/destinations.rs
+++ b/src/common/meta/alerts/destinations.rs
@@ -25,13 +25,32 @@ use super::templates::Template;
 pub struct Destination {
     #[serde(default)]
     pub name: String,
+    /// Required for `Http` destination_type
+    #[serde(default)]
     pub url: String,
+    /// Required for `Http` destination_type
+    #[serde(default)]
     pub method: HTTPType,
     #[serde(default)]
     pub skip_tls_verify: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<HashMap<String, String>>,
     pub template: String,
+    /// Required when `destination_type` is `Email`
+    #[serde(default)]
+    pub emails: Vec<String>,
+    #[serde(rename = "type")]
+    #[serde(default)]
+    pub destination_type: DestinationType,
+}
+
+#[derive(Serialize, Debug, Default, PartialEq, Eq, Deserialize, Clone, ToSchema)]
+pub enum DestinationType {
+    #[default]
+    #[serde(rename = "http")]
+    Http,
+    #[serde(rename = "email")]
+    Email,
 }
 
 impl Destination {
@@ -43,6 +62,8 @@ impl Destination {
             skip_tls_verify: self.skip_tls_verify,
             headers: self.headers.clone(),
             template,
+            emails: self.emails.clone(),
+            destination_type: self.destination_type.clone(),
         }
     }
 }
@@ -57,6 +78,8 @@ pub struct DestinationWithTemplate {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<HashMap<String, String>>,
     pub template: Template,
+    pub emails: Vec<String>,
+    pub destination_type: DestinationType,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, ToSchema)]

--- a/src/common/meta/alerts/templates.rs
+++ b/src/common/meta/alerts/templates.rs
@@ -16,6 +16,8 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use super::destinations::DestinationType;
+
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct Template {
     #[serde(default)]
@@ -25,4 +27,9 @@ pub struct Template {
     #[serde(rename = "isDefault")]
     #[serde(default)]
     pub is_default: Option<bool>,
+    /// Indicates whether the body is
+    /// http or email body
+    #[serde(rename = "type")]
+    #[serde(default)]
+    pub template_type: DestinationType,
 }

--- a/src/handler/http/request/alerts/destinations.rs
+++ b/src/handler/http/request/alerts/destinations.rs
@@ -48,7 +48,10 @@ pub async fn save_destination(
     let dest = dest.into_inner();
     match destinations::save(&org_id, "", dest, true).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert destination saved")),
-        Err(e) => Ok(MetaHttpResponse::bad_request(e)),
+        Err(e) => match e {
+            (http::StatusCode::BAD_REQUEST, e) => Ok(MetaHttpResponse::bad_request(e)),
+            (_, e) => Ok(MetaHttpResponse::internal_error(e)),
+        },
     }
 }
 
@@ -80,7 +83,10 @@ pub async fn update_destination(
     let name = name.trim();
     match destinations::save(&org_id, name, dest, false).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert destination saved")),
-        Err(e) => Ok(MetaHttpResponse::bad_request(e)),
+        Err(e) => match e {
+            (http::StatusCode::BAD_REQUEST, e) => Ok(MetaHttpResponse::bad_request(e)),
+            (_, e) => Ok(MetaHttpResponse::internal_error(e)),
+        },
     }
 }
 


### PR DESCRIPTION
Addresses #2601.

No breaking API changes. For destination and template, previous API payloads work as "http" type destination/template payload. For "email" destination/template -

**Email destination**
supports multiple emails. Example payload -
```
{
    "name": "email destination",
    "template": "my new template",
    "emails": ["example@hi.com", "hi@mail.com"],
    "type": "email"
}
```
The above payload creates the following Destination instance - 
```
{
    "name": "email destination",
    "url": "", //ignored
    "method": "post", //ignored
    "skip_tls_verify": false, //ignored
    "template": "my new template",
    "emails": [
      "subhradeepc461@gmail.com",
      "chakrabortyabhradeep79@gmail.com"
    ],
    "type": "email"
}
```

**Email template**
Example API payload. Supports all variables in "{}" as it does for the "http" template -
```
{
    "name": "my new template",
    "body": "<b>Hello</b> {alert_name} <i>World!</i>",
    "isDefault": true,
    "type": "email"
}
```
