### PR TITLE
fix: search got parquet not found

### DIFF
--- a/src/infra/src/cache/tmpfs.rs
+++ b/src/infra/src/cache/tmpfs.rs
@@ -13,10 +13,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
-
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use hashbrown::HashMap;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 

--- a/src/job/compact.rs
+++ b/src/job/compact.rs
@@ -44,7 +44,6 @@ async fn run_merge() -> Result<(), anyhow::Error> {
     interval.tick().await; // trigger the first run
     loop {
         interval.tick().await;
-        log::warn!("Running merge");
         let locker = service::compact::QUEUE_LOCKER.clone();
         let locker = locker.lock().await;
         let ret = service::compact::run_merge().await;

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -435,7 +435,7 @@ pub(crate) async fn generate_index_on_ingester(
         &hour_key,
     )
     .await?;
-    log::warn!("[INGESTER:JOB] Written index file successfully");
+    log::debug!("[INGESTER:JOB] Written index file successfully");
     Ok(arrow_file_name)
 }
 
@@ -498,7 +498,7 @@ pub(crate) async fn generate_index_on_compactor(
     )
     .await?;
 
-    log::warn!("[COMPACTOR:JOB] Written index file successfully");
+    log::debug!("[COMPACTOR:JOB] Written index file successfully");
     Ok((filename, filemeta))
 }
 

--- a/src/service/compact/file_list_deleted.rs
+++ b/src/service/compact/file_list_deleted.rs
@@ -28,29 +28,11 @@ pub async fn delete(
     time_max: i64,
     batch_size: i64,
 ) -> Result<i64, anyhow::Error> {
-    log::warn!(
-        "[COMPACT] delete file_list_deleted from {} to {} and org_id {}",
-        time_min,
-        time_max,
-        org_id
-    );
-
     let files = query_deleted(org_id, time_min, time_max, batch_size).await?;
     if files.is_empty() {
-        log::warn!(
-            "[COMPACT] delete file_list_deleted from {} to {} and org_id {} no files found",
-            time_min,
-            time_max,
-            org_id
-        );
         return Ok(0);
     }
     let files_num = files.values().flatten().count() as i64;
-
-    log::warn!(
-        "[COMPACT] delete file_list_deleted files keys: {:?}",
-        files.keys()
-    );
 
     // delete files from storage
     if let Err(e) = storage::del(

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -52,9 +52,6 @@ pub async fn merge_by_stream(
 ) -> Result<(), anyhow::Error> {
     let start = std::time::Instant::now();
 
-    log::warn!("Inside merge_by_stream");
-    log::warn!("CHECKING THE STREAM TYPE: {:?}", stream_type);
-
     // get last compacted offset
     let (mut offset, node) = db::compact::files::get_offset(org_id, stream_type, stream_name).await;
     if !node.is_empty() && LOCAL_NODE_UUID.ne(&node) && get_node_by_uuid(&node).is_some() {
@@ -155,7 +152,6 @@ pub async fn merge_by_stream(
                         .unwrap()
                         * 3))
     {
-        log::warn!("compactor merge: the time is not allowed, just wait");
         return Ok(()); // the time is future, just wait
     }
 
@@ -184,7 +180,6 @@ pub async fn merge_by_stream(
     .await
     .map_err(|e| anyhow::anyhow!("query file list failed: {}", e))?;
 
-    log::warn!("files = {:?}", files);
     if files.is_empty() {
         // this hour is no data, and check if pass allowed_upto, then just write new
         // offset if offset > 0 && offset_time_hour +
@@ -253,7 +248,6 @@ pub async fn merge_by_stream(
                         continue;
                     }
                 };
-                log::warn!("new_file_name = {:?}", new_file_name);
                 if new_file_name.is_empty() {
                     if CONFIG.common.print_key_event {
                         log::info!(

--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -96,7 +96,6 @@ pub async fn run_retention() -> Result<(), anyhow::Error> {
             ret?;
 
             for stream_type in stream_types {
-                log::warn!("Running retention for {} {}", org_id, stream_type);
                 let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
                 for stream_name in streams {
                     let schema = db::schema::get(&org_id, &stream_name, stream_type).await?;
@@ -190,7 +189,6 @@ pub async fn run_merge() -> Result<(), anyhow::Error> {
         StreamType::Index,
     ];
     for org_id in orgs {
-        log::warn!("Running merge for {}", org_id);
         // check backlist
         if !db::file_list::BLOCKED_ORGS.is_empty()
             && db::file_list::BLOCKED_ORGS.contains(&org_id.as_str())
@@ -198,14 +196,12 @@ pub async fn run_merge() -> Result<(), anyhow::Error> {
             continue;
         }
         for stream_type in stream_types {
-            log::warn!("Running merge for {} {}", org_id, stream_type);
             let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
             let mut tasks = Vec::with_capacity(streams.len());
             for stream_name in streams {
                 let Some(node) =
                     get_node_from_consistent_hash(&stream_name, &Role::Compactor).await
                 else {
-                    log::warn!("No compactor node for stream {}", stream_name);
                     continue; // no compactor node
                 };
                 if LOCAL_NODE_UUID.ne(&node) {

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -326,7 +326,7 @@ pub fn check_ingestion_allowed(org_id: &str, stream_name: Option<&str>) -> Resul
         return Err(anyhow!("not an ingester"));
     }
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
-        return Err(anyhow!("Quota exceeded for this organization"));
+        return Err(anyhow!("Quota exceeded for this organization [{}]", org_id));
     }
 
     // check if we are allowed to ingest

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -65,7 +65,7 @@ pub async fn ingest(
     }
 
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
-        return Err(anyhow!("Quota exceeded for this organization"));
+        return Err(anyhow!("Quota exceeded for this organization [{}]", org_id));
     }
 
     // check memtable

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use actix_web::web;
-use anyhow::{anyhow, Error, Result};
+use anyhow::{Error, Result};
 use chrono::{Duration, Utc};
 use config::{
     cluster,
@@ -61,11 +61,14 @@ pub async fn ingest(
 ) -> Result<BulkResponse, anyhow::Error> {
     let start = std::time::Instant::now();
     if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
-        return Err(anyhow!("not an ingester"));
+        return Err(anyhow::anyhow!("not an ingester"));
     }
 
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
-        return Err(anyhow!("Quota exceeded for this organization [{}]", org_id));
+        return Err(anyhow::anyhow!(
+            "Quota exceeded for this organization [{}]",
+            org_id
+        ));
     }
 
     // check memtable

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -72,7 +72,10 @@ pub async fn usage_ingest(
     }
 
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
-        return Err(anyhow::anyhow!("Quota exceeded for this organization"));
+        return Err(anyhow::anyhow!(
+            "Quota exceeded for this organization [{}]",
+            org_id
+        ));
     }
 
     // check if we are allowed to ingest
@@ -256,7 +259,7 @@ pub async fn handle_grpc_request(
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
         return Ok(HttpResponse::Forbidden().json(MetaHttpResponse::error(
             http::StatusCode::FORBIDDEN.into(),
-            "Quota exceeded for this organization".to_string(),
+            format!("Quota exceeded for this organization [{}]", org_id),
         )));
     }
 

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -106,7 +106,7 @@ pub async fn logs_json_handler(
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
         return Ok(HttpResponse::Forbidden().json(MetaHttpResponse::error(
             http::StatusCode::FORBIDDEN.into(),
-            "Quota exceeded for this organization".to_string(),
+            format!("Quota exceeded for this organization [{}]", org_id),
         )));
     }
 

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -52,7 +52,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes, thread_id: usize) -> Result<
     }
 
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
-        return Err(anyhow::anyhow!("Quota exceeded for this organization"));
+        return Err(anyhow!("Quota exceeded for this organization [{}]", org_id));
     }
 
     // check memtable

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -52,7 +52,10 @@ pub async fn ingest(org_id: &str, body: web::Bytes, thread_id: usize) -> Result<
     }
 
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
-        return Err(anyhow!("Quota exceeded for this organization [{}]", org_id));
+        return Err(anyhow::anyhow!(
+            "Quota exceeded for this organization [{}]",
+            org_id
+        ));
     }
 
     // check memtable

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -72,7 +72,7 @@ pub async fn handle_grpc_request(
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
         return Ok(HttpResponse::Forbidden().json(MetaHttpResponse::error(
             http::StatusCode::FORBIDDEN.into(),
-            "Quota exceeded for this organisation".to_string(),
+            format!("Quota exceeded for this organization [{}]", org_id),
         )));
     }
 

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -94,7 +94,7 @@ pub async fn metrics_json_handler(
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
         return Ok(HttpResponse::Forbidden().json(MetaHttpResponse::error(
             http::StatusCode::FORBIDDEN.into(),
-            "Quota exceeded for this organization".to_string(),
+            format!("Quota exceeded for this organization [{}]", org_id),
         )));
     }
 

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -69,7 +69,10 @@ pub async fn remote_write(
     }
 
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
-        return Err(anyhow::anyhow!("Quota exceeded for this organization"));
+        return Err(anyhow::anyhow!(
+            "Quota exceeded for this organization [{}]",
+            org_id
+        ));
     }
 
     // check memtable

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -856,7 +856,7 @@ pub async fn merge(
 
 fn merge_write_recordbatch(batches: &[RecordBatch]) -> Result<(Arc<Schema>, String)> {
     let mut i = 0;
-    let work_dir = format!("/tmp/merge/{}/", ider::generate());
+    let work_dir = format!("/tmp/merge/{}/", ider::uuid());
     let mut schema = Schema::empty();
     for row in batches.iter() {
         if row.num_rows() == 0 {

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -83,7 +83,7 @@ pub async fn handle_trace_request(
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
         return Ok(HttpResponse::Forbidden().json(MetaHttpResponse::error(
             http::StatusCode::FORBIDDEN.into(),
-            "Quota exceeded for this organization".to_string(),
+            format!("Quota exceeded for this organization [{}]", org_id),
         )));
     }
 

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -86,7 +86,7 @@ pub async fn traces_json(
     if !db::file_list::BLOCKED_ORGS.is_empty() && db::file_list::BLOCKED_ORGS.contains(&org_id) {
         return Ok(HttpResponse::Forbidden().json(MetaHttpResponse::error(
             http::StatusCode::FORBIDDEN.into(),
-            "Quota exceeded for this organization".to_string(),
+            format!("Quota exceeded for this organization [{}]", org_id),
         )));
     }
 


### PR DESCRIPTION
The error like this:
```
[session_id 2dFw4lQuKJC4YzLWGUTgdlCj2To] datafusion execute error: Object Store error: Object at location 2dFw4lQuKJC4YzLWGUTgdlCj2To/files/xxxxx/logs/default/0/2024/03/05/05/ef044358a99e1951/1709616013000000.1709616616553572.7170652240892412148.parquet not found: DbError# key /2dFw4lQuKJC4YzLWGUTgdlCj2To/files/xxxxx/logs/default/0/2024/03/05/05/ef044358a99e1951/1709616013000000.1709616616553572.7170652240892412148.parquet does not exist
````

The reason is recently we added search on arrow, but it used same tmpfs directory name, it will clean the tmpfs when arrow search done.