### PR TITLE
fix: debug inverted index

### DIFF
--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -314,6 +314,8 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
             let mut term_map: HashMap<String, Vec<String>> = HashMap::new();
             let mut term_counts: HashMap<String, u64> = HashMap::new();
 
+            println!("index got file_list: {:?}", sorted_data.len());
+
             for (term, filename, count, _timestamp) in sorted_data {
                 let current_count = term_counts.entry(term.clone()).or_insert(0);
                 if *current_count < limit_count {
@@ -321,6 +323,7 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
                     term_map.entry(term).or_insert_with(Vec::new).push(filename);
                 }
             }
+            println!("term_map: {:?}", term_map);
             (
                 term_map
                     .into_iter()
@@ -342,8 +345,8 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
         let mut idx_file_list: Vec<FileKey> = vec![];
         for filename in unique_files {
             let prefixed_filename = format!(
-                "files/{}/logs/{}/{}",
-                meta.org_id, meta.stream_name, filename
+                "files/{}/{}/{}/{}",
+                meta.org_id, stream_type, meta.stream_name, filename
             );
             if let Ok(file_meta) = file_list::get_file_meta(&prefixed_filename).await {
                 idx_file_list.push(FileKey {
@@ -369,6 +372,8 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
             None,
         )
     };
+
+    println!("final file_list: {:?}", file_list.len());
 
     #[cfg(not(feature = "enterprise"))]
     let work_group: Option<String> = None;

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -859,17 +859,17 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
 
     let inverted_index_count = inverted_index_count.unwrap_or_default() as usize;
     // TODO: ingester mixed with querier will has problem.
-    // let inverted_index_total = inverted_index_count + ingester_total;
+    let inverted_index_total = inverted_index_count + ingester_total;
     log::info!("response_total: {}", total);
     log::info!("ingester_total: {}", ingester_total);
     log::info!("inverted_index_count: {}", inverted_index_count);
 
     // Maybe inverted index count is wrong, we use the max value
-    //  if inverted_index_total > total {
-    // result.set_total(inverted_index_total);
-    // } else {
-    result.set_total(total);
-    //}
+    if inverted_index_total > total {
+        result.set_total(inverted_index_total);
+    } else {
+        result.set_total(total);
+    }
     result.set_cluster_took(start.elapsed().as_millis() as usize, took_wait);
     result.set_file_count(scan_stats.files as usize);
     result.set_scan_size(scan_stats.original_size as usize);

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -634,9 +634,7 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
         for agg in resp.aggs {
             // insert count
             if agg.name == "_count" && is_ingester(&node.role) {
-                let value = batches
-                    .entry(format!("agg_ingester_{}", agg.name))
-                    .or_default();
+                let value = batches.entry("agg_ingester_count".to_string()).or_default();
                 if !agg.hits.is_empty() {
                     let buf = Cursor::new(agg.hits.clone());
                     let reader = ipc::reader::FileReader::try_new(buf, None).unwrap();
@@ -661,7 +659,7 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
             sql.origin_sql.clone()
         } else {
             let mut agg_name = name.strip_prefix("agg_").unwrap();
-            if agg_name == "ingester__count" {
+            if agg_name == "ingester_count" {
                 agg_name = "_count";
             }
             sql.aggs.get(agg_name).unwrap().0.clone()
@@ -824,22 +822,22 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
     };
     result.aggs.remove("_count");
     // ingester total
-    let ingester_total = match result.aggs.get("ingester__count") {
+    let ingester_total = match result.aggs.get("ingester_count") {
         Some(v) => v.first().unwrap().get("num").unwrap().as_u64().unwrap() as usize,
         None => result.hits.len(),
     };
-    result.aggs.remove("ingester__count");
+    result.aggs.remove("ingester_count");
 
     let inverted_index_count = inverted_index_count.unwrap_or_default() as usize;
     // TODO: ingester mixed with querier will has problem.
-    // let inverted_index_total = inverted_index_count + ingester_total;
+    let inverted_index_total = inverted_index_count + ingester_total;
     log::info!("response_total: {}", total);
     log::info!("ingester_total: {}", ingester_total);
     log::info!("inverted_index_count: {}", inverted_index_count);
 
     // Maybe inverted index count is wrong, we use the max value
-    if inverted_index_count > total {
-        result.set_total(inverted_index_count + ingester_total);
+    if inverted_index_total > total {
+        result.set_total(inverted_index_total);
     } else {
         result.set_total(total);
     }

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -830,17 +830,17 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
 
     let inverted_index_count = inverted_index_count.unwrap_or_default() as usize;
     // TODO: ingester mixed with querier will has problem.
-    let inverted_index_total = inverted_index_count + ingester_total;
+    // let inverted_index_total = inverted_index_count + ingester_total;
     log::info!("response_total: {}", total);
     log::info!("ingester_total: {}", ingester_total);
     log::info!("inverted_index_count: {}", inverted_index_count);
 
     // Maybe inverted index count is wrong, we use the max value
-    if inverted_index_total > total {
-        result.set_total(inverted_index_total);
-    } else {
-        result.set_total(total);
-    }
+    //  if inverted_index_total > total {
+    // result.set_total(inverted_index_total);
+    // } else {
+    result.set_total(total);
+    //}
     result.set_cluster_took(start.elapsed().as_millis() as usize, took_wait);
     result.set_file_count(scan_stats.files as usize);
     result.set_scan_size(scan_stats.original_size as usize);

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -805,10 +805,28 @@ fn generate_fast_mode_fields_from_schema(
         Some(v) => v.fields(),
         None => schema.fields(),
     };
-    if schema_fields.is_empty() {
+    // TODO: debug for schema fields
+    if schema_fields.len() < 3 {
         log::warn!(
-            "schema fields is empty when generating fast mode fields from schema: {}",
+            "[QUICK_MODE] schema fields is empty when generating fast mode fields from schema: {}",
             stream_key
+        );
+        match file_schema {
+            Some(v) => {
+                log::debug!(
+                    "[QUICK_MODE] stream {}, file_list schema fields: {:?}",
+                    stream_key,
+                    v.fields().iter().map(|f| f.name()).collect::<Vec<_>>()
+                );
+            }
+            None => {
+                log::debug!("[QUICK_MODE] stream {}, file_list schema fields: NONE", stream_key);
+            }
+        }
+        log::debug!(
+            "[QUICK_MODE] stream {}, stream latest schema fields: {:?}",
+            stream_key,
+            schema.fields().iter().map(|f| f.name()).collect::<Vec<_>>()
         );
     }
     let mut fields = match strategy.as_str() {

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -805,10 +805,12 @@ fn generate_fast_mode_fields_from_schema(
         Some(v) => v.fields(),
         None => schema.fields(),
     };
-    log::warn!(
-        "schema fields is empty when generating fast mode fields from schema: {}",
-        stream_key
-    );
+    if schema_fields.is_empty() {
+        log::warn!(
+            "schema fields is empty when generating fast mode fields from schema: {}",
+            stream_key
+        );
+    }
     let mut fields = match strategy.as_str() {
         "last" => {
             let skip = std::cmp::max(0, schema_fields.len() - CONFIG.limit.fast_mode_num_fields);


### PR DESCRIPTION
- [x] fix: inverted index fast mode, need check by search term not by index term, like we search for `container`, if we got the count of all terms contains `container` more than 500, it is enough. if we use index term, like `container_xxx`, it might use all of the file_list
- [x] add some logs for debug empty schema for quick mode