### PR TITLE
feat: introduce cron jobs for alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,6 +2299,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4830,6 +4841,7 @@ dependencies = [
  "clap 4.5.0",
  "cloudevents-sdk",
  "config",
+ "cron",
  "csv",
  "dashmap",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ clap = { version = "4.1", default-features = false, features = [
 ] }
 cloudevents-sdk = { version = "0.7.0", features = ["actix"] }
 csv = "1.2.1"
+cron = "0.12.1"
 dashmap.workspace = true
 datafusion.workspace = true
 datafusion-expr.workspace = true

--- a/src/common/meta/alerts/mod.rs
+++ b/src/common/meta/alerts/mod.rs
@@ -47,6 +47,10 @@ pub struct Alert {
     pub description: String,
     #[serde(default)]
     pub enabled: bool,
+    #[serde(default)]
+    /// Timezone offset in minutes.
+    /// The negative secs means the Western Hemisphere
+    pub tz_offset: i32,
 }
 
 impl PartialEq for Alert {
@@ -72,6 +76,7 @@ impl Default for Alert {
             row_template: "".to_string(),
             description: "".to_string(),
             enabled: false,
+            tz_offset: 0, // UTC
         }
     }
 }
@@ -86,7 +91,20 @@ pub struct TriggerCondition {
     #[serde(default)]
     pub frequency: i64, // 1 minute
     #[serde(default)]
+    pub cron: String, // Cron Expression
+    #[serde(default)]
+    pub frequency_type: AlertFrequencyType,
+    #[serde(default)]
     pub silence: i64, // silence for 10 minutes after fire an alert
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub enum AlertFrequencyType {
+    #[serde(rename = "cron")]
+    Cron,
+    #[serde(rename = "minutes")]
+    #[default]
+    Minutes,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, ToSchema)]

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -13,7 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
 
 use actix_web::http;
 use arrow_schema::DataType;
@@ -27,6 +30,7 @@ use config::{
     },
     CONFIG, SMTP_CLIENT,
 };
+use cron::Schedule;
 use lettre::{message::SinglePart, AsyncTransport, Message};
 
 use super::promql;
@@ -35,7 +39,8 @@ use crate::{
         meta::{
             alerts::{
                 destinations::{DestinationType, DestinationWithTemplate, HTTPType},
-                AggFunction, Alert, Condition, Operator, QueryCondition, QueryType,
+                AggFunction, Alert, AlertFrequencyType, Condition, Operator, QueryCondition,
+                QueryType,
             },
             authz::Authz,
             search,
@@ -82,8 +87,11 @@ pub async fn save(
         }
     }
 
-    // default frequency is 60 seconds
-    if alert.trigger_condition.frequency == 0 {
+    if alert.trigger_condition.frequency_type == AlertFrequencyType::Cron {
+        // Check the cron expression
+        Schedule::from_str(&alert.trigger_condition.cron)?;
+    } else if alert.trigger_condition.frequency == 0 {
+        // default frequency is 60 seconds
         alert.trigger_condition.frequency = std::cmp::max(10, CONFIG.limit.alert_schedule_interval);
     }
 


### PR DESCRIPTION
Uses `cron` crate to parse the cron expressions. Additionally, rather than the standard 5 column cron expressions, it uses 7 columns (sec and year is added) -

| sec | min |  hour |  day of month |    month  |   day of week  |   year |
|-----|-----|--------|----------------|------------|-----------------|-------|
|  0   |  30  |  15     |      1,15            | May-Aug |  Mon,Wed,Fri  |     *    |


The above expression evaluates to - each year from May to Aug, on 1st and 15th day of month, on Mon/Wed/Fri at 15:30.

Non-breaking API changes. Adds the following optional extra fields -
```
{
      "name": "cron_alert_test_1",
      "org_id": "default",
      "stream_type": "logs",
      "stream_name": "default",
      "is_real_time": false,
      "query_condition": {
        "type": "custom",
        "conditions": [
          {
            "column": "kubernetes_pod_id",
            "operator": ">=",
            "value": "2000",
            "ignore_case": false
          }
        ],
        "sql": "",
        "promql": "",
        "promql_condition": null,
        "aggregation": null
      },
      "trigger_condition": {
        "period": 10,
        "operator": ">=",
        "threshold": 3,
        "frequency": 1, // Ignored when frequency type is "cron"
        "cron": "0 */2 * * * * *", // New field. Valid cron expression. Default is empty.
        "frequency_type": "cron", // New field: possible values - "cron", "minutes" (default)
        "silence": 10
      },
      "destinations": [
        "test_cron"
      ],
      "context_attributes": {},
      "row_template": "",
      "description": "cron description",
      "enabled": true,
      "tz_offset": 330 // New field. Timezone offset in minutes, negative means western hemisphere.
    }
```

If the cron expression is not valid, the alert with `frequency_type: "cron"` will not be saved.