### PR TITLE
 feat: added a new string_to_array_v2 udf function

### DIFF
--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -37,7 +37,7 @@ use config::{
 };
 use datafusion::{
     arrow::json as arrow_json, common::ExprSchema, datasource::MemTable,
-    execution::context::SessionContext, prelude::*, scalar::ScalarValue,
+    execution::context::SessionContext, prelude::*,
 };
 use infra::{cache, storage};
 use parquet::arrow::{

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -1455,6 +1455,7 @@ async fn register_udf(ctx: &mut SessionContext, _org_id: &str) {
     ctx.register_udf(super::regexp_udf::REGEX_NOT_MATCH_UDF.clone());
     ctx.register_udf(super::time_range_udf::TIME_RANGE_UDF.clone());
     ctx.register_udf(super::date_format_udf::DATE_FORMAT_UDF.clone());
+    ctx.register_udf(super::string_to_array_v2_udf::STRING_TO_ARRAY_V2_UDF.clone());
 
     {
         let udf_list = get_all_transform(_org_id).await;

--- a/src/service/search/datafusion/mod.rs
+++ b/src/service/search/datafusion/mod.rs
@@ -22,6 +22,7 @@ pub mod exec;
 pub mod match_udf;
 pub mod regexp_udf;
 pub mod storage;
+pub mod string_to_array_v2_udf;
 mod time_range_udf;
 mod transform_udf;
 

--- a/src/service/search/datafusion/string_to_array_v2_udf.rs
+++ b/src/service/search/datafusion/string_to_array_v2_udf.rs
@@ -1,0 +1,162 @@
+// Copyright 2023 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ListBuilder, StringBuilder};
+use arrow_schema::Field;
+use datafusion::{
+    arrow::{array::ArrayRef, datatypes::DataType},
+    common::cast::as_generic_string_array,
+    error::DataFusionError,
+    logical_expr::{ScalarFunctionImplementation, ScalarUDF, Volatility},
+    physical_plan::functions::make_scalar_function,
+    prelude::create_udf,
+};
+use once_cell::sync::Lazy;
+
+/// The name of the string_to_array_v2 UDF given to DataFusion.
+pub const STRING_TO_ARRAY_V2_UDF_NAME: &str = "string_to_array_v2";
+
+/// Implementation of string_to_array_v2
+pub(crate) static STRING_TO_ARRAY_V2_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
+    create_udf(
+        STRING_TO_ARRAY_V2_UDF_NAME,
+        // takes two arguments: regex, pattern
+        vec![DataType::Utf8, DataType::Utf8],
+        Arc::new(DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Utf8,
+            true,
+        )))),
+        Volatility::Immutable,
+        string_to_array_v2_impl(),
+    )
+});
+
+/// date_format function for datafusion
+pub fn string_to_array_v2_impl() -> ScalarFunctionImplementation {
+    let func = move |args: &[ArrayRef]| -> datafusion::error::Result<ArrayRef> {
+        let string_array = as_generic_string_array::<i32>(&args[0])?;
+        let delimiter_array = as_generic_string_array::<i32>(&args[1])?;
+
+        let mut list_builder = ListBuilder::new(StringBuilder::with_capacity(
+            string_array.len(),
+            string_array.get_buffer_memory_size(),
+        ));
+
+        match args.len() {
+            2 => {
+                string_array
+                    .iter()
+                    .zip(delimiter_array.iter())
+                    .for_each(|(string, delimiter)| {
+                        match (string, delimiter) {
+                            (Some(string), Some("")) => {
+                                list_builder.values().append_value(string);
+                                list_builder.append(true);
+                            }
+                            (Some(string), Some(delimiter)) => {
+                                string.split(|c| delimiter.contains(c)).for_each(|s| {
+                                    if !s.is_empty() {
+                                        list_builder.values().append_value(s);
+                                    }
+                                });
+                                list_builder.append(true);
+                            }
+                            (Some(string), None) => {
+                                string.chars().map(|c| c.to_string()).for_each(|c| {
+                                    list_builder.values().append_value(c);
+                                });
+                                list_builder.append(true);
+                            }
+                            _ => list_builder.append(false), // null value
+                        }
+                    });
+            }
+            _ => {
+                return Err(DataFusionError::NotImplemented(
+                    "Expect string_to_array_v2 function to take two or three parameters".into(),
+                ));
+            }
+        }
+
+        let list_array = list_builder.finish();
+        Ok(Arc::new(list_array) as ArrayRef)
+    };
+
+    make_scalar_function(func)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::{
+        arrow::{
+            array::StringArray,
+            datatypes::{DataType, Field, Schema},
+            record_batch::RecordBatch,
+        },
+        assert_batches_eq,
+        datasource::MemTable,
+        prelude::SessionContext,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_string_to_array_v2_format() {
+        // let log_line = r#"2024-02-29T14:25:27.964079614+00:00 INFO actix_web::middleware::logger:
+        // 10.1.59.229 "GET /healthz HTTP/1.1" 200 15 "-" "-" "kube-probe/1.28" 0.000049"#;
+        let log_line = r#"var-log0::log"#;
+        let sqls = [(
+            "select string_to_array_v2(log, '-:,::') as ret from t",
+            vec![
+                "+------------------+",
+                "| ret              |",
+                "+------------------+",
+                "| [var, log0, log] |",
+                "+------------------+",
+            ],
+        )];
+
+        // define a schema.
+        let schema = Arc::new(Schema::new(vec![Field::new("log", DataType::Utf8, false)]));
+
+        // define data.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![log_line]))],
+        )
+        .unwrap();
+
+        // declare a new context. In spark API, this corresponds to a new spark
+        // SQLsession
+        let ctx = SessionContext::new();
+        ctx.register_udf(STRING_TO_ARRAY_V2_UDF.clone());
+
+        // declare a table in memory. In spark API, this corresponds to
+        // createDataFrame(...).
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(&item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+}

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -480,6 +480,7 @@ impl Sql {
                     func = "ILIKE";
                 }
                 indexed_search.push(format!("\"{}\" {} '%{}%'", field.name(), func, item.1));
+
                 fts_terms.insert(item.1.clone());
             }
             if indexed_search.is_empty() {

--- a/web/src/components/dashboards/QueryEditor.vue
+++ b/web/src/components/dashboards/QueryEditor.vue
@@ -15,12 +15,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div
-    data-test="dashboard-panel-query-editor-div"
-    class="dashboard-query-editor"
-    ref="editorRef"
-    id="editor"
-  ></div>
+  <div data-test="dashboard-panel-query-editor-div" class="dashboard-query-editor" ref="editorRef" id="editor"></div>
 </template>
 
 <script lang="ts">
@@ -334,7 +329,7 @@ export default defineComponent({
       registerAutoCompleteProvider();
       window.addEventListener("resize", async () => {
         await nextTick();
-          editorObj.layout();
+        editorObj.layout();
         // queryEditorRef.value.resetEditorLayout();
       });
     });
@@ -407,6 +402,8 @@ export default defineComponent({
               insertText: `match_all_indexed_ignore_case('${lastElement}')`,
               range: range,
             });
+
+
           } else {
             props.suggestions.forEach((suggestion: any) => {
               filteredSuggestions.push({
@@ -504,6 +501,7 @@ export default defineComponent({
 
 <style lang="scss">
 .dashboard-query-editor {
+
   .monaco-editor,
   .monaco-editor .monaco-editor {
     padding: 0px 0px 0px 0px !important;

--- a/web/src/composables/useSuggestions.ts
+++ b/web/src/composables/useSuggestions.ts
@@ -115,6 +115,7 @@ const defaultSuggestions = [
     kind: "Text",
     insertText: (_keyword: string) => `match_all_indexed_ignore_case('${_keyword}')`,
   },
+
 ];
 
 const useSqlSuggestions = () => {


### PR DESCRIPTION
   
  
  Incoming utf-8 types can now be split via punctuation
  marks, rather than simply space.
  The difference from datafusion string_to_array() is that v2 which now accepts
  a list of delimiters, currently it is all the punctuation marks in
  english alphabets.
  
  The terms are also cleaned up using `btrim` using similar
  set of characters.
