### PR TITLE
feat: add file cache gc function

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -578,6 +578,10 @@ pub struct MemoryCache {
     // MB, when cache is full will release how many data once time, default is 1% of max_size
     #[env_config(name = "ZO_MEMORY_CACHE_RELEASE_SIZE", default = 0)]
     pub release_size: usize,
+    #[env_config(name = "ZO_MEMORY_CACHE_GC_SIZE", default = 10)] // MB
+    pub gc_size: usize,
+    #[env_config(name = "ZO_MEMORY_CACHE_GC_INTERVAL", default = 10)] // seconds
+    pub gc_interval: u64,
     // MB, default is 50% of system memory
     #[env_config(name = "ZO_MEMORY_CACHE_DATAFUSION_MAX_SIZE", default = 0)]
     pub datafusion_max_size: usize,
@@ -602,6 +606,10 @@ pub struct DiskCache {
     // MB, when cache is full will release how many data once time, default is 1% of max_size
     #[env_config(name = "ZO_DISK_CACHE_RELEASE_SIZE", default = 0)]
     pub release_size: usize,
+    #[env_config(name = "ZO_DISK_CACHE_GC_SIZE", default = 10)] // MB
+    pub gc_size: usize,
+    #[env_config(name = "ZO_DISK_CACHE_GC_INTERVAL", default = 10)] // seconds
+    pub gc_interval: u64,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -600,7 +600,7 @@ pub struct MemoryCache {
     pub release_size: usize,
     #[env_config(name = "ZO_MEMORY_CACHE_GC_SIZE", default = 10)] // MB
     pub gc_size: usize,
-    #[env_config(name = "ZO_MEMORY_CACHE_GC_INTERVAL", default = 10)] // seconds
+    #[env_config(name = "ZO_MEMORY_CACHE_GC_INTERVAL", default = 0)] // seconds
     pub gc_interval: u64,
     // MB, default is 50% of system memory
     #[env_config(name = "ZO_MEMORY_CACHE_DATAFUSION_MAX_SIZE", default = 0)]
@@ -628,7 +628,7 @@ pub struct DiskCache {
     pub release_size: usize,
     #[env_config(name = "ZO_DISK_CACHE_GC_SIZE", default = 10)] // MB
     pub gc_size: usize,
-    #[env_config(name = "ZO_DISK_CACHE_GC_INTERVAL", default = 10)] // seconds
+    #[env_config(name = "ZO_DISK_CACHE_GC_INTERVAL", default = 0)] // seconds
     pub gc_interval: u64,
 }
 

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -549,6 +549,8 @@ pub struct Compact {
     pub enabled: bool,
     #[env_config(name = "ZO_COMPACT_INTERVAL", default = 60)] // seconds
     pub interval: u64,
+    #[env_config(name = "ZO_COMPACT_LOOKBACK_HOURS", default = 0)] // hours
+    pub lookback_hours: i64,
     #[env_config(name = "ZO_COMPACT_STEP_SECS", default = 3600)] // seconds
     pub step_secs: i64,
     #[env_config(name = "ZO_COMPACT_SYNC_TO_DB_INTERVAL", default = 1800)] // seconds

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -158,7 +158,7 @@ impl FileData {
         need_release_size: usize,
     ) -> Result<(), anyhow::Error> {
         log::info!(
-            "[session_id {session_id}] File disk cache start gc {}/{}, need release {} bytes",
+            "[session_id {session_id}] File disk cache start gc {}/{}, need to release {} bytes",
             self.cur_size,
             self.max_size,
             need_release_size
@@ -192,6 +192,10 @@ impl FileData {
             }
         }
         self.cur_size -= release_size;
+        log::info!(
+            "[session_id {session_id}] File disk cache gc done, released {} bytes",
+            release_size
+        );
         Ok(())
     }
 

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -218,6 +218,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
     files.load().await?;
 
     tokio::task::spawn(async move {
+        if CONFIG.disk_cache.gc_interval == 0 {
+            return;
+        }
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(
             config::CONFIG.disk_cache.gc_interval,
         ));

--- a/src/infra/src/cache/file_data/memory.rs
+++ b/src/infra/src/cache/file_data/memory.rs
@@ -174,6 +174,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
     _ = files.get("", None).await;
 
     tokio::task::spawn(async move {
+        if CONFIG.memory_cache.gc_interval == 0 {
+            return;
+        }
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(
             config::CONFIG.memory_cache.gc_interval,
         ));

--- a/src/infra/src/cache/file_data/memory.rs
+++ b/src/infra/src/cache/file_data/memory.rs
@@ -113,7 +113,7 @@ impl FileData {
         need_release_size: usize,
     ) -> Result<(), anyhow::Error> {
         log::info!(
-            "[session_id {session_id}] File memory cache start gc {}/{}, need release {} bytes",
+            "[session_id {session_id}] File memory cache start gc {}/{}, need to release {} bytes",
             self.cur_size,
             self.max_size,
             need_release_size
@@ -149,6 +149,10 @@ impl FileData {
         }
         self.cur_size -= release_size;
         DATA.shrink_to_fit();
+        log::info!(
+            "[session_id {session_id}] File memory cache gc done, released {} bytes",
+            release_size
+        );
         Ok(())
     }
 


### PR DESCRIPTION
impl #2874 

Add new ENV for compactor:

```
ZO_COMPACT_LOOKBACK_HOURS=0
```

With this you can let the compactor process the files x hours ago.

Add new ENV for file cache:

```
ZO_MEMORY_CACHE_GC_SIZE=10 // MB
ZO_MEMORY_CACHE_GC_INTERVAL=0 // seconds
ZO_DISK_CACHE_GC_SIZE=10 // MB
ZO_DISK_CACHE_GC_INTERVAL=0 // seconds
```

If `gc_interval` greater than 0 will enable file cache `garbage collection` to guarantee there is always available space for caching new files. every time it will release `gc_size` if the availabe space less than `ZO_MEMORY_CACHE_RELEASE_SIZE`
