### PR TITLE
fix: ensure trim and split on different chars

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -60,6 +60,9 @@ pub const FILE_EXT_JSON: &str = ".json";
 pub const FILE_EXT_ARROW: &str = ".arrow";
 pub const FILE_EXT_PARQUET: &str = ".parquet";
 
+pub const DEFAULT_INDEX_TRIM_CHARS: &str = "!\"#$%&'()*+, -./:;<=>?@[\\]^_`{|}~";
+pub const INDEX_MIN_CHAR_LEN: usize = 3;
+
 const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 8] = [
     "log", "message", "msg", "content", "data", "body", "events", "json",
 ];
@@ -440,6 +443,14 @@ pub struct Common {
         help = "Toggle inverted index generation."
     )]
     pub inverted_index_enabled: bool,
+
+    #[env_config(
+        name = "ZO_INVERTED_INDEX_SPLIT_CHARS",
+        default = " ;,",
+        help = "Characters which should be used as a delimiter to split the string."
+    )]
+    pub inverted_index_split_chars: String,
+
     #[env_config(
         name = "ZO_QUERY_ON_STREAM_SELECTION",
         default = true,

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -33,7 +33,7 @@ use config::{
         parquet::read_metadata_from_file,
         schema_ext::SchemaExt,
     },
-    FxIndexMap, CONFIG,
+    FxIndexMap, CONFIG, DEFAULT_INDEX_TRIM_CHARS, INDEX_MIN_CHAR_LEN,
 };
 use datafusion::{arrow::json as arrow_json, datasource::MemTable, prelude::*};
 use infra::{cache, storage};
@@ -563,8 +563,9 @@ async fn prepare_index_record_batches_v1(
         }
 
         let column_name = column.name();
-        let split_chars = "!\"#$%&'()*+, -./:;<=>?@[\\]^_`{|}~";
-        let remove_chars_btrim = split_chars;
+        let split_chars = &CONFIG.common.inverted_index_split_chars;
+
+        let remove_chars_btrim = DEFAULT_INDEX_TRIM_CHARS;
         let lower_case_expr = lower(concat(&[col(column_name), lit("")]));
         let split_arr = STRING_TO_ARRAY_V2_UDF.call(vec![lower_case_expr, lit(split_chars)]);
         let distinct_terms = array_distinct(split_arr);
@@ -584,7 +585,7 @@ async fn prepare_index_record_batches_v1(
             )?
             .with_column("character_len", character_length(col("term")))?
             .with_column("deleted", lit(false))?
-            .filter(col("character_len").gt_eq(lit(3)))?
+            .filter(col("character_len").gt_eq(lit(INDEX_MIN_CHAR_LEN as i32)))?
             .select_columns(&["term", "file_name", "_timestamp", "_count", "deleted"])?
             .collect()
             .await?;

--- a/src/service/search/datafusion/string_to_array_v2_udf.rs
+++ b/src/service/search/datafusion/string_to_array_v2_udf.rs
@@ -115,9 +115,12 @@ mod tests {
     async fn test_string_to_array_v2_format() {
         // let log_line = r#"2024-02-29T14:25:27.964079614+00:00 INFO actix_web::middleware::logger:
         // 10.1.59.229 "GET /healthz HTTP/1.1" 200 15 "-" "-" "kube-probe/1.28" 0.000049"#;
-        let log_line = r#"var-log0::log"#;
+        let log_line = r#"2024-03-12T15:05:20.366673042+00:00 INFO ingester::writer: [INGESTER:WAL] dones add to IMMUTABLES, file: ./data/wal/logs/0/sunny_organization_11122_zugLe5petywQwty/metrics/1709633785173906.wal,"#;
+
+        // let log_line = r#"var-log0::log"#;
         let sqls = [(
-            "select string_to_array_v2(log, '-:,::') as ret from t",
+            // "select string_to_array_v2(log, '-:,::') as ret from t",
+            "select string_to_array_v2(log, ' /') as ret from t",
             vec![
                 "+------------------+",
                 "| ret              |",

--- a/src/service/search/datafusion/string_to_array_v2_udf.rs
+++ b/src/service/search/datafusion/string_to_array_v2_udf.rs
@@ -115,12 +115,15 @@ mod tests {
     async fn test_string_to_array_v2_format() {
         // let log_line = r#"2024-02-29T14:25:27.964079614+00:00 INFO actix_web::middleware::logger:
         // 10.1.59.229 "GET /healthz HTTP/1.1" 200 15 "-" "-" "kube-probe/1.28" 0.000049"#;
-        let log_line = r#"2024-03-12T15:05:20.366673042+00:00 INFO ingester::writer: [INGESTER:WAL] dones add to IMMUTABLES, file: ./data/wal/logs/0/sunny_organization_11122_zugLe5petywQwty/metrics/1709633785173906.wal,"#;
+        // let log_line = r#"2024-03-12T15:05:20.366673042+00:00 INFO ingester::writer:
+        // [INGESTER:WAL] dones add to IMMUTABLES, file:
+        // ./data/wal/logs/0/sunny_organization_11122_zugLe5petywQwty/metrics/1709633785173906.wal,"
+        // #;
 
-        // let log_line = r#"var-log0::log"#;
+        let log_line = r#"var-log0::log"#;
         let sqls = [(
-            // "select string_to_array_v2(log, '-:,::') as ret from t",
-            "select string_to_array_v2(log, ' /') as ret from t",
+            "select string_to_array_v2(log, '-:,::') as ret from t",
+            // "select string_to_array_v2(log, ' /') as ret from t",
             vec![
                 "+------------------+",
                 "| ret              |",


### PR DESCRIPTION
We now ensure that trim/split are being done on different set of chars. Earlier they were shared.

Also added a new env var to split ZO_INVERTED_INDEX_SPLIT_CHARS e.g.
ZO_INVERTED_INDEX_SPLIT_CHARS: '_/- '