### PR TITLE
fix: show absoulte time with timezone in header for printmode

### DIFF
--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -301,6 +301,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    initialTimezone: {
+      required: false,
+      default: null,
+    },
   },
 
   emits: ["on:date-change", "on:timezone-change"],
@@ -331,6 +335,31 @@ export default defineComponent({
     // Add the UTC option
     timezoneOptions.unshift("UTC");
     timezoneOptions.unshift(browserTime);
+
+    const onTimezoneChange = async () => {
+      let selectedTimezone = timezone.value;
+      if (selectedTimezone.toLowerCase() == browserTime.toLowerCase()) {
+        selectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      }
+      //Intl.DateTimeFormat().resolvedOptions().timeZone
+      useLocalTimezone(selectedTimezone);
+      store.dispatch("setTimezone", selectedTimezone);
+      await nextTick();
+      if (selectedType.value == "absolute") saveDate("absolute");
+      else saveDate("relative");
+      emit("on:timezone-change");
+    };
+
+    // if initial timezone is provided
+    if (props.initialTimezone) {
+      // check if it is a valid timezone
+      timezone.value =
+        timezoneOptions.find(
+          (tz) => tz.toLowerCase() === props.initialTimezone?.toLowerCase()
+        ) || currentTimezone;
+
+      onTimezoneChange();
+    }
 
     const filteredTimezone: any = ref([]);
 
@@ -424,20 +453,6 @@ export default defineComponent({
 
     const onCustomPeriodSelect = () => {
       if (props.autoApply) saveDate("relative-custom");
-    };
-
-    const onTimezoneChange = async () => {
-      let selectedTimezone = timezone.value;
-      if (selectedTimezone.toLowerCase() == browserTime.toLowerCase()) {
-        selectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      }
-      //Intl.DateTimeFormat().resolvedOptions().timeZone
-      useLocalTimezone(selectedTimezone);
-      store.dispatch("setTimezone", selectedTimezone);
-      await nextTick();
-      if (selectedType.value == "absolute") saveDate("absolute");
-      else saveDate("relative");
-      emit("on:timezone-change");
     };
 
     const setRelativeTime = (period) => {

--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -353,11 +353,13 @@ export default defineComponent({
     // if initial timezone is provided
     if (props.initialTimezone) {
       // check if it is a valid timezone
+      // ignore case
       timezone.value =
         timezoneOptions.find(
           (tz) => tz.toLowerCase() === props.initialTimezone?.toLowerCase()
         ) || currentTimezone;
 
+      // call onTimezoneChange to set the timezone in the store
       onTimezoneChange();
     }
 

--- a/web/src/components/DateTimePickerDashboard.vue
+++ b/web/src/components/DateTimePickerDashboard.vue
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     }"
     :default-relative-time="modelValue.relativeTimePeriod"
     @on:date-change="updateDateTime"
+    :initialTimezone="initialTimezone"
   >
   </date-time>
 </template>
@@ -46,6 +47,10 @@ export default defineComponent({
         relativeTimePeriod: "15m",
         valueType: "relative",
       }),
+    },
+    initialTimezone: {
+      required: false,
+      default: null,
     },
   },
   emits: ["update:modelValue"],

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -79,21 +79,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               style="padding-top: 5px"
             >
               {{
-                new Date(currentTimeObj?.start_time?.getTime() / 1000)
-                  .toISOString()
-                  .replace(/T/, " ")
-                  .replace(/\..+/, "")
-                  .replace(/-/g, "/")
-                  .slice(0, 16)
+                formatDate(
+                  new Date(currentTimeObj?.start_time?.getTime() / 1000)
+                )
               }}
               -
               {{
-                new Date(currentTimeObj?.end_time?.getTime() / 1000)
-                  .toISOString()
-                  .replace(/T/, " ")
-                  .replace(/\..+/, "")
-                  .replace(/-/g, "/")
-                  .slice(0, 16)
+                formatDate(new Date(currentTimeObj?.end_time?.getTime() / 1000))
               }}
             </div>
             <DateTimePickerDashboard
@@ -631,6 +623,16 @@ export default defineComponent({
       isFullscreen.value = false;
     });
 
+    const formatDate = (d: Date) => {
+      var year = d.getFullYear();
+      var month = ("0" + (d.getMonth() + 1)).slice(-2); // Months are zero-based
+      var day = ("0" + d.getDate()).slice(-2);
+      var hours = ("0" + d.getHours()).slice(-2);
+      var minutes = ("0" + d.getMinutes()).slice(-2);
+
+      return `${year}/${month}/${day} ${hours}:${minutes}`;
+    };
+
     return {
       currentDashboardData,
       toggleFullscreen,
@@ -661,6 +663,7 @@ export default defineComponent({
       selectedTabId,
       onMovePanel,
       printDashboard,
+      formatDate,
     };
   },
 });

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -655,16 +655,6 @@ export default defineComponent({
       isFullscreen.value = false;
     });
 
-    const formatDate = (d: Date) => {
-      var year = d.getUTCFullYear();
-      var month = ("0" + (d.getUTCMonth() + 1)).slice(-2); // Months are zero-based
-      var day = ("0" + d.getUTCDate()).slice(-2);
-      var hours = ("0" + d.getUTCHours()).slice(-2);
-      var minutes = ("0" + d.getUTCMinutes()).slice(-2);
-
-      return `${year}/${month}/${day} ${hours}:${minutes}`;
-    };
-
     return {
       currentDashboardData,
       toggleFullscreen,
@@ -695,7 +685,6 @@ export default defineComponent({
       selectedTabId,
       onMovePanel,
       printDashboard,
-      formatDate,
       initialTimezone,
       moment,
     };

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -624,11 +624,11 @@ export default defineComponent({
     });
 
     const formatDate = (d: Date) => {
-      var year = d.getFullYear();
-      var month = ("0" + (d.getMonth() + 1)).slice(-2); // Months are zero-based
-      var day = ("0" + d.getDate()).slice(-2);
-      var hours = ("0" + d.getHours()).slice(-2);
-      var minutes = ("0" + d.getMinutes()).slice(-2);
+      var year = d.getUTCFullYear();
+      var month = ("0" + (d.getUTCMonth() + 1)).slice(-2); // Months are zero-based
+      var day = ("0" + d.getUTCDate()).slice(-2);
+      var hours = ("0" + d.getUTCHours()).slice(-2);
+      var minutes = ("0" + d.getUTCMinutes()).slice(-2);
 
       return `${year}/${month}/${day} ${hours}:${minutes}`;
     };

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -69,10 +69,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           /> -->
             <!-- for Print Mode -->
             <!-- if time is relative, show start and end time -->
+            <!-- format: YYYY/MM/DD HH:mm - YYYY/MM/DD HH:mm (TIMEZONE) -->
             <div
               v-if="
                 store.state.printMode === true &&
-                selectedDate.valueType == 'relative' &&
                 currentTimeObj.start_time &&
                 currentTimeObj.end_time
               "
@@ -89,16 +89,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   .tz(store.state.timezone)
                   .format("YYYY/MM/DD HH:mm")
               }}
-              {{ store.state.timezone }}
+              ({{ store.state.timezone }})
             </div>
-            <!-- do not show date time picker for print mode and relative time is selected -->
+            <!-- do not show date time picker for print mode -->
             <DateTimePickerDashboard
-              v-if="
-                !(
-                  store.state.printMode === true &&
-                  selectedDate.valueType === 'relative'
-                )
-              "
+              v-if="store.state.printMode === false"
               ref="dateTimePicker"
               class="dashboard-icons q-ml-sm"
               size="sm"

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -67,6 +67,35 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             ref="refDateTime"
             v-model="selectedDate"
           /> -->
+            <!-- for Print Mode -->
+            <!-- if time is relative, show start and end time -->
+            <div
+              v-if="
+                store.state.printMode === true &&
+                selectedDate.valueType == 'relative' &&
+                currentTimeObj.start_time &&
+                currentTimeObj.end_time
+              "
+              style="padding-top: 5px"
+            >
+              {{
+                new Date(currentTimeObj?.start_time?.getTime() / 1000)
+                  .toISOString()
+                  .replace(/T/, " ")
+                  .replace(/\..+/, "")
+                  .replace(/-/g, "/")
+                  .slice(0, 16)
+              }}
+              -
+              {{
+                new Date(currentTimeObj?.end_time?.getTime() / 1000)
+                  .toISOString()
+                  .replace(/T/, " ")
+                  .replace(/\..+/, "")
+                  .replace(/-/g, "/")
+                  .slice(0, 16)
+              }}
+            </div>
             <DateTimePickerDashboard
               ref="dateTimePicker"
               class="dashboard-icons q-ml-sm"

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -93,7 +93,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
             <!-- do not show date time picker for print mode -->
             <DateTimePickerDashboard
-              v-if="store.state.printMode === false"
+              v-show="store.state.printMode === false"
               ref="dateTimePicker"
               class="dashboard-icons q-ml-sm"
               size="sm"


### PR DESCRIPTION
- show absolute time for print mode with provided timezone.
![image](https://github.com/openobserve/openobserve/assets/141122205/f8900b5b-d87a-49b4-ba02-a583e2d156f2)

