### PR TITLE
fix: Stream UI doesn't show key partition

### DIFF
--- a/web/src/components/logstream/schema.vue
+++ b/web/src/components/logstream/schema.vue
@@ -447,7 +447,7 @@ export default defineComponent({
 
               property.level = level;
 
-              if (partition.types === "values")
+              if (partition.types === "value")
                 fieldIndices.push("keyPartition");
 
               if (partition.types?.hash)


### PR DESCRIPTION
Looks like simple typo issue

https://github.com/openobserve/openobserve/blob/bcc5f7c8658d4dc2464c6bcad11847214f74b859/src/common/meta/stream.rs#L206-L212