### PR TITLE
test: prepopulate the amount of data for each test

### DIFF
--- a/tests/api-testing/tests/conftest.py
+++ b/tests/api-testing/tests/conftest.py
@@ -3,15 +3,18 @@ import pytest
 import os
 import random
 import string
-
+from pathlib import Path
 
 BASE_URL = os.environ["ZO_BASE_URL"]
+root_dir = Path(__file__).parent.parent.parent
+
 
 def random_string(length: int):
     # ascii_letters consist of alphabets for 'a' to 'z' and 'A' to 'Z'
     # digits consist of '0' to '9'
     characters = string.ascii_letters + string.digits
-    return ''.join(random.choices(characters, k=length))
+    return "".join(random.choices(characters, k=length))
+
 
 def _create_session_inner():
     s = requests.Session()
@@ -20,6 +23,7 @@ def _create_session_inner():
     s.auth = (username, password)
     s.post(BASE_URL)
     return s
+
 
 @pytest.fixture
 def create_session():
@@ -39,10 +43,9 @@ def ingest_data():
 
     session = _create_session_inner()
     # Open the json data file and read it
-    with open("tests/test-data/logs_data.json") as f:
+    with open(root_dir / "test-data/logs_data.json") as f:
         data = f.read()
 
-    
     stream_name = "stream_pytest_data"
     org = "org_pytest_data"
     url = f"{BASE_URL}api/{org}/{stream_name}/_json"

--- a/tests/api-testing/tests/conftest.py
+++ b/tests/api-testing/tests/conftest.py
@@ -1,15 +1,19 @@
 import requests
 import pytest
 import os
+import random
+import string
 
 
 BASE_URL = os.environ["ZO_BASE_URL"]
 
+def random_string(length: int):
+    # ascii_letters consist of alphabets for 'a' to 'z' and 'A' to 'Z'
+    # digits consist of '0' to '9'
+    characters = string.ascii_letters + string.digits
+    return ''.join(random.choices(characters, k=length))
 
-@pytest.fixture
-def create_session():
-    """Create a session and return it."""
-
+def _create_session_inner():
     s = requests.Session()
     username = os.environ["ZO_ROOT_USER_EMAIL"]
     password = os.environ["ZO_ROOT_USER_PASSWORD"]
@@ -17,9 +21,30 @@ def create_session():
     s.post(BASE_URL)
     return s
 
+@pytest.fixture
+def create_session():
+    """Create a session and return it."""
+    return _create_session_inner()
+
 
 @pytest.fixture
 def base_url():
     """Return the base URL."""
-
     return BASE_URL
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ingest_data():
+    """Ingest data into the openobserve running instance."""
+
+    session = _create_session_inner()
+    # Open the json data file and read it
+    with open("tests/test-data/logs_data.json") as f:
+        data = f.read()
+
+    
+    stream_name = "stream_pytest_data"
+    org = "org_pytest_data"
+    url = f"{BASE_URL}api/{org}/{stream_name}/_json"
+    resp = session.post(url, data=data, headers={"Content-Type": "application/json"})
+    return resp.status_code == 200

--- a/tests/api-testing/tests/test_logs.py
+++ b/tests/api-testing/tests/test_logs.py
@@ -1,6 +1,5 @@
 def test_e2e_ingestlogs(create_session, base_url):
     """Running an E2E test logs ingestion."""
-
     session = create_session
     url = base_url
     org_id = "default"


### PR DESCRIPTION
Created a fixture which will be available during `scope=session` This will ingest data present in `tests/test-data/logs_data.json` to `org_pytest_data` and `stream_pytest_data`