### PR TITLE
test: prepopulate the amount of data for each test #3000

### DIFF
--- a/tests/api-testing/tests/conftest.py
+++ b/tests/api-testing/tests/conftest.py
@@ -15,13 +15,25 @@ def random_string(length: int):
     characters = string.ascii_letters + string.digits
     return "".join(random.choices(characters, k=length))
 
-
 def _create_session_inner():
     s = requests.Session()
     username = os.environ["ZO_ROOT_USER_EMAIL"]
     password = os.environ["ZO_ROOT_USER_PASSWORD"]
     s.auth = (username, password)
-    s.post(BASE_URL)
+    resp = s.post(BASE_URL)
+    return s
+
+
+def _create_session_inner_v2():
+    s = requests.Session()
+    username = os.environ["ZO_ROOT_USER_EMAIL"]
+    password = os.environ["ZO_ROOT_USER_PASSWORD"]
+    # s.auth = (username, password)
+    # resp = s.post(BASE_URL)
+    resp = s.post(f"{BASE_URL}auth/login", json={"name": username, "password": password})
+    print (resp.status_code)
+    if resp.status_code != 200:
+        raise Exception("Invalid username/password")
     return s
 
 
@@ -50,4 +62,5 @@ def ingest_data():
     org = "org_pytest_data"
     url = f"{BASE_URL}api/{org}/{stream_name}/_json"
     resp = session.post(url, data=data, headers={"Content-Type": "application/json"})
+    print("Data ingested successfully, status code: ", resp.status_code)
     return resp.status_code == 200

--- a/tests/api-testing/tests/conftest.py
+++ b/tests/api-testing/tests/conftest.py
@@ -1,15 +1,22 @@
 import requests
 import pytest
 import os
-
+import random
+import string
+from pathlib import Path
 
 BASE_URL = os.environ["ZO_BASE_URL"]
+root_dir = Path(__file__).parent.parent.parent
 
 
-@pytest.fixture
-def create_session():
-    """Create a session and return it."""
+def random_string(length: int):
+    # ascii_letters consist of alphabets for 'a' to 'z' and 'A' to 'Z'
+    # digits consist of '0' to '9'
+    characters = string.ascii_letters + string.digits
+    return "".join(random.choices(characters, k=length))
 
+
+def _create_session_inner():
     s = requests.Session()
     username = os.environ["ZO_ROOT_USER_EMAIL"]
     password = os.environ["ZO_ROOT_USER_PASSWORD"]
@@ -19,7 +26,28 @@ def create_session():
 
 
 @pytest.fixture
+def create_session():
+    """Create a session and return it."""
+    return _create_session_inner()
+
+
+@pytest.fixture
 def base_url():
     """Return the base URL."""
-
     return BASE_URL
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ingest_data():
+    """Ingest data into the openobserve running instance."""
+
+    session = _create_session_inner()
+    # Open the json data file and read it
+    with open(root_dir / "test-data/logs_data.json") as f:
+        data = f.read()
+
+    stream_name = "stream_pytest_data"
+    org = "org_pytest_data"
+    url = f"{BASE_URL}api/{org}/{stream_name}/_json"
+    resp = session.post(url, data=data, headers={"Content-Type": "application/json"})
+    return resp.status_code == 200

--- a/tests/api-testing/tests/test_search.py
+++ b/tests/api-testing/tests/test_search.py
@@ -6,21 +6,21 @@ import time
 
 
 def test_e2e_alerts(create_session, base_url):
-    """Running an E2E test for get all the alerts list."""
+    """Running an E2E test no payload."""
 
     session = create_session
     url = base_url
     org_id = "default"
 
-    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs")
+    resp_get_allsearch = session.post(f"{url}api/{org_id}/_search?type=logs")
 
     # print(resp_get_allalerts.content)
     assert (
-        resp_get_allalerts.status_code == 400
-    ), f"No payload added 400, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+        resp_get_allsearch.status_code == 400
+    ), f"No payload added 400, but got {resp_get_allsearch.status_code} {resp_get_allsearch.content}"
 
 def test_e2e_query(create_session, base_url):
-    """Running an E2E test for get all the alerts list."""
+    """Running an E2E test for valid sql query."""
 
 
 
@@ -41,17 +41,17 @@ def test_e2e_query(create_session, base_url):
                 },
             }
 
-    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+    resp_get_allsearch = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
    
 
-    # print(resp_get_allalerts.content)
+  
     assert (
-        resp_get_allalerts.status_code == 200
-    ), f"Sql mode added 200, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+        resp_get_allsearch.status_code == 200
+    ), f"Sql mode added 200, but got {resp_get_allsearch.status_code} {resp_get_allsearch.content}"
 
 
 def test_e2e_invalidsqlquery(create_session, base_url):
-    """Running an E2E test for get all the alerts list."""
+    """Running an E2E test for invalid sql query."""
 
 
 
@@ -72,17 +72,17 @@ def test_e2e_invalidsqlquery(create_session, base_url):
                 },
             }
 
-    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+    resp_get_allsearch = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
    
 
     # print(resp_get_allalerts.content)
     assert (
-        resp_get_allalerts.status_code == 500
-    ), f"Sql mode added 500, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+        resp_get_allsearch.status_code == 500
+    ), f"Sql mode added 500, but got {resp_get_allsearch.status_code} {resp_get_allsearch.content}"
 
 
 def test_e2e_limitadded(create_session, base_url):
-    """Running an E2E test for get all the alerts list."""
+    """Running an E2E test add limit to sql query."""
 
 
 
@@ -103,17 +103,17 @@ def test_e2e_limitadded(create_session, base_url):
                 },
             }
 
-    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+    resp_get_allsearch = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
    
 
     # print(resp_get_allalerts.content)
     assert (
-        resp_get_allalerts.status_code == 200
-    ), f"Sql mode added  with limit 200, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+        resp_get_allsearch.status_code == 200
+    ), f"Sql mode added  with limit 200, but got {resp_get_allsearch.status_code} {resp_get_allsearch.content}"
 
 
 def test_e2e_validhistogram(create_session, base_url):
-    """Running an E2E test for get all the alerts list."""
+    """Running an E2E test for valid histogram."""
 
 
 
@@ -138,18 +138,18 @@ def test_e2e_validhistogram(create_session, base_url):
         }
     }
 
-    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+    resp_get_allsearch = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
    
 
     # print(resp_get_allalerts.content)
     assert (
-        resp_get_allalerts.status_code == 200
-    ), f"histogram mode added 200, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+        resp_get_allsearch.status_code == 200
+    ), f"histogram mode added 200, but got {resp_get_allsearch.status_code} {resp_get_allsearch.content}"
 
 
 
 def test_e2e_histogramwithlimit(create_session, base_url):
-    """Running an E2E test for get all the alerts list."""
+    """Running an E2E test for invalid query -history with limit  list."""
 
 
 
@@ -174,10 +174,10 @@ def test_e2e_histogramwithlimit(create_session, base_url):
         }
     }
 
-    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+    resp_get_allsearch = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
    
 
     # print(resp_get_allalerts.content)
     assert (
-        resp_get_allalerts.status_code == 500
-    ), f"histogram mode added 200, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+        resp_get_allsearch.status_code == 500
+    ), f"histogram mode added 200, but got {resp_get_allsearch.status_code} {resp_get_allsearch.content}"

--- a/tests/api-testing/tests/test_search.py
+++ b/tests/api-testing/tests/test_search.py
@@ -1,0 +1,183 @@
+import json
+import requests
+
+from datetime import datetime, timezone, timedelta
+import time
+
+
+def test_e2e_alerts(create_session, base_url):
+    """Running an E2E test for get all the alerts list."""
+
+    session = create_session
+    url = base_url
+    org_id = "default"
+
+    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs")
+
+    # print(resp_get_allalerts.content)
+    assert (
+        resp_get_allalerts.status_code == 400
+    ), f"No payload added 400, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+
+def test_e2e_query(create_session, base_url):
+    """Running an E2E test for get all the alerts list."""
+
+
+
+    session = create_session
+    url = base_url
+    org_id = "org_pytest_data"
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
+    json_data = {
+                "query": {
+                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE code=200',
+                        "start_time": one_min_ago,
+                        "end_time": end_time,
+                        "from": 0,
+                        "size": 150,
+                        "sql_mode": "full",
+                },
+            }
+
+    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+   
+
+    # print(resp_get_allalerts.content)
+    assert (
+        resp_get_allalerts.status_code == 200
+    ), f"Sql mode added 200, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+
+
+def test_e2e_invalidsqlquery(create_session, base_url):
+    """Running an E2E test for get all the alerts list."""
+
+
+
+    session = create_session
+    url = base_url
+    org_id = "org_pytest_data"
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
+    json_data = {
+                "query": {
+                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE code',
+                        "start_time": one_min_ago,
+                        "end_time": end_time,
+                        "from": 0,
+                        "size": 150,
+                        "sql_mode": "full",
+                },
+            }
+
+    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+   
+
+    # print(resp_get_allalerts.content)
+    assert (
+        resp_get_allalerts.status_code == 500
+    ), f"Sql mode added 500, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+
+
+def test_e2e_limitadded(create_session, base_url):
+    """Running an E2E test for get all the alerts list."""
+
+
+
+    session = create_session
+    url = base_url
+    org_id = "org_pytest_data"
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
+    json_data = {
+                "query": {
+                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE code=200 limit 5',
+                        "start_time": one_min_ago,
+                        "end_time": end_time,
+                        "from": 0,
+                        "size": 150,
+                        "sql_mode": "full",
+                },
+            }
+
+    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+   
+
+    # print(resp_get_allalerts.content)
+    assert (
+        resp_get_allalerts.status_code == 200
+    ), f"Sql mode added  with limit 200, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+
+
+def test_e2e_validhistogram(create_session, base_url):
+    """Running an E2E test for get all the alerts list."""
+
+
+
+    session = create_session
+    url = base_url
+    org_id = "org_pytest_data"
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
+    json_data = {
+        "query": {
+             "sql": 'select * from "stream_pytest_data" WHERE code=200',
+            "start_time": one_min_ago,
+            "end_time": end_time,
+            "from": 0,
+            "size": 0,
+            "fast_mode": True,
+            "track_total_hits": True
+        },
+        "aggs": {
+            "histogram": "select histogram(_timestamp, '10 second') AS zo_sql_key, count(*) AS zo_sql_num from query GROUP BY zo_sql_key ORDER BY zo_sql_key"
+        }
+    }
+
+    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+   
+
+    # print(resp_get_allalerts.content)
+    assert (
+        resp_get_allalerts.status_code == 200
+    ), f"histogram mode added 200, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"
+
+
+
+def test_e2e_histogramwithlimit(create_session, base_url):
+    """Running an E2E test for get all the alerts list."""
+
+
+
+    session = create_session
+    url = base_url
+    org_id = "org_pytest_data"
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
+    json_data = {
+        "query": {
+             "sql": 'select * from "stream_pytest_data" WHERE code=200 limit 5',
+            "start_time": one_min_ago,
+            "end_time": end_time,
+            "from": 0,
+            "size": 0,
+            "fast_mode": True,
+            "track_total_hits": True
+        },
+        "aggs": {
+            "histogram": "select histogram(_timestamp, '10 second') AS zo_sql_key, count(*) AS zo_sql_num from query GROUP BY zo_sql_key ORDER BY zo_sql_key"
+        }
+    }
+
+    resp_get_allalerts = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+   
+
+    # print(resp_get_allalerts.content)
+    assert (
+        resp_get_allalerts.status_code == 500
+    ), f"histogram mode added 200, but got {resp_get_allalerts.status_code} {resp_get_allalerts.content}"

--- a/tests/ui-testing/cypress/e2e/tests/alerts_tests.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/alerts_tests.cy.js
@@ -1,6 +1,7 @@
 //<reference types="cypress" />
 import * as logstests from "../allfunctions/logs";
-import logsdata from "../../data/logs_data.json";
+import logsdata from "../../../../../test-data/logs_data.json"
+// import logsdata from "../../data/logs_data.json";
 // import { login } from "../../support/commons"
 // import { selectStreamAndStreamType } from "../../support/log-commons";
 

--- a/tests/ui-testing/cypress/e2e/tests/alerts_tests.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/alerts_tests.cy.js
@@ -1,6 +1,6 @@
 //<reference types="cypress" />
 import * as logstests from "../allfunctions/logs";
-import logsdata from "../../../../../test-data/logs_data.json"
+import logsdata from "../../../../test-data/logs_data.json"
 // import logsdata from "../../data/logs_data.json";
 // import { login } from "../../support/commons"
 // import { selectStreamAndStreamType } from "../../support/log-commons";

--- a/tests/ui-testing/cypress/e2e/tests/dashboard/add_dashboard.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/dashboard/add_dashboard.cy.js
@@ -1,6 +1,7 @@
 ///<reference types="cypress" />
 import { fieldType } from "../../../support/commons";
-import logsdata from "../../../data/logs_data.json"
+import logsdata from "../../../../../test-data/logs_data.json"
+
 Cypress.on("uncaught:exception", (err, runnable) => {
   return false;
 });

--- a/tests/ui-testing/cypress/e2e/tests/dashboard/create_dashboard.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/dashboard/create_dashboard.cy.js
@@ -1,5 +1,7 @@
 ///<reference types="cypress" />
-import logsdata from "../../../data/logs_data.json";
+// import logsdata from "../../../data/logs_data.json";
+import logsdata from "../../../../../test-data/logs_data.json"
+
 import { fieldType } from "../../../support/commons";
 Cypress.on("uncaught:exception", (err, runnable) => {
   return false;

--- a/tests/ui-testing/cypress/e2e/tests/dashboard/edit_dashboard.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/dashboard/edit_dashboard.cy.js
@@ -1,6 +1,7 @@
 ///<reference types="cypress" />
 import { fieldType } from "../../../support/commons";
-import logsdata from "../../../data/logs_data.json"
+// import logsdata from "../../../data/logs_data.json"
+import logsdata from "../../../../../test-data/logs_data.json"
 Cypress.on("uncaught:exception", (err, runnable) => {
   return false;
 });

--- a/tests/ui-testing/cypress/e2e/tests/dashboard/folders.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/dashboard/folders.cy.js
@@ -1,6 +1,7 @@
 ///<reference types="cypress" />
 import { fieldType } from "../../../support/commons";
-import logsdata from "../../../data/logs_data.json";
+import logsdata from "../../../../../test-data/logs_data.json"
+// import logsdata from "../../../data/logs_data.json";
 Cypress.on("uncaught:exception", (err, runnable) => {
   return false;
 });

--- a/tests/ui-testing/cypress/e2e/tests/functions_tests.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/functions_tests.cy.js
@@ -1,7 +1,7 @@
 ///<reference types="cypress" />
 import * as logstests from "../allfunctions/logs";
 import "cypress-file-upload";
-import logsdata from "../../../../../test-data/logs_data.json"
+import logsdata from "../../../../test-data/logs_data.json"
 // import logsdata from "../../data/logs_data.json";
 import { getRandomText } from "../utils";
 // import { login } from "../../support/commons"

--- a/tests/ui-testing/cypress/e2e/tests/functions_tests.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/functions_tests.cy.js
@@ -1,7 +1,8 @@
 ///<reference types="cypress" />
 import * as logstests from "../allfunctions/logs";
 import "cypress-file-upload";
-import logsdata from "../../data/logs_data.json";
+import logsdata from "../../../../../test-data/logs_data.json"
+// import logsdata from "../../data/logs_data.json";
 import { getRandomText } from "../utils";
 // import { login } from "../../support/commons"
 // import { selectStreamAndStreamType } from "../../support/log-commons";

--- a/tests/ui-testing/cypress/e2e/tests/logs_fastmode.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/logs_fastmode.cy.js
@@ -1,6 +1,6 @@
 ///<reference types="cypress" />
 import * as logstests from "../allfunctions/logs";
-import logsdata from "../../data/logs_data.json";
+import logsdata from "../../../../test-data/logs_data.json"
 // import { login } from "../../support/commons"
 // import { selectStreamAndStreamType } from "../../support/log-commons";
 

--- a/tests/ui-testing/cypress/e2e/tests/logs_queries.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/logs_queries.cy.js
@@ -1,6 +1,6 @@
 ///<reference types="cypress" />
 import * as logstests from "../allfunctions/logs";
-import logsdata from "../../../../../test-data/logs_data.json"
+import logsdata from "../../../../test-data/logs_data.json"
 // import logsdata from "../../data/logs_data.json";
 // import { login } from "../../support/commons"
 // import { selectStreamAndStreamType } from "../../support/log-commons";

--- a/tests/ui-testing/cypress/e2e/tests/logs_queries.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/logs_queries.cy.js
@@ -1,6 +1,7 @@
 ///<reference types="cypress" />
 import * as logstests from "../allfunctions/logs";
-import logsdata from "../../data/logs_data.json";
+import logsdata from "../../../../../test-data/logs_data.json"
+// import logsdata from "../../data/logs_data.json";
 // import { login } from "../../support/commons"
 // import { selectStreamAndStreamType } from "../../support/log-commons";
 

--- a/tests/ui-testing/cypress/e2e/tests/logs_tests.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/logs_tests.cy.js
@@ -1,6 +1,6 @@
 ///<reference types="cypress" />
 import * as logstests from "../allfunctions/logs";
-import logsdata from "../../../../../test-data/logs_data.json"
+import logsdata from "../../../../test-data/logs_data.json"
 // import logsdata from "../../data/logs_data.json";
 // import { login } from "../../support/commons"
 // import { selectStreamAndStreamType } from "../../support/log-commons";

--- a/tests/ui-testing/cypress/e2e/tests/logs_tests.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/logs_tests.cy.js
@@ -1,6 +1,7 @@
 ///<reference types="cypress" />
 import * as logstests from "../allfunctions/logs";
-import logsdata from "../../data/logs_data.json";
+import logsdata from "../../../../../test-data/logs_data.json"
+// import logsdata from "../../data/logs_data.json";
 // import { login } from "../../support/commons"
 // import { selectStreamAndStreamType } from "../../support/log-commons";
 

--- a/tests/ui-testing/cypress/e2e/tests/menu_tests.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/menu_tests.cy.js
@@ -1,6 +1,7 @@
 ///<reference types="cypress" />
 import * as menutests from "../allfunctions/menufunctions";
-import logsdata from "../../data/logs_data.json";
+import logsdata from "../../../../../test-data/logs_data.json"
+// import logsdata from "../../data/logs_data.json";
 // import { login } from "../../support/commons"
 // import { selectStreamAndStreamType } from "../../support/log-commons";
 

--- a/tests/ui-testing/cypress/e2e/tests/menu_tests.cy.js
+++ b/tests/ui-testing/cypress/e2e/tests/menu_tests.cy.js
@@ -1,6 +1,6 @@
 ///<reference types="cypress" />
 import * as menutests from "../allfunctions/menufunctions";
-import logsdata from "../../../../../test-data/logs_data.json"
+import logsdata from "../../../../test-data/logs_data.json"
 // import logsdata from "../../data/logs_data.json";
 // import { login } from "../../support/commons"
 // import { selectStreamAndStreamType } from "../../support/log-commons";


### PR DESCRIPTION
Created a fixture which will be available during scope=session. This will ingest data present in tests/test-data/logs_data.json to org_pytest_data and stream_pytest_data

API Tests positive and negative scenarios - 
- Search without payload
- Search with valid sql query
- search with invalid sql query
- search with limit and sql query
- valid histogram query
- histogram query with limit