### PR TITLE
feat: regexp_match_to_fields UDF

### DIFF
--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -1265,6 +1265,7 @@ async fn register_udf(ctx: &mut SessionContext, _org_id: &str) {
     ctx.register_udf(super::match_udf::MATCH_IGNORE_CASE_UDF.clone());
     ctx.register_udf(super::regexp_udf::REGEX_MATCH_UDF.clone());
     ctx.register_udf(super::regexp_udf::REGEX_NOT_MATCH_UDF.clone());
+    ctx.register_udf(super::regexp_udf::REGEXP_MATCH_TO_FIELDS_UDF.clone());
     ctx.register_udf(super::time_range_udf::TIME_RANGE_UDF.clone());
     ctx.register_udf(super::date_format_udf::DATE_FORMAT_UDF.clone());
     ctx.register_udf(super::string_to_array_v2_udf::STRING_TO_ARRAY_V2_UDF.clone());


### PR DESCRIPTION
Impl #2815 

### Objective
For querying requests, when SQL function, such as `REGEXP_MATCH()`, is used, the found matches are nested in a single column instead of as separated individual columns, which could be used in subsequent subqueries. This PR intends to parse such concatenated string result returned by `REGEXP_MATCH()` into individual fields by implementing a new UDF `regexp_match_to_fields()` that wraps DataFusion's native `regexp_match()` function and parsed results accordingly. 

### Analysis
Prior to DataFusion version 36, UDFs' return type must be known when constructing the UDF. The most we could do in terms of being dynamic, was to implementing `return_type(&self, _arg_types: &[DataType])` of trait `ScalarUDFImpl`. However, this isn't flexible enough for this feature. In order to return individual `Fields`, in addition to data type, we must also know their associated field names, which couldn't be inferred from `DataType`. 

In DataFusion 36, below function was introduced to the `ScalarUDFImpl` trait. 
`return_type_from_exprs(&self, args: &[Expr], schema: &dyn datafusion::common::ExprSchema)`
Now, instead of `DataType`, args are passed in as `Expr`, which allows us to infer both DataType and Names to construct the returning `Fields`.

### Approach
Based on the analysis above, I implemented a `regexp_match_to_fields()` UDF by creating a `RegxpMatchToFields` sturct and implementing `ScalarUDFImpl` for this struct. 
1. Supports the same signature as the native `regexp_match()` function as the arguments were passed to the native function
2. Infers the Filed names and data types from the received arguments and pack it with `regexp_match()` result to a  `StructArray` as final result. 

### Limitations
1. The result is still a single column of key-value pairs instead of each fields of individual columns, but the result can be sub-queried by field name when subquery is supported in the future. 
2. There are other sql functions that return similar concatenated string. This approach only parse string to fields for `REGEXP_MATCH()` function. More enhancements are required to support a more generalized `string_to_fields()` UDF. 