### PR TITLE
fix: fixed event filtering condition in Session Viewer events query

### DIFF
--- a/web/src/views/RUM/SessionViewer.vue
+++ b/web/src/views/RUM/SessionViewer.vue
@@ -280,7 +280,7 @@ const getSessionEvents = () => {
   };
 
   const req = buildQueryPayload(queryPayload);
-  req.query.sql = `select * from "_rumdata" where session_id='${sessionId.value}' and type='error' or type='action' or type='view' order by date asc`;
+  req.query.sql = `select * from "_rumdata" where session_id='${sessionId.value}' and (type='error' or type='action' or type='view') order by date asc`;
   delete req.aggs;
   isLoading.value.push(true);
   searchService


### PR DESCRIPTION
Problem:
Observed that the User Session Viewer was yielding incorrect results when filtering session events data. The root cause was identified as the improper handling of a compound predicate within the SQL query used for data retrieval.

Solution:
When parentheses were added around the conditions `session_id='xyz' && (type='error' or type='action' or type='view')` to logically group them, this fixed the issue.