### PR TITLE
feat: add new endpoint for health check

### DIFF
--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -18,6 +18,7 @@ use std::io::Error;
 use actix_web::{get, put, web, HttpRequest, HttpResponse};
 use config::{
     cluster::{is_ingester, LOCAL_NODE_ROLE, LOCAL_NODE_UUID},
+    meta::cluster::NodeStatus,
     utils::json,
     CONFIG, HAS_FUNCTIONS, INSTANCE_ID, QUICK_MODEL_FIELDS, SQL_FULL_TEXT_SEARCH_FIELDS,
 };
@@ -128,7 +129,7 @@ pub async fn schedulez() -> Result<HttpResponse, Error> {
             status: "not ok".to_string(),
         }));
     };
-    Ok(if node.scheduled {
+    Ok(if node.scheduled && node.status == NodeStatus::Online {
         HttpResponse::Ok().json(HealthzResponse {
             status: "ok".to_string(),
         })

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -112,6 +112,33 @@ pub async fn healthz() -> Result<HttpResponse, Error> {
     }))
 }
 
+/// Healthz of the node for scheduled status
+#[utoipa::path(
+    path = "/schedulez",
+    tag = "Meta",
+    responses(
+        (status = 200, description="Staus OK", content_type = "application/json", body = HealthzResponse, example = json!({"status": "ok"}))
+    )
+)]
+#[get("/schedulez")]
+pub async fn schedulez() -> Result<HttpResponse, Error> {
+    let node_id = LOCAL_NODE_UUID.clone();
+    let Some(node) = cluster::get_node_by_uuid(&node_id).await else {
+        return Ok(HttpResponse::InternalServerError().json(HealthzResponse {
+            status: "not ok".to_string(),
+        }));
+    };
+    Ok(if node.scheduled {
+        HttpResponse::Ok().json(HealthzResponse {
+            status: "ok".to_string(),
+        })
+    } else {
+        HttpResponse::InternalServerError().json(HealthzResponse {
+            status: "not ok".to_string(),
+        })
+    })
+}
+
 #[get("")]
 pub async fn zo_config() -> Result<HttpResponse, Error> {
     #[cfg(feature = "enterprise")]

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -110,7 +110,7 @@ async fn proxy(
 
 pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
     let cors = get_cors();
-    cfg.service(status::healthz);
+    cfg.service(status::healthz).service(status::schedulez);
     cfg.service(
         web::scope("/auth")
             .wrap(cors.clone())

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -262,8 +262,8 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
 
     let is_inverted_index = !meta.fts_terms.is_empty();
 
-    log::warn!(
-        "searching in is_agg_query {:?} is_inverted_index {:?}",
+    log::info!(
+        "[session_id {session_id}] is_agg_query {:?} is_inverted_index {:?}",
         !req.aggs.is_empty(),
         is_inverted_index
     );
@@ -419,7 +419,11 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
         )
     };
 
-    println!("final file_list: {:?}", file_list.len());
+    log::info!(
+        "[session_id {session_id}] search->file_list.get: time_range: {:?}, num: {}",
+        meta.meta.time_range,
+        file_list.len(),
+    );
 
     #[cfg(not(feature = "enterprise"))]
     let work_group: Option<String> = None;
@@ -497,8 +501,9 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
             1
         }
     };
+
     log::info!(
-        "[session_id {session_id}] search->file_list: time_range: {:?}, num: {file_num}, offset: {offset}",
+        "[session_id {session_id}] search->file_list.partition: time_range: {:?}, num: {file_num}, offset: {offset}",
         meta.meta.time_range
     );
 

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -263,7 +263,7 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
     let is_inverted_index = !meta.fts_terms.is_empty();
 
     log::info!(
-        "[session_id {session_id}] is_agg_query {:?} is_inverted_index {:?}",
+        "[session_id {session_id}] search: is_agg_query {:?} is_inverted_index {:?}",
         !req.aggs.is_empty(),
         is_inverted_index
     );

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -509,7 +509,7 @@ async fn search_in_cluster(mut req: cluster_rpc::SearchRequest) -> Result<search
     };
 
     log::info!(
-        "[session_id {session_id}] search: file_list done partition, time_range: {:?}, num: {file_num}, offset: {offset}",
+        "[session_id {session_id}] search: file_list partition, time_range: {:?}, num: {file_num}, offset: {offset}",
         meta.meta.time_range
     );
 


### PR DESCRIPTION
- `/healthz` will always return `ok` when the node is ready.
- `/schedulez` will return the working status and return `ok` when the node is online and scheduled, or will return `not ok`.