### PR TITLE
feat: add query start_time and end_time for reporting a search query usage

### DIFF
--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -242,6 +242,8 @@ pub async fn search(
                 size: res.scan_size as f64,
                 request_body: Some(req.query.sql),
                 user_email: Some(user_id.to_str().unwrap().to_string()),
+                min_ts: Some(req.query.start_time),
+                max_ts: Some(req.query.end_time),
                 ..Default::default()
             };
             let num_fn = req.query.query_fn.is_some() as u16;

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -274,6 +274,8 @@ async fn search_in_cluster(
         response_time: op_start.elapsed().as_secs_f64(),
         request_body: Some(req.query.unwrap().query),
         user_email: Some(user_email.to_string()),
+        min_ts: Some(start),
+        max_ts: Some(end),
         ..Default::default()
     };
 

--- a/src/service/usage/mod.rs
+++ b/src/service/usage/mod.rs
@@ -125,8 +125,8 @@ pub async fn report_request_usage_stats(
             num_records: stats.records,
             stream_type,
             stream_name: stream_name.to_owned(),
-            min_ts: None,
-            max_ts: None,
+            min_ts: stats.min_ts,
+            max_ts: stats.max_ts,
             compressed_size: None,
         });
     };


### PR DESCRIPTION
Reports `query.start_time` and `query.end_time` as `min_ts` and `max_ts` respectively for the "Search" event in `usage` stream.