### PR TITLE
fix: dashboard variable dropdown on typing getting error

### DIFF
--- a/web/src/components/dashboards/settings/VariableQueryValueSelector.vue
+++ b/web/src/components/dashboards/settings/VariableQueryValueSelector.vue
@@ -72,7 +72,7 @@ export default defineComponent({
 
     // get filtered options
     const { filterFn: fieldsFilterFn, filteredOptions: fieldsFilteredOptions } =
-      useSelectAutoComplete(options, "name");
+      useSelectAutoComplete(options, "value");
 
     // set watcher on variable item changes at that time change the option value
     watch(


### PR DESCRIPTION
While implementing a filter search feature with dropdown menus for variables, an error occurred due to undefined values. This error hindered the functionality of the search feature, causing unexpected behavior when attempting to filter results.

