### PR TITLE
feat: frequently check for span element render for dashboard report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5194,12 +5194,12 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.7.0"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
 dependencies = [
  "log",
- "winapi 0.3.9",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -440,9 +440,10 @@ async fn wait_for_panel_data_load(page: &Page) -> Result<(), anyhow::Error> {
     let start = std::time::Instant::now();
     let timeout = Duration::from_secs(CONFIG.chrome.chrome_sleep_secs.into());
     loop {
-        if let Ok(_) = page
+        if page
             .find_element("span#dashboardVariablesAndPanelsDataLoaded")
             .await
+            .is_ok()
         {
             return Ok(());
         }


### PR DESCRIPTION
Instead of waiting for `CONFIG.chrome.chrome_sleep_secs` to let the data load in the dashboard for report, frequently, check for the `span` element with a loop.