### PR TITLE
test: run the forks on default github-runners

### DIFF
--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -16,7 +16,7 @@ jobs:
       permissions:
         id-token: write
         contents: read
-      runs-on: ubicloud-standard-8
+      runs-on: ${{ github.event.pull_request.head.repo.fork == true && 'ubuntu-2004-8-cores' || 'ubicloud-standard-8' }}
       steps:
         - name: Remove unused tools
           run: |


### PR DESCRIPTION
For the incoming PRs from external contributors run the action on github managed runners and everything else on ubicloud-runners