### PR TITLE
fix: only alert_manager should init the scheduler

### DIFF
--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -13,8 +13,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::CONFIG;
-
 pub mod cache;
 pub mod db;
 pub mod dist_lock;
@@ -30,11 +28,6 @@ pub async fn init() -> Result<(), anyhow::Error> {
     cache::init().await?;
     file_list::create_table().await?;
     queue::init().await?;
-    scheduler::init(
-        CONFIG.limit.scheduler_clean_interval,
-        CONFIG.limit.scheduler_watch_interval,
-    )
-    .await?;
     // because of asynchronous, we need to wait for a while
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     Ok(())

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -99,7 +99,7 @@ pub struct Trigger {
 }
 
 /// Initializes the scheduler
-pub(crate) async fn init(clean_interval: u64, watch_interval: u64) -> Result<()> {
+pub async fn init(clean_interval: u64, watch_interval: u64) -> Result<()> {
     create_table().await?;
     create_table_index().await?;
     tokio::task::spawn(async move {

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -13,7 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::cluster;
+use config::{cluster, config::CONFIG};
+use infra::scheduler;
 use tokio::time;
 
 use crate::service;
@@ -22,6 +23,13 @@ pub async fn run() -> Result<(), anyhow::Error> {
     if !cluster::is_alert_manager(&cluster::LOCAL_NODE_ROLE) {
         return Ok(());
     }
+
+    scheduler::init(
+        CONFIG.limit.scheduler_clean_interval,
+        CONFIG.limit.scheduler_watch_interval,
+    )
+    .await?;
+
     // should run it every 10 seconds
     let mut interval = time::interval(time::Duration::from_secs(30));
     interval.tick().await; // trigger the first run


### PR DESCRIPTION
Instead of initializing the scheduler inside `infra::init()`, the `alert_manager` only now initializes the scheduler.