### PR TITLE
fix: On sharing URL link, by default 1st tab was getting selected

### DIFF
--- a/web/src/views/Dashboards/Dashboards.vue
+++ b/web/src/views/Dashboards/Dashboards.vue
@@ -559,7 +559,7 @@ export default defineComponent({
       ].find((dashboard) => dashboard.dashboardId === row.id);
 
       const selectedTabId = selectedDashboard
-        ? selectedDashboard.tabs[0].tabId
+        ? selectedDashboard?.tabs[0]?.tabId
         : null;
       return router.push({
         path: "/dashboards/view",

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -280,7 +280,7 @@ export default defineComponent({
     const showDashboardSettingsDialog = ref(false);
 
     // selected tab
-    const selectedTabId: any = ref(null);
+    const selectedTabId: any = ref(route.query.tab ?? null);
     // provide it to child components
     provide("selectedTabId", selectedTabId);
 


### PR DESCRIPTION
Sharing dashboard URLs didn't work properly when tabs were involved. Regardless of the selected tab, the link always took users to the first tab. This issue has been fixed, ensuring that shared URLs now correctly direct users to the intended tab, providing a smoother experience for navigating dashboards.