### PR TITLE
feat: color palette for dashboard chart

### DIFF
--- a/web/src/components/dashboards/addPanel/ColorPaletteDropDown.vue
+++ b/web/src/components/dashboards/addPanel/ColorPaletteDropDown.vue
@@ -1,0 +1,201 @@
+<!-- Copyright 2023 Zinc Labs Inc.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+  <div>
+    <div style="display: flex; align-items: center">
+      <q-select
+        v-model="dashboardPanelData.data.config.color.mode"
+        :options="colorOptions"
+        outlined
+        dense
+        label="Color palette"
+        class="showLabelOnTop"
+        stack-label
+        :display-value="`${
+          dashboardPanelData.data.config.color.mode ?? 'palette-classic'
+        }`"
+        @update:model-value="onColorModeChange"
+        style="width: 100%"
+      >
+        <template v-slot:option="props">
+          <q-item v-bind="props.itemProps">
+            <q-item-section style="padding: 2px">
+              <q-item-label>{{ props.opt.label }}</q-item-label>
+              <q-item-label caption>
+                <div
+                  v-if="Array.isArray(props.opt.subLabel)"
+                  class="color-container"
+                >
+                  <div
+                    :style="{
+                      background: `linear-gradient(to right, ${props.opt.subLabel.join(
+                        ', '
+                      )})`,
+                      width: '100%',
+                      height: '8px',
+                      borderRadius: '3px',
+                    }"
+                  ></div>
+                </div>
+                <div v-else>
+                  <div style="font-weight: 200">
+                    {{ props.opt.subLabel }}
+                  </div>
+                </div>
+              </q-item-label>
+            </q-item-section>
+          </q-item>
+        </template>
+      </q-select>
+      <div
+        class="color-input-wrapper"
+        v-if="
+          ['fixed', 'shades'].includes(
+            dashboardPanelData.data.config.color.mode
+          )
+        "
+        style="margin-top: 30px; margin-left: 5px"
+      >
+        <input
+          type="color"
+          v-model="dashboardPanelData.data.config.color.fixedColor[0]"
+          format-model="rgb"
+        />
+      </div>
+    </div>
+    <div
+      class="q-pt-md"
+      v-if="
+        ['green-yellow-red', 'red-yellow-green'].includes(
+          dashboardPanelData.data.config.color.mode
+        )
+      "
+    >
+      Color series by:
+      <div>
+        <q-btn-toggle
+          v-model="dashboardPanelData.data.config.color.seriesBy"
+          push
+          toggle-color="primary"
+          size="md"
+          :options="[
+            { label: 'Last', value: 'last' },
+            { label: 'Min', value: 'min' },
+            { label: 'Max', value: 'max' },
+          ]"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+import useDashboardPanelData from "@/composables/useDashboardPanel";
+import { colorArrayBySeries } from "@/utils/dashboard/colorPalette";
+import { onBeforeMount } from "vue";
+import { defineComponent } from "vue";
+export default defineComponent({
+  name: "ColorPaletteDropdown",
+  setup() {
+    const { dashboardPanelData, promqlMode } = useDashboardPanelData();
+    // on before mount need to check whether color object is there or not else use palette-classic as a default
+    onBeforeMount(() => {
+      if (!dashboardPanelData?.data?.config?.color) {
+        dashboardPanelData.data.config.color = {
+          mode: "palette-classic",
+          fixedColor: ["#53ca53"],
+          seriesBy: "last",
+        };
+      }
+    });
+    const colorOptions = [
+      {
+        label: "Fixed",
+        subLabel: "Set a specific color to all series",
+        value: "fixed",
+      },
+      {
+        label: "Shades",
+        subLabel: "Different shades of specific color",
+        value: "shades",
+      },
+      {
+        label: "Palette-Classic",
+        subLabel: colorArrayBySeries,
+        value: "palette-classic",
+      },
+      {
+        label: "Green-Yellow-Red",
+        subLabel: ["#00FF00", "#FFFF00", "#FF0000"],
+        value: "green-yellow-red",
+      },
+      {
+        label: "Red-Yellow-Green",
+        subLabel: ["#FF0000", "#FFFF00", "#00FF00"],
+        value: "red-yellow-green",
+      },
+    ];
+    const onColorModeChange = (value: any) => {
+      // if value.value is fixed or shades, assign ["#53ca53"] to fixedcolor
+      if (["fixed", "shades"].includes(value.value)) {
+        dashboardPanelData.data.config.color.fixedColor = ["#53ca53"];
+        dashboardPanelData.data.config.color.seriesBy = "last";
+      } else {
+        // else assign sublabel to fixedcolor
+        dashboardPanelData.data.config.color.fixedColor = value.subLabel;
+      }
+      dashboardPanelData.data.config.color.mode = value.value;
+    };
+    return {
+      dashboardPanelData,
+      promqlMode,
+      colorOptions,
+      onColorModeChange,
+    };
+  },
+});
+</script>
+<style lang="scss" scoped>
+:deep(.selectedLabel span) {
+  text-transform: none !important;
+}
+.space {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+.color-input-wrapper {
+  height: 25px;
+  width: 25px;
+  overflow: hidden;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+}
+.color-input-wrapper input[type="color"] {
+  position: absolute;
+  height: 4em;
+  width: 4em;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  overflow: hidden;
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+.color-container {
+  display: flex;
+  height: 8px;
+}
+</style>

--- a/web/src/components/dashboards/addPanel/ColorPaletteDropDown.vue
+++ b/web/src/components/dashboards/addPanel/ColorPaletteDropDown.vue
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :display-value="selectedOptionLabel"
         @update:model-value="onColorModeChange"
         style="width: 100%"
-        :popup-content-style="{ height: '300px' }"
+        :popup-content-style="{ height: '300px', width: '200px' }"
       >
         <template v-slot:option="props">
           <q-item v-bind="props.itemProps">
@@ -128,13 +128,14 @@ export default defineComponent({
       },
       {
         label: "Palette-Classic (By Series)",
-        subLabel: "Same color for same series name",
+        subLabel: "Series with the same name will use the same color",
         colorPalette: classicColorPalette,
         value: "palette-classic-by-series",
       },
       {
         label: "Palette-Classic",
-        subLabel: "Random color for each series",
+        subLabel:
+          "A random color will be used for each series, regardless of its name",
         colorPalette: [
           "#5470c6",
           "#91cc75",

--- a/web/src/components/dashboards/addPanel/ColorPaletteDropDown.vue
+++ b/web/src/components/dashboards/addPanel/ColorPaletteDropDown.vue
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :display-value="selectedOptionLabel"
         @update:model-value="onColorModeChange"
         style="width: 100%"
+        :popup-content-style="{ height: '300px' }"
       >
         <template v-slot:option="props">
           <q-item v-bind="props.itemProps">
@@ -74,11 +75,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </div>
     <div
       class="q-pt-md"
-      v-if="
-        ['continuous-green-yellow-red', 'continuous-red-yellow-green'].includes(
-          dashboardPanelData.data.config.color.mode
-        )
-      "
+      v-if="dashboardPanelData.data.config.color.mode.startsWith('continuous')"
     >
       Color series by:
       <div>
@@ -107,11 +104,11 @@ export default defineComponent({
   name: "ColorPaletteDropdown",
   setup() {
     const { dashboardPanelData, promqlMode } = useDashboardPanelData();
-    // on before mount need to check whether color object is there or not else use palette-classic as a default
+    // on before mount need to check whether color object is there or not else use palette-classic-by-series as a default
     onBeforeMount(() => {
       if (!dashboardPanelData?.data?.config?.color) {
         dashboardPanelData.data.config.color = {
-          mode: "palette-classic",
+          mode: "palette-classic-by-series",
           fixedColor: ["#53ca53"],
           seriesBy: "last",
         };
@@ -128,6 +125,12 @@ export default defineComponent({
         label: "Shades",
         subLabel: "Different shades of specific color",
         value: "shades",
+      },
+      {
+        label: "Palette-Classic (By Series)",
+        subLabel: "Same color for same series name",
+        colorPalette: classicColorPalette,
+        value: "palette-classic-by-series",
       },
       {
         label: "Palette-Classic",
@@ -150,20 +153,62 @@ export default defineComponent({
         value: "palette-classic",
       },
       {
-        label: "Palette-Classic (By Series)",
-        subLabel: "Same color for same series name",
-        colorPalette: classicColorPalette,
-        value: "palette-classic-by-series",
-      },
-      {
-        label: "Green-Yellow-Red",
-        colorPalette: ["#00FF00", "#FFFF00", "#FF0000"],
+        label: "Green-Yellow-Red (By Value)",
+        colorPalette: [
+          "#69B34C",
+          "#ACB334",
+          "#FAB733",
+          "#FF8E15",
+          "#FF4E11",
+          "#FF0D0D",
+        ],
         value: "continuous-green-yellow-red",
       },
       {
-        label: "Red-Yellow-Green",
-        colorPalette: ["#FF0000", "#FFFF00", "#00FF00"],
+        label: "Red-Yellow-Green (By Value)",
+        colorPalette: [
+          "#FF0D0D",
+          "#FF4E11",
+          "#FF8E15",
+          "#FAB733",
+          "#ACB334",
+          "#69B34C",
+        ],
         value: "continuous-red-yellow-green",
+      },
+      {
+        label: "Temperature (By Value)",
+        colorPalette: ["#85CBD9", "#F6EADB", "#FBDBA2", "#FFC86D", "#FC8585"],
+        value: "continuous-temperature",
+      },
+      {
+        label: "Positive (By Value)",
+        colorPalette: ["#D3E8D3", "#A7D1A7", "#7AB97A", "#4EA24E", "#228B22"],
+        value: "continuous-positive",
+      },
+      {
+        label: "Negative (By Value)",
+        colorPalette: [
+          "#FEEAEA",
+          "#FFD4D4",
+          "#FFADAD",
+          "#F77272",
+          "#F03030",
+          "#B12E21",
+        ],
+        value: "continuous-negative",
+      },
+      {
+        label: "Light To Dark Blue (By Value)",
+        colorPalette: [
+          "#DBE9F3",
+          "#B8CCE0",
+          "#96AFCD",
+          "#7392BA",
+          "#5175A7",
+          "#2E5894",
+        ],
+        value: "continuous-light-to-dark-blue",
       },
     ];
 
@@ -171,13 +216,15 @@ export default defineComponent({
       const selectedOption = colorOptions.find(
         (option) =>
           option.value === dashboardPanelData?.data?.config?.color?.mode ??
-          "palette-classic"
+          "palette-classic-by-series"
       );
-      return selectedOption ? selectedOption.label : "palette-classic";
+      return selectedOption
+        ? selectedOption.label
+        : "Palette-Classic (By Series)";
     });
 
     const onColorModeChange = (value: any) => {
-      // if value.value is fixed or shades, assign ["#53ca53"] to fixedcolor
+      // if value.value is fixed or shades, assign ["#53ca53"] to fixedcolor as a default
       if (["fixed", "shades"].includes(value.value)) {
         dashboardPanelData.data.config.color.fixedColor = ["#53ca53"];
         dashboardPanelData.data.config.color.seriesBy = "last";

--- a/web/src/components/dashboards/addPanel/ColorPaletteDropDown.vue
+++ b/web/src/components/dashboards/addPanel/ColorPaletteDropDown.vue
@@ -22,9 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         label="Color palette"
         class="showLabelOnTop"
         stack-label
-        :display-value="`${
-          dashboardPanelData.data.config.color.mode ?? 'palette-classic'
-        }`"
+        :display-value="selectedOptionLabel"
         @update:model-value="onColorModeChange"
         style="width: 100%"
       >
@@ -33,13 +31,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <q-item-section style="padding: 2px">
               <q-item-label>{{ props.opt.label }}</q-item-label>
               <q-item-label caption>
+                <div v-if="props.opt.subLabel">
+                  <div style="font-weight: 200">
+                    {{ props.opt.subLabel }}
+                  </div>
+                </div>
                 <div
-                  v-if="Array.isArray(props.opt.subLabel)"
+                  v-if="Array.isArray(props.opt.colorPalette)"
                   class="color-container"
                 >
                   <div
                     :style="{
-                      background: `linear-gradient(to right, ${props.opt.subLabel.join(
+                      background: `linear-gradient(to right, ${props.opt.colorPalette.join(
                         ', '
                       )})`,
                       width: '100%',
@@ -47,11 +50,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       borderRadius: '3px',
                     }"
                   ></div>
-                </div>
-                <div v-else>
-                  <div style="font-weight: 200">
-                    {{ props.opt.subLabel }}
-                  </div>
                 </div>
               </q-item-label>
             </q-item-section>
@@ -77,7 +75,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <div
       class="q-pt-md"
       v-if="
-        ['green-yellow-red', 'red-yellow-green'].includes(
+        ['continuous'].includes(
           dashboardPanelData.data.config.color.mode
         )
       "
@@ -101,7 +99,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 <script lang="ts">
 import useDashboardPanelData from "@/composables/useDashboardPanel";
-import { colorArrayBySeries } from "@/utils/dashboard/colorPalette";
+import { classicColorPalette } from "@/utils/dashboard/colorPalette";
+import { computed } from "vue";
 import { onBeforeMount } from "vue";
 import { defineComponent } from "vue";
 export default defineComponent({
@@ -118,6 +117,7 @@ export default defineComponent({
         };
       }
     });
+
     const colorOptions = [
       {
         label: "Fixed",
@@ -131,20 +131,51 @@ export default defineComponent({
       },
       {
         label: "Palette-Classic",
-        subLabel: colorArrayBySeries,
+        subLabel: "Random color for each series",
+        colorPalette: [
+          "#5470c6",
+          "#91cc75",
+          "#fac858",
+          "#ee6666",
+          "#73c0de",
+          "#3ba272",
+          "#fc8452",
+          "#9a60b4",
+          "#ea7ccc",
+          "#59c4e6",
+          "#edafda",
+          "#93b7e3",
+          "#a5e7f0",
+        ],
         value: "palette-classic",
       },
       {
+        label: "Palette-Classic (By Series)",
+        subLabel: "Same color for same series name",
+        colorPalette: classicColorPalette,
+        value: "palette-classic-by-series",
+      },
+      {
         label: "Green-Yellow-Red",
-        subLabel: ["#00FF00", "#FFFF00", "#FF0000"],
-        value: "green-yellow-red",
+        colorPalette: ["#00FF00", "#FFFF00", "#FF0000"],
+        value: "continuous",
       },
       {
         label: "Red-Yellow-Green",
-        subLabel: ["#FF0000", "#FFFF00", "#00FF00"],
-        value: "red-yellow-green",
+        colorPalette: ["#FF0000", "#FFFF00", "#00FF00"],
+        value: "continuous",
       },
     ];
+
+    const selectedOptionLabel = computed(() => {
+      const selectedOption = colorOptions.find(
+        (option) =>
+          option.value === dashboardPanelData?.data?.config?.color?.mode ??
+          "palette-classic"
+      );
+      return selectedOption ? selectedOption.label : "palette-classic";
+    });
+
     const onColorModeChange = (value: any) => {
       // if value.value is fixed or shades, assign ["#53ca53"] to fixedcolor
       if (["fixed", "shades"].includes(value.value)) {
@@ -152,7 +183,7 @@ export default defineComponent({
         dashboardPanelData.data.config.color.seriesBy = "last";
       } else {
         // else assign sublabel to fixedcolor
-        dashboardPanelData.data.config.color.fixedColor = value.subLabel;
+        dashboardPanelData.data.config.color.fixedColor = value.colorPalette;
       }
       dashboardPanelData.data.config.color.mode = value.value;
     };
@@ -161,6 +192,7 @@ export default defineComponent({
       promqlMode,
       colorOptions,
       onColorModeChange,
+      selectedOptionLabel,
     };
   },
 });

--- a/web/src/components/dashboards/addPanel/ColorPaletteDropDown.vue
+++ b/web/src/components/dashboards/addPanel/ColorPaletteDropDown.vue
@@ -75,7 +75,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <div
       class="q-pt-md"
       v-if="
-        ['continuous'].includes(
+        ['continuous-green-yellow-red', 'continuous-red-yellow-green'].includes(
           dashboardPanelData.data.config.color.mode
         )
       "
@@ -158,12 +158,12 @@ export default defineComponent({
       {
         label: "Green-Yellow-Red",
         colorPalette: ["#00FF00", "#FFFF00", "#FF0000"],
-        value: "continuous",
+        value: "continuous-green-yellow-red",
       },
       {
         label: "Red-Yellow-Green",
         colorPalette: ["#FF0000", "#FFFF00", "#00FF00"],
-        value: "continuous",
+        value: "continuous-red-yellow-green",
       },
     ];
 

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -732,6 +732,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           )
         "
       />
+
+      <div class="space"></div>
+      <ColorPaletteDropDown v-if="dashboardPanelData.data.type != 'metric'" />
+      <div class="space"></div>
     </div>
   </div>
 </template>
@@ -742,9 +746,10 @@ import { computed, defineComponent, onBeforeMount } from "vue";
 import { useI18n } from "vue-i18n";
 import Drilldown from "./Drilldown.vue";
 import CommonAutoComplete from "@/components/dashboards/addPanel/CommonAutoComplete.vue";
+import ColorPaletteDropDown from "./ColorPaletteDropDown.vue";
 
 export default defineComponent({
-  components: { Drilldown, CommonAutoComplete },
+  components: { Drilldown, CommonAutoComplete, ColorPaletteDropDown },
   props: ["dashboardPanelData"],
   setup(props) {
     const { dashboardPanelData, promqlMode } = useDashboardPanelData();

--- a/web/src/composables/useDashboardPanel.ts
+++ b/web/src/composables/useDashboardPanel.ts
@@ -71,6 +71,9 @@ const getDefaultDashboardPanelData: any = () => ({
       drilldown: [],
       connect_nulls: false,
       wrap_table_cells: false,
+      color: {
+        mode: "palette-classic",
+      },
     },
     htmlContent: "",
     markdownContent: "",

--- a/web/src/composables/useDashboardPanel.ts
+++ b/web/src/composables/useDashboardPanel.ts
@@ -72,7 +72,9 @@ const getDefaultDashboardPanelData: any = () => ({
       connect_nulls: false,
       wrap_table_cells: false,
       color: {
-        mode: "palette-classic",
+        mode: "palette-classic-by-series",
+        fixedColor: ["#53ca53"],
+        seriesBy: "last",
       },
     },
     htmlContent: "",

--- a/web/src/utils/dashboard/colorPalette.ts
+++ b/web/src/utils/dashboard/colorPalette.ts
@@ -13,218 +13,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-export const colorArrayBySeries = [
-  "#5470c6",
-  "#91cc75",
-  "#fac858",
-  "#ee6666",
-  "#73c0de",
-  "#3ba272",
-  "#fc8452",
-  "#9a60b4",
-  "#dc1e1e",
-  "#9086e9",
-  "#27e162",
-  "#e08de6",
-  "#de6086",
-  "#ec8ceb",
-  "#99e9f1",
-  "#eec59c",
-];
-
-// Convert a hex color to HSL
-function hexToHsl(hex) {
-  let r = parseInt(hex.slice(1, 3), 16) / 255;
-  let g = parseInt(hex.slice(3, 5), 16) / 255;
-  let b = parseInt(hex.slice(5, 7), 16) / 255;
-
-  let max = Math.max(r, g, b),
-    min = Math.min(r, g, b);
-  let h,
-    s,
-    l = (max + min) / 2;
-
-  if (max === min) {
-    h = s = 0; // achromatic
-  } else {
-    let d = max - min;
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-    switch (max) {
-      case r:
-        h = (g - b) / d + (g < b ? 6 : 0);
-        break;
-      case g:
-        h = (b - r) / d + 2;
-        break;
-      case b:
-        h = (r - g) / d + 4;
-        break;
-    }
-    h /= 6;
-  }
-
-  return { h, s, l };
-}
-
-// Convert an HSL color to hex
-function hslToHex(hsl) {
-  let r, g, b;
-
-  if (hsl.s === 0) {
-    r = g = b = hsl.l; // achromatic
-  } else {
-    const hue2rgb = (p, q, t) => {
-      if (t < 0) t += 1;
-      if (t > 1) t -= 1;
-      if (t < 1 / 6) return p + (q - p) * 6 * t;
-      if (t < 1 / 2) return q;
-      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-      return p;
-    };
-    let q = hsl.l < 0.5 ? hsl.l * (1 + hsl.s) : hsl.l + hsl.s - hsl.l * hsl.s;
-    let p = 2 * hsl.l - q;
-    r = hue2rgb(p, q, hsl.h + 1 / 3);
-    g = hue2rgb(p, q, hsl.h);
-    b = hue2rgb(p, q, hsl.h - 1 / 3);
-  }
-
-  let toHex = (x) => {
-    let hex = Math.round(x * 255).toString(16);
-    return hex.length === 1 ? "0" + hex : hex;
-  };
-
-  return "#" + toHex(r) + toHex(g) + toHex(b);
-}
-
-// Get a color for a name
-function getColorForName(name) {
-  var hash = hashName(name);
-  var colorIndex = hash % colorArrayBySeries.length;
-  var baseColor = hexToHsl(colorArrayBySeries[colorIndex]);
-
-  // create a unique hue, saturation, and lightness value
-  baseColor.h = (baseColor.h + (hash % 360) / 360.0) % 1;
-  baseColor.s = baseColor.s + ((hash % 20) - 10) / 100.0; // vary by up to 10%
-  baseColor.l = baseColor.l + ((hash % 20) - 10) / 100.0; // vary by up to 10%
-
-  return hslToHex(baseColor);
-}
-
-// Define your hash function
-function hashName(name) {
-  var hash = 0;
-  for (var i = 0; i < name.length; i++) {
-    hash += name.charCodeAt(i);
-  }
-  return hash;
-}
-
-// // Convert a hex color to RGB
-// function hexToRgb(hex: any) {
-//     var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-//     return result ? {
-//         r: parseInt(result[1], 16),
-//         g: parseInt(result[2], 16),
-//         b: parseInt(result[3], 16)
-//     } : null;
-// }
-
-// // Convert an RGB color to hex
-// function rgbToHex(rgb) {
-//     return "#" + ((1 << 24) | (rgb.r << 16) | (rgb.g << 8) | rgb.b).toString(16).slice(1);
-// }
-
-// // Get a color for a name
-// function getColorForName(name: any) {
-//   var hash = hashName(name);
-//   var colorIndex = hash % colorArrayBySeries.length;
-//   var baseColor: any = hexToRgb(colorArrayBySeries[colorIndex]);
-
-//   // Create a unique offset for each RGB value
-//   var offset = Math.floor(hash / 256);
-
-//   var gradientColor = {
-//       r: (baseColor.r + offset) % 256,
-//       g: (baseColor.g + offset * 2) % 256,
-//       b: (baseColor.b + offset * 3) % 256
-//   };
-
-//   return rgbToHex(gradientColor);
-// }
-
-export const getIndexForName = (name: any, colorArray: any) => {
-  let index = 0;
-  for (let i = 0; i < 15; i++) {
-    const charCode = name.charCodeAt(i) || 0;
-    index += charCode * (i + 1);
-  }
-  return index % colorArray.length;
-};
-
-// const nameToColor = (name: any, colorArray: any) => {
-//   const index = getIndexForName(name, colorArray);
-//   return colorArray[index];
-// };
-const usedColors = new Map();
-const nameColorMap = new Map();
-
-const adjustColor = (color, amount) => {
-  const usePound = color[0] === "#";
-  const num = usePound ? color.slice(1) : color;
-  const scale = amount < 0 ? 0 : 255;
-  const inverseScale = amount < 0 ? -amount : 1 - amount;
-
-  const r =
-    scale -
-    Math.round((scale - parseInt(num.substring(0, 2), 16)) * inverseScale);
-  const g =
-    scale -
-    Math.round((scale - parseInt(num.substring(2, 4), 16)) * inverseScale);
-  const b =
-    scale -
-    Math.round((scale - parseInt(num.substring(4, 6), 16)) * inverseScale);
-
-  return (
-    (usePound ? "#" : "") +
-    ((0x1000000 + (r << 16)) | (g << 8) | b).toString(16).slice(1)
-  );
-};
-
-const nameToColor = (name, colorArray) => {
-  if (nameColorMap.has(name)) {
-    return nameColorMap.get(name);
-  }
-
-  const index = getIndexForName(name, colorArray);
-  let color = colorArray[index];
-
-  if (usedColors.has(color)) {
-    const amount = usedColors.get(color) * 99; // Adjust the shade by 10% each time
-    color = adjustColor(color, amount);
-    usedColors.set(color, usedColors.get(color) + 1);
-  } else {
-    usedColors.set(color, 1);
-  }
-
-  nameColorMap.set(name, color);
-  return color;
-};
-
-function stringToColor(str) {
-  // Create a hash from the string
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash);
-  }
-
-  // Convert the hash to an HSL color
-  let hue = hash % 360;
-  let saturation = (hash % 25) + 100; // Saturation range between 75-100%
-  let lightness = (hash % 15) + 100; // Lightness range between 70-85%
-
-  return "hsl(" + hue + ", " + saturation + "%, " + lightness + "%)";
-}
-
 function shadeColor(color: any, value: any, min: any, max: any) {
   let percent = (value - min) / (max - min);
   let num = parseInt(color.replace("#", ""), 16),
@@ -288,22 +76,27 @@ const getSeriesValueFrom2DArray = (panelSchema: any, values: any) => {
   let seriesvalue =
     values?.length > 0
       ? !isNaN(values[values.length - 1][1])
-        ? values[values.length - 1][1]
+        ? +values[values.length - 1][1]
         : 50
       : 50;
-  if (["shades", "continuous"].includes(panelSchema?.config?.color?.mode)) {
+
+  if (
+    ["shades", "continuous", "green-yellow-red", "red-yellow-green"].includes(
+      panelSchema?.config?.color?.mode
+    )
+  ) {
     if (panelSchema?.config?.color?.seriesBy == "min") {
       values.forEach((value: any) => {
         // value[1] should not NaN
         if (!isNaN(value[1])) {
-          seriesvalue = Math.min(value[1], seriesvalue);
+          seriesvalue = +Math.min(+value[1], +seriesvalue);
         }
       });
     } else if (panelSchema?.config?.color?.seriesBy == "max") {
       values.forEach((value: any) => {
         // value[1] should not NaN
         if (!isNaN(value[1])) {
-          seriesvalue = Math.max(value[1], seriesvalue);
+          seriesvalue = +Math.max(+value[1], +seriesvalue);
         }
       });
     }
@@ -341,70 +134,131 @@ const getSeriesValueFromArray = (panelSchema: any, values: any) => {
   return seriesvalue;
 };
 
-class Scale {
-  colors: any;
-  domain: any;
+export const classicColorPalette = [
+  "#5470c6",
+  "#91cc75",
+  "#fac858",
+  "#ee6666",
+  "#73c0de",
+  "#3ba272",
+  "#fc8452",
+  "#9a60b4",
+  "#ea7ccc",
+  "#59c4e6",
+  "#edafda",
+  "#93b7e3",
+  "#a5e7f0",
+  "#cbb0e3",
+  "#3fb1e3",
+  "#6be6c1",
+  "#a0a7e6",
+  "#c4ebad",
+  "#96dee8",
+  "#2ec7c9",
+  "#b6a2de",
+  "#5ab1ef",
+  "#ffb980",
+  "#d87a80",
+  "#8d98b3",
+  "#e5cf0d",
+  "#97b552",
+  "#dc69aa",
+  "#07a2a4",
+  "#9a7fd1",
+  "#588dd5",
+  "#f5994e",
+  "#c9ab00",
+  "#7eb00a",
+  "#fcce10",
+  "#b5c334",
+  "#fe8463",
+  "#9bca63",
+  "#fad860",
+  "#60c0dd",
+  "#c6e579",
+  "#f4e001",
+  "#f0805a",
+  "#26c0c0",
+  "#ff715e",
+  "#ffaf51",
+  "#ffee51",
+  "#8c6ac4",
+  "#e6b600",
+  "#0098d9",
+  "#339ca8",
+  "#32a487",
+  "#d95850",
+  "#eb8146",
+  "#ffb248",
+  "#f2d643",
+  "#759aa0",
+  "#e69d87",
+  "#8dc1a9",
+  "#ea7e53",
+  "#eedd78",
+  "#73b9bc",
+  "#91ca8c",
+  "#f49f42",
+  "#4ea397",
+  "#22c3aa",
+  "#7bd9a5",
+  "#d0648a",
+  "#f58db2",
+  "#f2b3c9",
+  "#b8d2c7",
+  "#a4d8c2",
+  "#f3d999",
+  "#d3758f",
+  "#dcc392",
+  "#82b6e9",
+  "#a092f1",
+  "#eaf889",
+  "#6699FF",
+  "#ff6666",
+  "#3cb371",
+  "#d5b158",
+  "#38b6b6",
+  "#5AB2E0",
+  "#32C5E9",
+  "#94E9EC",
+  "#BFEFCF",
+  "#FF9F7F",
+  "#FB7293",
+  "#E26BB3",
+  "#9D96F5",
+  "#8378EA",
+  "#98C0FF",
+];
 
-  constructor(colors: any) {
-    this.colors = colors;
-    this.domain = [0, 100];
-  }
+function getColorBasedOnValue(currentValue, minValue, maxValue, colorArray) {
+  // Calculate the size of each partition
+  var partitionSize = (maxValue - minValue) / colorArray.length;
 
-  setDomain(domain: any) {
-    this.domain = domain;
-  }
+  // Calculate the index based on the current value's position within the partitions
+  var index = Math.floor((currentValue - minValue) / partitionSize);
 
-  getColor(value: any) {
-    // NOTE: need to check value should not be NaN
-    // and it should not be less than domain[0] or greater than domain[1]
+  // Ensure the index is within the bounds of the array
+  index = Math.max(0, index); // Ensure the index is not less than 0
+  index = Math.min(colorArray.length - 1, index); // Ensure the index is not greater than the array length - 1
 
-    let t = (value - this.domain[0]) / (this.domain[1] - this.domain[0]);
-    let index = Math.floor(t * (this.colors.length - 1));
-    let color1 = this.colors[index];
-    let color2 = this.colors[index + 1] || color1; // use the same color if color2 is not defined
-    let tLocal = color2 === color1 ? 0 : t * (this.colors.length - 1) - index; // calculate local interpolation parameter
-    let interpolated = color1.interpolate(color2, tLocal);
-
-    return interpolated;
-  }
+  return colorArray[index];
 }
 
-class Color {
-  r: any;
-  g: any;
-  b: any;
-
-  constructor(hex: any) {
-    // NOTE: use default color if hex is not valid
-    let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    if (!result) {
-      throw new Error(`Invalid color: ${hex}`);
-    }
-    this.r = parseInt(result[1], 16);
-    this.g = parseInt(result[2], 16);
-    this.b = parseInt(result[3], 16);
+function djb2Hash(str) {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    // 5 times left shift means multiply by 32
+    hash = (hash << 5) + hash + str.charCodeAt(i); /* hash * 33 + c */
   }
-
-  interpolate(other: any, t: any) {
-    let r = this.r + t * (other.r - this.r);
-    let g = this.g + t * (other.g - this.g);
-    let b = this.b + t * (other.b - this.b);
-
-    return new Color(
-      this.rgbToHex(Math.round(r), Math.round(g), Math.round(b))
-    );
-  }
-
-  rgbToHex(r: any, g: any, b: any) {
-    return "#" + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
-  }
-
-  toCssString() {
-    return `rgb(${Math.round(this.r)}, ${Math.round(this.g)}, ${Math.round(
-      this.b
-    )})`;
-  }
+  return hash;
 }
+
+const getColorForSeries = (seriesName: string, colorArray: string[]) => {
+  // let hash = djb2Hash(seriesName);
+  let hash = djb2Hash(seriesName);
+  let index = Math.abs(hash) % colorArray.length;
+  return colorArray[index];
+};
 
 export const getColor = (
   panelSchema: any,
@@ -413,6 +267,7 @@ export const getColor = (
   chartMin?: any,
   chartMax?: any
 ) => {
+  console.log(panelSchema?.config?.color);
   // switch case based on panelSchema.color type
   switch (panelSchema?.config?.color?.mode) {
     case "fixed": {
@@ -434,115 +289,32 @@ export const getColor = (
       );
     }
 
+    case "palette-classic-by-series": {
+      return getColorForSeries(seriesName, classicColorPalette);
+    }
+
     case "palette-classic": {
-      // return color using colorArrayBySeries
-      // NOTE: here value will be series name
-      // return getColorForName(seriesName);
-      //   function stringToColor(str) {
-      //     let hash = 0;
-      //     for (let i = 0; i < str.length; i++) {
-      //         hash = str.charCodeAt(i) + ((hash << 5) - hash);
-      //     }
-
-      //     // Convert the hash to a number between 0 and 360
-      //     let hue = hash % 361;
-
-      //     // Generate the HSL color
-      //     return `hsl(${hue}, 50%, 50%)`;
-      // }
-      // return stringToColor(seriesName);
-      function hashCode(s) {
-        let hash = 0;
-        for (let i = 0; i < s.length; i++) {
-          hash = (Math.imul(31, hash) + s.charCodeAt(i)) | 0;
-        }
-        return Math.abs(hash);
-      }
-
-      function hslToRgb(h, s, l) {
-        let r, g, b;
-
-        if (s == 0) {
-          r = g = b = l; // achromatic
-        } else {
-          let hue2rgb = function hue2rgb(p, q, t) {
-            if (t < 0) t += 1;
-            if (t > 1) t -= 1;
-            if (t < 1 / 6) return p + (q - p) * 6 * t;
-            if (t < 1 / 2) return q;
-            if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-            return p;
-          };
-
-          let q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-          let p = 2 * l - q;
-          r = hue2rgb(p, q, h + 1 / 3);
-          g = hue2rgb(p, q, h);
-          b = hue2rgb(p, q, h - 1 / 3);
-        }
-
-        return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
-      }
-
-      function generateColorFromName(name: any, s = 0.8, l = 0.7) {
-        let hash = hashCode(name);
-        let h = (hash % 360) / 360;
-        let rgb = hslToRgb(h, s, l);
-        let hex =
-          "#" +
-          rgb
-            .map((x) => {
-              const hex = x.toString(16);
-              return hex.length === 1 ? "0" + hex : hex;
-            })
-            .join("");
-        return hex;
-      }
-
-      return generateColorFromName(seriesName, 0.8, 0.7);
+      return null;
     }
 
-    case "green-yellow-red": {
+    case "continuous": {
       const value =
         panelSchema?.queryType == "promql"
           ? getSeriesValueFrom2DArray(panelSchema, valuesArr) ?? 50
           : getSeriesValueFromArray(panelSchema, valuesArr) ?? 50;
 
-      let scale = new Scale(
-        panelSchema?.config?.color?.fixedColor?.map(
-          (color: any) => new Color(color)
-        )
+      return getColorBasedOnValue(
+        value,
+        chartMin ?? 0,
+        chartMax ?? 100,
+        panelSchema?.config?.color?.fixedColor ?? ["5470c6"]
       );
-
-      scale.setDomain([chartMin ?? 0, chartMax ?? 100]);
-
-      return scale.getColor(value).toCssString();
     }
-
-    case "red-yellow-green": {
-      const value =
-        panelSchema?.queryType == "promql"
-          ? getSeriesValueFrom2DArray(panelSchema, valuesArr) ?? 50
-          : getSeriesValueFromArray(panelSchema, valuesArr) ?? 50;
-
-      let scale = new Scale(
-        panelSchema?.config?.color?.fixedColor?.map(
-          (color: any) => new Color(color)
-        )
-      );
-
-      scale.setDomain([chartMin ?? 0, chartMax ?? 100]);
-
-      return scale.getColor(value).toCssString();
-    }
-
-    // case "scheme":
-
-    // case "opacity":
 
     default: {
       // return color using colorArrayBySeries
-      return getColorForName(seriesName);
+      return getColorForSeries(seriesName, classicColorPalette);
+      // return null
     }
   }
 };

--- a/web/src/utils/dashboard/colorPalette.ts
+++ b/web/src/utils/dashboard/colorPalette.ts
@@ -81,9 +81,11 @@ const getSeriesValueFrom2DArray = (panelSchema: any, values: any) => {
       : 50;
 
   if (
-    ["shades", "continuous", "green-yellow-red", "red-yellow-green"].includes(
-      panelSchema?.config?.color?.mode
-    )
+    [
+      "shades",
+      "continuous-green-yellow-red",
+      "continuous-red-yellow-green",
+    ].includes(panelSchema?.config?.color?.mode)
   ) {
     if (panelSchema?.config?.color?.seriesBy == "min") {
       values.forEach((value: any) => {
@@ -113,7 +115,13 @@ const getSeriesValueFromArray = (panelSchema: any, values: any) => {
         ? values[values.length - 1]
         : 50
       : 50;
-  if (["shades", "continuous"].includes(panelSchema?.config?.color?.mode)) {
+  if (
+    [
+      "shades",
+      "continuous-green-yellow-red",
+      "continuous-red-yellow-green",
+    ].includes(panelSchema?.config?.color?.mode)
+  ) {
     if (panelSchema?.config?.color?.seriesBy == "min") {
       values.forEach((value: any) => {
         // value[1] should not NaN
@@ -230,7 +238,12 @@ export const classicColorPalette = [
   "#98C0FF",
 ];
 
-function getColorBasedOnValue(currentValue, minValue, maxValue, colorArray) {
+function getColorBasedOnValue(
+  currentValue: any,
+  minValue: any,
+  maxValue: any,
+  colorArray: any
+) {
   // Calculate the size of each partition
   var partitionSize = (maxValue - minValue) / colorArray.length;
 
@@ -244,18 +257,22 @@ function getColorBasedOnValue(currentValue, minValue, maxValue, colorArray) {
   return colorArray[index];
 }
 
-function djb2Hash(str) {
-  let hash = 5381;
+function getHashFromSeriesName(str: string) {
+  // remove unwanted space
+  str = str.trim();
+
+  let hash = 0;
   for (let i = 0; i < str.length; i++) {
-    // 5 times left shift means multiply by 32
-    hash = (hash << 5) + hash + str.charCodeAt(i); /* hash * 33 + c */
+    hash += str.charCodeAt(i);
   }
   return hash;
 }
 
 const getColorForSeries = (seriesName: string, colorArray: string[]) => {
-  // let hash = djb2Hash(seriesName);
-  let hash = djb2Hash(seriesName);
+  // Calculate the hash of the series name
+  let hash = getHashFromSeriesName(seriesName);
+
+  // Use the hash to select a color from the color array
   let index = Math.abs(hash) % colorArray.length;
   return colorArray[index];
 };
@@ -267,7 +284,6 @@ export const getColor = (
   chartMin?: any,
   chartMax?: any
 ) => {
-  console.log(panelSchema?.config?.color);
   // switch case based on panelSchema.color type
   switch (panelSchema?.config?.color?.mode) {
     case "fixed": {
@@ -297,7 +313,8 @@ export const getColor = (
       return null;
     }
 
-    case "continuous": {
+    case "continuous-green-yellow-red":
+    case "continuous-red-yellow-green": {
       const value =
         panelSchema?.queryType == "promql"
           ? getSeriesValueFrom2DArray(panelSchema, valuesArr) ?? 50

--- a/web/src/utils/dashboard/colorPalette.ts
+++ b/web/src/utils/dashboard/colorPalette.ts
@@ -1,0 +1,548 @@
+// Copyright 2023 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+export const colorArrayBySeries = [
+  "#5470c6",
+  "#91cc75",
+  "#fac858",
+  "#ee6666",
+  "#73c0de",
+  "#3ba272",
+  "#fc8452",
+  "#9a60b4",
+  "#dc1e1e",
+  "#9086e9",
+  "#27e162",
+  "#e08de6",
+  "#de6086",
+  "#ec8ceb",
+  "#99e9f1",
+  "#eec59c",
+];
+
+// Convert a hex color to HSL
+function hexToHsl(hex) {
+  let r = parseInt(hex.slice(1, 3), 16) / 255;
+  let g = parseInt(hex.slice(3, 5), 16) / 255;
+  let b = parseInt(hex.slice(5, 7), 16) / 255;
+
+  let max = Math.max(r, g, b),
+    min = Math.min(r, g, b);
+  let h,
+    s,
+    l = (max + min) / 2;
+
+  if (max === min) {
+    h = s = 0; // achromatic
+  } else {
+    let d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  return { h, s, l };
+}
+
+// Convert an HSL color to hex
+function hslToHex(hsl) {
+  let r, g, b;
+
+  if (hsl.s === 0) {
+    r = g = b = hsl.l; // achromatic
+  } else {
+    const hue2rgb = (p, q, t) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+    let q = hsl.l < 0.5 ? hsl.l * (1 + hsl.s) : hsl.l + hsl.s - hsl.l * hsl.s;
+    let p = 2 * hsl.l - q;
+    r = hue2rgb(p, q, hsl.h + 1 / 3);
+    g = hue2rgb(p, q, hsl.h);
+    b = hue2rgb(p, q, hsl.h - 1 / 3);
+  }
+
+  let toHex = (x) => {
+    let hex = Math.round(x * 255).toString(16);
+    return hex.length === 1 ? "0" + hex : hex;
+  };
+
+  return "#" + toHex(r) + toHex(g) + toHex(b);
+}
+
+// Get a color for a name
+function getColorForName(name) {
+  var hash = hashName(name);
+  var colorIndex = hash % colorArrayBySeries.length;
+  var baseColor = hexToHsl(colorArrayBySeries[colorIndex]);
+
+  // create a unique hue, saturation, and lightness value
+  baseColor.h = (baseColor.h + (hash % 360) / 360.0) % 1;
+  baseColor.s = baseColor.s + ((hash % 20) - 10) / 100.0; // vary by up to 10%
+  baseColor.l = baseColor.l + ((hash % 20) - 10) / 100.0; // vary by up to 10%
+
+  return hslToHex(baseColor);
+}
+
+// Define your hash function
+function hashName(name) {
+  var hash = 0;
+  for (var i = 0; i < name.length; i++) {
+    hash += name.charCodeAt(i);
+  }
+  return hash;
+}
+
+// // Convert a hex color to RGB
+// function hexToRgb(hex: any) {
+//     var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+//     return result ? {
+//         r: parseInt(result[1], 16),
+//         g: parseInt(result[2], 16),
+//         b: parseInt(result[3], 16)
+//     } : null;
+// }
+
+// // Convert an RGB color to hex
+// function rgbToHex(rgb) {
+//     return "#" + ((1 << 24) | (rgb.r << 16) | (rgb.g << 8) | rgb.b).toString(16).slice(1);
+// }
+
+// // Get a color for a name
+// function getColorForName(name: any) {
+//   var hash = hashName(name);
+//   var colorIndex = hash % colorArrayBySeries.length;
+//   var baseColor: any = hexToRgb(colorArrayBySeries[colorIndex]);
+
+//   // Create a unique offset for each RGB value
+//   var offset = Math.floor(hash / 256);
+
+//   var gradientColor = {
+//       r: (baseColor.r + offset) % 256,
+//       g: (baseColor.g + offset * 2) % 256,
+//       b: (baseColor.b + offset * 3) % 256
+//   };
+
+//   return rgbToHex(gradientColor);
+// }
+
+export const getIndexForName = (name: any, colorArray: any) => {
+  let index = 0;
+  for (let i = 0; i < 15; i++) {
+    const charCode = name.charCodeAt(i) || 0;
+    index += charCode * (i + 1);
+  }
+  return index % colorArray.length;
+};
+
+// const nameToColor = (name: any, colorArray: any) => {
+//   const index = getIndexForName(name, colorArray);
+//   return colorArray[index];
+// };
+const usedColors = new Map();
+const nameColorMap = new Map();
+
+const adjustColor = (color, amount) => {
+  const usePound = color[0] === "#";
+  const num = usePound ? color.slice(1) : color;
+  const scale = amount < 0 ? 0 : 255;
+  const inverseScale = amount < 0 ? -amount : 1 - amount;
+
+  const r =
+    scale -
+    Math.round((scale - parseInt(num.substring(0, 2), 16)) * inverseScale);
+  const g =
+    scale -
+    Math.round((scale - parseInt(num.substring(2, 4), 16)) * inverseScale);
+  const b =
+    scale -
+    Math.round((scale - parseInt(num.substring(4, 6), 16)) * inverseScale);
+
+  return (
+    (usePound ? "#" : "") +
+    ((0x1000000 + (r << 16)) | (g << 8) | b).toString(16).slice(1)
+  );
+};
+
+const nameToColor = (name, colorArray) => {
+  if (nameColorMap.has(name)) {
+    return nameColorMap.get(name);
+  }
+
+  const index = getIndexForName(name, colorArray);
+  let color = colorArray[index];
+
+  if (usedColors.has(color)) {
+    const amount = usedColors.get(color) * 99; // Adjust the shade by 10% each time
+    color = adjustColor(color, amount);
+    usedColors.set(color, usedColors.get(color) + 1);
+  } else {
+    usedColors.set(color, 1);
+  }
+
+  nameColorMap.set(name, color);
+  return color;
+};
+
+function stringToColor(str) {
+  // Create a hash from the string
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  // Convert the hash to an HSL color
+  let hue = hash % 360;
+  let saturation = (hash % 25) + 100; // Saturation range between 75-100%
+  let lightness = (hash % 15) + 100; // Lightness range between 70-85%
+
+  return "hsl(" + hue + ", " + saturation + "%, " + lightness + "%)";
+}
+
+function shadeColor(color: any, value: any, min: any, max: any) {
+  let percent = (value - min) / (max - min);
+  let num = parseInt(color.replace("#", ""), 16),
+    amt = Math.round(1.55 * percent * 100),
+    R = (num >> 16) + amt,
+    B = ((num >> 8) & 0x00ff) + amt,
+    G = (num & 0x0000ff) + amt;
+
+  let newColor = (
+    0x1000000 +
+    (R < 255 ? (R < 1 ? 0 : R) : 255) * 0x10000 +
+    (B < 255 ? (B < 1 ? 0 : B) : 255) * 0x100 +
+    (G < 255 ? (G < 1 ? 0 : G) : 255)
+  )
+    .toString(16)
+    .slice(1);
+  return "#" + newColor;
+}
+
+export const getMetricMinMaxValue = (searchQueryData: any) => {
+  // need min and max value for color
+  let min = Infinity;
+  let max = -Infinity;
+  searchQueryData.forEach((metric: any) => {
+    if (metric.result && Array.isArray(metric.result)) {
+      metric?.result?.forEach((valuesArr: any) => {
+        if (valuesArr.values && Array.isArray(valuesArr.values)) {
+          valuesArr.values.forEach((val: any) => {
+            // val[1] should not NaN
+            if (!isNaN(val[1])) {
+              min = Math.min(min, val[1]);
+              max = Math.max(max, val[1]);
+            }
+          });
+        }
+      });
+    }
+  });
+  return [min, max];
+};
+
+export const getSQLMinMaxValue = (yaxiskeys: any, searchQueryData: any) => {
+  // need min and max value for color
+  let min = Infinity;
+  let max = -Infinity;
+
+  searchQueryData[0]?.forEach((data: any) => {
+    yaxiskeys?.forEach((key: any) => {
+      if (data[key] !== undefined && !isNaN(data[key]) && data[key] !== null) {
+        min = Math.min(min, data[key]);
+        max = Math.max(max, data[key]);
+      }
+    });
+  });
+
+  return [min, max];
+};
+
+const getSeriesValueFrom2DArray = (panelSchema: any, values: any) => {
+  // if color is based on value then need to find seriesmin or seriesmax or last value
+  let seriesvalue =
+    values?.length > 0
+      ? !isNaN(values[values.length - 1][1])
+        ? values[values.length - 1][1]
+        : 50
+      : 50;
+  if (["shades", "continuous"].includes(panelSchema?.config?.color?.mode)) {
+    if (panelSchema?.config?.color?.seriesBy == "min") {
+      values.forEach((value: any) => {
+        // value[1] should not NaN
+        if (!isNaN(value[1])) {
+          seriesvalue = Math.min(value[1], seriesvalue);
+        }
+      });
+    } else if (panelSchema?.config?.color?.seriesBy == "max") {
+      values.forEach((value: any) => {
+        // value[1] should not NaN
+        if (!isNaN(value[1])) {
+          seriesvalue = Math.max(value[1], seriesvalue);
+        }
+      });
+    }
+  }
+
+  return seriesvalue;
+};
+
+const getSeriesValueFromArray = (panelSchema: any, values: any) => {
+  // if color is based on value then need to find seriesmin or seriesmax or last value
+  let seriesvalue =
+    values?.length > 0
+      ? !isNaN(values[values.length - 1])
+        ? values[values.length - 1]
+        : 50
+      : 50;
+  if (["shades", "continuous"].includes(panelSchema?.config?.color?.mode)) {
+    if (panelSchema?.config?.color?.seriesBy == "min") {
+      values.forEach((value: any) => {
+        // value[1] should not NaN
+        if (!isNaN(value)) {
+          seriesvalue = Math.min(value, seriesvalue);
+        }
+      });
+    } else if (panelSchema?.config?.color?.seriesBy == "max") {
+      values.forEach((value: any) => {
+        // value[1] should not NaN
+        if (!isNaN(value)) {
+          seriesvalue = Math.max(value, seriesvalue);
+        }
+      });
+    }
+  }
+
+  return seriesvalue;
+};
+
+class Scale {
+  colors: any;
+  domain: any;
+
+  constructor(colors: any) {
+    this.colors = colors;
+    this.domain = [0, 100];
+  }
+
+  setDomain(domain: any) {
+    this.domain = domain;
+  }
+
+  getColor(value: any) {
+    // NOTE: need to check value should not be NaN
+    // and it should not be less than domain[0] or greater than domain[1]
+
+    let t = (value - this.domain[0]) / (this.domain[1] - this.domain[0]);
+    let index = Math.floor(t * (this.colors.length - 1));
+    let color1 = this.colors[index];
+    let color2 = this.colors[index + 1] || color1; // use the same color if color2 is not defined
+    let tLocal = color2 === color1 ? 0 : t * (this.colors.length - 1) - index; // calculate local interpolation parameter
+    let interpolated = color1.interpolate(color2, tLocal);
+
+    return interpolated;
+  }
+}
+
+class Color {
+  r: any;
+  g: any;
+  b: any;
+
+  constructor(hex: any) {
+    // NOTE: use default color if hex is not valid
+    let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    if (!result) {
+      throw new Error(`Invalid color: ${hex}`);
+    }
+    this.r = parseInt(result[1], 16);
+    this.g = parseInt(result[2], 16);
+    this.b = parseInt(result[3], 16);
+  }
+
+  interpolate(other: any, t: any) {
+    let r = this.r + t * (other.r - this.r);
+    let g = this.g + t * (other.g - this.g);
+    let b = this.b + t * (other.b - this.b);
+
+    return new Color(
+      this.rgbToHex(Math.round(r), Math.round(g), Math.round(b))
+    );
+  }
+
+  rgbToHex(r: any, g: any, b: any) {
+    return "#" + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+  }
+
+  toCssString() {
+    return `rgb(${Math.round(this.r)}, ${Math.round(this.g)}, ${Math.round(
+      this.b
+    )})`;
+  }
+}
+
+export const getColor = (
+  panelSchema: any,
+  seriesName: any,
+  valuesArr?: any,
+  chartMin?: any,
+  chartMax?: any
+) => {
+  // switch case based on panelSchema.color type
+  switch (panelSchema?.config?.color?.mode) {
+    case "fixed": {
+      return panelSchema?.config?.color?.fixedColor
+        ? panelSchema?.config?.color?.fixedColor[0] ?? "#53ca53"
+        : "#53ca53";
+    }
+    case "shades": {
+      // based on selected color pass different shades of same color
+      return shadeColor(
+        panelSchema?.config?.color?.fixedColor
+          ? panelSchema?.config?.color?.fixedColor[0] ?? "#53ca53"
+          : "#53ca53",
+        panelSchema.queryType == "promql"
+          ? getSeriesValueFrom2DArray(panelSchema, valuesArr) ?? 50
+          : getSeriesValueFromArray(panelSchema, valuesArr) ?? 50,
+        chartMin ?? 0,
+        chartMax ?? 100
+      );
+    }
+
+    case "palette-classic": {
+      // return color using colorArrayBySeries
+      // NOTE: here value will be series name
+      // return getColorForName(seriesName);
+      //   function stringToColor(str) {
+      //     let hash = 0;
+      //     for (let i = 0; i < str.length; i++) {
+      //         hash = str.charCodeAt(i) + ((hash << 5) - hash);
+      //     }
+
+      //     // Convert the hash to a number between 0 and 360
+      //     let hue = hash % 361;
+
+      //     // Generate the HSL color
+      //     return `hsl(${hue}, 50%, 50%)`;
+      // }
+      // return stringToColor(seriesName);
+      function hashCode(s) {
+        let hash = 0;
+        for (let i = 0; i < s.length; i++) {
+          hash = (Math.imul(31, hash) + s.charCodeAt(i)) | 0;
+        }
+        return Math.abs(hash);
+      }
+
+      function hslToRgb(h, s, l) {
+        let r, g, b;
+
+        if (s == 0) {
+          r = g = b = l; // achromatic
+        } else {
+          let hue2rgb = function hue2rgb(p, q, t) {
+            if (t < 0) t += 1;
+            if (t > 1) t -= 1;
+            if (t < 1 / 6) return p + (q - p) * 6 * t;
+            if (t < 1 / 2) return q;
+            if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+            return p;
+          };
+
+          let q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+          let p = 2 * l - q;
+          r = hue2rgb(p, q, h + 1 / 3);
+          g = hue2rgb(p, q, h);
+          b = hue2rgb(p, q, h - 1 / 3);
+        }
+
+        return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+      }
+
+      function generateColorFromName(name: any, s = 0.8, l = 0.7) {
+        let hash = hashCode(name);
+        let h = (hash % 360) / 360;
+        let rgb = hslToRgb(h, s, l);
+        let hex =
+          "#" +
+          rgb
+            .map((x) => {
+              const hex = x.toString(16);
+              return hex.length === 1 ? "0" + hex : hex;
+            })
+            .join("");
+        return hex;
+      }
+
+      return generateColorFromName(seriesName, 0.8, 0.7);
+    }
+
+    case "green-yellow-red": {
+      const value =
+        panelSchema?.queryType == "promql"
+          ? getSeriesValueFrom2DArray(panelSchema, valuesArr) ?? 50
+          : getSeriesValueFromArray(panelSchema, valuesArr) ?? 50;
+
+      let scale = new Scale(
+        panelSchema?.config?.color?.fixedColor?.map(
+          (color: any) => new Color(color)
+        )
+      );
+
+      scale.setDomain([chartMin ?? 0, chartMax ?? 100]);
+
+      return scale.getColor(value).toCssString();
+    }
+
+    case "red-yellow-green": {
+      const value =
+        panelSchema?.queryType == "promql"
+          ? getSeriesValueFrom2DArray(panelSchema, valuesArr) ?? 50
+          : getSeriesValueFromArray(panelSchema, valuesArr) ?? 50;
+
+      let scale = new Scale(
+        panelSchema?.config?.color?.fixedColor?.map(
+          (color: any) => new Color(color)
+        )
+      );
+
+      scale.setDomain([chartMin ?? 0, chartMax ?? 100]);
+
+      return scale.getColor(value).toCssString();
+    }
+
+    // case "scheme":
+
+    // case "opacity":
+
+    default: {
+      // return color using colorArrayBySeries
+      return getColorForName(seriesName);
+    }
+  }
+};

--- a/web/src/utils/dashboard/colorPalette.ts
+++ b/web/src/utils/dashboard/colorPalette.ts
@@ -81,11 +81,8 @@ const getSeriesValueFrom2DArray = (panelSchema: any, values: any) => {
       : 50;
 
   if (
-    [
-      "shades",
-      "continuous-green-yellow-red",
-      "continuous-red-yellow-green",
-    ].includes(panelSchema?.config?.color?.mode)
+    ["shades"].includes(panelSchema?.config?.color?.mode) ||
+    panelSchema?.config?.color?.mode.startsWith("continuous")
   ) {
     if (panelSchema?.config?.color?.seriesBy == "min") {
       values.forEach((value: any) => {
@@ -116,11 +113,8 @@ const getSeriesValueFromArray = (panelSchema: any, values: any) => {
         : 50
       : 50;
   if (
-    [
-      "shades",
-      "continuous-green-yellow-red",
-      "continuous-red-yellow-green",
-    ].includes(panelSchema?.config?.color?.mode)
+    ["shades"].includes(panelSchema?.config?.color?.mode) ||
+    panelSchema?.config?.color?.mode.startsWith("continuous")
   ) {
     if (panelSchema?.config?.color?.seriesBy == "min") {
       values.forEach((value: any) => {
@@ -313,25 +307,24 @@ export const getColor = (
       return null;
     }
 
-    case "continuous-green-yellow-red":
-    case "continuous-red-yellow-green": {
-      const value =
-        panelSchema?.queryType == "promql"
-          ? getSeriesValueFrom2DArray(panelSchema, valuesArr) ?? 50
-          : getSeriesValueFromArray(panelSchema, valuesArr) ?? 50;
-
-      return getColorBasedOnValue(
-        value,
-        chartMin ?? 0,
-        chartMax ?? 100,
-        panelSchema?.config?.color?.fixedColor ?? ["5470c6"]
-      );
-    }
-
     default: {
-      // return color using colorArrayBySeries
+      // if mode starts with "continuous", execute this code
+      if (panelSchema?.config?.color?.mode?.startsWith("continuous")) {
+        const value =
+          panelSchema?.queryType == "promql"
+            ? getSeriesValueFrom2DArray(panelSchema, valuesArr) ?? 50
+            : getSeriesValueFromArray(panelSchema, valuesArr) ?? 50;
+
+        return getColorBasedOnValue(
+          value,
+          chartMin ?? 0,
+          chartMax ?? 100,
+          panelSchema?.config?.color?.fixedColor ?? ["5470c6"]
+        );
+      }
+
+      // for all other cases, default will be palette-classic-by-series
       return getColorForSeries(seriesName, classicColorPalette);
-      // return null
     }
   }
 };

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -352,11 +352,7 @@ export const convertPromQLData = async (
   // if color type is shades, continuous then required to calculate min and max for chart.
   let chartMin: any = Infinity;
   let chartMax: any = -Infinity;
-  if (
-    ["shades", "green-yellow-red", "red-yellow-green"].includes(
-      panelSchema?.config?.color?.mode
-    )
-  ) {
+  if (["shades", "continuous"].includes(panelSchema?.config?.color?.mode)) {
     [chartMin, chartMax] = getMetricMinMaxValue(searchQueryData);
   }
 
@@ -393,7 +389,7 @@ export const convertPromQLData = async (
                       metric.metric,
                       panelSchema.queries[index].config.promql_legend
                     ),
-                    metric.metric,
+                    metric.values,
                     chartMin,
                     chartMax
                   ),
@@ -826,7 +822,7 @@ const getPropsByChartTypeForSeries = (type: string) => {
         emphasis: { focus: "series" },
         smooth: true,
         areaStyle: {
-          opacity: 0.4,
+          // opacity: 0.4,
         },
         showSymbol: false,
         lineStyle: { width: 1.5 },
@@ -843,7 +839,7 @@ const getPropsByChartTypeForSeries = (type: string) => {
         smooth: true,
         stack: "Total",
         areaStyle: {
-          opacity: 0.4,
+          // opacity: 0.4,
         },
         showSymbol: false,
         emphasis: {

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -352,7 +352,10 @@ export const convertPromQLData = async (
   // if color type is shades, continuous then required to calculate min and max for chart.
   let chartMin: any = Infinity;
   let chartMax: any = -Infinity;
-  if (["shades", "continuous-green-yellow-red", "continuous-red-yellow-green"].includes(panelSchema?.config?.color?.mode)) {
+  if (
+    ["shades"].includes(panelSchema?.config?.color?.mode) ||
+    panelSchema?.config?.color?.mode.startsWith("continuous")
+  ) {
     [chartMin, chartMax] = getMetricMinMaxValue(searchQueryData);
   }
 

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -352,7 +352,7 @@ export const convertPromQLData = async (
   // if color type is shades, continuous then required to calculate min and max for chart.
   let chartMin: any = Infinity;
   let chartMax: any = -Infinity;
-  if (["shades", "continuous"].includes(panelSchema?.config?.color?.mode)) {
+  if (["shades", "continuous-green-yellow-red", "continuous-red-yellow-green"].includes(panelSchema?.config?.color?.mode)) {
     [chartMin, chartMax] = getMetricMinMaxValue(searchQueryData);
   }
 

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -28,6 +28,8 @@ import {
   getUnitValue,
 } from "./convertDataIntoUnitValue";
 import { calculateGridPositions } from "./calculateGridForSubPlot";
+import { getColor, getSQLMinMaxValue } from "./colorPalette";
+
 export const convertSQLData = (
   panelSchema: any,
   searchQueryData: any,
@@ -416,6 +418,17 @@ export const convertSQLData = (
     series: [],
   };
   const defaultSeriesProps = getPropsByChartTypeForSeries(panelSchema.type);
+
+  // if color type is shades, continuous then required to calculate min and max for chart.
+  let chartMin: any = Infinity;
+  let chartMax: any = -Infinity;
+  if (
+    ["shades", "green-yellow-red", "red-yellow-green"].includes(
+      panelSchema?.config?.color?.mode
+    )
+  ) {
+    [chartMin, chartMax] = getSQLMinMaxValue(yAxisKeys, searchQueryData);
+  }
 
   // Now set the series values as per the chart data
   // Override any configs if required as per the chart type

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -423,11 +423,8 @@ export const convertSQLData = (
   let chartMin: any = Infinity;
   let chartMax: any = -Infinity;
   if (
-    [
-      "shades",
-      "continuous-green-yellow-red",
-      "continuous-red-yellow-green",
-    ].includes(panelSchema?.config?.color?.mode)
+    ["shades"].includes(panelSchema?.config?.color?.mode) ||
+    panelSchema?.config?.color?.mode.startsWith("continuous")
   ) {
     // if heatmap then get min and max from z axis sql data
     if (panelSchema.type == "heatmap") {


### PR DESCRIPTION
- Color palette for dashboard chart.
- By default, `Palette-Classic (By Series)` will be selected.
![image](https://github.com/openobserve/openobserve/assets/141122205/ae455eb3-4da5-4f68-bd52-7adc7922c11b)

