### PR TITLE
feat: publish usage report to external url

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -542,9 +542,10 @@ pub struct Common {
         help = "possible values - 'local', 'remote', 'both'"
     )] // local, remote , both
     pub usage_reporting_mode: String,
-    #[env_config(name = "ZO_USAGE_REPORTING_REMOTE_STREAM_NAME", default = "")]
-    pub usage_reporting_remote_stream_name: String,
-    #[env_config(name = "ZO_USAGE_REPORTING_URL", default = "http://localhost:5080")]
+    #[env_config(
+        name = "ZO_USAGE_REPORTING_URL",
+        default = "http://localhost:5080/api/_meta/usage/_json"
+    )]
     pub usage_reporting_url: String,
     #[env_config(name = "ZO_USAGE_REPORTING_CREDS", default = "")]
     pub usage_reporting_creds: String,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -536,6 +536,18 @@ pub struct Common {
     pub usage_report_compressed_size: bool,
     #[env_config(name = "ZO_USAGE_ORG", default = "_meta")]
     pub usage_org: String,
+    #[env_config(
+        name = "ZO_USAGE_REPORTING_MODE",
+        default = "local",
+        help = "possible values - 'local', 'remote', 'both'"
+    )] // local, remote , both
+    pub usage_reporting_mode: String,
+    #[env_config(name = "ZO_USAGE_REPORTING_REMOTE_STREAM_NAME", default = "")]
+    pub usage_reporting_remote_stream_name: String,
+    #[env_config(name = "ZO_USAGE_REPORTING_URL", default = "http://localhost:5080")]
+    pub usage_reporting_url: String,
+    #[env_config(name = "ZO_USAGE_REPORTING_CREDS", default = "")]
+    pub usage_reporting_creds: String,
     #[env_config(name = "ZO_USAGE_BATCH_SIZE", default = 2000)]
     pub usage_batch_size: usize,
     #[env_config(name = "ZO_MMDB_DATA_DIR")] // ./data/openobserve/mmdb/

--- a/src/service/usage/mod.rs
+++ b/src/service/usage/mod.rs
@@ -61,11 +61,6 @@ pub async fn report_request_usage_stats(
     if !CONFIG.common.usage_enabled {
         return;
     }
-    if CONFIG.common.usage_org.eq(org_id)
-        && (stream_name.eq(STATS_STREAM) || stream_name.eq(USAGE_STREAM))
-    {
-        return;
-    }
 
     let request_body = stats.request_body.unwrap_or(usage_type.to_string());
     let user_email = stats.user_email.unwrap_or("".to_owned());
@@ -248,17 +243,10 @@ pub async fn publish_usage(mut usage: Vec<UsageData>) {
     }
 
     if &CONFIG.common.usage_reporting_mode != "local"
-        && !CONFIG.common.usage_reporting_remote_stream_name.is_empty()
         && !CONFIG.common.usage_reporting_url.is_empty()
         && !CONFIG.common.usage_reporting_creds.is_empty()
     {
-        let url = format!(
-            "{}/api/{}/{}/_json",
-            &CONFIG.common.usage_reporting_url,
-            &CONFIG.common.usage_org,
-            &CONFIG.common.usage_reporting_remote_stream_name
-        );
-        let url = url::Url::parse(&url).unwrap();
+        let url = url::Url::parse(&CONFIG.common.usage_reporting_url).unwrap();
         let creds = CONFIG.common.usage_reporting_creds.to_string();
         if let Err(e) = Client::builder()
             .build()


### PR DESCRIPTION
ENVs introduced - 

| `ENV` | Description |
|--------|-------------|
| `ZO_USAGE_REPORTING_MODE` | Possible values - `local`, `remote` and `both`. `local` means usage is only reported in internal cluster. `remote` means store it in remote address and `both` means reporting is done in the both `local` and `remote`. Default is `local` |
| `ZO_USAGE_REPORTING_URL` | Remote Reporting URL (with full api endpoint). Default is `http://localhost:5080/api/_meta/usage/_json` |
| `ZO_USAGE_REPORTING_CREDS` | Credentials required for posting the usage report to remote reporting URL |