### PR TITLE
fix: print better error message with NATS server address for which failed to connect

### DIFF
--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -476,10 +476,14 @@ pub async fn connect() -> async_nats::Client {
         .map(|a| a.parse().unwrap())
         .collect::<Vec<ServerAddr>>();
     match async_nats::connect_with_options(addrs.clone(), opts).await {
-        Ok(client) => Ok(client),
-        Err(_) => {
-            log::error!("NATS connect failed for address(es): {:?}", addrs);
-            Err("NATS connect failed".into())
+        Ok(client) => client,
+        Err(e) => {
+            log::error!(
+                "NATS connect failed for address(es): {:?}, err: {}",
+                addrs,
+                e
+            );
+            panic!("NATS connect failed");
         }
     }
 }

--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -475,9 +475,13 @@ pub async fn connect() -> async_nats::Client {
         .split(',')
         .map(|a| a.parse().unwrap())
         .collect::<Vec<ServerAddr>>();
-    async_nats::connect_with_options(addrs, opts)
-        .await
-        .expect("Nats connect failed")
+    match async_nats::connect_with_options(addrs.clone(), opts).await {
+        Ok(client) => Ok(client),
+        Err(_) => {
+            log::error!("NATS connect failed for address(es): {:?}", addrs);
+            Err("NATS connect failed".into())
+        }
+    }
 }
 
 pub(crate) struct Locker {


### PR DESCRIPTION
This PR prints error message with NATS server address when connection to NATS fails.