### PR TITLE
fix: ensure that rum proxy endpoint uses cookies

### DIFF
--- a/src/handler/http/auth/validator.rs
+++ b/src/handler/http/auth/validator.rs
@@ -372,6 +372,19 @@ async fn oo_validator_internal(
     }
 }
 
+/// Validates the authentication information in the incoming request and returns the request if
+/// valid, or an error if invalid.
+///
+/// This function is responsible for validating the authentication information in the incoming
+/// request. It supports both Basic and Bearer authentication (in enterprise).
+/// Works exclusively on `/api` prefix
+///
+/// For Basic authentication, it decodes the base64-encoded credentials, splits them into username
+/// and password, and calls the `validator` function to validate the credentials.
+///
+/// For Bearer authentication, it calls the `token_validator` function to validate the token.
+///
+/// If the authentication is invalid, it returns an `ErrorUnauthorized` error.
 pub async fn oo_validator(
     req: ServiceRequest,
     auth_info: AuthExtractor,

--- a/web/src/components/rum/VideoPlayer.vue
+++ b/web/src/components/rum/VideoPlayer.vue
@@ -16,58 +16,105 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div class="player-container full-height q-pa-sm">
-    <div v-if="isLoading" class="q-pb-lg flex items-center justify-center text-center full-width"
-      style="height: calc(100vh - 200px)">
+    <div
+      v-if="isLoading"
+      class="q-pb-lg flex items-center justify-center text-center full-width"
+      style="height: calc(100vh - 200px)"
+    >
       <div>
-        <q-spinner-hourglass color="primary" size="40px" style="margin: 0 auto; display: block" />
+        <q-spinner-hourglass
+          color="primary"
+          size="40px"
+          style="margin: 0 auto; display: block"
+        />
         <div class="text-center full-width">
           Hold on tight, we're fetching session.
         </div>
       </div>
     </div>
-    <div ref="playerContainerRef" class="flex items-center justify-center" style="height: calc(100vh - 198px)">
-      <div ref="playerRef" id="player" class="player flex items-center cursor-pointer" @click="togglePlay" />
+    <div
+      ref="playerContainerRef"
+      class="flex items-center justify-center"
+      style="height: calc(100vh - 198px)"
+    >
+      <div
+        ref="playerRef"
+        id="player"
+        class="player flex items-center cursor-pointer"
+        @click="togglePlay"
+      />
     </div>
     <div class="full-width q-pa-sm q-pt-md controls-container">
-      <div ref="playbackBarRef" class="playback_bar q-mt-sm q-mb-md relative-position cursor-pointer"
-        @click="handlePlaybackBarClick">
-        <div class="progressTime bg-primary absolute" :style="{
-      width: playerState.progressWidth + 'px',
-      left: 0,
-      top: 0,
-      height: '100%',
-      transition: 'all 0.1s linear',
-    }" />
-        <div class="progressTime bg-primary absolute" :style="{
-      width: '2px',
-      left: playerState.progressWidth - 2 + 'px',
-      bottom: '-5px',
-      height: '15px',
-      transition: 'all 0.1s linear',
-    }" />
+      <div
+        ref="playbackBarRef"
+        class="playback_bar q-mt-sm q-mb-md relative-position cursor-pointer"
+        @click="handlePlaybackBarClick"
+      >
+        <div
+          class="progressTime bg-primary absolute"
+          :style="{
+            width: playerState.progressWidth + 'px',
+            left: 0,
+            top: 0,
+            height: '100%',
+            transition: 'all 0.1s linear',
+          }"
+        />
+        <div
+          class="progressTime bg-primary absolute"
+          :style="{
+            width: '2px',
+            left: playerState.progressWidth - 2 + 'px',
+            bottom: '-5px',
+            height: '15px',
+            transition: 'all 0.1s linear',
+          }"
+        />
 
-        <div v-for="event in (events as any[])" :key="event.id"
-          class="progressTime bg-secondary absolute cursor-pointer" :style="{
-      width: '2px',
-      left:
-        (event.relativeTime / playerState.totalTime) * playerState.width +
-        'px',
-      bottom: '-5px',
-      height: '15px',
-    }" :title="event.name.length > 100
-      ? event.name.slice(0, 100) + '...'
-      : event.name
-      " />
+        <div
+          v-for="event in (events as any[])"
+          :key="event.id"
+          class="progressTime bg-secondary absolute cursor-pointer"
+          :style="{
+            width: '2px',
+            left:
+              (event.relativeTime / playerState.totalTime) * playerState.width +
+              'px',
+            bottom: '-5px',
+            height: '15px',
+          }"
+          :title="
+            event.name.length > 100
+              ? event.name.slice(0, 100) + '...'
+              : event.name
+          "
+        />
       </div>
       <div class="controls flex justify-between items-center">
         <div class="flex items-center">
           <div>
-            <q-icon name="replay_10" size="24px" class="q-mr-sm cursor-pointer" @click="skipTo('backward')" />
-            <q-icon :name="playerState.isPlaying
-      ? 'pause_circle_filled'
-      : 'play_circle_filled'
-      " size="32px" class="cursor-pointer" @click="togglePlay" />
-            <q-icon name="forward_10" size="24px" class="q-ml-sm cursor-pointer" @click="skipTo('forward')" />
+            <q-icon
+              name="replay_10"
+              size="24px"
+              class="q-mr-sm cursor-pointer"
+              @click="skipTo('backward')"
+            />
+            <q-icon
+              :name="
+                playerState.isPlaying
+                  ? 'pause_circle_filled'
+                  : 'play_circle_filled'
+              "
+              size="32px"
+              class="cursor-pointer"
+              @click="togglePlay"
+            />
+            <q-icon
+              name="forward_10"
+              size="24px"
+              class="q-ml-sm cursor-pointer"
+              @click="skipTo('forward')"
+            />
           </div>
           <div class="flex q-ml-lg items-center">
             <div>{{ playerState.time }}</div>
@@ -76,10 +123,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
         </div>
         <div class="flex items-center">
-          <q-toggle class="q-mr-md" v-model="playerState.skipInactivity" :label="t('rum.skipInactivity')" size="xs"
-            @update:model-value="toggleSkipInactive" />
-          <q-select class="speed-selector" v-model="playerState.speed" :options="speedOptions" color="input-border"
-            bg-color="input-bg" stack-label outlined filled dense size="xs" @update:model-value="setSpeed" />
+          <q-toggle
+            class="q-mr-md"
+            v-model="playerState.skipInactivity"
+            :label="t('rum.skipInactivity')"
+            size="xs"
+            @update:model-value="toggleSkipInactive"
+          />
+          <q-select
+            class="speed-selector"
+            v-model="playerState.speed"
+            :options="speedOptions"
+            color="input-border"
+            bg-color="input-bg"
+            stack-label
+            outlined
+            filled
+            dense
+            size="xs"
+            @update:model-value="setSpeed"
+          />
         </div>
       </div>
     </div>

--- a/web/src/workers/rumcssworker.js
+++ b/web/src/workers/rumcssworker.js
@@ -2,20 +2,16 @@ self.addEventListener("message", (e) => {
   const cssString = e.data.cssString;
   const proxyUrl = e.data.proxyUrl;
   const id = e.data.id;
-  const token = e.data.token;
-  const updatedCssString = replaceAbsoluteUrlsWithProxies(
-    proxyUrl,
-    cssString,
-    token,
-    ["fonts.gstatic.com", "fonts.googleapis.com"]
-  );
+  const updatedCssString = replaceAbsoluteUrlsWithProxies(proxyUrl, cssString, [
+    "fonts.gstatic.com",
+    "fonts.googleapis.com",
+  ]);
   self.postMessage({ updatedCssString, id });
 });
 
 function replaceAbsoluteUrlsWithProxies(
   proxyUrl,
   cssString,
-  token,
   excludedDomains = []
 ) {
   const urlRegex = /url\(\s*(['"]?)(https?:\/\/[^'"\)]+)\1\s*\)/g;
@@ -25,7 +21,7 @@ function replaceAbsoluteUrlsWithProxies(
     if (isExcluded) {
       return match;
     }
-    return `url("${proxyUrl}/${url}?proxy-token=${token}")`;
+    return `url("${proxyUrl}/${url}")`;
   }
 
   return cssString.replace(urlRegex, replaceWithProxy);


### PR DESCRIPTION
Due to changes in the current architecture the access-token is being sent as a cookie - `access_token` so this change facilitates accessing the proxy url via the same mechanism