### PR TITLE
fix: trace get_file_list

### DIFF
--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -721,7 +721,7 @@ async fn merge_grpc_result(
     Ok((merge_batches, scan_stats))
 }
 
-#[tracing::instrument(skip(sql), fields(trace_id = ?_trace_id, org_id = sql.org_id, stream_name = sql.stream_name))]
+#[tracing::instrument(skip(sql), fields(org_id = sql.org_id, stream_name = sql.stream_name))]
 pub(crate) async fn get_file_list(
     _trace_id: &str,
     sql: &super::sql::Sql,


### PR DESCRIPTION
before this pr
<img width="1019" alt="image" src="https://github.com/openobserve/openobserve/assets/47685845/21e48c8c-a832-493b-a1aa-4f5fc0080b10">
after this pr
<img width="1009" alt="image" src="https://github.com/openobserve/openobserve/assets/47685845/250b8309-7628-4f1e-873b-85cc1cc73782">
