### PR TITLE
fix: dashboard query inspector time based on its time zone

### DIFF
--- a/web/src/components/dashboards/QueryInspector.vue
+++ b/web/src/components/dashboards/QueryInspector.vue
@@ -50,7 +50,7 @@ export default defineComponent({
         store.state.timezone,
         "yyyy-MM-dd HH:mm:ss.SSS"
       );
-      const startTimeEntry = `${timestampOfStartTime} (${formattedStartTime})`;
+      const startTimeEntry = `${timestampOfStartTime} (${formattedStartTime} ${store.state.timezone})`;
 
       const timestampOfEndTime = query?.endTime;
       const formattedEndTime = timestampToTimezoneDate(
@@ -58,7 +58,7 @@ export default defineComponent({
         store.state.timezone,
         "yyyy-MM-dd HH:mm:ss.SSS"
       );
-      const endTimeEntry = `${timestampOfEndTime} (${formattedEndTime})`;
+      const endTimeEntry = `${timestampOfEndTime} (${formattedEndTime} ${store.state.timezone})`;
 
       const rows: any[] = [
         ["Original Query", query?.originalQuery],

--- a/web/src/components/dashboards/QueryInspector.vue
+++ b/web/src/components/dashboards/QueryInspector.vue
@@ -44,6 +44,7 @@ export default defineComponent({
     const store = useStore();
     
     const getRows = (query: any) => {
+      
       const timestampOfStartTime = query?.startTime;
       const formattedStartTime = timestampToTimezoneDate(
         timestampOfStartTime / 1000,

--- a/web/src/components/dashboards/QueryInspector.vue
+++ b/web/src/components/dashboards/QueryInspector.vue
@@ -21,6 +21,8 @@
 
 <script lang="ts">
 import { computed, defineComponent, ref } from "vue";
+import { timestampToTimezoneDate } from "@/utils/zincutils";
+import { useStore } from "vuex";
 
 export default defineComponent({
   name: "QueryInspector",
@@ -39,14 +41,23 @@ export default defineComponent({
   },
   setup(props: any) {
     const queryData = props.metaData?.queries || [] ;
+    const store = useStore();
     
     const getRows = (query: any) => {
       const timestampOfStartTime = query?.startTime;
-      const formattedStartTime = new Date(timestampOfStartTime / 1000);
+      const formattedStartTime = timestampToTimezoneDate(
+        timestampOfStartTime / 1000,
+        store.state.timezone,
+        "yyyy-MM-dd HH:mm:ss.SSS"
+      );
       const startTimeEntry = `${timestampOfStartTime} (${formattedStartTime})`;
 
       const timestampOfEndTime = query?.endTime;
-      const formattedEndTime = new Date(timestampOfEndTime / 1000);
+      const formattedEndTime = timestampToTimezoneDate(
+        timestampOfEndTime / 1000,
+        store.state.timezone,
+        "yyyy-MM-dd HH:mm:ss.SSS"
+      );
       const endTimeEntry = `${timestampOfEndTime} (${formattedEndTime})`;
 
       const rows: any[] = [


### PR DESCRIPTION
The dashboard query inspector originally set the start and end times in UTC. These times, however, have been adjusted to the appropriate time zone.