### PR TITLE
fix: migration from old TRIGGERS to scheduled jobs

### DIFF
--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -19,6 +19,7 @@ pub mod dashboards;
 pub mod file_list;
 pub mod meta;
 pub mod schema;
+pub mod triggers;
 
 pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::Error> {
     let old_ver = Version::from(old_ver).unwrap();
@@ -45,6 +46,11 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
         return Ok(());
     }
 
+    let v0100 = Version::from("v0.10.0").unwrap();
+    if old_ver < v0100 {
+        upgrade_093_0100().await?;
+    }
+
     Ok(())
 }
 
@@ -62,5 +68,11 @@ async fn upgrade_092_093() -> Result<(), anyhow::Error> {
     // migration schema
     schema::run().await?;
 
+    Ok(())
+}
+
+async fn upgrade_093_0100() -> Result<(), anyhow::Error> {
+    // migration trigger
+    triggers::run().await?;
     Ok(())
 }

--- a/src/common/migration/triggers.rs
+++ b/src/common/migration/triggers.rs
@@ -1,0 +1,148 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use chrono::Utc;
+use config::utils::json;
+use infra::{db as infra_db, dist_lock, scheduler};
+
+const TRIGGER_MIGRATION_KEY: &str = "/migration/triggers/status";
+
+pub async fn run() -> Result<(), anyhow::Error> {
+    match upgrade_required().await {
+        std::result::Result::Ok(true) => {
+            log::info!("[Trigger:Migration]: Starting trigger migration");
+        }
+        std::result::Result::Ok(false) => {
+            log::info!("[Trigger:Migration]: Trigger migration already done");
+            return Ok(());
+        }
+        Err(err) => {
+            log::error!(
+                "[Trigger:Migration]: Error checking trigger migration status: {}",
+                err
+            );
+            return Err(err);
+        }
+    };
+
+    // get lock
+    let locker = dist_lock::lock(TRIGGER_MIGRATION_KEY, 0).await?;
+
+    // after get lock, need check again
+    match upgrade_required().await {
+        std::result::Result::Ok(true) => {
+            log::info!("[Trigger:Migration]: Starting trigger migration");
+        }
+        std::result::Result::Ok(false) => {
+            log::info!("[Trigger:Migration]: Trigger migration already done");
+            dist_lock::unlock(&locker).await?;
+            return Ok(());
+        }
+        Err(err) => {
+            log::error!(
+                "[Trigger:Migration]: Error checking trigger migration status: {}",
+                err
+            );
+            dist_lock::unlock(&locker).await?;
+            return Err(err);
+        }
+    };
+
+    let db = infra_db::get_db().await;
+
+    log::info!("[Trigger:Migration]: Inside migrating triggers");
+    let db_key_prefix = "/trigger/".to_string();
+    log::info!("[Trigger:Migration]: Listing all triggers");
+    let data = match db.list(&db_key_prefix).await {
+        Ok(v) => v,
+        Err(e) => {
+            dist_lock::unlock(&locker).await?;
+            return Err(e.into());
+        }
+    };
+    for (key, val) in data {
+        let db_key = key;
+        let key = db_key.strip_prefix(&db_key_prefix).unwrap();
+        println!("[Trigger:Migration]: Start migrating trigger: {}", key);
+        let columns = match key.split_once('/') {
+            Some(columns) => columns,
+            None => {
+                // Corrupted data, delete the trigger
+                _ = db.delete(&db_key, false, infra_db::NEED_WATCH, None).await;
+                continue;
+            }
+        };
+        let data: json::Value = json::from_slice(&val).unwrap();
+        let data = data.as_object().unwrap();
+        if let Err(e) = scheduler::push(scheduler::Trigger {
+            org: columns.0.to_string(),
+            module: scheduler::TriggerModule::Alert,
+            module_key: columns.1.to_string(),
+            next_run_at: data
+                .get("next_run_at")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .parse::<i64>()
+                .unwrap_or(0),
+            is_realtime: data
+                .get("is_realtime")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .parse::<bool>()
+                .unwrap_or(false),
+            is_silenced: data
+                .get("is_silenced")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .parse::<bool>()
+                .unwrap_or(false),
+            status: scheduler::TriggerStatus::Waiting,
+            ..Default::default()
+        })
+        .await
+        {
+            dist_lock::unlock(&locker).await?;
+            return Err(e.into());
+        }
+        println!("[Schema:Migration]: Done migrating trigger: {}", key);
+    }
+
+    // unlock the lock
+    dist_lock::unlock(&locker).await?;
+
+    db.put(
+        TRIGGER_MIGRATION_KEY,
+        Utc::now().timestamp_micros().to_string().into(),
+        infra_db::NO_NEED_WATCH,
+        None,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn upgrade_required() -> Result<bool, anyhow::Error> {
+    let db = infra_db::get_db().await;
+    match db.get(TRIGGER_MIGRATION_KEY).await {
+        std::result::Result::Ok(val) => {
+            let val_str = std::str::from_utf8(&val).unwrap();
+            let val = val_str.parse::<i64>().unwrap_or(0);
+            if val > 0 { Ok(false) } else { Ok(true) }
+        }
+        Err(_) => Ok(true),
+    }
+}

--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -29,6 +29,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     cache::init().await?;
     file_list::create_table().await?;
     queue::init().await?;
+    scheduler::init().await?;
     // because of asynchronous, we need to wait for a while
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     Ok(())

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -98,10 +98,15 @@ pub struct Trigger {
     pub retries: i32,
 }
 
-/// Initializes the scheduler
-pub async fn init(clean_interval: u64, watch_interval: u64) -> Result<()> {
+/// Initializes the scheduler - creates table and index
+pub async fn init() -> Result<()> {
     create_table().await?;
     create_table_index().await?;
+    Ok(())
+}
+
+/// Must be called after calling `scheduler::init()`
+pub async fn init_background_jobs(clean_interval: u64, watch_interval: u64) -> Result<()> {
     tokio::task::spawn(async move {
         clean_complete(clean_interval).await;
     });

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -45,7 +45,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
         .await?;
     }
 
-    scheduler::init(
+    scheduler::init_background_jobs(
         CONFIG.limit.scheduler_clean_interval,
         CONFIG.limit.scheduler_watch_interval,
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,8 +171,10 @@ async fn main() -> Result<(), anyhow::Error> {
     // init config
     config::init().await.expect("config init failed");
     // init infra
-    infra::init().await.expect("config init failed");
-    common_infra::init().await.expect("infra init failed");
+    infra::init().await.expect("infra init failed");
+    common_infra::init()
+        .await
+        .expect("common infra init failed");
 
     // check version upgrade
     let old_version = db::version::get().await.unwrap_or("v0.0.0".to_string());


### PR DESCRIPTION
Fixes #3249 .

Migrates previously used alert `Triggers` into `scheduled_jobs` table.

## NOT TESTED YET