### PR TITLE
feat: add a new option for limit merge on ingester

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -660,6 +660,9 @@ pub struct Limit {
     pub file_push_interval: u64,
     #[env_config(name = "ZO_FILE_PUSH_LIMIT", default = 0)] // files
     pub file_push_limit: usize,
+    // over this limit will skip merging on ingester
+    #[env_config(name = "ZO_FILE_MOVE_FIELDS_LIMIT", default = 2000)]
+    pub file_move_fields_limit: usize,
     #[env_config(name = "ZO_FILE_MOVE_THREAD_NUM", default = 0)]
     pub file_move_thread_num: usize,
     #[env_config(name = "ZO_QUERY_THREAD_NUM", default = 0)]

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -413,8 +413,8 @@ async fn merge_files(
     for file in files_with_size.iter() {
         if new_file_size > 0
             && ((new_file_size + file.meta.original_size > CONFIG.compact.max_file_size as i64)
-                || (CONFIG.limit.quick_mode_num_fields > 0
-                    && latest_schema.fields().len() > CONFIG.limit.quick_mode_num_fields))
+                || (CONFIG.limit.file_move_fields_limit > 0
+                    && latest_schema.fields().len() > CONFIG.limit.file_move_fields_limit))
         {
             break;
         }


### PR DESCRIPTION
Added a new option for limit merge files on ingester
```
ZO_FILE_MOVE_FIELDS_LIMIT=2000
```