### PR TITLE
fix: show savedview and report resources in role permissions and fix `list_objects_for_user` for `_all_{org}`

### DIFF
--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -239,7 +239,11 @@ impl FromRequest for AuthExtractor {
                     OFGA_MODELS.get("streams").unwrap().key,
                     path_columns[1]
                 )
-            } else if method.eq("PUT") || method.eq("DELETE") {
+            } else if method.eq("PUT")
+                || method.eq("DELETE")
+                || path_columns[1].starts_with("reports")
+                || path_columns[1].starts_with("savedviews")
+            {
                 format!(
                     "{}:{}",
                     OFGA_MODELS

--- a/src/service/alerts/destinations.rs
+++ b/src/service/alerts/destinations.rs
@@ -147,7 +147,7 @@ pub async fn list(
                     || permitted
                         .as_ref()
                         .unwrap()
-                        .contains(&format!("destination:{}", org_id))
+                        .contains(&format!("destination:_all_{}", org_id))
                 {
                     result.push(dest);
                 }

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -203,7 +203,7 @@ pub async fn list(
                     || permitted
                         .as_ref()
                         .unwrap()
-                        .contains(&format!("alert:{}", org_id))
+                        .contains(&format!("alert:_all_{}", org_id))
                 {
                     result.push(alert);
                 }

--- a/src/service/alerts/templates.rs
+++ b/src/service/alerts/templates.rs
@@ -89,7 +89,7 @@ pub async fn list(
                     || permitted
                         .as_ref()
                         .unwrap()
-                        .contains(&format!("template:{}", org_id))
+                        .contains(&format!("template:_all_{}", org_id))
                 {
                     result.push(template);
                 }

--- a/src/service/dashboards/folders.rs
+++ b/src/service/dashboards/folders.rs
@@ -111,7 +111,7 @@ pub async fn list_folders(
     if let Ok(folders) = db::dashboards::folders::list(org_id).await {
         let filtered = match permitted_folders {
             Some(permitted_folders) => {
-                if permitted_folders.contains(&format!("{}:{}", "dfolder", org_id)) {
+                if permitted_folders.contains(&format!("{}:_all_{}", "dfolder", org_id)) {
                     folders
                 } else {
                     folders

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -148,7 +148,7 @@ pub async fn list_functions(
                 || permitted
                     .as_ref()
                     .unwrap()
-                    .contains(&format!("function:{}", org_id))
+                    .contains(&format!("function:_all_{}", org_id))
             {
                 result.push(function);
             }

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -81,7 +81,7 @@ pub async fn get_streams(
     let filtered_indices = if let Some(s_type) = stream_type {
         match permitted_streams {
             Some(permitted_streams) => {
-                if permitted_streams.contains(&format!("{}:{}", s_type, org_id)) {
+                if permitted_streams.contains(&format!("{}:_all_{}", s_type, org_id)) {
                     indices
                 } else {
                     indices

--- a/web/src/components/iam/roles/EditRole.vue
+++ b/web/src/components/iam/roles/EditRole.vue
@@ -325,6 +325,7 @@ import { useQuasar } from "quasar";
 import type { AxiosPromise } from "axios";
 import streamService from "@/services/stream";
 import alertService from "@/services/alerts";
+import reportService from "@/services/reports";
 import templateService from "@/services/alert_templates";
 import destinationService from "@/services/alert_destination";
 import jsTransformService from "@/services/jstransform";
@@ -1246,6 +1247,7 @@ const getResourceEntities = (resource: Resource | Entity) => {
     dfolder: getFolders,
     dashboard: getDashboards,
     metadata: getMetadataStreams,
+    report: getReports,
   };
 
   return new Promise(async (resolve, reject) => {
@@ -1318,7 +1320,13 @@ const getSavedViews = async () => {
   const savedViews = await savedviewsService.get(
     store.state.selectedOrganization.identifier
   );
-  updateResourceEntities("savedviews", ["name"], [...savedViews.data.views]);
+  updateResourceEntities(
+    "savedviews",
+    ["view_id"],
+    [...savedViews.data.views],
+    false,
+    "view_name"
+  );
 
   return new Promise((resolve) => {
     resolve(true);
@@ -1487,6 +1495,18 @@ const getStreamsTypes = async () => {
   });
 
   return new Promise((resolve, reject) => {
+    resolve(true);
+  });
+};
+
+const getReports = async () => {
+  const reports = await reportService.list(
+    store.state.selectedOrganization.identifier
+  );
+
+  updateResourceEntities("report", ["name"], [...reports.data]);
+
+  return new Promise((resolve) => {
     resolve(true);
   });
 };


### PR DESCRIPTION
For enterprise in rbac, `GET` methods for `reports` and `savedviews` consists of `{org_id}/<reports|savedviews>/{id}` format, i.e. `url_len` is 3. This PR corrects how the fga object string is extracted (which should be `report:{report_name}` or `savedview:{view_id}`) from the url path with the above format with `GET` method.