### PR TITLE
ci: integrate an ok-to-test pull-request command

### DIFF
--- a/.github/workflows/build-fork-pr-image.yml
+++ b/.github/workflows/build-fork-pr-image.yml
@@ -1,24 +1,28 @@
 
-name: Build PR Docker Image
+name: Build PR Docker Image on Fork
 
 on:
-  pull_request:
-    branches:
-      - "*"
-    paths-ignore:
-      - "**.md"
-  workflow_dispatch:
+  repository_dispatch:
+    types: [ok-to-test-command]
 
 env:
     AWS_REGION: us-east-1
 
 jobs:
-    build_pr_image:
-      name: build_pr_image
+    build_pr_image_on_fork:
+      name: build_pr_image_on_fork
       permissions:
         id-token: write
         contents: read
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        pull-requests: write
+        checks: write
+      if: |
+        github.event_name == 'repository_dispatch' &&
+        github.event.client_payload.slash_command.args.named.sha != '' &&
+        contains(
+          github.event.client_payload.pull_request.head.sha,
+          github.event.client_payload.slash_command.args.named.sha
+        )
       runs-on: ${{ github.event.pull_request.head.repo.fork == true && 'ubuntu-2004-8-cores' || 'ubicloud-standard-8' }}
       steps:
         - name: Remove unused tools
@@ -31,11 +35,11 @@ jobs:
         - name: Clone the current repo
           uses: actions/checkout@v4
           with:
-            repository: ${{ github.event.pull_request.head.repo.full_name }}
-            ref: ${{ github.event.pull_request.head.ref || github.ref }}
+            repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+            ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
             fetch-depth: 0
             fetch-tags: true
-  
+
         - name: Setup Rust Toolchain
           uses: dtolnay/rust-toolchain@master
           with:
@@ -98,3 +102,35 @@ jobs:
             push: true
             cache-from: type=gha
             cache-to: type=gha,mode=max
+        - uses: actions/github-script@v6
+          id: update-check-run
+          if: ${{ always() }}
+          env:
+            number: ${{ github.event.client_payload.pull_request.number }}
+            job: ${{ github.job }}
+            # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
+            conclusion: ${{ job.status }} 
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            script: |
+              const { data: pull } = await github.rest.pulls.get({
+                ...context.repo,
+                pull_number: process.env.number
+              });
+              const ref = pull.head.sha;
+    
+              const { data: checks } = await github.rest.checks.listForRef({
+                ...context.repo,
+                ref
+              });
+    
+              const check = checks.check_runs.filter(c => c.name === process.env.job);
+    
+              const { data: result } = await github.rest.checks.update({
+                ...context.repo,
+                check_run_id: check[0].id,
+                status: 'completed',
+                conclusion: process.env.conclusion
+              });
+    
+              return result;

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,0 +1,39 @@
+# If someone with write access comments "/ok-to-test" on a pull request, emit a repository_dispatch event
+name: Ok To Test
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ok-to-test:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    # Only run for PRs, not issue comments
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+    # Generate a GitHub App installation access token from an App ID and private key
+    # To create a new GitHub App:
+    #   https://developer.github.com/apps/building-github-apps/creating-a-github-app/
+    # See app.yml for an example app manifest - you can use fake URLs when generating
+    # the app such as example.com urls. They do not need to properly resolve for the
+    # purpose that they app is being used for.
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        private_key: ${{ secrets.PRIVATE_KEY }}
+
+    - name: Slash Command Dispatch
+      uses: peter-evans/slash-command-dispatch@v3
+      env:
+        TOKEN: ${{ steps.generate_token.outputs.token }}
+      with:
+        token: ${{ env.TOKEN }} # GitHub App installation access token
+        # token: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # PAT or OAuth token will also work
+        reaction-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-type: pull-request
+        commands: ok-to-test
+        permission: write


### PR DESCRIPTION
Several of the contributors who sent a PR see several failures in the CI especially the part where a docker container image is built and pushed to public aws-ecr.

This PR ensures that whenever a PR comes from an external contributor, a developer after carefully reviewing the code, writes `/ok-to-test <commit-to-test>` This comment will trigger a repository_dispatch event which will run a new workflow `build-fork-pr-image.yml` in the context of a privileged user, thus building and pushing the image to ECR and in the end it also updates the status of the existing pipelines.

Finally, the `build-pr-image.yml` will now run for only the members of the Openobserve organization.