### PR TITLE
fix: for forked pull-requests pick up the correct git ref

### DIFF
--- a/.github/workflows/build-fork-pr-image.yml
+++ b/.github/workflows/build-fork-pr-image.yml
@@ -23,7 +23,7 @@ jobs:
           github.event.client_payload.pull_request.head.sha,
           github.event.client_payload.slash_command.args.named.sha
         )
-      runs-on: ${{ github.event.pull_request.head.repo.fork == true && 'ubuntu-2004-8-cores' || 'ubicloud-standard-8' }}
+      runs-on: ${{ github.event.client_payload.pull_request.head.repo.fork == true && 'ubuntu-2004-8-cores' || 'ubicloud-standard-8' }}
       steps:
         - name: Remove unused tools
           run: |
@@ -36,7 +36,7 @@ jobs:
           uses: actions/checkout@v4
           with:
             repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-            ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+            ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref }}
             fetch-depth: 0
             fetch-tags: true
 


### PR DESCRIPTION
Since this workflow runs via a repository_dispatch event the payload contains all the data behind `github.event.client_payload.pull_request`