### PR TITLE
fix: don't use stream_type from query params for alert create/update

### DIFF
--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -50,22 +50,14 @@ pub mod templates;
 pub async fn save_alert(
     path: web::Path<(String, String)>,
     alert: web::Json<Alert>,
-    req: HttpRequest,
 ) -> Result<HttpResponse, Error> {
     let (org_id, stream_name) = path.into_inner();
-    let query = web::Query::<HashMap<String, String>>::from_query(req.query_string()).unwrap();
-    let stream_type = match get_stream_type_from_request(&query) {
-        Ok(v) => v.unwrap_or_default(),
-        Err(e) => {
-            return Ok(MetaHttpResponse::bad_request(e));
-        }
-    };
 
     // Hack for frequency: convert minutes to seconds
     let mut alert = alert.into_inner();
     alert.trigger_condition.frequency *= 60;
 
-    match alerts::save(&org_id, stream_type, &stream_name, "", alert, true).await {
+    match alerts::save(&org_id, &stream_name, "", alert, true).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert saved")),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }
@@ -94,23 +86,15 @@ pub async fn save_alert(
 pub async fn update_alert(
     path: web::Path<(String, String, String)>,
     alert: web::Json<Alert>,
-    req: HttpRequest,
 ) -> Result<HttpResponse, Error> {
     let (org_id, stream_name, name) = path.into_inner();
-    let query = web::Query::<HashMap<String, String>>::from_query(req.query_string()).unwrap();
-    let stream_type = match get_stream_type_from_request(&query) {
-        Ok(v) => v.unwrap_or_default(),
-        Err(e) => {
-            return Ok(MetaHttpResponse::bad_request(e));
-        }
-    };
 
     // Hack for frequency: convert minutes to seconds
     let mut alert = alert.into_inner();
     alert.trigger_condition.frequency *= 60;
 
     let name = name.trim();
-    match alerts::save(&org_id, stream_type, &stream_name, name, alert, false).await {
+    match alerts::save(&org_id, &stream_name, name, alert, false).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert Updated")),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -55,7 +55,6 @@ pub mod templates;
 
 pub async fn save(
     org_id: &str,
-    stream_type: StreamType,
     stream_name: &str,
     name: &str,
     mut alert: Alert,
@@ -65,7 +64,7 @@ pub async fn save(
         alert.name = name.trim().to_string();
     }
     alert.org_id = org_id.to_string();
-    alert.stream_type = stream_type;
+    let stream_type = alert.stream_type;
     alert.stream_name = stream_name.to_string();
     alert.row_template = alert.row_template.trim().to_string();
 
@@ -1270,14 +1269,13 @@ mod tests {
     #[tokio::test]
     async fn test_alert_create() {
         let org_id = "default";
-        let stream_type = StreamType::Logs;
         let stream_name = "default";
         let alert_name = "abc/alert";
         let alert = Alert {
             name: alert_name.to_string(),
             ..Default::default()
         };
-        let ret = save(org_id, stream_type, stream_name, alert_name, alert, true).await;
+        let ret = save(org_id, stream_name, alert_name, alert, true).await;
         // alert name should not contain /
         assert!(ret.is_err());
     }


### PR DESCRIPTION
Fixes #3283 