### PR TITLE
fix: introduce realtime alert triggers cache

### DIFF
--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -33,7 +33,7 @@ use crate::{
         syslog::SyslogRoute,
         user::User,
     },
-    service::{enrichment::StreamTable, enrichment_table::geoip::Geoip},
+    service::{enrichment::StreamTable, enrichment_table::geoip::Geoip, db::scheduler as db_scheduler},
 };
 
 // global version variables
@@ -58,6 +58,8 @@ pub static METRIC_CLUSTER_MAP: Lazy<Arc<RwAHashMap<String, Vec<String>>>> =
 pub static METRIC_CLUSTER_LEADER: Lazy<Arc<RwAHashMap<String, ClusterLeader>>> =
     Lazy::new(|| Arc::new(tokio::sync::RwLock::new(HashMap::new())));
 pub static STREAM_ALERTS: Lazy<RwAHashMap<String, Vec<alerts::Alert>>> =
+    Lazy::new(Default::default);
+pub static REALTIME_ALERT_TRIGGERS: Lazy<RwAHashMap<String, Vec<db_scheduler::Trigger>>> =
     Lazy::new(Default::default);
 pub static ALERTS_TEMPLATES: Lazy<RwHashMap<String, alerts::templates::Template>> =
     Lazy::new(Default::default);

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -59,7 +59,7 @@ pub static METRIC_CLUSTER_LEADER: Lazy<Arc<RwAHashMap<String, ClusterLeader>>> =
     Lazy::new(|| Arc::new(tokio::sync::RwLock::new(HashMap::new())));
 pub static STREAM_ALERTS: Lazy<RwAHashMap<String, Vec<alerts::Alert>>> =
     Lazy::new(Default::default);
-pub static REALTIME_ALERT_TRIGGERS: Lazy<RwAHashMap<String, Vec<db_scheduler::Trigger>>> =
+pub static REALTIME_ALERT_TRIGGERS: Lazy<RwAHashMap<String, db_scheduler::Trigger>> =
     Lazy::new(Default::default);
 pub static ALERTS_TEMPLATES: Lazy<RwHashMap<String, alerts::templates::Template>> =
     Lazy::new(Default::default);

--- a/src/common/migration/meta.rs
+++ b/src/common/migration/meta.rs
@@ -112,7 +112,7 @@ async fn migrate_scheduler(from: &str, to: &str) -> Result<(), anyhow::Error> {
     dest.create_table().await?;
     dest.create_table_index().await?;
 
-    let items = src.list().await?;
+    let items = src.list(None).await?;
     for item in items.iter() {
         dest.push(item.to_owned()).await?;
     }

--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -51,10 +51,8 @@ pub struct TriggerData {
     pub is_realtime: bool,
     pub is_silenced: bool,
     pub status: TriggerDataStatus,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_time: Option<i64>,
+    pub start_time: i64,
+    pub end_time: i64,
     pub retries: i32,
     pub error: Option<String>,
 }

--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -51,8 +51,10 @@ pub struct TriggerData {
     pub is_realtime: bool,
     pub is_silenced: bool,
     pub status: TriggerDataStatus,
-    pub start_time: i64,
-    pub end_time: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_time: Option<i64>,
     pub retries: i32,
     pub error: Option<String>,
 }

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -56,6 +56,7 @@ pub trait Scheduler: Sync + Send + 'static {
         report_timeout: i64,
     ) -> Result<Vec<Trigger>>;
     async fn list(&self) -> Result<Vec<Trigger>>;
+    async fn list_module(&self, module: TriggerModule) -> Result<Vec<Trigger>>;
     async fn clean_complete(&self, interval: u64);
     async fn watch_timeout(&self, interval: u64);
     async fn len_module(&self, module: TriggerModule) -> usize;
@@ -211,6 +212,12 @@ pub async fn len_module(module: TriggerModule) -> usize {
 #[inline]
 pub async fn len() -> usize {
     CLIENT.len().await
+}
+
+/// List the jobs for the given module
+#[inline]
+pub async fn list_module(module: TriggerModule) -> Result<Vec<Trigger>> {
+    CLIENT.list_module(module).await
 }
 
 #[inline]

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -106,6 +106,9 @@ pub struct Trigger {
     pub is_realtime: bool,
     pub is_silenced: bool,
     pub status: TriggerStatus,
+    // #[sqlx(default)] only works when the column itself is missing.
+    // For NULL value it does not work.
+    // TODO: See https://github.com/launchbadge/sqlx/issues/1106
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -57,8 +57,7 @@ pub trait Scheduler: Sync + Send + 'static {
         report_timeout: i64,
     ) -> Result<Vec<Trigger>>;
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger>;
-    async fn list(&self) -> Result<Vec<Trigger>>;
-    async fn list_module(&self, module: TriggerModule) -> Result<Vec<Trigger>>;
+    async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>>;
     async fn clean_complete(&self, interval: u64);
     async fn watch_timeout(&self, interval: u64);
     async fn len_module(&self, module: TriggerModule) -> usize;
@@ -235,8 +234,8 @@ pub async fn len() -> usize {
 
 /// List the jobs for the given module
 #[inline]
-pub async fn list_module(module: TriggerModule) -> Result<Vec<Trigger>> {
-    CLIENT.list_module(module).await
+pub async fn list(module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
+    CLIENT.list(module).await
 }
 
 #[inline]

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -107,8 +107,10 @@ pub struct Trigger {
     pub is_realtime: bool,
     pub is_silenced: bool,
     pub status: TriggerStatus,
-    pub start_time: i64,
-    pub end_time: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_time: Option<i64>,
     pub retries: i32,
 }
 

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -313,6 +313,16 @@ WHERE FIND_IN_SET(id, ?);
         Ok(jobs)
     }
 
+    async fn list_module(&self, module: TriggerModule) -> Result<Vec<Trigger>> {
+        let pool = CLIENT.clone();
+        let query = r#"SELECT * FROM scheduled_jobs WHERE module = ? ORDER BY id;"#;
+        let jobs: Vec<Trigger> = sqlx::query_as::<_, Trigger>(query)
+            .bind(module)
+            .fetch_all(&pool)
+            .await?;
+        Ok(jobs)
+    }
+
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
     async fn clean_complete(&self, interval: u64) {

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -121,8 +121,8 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
 
         if let Err(e) = sqlx::query(
             r#"
-INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ? , ?);
         "#,
         )
         .bind(&trigger.org)
@@ -133,6 +133,8 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         .bind(&trigger.status)
         .bind(0)
         .bind(trigger.next_run_at)
+        .bind(0)
+        .bind(0)
         .execute(&mut *tx)
         .await
         {

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -348,7 +348,7 @@ WHERE FIND_IN_SET(id, ?);
         let pool = CLIENT.clone();
         let query = r#"
 SELECT * FROM scheduled_jobs
-WHERE org = ? AND module_key = ? AND module = ?;"#;
+WHERE org = ? AND module = ? AND module_key = ?;"#;
         let job = match sqlx::query_as::<_, Trigger>(query)
             .bind(org)
             .bind(module.clone())

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -266,6 +266,16 @@ RETURNING *;"#;
         Ok(jobs)
     }
 
+    async fn list_module(&self, module: TriggerModule) -> Result<Vec<Trigger>> {
+        let pool = CLIENT.clone();
+        let query = r#"SELECT * FROM scheduled_jobs WHERE module = $1 ORDER BY id;"#;
+        let jobs: Vec<Trigger> = sqlx::query_as::<_, Trigger>(query)
+            .bind(module)
+            .fetch_all(&pool)
+            .await?;
+        Ok(jobs)
+    }
+
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
     async fn clean_complete(&self, interval: u64) {

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -118,8 +118,8 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs WHERE module = $1;"#,
 
         if let Err(e) = sqlx::query(
             r#"
-INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
     ON CONFLICT DO NOTHING;
         "#,
         )
@@ -131,6 +131,8 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         .bind(&trigger.status)
         .bind(0)
         .bind(trigger.next_run_at)
+        .bind(0)
+        .bind(0)
         .execute(&mut *tx)
         .await
         {

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -302,7 +302,7 @@ RETURNING *;"#;
         let pool = CLIENT.clone();
         let query = r#"
 SELECT * FROM scheduled_jobs
-WHERE org = $1 AND module_key = $2 AND module = $3;"#;
+WHERE org = $1 AND module = $2 AND module_key = $3;"#;
         let job = match sqlx::query_as::<_, Trigger>(query)
             .bind(org)
             .bind(&module)

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -118,8 +118,8 @@ SELECT COUNT(*) as num FROM scheduled_jobs WHERE module = $1;"#,
 
         if let Err(e) = sqlx::query(
             r#"
-INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
     ON CONFLICT DO NOTHING;
         "#,
         )
@@ -131,6 +131,8 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         .bind(&trigger.status)
         .bind(0)
         .bind(trigger.next_run_at)
+        .bind(0)
+        .bind(0)
         .execute(&mut *tx)
         .await
         {

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -320,7 +320,7 @@ RETURNING *;"#;
         let pool = CLIENT_RO.clone();
         let query = r#"
 SELECT * FROM scheduled_jobs
-WHERE org = $1 AND module_key = $2 AND module = $3;"#;
+WHERE org = $1 AND module = $2 AND module_key = $3;"#;
         let job = match sqlx::query_as::<_, Trigger>(query)
             .bind(org)
             .bind(module.clone())

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -272,6 +272,16 @@ RETURNING *;"#;
         Ok(jobs)
     }
 
+    async fn list_module(&self, module: TriggerModule) -> Result<Vec<Trigger>> {
+        let client = CLIENT_RO.clone();
+        let query = r#"SELECT * FROM scheduled_jobs WHERE module = $1 ORDER BY id;"#;
+        let jobs: Vec<Trigger> = sqlx::query_as::<_, Trigger>(query)
+            .bind(module)
+            .fetch_all(&client)
+            .await?;
+        Ok(jobs)
+    }
+
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
     async fn clean_complete(&self, interval: u64) {

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -100,6 +100,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     tokio::task::spawn(async move { db::metrics::watch_prom_cluster_leader().await });
     tokio::task::spawn(async move { db::alerts::templates::watch().await });
     tokio::task::spawn(async move { db::alerts::destinations::watch().await });
+    tokio::task::spawn(async move { db::alerts::realtime_triggers::watch().await });
     tokio::task::spawn(async move { db::alerts::watch().await });
     tokio::task::spawn(async move { db::dashboards::reports::watch().await });
     tokio::task::spawn(async move { db::organization::watch().await });
@@ -132,6 +133,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
     db::alerts::destinations::cache()
         .await
         .expect("alerts destinations cache failed");
+    db::alerts::realtime_triggers::cache()
+        .await
+        .expect("alerts realtime triggers cache failed");
     db::alerts::cache().await.expect("alerts cache failed");
     db::dashboards::reports::cache()
         .await

--- a/src/service/alerts/alert_manager.rs
+++ b/src/service/alerts/alert_manager.rs
@@ -151,8 +151,8 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         is_realtime: trigger.is_realtime,
         is_silenced: trigger.is_silenced,
         status: TriggerDataStatus::Completed,
-        start_time: trigger.start_time,
-        end_time: trigger.end_time,
+        start_time: trigger.start_time.unwrap_or_default(),
+        end_time: trigger.end_time.unwrap_or_default(),
         retries: trigger.retries,
         error: None,
     };
@@ -205,7 +205,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
     }
 
     // publish the triggers as stream
-    trigger_data_stream.end_time = Some(Utc::now().timestamp_micros());
+    trigger_data_stream.end_time = Utc::now().timestamp_micros();
     publish_triggers_usage(trigger_data_stream).await;
 
     Ok(())
@@ -299,8 +299,8 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         is_realtime: trigger.is_realtime,
         is_silenced: trigger.is_silenced,
         status: TriggerDataStatus::Completed,
-        start_time: trigger.start_time,
-        end_time: trigger.end_time,
+        start_time: trigger.start_time.unwrap_or_default(),
+        end_time: trigger.end_time.unwrap_or_default(),
         retries: trigger.retries,
         error: None,
     };
@@ -315,7 +315,7 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
             }
             db::scheduler::update_trigger(new_trigger).await?;
             log::debug!("Update trigger for report: {}", report_name);
-            trigger_data_stream.end_time = Some(Utc::now().timestamp_micros());
+            trigger_data_stream.end_time = Utc::now().timestamp_micros();
         }
         Err(e) => {
             log::error!("Error sending report to subscribers: {e}");
@@ -337,7 +337,7 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
                 )
                 .await?;
             }
-            trigger_data_stream.end_time = Some(Utc::now().timestamp_micros());
+            trigger_data_stream.end_time = Utc::now().timestamp_micros();
             trigger_data_stream.status = TriggerDataStatus::Failed;
             trigger_data_stream.error = Some(format!("error processing report: {e}"));
         }

--- a/src/service/alerts/alert_manager.rs
+++ b/src/service/alerts/alert_manager.rs
@@ -205,7 +205,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
     }
 
     // publish the triggers as stream
-    trigger_data_stream.end_time = Utc::now().timestamp_micros();
+    trigger_data_stream.end_time = Some(Utc::now().timestamp_micros());
     publish_triggers_usage(trigger_data_stream).await;
 
     Ok(())
@@ -315,7 +315,7 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
             }
             db::scheduler::update_trigger(new_trigger).await?;
             log::debug!("Update trigger for report: {}", report_name);
-            trigger_data_stream.end_time = Utc::now().timestamp_micros();
+            trigger_data_stream.end_time = Some(Utc::now().timestamp_micros());
         }
         Err(e) => {
             log::error!("Error sending report to subscribers: {e}");
@@ -337,7 +337,7 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
                 )
                 .await?;
             }
-            trigger_data_stream.end_time = Utc::now().timestamp_micros();
+            trigger_data_stream.end_time = Some(Utc::now().timestamp_micros());
             trigger_data_stream.status = TriggerDataStatus::Failed;
             trigger_data_stream.error = Some(format!("error processing report: {e}"));
         }

--- a/src/service/db/alerts/mod.rs
+++ b/src/service/db/alerts/mod.rs
@@ -23,6 +23,7 @@ use crate::{
 };
 
 pub mod destinations;
+pub mod realtime_triggers;
 pub mod templates;
 
 pub async fn get(

--- a/src/service/db/alerts/realtime_triggers.rs
+++ b/src/service/db/alerts/realtime_triggers.rs
@@ -45,6 +45,7 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                 // item_key format -> {org_id}/{module_key}
                 let item_key = ev.key.strip_prefix(&key).unwrap();
                 let columns = item_key.split_once('/').unwrap();
+                log::info!("columns put {}, {}", columns.0, columns.1);
                 let item_value: db::scheduler::Trigger =
                     if ev.value.is_none() || ev.value.as_ref().unwrap().is_empty() {
                         match db::scheduler::get(

--- a/src/service/db/alerts/realtime_triggers.rs
+++ b/src/service/db/alerts/realtime_triggers.rs
@@ -24,7 +24,7 @@ pub async fn watch() -> Result<(), anyhow::Error> {
     let key = format!(
         "{}{}/",
         db::scheduler::TRIGGERS_KEY,
-        db::scheduler::TriggerModule::Alert.to_string()
+        db::scheduler::TriggerModule::Alert
     );
     let cluster_coordinator = db::get_coordinator().await;
     let mut events = cluster_coordinator.watch(&key).await?;

--- a/src/service/db/alerts/realtime_triggers.rs
+++ b/src/service/db/alerts/realtime_triggers.rs
@@ -1,0 +1,99 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use config::utils::json;
+
+use crate::{common::infra::config::REALTIME_ALERT_TRIGGERS, service::db};
+
+// Watches only for realtime alert triggers
+pub async fn watch() -> Result<(), anyhow::Error> {
+    let key = format!(
+        "{}{}/",
+        db::scheduler::TRIGGERS_KEY,
+        db::scheduler::TriggerModule::Alert.to_string()
+    );
+    let cluster_coordinator = db::get_coordinator().await;
+    let mut events = cluster_coordinator.watch(&key).await?;
+    let events = Arc::get_mut(&mut events).unwrap();
+    log::info!("Start watching alert realtime triggers");
+    loop {
+        let ev = match events.recv().await {
+            Some(ev) => ev,
+            None => {
+                log::error!("watch_alert_realtime_triggers: event channel closed");
+                break;
+            }
+        };
+        match ev {
+            db::Event::Put(ev) => {
+                // Currently, cluster coordinator sends only the alert triggers
+                // ev.key format -> /triggers/<alert|report>/{item_key}
+                // item_key format -> {org_id}/{module_key}
+                let item_key = ev.key.strip_prefix(&key).unwrap();
+                let columns = item_key.split_once('/').unwrap();
+                let item_value: db::scheduler::Trigger =
+                    if ev.value.is_none() || ev.value.as_ref().unwrap().is_empty() {
+                        match db::scheduler::get(
+                            columns.0,
+                            infra::scheduler::TriggerModule::Alert,
+                            columns.1,
+                        )
+                        .await
+                        {
+                            Ok(val) => val,
+                            Err(e) => {
+                                log::error!("Error getting value: {}", e);
+                                continue;
+                            }
+                        }
+                    } else {
+                        json::from_slice(&ev.value.unwrap()).unwrap()
+                    };
+
+                if item_value.is_realtime {
+                    REALTIME_ALERT_TRIGGERS
+                        .write()
+                        .await
+                        .insert(item_key.to_owned(), item_value);
+                } else if REALTIME_ALERT_TRIGGERS.read().await.contains_key(item_key) {
+                    // This means this trigger was earlier a realtime trigger,
+                    // but now it is updated to a non-realtime trigger. So, simply
+                    // delete this trigger from triggers cache
+                    REALTIME_ALERT_TRIGGERS.write().await.remove(item_key);
+                }
+            }
+            db::Event::Delete(ev) => {
+                let item_key = ev.key.strip_prefix(&key).unwrap();
+                REALTIME_ALERT_TRIGGERS.write().await.remove(item_key);
+            }
+            db::Event::Empty => {}
+        }
+    }
+    Ok(())
+}
+
+pub async fn cache() -> Result<(), anyhow::Error> {
+    let triggers = db::scheduler::list_module(db::scheduler::TriggerModule::Alert).await?;
+    let mut cache = REALTIME_ALERT_TRIGGERS.write().await;
+    for trigger in triggers {
+        if trigger.is_realtime {
+            cache.insert(trigger.module_key.clone(), trigger);
+        }
+    }
+    log::info!("Alert realtime triggers Cached");
+    Ok(())
+}

--- a/src/service/db/scheduler.rs
+++ b/src/service/db/scheduler.rs
@@ -124,6 +124,12 @@ pub async fn len() -> usize {
     infra_scheduler::len().await
 }
 
+/// List the jobs for the given module
+#[inline]
+pub async fn list_module(module: TriggerModule) -> Result<Vec<Trigger>> {
+    infra_scheduler::list_module(module).await
+}
+
 #[inline]
 pub async fn is_empty() -> bool {
     infra_scheduler::is_empty().await

--- a/src/service/db/scheduler.rs
+++ b/src/service/db/scheduler.rs
@@ -13,7 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use infra::scheduler::{Trigger, TriggerModule, TriggerStatus};
+pub use infra::scheduler::{
+    Trigger,
+    TriggerModule,
+    TriggerStatus,
+    TRIGGERS_KEY
+};
 use infra::{
     errors::Result,
     scheduler::{self as infra_scheduler},
@@ -101,6 +106,12 @@ pub async fn pull(
     report_timeout: i64,
 ) -> Result<Vec<Trigger>> {
     infra_scheduler::pull(concurrency, alert_timeout, report_timeout).await
+}
+
+/// Returns the scheduled job associated with the given id in read-only fashion
+#[inline]
+pub async fn get(org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
+    infra_scheduler::get(org, module, key).await
 }
 
 #[inline]

--- a/src/service/db/scheduler.rs
+++ b/src/service/db/scheduler.rs
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use infra::scheduler::{
-    Trigger,
-    TriggerModule,
-    TriggerStatus,
-    TRIGGERS_KEY
-};
+pub use infra::scheduler::{Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
 use infra::{
     errors::Result,
     scheduler::{self as infra_scheduler},
@@ -137,8 +132,8 @@ pub async fn len() -> usize {
 
 /// List the jobs for the given module
 #[inline]
-pub async fn list_module(module: TriggerModule) -> Result<Vec<Trigger>> {
-    infra_scheduler::list_module(module).await
+pub async fn list(module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
+    infra_scheduler::list(module).await
 }
 
 #[inline]

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -37,7 +37,7 @@ use vrl::{
 
 use crate::{
     common::{
-        infra::config::{STREAM_ALERTS, STREAM_FUNCTIONS},
+        infra::config::{REALTIME_ALERT_TRIGGERS, STREAM_ALERTS, STREAM_FUNCTIONS},
         meta::{
             alerts::Alert,
             functions::{StreamTransform, VRLResultResolver, VRLRuntimeConfig},
@@ -167,10 +167,18 @@ pub async fn get_stream_alerts(
         if alerts_list.is_none() {
             return;
         }
+        let triggers_cache = REALTIME_ALERT_TRIGGERS.read().await;
         let alerts = alerts_list
             .unwrap()
             .iter()
             .filter(|alert| alert.enabled && alert.is_real_time)
+            .filter(|alert| {
+                let key = format!("{}/{}", key, alert.name);
+                match triggers_cache.get(&key) {
+                    Some(v) => !v.is_silenced,
+                    None => true,
+                }
+            })
             .cloned()
             .collect::<Vec<_>>();
 

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -195,6 +195,13 @@ pub async fn evaluate_trigger(trigger: Option<TriggerAlertData>) {
         if let Err(e) = alert.send_notification(val).await {
             log::error!("Failed to send notification: {}", e);
         } else if alert.trigger_condition.silence > 0 {
+            log::debug!(
+                "Realtime alert {}/{}/{}/{} triggered successfully, hence applying silence period",
+                &alert.org_id,
+                &alert.stream_type,
+                &alert.stream_name,
+                &alert.name
+            );
             // After the notification is sent successfully, we need to update
             // the silence period of the trigger
             _ = db::scheduler::update_trigger(db::scheduler::Trigger {


### PR DESCRIPTION
Fixes #2908 

When the realtime alert is triggered and the notification is sent successfully, the silence period is now updated in the scheduled jobs table and updated locally via the realtime triggers cache.