### PR TITLE
fix: remove unused code

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -546,8 +546,6 @@ pub struct Common {
     pub print_key_sql: bool,
     #[env_config(name = "ZO_USAGE_REPORTING_ENABLED", default = false)]
     pub usage_enabled: bool,
-    #[env_config(name = "ZO_USAGE_REPORTING_COMPRESSED_SIZE", default = false)]
-    pub usage_report_compressed_size: bool,
     #[env_config(name = "ZO_USAGE_ORG", default = "_meta")]
     pub usage_org: String,
     #[env_config(

--- a/src/infra/src/cache/stats.rs
+++ b/src/infra/src/cache/stats.rs
@@ -96,3 +96,31 @@ pub fn get_stream_stats_in_memory_size() -> usize {
         .map(|v| v.key().len() + STREAM_STATS_MEM_SIZE)
         .sum()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_stream_stats_len() {
+        let stats = get_stats();
+        assert_eq!(get_stream_stats_len(), stats.len());
+
+        let val = StreamStats {
+            created_at: 1667978841102,
+            doc_time_min: 1667978841102,
+            doc_time_max: 1667978845374,
+            doc_num: 5000,
+            file_num: 1,
+            storage_size: 200.00,
+            compressed_size: 3.00,
+        };
+
+        set_stream_stats("nexus", "default", StreamType::Logs, val);
+        let stats = get_stream_stats("nexus", "default", StreamType::Logs);
+        assert_eq!(stats, val);
+
+        let stats = get_stream_stats("nexus", "default", StreamType::Logs);
+        assert_eq!(stats.doc_num, 5000);
+    }
+}

--- a/src/infra/src/cache/stats.rs
+++ b/src/infra/src/cache/stats.rs
@@ -96,31 +96,3 @@ pub fn get_stream_stats_in_memory_size() -> usize {
         .map(|v| v.key().len() + STREAM_STATS_MEM_SIZE)
         .sum()
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_get_stream_stats_len() {
-        let stats = get_stats();
-        assert_eq!(get_stream_stats_len(), stats.len());
-
-        let val = StreamStats {
-            created_at: 1667978841102,
-            doc_time_min: 1667978841102,
-            doc_time_max: 1667978845374,
-            doc_num: 5000,
-            file_num: 1,
-            storage_size: 200.00,
-            compressed_size: 3.00,
-        };
-
-        set_stream_stats("nexus", "default", StreamType::Logs, val);
-        let stats = get_stream_stats("nexus", "default", StreamType::Logs);
-        assert_eq!(stats, val);
-
-        let stats = get_stream_stats("nexus", "default", StreamType::Logs);
-        assert_eq!(stats.doc_num, 5000);
-    }
-}

--- a/src/service/usage/stats.rs
+++ b/src/service/usage/stats.rs
@@ -72,19 +72,11 @@ pub async fn publish_stats() -> Result<(), anyhow::Error> {
 
         let current_ts = chrono::Utc::now().timestamp_micros();
 
-        let sql = if CONFIG.common.usage_report_compressed_size {
-            format!(
-                "SELECT sum(num_records) as records ,sum(size) as original_size, org_id , stream_type  ,stream_name ,min(min_ts) as min_ts , max(max_ts) as max_ts, sum(compressed_size) as compressed_size  FROM \"{USAGE_STREAM}\" where _timestamp between {last_query_ts} and {current_ts} and event = \'{}\' and org_id = \'{}\' group by  org_id , stream_type ,stream_name",
-                UsageEvent::Ingestion,
-                org_id
-            )
-        } else {
-            format!(
-                "SELECT sum(num_records) as records ,sum(size) as original_size, org_id , stream_type  ,stream_name FROM \"{USAGE_STREAM}\" where _timestamp between {last_query_ts} and {current_ts} and event = \'{}\' and org_id = \'{}\' group by  org_id , stream_type ,stream_name",
-                UsageEvent::Ingestion,
-                org_id
-            )
-        };
+        let sql = format!(
+            "SELECT sum(num_records) as records, sum(size) as original_size, org_id, stream_type, stream_name FROM \"{USAGE_STREAM}\" where _timestamp between {last_query_ts} and {current_ts} and event = \'{}\' and org_id = \'{}\' group by org_id, stream_type, stream_name",
+            UsageEvent::Ingestion,
+            org_id
+        );
 
         let query = config::meta::search::Query {
             sql,
@@ -141,15 +133,9 @@ async fn get_last_stats(
     org_id: &str,
     stats_ts: i64,
 ) -> std::result::Result<Vec<json::Value>, anyhow::Error> {
-    let sql = if CONFIG.common.usage_report_compressed_size {
-        format!(
-            "SELECT records ,original_size, org_id , stream_type ,stream_name ,min_ts , max_ts, compressed_size FROM \"{STATS_STREAM}\" where _timestamp ={stats_ts} and org_id = \'{org_id}\'"
-        )
-    } else {
-        format!(
-            "SELECT records ,original_size, org_id , stream_type ,stream_name ,min_ts , max_ts FROM \"{STATS_STREAM}\" where _timestamp ={stats_ts} and org_id = \'{org_id}\'"
-        )
-    };
+    let sql = format!(
+        "SELECT records, original_size, org_id, stream_type, stream_name, min_ts, max_ts FROM \"{STATS_STREAM}\" where _timestamp = {stats_ts} and org_id = \'{org_id}\'"
+    );
 
     let query = config::meta::search::Query {
         sql,
@@ -194,29 +180,12 @@ async fn report_stats(
                 value.records += existing_value.records;
                 value.original_size += existing_value.original_size;
                 value._timestamp = curr_ts;
-
-                if !CONFIG.common.usage_report_compressed_size {
-                    if value.min_ts == 0 && existing_value.min_ts != 0 {
-                        value.min_ts = existing_value.min_ts;
-                    } else {
-                        value.min_ts = curr_ts;
-                    }
-                    value.max_ts = curr_ts;
+                if value.min_ts == 0 && existing_value.min_ts != 0 {
+                    value.min_ts = existing_value.min_ts;
                 } else {
-                    if existing_value.min_ts != 0 && value.min_ts > existing_value.min_ts {
-                        value.min_ts = existing_value.min_ts;
-                    }
-                    if value.max_ts < existing_value.max_ts {
-                        value.max_ts = existing_value.max_ts;
-                    }
-
-                    if value.compressed_size.is_some() && existing_value.compressed_size.is_some() {
-                        value.compressed_size = Some(
-                            value.compressed_size.unwrap()
-                                + existing_value.compressed_size.unwrap(),
-                        );
-                    }
+                    value.min_ts = curr_ts;
                 }
+                value.max_ts = curr_ts;
             } else {
                 value._timestamp = curr_ts;
             }


### PR DESCRIPTION
The `ZO_USAGE_REPORTING_COMPRESSED_SIZE` we no longer use it, but i saw we enabled this configure in alpha1 and monitor, it will cause problem because there is no backend report job for it.