### PR TITLE
fix: dashboard variables values API context SQL

### DIFF
--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -376,7 +376,7 @@ export default defineComponent({
 
               const filterConditions =
                 currentVariable?.query_data?.filter ?? [];
-              let dummyQuery = `SELECT * FROM '${currentVariable?.query_data?.stream}'`;
+              let dummyQuery = `SELECT _timestamp FROM '${currentVariable?.query_data?.stream}'`;
               const constructedFilter = filterConditions.map(
                 (condition: any) => ({
                   name: condition.name,

--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -376,7 +376,7 @@ export default defineComponent({
 
               const filterConditions =
                 currentVariable?.query_data?.filter ?? [];
-              let dummyQuery = `SELECT _timestamp FROM '${currentVariable?.query_data?.stream}'`;
+              let dummyQuery = `SELECT ${store.state.zoConfig.timestamp_column || "_timestamp"} FROM '${currentVariable?.query_data?.stream}'`;
               const constructedFilter = filterConditions.map(
                 (condition: any) => ({
                   name: condition.name,


### PR DESCRIPTION
Avoid using `SELECT * FROM` for performance while loading dashboard variables