### PR TITLE
test: e2e-search-around

### DIFF
--- a/tests/ui-testing/playwright-tests/logspage.spec.js
+++ b/tests/ui-testing/playwright-tests/logspage.spec.js
@@ -530,16 +530,30 @@ test.describe("Logs UI testcases", () => {
     expect(isVisible).toBeTruthy();
     
   });
-  
-  // test('should display search around in SQL mode', async ({ page }) => {
-  //   await page.waitForTimeout(1000);
-  //   await page.getByLabel('SQL Mode').locator('div').nth(2).click();
-  //   await page.locator('[data-test="log-table-column-2-\\@timestamp"]').click();
-  //   await page.locator('[data-test="logs-detail-table-search-around-btn"]').click();
-  //   // const element = await page.locator('[data-test="log-table-column-2-\\@timestamp"]');
-  //   // const isVisible = await element.isVisible();
-  //   // expect(isVisible).toBeTruthy();
-  //   await page.locator('[data-test="logs-search-error-message"]').click();
+
+
+  test('should display results for search around after adding function', async ({ page }) => {
+    await page.waitForTimeout(1000);
+    await page.locator('#fnEditor > .monaco-editor > .overflow-guard > .monaco-scrollable-element > .lines-content > .view-lines > .view-line').click();
+    await page.locator('#fnEditor').getByLabel('Editor content;Press Alt+F1').fill('.a=1');
+    await page.locator('[data-test="logs-search-bar-refresh-btn"]').click();
+    await page.locator('[data-test="log-table-column-3-source"]').getByText('{"_timestamp":').click();
+    await page.locator('[data-test="logs-detail-table-search-around-btn"]').click();
+    // const element = await page.locator('[data-test="log-table-column-2-\\@timestamp"]');
+    // const isVisible = await element.isVisible();
+    // expect(isVisible).toBeTruthy();
     
-  // });
+  });
+  
+  test('should display search around in SQL mode', async ({ page }) => {
+    await page.waitForTimeout(1000);
+    await page.getByLabel('SQL Mode').locator('div').nth(2).click();
+    await page.locator('[data-test="log-table-column-2-\\@timestamp"]').click();
+    await page.locator('[data-test="logs-detail-table-search-around-btn"]').click();
+    const element = await page.locator('[data-test="log-table-column-2-\\@timestamp"]');
+    const isVisible = await element.isVisible();
+    expect(isVisible).toBeTruthy();
+   
+    
+  });
 });


### PR DESCRIPTION
Automation for bug - #3480 
-Logs: Blank page displayed after user adds a function on logs page, clicks on any log result and then selects search around