### PR TITLE
fix: user, pipeline list rbac issues

### DIFF
--- a/src/service/pipelines.rs
+++ b/src/service/pipelines.rs
@@ -115,7 +115,7 @@ pub async fn list_pipelines(
                 || permitted
                     .as_ref()
                     .unwrap()
-                    .contains(&format!("logs:{}", org_id))
+                    .contains(&format!("logs:_all_{}", org_id))
             {
                 let fn_list = STREAM_FUNCTIONS
                     .get(&format!(


### PR DESCRIPTION


- [x] When an user is deleted, the corresponding rbac records are not deleted. If same user is created again, it will simply use the old rbac record (since the rbac entry for this user is already there).
- [x] #3478 
- [x] When an user role is updated (e.g. from Admin to User), the fga roles are not updated because, the backend tries to give it a role user/service_account instead of allowed_user. So changing from admin to user or service account don't work in openfga.