### PR TITLE
fix: don't set rbac ownership for creating default folders

### DIFF
--- a/src/service/dashboards/folders.rs
+++ b/src/service/dashboards/folders.rs
@@ -60,7 +60,9 @@ pub async fn save_folder(
 
     match db::dashboards::folders::put(org_id, folder).await {
         Ok(folder) => {
-            set_ownership(org_id, "folders", Authz::new(&folder.folder_id)).await;
+            if folder.folder_id != DEFAULT_FOLDER {
+                set_ownership(org_id, "folders", Authz::new(&folder.folder_id)).await;
+            }
             Ok(HttpResponse::Ok().json(folder))
         }
         Err(error) => Ok(


### PR DESCRIPTION
Since for rbac, the `dfolder:default` permissions are being created while creating an org, it is ok to ignore `set_ownership` for default folders.