### PR TITLE
perf: optimize ingester writing

### DIFF
--- a/src/ingester/src/memtable.rs
+++ b/src/ingester/src/memtable.rs
@@ -13,7 +13,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 use arrow_schema::Schema;
 use config::metrics;
@@ -27,8 +33,8 @@ use crate::{
 
 pub(crate) struct MemTable {
     streams: RwMap<Arc<str>, Arc<Stream>>, // key: schema name, val: stream
-    json_bytes_written: usize,
-    arrow_bytes_written: usize,
+    json_bytes_written: AtomicU64,
+    arrow_bytes_written: AtomicU64,
 }
 
 impl MemTable {
@@ -36,12 +42,12 @@ impl MemTable {
         metrics::INGEST_MEMTABLE_FILES.with_label_values(&[]).inc();
         Self {
             streams: RwMap::default(),
-            json_bytes_written: 0,
-            arrow_bytes_written: 0,
+            json_bytes_written: AtomicU64::new(0),
+            arrow_bytes_written: AtomicU64::new(0),
         }
     }
 
-    pub(crate) async fn write(&mut self, schema: Arc<Schema>, entry: Entry) -> Result<()> {
+    pub(crate) async fn write(&self, schema: Arc<Schema>, entry: Entry) -> Result<()> {
         let partitions = self.streams.read().await.get(&entry.stream).cloned();
         let partitions = match partitions {
             Some(v) => v,
@@ -54,8 +60,10 @@ impl MemTable {
         };
         let json_size = entry.data_size;
         let arrow_size = partitions.write(schema, entry).await?;
-        self.arrow_bytes_written += arrow_size;
-        self.json_bytes_written += json_size;
+        self.json_bytes_written
+            .fetch_add(json_size as u64, Ordering::SeqCst);
+        self.arrow_bytes_written
+            .fetch_add(arrow_size as u64, Ordering::SeqCst);
         Ok(())
     }
 
@@ -92,6 +100,9 @@ impl MemTable {
 
     // Return the number of bytes written (json format size, arrow format size)
     pub(crate) fn size(&self) -> (usize, usize) {
-        (self.json_bytes_written, self.arrow_bytes_written)
+        (
+            self.json_bytes_written.load(Ordering::SeqCst) as usize,
+            self.arrow_bytes_written.load(Ordering::SeqCst) as usize,
+        )
     }
 }

--- a/src/ingester/src/partition.rs
+++ b/src/ingester/src/partition.rs
@@ -50,7 +50,7 @@ impl Partition {
         }
     }
 
-    pub(crate) async fn write(&mut self, entry: Entry) -> Result<usize> {
+    pub(crate) async fn write(&self, entry: Entry) -> Result<usize> {
         let mut rw = self.files.write().await;
         let partition = rw
             .entry(entry.partition_key.clone())
@@ -67,6 +67,7 @@ impl Partition {
         for file in r.values() {
             batches.extend(file.read(time_range)?);
         }
+        drop(r);
         Ok((self.schema.clone(), batches))
     }
 

--- a/src/ingester/src/wal.rs
+++ b/src/ingester/src/wal.rs
@@ -129,7 +129,7 @@ pub(crate) async fn replay_wal_files() -> Result<()> {
             .parse()
             .unwrap_or_default();
         let key = WriterKey::new(org_id, stream_type);
-        let mut memtable = memtable::MemTable::new();
+        let memtable = memtable::MemTable::new();
         let mut reader = match wal::Reader::from_path(wal_file) {
             Ok(v) => v,
             Err(e) => {

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -18,13 +18,15 @@ use actix_web::{http::Error, route, web, HttpRequest, HttpResponse};
 
 use crate::common::infra::cluster;
 
-const QUERIER_ROUTES: [&str; 16] = [
+const QUERIER_ROUTES: [&str; 18] = [
     "/config",
     "/summary",
     "/organizations",
     "/settings",
     "/schema",
     "/streams",
+    "/clusters",
+    "/query_manager",
     "/_search",
     "/_around",
     "/_values",

--- a/src/service/db/compact/stats.rs
+++ b/src/service/db/compact/stats.rs
@@ -13,17 +13,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::atomic;
+use std::sync::atomic::{AtomicI64, Ordering};
 
 use config::CONFIG;
 
 use crate::service::db;
 
-static LOCAL_OFFSET: atomic::AtomicI64 = atomic::AtomicI64::new(0);
+static LOCAL_OFFSET: AtomicI64 = AtomicI64::new(0);
 
 pub async fn get_offset() -> (i64, String) {
     if !CONFIG.common.meta_store_external {
-        let offset = LOCAL_OFFSET.load(atomic::Ordering::Relaxed);
+        let offset = LOCAL_OFFSET.load(Ordering::Relaxed);
         return (offset, String::from(""));
     }
 
@@ -44,7 +44,7 @@ pub async fn get_offset() -> (i64, String) {
 
 pub async fn set_offset(offset: i64, node: Option<&str>) -> Result<(), anyhow::Error> {
     if !CONFIG.common.meta_store_external {
-        LOCAL_OFFSET.store(offset, atomic::Ordering::Release);
+        LOCAL_OFFSET.store(offset, Ordering::Release);
         return Ok(());
     }
 

--- a/src/service/db/file_list/remote.rs
+++ b/src/service/db/file_list/remote.rs
@@ -16,7 +16,7 @@
 use std::{
     collections::HashSet,
     io::{BufRead, BufReader},
-    sync::atomic,
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use bytes::Buf;
@@ -31,7 +31,7 @@ use crate::service::db;
 
 pub static LOADED_FILES: Lazy<RwLock<HashSet<String>>> =
     Lazy::new(|| RwLock::new(HashSet::with_capacity(24)));
-pub static LOADED_ALL_FILES: atomic::AtomicBool = atomic::AtomicBool::new(false);
+pub static LOADED_ALL_FILES: AtomicBool = AtomicBool::new(false);
 
 pub async fn cache(prefix: &str, force: bool) -> Result<(), anyhow::Error> {
     let prefix = format!("file_list/{prefix}");
@@ -231,7 +231,7 @@ pub async fn cache_day(day: &str) -> Result<(), anyhow::Error> {
 }
 
 pub async fn cache_all() -> Result<(), anyhow::Error> {
-    if LOADED_ALL_FILES.load(atomic::Ordering::Relaxed) {
+    if LOADED_ALL_FILES.load(Ordering::Relaxed) {
         return Ok(());
     }
     let prefix = "file_list/".to_string();
@@ -249,7 +249,7 @@ pub async fn cache_all() -> Result<(), anyhow::Error> {
     for prefix in prefixes {
         cache(&prefix, false).await?;
     }
-    LOADED_ALL_FILES.store(true, atomic::Ordering::Release);
+    LOADED_ALL_FILES.store(true, Ordering::Release);
     Ok(())
 }
 

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -135,7 +135,7 @@ fn handle_channel() -> Arc<mpsc::Sender<DvEvent>> {
                 if let Err(e) = INSTANCE.flush().await {
                     log::error!("[DISTINCT_VALUES] flush error: {}", e);
                 }
-                INSTANCE.shutdown.store(true, Ordering::SeqCst);
+                INSTANCE.shutdown.store(true, Ordering::Release);
                 break;
             }
             let mut mem_table = INSTANCE.mem_table.write().await;
@@ -261,7 +261,7 @@ impl Metadata for DistinctValues {
             .map_err(|e| Error::Message(e.to_string()))?;
         let mut i = 0;
         while i < 10 {
-            if self.shutdown.load(Ordering::SeqCst) {
+            if self.shutdown.load(Ordering::Relaxed) {
                 break;
             }
             time::sleep(time::Duration::from_secs(1)).await;


### PR DESCRIPTION
- [x] This PR optimized the ingester wring logic that we can use `read lock` to replace `write lock` when the key is exists.
- [x] The clusters API should be on querier