### PR TITLE
fix: Auto Complete promql legend on select not getting proper value with {

### DIFF
--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -935,7 +935,7 @@ export default defineComponent({
       //if { is not present add it at the start and than return
       if (openingBraceIndex === -1) {
         const newValue =
-          "{ " + inputValue.slice(0, openingBraceIndex + 1) + option + "}";
+          "{" + inputValue.slice(0, openingBraceIndex + 1) + option + "}";
         return newValue;
       } else {
         const newValue =

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -932,15 +932,16 @@ export default defineComponent({
       // Find the index of the last opening brace '{'
       const openingBraceIndex = inputValue.lastIndexOf("{");
 
-      let newValue;
-      if (openingBraceIndex !== -1) {
-        // If there is an opening brace, replace the content inside it
-        newValue = inputValue.slice(0, openingBraceIndex + 1) + option + "}";
+      //if { is not present add it at the start and than return
+      if (openingBraceIndex === -1) {
+        const newValue =
+          "{ " + inputValue.slice(0, openingBraceIndex + 1) + option + "}";
+        return newValue;
       } else {
-        // If no opening brace, simply append the option inside new braces
-        newValue = `${inputValue} {${option}}`;
+        const newValue =
+          inputValue.slice(0, openingBraceIndex + 1) + option + "}";
+        return newValue;
       }
-      return newValue;
     };
 
     const dashboardSelectfieldPromQlList = computed(() =>

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -933,6 +933,7 @@ export default defineComponent({
       const openingBraceIndex = inputValue.lastIndexOf("{");
 
       //if { is not present add it at the start and than return
+
       if (openingBraceIndex === -1) {
         const newValue =
           "{" + inputValue.slice(0, openingBraceIndex + 1) + option + "}";

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -929,9 +929,17 @@ export default defineComponent({
           dashboardPanelData.layout.currentQueryIndex
         ].config.promql_legend;
 
+      // Find the index of the last opening brace '{'
       const openingBraceIndex = inputValue.lastIndexOf("{");
-      const newValue =
-        inputValue.slice(0, openingBraceIndex + 1) + option + "}";
+
+      let newValue;
+      if (openingBraceIndex !== -1) {
+        // If there is an opening brace, replace the content inside it
+        newValue = inputValue.slice(0, openingBraceIndex + 1) + option + "}";
+      } else {
+        // If no opening brace, simply append the option inside new braces
+        newValue = `${inputValue} {${option}}`;
+      }
       return newValue;
     };
 


### PR DESCRIPTION
When a user directly selects anything from the dropdown, it incorrectly puts the value in the Legend config in dashboard's add panel config for PromQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved input handling in the configuration panel to ensure proper formatting of values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->