### PR TITLE
fix: concat record batches error

### DIFF
--- a/src/handler/http/request/logs/ingest.rs
+++ b/src/handler/http/request/logs/ingest.rs
@@ -62,7 +62,7 @@ pub async fn bulk(
         match logs::bulk::ingest(&org_id, body, **thread_id, user_email).await {
             Ok(v) => MetaHttpResponse::json(v),
             Err(e) => {
-                log::error!("Error processing request: {:?}", e);
+                log::error!("Error processing request {org_id}/_bulk: {:?}", e);
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
                     http::StatusCode::BAD_REQUEST.into(),
                     e.to_string(),
@@ -114,7 +114,7 @@ pub async fn multi(
                 _ => MetaHttpResponse::json(v),
             },
             Err(e) => {
-                log::error!("Error processing request: {:?}", e);
+                log::error!("Error processing request {org_id}/{stream_name}: {:?}", e);
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
                     http::StatusCode::BAD_REQUEST.into(),
                     e.to_string(),
@@ -166,7 +166,7 @@ pub async fn json(
                 _ => MetaHttpResponse::json(v),
             },
             Err(e) => {
-                log::error!("Error processing request: {:?}", e);
+                log::error!("Error processing request {org_id}/{stream_name}: {:?}", e);
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
                     http::StatusCode::BAD_REQUEST.into(),
                     e.to_string(),
@@ -255,7 +255,7 @@ pub async fn handle_gcp_request(
         {
             Ok(v) => MetaHttpResponse::json(v),
             Err(e) => {
-                log::error!("Error processing request: {:?}", e);
+                log::error!("Error processing request {org_id}/{stream_name}: {:?}", e);
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
                     http::StatusCode::BAD_REQUEST.into(),
                     e.to_string(),

--- a/src/handler/http/request/metrics/ingest.rs
+++ b/src/handler/http/request/metrics/ingest.rs
@@ -54,7 +54,7 @@ pub async fn json(
         match metrics::json::ingest(&org_id, body, **thread_id).await {
             Ok(v) => HttpResponse::Ok().json(v),
             Err(e) => {
-                log::error!("Error processing request: {:?}", e);
+                log::error!("Error processing request {org_id}/metrics: {:?}", e);
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
                     http::StatusCode::BAD_REQUEST.into(),
                     e.to_string(),

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -1008,7 +1008,7 @@ pub async fn merge_parquet_files(
         })?;
 
         let batches = match read_recordbatch_from_bytes(&bytes).await {
-            Ok((parquet_schema, batches)) if parquet_schema == schema => batches,
+            Ok((parquet_schema, batches)) if parquet_schema.fields == schema.fields => batches,
             Ok((parquet_schema, _)) => {
                 log::warn!(
                     "[INGESTER:JOB:{thread_id}] merge small files without DataFusion failed due to schema mismatch,expected {:?}, got {:?}",


### PR DESCRIPTION
Concatenating record batches will fail if the types of underlying arrays are different. For now, fall back on using DataFusion to merge in such cases.