### PR TITLE
fix: report issues

### DIFF
--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -293,7 +293,15 @@ impl FromRequest for AuthExtractor {
                 )
             }
         } else if url_len == 4 {
-            if method.eq("PUT") && path_columns[1] != "streams" || method.eq("DELETE") {
+            if method.eq("PUT") && path_columns[1].eq("reports") {
+                format!(
+                    "{}:{}",
+                    OFGA_MODELS
+                        .get(path_columns[1])
+                        .map_or(path_columns[1], |model| model.key),
+                    path_columns[2]
+                )
+            } else if method.eq("PUT") && path_columns[1] != "streams" || method.eq("DELETE") {
                 format!(
                     "{}:{}",
                     OFGA_MODELS

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -83,7 +83,7 @@ async fn watch_timeout_jobs() -> Result<(), anyhow::Error> {
     interval.tick().await; // trigger the first run
     loop {
         interval.tick().await;
-        if let Err(e) = infra::scheduler::clean_complete().await {
+        if let Err(e) = infra::scheduler::watch_timeout().await {
             log::error!("[ALERT MANAGER] watch timeout jobs error: {}", e);
         }
     }

--- a/src/service/alerts/alert_manager.rs
+++ b/src/service/alerts/alert_manager.rs
@@ -332,6 +332,9 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
                 );
                 db::scheduler::update_trigger(new_trigger).await?;
             } else {
+                if run_once {
+                    report.enabled = true;
+                }
                 // Otherwise update its status only
                 db::scheduler::update_status(
                     &new_trigger.org,

--- a/src/service/alerts/alert_manager.rs
+++ b/src/service/alerts/alert_manager.rs
@@ -349,6 +349,11 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
     }
 
     report.last_triggered_at = Some(now);
+    // Check if the report has been disabled in the mean time
+    let old_report = db::dashboards::reports::get(org_id, report_name).await?;
+    if !old_report.enabled {
+        report.enabled = old_report.enabled;
+    }
     let result = db::dashboards::reports::set_without_updating_trigger(org_id, &report).await;
     if result.is_err() {
         log::error!(

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -338,7 +338,9 @@ async fn generate_report(
 
     let web_url = format!("{}{}/web", CONFIG.common.web_url, CONFIG.common.base_uri);
     log::debug!("Navigating to web url: {}", &web_url);
-    let page = browser.new_page(&format!("{web_url}/login")).await?;
+    let page = browser
+        .new_page(&format!("{web_url}/login?login_as_internal_user=true"))
+        .await?;
     page.disable_log().await?;
     log::debug!("headless: new page created");
 

--- a/src/service/db/dashboards/reports.rs
+++ b/src/service/db/dashboards/reports.rs
@@ -53,28 +53,26 @@ pub async fn set(org_id: &str, report: &Report, create: bool) -> Result<(), anyh
                         Ok(())
                     }
                 }
-            } else {
-                if db::scheduler::exists(
-                    org_id,
-                    db::scheduler::TriggerModule::Report,
-                    &schedule_key,
-                )
-                .await
-                {
-                    match db::scheduler::update_trigger(trigger).await {
-                        Ok(_) => Ok(()),
-                        Err(e) => {
-                            log::error!("Failed to update trigger: {}", e);
-                            Ok(())
-                        }
+            } else if db::scheduler::exists(
+                org_id,
+                db::scheduler::TriggerModule::Report,
+                &schedule_key,
+            )
+            .await
+            {
+                match db::scheduler::update_trigger(trigger).await {
+                    Ok(_) => Ok(()),
+                    Err(e) => {
+                        log::error!("Failed to update trigger: {}", e);
+                        Ok(())
                     }
-                } else {
-                    match db::scheduler::push(trigger).await {
-                        Ok(_) => Ok(()),
-                        Err(e) => {
-                            log::error!("Failed to save trigger: {}", e);
-                            Ok(())
-                        }
+                }
+            } else {
+                match db::scheduler::push(trigger).await {
+                    Ok(_) => Ok(()),
+                    Err(e) => {
+                        log::error!("Failed to save trigger: {}", e);
+                        Ok(())
                     }
                 }
             }

--- a/src/service/db/scheduler.rs
+++ b/src/service/db/scheduler.rs
@@ -109,6 +109,12 @@ pub async fn get(org: &str, module: TriggerModule, key: &str) -> Result<Trigger>
     infra_scheduler::get(org, module, key).await
 }
 
+/// Returns the scheduled job associated with the given id in read-only fashion
+#[inline]
+pub async fn exists(org: &str, module: TriggerModule, key: &str) -> bool {
+    infra_scheduler::get(org, module, key).await.is_ok()
+}
+
 /// The count of jobs for the given module (Report/Alert etc.)
 #[inline]
 pub async fn len_module(module: TriggerModule) -> usize {


### PR DESCRIPTION
Fixes #3558 

- [x] When SSO is enabled reports don't work , because of UI having two login options
- [x]  Scheduled job has end_time which is not current & retries are not working
- [x]  If a report is paused during execution , the reports status get changed after execution to enabled = true again
- [x] After editing a report that was set to once to per min, the report is not sent every minute
- [x] RBAC error while trying to enable/disable a report