### PR TITLE
perf: testing optimise aggeration query

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -603,6 +603,8 @@ pub struct Common {
     pub allow_user_defined_schemas: bool,
     #[env_config(name = "ZO_DATAFUSION_PARQUET_STAT_DISABLE_FOR_AGGS", default = false)]
     pub datafusion_parquet_stat_disable_for_aggs: bool,
+    #[env_config(name = "ZO_DATAFUSION_PARQUET_ENABLE_SORT_ORDER", default = false)]
+    pub datafusion_parquet_sort_order: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -601,6 +601,8 @@ pub struct Common {
     pub bulk_api_response_errors_only: bool,
     #[env_config(name = "ZO_ALLOW_USER_DEFINED_SCHEMAS", default = false)]
     pub allow_user_defined_schemas: bool,
+    #[env_config(name = "ZO_DATAFUSION_PARQUET_STAT_DISABLE_FOR_AGGS", default = false)]
+    pub datafusion_parquet_stat_disable_for_aggs: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/utils/parquet.rs
+++ b/src/config/src/utils/parquet.rs
@@ -22,7 +22,6 @@ use parquet::{
     arrow::{arrow_reader::ArrowReaderMetadata, AsyncArrowWriter, ParquetRecordBatchStreamBuilder},
     basic::{Compression, Encoding},
     file::{metadata::KeyValue, properties::WriterProperties},
-    format::SortingColumn,
 };
 
 use crate::{config::*, ider, meta::stream::FileMeta};
@@ -34,9 +33,6 @@ pub fn new_parquet_writer<'a>(
     full_text_search_fields: &'a [String],
     metadata: &'a FileMeta,
 ) -> AsyncArrowWriter<&'a mut Vec<u8>> {
-    let sort_column_id = schema
-        .index_of(&CONFIG.common.column_timestamp)
-        .expect("Not found timestamp field");
     let row_group_size = if CONFIG.limit.parquet_max_row_group_size > 0 {
         CONFIG.limit.parquet_max_row_group_size
     } else {
@@ -49,9 +45,6 @@ pub fn new_parquet_writer<'a>(
         .set_compression(Compression::ZSTD(Default::default()))
         .set_dictionary_enabled(true)
         .set_encoding(Encoding::PLAIN)
-        .set_sorting_columns(Some(
-            vec![SortingColumn::new(sort_column_id as i32, true, false)],
-        ))
         .set_column_dictionary_enabled(
             CONFIG.common.column_timestamp.as_str().into(),
             false,

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -123,6 +123,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
 }
 
 async fn prepare_files() -> Result<FxIndexMap<String, Vec<FileKey>>, anyhow::Error> {
+    let start = std::time::Instant::now();
     let wal_dir = Path::new(&CONFIG.common.data_wal_dir)
         .canonicalize()
         .unwrap();
@@ -133,7 +134,11 @@ async fn prepare_files() -> Result<FxIndexMap<String, Vec<FileKey>>, anyhow::Err
     if files.is_empty() {
         return Ok(FxIndexMap::default());
     }
-    log::debug!("[INGESTER:JOB] move files get: {}", files.len());
+    log::debug!(
+        "[INGESTER:JOB] move files get: {}, took: {} ms",
+        files.len(),
+        start.elapsed().as_millis()
+    );
 
     // do partition by partition key
     let mut partition_files_with_size: FxIndexMap<String, Vec<FileKey>> = FxIndexMap::default();
@@ -592,7 +597,7 @@ async fn merge_files(
     let new_file_key =
         super::generate_storage_file_name(&org_id, stream_type, &stream_name, &file_name);
     log::info!(
-        "[INGESTER:JOB:{thread_id}] merge file succeeded, {} files into a new file: {}, original_size: {}, compressed_size: {}, took: {:?}",
+        "[INGESTER:JOB:{thread_id}] merge file succeeded, {} files into a new file: {}, original_size: {}, compressed_size: {}, took: {} ms",
         retain_file_list.len(),
         new_file_key,
         new_file_meta.original_size,

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -1039,8 +1039,8 @@ pub async fn merge_parquet_files(
                 )
             })?,
         Some(arrow_schema::SortOptions {
-            descending: true,
-            nulls_first: false,
+            descending: false,
+            nulls_first: true,
         }),
         None,
     )?;

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -1061,7 +1061,7 @@ pub async fn merge_parquet_files(
     let query_sql = if stream_type == StreamType::Index {
         // TODO: NOT IN is not efficient, need to optimize it: NOT EXIST
         format!(
-            "SELECT * FROM tbl WHERE file_name NOT IN (SELECT file_name FROM tbl WHERE deleted is True) ORDER BY {} DESC",
+            "SELECT * FROM tbl WHERE file_name NOT IN (SELECT file_name FROM tbl WHERE deleted is True) ORDER BY {} ASC",
             CONFIG.common.column_timestamp
         )
     } else if CONFIG.limit.distinct_values_hourly
@@ -1069,14 +1069,14 @@ pub async fn merge_parquet_files(
         && stream_name == "distinct_values"
     {
         format!(
-            "SELECT MIN({}) AS {}, SUM(count) as count, field_name, field_value, filter_name, filter_value, stream_name, stream_type FROM tbl GROUP BY field_name, field_value, filter_name, filter_value, stream_name, stream_type ORDER BY {} DESC",
+            "SELECT MIN({}) AS {}, SUM(count) as count, field_name, field_value, filter_name, filter_value, stream_name, stream_type FROM tbl GROUP BY field_name, field_value, filter_name, filter_value, stream_name, stream_type ORDER BY {} ASC",
             CONFIG.common.column_timestamp,
             CONFIG.common.column_timestamp,
             CONFIG.common.column_timestamp
         )
     } else {
         format!(
-            "SELECT * FROM tbl ORDER BY {} DESC",
+            "SELECT * FROM tbl ORDER BY {} ASC",
             CONFIG.common.column_timestamp
         )
     };

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -1231,12 +1231,20 @@ pub async fn register_table(
             ListingOptions::new(Arc::new(file_format))
                 .with_file_extension(FileType::PARQUET.get_ext())
                 .with_target_partitions(CONFIG.limit.cpu_num)
+                .with_collect_stat(
+                    session.search_type != SearchType::Aggregation
+                        || !CONFIG.common.datafusion_parquet_stat_disable_for_aggs,
+                )
         }
         FileType::JSON => {
             let file_format = JsonFormat::default();
             ListingOptions::new(Arc::new(file_format))
                 .with_file_extension(FileType::JSON.get_ext())
                 .with_target_partitions(CONFIG.limit.cpu_num)
+                .with_collect_stat(
+                    session.search_type != SearchType::Aggregation
+                        || !CONFIG.common.datafusion_parquet_stat_disable_for_aggs,
+                )
         }
         _ => {
             return Err(DataFusionError::Execution(format!(

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -1224,6 +1224,14 @@ pub async fn register_table(
         &session.search_type,
         without_optimizer,
     )?;
+
+    let file_sort_order = if CONFIG.common.datafusion_parquet_sort_order {
+        vec![vec![
+            col(CONFIG.common.column_timestamp.to_owned()).sort(true, true),
+        ]]
+    } else {
+        vec![vec![]]
+    };
     // Configure listing options
     let listing_options = match file_type {
         FileType::PARQUET => {
@@ -1235,6 +1243,7 @@ pub async fn register_table(
                     session.search_type != SearchType::Aggregation
                         || !CONFIG.common.datafusion_parquet_stat_disable_for_aggs,
                 )
+                .with_file_sort_order(file_sort_order)
         }
         FileType::JSON => {
             let file_format = JsonFormat::default();

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -222,7 +222,12 @@ pub async fn search(
         let session = config::meta::search::Session {
             id: format!("{trace_id}-{ver}"),
             storage_type: StorageType::Memory,
-            search_type: if !sql.meta.group_by.is_empty() {
+            search_type: if !sql.meta.group_by.is_empty()
+                || sql
+                    .aggs
+                    .iter()
+                    .any(|(_, (_, meta))| !meta.group_by.is_empty())
+            {
                 SearchType::Aggregation
             } else {
                 SearchType::Normal

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -252,7 +252,12 @@ pub async fn search_parquet(
         let session = config::meta::search::Session {
             id: format!("{trace_id}-wal-{ver}"),
             storage_type: StorageType::Wal,
-            search_type: if !sql.meta.group_by.is_empty() {
+            search_type: if !sql.meta.group_by.is_empty()
+                || sql
+                    .aggs
+                    .iter()
+                    .any(|(_, (_, meta))| !meta.group_by.is_empty())
+            {
                 SearchType::Aggregation
             } else {
                 SearchType::Normal
@@ -459,7 +464,12 @@ pub async fn search_memtable(
         let session = config::meta::search::Session {
             id: format!("{trace_id}-mem-{ver}"),
             storage_type: StorageType::Tmpfs,
-            search_type: if !sql.meta.group_by.is_empty() {
+            search_type: if !sql.meta.group_by.is_empty()
+                || sql
+                    .aggs
+                    .iter()
+                    .any(|(_, (_, meta))| !meta.group_by.is_empty())
+            {
                 SearchType::Aggregation
             } else {
                 SearchType::Normal


### PR DESCRIPTION
add a new test environment:
```
ZO_DATAFUSION_PARQUET_STAT_DISABLE_FOR_AGGS=false
```

Set to `true` will skip collect stat for parquet files, then it will faster.

And, i am thinking the final solution should be cache parquet statistics, or we can optimize datafusion let it only collect stat for registered schema fields.