### PR TITLE
feat: integrate embedded reportserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5328,6 +5328,7 @@ dependencies = [
  "rayon",
  "regex",
  "regex-syntax 0.8.3",
+ "reportserver",
  "reqwest 0.12.4",
  "rust-embed-for-web",
  "segment",
@@ -6352,6 +6353,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reportserver"
+version = "0.1.0"
+dependencies = [
+ "actix-web",
+ "anyhow",
+ "chromiumoxide",
+ "chrono",
+ "config",
+ "env_logger",
+ "futures",
+ "lettre",
+ "log",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ zstd.workspace = true
 config.workspace = true
 infra.workspace = true
 ingester.workspace = true
+reportserver.workspace = true
 chromiumoxide.workspace = true
 lettre.workspace = true
 
@@ -172,7 +173,7 @@ float-cmp = "0.9"
 async-walkdir = "1.0.0"
 
 [workspace]
-members = ["src/config", "src/infra", "src/ingester", "src/wal", "src/proto"]
+members = ["src/config", "src/infra", "src/ingester", "src/wal", "src/proto", "src/reportserver"]
 resolver = "2"
 
 [workspace.package]
@@ -186,6 +187,7 @@ infra = { path = "src/infra" }
 ingester = { path = "src/ingester" }
 wal = { path = "src/wal" }
 proto = { path = "src/proto" }
+reportserver = { path = "src/reportserver" }
 
 ahash = { version = "0.8", features = ["serde"] }
 actix-web = "4.5"

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ exceptions = [
     { name = "ingester", allow = ["AGPL-3.0"] },
     { name = "wal", allow = ["AGPL-3.0"] },
     { name = "proto", allow = ["AGPL-3.0"] },
+    { name = "reportserver", allow = ["AGPL-3.0"] },
 ]
 
 allow = [

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -630,6 +630,8 @@ pub struct Common {
     pub report_user_password: String,
     #[env_config(name = "ZO_REPORT_SERVER_URL", default = "localhost:5083")]
     pub report_server_url: String,
+    #[env_config(name = "ZO_REPORT_SERVER_SKIP_TLS_VERIFY", default = false)]
+    pub report_server_skip_tls_verify: bool,
     #[env_config(name = "ZO_CONCATENATED_SCHEMA_FIELD_NAME", default = "_all")]
     pub all_fields_name: String,
     #[env_config(name = "ZO_SCHEMA_CACHE_COMPRESS_ENABLED", default = false)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -242,6 +242,7 @@ pub static BLOCKED_STREAMS: Lazy<Vec<&str>> =
 #[derive(EnvConfig)]
 pub struct Config {
     pub auth: Auth,
+    pub report_server: ReportServer,
     pub http: Http,
     pub grpc: Grpc,
     pub route: Route,
@@ -264,6 +265,22 @@ pub struct Config {
 }
 
 #[derive(EnvConfig)]
+pub struct ReportServer {
+    #[env_config(name = "ZO_ENABLE_EMBEDDED_REPORT_SERVER", default = false)]
+    pub enable_report_server: bool,
+    #[env_config(name = "ZO_REPORT_USER_EMAIL", default = "")]
+    pub user_email: String,
+    #[env_config(name = "ZO_REPORT_USER_PASSWORD", default = "")]
+    pub user_password: String,
+    #[env_config(name = "ZO_HTTP_PORT", default = 5082)]
+    pub port: u16,
+    #[env_config(name = "ZO_HTTP_ADDR", default = "127.0.0.1")]
+    pub addr: String,
+    #[env_config(name = "ZO_HTTP_IPV6_ENABLED", default = false)]
+    pub ipv6_enabled: bool,
+}
+
+#[derive(EnvConfig)]
 pub struct TokioConsole {
     #[env_config(name = "ZO_TOKIO_CONSOLE_SERVER_ADDR", default = "0.0.0.0")]
     pub tokio_console_server_addr: String,
@@ -273,12 +290,34 @@ pub struct TokioConsole {
     pub tokio_console_retention: u64,
 }
 
+// #[derive(EnvConfig)]
+// pub struct Chrome {
+//     #[env_config(name = "ZO_CHROME_ENABLED", default = false)]
+//     pub chrome_enabled: bool,
+//     #[env_config(name = "ZO_CHROME_PATH", default = "")]
+//     pub chrome_path: String,
+//     #[env_config(name = "ZO_CHROME_NO_SANDBOX", default = false)]
+//     pub chrome_no_sandbox: bool,
+//     #[env_config(name = "ZO_CHROME_WITH_HEAD", default = false)]
+//     pub chrome_with_head: bool,
+//     #[env_config(name = "ZO_CHROME_SLEEP_SECS", default = 20)]
+//     pub chrome_sleep_secs: u16,
+//     #[env_config(name = "ZO_CHROME_WINDOW_WIDTH", default = 1370)]
+//     pub chrome_window_width: u32,
+//     #[env_config(name = "ZO_CHROME_WINDOW_HEIGHT", default = 730)]
+//     pub chrome_window_height: u32,
+// }
+
 #[derive(EnvConfig)]
 pub struct Chrome {
     #[env_config(name = "ZO_CHROME_ENABLED", default = false)]
     pub chrome_enabled: bool,
     #[env_config(name = "ZO_CHROME_PATH", default = "")]
     pub chrome_path: String,
+    #[env_config(name = "ZO_CHROME_CHECK_DEFAULT_PATH", default = true)]
+    pub chrome_check_default: bool,
+    #[env_config(name = "ZO_CHROME_DOWNLOAD_PATH", default = "./download")]
+    pub chrome_download_path: String,
     #[env_config(name = "ZO_CHROME_NO_SANDBOX", default = false)]
     pub chrome_no_sandbox: bool,
     #[env_config(name = "ZO_CHROME_WITH_HEAD", default = false)]
@@ -589,7 +628,7 @@ pub struct Common {
     pub report_user_name: String,
     #[env_config(name = "ZO_REPORT_USER_PASSWORD", default = "")]
     pub report_user_password: String,
-    #[env_config(name = "ZO_REPORT_SERVER_URL", default = "")]
+    #[env_config(name = "ZO_REPORT_SERVER_URL", default = "localhost:5083")]
     pub report_server_url: String,
     #[env_config(name = "ZO_CONCATENATED_SCHEMA_FIELD_NAME", default = "_all")]
     pub all_fields_name: String,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -290,24 +290,6 @@ pub struct TokioConsole {
     pub tokio_console_retention: u64,
 }
 
-// #[derive(EnvConfig)]
-// pub struct Chrome {
-//     #[env_config(name = "ZO_CHROME_ENABLED", default = false)]
-//     pub chrome_enabled: bool,
-//     #[env_config(name = "ZO_CHROME_PATH", default = "")]
-//     pub chrome_path: String,
-//     #[env_config(name = "ZO_CHROME_NO_SANDBOX", default = false)]
-//     pub chrome_no_sandbox: bool,
-//     #[env_config(name = "ZO_CHROME_WITH_HEAD", default = false)]
-//     pub chrome_with_head: bool,
-//     #[env_config(name = "ZO_CHROME_SLEEP_SECS", default = 20)]
-//     pub chrome_sleep_secs: u16,
-//     #[env_config(name = "ZO_CHROME_WINDOW_WIDTH", default = 1370)]
-//     pub chrome_window_width: u32,
-//     #[env_config(name = "ZO_CHROME_WINDOW_HEIGHT", default = 730)]
-//     pub chrome_window_height: u32,
-// }
-
 #[derive(EnvConfig)]
 pub struct Chrome {
     #[env_config(name = "ZO_CHROME_ENABLED", default = false)]
@@ -630,7 +612,7 @@ pub struct Common {
     pub report_user_name: String,
     #[env_config(name = "ZO_REPORT_USER_PASSWORD", default = "")]
     pub report_user_password: String,
-    #[env_config(name = "ZO_REPORT_SERVER_URL", default = "localhost:5083")]
+    #[env_config(name = "ZO_REPORT_SERVER_URL", default = "localhost:5082")]
     pub report_server_url: String,
     #[env_config(name = "ZO_REPORT_SERVER_SKIP_TLS_VERIFY", default = false)]
     pub report_server_skip_tls_verify: bool,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -316,6 +316,8 @@ pub struct Chrome {
     pub chrome_path: String,
     #[env_config(name = "ZO_CHROME_CHECK_DEFAULT_PATH", default = true)]
     pub chrome_check_default: bool,
+    #[env_config(name = "ZO_CHROME_AUTO_DOWNLOAD", default = false)]
+    pub chrome_auto_download: bool,
     #[env_config(name = "ZO_CHROME_DOWNLOAD_PATH", default = "./download")]
     pub chrome_download_path: String,
     #[env_config(name = "ZO_CHROME_NO_SANDBOX", default = false)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -272,9 +272,9 @@ pub struct ReportServer {
     pub user_email: String,
     #[env_config(name = "ZO_REPORT_USER_PASSWORD", default = "")]
     pub user_password: String,
-    #[env_config(name = "ZO_HTTP_PORT", default = 5082)]
+    #[env_config(name = "ZO_REPORT_SERVER_HTTP_PORT", default = 5082)]
     pub port: u16,
-    #[env_config(name = "ZO_HTTP_ADDR", default = "127.0.0.1")]
+    #[env_config(name = "ZO_REPORT_SERVER_HTTP_ADDR", default = "127.0.0.1")]
     pub addr: String,
     #[env_config(name = "ZO_HTTP_IPV6_ENABLED", default = false)]
     pub ipv6_enabled: bool,

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -213,7 +213,6 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
     #[cfg(not(feature = "enterprise"))]
     let build_type = "opensource";
 
-    
     Ok(HttpResponse::Ok().json(ConfigResponse {
         version: VERSION.to_string(),
         instance: INSTANCE_ID.get("instance_id").unwrap().to_string(),

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -25,6 +25,18 @@ pub async fn run() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
+    log::info!(
+        "Spawning embedded report server {}",
+        CONFIG.report_server.enable_report_server
+    );
+    if CONFIG.report_server.enable_report_server {
+        tokio::task::spawn(async move {
+            if let Err(e) = reportserver::spawn_server().await {
+                log::error!("report server failed to spawn {}", e);
+            }
+        });
+    }
+
     // check super cluster
     #[cfg(feature = "enterprise")]
     if O2_CONFIG.super_cluster.enabled {

--- a/src/reportserver/Cargo.toml
+++ b/src/reportserver/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "reportserver"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+tempfile.workspace = true
+log.workspace = true    
+anyhow.workspace = true
+actix-web.workspace = true
+env_logger.workspace = true
+config.workspace = true
+serde.workspace = true
+tokio.workspace = true
+chromiumoxide.workspace=true
+once_cell.workspace=true
+lettre.workspace=true
+chrono.workspace=true
+futures.workspace=true

--- a/src/reportserver/src/lib.rs
+++ b/src/reportserver/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod models;
+pub mod report;
+pub mod router;
+pub mod server;
+
+pub use server::spawn_server;

--- a/src/reportserver/src/models.rs
+++ b/src/reportserver/src/models.rs
@@ -1,0 +1,73 @@
+use lettre::{AsyncSmtpTransport, Tokio1Executor};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone)]
+pub struct SmtpConfig {
+    pub from_email: String,
+    pub reply_to: String,
+    pub client: &'static AsyncSmtpTransport<Tokio1Executor>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EmailDetails {
+    pub recepients: Vec<String>,
+    pub title: String,
+    pub name: String,
+    pub message: String,
+    pub dashb_url: String,
+}
+
+#[derive(Serialize, Debug, Deserialize, Clone)]
+pub struct Report {
+    pub dashboards: Vec<ReportDashboard>,
+    pub email_details: EmailDetails,
+}
+
+#[derive(Serialize, Debug, Deserialize, Clone)]
+pub struct ReportDashboard {
+    pub dashboard: String,
+    pub folder: String,
+    pub tabs: Vec<String>,
+    #[serde(default)]
+    pub variables: Vec<ReportDashboardVariable>,
+    /// The timerange of dashboard data.
+    #[serde(default)]
+    pub timerange: ReportTimerange,
+}
+
+#[derive(Serialize, Debug, Default, Deserialize, Clone)]
+pub struct ReportDashboardVariable {
+    pub key: String,
+    pub value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+}
+
+#[derive(Serialize, Debug, Default, Deserialize, Clone)]
+pub enum ReportTimerangeType {
+    #[default]
+    #[serde(rename = "relative")]
+    Relative,
+    #[serde(rename = "absolute")]
+    Absolute,
+}
+
+#[derive(Serialize, Debug, Deserialize, Clone)]
+pub struct ReportTimerange {
+    #[serde(rename = "type")]
+    pub range_type: ReportTimerangeType,
+    pub period: String, // 15m, 4M etc. For relative.
+    pub from: i64,      // For absolute, in microseconds
+    pub to: i64,        // For absolute, in microseconds
+}
+
+impl Default for ReportTimerange {
+    fn default() -> Self {
+        Self {
+            range_type: ReportTimerangeType::default(),
+            period: "1w".to_string(),
+            from: 0,
+            to: 0,
+        }
+    }
+}

--- a/src/reportserver/src/report.rs
+++ b/src/reportserver/src/report.rs
@@ -1,0 +1,391 @@
+use chromiumoxide::{
+    browser::{Browser, BrowserConfig},
+    cdp::browser_protocol::page::PrintToPdfParams,
+    detection::{default_executable, DetectionOptions},
+    fetcher::{BrowserFetcher, BrowserFetcherOptions},
+    handler::viewport::Viewport,
+    Page,
+};
+use config::CONFIG;
+use futures::StreamExt;
+use lettre::{
+    message::{header::ContentType, MultiPart, SinglePart},
+    transport::smtp::{
+        authentication::Credentials,
+        client::{Tls, TlsParameters},
+    },
+    AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor,
+};
+use once_cell::sync::Lazy;
+use tokio::time::{sleep, Duration};
+
+use crate::models;
+
+static CHROME_LAUNCHER_OPTIONS: tokio::sync::OnceCell<BrowserConfig> =
+    tokio::sync::OnceCell::const_new();
+
+pub async fn get_chrome_launch_options() -> &'static BrowserConfig {
+    CHROME_LAUNCHER_OPTIONS
+        .get_or_init(init_chrome_launch_options)
+        .await
+}
+
+async fn init_chrome_launch_options() -> BrowserConfig {
+    let mut browser_config = BrowserConfig::builder()
+        .window_size(
+            CONFIG.chrome.chrome_window_width,
+            CONFIG.chrome.chrome_window_height,
+        )
+        .viewport(Viewport {
+            width: CONFIG.chrome.chrome_window_width,
+            height: CONFIG.chrome.chrome_window_height,
+            device_scale_factor: Some(1.0),
+            ..Viewport::default()
+        });
+
+    if CONFIG.chrome.chrome_with_head {
+        browser_config = browser_config.with_head();
+    }
+
+    if CONFIG.chrome.chrome_no_sandbox {
+        browser_config = browser_config.no_sandbox();
+    }
+
+    if !CONFIG.chrome.chrome_path.is_empty() {
+        browser_config = browser_config.chrome_executable(CONFIG.chrome.chrome_path.as_str());
+    } else {
+        let mut should_download = false;
+
+        if !CONFIG.chrome.chrome_check_default {
+            should_download = true;
+        } else {
+            // Check if chrome is available on default paths
+            // 1. Check the CHROME env
+            // 2. Check usual chrome file names in user path
+            // 3. (Windows) Registry
+            // 4. (Windows & MacOS) Usual installations paths
+            if let Ok(exec_path) = default_executable(DetectionOptions::default()) {
+                browser_config = browser_config.chrome_executable(exec_path);
+            } else {
+                should_download = true;
+            }
+        }
+        if should_download {
+            // Download known good chrome version
+            let download_path = &CONFIG.chrome.chrome_download_path;
+            log::info!("fetching chrome at: {download_path}");
+            tokio::fs::create_dir_all(download_path).await.unwrap();
+            let fetcher = BrowserFetcher::new(
+                BrowserFetcherOptions::builder()
+                    .with_path(download_path)
+                    .build()
+                    .unwrap(),
+            );
+
+            // Fetches the browser revision, either locally if it was previously
+            // installed or remotely. Returns error when the download/installation
+            // fails. Since it doesn't retry on network errors during download,
+            // if the installation fails, it might leave the cache in a bad state
+            // and it is advised to wipe it.
+            // Note: Does not work on LinuxArm platforms.
+            let info = fetcher
+                .fetch()
+                .await
+                .expect("chrome could not be downloaded");
+            log::info!(
+                "chrome fetched at path {:#?}",
+                info.executable_path.as_path()
+            );
+            browser_config = browser_config.chrome_executable(info.executable_path);
+        }
+    }
+    browser_config.build().unwrap()
+}
+
+pub static SMTP_CLIENT: Lazy<AsyncSmtpTransport<Tokio1Executor>> = Lazy::new(|| {
+    let tls_parameters = TlsParameters::new(CONFIG.smtp.smtp_host.clone()).unwrap();
+    let mut transport_builder =
+        AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&CONFIG.smtp.smtp_host)
+            .port(CONFIG.smtp.smtp_port);
+
+    let option = &CONFIG.smtp.smtp_encryption;
+    transport_builder = if option == "starttls" {
+        transport_builder.tls(Tls::Required(tls_parameters))
+    } else if option == "ssltls" {
+        transport_builder.tls(Tls::Wrapper(tls_parameters))
+    } else {
+        transport_builder
+    };
+
+    if !CONFIG.smtp.smtp_username.is_empty() && !CONFIG.smtp.smtp_password.is_empty() {
+        transport_builder = transport_builder.credentials(Credentials::new(
+            CONFIG.smtp.smtp_username.clone(),
+            CONFIG.smtp.smtp_password.clone(),
+        ));
+    }
+    transport_builder.build()
+});
+
+pub async fn generate_report(
+    dashboard: &models::ReportDashboard,
+    org_id: &str,
+    user_id: &str,
+    user_pass: &str,
+    web_url: &str,
+    timezone: &str,
+) -> Result<(Vec<u8>, String), anyhow::Error> {
+    let dashboard_id = &dashboard.dashboard;
+    let folder_id = &dashboard.folder;
+
+    let mut dashb_vars = "".to_string();
+    for variable in dashboard.variables.iter() {
+        dashb_vars = format!("{}&var-{}={}", dashb_vars, variable.key, variable.value);
+    }
+
+    if dashboard.tabs.is_empty() {
+        return Err(anyhow::anyhow!("Atleast one tab is required"));
+    }
+    // Only one tab is supported for now
+    let tab_id = &dashboard.tabs[0];
+
+    log::info!("launching browser for dashboard {dashboard_id}");
+    let (mut browser, mut handler) =
+        Browser::launch(get_chrome_launch_options().await.clone()).await?;
+    log::info!("browser launched");
+
+    let handle = tokio::task::spawn(async move {
+        while let Some(h) = handler.next().await {
+            match h {
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+    });
+
+    log::debug!("Navigating to web url: {}", &web_url);
+    let page = browser
+        .new_page(&format!("{web_url}/login?login_as_internal_user=true"))
+        .await?;
+    page.disable_log().await?;
+    log::debug!("headless: new page created");
+
+    page.find_element("input[type='email']")
+        .await?
+        .click()
+        .await?
+        .type_str(user_id)
+        .await?;
+    log::debug!("headless: email input filled");
+
+    page.find_element("input[type='password']")
+        .await?
+        .click()
+        .await?
+        .type_str(user_pass)
+        .await?
+        .press_key("Enter")
+        .await?;
+    log::debug!("headless: password input filled");
+
+    // Does not seem to work for single page client application
+    page.wait_for_navigation().await?;
+    sleep(Duration::from_secs(5)).await;
+
+    let timerange = &dashboard.timerange;
+
+    // dashboard link in the email should contain data of the same period as the report
+    let (dashb_url, email_dashb_url) = match timerange.range_type {
+        models::ReportTimerangeType::Relative => {
+            let period = &timerange.period;
+            let (time_duration, time_unit) = period.split_at(period.len() - 1);
+            let dashb_url = format!(
+                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&period={period}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
+            );
+            log::debug!("dashb_url for dashboard {folder_id}/{dashboard_id}: {dashb_url}");
+
+            let time_duration: i64 = time_duration.parse()?;
+            let end_time = chrono::Utc::now().timestamp_micros();
+            let start_time = match time_unit {
+                "m" => {
+                    end_time
+                        - chrono::Duration::try_minutes(time_duration)
+                            .unwrap()
+                            .num_microseconds()
+                            .unwrap()
+                }
+                "h" => {
+                    end_time
+                        - chrono::Duration::try_hours(time_duration)
+                            .unwrap()
+                            .num_microseconds()
+                            .unwrap()
+                }
+                "d" => {
+                    end_time
+                        - chrono::Duration::try_days(time_duration)
+                            .unwrap()
+                            .num_microseconds()
+                            .unwrap()
+                }
+                "w" => {
+                    end_time
+                        - chrono::Duration::try_weeks(time_duration)
+                            .unwrap()
+                            .num_microseconds()
+                            .unwrap()
+                }
+                _ => {
+                    end_time
+                        - chrono::Duration::try_days(30 * time_duration)
+                            .unwrap()
+                            .num_microseconds()
+                            .unwrap()
+                }
+            };
+
+            let email_dashb_url = format!(
+                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&from={start_time}&to={end_time}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
+            );
+            (dashb_url, email_dashb_url)
+        }
+        models::ReportTimerangeType::Absolute => {
+            let url = format!(
+                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&from={}&to={}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
+                &timerange.from, &timerange.to
+            );
+            log::debug!("dashb_url for dashboard {folder_id}/{dashboard_id}: {url}");
+
+            (url.clone(), url)
+        }
+    };
+
+    log::debug!("headless: going to dash url");
+    // First navigate to the correct org
+    page.goto(&format!("{web_url}/?org_identifier={org_id}"))
+        .await?;
+    page.wait_for_navigation().await?;
+    sleep(Duration::from_secs(2)).await;
+    log::debug!("headless: navigated to the org_id: {org_id}");
+
+    page.goto(&dashb_url).await?;
+    log::debug!("headless: going to dash url");
+
+    // Wait for navigation does not really wait until it is fully loaded
+    page.wait_for_navigation().await?;
+
+    log::debug!("waiting for data to load for dashboard {dashboard_id}");
+
+    // If the span element is not rendered yet, capture whatever is loaded till now
+    if let Err(e) = wait_for_panel_data_load(&page).await {
+        log::error!(
+            "[REPORT] error occurred while finding the span element for dashboard {dashboard_id}:{e}"
+        );
+    } else {
+        log::info!("[REPORT] all panel data loaded for report dashboard: {dashboard_id}");
+    }
+
+    if let Err(e) = page.find_element("main").await {
+        browser.close().await?;
+        handle.await?;
+        return Err(anyhow::anyhow!(
+            "[REPORT] main element not rendered yet for dashboard {dashboard_id}: {e}"
+        ));
+    }
+    if let Err(e) = page.find_element("div.displayDiv").await {
+        browser.close().await?;
+        handle.await?;
+        return Err(anyhow::anyhow!(
+            "[REPORT] div.displayDiv element not rendered yet for dashboard {dashboard_id}: {e}"
+        ));
+    }
+
+    // Last two elements loaded means atleast the metric components have loaded.
+    // Convert the page into pdf
+    let pdf_data = page
+        .pdf(PrintToPdfParams {
+            landscape: Some(true),
+            ..Default::default()
+        })
+        .await?;
+
+    browser.close().await?;
+    handle.await?;
+    log::debug!("done with headless browser");
+    Ok((pdf_data, email_dashb_url))
+}
+
+/// Sends emails to the [`Report`] recepients. Currently only one pdf data is supported.
+pub async fn send_email(
+    pdf_data: &[u8],
+    email_details: models::EmailDetails,
+    config: models::SmtpConfig,
+) -> Result<(), anyhow::Error> {
+    let mut recepients = vec![];
+    for recepient in &email_details.recepients {
+        recepients.push(recepient);
+    }
+
+    let mut email = Message::builder()
+        .from(config.from_email.parse()?)
+        .subject(format!("Openobserve Report - {}", &email_details.title));
+
+    for recepient in recepients {
+        email = email.to(recepient.parse()?);
+    }
+
+    if !config.reply_to.is_empty() {
+        email = email.reply_to(config.reply_to.parse()?);
+    }
+
+    let email = email
+        .multipart(
+            MultiPart::mixed()
+                .singlepart(SinglePart::html(email_details.message))
+                .singlepart(SinglePart::html(format!(
+                    "<p><a href='{}' target='_blank'>Link to dashboard</a></p>",
+                    email_details.dashb_url
+                )))
+                .singlepart(
+                    // Only supports PDF for now, attach the PDF
+                    lettre::message::Attachment::new(
+                        email_details.title, // Attachment filename
+                    )
+                    .body(pdf_data.to_owned(), ContentType::parse("application/pdf")?),
+                ),
+        )
+        .unwrap();
+
+    // Send the email
+    match config.client.send(email).await {
+        Ok(_) => {
+            log::info!(
+                "email sent successfully for the report {}",
+                &email_details.name
+            );
+            Ok(())
+        }
+        Err(e) => Err(anyhow::anyhow!("Error sending email: {e}")),
+    }
+}
+
+pub async fn wait_for_panel_data_load(page: &Page) -> Result<(), anyhow::Error> {
+    let start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(CONFIG.chrome.chrome_sleep_secs.into());
+    loop {
+        if page
+            .find_element("span#dashboardVariablesAndPanelsDataLoaded")
+            .await
+            .is_ok()
+        {
+            return Ok(());
+        }
+
+        if start.elapsed() >= timeout {
+            return Err(anyhow::anyhow!(
+                "span element indicator for data load not rendered yet"
+            ));
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/src/reportserver/src/router.rs
+++ b/src/reportserver/src/router.rs
@@ -1,0 +1,109 @@
+use std::{collections::HashMap, io::Error};
+
+use actix_web::{get, http::StatusCode, put, web, HttpRequest, HttpResponse as ActixHttpResponse};
+use config::CONFIG;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models,
+    report::{generate_report, send_email, SMTP_CLIENT},
+};
+
+/// HTTP response
+/// code 200 is success
+/// code 400 is error
+/// code 404 is not found
+/// code 500 is internal server error
+/// code 503 is service unavailable
+/// code >= 1000 is custom error code
+/// message is the message or error message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HttpResponse {
+    pub code: u16,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+}
+
+impl HttpResponse {
+    pub fn internal_server_error(e: String) -> Self {
+        Self {
+            code: StatusCode::INTERNAL_SERVER_ERROR.into(),
+            message: e,
+            error_detail: None,
+            trace_id: None,
+        }
+    }
+
+    pub fn success(msg: String) -> Self {
+        Self {
+            code: StatusCode::OK.into(),
+            message: msg,
+            error_detail: None,
+            trace_id: None,
+        }
+    }
+}
+
+#[get("/healthz")]
+pub async fn healthz() -> Result<ActixHttpResponse, Error> {
+    Ok(ActixHttpResponse::Ok().body("Server up and running"))
+}
+
+#[put("/{org_id}/reports/{name}/send")]
+pub async fn send_report(
+    report: web::Json<models::Report>,
+    path: web::Path<(String, String)>,
+    req: HttpRequest,
+) -> Result<ActixHttpResponse, Error> {
+    let report = report.into_inner();
+    let (org_id, report_name) = path.into_inner();
+    let query = web::Query::<HashMap<String, String>>::from_query(req.query_string()).unwrap();
+    let timezone = match query.get("timezone") {
+        Some(v) => v,
+        None => "Europe/London",
+    };
+    let (pdf_data, email_dashboard_url) = match generate_report(
+        &report.dashboards[0],
+        &org_id,
+        &CONFIG.report_server.user_email,
+        &CONFIG.report_server.user_password,
+        &report.email_details.dashb_url,
+        timezone,
+    )
+    .await
+    {
+        Ok(res) => res,
+        Err(e) => {
+            log::error!("Error generating pdf for report {org_id}/{report_name}: {e}");
+            return Ok(ActixHttpResponse::InternalServerError()
+                .json(HttpResponse::internal_server_error(e.to_string())));
+        }
+    };
+
+    match send_email(
+        &pdf_data,
+        models::EmailDetails {
+            dashb_url: email_dashboard_url,
+            ..report.email_details
+        },
+        models::SmtpConfig {
+            from_email: CONFIG.smtp.smtp_from_email.to_string(),
+            reply_to: CONFIG.smtp.smtp_reply_to.to_string(),
+            client: &SMTP_CLIENT,
+        },
+    )
+    .await
+    {
+        Ok(_) => Ok(ActixHttpResponse::Ok().json(HttpResponse::success(
+            "report sent to emails successfully".into(),
+        ))),
+        Err(e) => {
+            log::error!("Error sending emails to recepients: {e}");
+            Ok(ActixHttpResponse::InternalServerError()
+                .json(HttpResponse::internal_server_error(e.to_string())))
+        }
+    }
+}

--- a/src/reportserver/src/server.rs
+++ b/src/reportserver/src/server.rs
@@ -1,0 +1,87 @@
+use std::net::SocketAddr;
+
+use actix_web::{dev::ServerHandle, middleware, web, App, HttpServer};
+use config::CONFIG;
+
+use crate::router::{healthz, send_report};
+
+pub async fn spawn_server() -> Result<(), anyhow::Error> {
+    // Locate or fetch chromium
+    _ = config::get_chrome_launch_options().await;
+
+    log::info!("starting o2 chrome server");
+
+    if CONFIG.report_server.user_email.is_empty() || CONFIG.report_server.user_password.is_empty() {
+        log::error!("Missing ZO_REPORT_USER_EMAIL or ZO_REPORT_USER_PASSWORD env vars");
+        return Err(anyhow::anyhow!(
+            "Please set ZO_REPORT_USER_EMAIL and ZO_REPORT_USER_PASSWORD to use report server"
+        ));
+    }
+
+    let haddr: SocketAddr = if CONFIG.http.ipv6_enabled {
+        format!("[::]:{}", CONFIG.http.port).parse()?
+    } else {
+        let ip = if !CONFIG.http.addr.is_empty() {
+            CONFIG.http.addr.clone()
+        } else {
+            "0.0.0.0".to_string()
+        };
+        format!("{}:{}", ip, CONFIG.http.port).parse()?
+    };
+    log::info!("starting Report server at: {}", haddr);
+    let server = HttpServer::new(move || {
+        App::new()
+            .service(web::scope("/api").service(send_report).service(healthz))
+            .wrap(middleware::Logger::new(
+                r#"%a "%r" %s %b "%{Content-Length}i" "%{Referer}i" "%{User-Agent}i" %T"#,
+            ))
+    })
+    .bind(haddr)?
+    .run();
+
+    let handle = server.handle();
+    tokio::task::spawn(async move {
+        graceful_shutdown(handle).await;
+    });
+    server.await?;
+    log::info!("Report server stopped");
+    Ok(())
+}
+
+async fn graceful_shutdown(handle: ServerHandle) {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        let mut sigquit = signal(SignalKind::quit()).unwrap();
+        let mut sigterm = signal(SignalKind::terminate()).unwrap();
+        let mut sigint = signal(SignalKind::interrupt()).unwrap();
+
+        tokio::select! {
+            _ = sigquit.recv() =>  log::info!("SIGQUIT received"),
+            _ = sigterm.recv() =>  log::info!("SIGTERM received"),
+            _ = sigint.recv() =>   log::info!("SIGINT received"),
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        use tokio::signal::windows::*;
+
+        let mut sigbreak = ctrl_break().unwrap();
+        let mut sigint = ctrl_c().unwrap();
+        let mut sigquit = ctrl_close().unwrap();
+        let mut sigterm = ctrl_shutdown().unwrap();
+
+        tokio::select! {
+            _ = sigbreak.recv() =>  log::info!("ctrl-break received"),
+            _ = sigquit.recv() =>  log::info!("ctrl-c received"),
+            _ = sigterm.recv() =>  log::info!("ctrl-close received"),
+            _ = sigint.recv() =>   log::info!("ctrl-shutdown received"),
+        }
+    }
+    // tokio::signal::ctrl_c().await.unwrap();
+    // println!("ctrl-c received!");
+
+    handle.stop(true).await;
+}

--- a/src/reportserver/src/server.rs
+++ b/src/reportserver/src/server.rs
@@ -18,15 +18,15 @@ pub async fn spawn_server() -> Result<(), anyhow::Error> {
         ));
     }
 
-    let haddr: SocketAddr = if CONFIG.http.ipv6_enabled {
-        format!("[::]:{}", CONFIG.http.port).parse()?
+    let haddr: SocketAddr = if CONFIG.report_server.ipv6_enabled {
+        format!("[::]:{}", CONFIG.report_server.port).parse()?
     } else {
-        let ip = if !CONFIG.http.addr.is_empty() {
-            CONFIG.http.addr.clone()
+        let ip = if !CONFIG.report_server.addr.is_empty() {
+            CONFIG.report_server.addr.clone()
         } else {
             "0.0.0.0".to_string()
         };
-        format!("{}:{}", ip, CONFIG.http.port).parse()?
+        format!("{}:{}", ip, CONFIG.report_server.port).parse()?
     };
     log::info!("starting Report server at: {}", haddr);
     let server = HttpServer::new(move || {

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -265,12 +265,12 @@ impl Report {
             ))
             .unwrap();
             match Client::builder()
+                .danger_accept_invalid_certs(CONFIG.common.report_server_skip_tls_verify)
                 .build()
                 .unwrap()
                 .put(url)
                 .query(&[("timezone", &self.timezone)])
                 .header("Content-Type", "application/json")
-                // .header(reqwest::header::AUTHORIZATION, creds)
                 .json(&report_data)
                 .send()
                 .await


### PR DESCRIPTION
There are three cases to consider:

if ZO_ENABLE_EMBEDDED_REPORT_SERVER=true

If running a binary, alertmanager node will spawn an embedded server running at localhost:5082.
All the requests from alert-manager will go to localhost:5082 for pdf generation related tasks.

For single node k8s deployment, as this is running in a container there is no chromium installed, so even if you set the variable to true, the report server will panic due to missing dependencies. For this situation helm chart will spawn a report-server instance which can be used.

Same for cluster deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new report server for generating and sending reports.
  - Added health check and report sending endpoints.

- **Improvements**
  - Enhanced logging for report server operations.
  - Configurable option to skip TLS verification for report server connections.

- **Bug Fixes**
  - Fixed formatting issue in HTTP status request handler.

- **Chores**
  - Updated dependencies and configurations for the new report server module.

- **Documentation**
  - Added new structures and functions for email configuration, report generation, and server operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->