### PR TITLE
fix: ofga check versions before acquiring lock

### DIFF
--- a/src/common/infra/ofga.rs
+++ b/src/common/infra/ofga.rs
@@ -35,6 +35,15 @@ pub async fn init() {
             None
         }
     };
+
+    let meta = o2_enterprise::enterprise::openfga::model::read_ofga_model().await;
+    if let Some(existing_model) = &existing_meta {
+        if meta.version == existing_model.version {
+            log::info!("OFGA model already exists & no changes required");
+            return;
+        }
+    }
+
     // 1. create a cluster lock
     let locker = dist_lock::lock("/ofga/model/", 0)
         .await


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced initialization process to prevent redundant cluster lock creation when the existing OFGA model version matches the fetched version. This improvement reduces unnecessary operations and improves system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->