### PR TITLE
perf: use parquet file static cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.34.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea7b126ebfa4db78e9e788b2a792b6329f35b4f2fdd56dbc646dedc2beec7a5"
+checksum = "ab8df97cb8fc4a884af29ab383e9292ea0939cfcdd7d2a17179086dc6c427e7f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -928,7 +928,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tracing",
  "tryhard",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,7 +241,7 @@ lettre = { version = "0.11", default-features = false, features = [
 log = "0.4"
 memchr = "2.5"
 murmur3 = "0.5"
-async-nats = "0.34.0"
+async-nats = "0.35.1"
 once_cell = "1.17"
 parking_lot = "0.12"
 prometheus = "0.13"

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -628,8 +628,6 @@ pub struct Common {
     pub allow_user_defined_schemas: bool,
     #[env_config(name = "ZO_DATAFUSION_PARQUET_STAT_DISABLE_FOR_AGGS", default = false)]
     pub datafusion_parquet_stat_disable_for_aggs: bool,
-    #[env_config(name = "ZO_DATAFUSION_PARQUET_ENABLE_SORT_ORDER", default = false)]
-    pub datafusion_parquet_sort_order: bool,
 }
 
 #[derive(EnvConfig)]
@@ -763,6 +761,8 @@ pub struct Limit {
     pub distinct_values_hourly: bool,
     #[env_config(name = "ZO_CONSISTENT_HASH_VNODES", default = 3)]
     pub consistent_hash_vnodes: usize,
+    #[env_config(name = "ZO_DATAFUSION_FILE_STAT_CACHE_MAX_ENTRIES", default = 100000)]
+    pub datafusion_file_stat_cache_max_entries: usize,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -626,8 +626,6 @@ pub struct Common {
     pub bulk_api_response_errors_only: bool,
     #[env_config(name = "ZO_ALLOW_USER_DEFINED_SCHEMAS", default = false)]
     pub allow_user_defined_schemas: bool,
-    #[env_config(name = "ZO_DATAFUSION_PARQUET_STAT_DISABLE_FOR_AGGS", default = false)]
-    pub datafusion_parquet_stat_disable_for_aggs: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -61,7 +61,10 @@ use crate::{
         infra::{cluster, config::*},
         meta::{functions::ZoFunction, http::HttpResponse as MetaHttpResponse, user::AuthTokens},
     },
-    service::{db, search::datafusion::DEFAULT_FUNCTIONS},
+    service::{
+        db,
+        search::datafusion::{storage::file_statistics_cache, DEFAULT_FUNCTIONS},
+    },
 };
 
 #[derive(Serialize, ToSchema)]
@@ -306,6 +309,10 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
     stats.insert(
         "COMPACT",
         json::json!({"file_list_offset": last_file_list_offset}),
+    );
+    stats.insert(
+        "DATAFUSION",
+        json::json!({"file_stat_cache": file_statistics_cache::GLOBAL_CACHE.clone().len()}),
     );
 
     Ok(HttpResponse::Ok().json(stats))

--- a/src/infra/src/cache/mod.rs
+++ b/src/infra/src/cache/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Zinc Labs Inc.
+// Copyright 2024 Zinc Labs Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -1237,20 +1237,14 @@ pub async fn register_table(
             ListingOptions::new(Arc::new(file_format))
                 .with_file_extension(FileType::PARQUET.get_ext())
                 .with_target_partitions(CONFIG.limit.cpu_num)
-                .with_collect_stat(
-                    session.search_type != SearchType::Aggregation
-                        || !CONFIG.common.datafusion_parquet_stat_disable_for_aggs,
-                )
+                .with_collect_stat(true)
         }
         FileType::JSON => {
             let file_format = JsonFormat::default();
             ListingOptions::new(Arc::new(file_format))
                 .with_file_extension(FileType::JSON.get_ext())
                 .with_target_partitions(CONFIG.limit.cpu_num)
-                .with_collect_stat(
-                    session.search_type != SearchType::Aggregation
-                        || !CONFIG.common.datafusion_parquet_stat_disable_for_aggs,
-                )
+                .with_collect_stat(true)
         }
         _ => {
             return Err(DataFusionError::Execution(format!(

--- a/src/service/search/datafusion/storage/file_list.rs
+++ b/src/service/search/datafusion/storage/file_list.rs
@@ -30,11 +30,12 @@ pub fn get(trace_id: &str) -> Result<Vec<ObjectMeta>, anyhow::Error> {
     Ok(data)
 }
 
-pub async fn set(trace_id: &str, files: &[FileKey]) {
+pub async fn set(trace_id: &str, schema_key: &str, files: &[FileKey]) {
+    let key = format!("{}/schema={}", trace_id, schema_key);
     let mut values = Vec::with_capacity(files.len());
     for file in files {
         let modified = Utc.timestamp_nanos(file.meta.max_ts * 1000);
-        let file_name = format!("/{}/$$/{}", trace_id, file.key);
+        let file_name = format!("/{}/$$/{}", key, file.key);
         values.push(ObjectMeta {
             location: file_name.into(),
             last_modified: modified,
@@ -43,7 +44,7 @@ pub async fn set(trace_id: &str, files: &[FileKey]) {
             version: None,
         });
     }
-    FILES.write().insert(trace_id.to_string(), values);
+    FILES.write().insert(key, values);
 }
 
 pub fn clear(trace_id: &str) {

--- a/src/service/search/datafusion/storage/file_statistics_cache.rs
+++ b/src/service/search/datafusion/storage/file_statistics_cache.rs
@@ -1,0 +1,192 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{collections::VecDeque, sync::Arc};
+
+use dashmap::DashMap;
+use datafusion::{common::Statistics, execution::cache::CacheAccessor};
+use object_store::{path::Path, ObjectMeta};
+use once_cell::sync::Lazy;
+
+pub static GLOBAL_CACHE: Lazy<Arc<FileStatisticsCache>> =
+    Lazy::new(|| Arc::new(FileStatisticsCache::default()));
+
+/// Collected statistics for files
+/// Cache is invalided when file size or last modification has changed
+pub struct FileStatisticsCache {
+    statistics: DashMap<String, (ObjectMeta, Arc<Statistics>)>,
+    cacher: parking_lot::Mutex<VecDeque<String>>,
+    max_entries: usize,
+}
+
+impl FileStatisticsCache {
+    pub fn new(max_entries: usize) -> Self {
+        Self {
+            statistics: DashMap::new(),
+            cacher: parking_lot::Mutex::new(VecDeque::new()),
+            max_entries,
+        }
+    }
+    pub fn len(&self) -> usize {
+        self.statistics.len()
+    }
+    fn format_key(&self, k: &Path) -> String {
+        if let Some(mut p) = k.as_ref().find("/$$/") {
+            if let Some(pp) = k.as_ref()[..p].find("/schema=") {
+                p = pp;
+            }
+            k.as_ref()[p..].to_string()
+        } else {
+            k.to_string()
+        }
+    }
+}
+
+impl Default for FileStatisticsCache {
+    fn default() -> Self {
+        Self::new(config::CONFIG.limit.datafusion_file_stat_cache_max_entries)
+    }
+}
+
+impl CacheAccessor<Path, Arc<Statistics>> for FileStatisticsCache {
+    type Extra = ObjectMeta;
+
+    /// Get `Statistics` for file location.
+    fn get(&self, k: &Path) -> Option<Arc<Statistics>> {
+        let k = self.format_key(k);
+        self.statistics
+            .get(&k)
+            .map(|s| Some(s.value().1.clone()))
+            .unwrap_or(None)
+    }
+
+    /// Get `Statistics` for file location. Returns None if file has changed or not found.
+    fn get_with_extra(&self, k: &Path, e: &Self::Extra) -> Option<Arc<Statistics>> {
+        let k = self.format_key(k);
+        self.statistics
+            .get(&k)
+            .map(|s| {
+                let (saved_meta, statistics) = s.value();
+                if saved_meta.size != e.size || saved_meta.last_modified != e.last_modified {
+                    // file has changed
+                    None
+                } else {
+                    Some(statistics.clone())
+                }
+            })
+            .unwrap_or(None)
+    }
+
+    /// Save collected file statistics
+    fn put(&self, _key: &Path, _value: Arc<Statistics>) -> Option<Arc<Statistics>> {
+        panic!("Put cache in FileStatisticsCache without Extra not supported.")
+    }
+
+    fn put_with_extra(
+        &self,
+        k: &Path,
+        value: Arc<Statistics>,
+        e: &Self::Extra,
+    ) -> Option<Arc<Statistics>> {
+        let k = self.format_key(k);
+        let mut w = self.cacher.lock();
+        if w.len() >= self.max_entries {
+            // release 5% of the cache
+            for _ in 0..(self.max_entries / 20) {
+                if let Some(k) = w.pop_front() {
+                    self.statistics.remove(&k);
+                } else {
+                    break;
+                }
+            }
+        }
+        w.push_back(k.clone());
+        drop(w);
+        self.statistics.insert(k, (e.clone(), value)).map(|x| x.1)
+    }
+
+    fn remove(&mut self, k: &Path) -> Option<Arc<Statistics>> {
+        let k = self.format_key(k);
+        self.statistics.remove(&k).map(|x| x.1.1)
+    }
+
+    fn contains_key(&self, k: &Path) -> bool {
+        let k = self.format_key(k);
+        self.statistics.contains_key(&k)
+    }
+
+    fn len(&self) -> usize {
+        self.statistics.len()
+    }
+
+    fn clear(&self) {
+        self.statistics.clear()
+    }
+    fn name(&self) -> String {
+        "FileStatisticsCache".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::DateTime;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+
+    use super::*;
+
+    #[test]
+    fn test_file_statistics_cache() {
+        let meta = ObjectMeta {
+            location: Path::from("test"),
+            last_modified: DateTime::parse_from_rfc3339("2022-09-27T22:36:00+02:00")
+                .unwrap()
+                .into(),
+            size: 1024,
+            e_tag: None,
+            version: None,
+        };
+        let cache = FileStatisticsCache::default();
+        assert!(cache.get_with_extra(&meta.location, &meta).is_none());
+
+        cache.put_with_extra(
+            &meta.location,
+            Statistics::new_unknown(&Schema::new(vec![Field::new(
+                "test_column",
+                DataType::Timestamp(TimeUnit::Second, None),
+                false,
+            )]))
+            .into(),
+            &meta,
+        );
+        assert!(cache.get_with_extra(&meta.location, &meta).is_some());
+
+        // file size changed
+        let mut meta2 = meta.clone();
+        meta2.size = 2048;
+        assert!(cache.get_with_extra(&meta2.location, &meta2).is_none());
+
+        // file last_modified changed
+        let mut meta2 = meta.clone();
+        meta2.last_modified = DateTime::parse_from_rfc3339("2022-09-27T22:40:00+02:00")
+            .unwrap()
+            .into();
+        assert!(cache.get_with_extra(&meta2.location, &meta2).is_none());
+
+        // different file
+        let mut meta2 = meta;
+        meta2.location = Path::from("test2");
+        assert!(cache.get_with_extra(&meta2.location, &meta2).is_none());
+    }
+}

--- a/src/service/search/datafusion/storage/mod.rs
+++ b/src/service/search/datafusion/storage/mod.rs
@@ -20,6 +20,7 @@ use snafu::Snafu;
 use thiserror::Error as ThisError;
 
 pub mod file_list;
+pub mod file_statistics_cache;
 pub mod memory;
 pub mod tmpfs;
 pub mod wal;


### PR DESCRIPTION
Last PR i added a new ENV `ZO_DATAFUSION_PARQUET_STAT_DISABLE_FOR_AGGS`, but now we can use parquet file statistics cache to do better, so i deleted the ENV.

Query for last 3 days within 100GB data:
- without cache: 10s
- with stat cache: 8s

This is for all the query not only for aggregation.

Also added a new ENV:
```
ZO_DATAFUSION_FILE_STAT_CACHE_MAX_ENTRIES=100000
```