### PR TITLE
refactor: rename match_all & match_all_indexed

### DIFF
--- a/src/service/search/datafusion/mod.rs
+++ b/src/service/search/datafusion/mod.rs
@@ -58,6 +58,14 @@ pub const REGEX_NOT_MATCH_UDF_NAME: &str = "re_not_match";
 
 pub const DEFAULT_FUNCTIONS: [ZoFunction; 8] = [
     ZoFunction {
+        name: "match_all_raw",
+        text: "match_all_raw('v')",
+    },
+    ZoFunction {
+        name: "match_all_raw_ignore_case",
+        text: "match_all_raw_ignore_case('v')",
+    },
+    ZoFunction {
         name: "match_all",
         text: "match_all('v')",
     },
@@ -66,20 +74,12 @@ pub const DEFAULT_FUNCTIONS: [ZoFunction; 8] = [
         text: "match_all_ignore_case('v')",
     },
     ZoFunction {
-        name: "match_all_indexed",
-        text: "match_all_indexed('v')",
-    },
-    ZoFunction {
-        name: "match_all_indexed_ignore_case",
-        text: "match_all_indexed_ignore_case('v')",
-    },
-    ZoFunction {
         name: MATCH_UDF_NAME,
-        text: "match_all('v')",
+        text: "match_all_raw('v')",
     },
     ZoFunction {
         name: MATCH_UDF_IGNORE_CASE_NAME,
-        text: "match_all_ignore_case('v')",
+        text: "match_all_raw_ignore_case('v')",
     },
     ZoFunction {
         name: REGEX_MATCH_UDF_NAME,

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -56,13 +56,14 @@ static RE_ONLY_WHERE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i) where ").unwr
 static RE_ONLY_FROM: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i) from[ ]+query").unwrap());
 
 static RE_HISTOGRAM: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)histogram\(([^\)]*)\)").unwrap());
-static RE_MATCH_ALL: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)match_all\('([^']*)'\)").unwrap());
+static RE_MATCH_ALL: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)match_all_raw\('([^']*)'\)").unwrap());
 static RE_MATCH_ALL_IGNORE_CASE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)match_all_ignore_case\('([^']*)'\)").unwrap());
+    Lazy::new(|| Regex::new(r"(?i)match_all_raw_ignore_case\('([^']*)'\)").unwrap());
 static RE_MATCH_ALL_INDEXED: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)match_all_indexed\('([^']*)'\)").unwrap());
+    Lazy::new(|| Regex::new(r"(?i)match_all\('([^']*)'\)").unwrap());
 static RE_MATCH_ALL_INDEXED_IGNORE_CASE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)match_all_indexed_ignore_case\('([^']*)'\)").unwrap());
+    Lazy::new(|| Regex::new(r"(?i)match_all_ignore_case\('([^']*)'\)").unwrap());
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Sql {
@@ -694,6 +695,8 @@ impl Sql {
         } else {
             Some(req_query.query_fn.clone())
         };
+
+        log::warn!("original: {}, rewrite: {}", origin_sql, rewrite_sql);
 
         Ok(Sql {
             origin_sql,

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -696,8 +696,6 @@ impl Sql {
             Some(req_query.query_fn.clone())
         };
 
-        log::warn!("original: {}, rewrite: {}", origin_sql, rewrite_sql);
-
         Ok(Sql {
             origin_sql,
             rewrite_sql,

--- a/tests/api-testing/tests/test_search.py
+++ b/tests/api-testing/tests/test_search.py
@@ -314,7 +314,7 @@ def test_e2e_matchallindexedignorecasewithoutsearchfeild(create_session, base_ur
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
         "query": {
-            "sql": 'select * from "stream_pytest_data" WHERE match_all_raw_indexed_ignore_case()',
+            "sql": 'select * from "stream_pytest_data" WHERE match_all_raw_ignore_case()',
             "start_time": one_min_ago,
             "end_time": end_time,
             "from": 0,

--- a/tests/api-testing/tests/test_search.py
+++ b/tests/api-testing/tests/test_search.py
@@ -181,7 +181,7 @@ def test_e2e_matchallhistogram(create_session, base_url):
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
         "query": {
-            "sql": 'select * from "stream_pytest_data" WHERE match_all(\'provide_credentials\')',
+            "sql": 'select * from "stream_pytest_data" WHERE match_all_raw(\'provide_credentials\')',
             "start_time": one_min_ago,
             "end_time": end_time,
             "from": 0,
@@ -214,7 +214,7 @@ def test_e2e_matchallindexhistogram(create_session, base_url):
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
         "query": {
-            "sql": 'select * from "stream_pytest_data" WHERE match_all_indexed(\'provide_credentials\')',
+            "sql": 'select * from "stream_pytest_data" WHERE match_all(\'provide_credentials\')',
             "start_time": one_min_ago,
             "end_time": end_time,
             "from": 0,
@@ -247,7 +247,7 @@ def test_e2e_matchallignorecasehistogram(create_session, base_url):
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
         "query": {
-            "sql": 'select * from "stream_pytest_data" WHERE match_all_ignore_case(\'provide_credentials\')',
+            "sql": 'select * from "stream_pytest_data" WHERE match_all_raw_ignore_case(\'provide_credentials\')',
             "start_time": one_min_ago,
             "end_time": end_time,
             "from": 0,
@@ -274,7 +274,7 @@ def test_e2e_matchallindexedignorecasehistogram(create_session, base_url):
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
         "query": {
-            "sql": 'select * from "stream_pytest_data" WHERE match_all_indexed_ignore_case(\'provide_credentials\')',
+            "sql": 'select * from "stream_pytest_data" WHERE match_all_ignore_case(\'provide_credentials\')',
             "start_time": one_min_ago,
             "end_time": end_time,
             "from": 0,
@@ -314,7 +314,7 @@ def test_e2e_matchallindexedignorecasewithoutsearchfeild(create_session, base_ur
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
         "query": {
-            "sql": 'select * from "stream_pytest_data" WHERE match_all_indexed_ignore_case()',
+            "sql": 'select * from "stream_pytest_data" WHERE match_all_raw_indexed_ignore_case()',
             "start_time": one_min_ago,
             "end_time": end_time,
             "from": 0,
@@ -347,7 +347,7 @@ def test_e2e_matchallindexedignorecaseinvalidsearchfeild(create_session, base_ur
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
         "query": {
-            "sql": 'select * from "stream_pytest_data" WHERE match_all_indexed_ignore_case('')',
+            "sql": 'select * from "stream_pytest_data" WHERE match_all_ignore_case('')',
             "start_time": one_min_ago,
             "end_time": end_time,
             "from": 0,
@@ -379,7 +379,7 @@ def test_e2e_matchallsql(create_session, base_url):
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
                 "query": {
-                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE match_all(\'provide_credentials\')',
+                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE match_all_raw(\'provide_credentials\')',
                         "start_time": one_min_ago,
                         "end_time": end_time,
                         "from": 0,
@@ -406,7 +406,7 @@ def test_e2e_matchallindexedsql(create_session, base_url):
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
                 "query": {
-                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE match_all_indexed(\'provide_credentials\')',
+                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE match_all(\'provide_credentials\')',
                         "start_time": one_min_ago,
                         "end_time": end_time,
                         "from": 0,
@@ -444,7 +444,7 @@ def test_e2e_matchallindexedignorecasesql(create_session, base_url):
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
                 "query": {
-                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE match_all_indexed_ignore_case(\'provide_credentials\')',
+                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE match_all_ignore_case(\'provide_credentials\')',
                         "start_time": one_min_ago,
                         "end_time": end_time,
                         "from": 0,
@@ -482,7 +482,7 @@ def test_e2e_matchallignorecasesql(create_session, base_url):
     one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
     json_data = {
                 "query": {
-                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE match_all_ignore_case(\'provide_credentials\')',
+                        "sql": 'SELECT * FROM "stream_pytest_data" WHERE match_all_raw_ignore_case(\'provide_credentials\')',
                         "start_time": one_min_ago,
                         "end_time": end_time,
                         "from": 0,


### PR DESCRIPTION
match_all                  renamed to match_all_raw
match_all_indexed   renamed to match_all

same pattern applied to *_ignore_case functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved clarity in function names for better understanding and usability.

- **Tests**
  - Updated SQL queries in test cases to reflect changes in function names, ensuring accurate test results.

- **Chores**
  - Adjusted logging statements to provide better insights during debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->