### PR TITLE
fix: prefetching monaco editor

### DIFF
--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -439,6 +439,8 @@ export default defineComponent({
     const isLoading = ref(false);
     const { getStreams, resetStreams } = useStreams();
 
+    const isMonacoEditorLoaded = ref(false);
+
     let customOrganization = router.currentRoute.value.query.hasOwnProperty(
       "org_identifier"
     )
@@ -961,28 +963,23 @@ export default defineComponent({
 
     const prefetch = () => {
       const href = "/web/assets/editor.api.v1.js";
-      console.log(document);
-
       const existingLink = document.querySelector(
         `link[rel="prefetch"][href="${href}"]`
       );
 
-      console.log("existingLink", existingLink);
       if (!existingLink) {
         // Create a new link element
+        isMonacoEditorLoaded.value = true;
         const link = document.createElement("link");
         link.rel = "prefetch";
         link.href = href;
         document.head.appendChild(link);
-        console.log(`Prefetch link for ${href} added.`);
-      } else {
-        console.log(`Prefetch link for ${href} already exists.`);
       }
     };
 
     const expandMenu = () => {
       miniMode.value = false;
-      prefetch();
+      if (!isMonacoEditorLoaded.value) prefetch();
     };
 
     return {

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -250,7 +250,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :mini="miniMode"
       bordered
       show-if-above
-      @mouseover="miniMode = false"
+      @mouseover="expandMenu"
       @mouseout="miniMode = true"
       mini-to-overlay
     >
@@ -258,6 +258,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <menu-link
           v-for="nav in linksList"
           :key="nav.title"
+          :link-name="nav.name"
           v-bind="{ ...nav, mini: miniMode }"
         />
       </q-list>
@@ -958,6 +959,32 @@ export default defineComponent({
       }
     };
 
+    const prefetch = () => {
+      const href = "/web/assets/editor.api.v1.js";
+      console.log(document);
+
+      const existingLink = document.querySelector(
+        `link[rel="prefetch"][href="${href}"]`
+      );
+
+      console.log("existingLink", existingLink);
+      if (!existingLink) {
+        // Create a new link element
+        const link = document.createElement("link");
+        link.rel = "prefetch";
+        link.href = href;
+        document.head.appendChild(link);
+        console.log(`Prefetch link for ${href} added.`);
+      } else {
+        console.log(`Prefetch link for ${href} already exists.`);
+      }
+    };
+
+    const expandMenu = () => {
+      miniMode.value = false;
+      prefetch();
+    };
+
     return {
       t,
       router,
@@ -980,6 +1007,8 @@ export default defineComponent({
       getOrganizationSettings,
       resetStreams,
       triggerRefreshToken,
+      prefetch,
+      expandMenu,
     };
   },
   computed: {

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -25,16 +25,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         horizontal
       >
         <template v-slot:before>
-          <search-bar
-            data-test="logs-search-bar"
-            ref="searchBarRef"
-            :fieldValues="fieldValues"
-            :key="searchObj.data.transforms.length || -1"
-            @searchdata="searchData"
-            @onChangeInterval="onChangeInterval"
-            @onChangeTimezone="refreshTimezone"
-            @handleQuickModeChange="handleQuickModeChange"
-          />
+          <Suspense>
+            <search-bar
+              data-test="logs-search-bar"
+              ref="searchBarRef"
+              :fieldValues="fieldValues"
+              :key="searchObj.data.transforms.length || -1"
+              @searchdata="searchData"
+              @onChangeInterval="onChangeInterval"
+              @onChangeTimezone="refreshTimezone"
+              @handleQuickModeChange="handleQuickModeChange"
+            />
+          </Suspense>
         </template>
         <template v-slot:after>
           <div

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -154,6 +154,11 @@ export default defineConfig({
           if (name.startsWith("o2cs-")) {
             return `assets/vendor/${name}.[hash].js`;
           }
+          
+          if (name.includes("editor.api")) {
+            return `assets/${name}.v1.js`;
+          }
+
           return `assets/${name}.[hash].js`;
         },
       },


### PR DESCRIPTION
Prefetched Monao Editor when user hover's over the left side menubar for first time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functionality to expand the menu on mouseover.
  - Introduced script prefetching for improved performance.

- **Enhancements**
  - Wrapped the `<search-bar>` component with `<Suspense>` for better loading experience.

- **Configuration**
  - Updated asset naming strategy to include versioning for specific assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->