### PR TITLE
fix: reload .env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5255,7 +5255,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openobserve"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = [
 license = "AGPL-3.0-only"
 name = "openobserve"
 repository = "https://github.com/openobserve/openobserve/"
-version = "0.10.6"
+version = "0.10.7"
 publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -18,7 +18,7 @@ use std::{cmp::max, collections::BTreeMap, path::Path, sync::Arc, time::Duration
 use arc_swap::ArcSwap;
 use chromiumoxide::{browser::BrowserConfig, handler::viewport::Viewport};
 use dotenv_config::EnvConfig;
-use dotenvy::dotenv;
+use dotenvy::dotenv_override;
 use hashbrown::{HashMap, HashSet};
 use itertools::chain;
 use lettre::{
@@ -1028,7 +1028,7 @@ pub struct RUM {
 }
 
 pub fn init() -> Config {
-    dotenv().ok();
+    dotenv_override().ok();
     let mut cfg = Config::init().unwrap();
     // set cpu num
     let cpu_num = cgroup::get_cpu_limit();


### PR DESCRIPTION
By default, it will skip existing environment variables when loading the .env file. We need to override existing environment variables upon reloading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Version updated from 0.10.6 to 0.10.7.

- **Improvements**
  - Enhanced configuration initialization for better environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->