### PR TITLE
fix: NaN issue on pagination message

### DIFF
--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -393,12 +393,25 @@ export default defineComponent({
 
     onMounted(() => {
       // updateDisplayValue();
+      console.log(props.defaultAbsoluteTime)
       try {
         resetTime("", "");
+
+        let startTime = (new Date().getTime() - 900000) * 1000;
+        let endTime = new Date().getTime();
+
+        if(props.defaultAbsoluteTime?.startTime) {
+          startTime = props.defaultAbsoluteTime?.startTime.toString().length > 13? props.defaultAbsoluteTime?.startTime : props.defaultAbsoluteTime?.startTime * 1000;
+        }
+
+        if(props.defaultAbsoluteTime?.endTime) {
+          endTime = props.defaultAbsoluteTime?.endTime.toString().length > 13? props.defaultAbsoluteTime?.endTime : props.defaultAbsoluteTime?.endTime * 1000;
+        }
+
         selectedType.value = props.defaultType;
         setAbsoluteTime(
-          props.defaultAbsoluteTime?.startTime,
-          props.defaultAbsoluteTime?.endTime
+          startTime,
+          endTime
         );
         setRelativeTime(props.defaultRelativeTime);
         displayValue.value = getDisplayValue();

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2210,11 +2210,11 @@ const useLogs = () => {
       totalCount = searchAggData.total;
     }
 
-    if (typeof totalCount === "NaN") {
+    if (isNaN(totalCount)) {
       totalCount = 0;
     }
 
-    if (typeof endCount === "NaN") {
+    if (isNaN(endCount)) {
       endCount = 0;
     }
     const title =

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1236,9 +1236,13 @@ const useLogs = () => {
         searchObj.data.histogramQuery.query.sql_mode = "full";
 
         searchObj.data.histogramQuery.query.start_time =
-          searchObj.data.datetime.startTime;
+          searchObj.data.datetime.startTime.toString().length > 13
+            ? searchObj.data.datetime.startTime
+            : searchObj.data.datetime.startTime * 1000;
         searchObj.data.histogramQuery.query.end_time =
-          searchObj.data.datetime.endTime;
+          searchObj.data.datetime.endTime.toString().length > 13
+            ? searchObj.data.datetime.endTime
+            : searchObj.data.datetime.endTime * 1000;
         delete searchObj.data.histogramQuery.query.quick_mode;
         delete searchObj.data.histogramQuery.query.from;
 

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1571,7 +1571,10 @@ const useLogs = () => {
           searchAggData.total = 0;
           searchAggData.hasAggregation = false;
           if (searchObj.meta.sqlMode == true) {
-            if (hasAggregation(parsedSQL?.columns) || parsedSQL.groupby != null) {
+            if (
+              hasAggregation(parsedSQL?.columns) ||
+              parsedSQL.groupby != null
+            ) {
               const parsedSQL: any = fnParsedSQL();
               searchAggData.total = res.data.total;
               searchAggData.hasAggregation = true;
@@ -2201,6 +2204,14 @@ const useLogs = () => {
 
     if (searchObj.meta.sqlMode && searchAggData.hasAggregation) {
       totalCount = searchAggData.total;
+    }
+
+    if (typeof totalCount === "NaN") {
+      totalCount = 0;
+    }
+
+    if (typeof endCount === "NaN") {
+      endCount = 0;
     }
     const title =
       "Showing " +

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -168,8 +168,8 @@ const defaultObject = {
     },
     editorValue: <any>"",
     datetime: <any>{
-      startTime: 0,
-      endTime: 0,
+      startTime: (new Date().getTime() - 900000) * 1000,
+      endTime: new Date().getTime(),
       relativeTimePeriod: "15m",
       type: "relative",
       selectedDate: <any>{},

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -25,18 +25,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         horizontal
       >
         <template v-slot:before>
-          <Suspense>
-            <search-bar
-              data-test="logs-search-bar"
-              ref="searchBarRef"
-              :fieldValues="fieldValues"
-              :key="searchObj.data.transforms.length || -1"
-              @searchdata="searchData"
-              @onChangeInterval="onChangeInterval"
-              @onChangeTimezone="refreshTimezone"
-              @handleQuickModeChange="handleQuickModeChange"
-            />
-          </Suspense>
+          <search-bar
+            data-test="logs-search-bar"
+            ref="searchBarRef"
+            :fieldValues="fieldValues"
+            :key="searchObj.data.transforms.length || -1"
+            @searchdata="searchData"
+            @onChangeInterval="onChangeInterval"
+            @onChangeTimezone="refreshTimezone"
+            @handleQuickModeChange="handleQuickModeChange"
+          />
         </template>
         <template v-slot:after>
           <div


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where `totalCount` and `endCount` could be `NaN` by setting them to 0 if they are `NaN`.

- **Improvements**
  - Enhanced the `DateTime` component to initialize `startTime` and `endTime` based on provided values or default to the current time with adjustments.

- **Refactor**
  - Simplified the `logs` plugin UI by removing the `<Suspense>` wrapper around the `<search-bar>` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->