### PR TITLE
fix: format the WHERE IN clause in scheduler mysql pull query

### DIFF
--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -312,24 +312,24 @@ FOR UPDATE;
         }
 
         let job_ids: Vec<String> = job_ids.into_iter().map(|id| id.id.to_string()).collect();
-        if let Err(e) = sqlx::query(
-            r#"UPDATE scheduled_jobs
+        let query = format!(
+            "UPDATE scheduled_jobs
 SET status = ?, start_time = ?,
     end_time = CASE
         WHEN module = ? THEN ?
         ELSE ?
     END
-WHERE id IN (?);
-            "#,
-        )
-        .bind(TriggerStatus::Processing)
-        .bind(now)
-        .bind(TriggerModule::Alert)
-        .bind(alert_max_time)
-        .bind(report_max_time)
-        .bind(job_ids.join(","))
-        .execute(&mut *tx)
-        .await
+WHERE id IN ({});",
+            job_ids.join(",")
+        );
+        if let Err(e) = sqlx::query(&query)
+            .bind(TriggerStatus::Processing)
+            .bind(now)
+            .bind(TriggerModule::Alert)
+            .bind(alert_max_time)
+            .bind(report_max_time)
+            .execute(&mut *tx)
+            .await
         {
             if let Err(e) = tx.rollback().await {
                 log::error!("[MYSQL] rollback update scheduled jobs status error: {}", e);
@@ -343,10 +343,12 @@ WHERE id IN (?);
             return Err(e.into());
         }
 
-        let query = r#"SELECT * FROM scheduled_jobs WHERE id IN (?);"#;
+        let query = format!(
+            "SELECT * FROM scheduled_jobs WHERE id IN ({});",
+            job_ids.join(",")
+        );
         let pool = CLIENT.clone();
-        let jobs: Vec<Trigger> = sqlx::query_as::<_, Trigger>(query)
-            .bind(job_ids.join(","))
+        let jobs: Vec<Trigger> = sqlx::query_as::<_, Trigger>(query.as_str())
             .fetch_all(&pool)
             .await?;
         log::debug!("Returning the pulled triggers: {}", jobs.len());


### PR DESCRIPTION
Fixes #3640 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the efficiency of updating and fetching scheduled jobs by using dynamic SQL query construction based on job IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->