### PR TITLE
fix: Time Selection popup gets hidden behind Date-Time UI 

### DIFF
--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -166,6 +166,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           <q-popup-proxy
                             transition-show="scale"
                             transition-hide="scale"
+                            style="z-index: 10002"
                           >
                             <q-time v-model="selectedTime.startTime">
                               <div class="row items-center justify-end">
@@ -198,6 +199,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           <q-popup-proxy
                             transition-show="scale"
                             transition-hide="scale"
+                            style="z-index: 10002"
                           >
                             <q-time v-model="selectedTime.endTime">
                               <div class="row items-center justify-end">


### PR DESCRIPTION
#3656 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved visibility of date and time pop-ups by adjusting their z-index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->