### PR TITLE
feat: add limit -1 for query

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -694,8 +694,8 @@ pub struct Limit {
     pub query_thread_num: usize,
     #[env_config(name = "ZO_QUERY_TIMEOUT", default = 600)]
     pub query_timeout: u64,
-    #[env_config(name = "ZO_QUERY_FULL_MODE_LIMIT", default = 1000)]
-    pub query_full_mode_limit: usize,
+    #[env_config(name = "ZO_QUERY_DEFAULT_LIMIT", default = 1000)]
+    pub query_default_limit: i64,
     #[env_config(name = "ZO_QUERY_PARTITION_BY_SECS", default = 10)] // seconds
     pub query_partition_by_secs: usize,
     #[env_config(name = "ZO_QUERY_PARTITION_MIN_SECS", default = 600)] // seconds
@@ -1358,8 +1358,8 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     if cfg.limit.query_partition_min_secs == 0 {
         cfg.limit.query_partition_min_secs = 600;
     }
-    if cfg.limit.query_full_mode_limit == 0 {
-        cfg.limit.query_full_mode_limit = 1000;
+    if cfg.limit.query_default_limit == 0 {
+        cfg.limit.query_default_limit = 1000;
     }
     Ok(())
 }

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -94,9 +94,9 @@ impl std::fmt::Display for RequestEncoding {
 pub struct Query {
     pub sql: String,
     #[serde(default)]
-    pub from: usize,
+    pub from: i64,
     #[serde(default = "default_size")]
-    pub size: usize,
+    pub size: i64,
     #[serde(default)]
     pub start_time: i64,
     #[serde(default)]
@@ -121,8 +121,8 @@ pub struct Query {
     pub skip_wal: bool,
 }
 
-fn default_size() -> usize {
-    10
+fn default_size() -> i64 {
+    crate::get_config().limit.query_default_limit
 }
 
 impl Default for Query {
@@ -189,8 +189,8 @@ pub struct Response {
     #[schema(value_type = Object)]
     pub aggs: HashMap<String, Vec<json::Value>>,
     pub total: usize,
-    pub from: usize,
-    pub size: usize,
+    pub from: i64,
+    pub size: i64,
     #[serde(default)]
     #[serde(skip_serializing)]
     pub file_count: usize,
@@ -230,7 +230,7 @@ pub struct ResponseNodeTook {
 }
 
 impl Response {
-    pub fn new(from: usize, size: usize) -> Self {
+    pub fn new(from: i64, size: i64) -> Self {
         Response {
             took: 0,
             took_detail: None,

--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -27,8 +27,8 @@ use sqlparser::{
 
 use crate::get_config;
 
-const MAX_LIMIT: usize = 100000;
-const MAX_OFFSET: usize = 100000;
+const MAX_LIMIT: i64 = 100000;
+const MAX_OFFSET: i64 = 100000;
 
 /// parsed sql
 #[derive(Clone, Debug, Serialize)]
@@ -39,8 +39,8 @@ pub struct Sql {
     pub order_by: Vec<(String, bool)>, // desc: true / false
     pub group_by: Vec<String>,         // field
     pub having: bool,
-    pub offset: usize,
-    pub limit: usize,
+    pub offset: i64,
+    pub limit: i64,
     pub time_range: Option<(i64, i64)>,
     pub quick_text: Vec<(String, String, SqlOperator)>, // use text line quick filter
     pub field_alias: Vec<(String, String)>,             // alias for select field
@@ -185,14 +185,14 @@ impl std::fmt::Display for SqlValue {
     }
 }
 
-impl<'a> From<Offset<'a>> for usize {
+impl<'a> From<Offset<'a>> for i64 {
     fn from(offset: Offset) -> Self {
         match offset.0 {
             SqlOffset {
                 value: SqlExpr::Value(Value::Number(v, _b)),
                 ..
             } => {
-                let mut v: usize = v.parse().unwrap_or(0);
+                let mut v: i64 = v.parse().unwrap_or(0);
                 if v > MAX_OFFSET {
                     v = MAX_OFFSET;
                 }
@@ -203,11 +203,11 @@ impl<'a> From<Offset<'a>> for usize {
     }
 }
 
-impl<'a> From<Limit<'a>> for usize {
+impl<'a> From<Limit<'a>> for i64 {
     fn from(l: Limit<'a>) -> Self {
         match l.0 {
             SqlExpr::Value(Value::Number(v, _b)) => {
-                let mut v: usize = v.parse().unwrap_or(0);
+                let mut v: i64 = v.parse().unwrap_or(0);
                 if v > MAX_LIMIT {
                     v = MAX_LIMIT;
                 }

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -447,7 +447,7 @@ pub async fn around(
 
     let around_size = query
         .get("size")
-        .map_or(10, |v| v.parse::<usize>().unwrap_or(10));
+        .map_or(10, |v| v.parse::<i64>().unwrap_or(10));
 
     let regions = query.get("regions").map_or(vec![], |regions| {
         regions
@@ -934,7 +934,7 @@ async fn values_v1(
 
     let size = query
         .get("size")
-        .map_or(10, |v| v.parse::<usize>().unwrap_or(10));
+        .map_or(10, |v| v.parse::<i64>().unwrap_or(10));
     let start_time = query
         .get("start_time")
         .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
@@ -1181,7 +1181,7 @@ async fn values_v2(
 
     let size = query
         .get("size")
-        .map_or(10, |v| v.parse::<usize>().unwrap_or(10));
+        .map_or(10, |v| v.parse::<i64>().unwrap_or(10));
     let start_time = query
         .get("start_time")
         .map_or(0, |v| v.parse::<i64>().unwrap_or(0));

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -200,10 +200,10 @@ pub async fn get_latest_traces(
     };
     let from = query
         .get("from")
-        .map_or(0, |v| v.parse::<usize>().unwrap_or(0));
+        .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
     let size = query
         .get("size")
-        .map_or(10, |v| v.parse::<usize>().unwrap_or(10));
+        .map_or(10, |v| v.parse::<i64>().unwrap_or(10));
     let mut start_time = query
         .get("start_time")
         .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
@@ -419,7 +419,7 @@ pub async fn get_latest_traces(
             }
         };
 
-        let resp_size = resp_search.hits.len();
+        let resp_size = resp_search.hits.len() as i64;
         for item in resp_search.hits {
             let trace_id = item.get("trace_id").unwrap().as_str().unwrap().to_string();
             let trace_start_time = item.get("start_time").unwrap().as_i64().unwrap();

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -502,7 +502,7 @@ async fn get_fast_mode_ctx(
     let mut new_files = Vec::new();
     let needs = sql.meta.limit + sql.meta.offset;
     for i in (0..files.len()).rev() {
-        loaded_records += files.get(i).unwrap().meta.records as usize;
+        loaded_records += files.get(i).unwrap().meta.records;
         new_files.push(files[i].clone());
         if loaded_records >= needs && (desc || new_files.len() > 1) {
             break;
@@ -550,8 +550,8 @@ fn replace_in_query(replace_pat: &str, where_query: &mut String, is_alias: bool)
 
 pub async fn merge(
     org_id: &str,
-    offset: usize,
-    limit: usize,
+    offset: i64,
+    limit: i64,
     sql: &str,
     batches: &[RecordBatch],
     select_fields: &[Arc<Field>],

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -337,6 +337,7 @@ impl Sql {
         // Hack offset limit and sort by for sql
         if meta.limit == 0 {
             meta.offset = req_query.from as i64;
+            // If `size` is negative, use the backend's default limit setting
             meta.limit = if req_query.size >= 0 {
                 req_query.size as i64
             } else {

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -336,13 +336,12 @@ impl Sql {
 
         // Hack offset limit and sort by for sql
         if meta.limit == 0 {
-            meta.offset = req_query.from as usize;
-            meta.limit = req_query.size as usize;
-            if meta.limit == 0 && sql_mode.eq(&SqlMode::Full) && !track_total_hits {
-                // sql mode context, allow limit 0, used to no hits, but return aggs
-                // sql mode full, disallow without limit, default limit 1000
-                meta.limit = cfg.limit.query_full_mode_limit;
-            }
+            meta.offset = req_query.from as i64;
+            meta.limit = if req_query.size >= 0 {
+                req_query.size as i64
+            } else {
+                cfg.limit.query_default_limit
+            };
             origin_sql = if meta.order_by.is_empty()
                 && (!sql_mode.eq(&SqlMode::Full)
                     || (meta.group_by.is_empty()

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -308,7 +308,7 @@ export const usePanelDataLoader = (
                     sql_mode: "full",
                     start_time: startISOTimestamp,
                     end_time: endISOTimestamp,
-                    size: 0,
+                    size: -1,
                   },
                 },
                 page_type: pageType,

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1804,7 +1804,7 @@ const useLogs = () => {
         searchObj.data.histogram.errorCode = 0;
         searchObj.data.histogram.errorDetail = "";
         searchObj.loadingHistogram = true;
-        queryReq.query.size = 0;
+        queryReq.query.size = -1;
         const parsedSQL: any = fnParsedSQL();
 
         // let hasAggregationFlag = false;

--- a/web/src/test/unit/mockData/alerts.ts
+++ b/web/src/test/unit/mockData/alerts.ts
@@ -8,7 +8,7 @@ export default {
           query: {
             sql: "select * from default",
             from: 0,
-            size: 0,
+            size: -1,
             start_time: 0,
             end_time: 0,
             sql_mode: "full",


### PR DESCRIPTION
The query `size` works like this, it should more clear now:
1. size > 0, it will return hits equal to `size`
2. size = 0, it will return empty hits, this used to other purposes, like: get total, get aggs.
3. size = -1, it will use a backend default limit to return hits, setting by  `ZO_QUERY_DEFAULT_LIMIT=1000`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of query parameters by changing types from `usize` to `i64` to support larger values and prevent potential overflow issues.

- **Improvements**
  - Enhanced the logic for setting query limits to handle negative values more gracefully, ensuring better default behavior.

- **Refactor**
  - Updated various internal structures and function signatures to use `i64` instead of `usize` for consistency and improved range handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->