### PR TITLE
fix: datetime-picker-z-index-issue

### DIFF
--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -119,6 +119,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       filled
                       emit-value
                       @update:modelValue="onCustomPeriodSelect"
+                      popup-content-style="z-index: 10002"
                     >
                       <template v-slot:selected-item>
                         <div>{{ getPeriodLabel }}</div>
@@ -243,6 +244,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           @update:modelValue="onTimezoneChange"
           :display-value="`Timezone: ${timezone}`"
           class="timezone-select"
+          popup-content-style="z-index: 10002"
         >
         </q-select>
         <div v-if="!autoApply" class="flex justify-end q-py-sm q-px-md">


### PR DESCRIPTION
![image](https://github.com/openobserve/openobserve/assets/141122205/45c15c7a-d31a-4c1c-8364-51b88f0f4c06)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced popup content styling for date and time selectors to ensure proper display order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->