### PR TITLE
fix: use severity number for otlp grpc ingestion when severity text is missing

### DIFF
--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -395,7 +395,11 @@ pub async fn handle_grpc_request(
                 }
 
                 rec[cfg.common.column_timestamp.clone()] = ts.into();
-                rec["severity"] = log_record.severity_text.to_owned().into();
+                rec["severity"] = if !log_record.severity_text.is_empty() {
+                    log_record.severity_text.to_owned().into()
+                } else {
+                    log_record.severity_number.into()
+                };
                 // rec["name"] = log_record.name.to_owned().into();
                 rec["body"] = get_val(&log_record.body.as_ref());
                 for item in &log_record.attributes {


### PR DESCRIPTION
Fixes #3649 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logic for setting the "severity" field in log records to ensure accurate assignment based on the content of the severity text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->