### PR TITLE
feat: improve search group resource management

### DIFF
--- a/src/infra/src/storage/local.rs
+++ b/src/infra/src/storage/local.rs
@@ -214,7 +214,8 @@ impl ObjectStore for Local {
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>> {
-        let prefix = format_key(prefix.unwrap().as_ref(), self.with_prefix);
+        let key = prefix.map(|p| p.as_ref());
+        let prefix = format_key(key.unwrap_or(""), self.with_prefix);
         self.client.list(Some(&prefix.into()))
     }
 

--- a/src/infra/src/storage/remote.rs
+++ b/src/infra/src/storage/remote.rs
@@ -204,8 +204,9 @@ impl ObjectStore for Remote {
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>> {
-        self.client
-            .list(Some(&format_key(prefix.unwrap().as_ref(), true).into()))
+        let key = prefix.map(|p| p.as_ref());
+        let prefix = format_key(key.unwrap_or(""), true);
+        self.client.list(Some(&prefix.into()))
     }
 
     async fn list_with_delimiter(&self, _prefix: Option<&Path>) -> Result<ListResult> {

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -41,11 +41,7 @@ use config::{
 };
 use datafusion::{datasource::MemTable, prelude::*};
 use hashbrown::HashSet;
-use infra::{
-    cache::{self, tmpfs},
-    schema::SchemaCache,
-    storage,
-};
+use infra::{cache::tmpfs, schema::SchemaCache, storage};
 use ingester::WAL_PARQUET_METADATA;
 use once_cell::sync::Lazy;
 use tokio::{
@@ -483,6 +479,7 @@ async fn merge_files(
 
     let cfg = get_config();
     let mut new_file_size: i64 = 0;
+    let mut new_compressed_file_size = 0;
     let mut new_file_list = Vec::new();
     let mut deleted_files = Vec::new();
     let mut min_ts = i64::MAX;
@@ -491,20 +488,22 @@ async fn merge_files(
 
     for file in files_with_size.iter() {
         if new_file_size > 0
-            && ((new_file_size + file.meta.original_size > cfg.compact.max_file_size as i64)
+            && (new_file_size + file.meta.original_size > cfg.compact.max_file_size as i64
+                || new_compressed_file_size + file.meta.compressed_size
+                    > cfg.compact.max_file_size as i64
                 || (cfg.limit.file_move_fields_limit > 0
                     && group_schema_field_num > cfg.limit.file_move_fields_limit))
         {
             break;
         }
         new_file_size += file.meta.original_size;
-
+        new_compressed_file_size += file.meta.compressed_size;
         new_file_list.push(file.clone());
     }
     let mut retain_file_list = new_file_list.clone();
 
     // write parquet files into tmpfs
-    let tmp_dir = cache::tmpfs::Directory::default();
+    let tmp_dir = tmpfs::Directory::default();
     for file in retain_file_list.iter_mut() {
         log::info!("[INGESTER:JOB:{thread_id}] merge small file: {}", &file.key);
         let data = match get_file_contents(&wal_dir.join(&file.key)).await {

--- a/src/service/promql/search/grpc/wal.rs
+++ b/src/service/promql/search/grpc/wal.rs
@@ -133,7 +133,7 @@ pub(crate) async fn create_context(
         })?;
     for (_, (mut arrow_schema, record_batches)) in record_batches_meta {
         if !record_batches.is_empty() {
-            let ctx = prepare_datafusion_context(None, &SearchType::Normal, false)?;
+            let ctx = prepare_datafusion_context(None, &SearchType::Normal, false).await?;
             // calculate schema diff
             let mut diff_fields = HashMap::new();
             let group_fields = arrow_schema.fields();


### PR DESCRIPTION
## Before
We use static memory limit for search group: 
```
mem = TOTAL_DATAFUSION_MEMORY_POOL 
    * (WORK_GROUP_MAX_SIZE(%) / WORK_GROUP_MAX_CONCURRENCY) 
    / 100;
```

## After
We use dynamic memory limit for search group, if always use 50% of the available resource.
```
group_limit = max(
    WORK_GROUP_MAX_SIZE(%) / WORK_GROUP_MAX_CONCURRENCY, 
    WORK_GROUP_MAX_SIZE(%) >> min(WORK_GROUP_MAX_CONCURRENCY, group_job_count)
);
mem = TOTAL_DATAFUSION_MEMORY_POOL * group_limit / 100;
```