### PR TITLE
fix: view panel parser issue due to lazy load

### DIFF
--- a/web/src/components/dashboards/viewPanel/ViewPanel.vue
+++ b/web/src/components/dashboards/viewPanel/ViewPanel.vue
@@ -215,7 +215,11 @@ export default defineComponent({
 
     watch(
       () => histogramInterval.value,
-      () => {
+      async () => {
+        // import sql parser if not imported
+        if (!parser) {
+          await importSqlParser();
+        }
         // replace the histogram interval in the query by finding histogram aggregation
         dashboardPanelData?.data?.queries?.forEach((query: any) => {
           const ast: any = parser.astify(query?.query);


### PR DESCRIPTION
![image](https://github.com/openobserve/openobserve/assets/141122205/4b1b4f4b-da64-4757-b374-9c3ae9c095a6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved query processing by adding asynchronous SQL parser import in the histogram interval watch block. This enhances performance and ensures the parser is only loaded when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->