### PR TITLE
fix: include trace_id in search usage reporting

### DIFF
--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -76,6 +76,8 @@ pub struct UsageData {
     pub num_records: i64,
     pub stream_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cached_ratio: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compressed_size: Option<f64>,
@@ -225,6 +227,8 @@ pub struct RequestStats {
     pub user_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub search_type: Option<SearchEventType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
 }
 impl Default for RequestStats {
     fn default() -> Self {
@@ -239,6 +243,7 @@ impl Default for RequestStats {
             max_ts: None,
             user_email: None,
             search_type: None,
+            trace_id: None,
         }
     }
 }
@@ -256,6 +261,7 @@ impl From<FileMeta> for RequestStats {
             max_ts: Some(meta.max_ts),
             user_email: None,
             search_type: None,
+            trace_id: None,
         }
     }
 }

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -279,7 +279,7 @@ pub async fn search(
                     stream_type.to_string().as_str(),
                 ])
                 .inc();
-            res.set_trace_id(trace_id);
+            res.set_trace_id(trace_id.clone());
             res.set_local_took(start.elapsed().as_millis() as usize, took_wait);
 
             let req_stats = RequestStats {
@@ -292,6 +292,7 @@ pub async fn search(
                 max_ts: Some(req.query.end_time),
                 cached_ratio: Some(res.cached_ratio),
                 search_type,
+                trace_id: Some(trace_id),
                 ..Default::default()
             };
             let num_fn = req.query.query_fn.is_some() as u16;
@@ -710,6 +711,7 @@ pub async fn around(
         min_ts: Some(around_start_time),
         max_ts: Some(around_end_time),
         cached_ratio: Some(resp.cached_ratio),
+        trace_id: Some(trace_id),
         ..Default::default()
     };
     let num_fn = req.query.query_fn.is_some() as u16;
@@ -1143,6 +1145,7 @@ async fn values_v1(
         max_ts: Some(end_time),
         cached_ratio: Some(resp.cached_ratio),
         search_type: Some(SearchEventType::Values),
+        trace_id: Some(trace_id),
         ..Default::default()
     };
     let num_fn = req.query.query_fn.is_some() as u16;
@@ -1369,6 +1372,7 @@ async fn values_v2(
         max_ts: Some(end_time),
         cached_ratio: Some(resp.cached_ratio),
         search_type: Some(SearchEventType::Values),
+        trace_id: Some(trace_id),
         ..Default::default()
     };
     let num_fn = req.query.query_fn.is_some() as u16;

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -111,7 +111,7 @@ async fn search_in_cluster(
     let trace_id = ider::uuid();
     let job_id = trace_id[0..6].to_string(); // take the last 6 characters as job id
     let job = cluster_rpc::Job {
-        trace_id,
+        trace_id: trace_id.clone(),
         job: job_id,
         stage: 0,
         partition: 0,
@@ -287,6 +287,7 @@ async fn search_in_cluster(
         user_email: Some(user_email.to_string()),
         min_ts: Some(start),
         max_ts: Some(end),
+        trace_id: Some(trace_id),
         ..Default::default()
     };
 

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -178,6 +178,7 @@ pub async fn search(
                     max_ts: Some(req_query.end_time),
                     cached_ratio: Some(res.cached_ratio),
                     search_type,
+                    trace_id: Some(trace_id),
                     ..Default::default()
                 };
                 report_request_usage_stats(

--- a/src/service/usage/mod.rs
+++ b/src/service/usage/mod.rs
@@ -99,6 +99,7 @@ pub async fn report_request_usage_stats(
             cached_ratio: None,
             compressed_size: None,
             search_type: stats.search_type,
+            trace_id: None,
         });
     };
 
@@ -129,6 +130,7 @@ pub async fn report_request_usage_stats(
         cached_ratio: stats.cached_ratio,
         compressed_size: None,
         search_type: stats.search_type,
+        trace_id: stats.trace_id,
     });
     if !usage.is_empty() {
         publish_usage(usage).await;


### PR DESCRIPTION
Fixes #3695 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `trace_id` support across various functions to enhance tracking and debugging capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->