### PR TITLE
feat: introduce UDFs applicable on array fields

### DIFF
--- a/src/service/search/datafusion/arr_descending_udf.rs
+++ b/src/service/search/datafusion/arr_descending_udf.rs
@@ -1,0 +1,205 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{cmp::Ordering, sync::Arc};
+
+use config::utils::json;
+use datafusion::{
+    arrow::{
+        array::{ArrayRef, StringArray},
+        datatypes::DataType,
+    },
+    common::cast::as_string_array,
+    error::DataFusionError,
+    logical_expr::{ScalarUDF, Volatility},
+    prelude::create_udf,
+    sql::sqlparser::parser::ParserError,
+};
+use datafusion_expr::ColumnarValue;
+use once_cell::sync::Lazy;
+
+/// The name of the date_format UDF given to DataFusion.
+pub const ARR_DESCENDING_UDF_NAME: &str = "arr_descending";
+
+/// Implementation of date_format
+pub(crate) static ARR_DESCENDING_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
+    create_udf(
+        ARR_DESCENDING_UDF_NAME,
+        // expects three string
+        vec![DataType::Utf8],
+        // returns string
+        Arc::new(DataType::Utf8),
+        Volatility::Immutable,
+        Arc::new(arr_descending_impl),
+    )
+});
+
+/// date_format function for datafusion
+pub fn arr_descending_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+    log::debug!("Inside arr_descending");
+    if args.len() != 1 {
+        return Err(DataFusionError::SQL(
+            ParserError::ParserError("UDF params should be: arr_descending(field1)".to_string()),
+            None,
+        ));
+    }
+    let args = ColumnarValue::values_to_arrays(args)?;
+    log::debug!("Got the args: {:#?}", args);
+
+    // 1. cast both arguments to Union. These casts MUST be aligned with the signature or this
+    //    function panics!
+    let arr_field = as_string_array(&args[0]).expect("cast failed");
+
+    // 2. perform the computation
+    let array = arr_field
+        .iter()
+        .map(|arr_field| {
+            let mut desc_arrs = vec![];
+
+            if let Some(arr_field) = arr_field {
+                let arr_field: json::Value =
+                    json::from_str(arr_field).expect("Failed to deserialize arrzip field1");
+                // This field is assumed to be a multivalue field
+                if let json::Value::Array(mut field1) = arr_field {
+                    field1.sort_by(|a, b| {
+                        // Assuming the array having elements of same type
+                        if a.is_f64() {
+                            b.as_f64().unwrap().total_cmp(a.as_f64().as_ref().unwrap())
+                        } else if a.is_i64() {
+                            b.as_i64().unwrap().cmp(a.as_i64().as_ref().unwrap())
+                        } else if a.is_u64() {
+                            b.as_u64().unwrap().cmp(a.as_u64().as_ref().unwrap())
+                        } else if a.is_string() {
+                            b.as_str().unwrap().cmp(a.as_str().unwrap())
+                        } else if a.is_boolean() {
+                            b.as_bool().unwrap().cmp(a.as_bool().as_ref().unwrap())
+                        } else {
+                            Ordering::Greater
+                        }
+                    });
+                    desc_arrs.append(&mut field1);
+                }
+                let desc_arrs =
+                    json::to_string(&desc_arrs).expect("Failed to stringify descending arrs");
+                Some(desc_arrs)
+            } else {
+                None
+            }
+        })
+        .collect::<StringArray>();
+
+    // `Ok` because no error occurred during the calculation
+    // `Arc` because arrays are immutable, thread-safe, trait objects.
+    Ok(ColumnarValue::from(Arc::new(array) as ArrayRef))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::{
+            datatypes::{Field, Schema},
+            record_batch::RecordBatch,
+        },
+        assert_batches_eq,
+        datasource::MemTable,
+        prelude::SessionContext,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_arr_descending_udf() {
+        let sqls = [
+            (
+                "select arr_descending(bools) as ret from t",
+                vec![
+                    "+-------------------+",
+                    "| ret               |",
+                    "+-------------------+",
+                    "| [true,true,false] |",
+                    "+-------------------+",
+                ],
+            ),
+            (
+                "select arr_descending(names) as ret from t",
+                vec![
+                    "+-------------------------+",
+                    "| ret                     |",
+                    "+-------------------------+",
+                    "| [\"hi2\",\"hello2\",\"bye2\"] |",
+                    "+-------------------------+",
+                ],
+            ),
+            (
+                "select arr_descending(nums) as ret from t",
+                vec![
+                    "+----------------+",
+                    "| ret            |",
+                    "+----------------+",
+                    "| [345,45,23,12] |",
+                    "+----------------+",
+                ],
+            ),
+            (
+                "select arr_descending(floats) as ret from t",
+                vec![
+                    "+--------------------+",
+                    "| ret                |",
+                    "+--------------------+",
+                    "| [34.5,4.5,2.6,1.9] |",
+                    "+--------------------+",
+                ],
+            ),
+        ];
+
+        // define a schema.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("log", DataType::Utf8, false),
+            Field::new("bools", DataType::Utf8, false),
+            Field::new("names", DataType::Utf8, false),
+            Field::new("nums", DataType::Utf8, false),
+            Field::new("floats", DataType::Utf8, false),
+        ]));
+
+        // define data.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a"])),
+                Arc::new(StringArray::from(vec!["[true,false,true]"])),
+                Arc::new(StringArray::from(vec!["[\"hello2\",\"hi2\",\"bye2\"]"])),
+                Arc::new(StringArray::from(vec!["[12, 345, 23, 45]"])),
+                Arc::new(StringArray::from(vec!["[1.9, 34.5, 2.6, 4.5]"])),
+            ],
+        )
+        .unwrap();
+
+        // declare a new context. In spark API, this corresponds to a new spark
+        // SQLsession
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_DESCENDING_UDF.clone());
+
+        // declare a table in memory. In spark API, this corresponds to
+        // createDataFrame(...).
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+}

--- a/src/service/search/datafusion/arr_descending_udf.rs
+++ b/src/service/search/datafusion/arr_descending_udf.rs
@@ -30,10 +30,10 @@ use datafusion::{
 use datafusion_expr::ColumnarValue;
 use once_cell::sync::Lazy;
 
-/// The name of the date_format UDF given to DataFusion.
+/// The name of the arr_descending UDF given to DataFusion.
 pub const ARR_DESCENDING_UDF_NAME: &str = "arr_descending";
 
-/// Implementation of date_format
+/// Implementation of arr_descending
 pub(crate) static ARR_DESCENDING_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
     create_udf(
         ARR_DESCENDING_UDF_NAME,
@@ -46,7 +46,7 @@ pub(crate) static ARR_DESCENDING_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
     )
 });
 
-/// date_format function for datafusion
+/// arr_descending function for datafusion
 pub fn arr_descending_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
     log::debug!("Inside arr_descending");
     if args.len() != 1 {
@@ -58,8 +58,8 @@ pub fn arr_descending_impl(args: &[ColumnarValue]) -> datafusion::error::Result<
     let args = ColumnarValue::values_to_arrays(args)?;
     log::debug!("Got the args: {:#?}", args);
 
-    // 1. cast both arguments to Union. These casts MUST be aligned with the signature or this
-    //    function panics!
+    // 1. cast the argument to Union. This cast MUST be aligned with the signature or this function
+    //    panics!
     let arr_field = as_string_array(&args[0]).expect("cast failed");
 
     // 2. perform the computation
@@ -92,7 +92,7 @@ pub fn arr_descending_impl(args: &[ColumnarValue]) -> datafusion::error::Result<
                     desc_arrs.append(&mut field1);
                 }
                 let desc_arrs =
-                    json::to_string(&desc_arrs).expect("Failed to stringify descending arrs");
+                    json::to_string(&desc_arrs).expect("Failed to stringify descending array");
                 Some(desc_arrs)
             } else {
                 None

--- a/src/service/search/datafusion/arrcount_udf.rs
+++ b/src/service/search/datafusion/arrcount_udf.rs
@@ -28,10 +28,10 @@ use datafusion::{
 use datafusion_expr::ColumnarValue;
 use once_cell::sync::Lazy;
 
-/// The name of the date_format UDF given to DataFusion.
+/// The name of the arrcount UDF given to DataFusion.
 pub const ARR_COUNT_UDF_NAME: &str = "arrcount";
 
-/// Implementation of date_format
+/// Implementation of arrcount
 pub(crate) static ARR_COUNT_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
     create_udf(
         ARR_COUNT_UDF_NAME,
@@ -44,7 +44,7 @@ pub(crate) static ARR_COUNT_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
     )
 });
 
-/// date_format function for datafusion
+/// arrcount function for datafusion
 pub fn arr_count_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
     log::debug!("Inside arrcount");
     if args.len() != 1 {
@@ -56,8 +56,8 @@ pub fn arr_count_impl(args: &[ColumnarValue]) -> datafusion::error::Result<Colum
     let args = ColumnarValue::values_to_arrays(args)?;
     log::debug!("Got the args: {:#?}", args);
 
-    // 1. cast both arguments to Union. These casts MUST be aligned with the signature or this
-    //    function panics!
+    // 1. cast the argument to Union. This cast MUST be aligned with the signature or this function
+    //    panics!
     let arr_field = as_string_array(&args[0]).expect("cast failed");
 
     // 2. perform the computation
@@ -66,7 +66,7 @@ pub fn arr_count_impl(args: &[ColumnarValue]) -> datafusion::error::Result<Colum
         .map(|arr_field| {
             match arr_field {
                 // in arrow, any value can be null.
-                // Here we decide to make our UDF to return null when either argument is null.
+                // Here we decide to make our UDF to return 0 when the argument is null.
                 Some(arr_field) => {
                     let arr_field: json::Value =
                         json::from_str(arr_field).expect("Failed to deserialize arrzip field1");

--- a/src/service/search/datafusion/arrcount_udf.rs
+++ b/src/service/search/datafusion/arrcount_udf.rs
@@ -1,0 +1,170 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use arrow::array::UInt64Array;
+use config::utils::json;
+use datafusion::{
+    arrow::{array::ArrayRef, datatypes::DataType},
+    common::cast::as_string_array,
+    error::DataFusionError,
+    logical_expr::{ScalarUDF, Volatility},
+    prelude::create_udf,
+    sql::sqlparser::parser::ParserError,
+};
+use datafusion_expr::ColumnarValue;
+use once_cell::sync::Lazy;
+
+/// The name of the date_format UDF given to DataFusion.
+pub const ARR_COUNT_UDF_NAME: &str = "arrcount";
+
+/// Implementation of date_format
+pub(crate) static ARR_COUNT_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
+    create_udf(
+        ARR_COUNT_UDF_NAME,
+        // expects two string - the field and the delimiter
+        vec![DataType::Utf8],
+        // returns string
+        Arc::new(DataType::UInt64),
+        Volatility::Immutable,
+        Arc::new(arr_count_impl),
+    )
+});
+
+/// date_format function for datafusion
+pub fn arr_count_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+    log::debug!("Inside arrcount");
+    if args.len() != 1 {
+        return Err(DataFusionError::SQL(
+            ParserError::ParserError("UDF params should be: arrcount(arr_field)".to_string()),
+            None,
+        ));
+    }
+    let args = ColumnarValue::values_to_arrays(args)?;
+    log::debug!("Got the args: {:#?}", args);
+
+    // 1. cast both arguments to Union. These casts MUST be aligned with the signature or this
+    //    function panics!
+    let arr_field = as_string_array(&args[0]).expect("cast failed");
+
+    // 2. perform the computation
+    let array = arr_field
+        .iter()
+        .map(|arr_field| {
+            match arr_field {
+                // in arrow, any value can be null.
+                // Here we decide to make our UDF to return null when either argument is null.
+                Some(arr_field) => {
+                    let arr_field: json::Value =
+                        json::from_str(arr_field).expect("Failed to deserialize arrzip field1");
+                    match arr_field {
+                        json::Value::Array(field) => Some(field.len() as u64),
+                        _ => Some(0),
+                    }
+                }
+                _ => Some(0),
+            }
+        })
+        .collect::<UInt64Array>();
+
+    // `Ok` because no error occurred during the calculation
+    // `Arc` because arrays are immutable, thread-safe, trait objects.
+    Ok(ColumnarValue::from(Arc::new(array) as ArrayRef))
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::StringArray;
+    use datafusion::{
+        arrow::{
+            datatypes::{Field, Schema},
+            record_batch::RecordBatch,
+        },
+        assert_batches_eq,
+        datasource::MemTable,
+        prelude::SessionContext,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_arr_count_udf() {
+        let sqls = [
+            (
+                "select arrcount(bools) as ret from t",
+                vec!["+-----+", "| ret |", "+-----+", "| 3   |", "+-----+"],
+            ),
+            (
+                "select arrcount(names) as ret from t",
+                vec!["+-----+", "| ret |", "+-----+", "| 3   |", "+-----+"],
+            ),
+            (
+                "select arrcount(nums) as ret from t",
+                vec!["+-----+", "| ret |", "+-----+", "| 4   |", "+-----+"],
+            ),
+            (
+                "select arrcount(floats) as ret from t",
+                vec!["+-----+", "| ret |", "+-----+", "| 4   |", "+-----+"],
+            ),
+            (
+                "select arrcount(mixed) as ret from t",
+                vec!["+-----+", "| ret |", "+-----+", "| 5   |", "+-----+"],
+            ),
+        ];
+
+        // define a schema.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("log", DataType::Utf8, false),
+            Field::new("bools", DataType::Utf8, false),
+            Field::new("names", DataType::Utf8, false),
+            Field::new("nums", DataType::Utf8, false),
+            Field::new("floats", DataType::Utf8, false),
+            Field::new("mixed", DataType::Utf8, false),
+        ]));
+
+        // define data.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a"])),
+                Arc::new(StringArray::from(vec!["[true,false,true]"])),
+                Arc::new(StringArray::from(vec!["[\"hello2\",\"hi2\",\"bye2\"]"])),
+                Arc::new(StringArray::from(vec!["[12, 345, 23, 45]"])),
+                Arc::new(StringArray::from(vec!["[1.9, 34.5, 2.6, 4.5]"])),
+                Arc::new(StringArray::from(vec![
+                    "[\"hello2\",\"hi2\",123, 23.90, false]",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        // declare a new context. In spark API, this corresponds to a new spark
+        // SQLsession
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_COUNT_UDF.clone());
+
+        // declare a table in memory. In spark API, this corresponds to
+        // createDataFrame(...).
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+}

--- a/src/service/search/datafusion/arrindex_udf.rs
+++ b/src/service/search/datafusion/arrindex_udf.rs
@@ -1,0 +1,242 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{iter::zip, sync::Arc};
+
+use arrow::datatypes::ArrowNativeType;
+use config::utils::json;
+use datafusion::{
+    arrow::{
+        array::{ArrayRef, StringArray},
+        datatypes::DataType,
+    },
+    common::cast::{as_int64_array, as_string_array},
+    error::DataFusionError,
+    logical_expr::{ScalarUDF, Volatility},
+    prelude::create_udf,
+    sql::sqlparser::parser::ParserError,
+};
+use datafusion_expr::ColumnarValue;
+use once_cell::sync::Lazy;
+
+/// The name of the arrindex UDF given to DataFusion.
+pub const ARR_INDEX_UDF_NAME: &str = "arrindex";
+
+/// Implementation of arrindex
+pub(crate) static ARR_INDEX_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
+    create_udf(
+        ARR_INDEX_UDF_NAME,
+        // expects a string (the array field) and two integers - start index and end index
+        vec![DataType::Utf8, DataType::Int64, DataType::Int64],
+        // returns string
+        Arc::new(DataType::Utf8),
+        Volatility::Immutable,
+        Arc::new(arr_index_impl),
+    )
+});
+
+/// arrindex function for datafusion
+pub fn arr_index_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+    log::debug!("Inside arrindex");
+    if args.len() < 2 {
+        return Err(DataFusionError::SQL(
+            ParserError::ParserError(
+                "UDF params should be: arrindex(field1, start, end)".to_string(),
+            ),
+            None,
+        ));
+    }
+    let args = ColumnarValue::values_to_arrays(args)?;
+    log::debug!("Got the args: {:#?}", args);
+
+    // 1. cast both arguments to Union. These casts MUST be aligned with the signature or this
+    //    function panics!
+    let arr_field1 = as_string_array(&args[0]).expect("cast failed");
+    let start = as_int64_array(&args[1]).expect("cast failed");
+    let end = if args.len() == 3 {
+        let end = as_int64_array(&args[2]).expect("cast failed");
+        if !end.is_empty() {
+            Some(end.value(0))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // 2. perform the computation
+    let array = zip(arr_field1.iter(), start.iter())
+        .map(|(arr_field1, start)| {
+            let mut index_arrs = vec![];
+
+            match (arr_field1, start) {
+                // in arrow, any value can be null.
+                // Here we decide to make our UDF to return null when either argument is null.
+                (Some(arr_field1), Some(start)) => {
+                    let start = start as usize;
+                    let arr_field1: json::Value =
+                        json::from_str(arr_field1).expect("Failed to deserialize arrzip field1");
+                    // This field is assumed to be an array field
+                    if let json::Value::Array(field1) = arr_field1 {
+                        if field1.len() > start {
+                            if let Some(end) = end {
+                                // end is min(end, field1.len)
+                                let end = if end.as_usize() < field1.len() {
+                                    end as usize
+                                } else {
+                                    field1.len() - 1
+                                };
+                                if start <= end && end < field1.len() {
+                                    for item in field1.into_iter().take(end + 1).skip(start) {
+                                        index_arrs.push(item);
+                                    }
+                                }
+                            } else {
+                                index_arrs.push(field1[start].clone());
+                            }
+                        }
+                    }
+                    let index_arrs =
+                        json::to_string(&index_arrs).expect("Failed to stringify arrs");
+                    Some(index_arrs)
+                }
+                _ => None,
+            }
+        })
+        .collect::<StringArray>();
+
+    // `Ok` because no error occurred during the calculation
+    // `Arc` because arrays are immutable, thread-safe, trait objects.
+    Ok(ColumnarValue::from(Arc::new(array) as ArrayRef))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::{
+            datatypes::{Field, Schema},
+            record_batch::RecordBatch,
+        },
+        assert_batches_eq,
+        datasource::MemTable,
+        prelude::SessionContext,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_arr_index_udf() {
+        let sqls = [
+            (
+                // Should include values at index 0 to index 1 (inclusive)
+                "select arrindex(bools, 0, 1) as ret from t",
+                vec![
+                    "+--------------+",
+                    "| ret          |",
+                    "+--------------+",
+                    "| [true,false] |",
+                    "+--------------+",
+                ],
+            ),
+            (
+                // Should include all the elements
+                "select arrindex(names, 0, 6) as ret from t",
+                vec![
+                    "+-------------------------+",
+                    "| ret                     |",
+                    "+-------------------------+",
+                    "| [\"hello2\",\"hi2\",\"bye2\"] |",
+                    "+-------------------------+",
+                ],
+            ),
+            (
+                "select arrindex(nums, 1, 1) as ret from t",
+                vec![
+                    "+-------+",
+                    "| ret   |",
+                    "+-------+",
+                    "| [345] |",
+                    "+-------+",
+                ],
+            ),
+            (
+                "select arrindex(floats, 1, 3) as ret from t",
+                vec![
+                    "+----------------+",
+                    "| ret            |",
+                    "+----------------+",
+                    "| [34.5,2.6,4.5] |",
+                    "+----------------+",
+                ],
+            ),
+            (
+                "select arrindex(floats, 7, 9) as ret from t",
+                vec!["+-----+", "| ret |", "+-----+", "| []  |", "+-----+"],
+            ),
+            (
+                "select arrindex(mixed, 2, 4) as ret from t",
+                vec![
+                    "+------------------+",
+                    "| ret              |",
+                    "+------------------+",
+                    "| [123,23.9,false] |",
+                    "+------------------+",
+                ],
+            ),
+        ];
+
+        // define a schema.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("log", DataType::Utf8, false),
+            Field::new("bools", DataType::Utf8, false),
+            Field::new("names", DataType::Utf8, false),
+            Field::new("nums", DataType::Utf8, false),
+            Field::new("floats", DataType::Utf8, false),
+            Field::new("mixed", DataType::Utf8, false),
+        ]));
+
+        // define data.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a"])),
+                Arc::new(StringArray::from(vec!["[true,false,true]"])),
+                Arc::new(StringArray::from(vec!["[\"hello2\",\"hi2\",\"bye2\"]"])),
+                Arc::new(StringArray::from(vec!["[12, 345, 23, 45]"])),
+                Arc::new(StringArray::from(vec!["[1.9, 34.5, 2.6, 4.5]"])),
+                Arc::new(StringArray::from(vec![
+                    "[\"hello2\",\"hi2\",123, 23.9, false]",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        // declare a new context. In spark API, this corresponds to a new spark
+        // SQLsession
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_INDEX_UDF.clone());
+
+        // declare a table in memory. In spark API, this corresponds to
+        // createDataFrame(...).
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+}

--- a/src/service/search/datafusion/arrjoin_udf.rs
+++ b/src/service/search/datafusion/arrjoin_udf.rs
@@ -28,6 +28,8 @@ use datafusion::{
 use datafusion_expr::ColumnarValue;
 use once_cell::sync::Lazy;
 
+use crate::service::search::datafusion::stringify_json_value;
+
 /// The name of the arrjoin UDF given to DataFusion.
 pub const ARR_JOIN_UDF_NAME: &str = "arrjoin";
 
@@ -72,26 +74,9 @@ pub fn arr_join_impl(args: &[ColumnarValue]) -> datafusion::error::Result<Column
                         json::from_str(arr_field1).expect("Failed to deserialize arrzip field1");
                     let mut join_arrs = vec![];
                     if let json::Value::Array(field1) = arr_field1 {
-                        field1.iter().for_each(|field1| {
-                            let field1 = if field1.is_boolean() {
-                                let field1 = field1.as_bool().unwrap();
-                                field1.to_string()
-                            } else if field1.is_f64() {
-                                let field1 = field1.as_f64().unwrap();
-                                field1.to_string()
-                            } else if field1.is_i64() {
-                                let field1 = field1.as_i64().unwrap();
-                                field1.to_string()
-                            } else if field1.is_u64() {
-                                let field1 = field1.as_u64().unwrap();
-                                field1.to_string()
-                            } else if field1.is_string() {
-                                let field1 = field1.as_str().unwrap();
-                                field1.to_string()
-                            } else {
-                                "".to_string()
-                            };
-                            join_arrs.push(field1);
+                        field1.iter().for_each(|field| {
+                            let field = stringify_json_value(field);
+                            join_arrs.push(field);
                         });
                     }
                     let join_arrs = join_arrs.join(delim);

--- a/src/service/search/datafusion/arrjoin_udf.rs
+++ b/src/service/search/datafusion/arrjoin_udf.rs
@@ -1,0 +1,223 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{iter::zip, sync::Arc};
+
+use arrow::array::StringArray;
+use config::utils::json;
+use datafusion::{
+    arrow::{array::ArrayRef, datatypes::DataType},
+    common::cast::as_string_array,
+    error::DataFusionError,
+    logical_expr::{ScalarUDF, Volatility},
+    prelude::create_udf,
+    sql::sqlparser::parser::ParserError,
+};
+use datafusion_expr::ColumnarValue;
+use once_cell::sync::Lazy;
+
+/// The name of the arrjoin UDF given to DataFusion.
+pub const ARR_JOIN_UDF_NAME: &str = "arrjoin";
+
+/// Implementation of arrjoin
+pub(crate) static ARR_JOIN_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
+    create_udf(
+        ARR_JOIN_UDF_NAME,
+        // expects two string - the field and the delimiter
+        vec![DataType::Utf8, DataType::Utf8],
+        // returns string
+        Arc::new(DataType::Utf8),
+        Volatility::Immutable,
+        Arc::new(arr_join_impl),
+    )
+});
+
+/// arrjoin function for datafusion
+pub fn arr_join_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+    log::debug!("Inside arrjoin");
+    if args.len() != 2 {
+        return Err(DataFusionError::SQL(
+            ParserError::ParserError("UDF params should be: arrjoin(field1, delim)".to_string()),
+            None,
+        ));
+    }
+    let args = ColumnarValue::values_to_arrays(args)?;
+    log::debug!("Got the args: {:#?}", args);
+
+    // 1. cast both arguments to Union. These casts MUST be aligned with the signature or this
+    //    function panics!
+    let arr_field1 = as_string_array(&args[0]).expect("cast failed");
+    let delim = as_string_array(&args[1]).expect("cast failed");
+
+    // 2. perform the computation
+    let array = zip(arr_field1.iter(), delim.iter())
+        .map(|(arr_field1, val)| {
+            match (arr_field1, val) {
+                // in arrow, any value can be null.
+                // Here we decide to make our UDF to return null when either argument is null.
+                (Some(arr_field1), Some(delim)) => {
+                    let arr_field1: json::Value =
+                        json::from_str(arr_field1).expect("Failed to deserialize arrzip field1");
+                    let mut join_arrs = vec![];
+                    if let json::Value::Array(field1) = arr_field1 {
+                        field1.iter().for_each(|field1| {
+                            let field1 = if field1.is_boolean() {
+                                let field1 = field1.as_bool().unwrap();
+                                field1.to_string()
+                            } else if field1.is_f64() {
+                                let field1 = field1.as_f64().unwrap();
+                                field1.to_string()
+                            } else if field1.is_i64() {
+                                let field1 = field1.as_i64().unwrap();
+                                field1.to_string()
+                            } else if field1.is_u64() {
+                                let field1 = field1.as_u64().unwrap();
+                                field1.to_string()
+                            } else if field1.is_string() {
+                                let field1 = field1.as_str().unwrap();
+                                field1.to_string()
+                            } else {
+                                "".to_string()
+                            };
+                            join_arrs.push(field1);
+                        });
+                    }
+                    let join_arrs = join_arrs.join(delim);
+                    Some(join_arrs)
+                }
+                _ => None,
+            }
+        })
+        .collect::<StringArray>();
+
+    // `Ok` because no error occurred during the calculation
+    // `Arc` because arrays are immutable, thread-safe, trait objects.
+    Ok(ColumnarValue::from(Arc::new(array) as ArrayRef))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::{
+            datatypes::{Field, Schema},
+            record_batch::RecordBatch,
+        },
+        assert_batches_eq,
+        datasource::MemTable,
+        prelude::SessionContext,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_arr_join_udf() {
+        let sqls = [
+            (
+                // Should include values at index 0 to index 1 (inclusive)
+                "select arrjoin(bools, ',') as ret from t",
+                vec![
+                    "+-----------------+",
+                    "| ret             |",
+                    "+-----------------+",
+                    "| true,false,true |",
+                    "+-----------------+",
+                ],
+            ),
+            (
+                // Should include all the elements
+                "select arrjoin(names, ',') as ret from t",
+                vec![
+                    "+-----------------+",
+                    "| ret             |",
+                    "+-----------------+",
+                    "| hello2,hi2,bye2 |",
+                    "+-----------------+",
+                ],
+            ),
+            (
+                "select arrjoin(nums, ',') as ret from t",
+                vec![
+                    "+--------------+",
+                    "| ret          |",
+                    "+--------------+",
+                    "| 12,345,23,45 |",
+                    "+--------------+",
+                ],
+            ),
+            (
+                "select arrjoin(floats, ',') as ret from t",
+                vec![
+                    "+------------------+",
+                    "| ret              |",
+                    "+------------------+",
+                    "| 1.9,34.5,2.6,4.5 |",
+                    "+------------------+",
+                ],
+            ),
+            (
+                "select arrjoin(mixed, ',') as ret from t",
+                vec![
+                    "+---------------------------+",
+                    "| ret                       |",
+                    "+---------------------------+",
+                    "| hello2,hi2,123,23.9,false |",
+                    "+---------------------------+",
+                ],
+            ),
+        ];
+
+        // define a schema.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("log", DataType::Utf8, false),
+            Field::new("bools", DataType::Utf8, false),
+            Field::new("names", DataType::Utf8, false),
+            Field::new("nums", DataType::Utf8, false),
+            Field::new("floats", DataType::Utf8, false),
+            Field::new("mixed", DataType::Utf8, false),
+        ]));
+
+        // define data.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a"])),
+                Arc::new(StringArray::from(vec!["[true,false,true]"])),
+                Arc::new(StringArray::from(vec!["[\"hello2\",\"hi2\",\"bye2\"]"])),
+                Arc::new(StringArray::from(vec!["[12, 345, 23, 45]"])),
+                Arc::new(StringArray::from(vec!["[1.9, 34.5, 2.6, 4.5]"])),
+                Arc::new(StringArray::from(vec![
+                    "[\"hello2\",\"hi2\",123, 23.9, false]",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        // declare a new context. In spark API, this corresponds to a new spark
+        // SQLsession
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_JOIN_UDF.clone());
+
+        // declare a table in memory. In spark API, this corresponds to
+        // createDataFrame(...).
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+}

--- a/src/service/search/datafusion/arrsort_udf.rs
+++ b/src/service/search/datafusion/arrsort_udf.rs
@@ -1,0 +1,205 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{cmp::Ordering, sync::Arc};
+
+use config::utils::json;
+use datafusion::{
+    arrow::{
+        array::{ArrayRef, StringArray},
+        datatypes::DataType,
+    },
+    common::cast::as_string_array,
+    error::DataFusionError,
+    logical_expr::{ScalarUDF, Volatility},
+    prelude::create_udf,
+    sql::sqlparser::parser::ParserError,
+};
+use datafusion_expr::ColumnarValue;
+use once_cell::sync::Lazy;
+
+/// The name of the arrsort UDF given to DataFusion.
+pub const ARR_SORT_UDF_NAME: &str = "arrsort";
+
+/// Implementation of arrsort
+pub(crate) static ARR_SORT_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
+    create_udf(
+        ARR_SORT_UDF_NAME,
+        // expects one string - the array field
+        vec![DataType::Utf8],
+        // returns string
+        Arc::new(DataType::Utf8),
+        Volatility::Immutable,
+        Arc::new(arr_sort_impl),
+    )
+});
+
+/// date_format function for datafusion
+pub fn arr_sort_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+    log::debug!("Inside arrsort");
+    if args.len() != 1 {
+        return Err(DataFusionError::SQL(
+            ParserError::ParserError("UDF params should be: arrsort(field)".to_string()),
+            None,
+        ));
+    }
+    let args = ColumnarValue::values_to_arrays(args)?;
+    log::debug!("Got the args: {:#?}", args);
+
+    // 1. cast argument to a string array. These casts MUST be aligned with the signature or this
+    //    function panics!
+    let arr_field = as_string_array(&args[0]).expect("cast failed");
+
+    // 2. perform the computation
+    let array = arr_field
+        .iter()
+        .map(|arr_field| {
+            let mut arr_sorted = vec![];
+
+            if let Some(arr_field) = arr_field {
+                let arr_field: json::Value =
+                    json::from_str(arr_field).expect("Failed to deserialize arrzip field1");
+                // This field is assumed to be a multivalue field
+                if let json::Value::Array(mut field) = arr_field {
+                    field.sort_by(|a, b| {
+                        // Assuming the array having elements of same type
+                        if a.is_f64() {
+                            a.as_f64().unwrap().total_cmp(b.as_f64().as_ref().unwrap())
+                        } else if a.is_i64() {
+                            a.as_i64().unwrap().cmp(b.as_i64().as_ref().unwrap())
+                        } else if a.is_u64() {
+                            a.as_u64().unwrap().cmp(b.as_u64().as_ref().unwrap())
+                        } else if a.is_string() {
+                            a.as_str().unwrap().cmp(b.as_str().unwrap())
+                        } else if a.is_boolean() {
+                            a.as_bool().unwrap().cmp(b.as_bool().as_ref().unwrap())
+                        } else {
+                            Ordering::Less
+                        }
+                    });
+                    arr_sorted.append(&mut field);
+                }
+                let arr_sorted =
+                    json::to_string(&arr_sorted).expect("Failed to stringify sorted arrs");
+                Some(arr_sorted)
+            } else {
+                None
+            }
+        })
+        .collect::<StringArray>();
+
+    // `Ok` because no error occurred during the calculation
+    // `Arc` because arrays are immutable, thread-safe, trait objects.
+    Ok(ColumnarValue::from(Arc::new(array) as ArrayRef))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::{
+            datatypes::{Field, Schema},
+            record_batch::RecordBatch,
+        },
+        assert_batches_eq,
+        datasource::MemTable,
+        prelude::SessionContext,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_arr_sort_udf() {
+        let sqls = [
+            (
+                "select arrsort(bools) as ret from t",
+                vec![
+                    "+-------------------+",
+                    "| ret               |",
+                    "+-------------------+",
+                    "| [false,true,true] |",
+                    "+-------------------+",
+                ],
+            ),
+            (
+                "select arrsort(names) as ret from t",
+                vec![
+                    "+-------------------------+",
+                    "| ret                     |",
+                    "+-------------------------+",
+                    "| [\"bye2\",\"hello2\",\"hi2\"] |",
+                    "+-------------------------+",
+                ],
+            ),
+            (
+                "select arrsort(nums) as ret from t",
+                vec![
+                    "+----------------+",
+                    "| ret            |",
+                    "+----------------+",
+                    "| [12,23,45,345] |",
+                    "+----------------+",
+                ],
+            ),
+            (
+                "select arrsort(floats) as ret from t",
+                vec![
+                    "+--------------------+",
+                    "| ret                |",
+                    "+--------------------+",
+                    "| [1.9,2.6,4.5,34.5] |",
+                    "+--------------------+",
+                ],
+            ),
+        ];
+
+        // define a schema.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("log", DataType::Utf8, false),
+            Field::new("bools", DataType::Utf8, false),
+            Field::new("names", DataType::Utf8, false),
+            Field::new("nums", DataType::Utf8, false),
+            Field::new("floats", DataType::Utf8, false),
+        ]));
+
+        // define data.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a"])),
+                Arc::new(StringArray::from(vec!["[true,false,true]"])),
+                Arc::new(StringArray::from(vec!["[\"hello2\",\"hi2\",\"bye2\"]"])),
+                Arc::new(StringArray::from(vec!["[12, 345, 23, 45]"])),
+                Arc::new(StringArray::from(vec!["[1.9, 34.5, 2.6, 4.5]"])),
+            ],
+        )
+        .unwrap();
+
+        // declare a new context. In spark API, this corresponds to a new spark
+        // SQLsession
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_SORT_UDF.clone());
+
+        // declare a table in memory. In spark API, this corresponds to
+        // createDataFrame(...).
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+}

--- a/src/service/search/datafusion/arrsort_udf.rs
+++ b/src/service/search/datafusion/arrsort_udf.rs
@@ -46,7 +46,7 @@ pub(crate) static ARR_SORT_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
     )
 });
 
-/// date_format function for datafusion
+/// arrsort function for datafusion
 pub fn arr_sort_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
     log::debug!("Inside arrsort");
     if args.len() != 1 {

--- a/src/service/search/datafusion/arrzip_udf.rs
+++ b/src/service/search/datafusion/arrzip_udf.rs
@@ -1,0 +1,231 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{iter::zip, sync::Arc};
+
+use arrow::array::StringArray;
+use config::utils::json;
+use datafusion::{
+    arrow::{array::ArrayRef, datatypes::DataType},
+    common::cast::as_string_array,
+    error::DataFusionError,
+    logical_expr::{ScalarUDF, Volatility},
+    prelude::create_udf,
+    sql::sqlparser::parser::ParserError,
+};
+use datafusion_expr::ColumnarValue;
+use once_cell::sync::Lazy;
+
+/// The name of the arrzip UDF given to DataFusion.
+pub const ARR_ZIP_UDF_NAME: &str = "arrzip";
+
+/// Implementation of arrzip UDF
+pub(crate) static ARR_ZIP_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
+    create_udf(
+        ARR_ZIP_UDF_NAME,
+        // expects three string - field1, field2 and the delim
+        vec![DataType::Utf8, DataType::Utf8, DataType::Utf8],
+        // returns string
+        Arc::new(DataType::Utf8),
+        Volatility::Immutable,
+        Arc::new(arr_zip_impl),
+    )
+});
+
+/// arrzip function for datafusion
+pub fn arr_zip_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+    log::debug!("Inside arrzip");
+    if args.len() != 3 {
+        return Err(DataFusionError::SQL(
+            ParserError::ParserError(
+                "UDF params should be: arrzip(field1, field2, delim)".to_string(),
+            ),
+            None,
+        ));
+    }
+    let args = ColumnarValue::values_to_arrays(args)?;
+    log::debug!("Got the args: {:#?}", args);
+
+    // 1. cast both arguments to Union. These casts MUST be aligned with the signature or this
+    //    function panics!
+    let arr_field1 = as_string_array(&args[0]).expect("cast failed");
+    let arr_field2 = as_string_array(&args[1]).expect("cast failed");
+    let delim = as_string_array(&args[2]).expect("cast failed");
+
+    // 2. perform the computation
+    let array = zip(arr_field1.iter(), zip(arr_field2.iter(), delim.iter()))
+        .map(|(arr_field1, val)| {
+            match (arr_field1, val) {
+                // in arrow, any value can be null.
+                // Here we decide to make our UDF to return null when either argument is null.
+                (Some(arr_field1), (Some(arr_field2), Some(delim))) => {
+                    let arr_field1: json::Value =
+                        json::from_str(arr_field1).expect("Failed to deserialize arrzip field1");
+                    let arr_field2: json::Value =
+                        json::from_str(arr_field2).expect("Failed to deserialize arrzip field2");
+                    let mut zipped_arrs = vec![];
+                    if let (json::Value::Array(field1), json::Value::Array(field2)) =
+                        (arr_field1, arr_field2)
+                    {
+                        // Field1 and field2 can be of different types
+                        zip(field1.iter(), field2.iter()).for_each(|(field1, field2)| {
+                            let field1 = if field1.is_boolean() {
+                                let field1 = field1.as_bool().unwrap();
+                                field1.to_string()
+                            } else if field1.is_f64() {
+                                let field1 = field1.as_f64().unwrap();
+                                field1.to_string()
+                            } else if field1.is_i64() {
+                                let field1 = field1.as_i64().unwrap();
+                                field1.to_string()
+                            } else if field1.is_u64() {
+                                let field1 = field1.as_u64().unwrap();
+                                field1.to_string()
+                            } else if field1.is_string() {
+                                let field1 = field1.as_str().unwrap();
+                                field1.to_string()
+                            } else {
+                                "".to_string()
+                            };
+                            let field2 = if field2.is_boolean() {
+                                let field2 = field2.as_bool().unwrap();
+                                field2.to_string()
+                            } else if field2.is_f64() {
+                                let field2 = field2.as_f64().unwrap();
+                                field2.to_string()
+                            } else if field2.is_i64() {
+                                let field2 = field2.as_i64().unwrap();
+                                field2.to_string()
+                            } else if field2.is_u64() {
+                                let field2 = field2.as_u64().unwrap();
+                                field2.to_string()
+                            } else if field2.is_string() {
+                                let field2 = field2.as_str().unwrap();
+                                field2.to_string()
+                            } else {
+                                "".to_string()
+                            };
+
+                            zipped_arrs.push(format!("{field1}{delim}{field2}"));
+                        });
+                    }
+                    let zipped_arrs =
+                        json::to_string(&zipped_arrs).expect("Failed to stringify zipped arrs");
+                    Some(zipped_arrs)
+                }
+                _ => None,
+            }
+        })
+        .collect::<StringArray>();
+
+    // `Ok` because no error occurred during the calculation
+    // `Arc` because arrays are immutable, thread-safe, trait objects.
+    Ok(ColumnarValue::from(Arc::new(array) as ArrayRef))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::{
+            datatypes::{Field, Schema},
+            record_batch::RecordBatch,
+        },
+        assert_batches_eq,
+        datasource::MemTable,
+        prelude::SessionContext,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_arr_zip_udf() {
+        let sqls = [
+            (
+                // Should include values at index 0 to index 1 (inclusive)
+                "select arrzip(bools, names, ',') as ret from t",
+                vec![
+                    "+-----------------------------------------+",
+                    "| ret                                     |",
+                    "+-----------------------------------------+",
+                    "| [\"true,hello2\",\"false,hi2\",\"true,bye2\"] |",
+                    "+-----------------------------------------+",
+                ],
+            ),
+            (
+                // Should include all the elements
+                "select arrzip(nums, floats, ',') as ret from t",
+                vec![
+                    "+-----------------------------------------+",
+                    "| ret                                     |",
+                    "+-----------------------------------------+",
+                    "| [\"12,1.9\",\"345,34.5\",\"23,2.6\",\"45,4.5\"] |",
+                    "+-----------------------------------------+",
+                ],
+            ),
+            (
+                "select arrzip(nums, mixed, ',') as ret from t",
+                vec![
+                    "+--------------------------------------------+",
+                    "| ret                                        |",
+                    "+--------------------------------------------+",
+                    "| [\"12,hello2\",\"345,hi2\",\"23,123\",\"45,23.9\"] |",
+                    "+--------------------------------------------+",
+                ],
+            ),
+        ];
+
+        // define a schema.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("log", DataType::Utf8, false),
+            Field::new("bools", DataType::Utf8, false),
+            Field::new("names", DataType::Utf8, false),
+            Field::new("nums", DataType::Utf8, false),
+            Field::new("floats", DataType::Utf8, false),
+            Field::new("mixed", DataType::Utf8, false),
+        ]));
+
+        // define data.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a"])),
+                Arc::new(StringArray::from(vec!["[true,false,true]"])),
+                Arc::new(StringArray::from(vec!["[\"hello2\",\"hi2\",\"bye2\"]"])),
+                Arc::new(StringArray::from(vec!["[12, 345, 23, 45]"])),
+                Arc::new(StringArray::from(vec!["[1.9, 34.5, 2.6, 4.5]"])),
+                Arc::new(StringArray::from(vec![
+                    "[\"hello2\",\"hi2\",123, 23.9, false]",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        // declare a new context. In spark API, this corresponds to a new spark
+        // SQLsession
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_ZIP_UDF.clone());
+
+        // declare a table in memory. In spark API, this corresponds to
+        // createDataFrame(...).
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+}

--- a/src/service/search/datafusion/arrzip_udf.rs
+++ b/src/service/search/datafusion/arrzip_udf.rs
@@ -28,6 +28,8 @@ use datafusion::{
 use datafusion_expr::ColumnarValue;
 use once_cell::sync::Lazy;
 
+use crate::service::search::datafusion::stringify_json_value;
+
 /// The name of the arrzip UDF given to DataFusion.
 pub const ARR_ZIP_UDF_NAME: &str = "arrzip";
 
@@ -81,42 +83,8 @@ pub fn arr_zip_impl(args: &[ColumnarValue]) -> datafusion::error::Result<Columna
                     {
                         // Field1 and field2 can be of different types
                         zip(field1.iter(), field2.iter()).for_each(|(field1, field2)| {
-                            let field1 = if field1.is_boolean() {
-                                let field1 = field1.as_bool().unwrap();
-                                field1.to_string()
-                            } else if field1.is_f64() {
-                                let field1 = field1.as_f64().unwrap();
-                                field1.to_string()
-                            } else if field1.is_i64() {
-                                let field1 = field1.as_i64().unwrap();
-                                field1.to_string()
-                            } else if field1.is_u64() {
-                                let field1 = field1.as_u64().unwrap();
-                                field1.to_string()
-                            } else if field1.is_string() {
-                                let field1 = field1.as_str().unwrap();
-                                field1.to_string()
-                            } else {
-                                "".to_string()
-                            };
-                            let field2 = if field2.is_boolean() {
-                                let field2 = field2.as_bool().unwrap();
-                                field2.to_string()
-                            } else if field2.is_f64() {
-                                let field2 = field2.as_f64().unwrap();
-                                field2.to_string()
-                            } else if field2.is_i64() {
-                                let field2 = field2.as_i64().unwrap();
-                                field2.to_string()
-                            } else if field2.is_u64() {
-                                let field2 = field2.as_u64().unwrap();
-                                field2.to_string()
-                            } else if field2.is_string() {
-                                let field2 = field2.as_str().unwrap();
-                                field2.to_string()
-                            } else {
-                                "".to_string()
-                            };
+                            let field1 = stringify_json_value(field1);
+                            let field2 = stringify_json_value(field2);
 
                             zipped_arrs.push(format!("{field1}{delim}{field2}"));
                         });

--- a/src/service/search/datafusion/cast_to_arr_udf.rs
+++ b/src/service/search/datafusion/cast_to_arr_udf.rs
@@ -1,0 +1,198 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ListBuilder, StringBuilder};
+use arrow_schema::Field;
+use config::utils::json;
+use datafusion::{
+    arrow::{array::ArrayRef, datatypes::DataType},
+    common::cast::as_generic_string_array,
+    error::DataFusionError,
+    logical_expr::{ScalarUDF, Volatility},
+    prelude::create_udf,
+    sql::sqlparser::parser::ParserError,
+};
+use datafusion_expr::ColumnarValue;
+use once_cell::sync::Lazy;
+
+/// The name of the cast_to_arr UDF given to DataFusion.
+pub const CAST_TO_ARR_UDF_NAME: &str = "cast_to_arr";
+
+/// Implementation of cast_to_arr
+pub(crate) static CAST_TO_ARR_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
+    create_udf(
+        CAST_TO_ARR_UDF_NAME,
+        // takes one argument: the field
+        vec![DataType::Utf8],
+        Arc::new(DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Utf8,
+            true,
+        )))),
+        Volatility::Immutable,
+        Arc::new(cast_to_arr_impl),
+    )
+});
+
+/// cast_to_arr function for datafusion
+pub fn cast_to_arr_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+    let args = ColumnarValue::values_to_arrays(args)?;
+    log::debug!("Inside cast_to_arr_impl");
+    if args.len() != 1 {
+        return Err(DataFusionError::SQL(
+            ParserError::ParserError("UDF params should be: cast_to_arr(field)".to_string()),
+            None,
+        ));
+    }
+
+    let string_array = as_generic_string_array::<i32>(&args[0])?;
+
+    let mut list_builder = ListBuilder::new(StringBuilder::with_capacity(
+        string_array.len(),
+        string_array.get_buffer_memory_size(),
+    ));
+
+    string_array.iter().for_each(|string| {
+        if let Some(string) = string {
+            let arr: json::Value =
+                json::from_str(string).expect("Failed to deserialize the field into an array");
+            if let json::Value::Array(arr) = arr {
+                arr.iter().for_each(|field| {
+                    let field = if field.is_boolean() {
+                        let field = field.as_bool().unwrap();
+                        field.to_string()
+                    } else if field.is_f64() {
+                        let field = field.as_f64().unwrap();
+                        field.to_string()
+                    } else if field.is_i64() {
+                        let field = field.as_i64().unwrap();
+                        field.to_string()
+                    } else if field.is_u64() {
+                        let field = field.as_u64().unwrap();
+                        field.to_string()
+                    } else if field.is_string() {
+                        let field = field.as_str().unwrap();
+                        field.to_string()
+                    } else {
+                        json::to_string(field).expect("failed to stringify json field")
+                    };
+                    if !field.is_empty() {
+                        list_builder.values().append_value(field);
+                    }
+                });
+                list_builder.append(true);
+            }
+        }
+    });
+
+    let list_array = list_builder.finish();
+    Ok(ColumnarValue::from(Arc::new(list_array) as ArrayRef))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::{array::StringArray, datatypes::Schema, record_batch::RecordBatch},
+        assert_batches_eq,
+        datasource::MemTable,
+        prelude::SessionContext,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cast_to_arr() {
+        let log_line = r#"[12, 345, 23, 45]"#;
+        let sqls = [(
+            "select cast_to_arr(log) as ret from t",
+            vec![
+                "+-------------------+",
+                "| ret               |",
+                "+-------------------+",
+                "| [12, 345, 23, 45] |",
+                "+-------------------+",
+            ],
+        )];
+
+        // define a schema.
+        let schema = Arc::new(Schema::new(vec![Field::new("log", DataType::Utf8, false)]));
+
+        // define data.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![log_line]))],
+        )
+        .unwrap();
+
+        // declare a new context. In spark API, this corresponds to a new spark
+        // SQLsession
+        let ctx = SessionContext::new();
+        ctx.register_udf(CAST_TO_ARR_UDF.clone());
+
+        // declare a table in memory. In spark API, this corresponds to
+        // createDataFrame(...).
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cast_to_arr_string() {
+        let log_line = r#"["hello2","hi2","bye2"]"#;
+        let sqls = [(
+            "select cast_to_arr(log) as ret from t",
+            vec![
+                "+---------------------+",
+                "| ret                 |",
+                "+---------------------+",
+                "| [hello2, hi2, bye2] |",
+                "+---------------------+",
+            ],
+        )];
+
+        // define a schema.
+        let schema = Arc::new(Schema::new(vec![Field::new("log", DataType::Utf8, false)]));
+
+        // define data.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![log_line]))],
+        )
+        .unwrap();
+
+        // declare a new context. In spark API, this corresponds to a new spark
+        // SQLsession
+        let ctx = SessionContext::new();
+        ctx.register_udf(CAST_TO_ARR_UDF.clone());
+
+        // declare a table in memory. In spark API, this corresponds to
+        // createDataFrame(...).
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+}

--- a/src/service/search/datafusion/cast_to_arr_udf.rs
+++ b/src/service/search/datafusion/cast_to_arr_udf.rs
@@ -29,6 +29,8 @@ use datafusion::{
 use datafusion_expr::ColumnarValue;
 use once_cell::sync::Lazy;
 
+use crate::service::search::datafusion::stringify_json_value;
+
 /// The name of the cast_to_arr UDF given to DataFusion.
 pub const CAST_TO_ARR_UDF_NAME: &str = "cast_to_arr";
 
@@ -72,24 +74,7 @@ pub fn cast_to_arr_impl(args: &[ColumnarValue]) -> datafusion::error::Result<Col
                 json::from_str(string).expect("Failed to deserialize the field into an array");
             if let json::Value::Array(arr) = arr {
                 arr.iter().for_each(|field| {
-                    let field = if field.is_boolean() {
-                        let field = field.as_bool().unwrap();
-                        field.to_string()
-                    } else if field.is_f64() {
-                        let field = field.as_f64().unwrap();
-                        field.to_string()
-                    } else if field.is_i64() {
-                        let field = field.as_i64().unwrap();
-                        field.to_string()
-                    } else if field.is_u64() {
-                        let field = field.as_u64().unwrap();
-                        field.to_string()
-                    } else if field.is_string() {
-                        let field = field.as_str().unwrap();
-                        field.to_string()
-                    } else {
-                        json::to_string(field).expect("failed to stringify json field")
-                    };
+                    let field = stringify_json_value(field);
                     if !field.is_empty() {
                         list_builder.values().append_value(field);
                     }

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -1179,6 +1179,14 @@ async fn register_udf(ctx: &mut SessionContext, _org_id: &str) {
     ctx.register_udf(super::time_range_udf::TIME_RANGE_UDF.clone());
     ctx.register_udf(super::date_format_udf::DATE_FORMAT_UDF.clone());
     ctx.register_udf(super::string_to_array_v2_udf::STRING_TO_ARRAY_V2_UDF.clone());
+    ctx.register_udf(super::arrzip_udf::ARR_ZIP_UDF.clone());
+    ctx.register_udf(super::arrindex_udf::ARR_INDEX_UDF.clone());
+    ctx.register_udf(super::arr_descending_udf::ARR_DESCENDING_UDF.clone());
+    ctx.register_udf(super::arrjoin_udf::ARR_JOIN_UDF.clone());
+    ctx.register_udf(super::arrcount_udf::ARR_COUNT_UDF.clone());
+    ctx.register_udf(super::arrsort_udf::ARR_SORT_UDF.clone());
+    ctx.register_udf(super::cast_to_arr_udf::CAST_TO_ARR_UDF.clone());
+    ctx.register_udf(super::spath_udf::SPATH_UDF.clone());
 
     {
         let udf_list = get_all_transform(_org_id).await;

--- a/src/service/search/datafusion/mod.rs
+++ b/src/service/search/datafusion/mod.rs
@@ -15,6 +15,8 @@
 
 use std::str::FromStr;
 
+use config::utils::json;
+
 use crate::common::meta::functions::ZoFunction;
 
 pub mod arr_descending_udf;
@@ -63,6 +65,18 @@ pub const MATCH_UDF_IGNORE_CASE_NAME: &str = "str_match_ignore_case";
 pub const REGEX_MATCH_UDF_NAME: &str = "re_match";
 /// The name of the not_regex_match UDF given to DataFusion.
 pub const REGEX_NOT_MATCH_UDF_NAME: &str = "re_not_match";
+
+pub fn stringify_json_value(field: &json::Value) -> String {
+    match field {
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => match n.as_f64() {
+            Some(f) => f.to_string(),
+            None => n.as_i64().unwrap().to_string(),
+        },
+        serde_json::Value::String(s) => s.clone(),
+        _ => json::to_string(field).expect("failed to stringify json field"),
+    }
+}
 
 pub const DEFAULT_FUNCTIONS: [ZoFunction; 7] = [
     ZoFunction {

--- a/src/service/search/datafusion/mod.rs
+++ b/src/service/search/datafusion/mod.rs
@@ -17,11 +17,19 @@ use std::str::FromStr;
 
 use crate::common::meta::functions::ZoFunction;
 
+pub mod arr_descending_udf;
+pub mod arrcount_udf;
+pub mod arrindex_udf;
+pub mod arrjoin_udf;
+pub mod arrsort_udf;
+pub mod arrzip_udf;
+pub mod cast_to_arr_udf;
 mod date_format_udf;
 pub mod exec;
 pub mod match_udf;
 pub mod regexp_udf;
 mod rewrite;
+pub mod spath_udf;
 pub mod storage;
 pub mod string_to_array_v2_udf;
 mod time_range_udf;

--- a/src/service/search/datafusion/spath_udf.rs
+++ b/src/service/search/datafusion/spath_udf.rs
@@ -1,0 +1,193 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{iter::zip, sync::Arc};
+
+use arrow::array::StringArray;
+use config::utils::json;
+use datafusion::{
+    arrow::{array::ArrayRef, datatypes::DataType},
+    common::cast::as_string_array,
+    error::DataFusionError,
+    logical_expr::{ScalarUDF, Volatility},
+    prelude::create_udf,
+    sql::sqlparser::parser::ParserError,
+};
+use datafusion_expr::ColumnarValue;
+use once_cell::sync::Lazy;
+
+/// The name of the arrjoin UDF given to DataFusion.
+pub const SPATH_UDF_NAME: &str = "spath";
+
+/// Implementation of arrjoin
+pub(crate) static SPATH_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
+    create_udf(
+        SPATH_UDF_NAME,
+        // expects two string - the field and the delimiter
+        vec![DataType::Utf8, DataType::Utf8],
+        // returns string
+        Arc::new(DataType::Utf8),
+        Volatility::Immutable,
+        Arc::new(spath_impl),
+    )
+});
+
+/// arrjoin function for datafusion
+pub fn spath_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+    log::debug!("Inside spath");
+    if args.len() != 2 {
+        return Err(DataFusionError::SQL(
+            ParserError::ParserError("UDF params should be: spath(field, path)".to_string()),
+            None,
+        ));
+    }
+    let args = ColumnarValue::values_to_arrays(args)?;
+    log::debug!("Got the args: {:#?}", args);
+
+    // 1. cast both arguments to Union. These casts MUST be aligned with the signature or this
+    //    function panics!
+    let field = as_string_array(&args[0]).expect("cast failed");
+    let path = as_string_array(&args[1]).expect("cast failed");
+
+    // 2. perform the computation
+    let array = zip(field.iter(), path.iter())
+        .map(|(field, path)| {
+            match (field, path) {
+                // in arrow, any value can be null.
+                // Here we decide to make our UDF to return null when either argument is null.
+                (Some(field), Some(path)) => {
+                    let mut field: json::Value =
+                        json::from_str(field).expect("Failed to deserialize arrzip field1");
+                    let mut found = true;
+                    let paths = path.split('.').collect::<Vec<&str>>();
+                    for path in paths.into_iter() {
+                        if let json::Value::Object(mut obj) = field.clone() {
+                            if let Some(val) = obj.remove(path) {
+                                field = val;
+                            } else {
+                                found = false;
+                                break;
+                            }
+                        } else {
+                            found = false;
+                            break;
+                        }
+                    }
+                    if found {
+                        let field = if field.is_boolean() {
+                            let field = field.as_bool().unwrap();
+                            field.to_string()
+                        } else if field.is_f64() {
+                            let field = field.as_f64().unwrap();
+                            field.to_string()
+                        } else if field.is_i64() {
+                            let field = field.as_i64().unwrap();
+                            field.to_string()
+                        } else if field.is_u64() {
+                            let field = field.as_u64().unwrap();
+                            field.to_string()
+                        } else if field.is_string() {
+                            let field = field.as_str().unwrap();
+                            field.to_string()
+                        } else {
+                            json::to_string(&field).expect("failed to stringify json field")
+                        };
+                        Some(field)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        })
+        .collect::<StringArray>();
+
+    // `Ok` because no error occurred during the calculation
+    // `Arc` because arrays are immutable, thread-safe, trait objects.
+    Ok(ColumnarValue::from(Arc::new(array) as ArrayRef))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::{
+            datatypes::{Field, Schema},
+            record_batch::RecordBatch,
+        },
+        assert_batches_eq,
+        datasource::MemTable,
+        prelude::SessionContext,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_spath_udf() {
+        let sqls = [
+            (
+                // Should include values at index 0 to index 1 (inclusive)
+                "select spath(object, 'nested.value') as ret from t",
+                vec!["+------+", "| ret  |", "+------+", "| jene |", "+------+"],
+            ),
+            (
+                // Should include all the elements
+                "select spath(object, 'unnested') as ret from t",
+                vec!["+-----+", "| ret |", "+-----+", "| doe |", "+-----+"],
+            ),
+            (
+                "select spath(object, 'array') as ret from t",
+                vec![
+                    "+------------+",
+                    "| ret        |",
+                    "+------------+",
+                    "| [34,54,45] |",
+                    "+------------+",
+                ],
+            ),
+        ];
+
+        // define a schema.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "object",
+            DataType::Utf8,
+            false,
+        )]));
+
+        // define data.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![
+                "{\"nested\":{\"value\":\"jene\"},\"unnested\":\"doe\",\"array\":[34,54,45]}",
+            ]))],
+        )
+        .unwrap();
+
+        // declare a new context. In spark API, this corresponds to a new spark
+        // SQLsession
+        let ctx = SessionContext::new();
+        ctx.register_udf(SPATH_UDF.clone());
+
+        // declare a table in memory. In spark API, this corresponds to
+        // createDataFrame(...).
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+}

--- a/src/service/search/datafusion/spath_udf.rs
+++ b/src/service/search/datafusion/spath_udf.rs
@@ -28,6 +28,8 @@ use datafusion::{
 use datafusion_expr::ColumnarValue;
 use once_cell::sync::Lazy;
 
+use crate::service::search::datafusion::stringify_json_value;
+
 /// The name of the arrjoin UDF given to DataFusion.
 pub const SPATH_UDF_NAME: &str = "spath";
 
@@ -86,24 +88,7 @@ pub fn spath_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarV
                         }
                     }
                     if found {
-                        let field = if field.is_boolean() {
-                            let field = field.as_bool().unwrap();
-                            field.to_string()
-                        } else if field.is_f64() {
-                            let field = field.as_f64().unwrap();
-                            field.to_string()
-                        } else if field.is_i64() {
-                            let field = field.as_i64().unwrap();
-                            field.to_string()
-                        } else if field.is_u64() {
-                            let field = field.as_u64().unwrap();
-                            field.to_string()
-                        } else if field.is_string() {
-                            let field = field.as_str().unwrap();
-                            field.to_string()
-                        } else {
-                            json::to_string(&field).expect("failed to stringify json field")
-                        };
+                        let field = stringify_json_value(&field);
                         Some(field)
                     } else {
                         None

--- a/src/service/search/datafusion/string_to_array_v2_udf.rs
+++ b/src/service/search/datafusion/string_to_array_v2_udf.rs
@@ -46,7 +46,7 @@ pub(crate) static STRING_TO_ARRAY_V2_UDF: Lazy<ScalarUDF> = Lazy::new(|| {
     )
 });
 
-/// date_format function for datafusion
+/// string_to_array_v2 function for datafusion
 pub fn string_to_array_v2_impl(args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
     let args = ColumnarValue::values_to_arrays(args)?;
 


### PR DESCRIPTION
Implemented UDFs -
- `arr_descending`: Sorts arrays in descending order.  E.g. `arr_descending(arrfield)`. Expects the array fields to be of same type.
- `arrcount`: Counts elements in an array. E.g. `arrcount(arrfield)` returns the number of elements in the array field.
- `arrindex`: Selects a range of elements from an array. `arrindex(field, start, end)` where end is inclusive. E.g. `arrindex(arrfield, 0, 2)` returns `"[\"element1\", \"element2\", \"element3\"]"`.
- `arrjoin`: Concatenates arrays with a specified delimiter. E.g. `arrjoin(field, ' | ')` returns `"element1 | element2 | element3"`.
- `arrsort`: Sorts arrays in increasing order. E.g. `arrsort(arrfield)`. Expects the array fields to be of same type.
- `arrzip`: Zips multiple arrays together with a delimiter. E.g. `arrzip(arrfield1, arrfield2, ',')` returns `"[\"element01,element11\", \"element02,element12\"]"`.
- `spath`: Processes JSON data by splitting paths and extracting values. E.g. `spath(json_field, 'nested.value')`.
- `cast_to_arr(field)`: Casts an array string to a datafusion array that can be used with `unnest()`, and other datafusion array functions such as `array_pop_back(cast_to_arr(arrfield))` etc.

**NOTE**: Native datafusion array functions don't work with array field, so `cast_to_arr(field)` udf needs to be applied before applying other native datafusion udfs. Native datafusion array functions - https://datafusion.apache.org/user-guide/expressions.html#array-expressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced multiple user-defined functions (UDFs) for DataFusion:
    - `arr_descending`: Sorts arrays in descending order.
    - `arrcount`: Counts elements in an array.
    - `arrindex`: Extracts a subset of an array.
    - `arrjoin`: Joins array elements using a delimiter.
    - `arrsort`: Sorts arrays in ascending order.
    - `cast_to_arr`: Converts a string field to an array.
    - `spath`: Performs computations on string arguments.
    - `string_to_array_v2`: Renamed from `date_format` for clarity.

- **Enhancements**
  - Added registration for the newly introduced UDFs to the system for better data processing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->