### PR TITLE
fix: Decode URL-safe base64 encoded JWT tokens

### DIFF
--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -111,8 +111,8 @@ export const getUserInfo = (loginString: string) => {
         if (parts.length === 3) {
           try {
             // Attempt to parse the token as a JWT
-            const header = JSON.parse(atob(parts[0]));
-            const payload = JSON.parse(atob(parts[1]));
+            const header = JSON.parse(b64DecodeUnicode(parts[0]) || "");
+            const payload = JSON.parse(b64DecodeUnicode(parts[1]) || "");
             const signature = parts[2];
             payload["family_name"] = payload["name"];
             payload["given_name"] = "";


### PR DESCRIPTION
Fixed: #3720

The atob function has been replaced with the b64DecodeUnicode function. This fixes the decoding of URL-safe base64 encoded JWT tokens.
The decoding of each part of the JWT token (header and payload) has been modified. It now uses the b64DecodeUnicode function before parsing with JSON.parse.

Previously, the code used the atob function, which only supported non-URL-safe base64 encoding. This caused issues when trying to decode URL-safe base64 encoded JWT tokens. With this fix, the code now supports both non-URL-safe and URL-safe base64 encoding, ensuring proper decoding of JWT tokens in all cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JWT token parsing by updating the decoding method to handle potential errors more effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->