### PR TITLE
fix: multiple timestamp columns displayed on result grid

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2188,7 +2188,7 @@ const useLogs = () => {
         if (
           (searchObj.meta.sqlMode == true &&
             parsedSQL.hasOwnProperty("columns") &&
-            hasTimeStampColumn(parsedSQL.columns)) ||
+            searchObj.data.queryResults?.hits[0].hasOwnProperty(store.state.zoConfig.timestamp_column)) ||
           searchObj.meta.sqlMode == false ||
           searchObj.data.stream.selectedFields.includes(
             store.state.zoConfig.timestamp_column
@@ -2230,7 +2230,7 @@ const useLogs = () => {
           if (
             (searchObj.meta.sqlMode == true &&
               parsedSQL.hasOwnProperty("columns") &&
-              hasTimeStampColumn(parsedSQL.columns)) ||
+              field == store.state.zoConfig.timestamp_column) ||
             field == store.state.zoConfig.timestamp_column
           ) {
             searchObj.data.resultGrid.columns.unshift({


### PR DESCRIPTION
Issue : #3724
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy in detecting timestamp columns in log queries, ensuring more reliable data handling and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->