### PR TITLE
feat: optimize default NDV of bloom filter

### DIFF
--- a/src/config/src/utils/parquet.rs
+++ b/src/config/src/utils/parquet.rs
@@ -49,8 +49,6 @@ pub fn new_parquet_writer<'a>(
         .set_data_page_size_limit(PARQUET_PAGE_SIZE) // maximum size of a data page in bytes
         .set_max_row_group_size(row_group_size) // maximum number of rows in a row group
         .set_compression(Compression::ZSTD(Default::default()))
-        .set_dictionary_enabled(true)
-        .set_encoding(Encoding::PLAIN)
         .set_column_dictionary_enabled(
             cfg.common.column_timestamp.as_str().into(),
             false,
@@ -103,7 +101,6 @@ pub fn new_parquet_writer<'a>(
         };
         for field in fields {
             writer_props = writer_props
-                .set_column_dictionary_enabled(field.as_str().into(), false)
                 .set_column_bloom_filter_enabled(field.as_str().into(), true)
                 .set_column_bloom_filter_fpp(field.as_str().into(), DEFAULT_BLOOM_FILTER_FPP)
                 .set_column_bloom_filter_ndv(field.into(), bf_ndv); // take the field ownership


### PR DESCRIPTION
The NDV shouldn't too small at least `1000` or equal to the row_count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Optimized memory usage by adjusting the calculation of the bloom filter NDV (Number of Distinct Values) in data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->