### PR TITLE
feat: sync hotfix from v0.10.6-rc3

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -599,8 +599,8 @@ pub struct Common {
     pub usage_batch_size: usize,
     #[env_config(
         name = "ZO_USAGE_PUBLISH_INTERVAL",
-        help = "duration in seconds after last reporting usage will be published",
-        default = 600
+        default = 600,
+        help = "duration in seconds after last reporting usage will be published"
     )]
     // in seconds
     pub usage_publish_interval: i64,
@@ -738,6 +738,10 @@ pub struct Limit {
     pub file_move_fields_limit: usize,
     #[env_config(name = "ZO_FILE_MOVE_THREAD_NUM", default = 0)]
     pub file_move_thread_num: usize,
+    #[env_config(name = "ZO_FILE_MERGE_THREAD_NUM", default = 0)]
+    pub file_merge_thread_num: usize,
+    #[env_config(name = "ZO_MEM_DUMP_THREAD_NUM", default = 0)]
+    pub mem_dump_thread_num: usize,
     #[env_config(name = "ZO_QUERY_THREAD_NUM", default = 0)]
     pub query_thread_num: usize,
     #[env_config(name = "ZO_QUERY_TIMEOUT", default = 600)]
@@ -818,14 +822,14 @@ pub struct Limit {
     pub sql_max_db_connections: u32,
     #[env_config(
         name = "ZO_META_TRANSACTION_RETRIES",
-        help = "max time of transaction will retry",
-        default = 3
+        default = 3,
+        help = "max time of transaction will retry"
     )]
     pub meta_transaction_retries: usize,
     #[env_config(
         name = "ZO_META_TRANSACTION_LOCK_TIMEOUT",
-        help = "timeout of transaction lock",
-        default = 600
+        default = 600,
+        help = "timeout of transaction lock"
     )] // seconds
     pub meta_transaction_lock_timeout: usize,
     #[env_config(name = "ZO_DISTINCT_VALUES_INTERVAL", default = 10)] // seconds
@@ -860,6 +864,12 @@ pub struct Compact {
     pub blocked_orgs: String,
     #[env_config(name = "ZO_COMPACT_DATA_RETENTION_HISTORY", default = false)]
     pub data_retention_history: bool,
+    #[env_config(
+        name = "ZO_COMPACT_FAST_MODE",
+        default = true,
+        help = "Enable fast mode compact, will use more memory but faster"
+    )]
+    pub fast_mode: bool,
 }
 
 #[derive(EnvConfig)]
@@ -1096,6 +1106,14 @@ pub fn init() -> Config {
     // HACK for move_file_thread_num equal to CPU core
     if cfg.limit.file_move_thread_num == 0 {
         cfg.limit.file_move_thread_num = cpu_num;
+    }
+    // HACK for file_merge_thread_num equal to CPU core
+    if cfg.limit.file_merge_thread_num == 0 {
+        cfg.limit.file_merge_thread_num = cpu_num;
+    }
+    // HACK for mem_dump_thread_num equal to CPU core
+    if cfg.limit.mem_dump_thread_num == 0 {
+        cfg.limit.mem_dump_thread_num = cpu_num;
     }
     if cfg.limit.file_push_interval == 0 {
         cfg.limit.file_push_interval = 10;

--- a/src/config/src/utils/record_batch_ext.rs
+++ b/src/config/src/utils/record_batch_ext.rs
@@ -484,7 +484,7 @@ pub fn format_recordbatch_by_schema(schema: Arc<Schema>, batch: RecordBatch) -> 
 pub fn concat_batches(
     schema: Arc<Schema>,
     mut batches: Vec<RecordBatch>,
-    less_memory_mode: bool,
+    fast_mode: bool,
 ) -> Result<RecordBatch, ArrowError> {
     // When schema is empty, sum the number of the rows of all batches
     if schema.fields().is_empty() {
@@ -500,7 +500,14 @@ pub fn concat_batches(
     let field_num = schema.fields().len();
     let mut arrays = Vec::with_capacity(field_num);
     for i in 0..field_num {
-        let array = if less_memory_mode {
+        let array = if fast_mode {
+            arrow::compute::concat(
+                &batches
+                    .iter()
+                    .map(|batch| batch.column(i).as_ref())
+                    .collect::<Vec<_>>(),
+            )?
+        } else {
             let mut new_batches = Vec::with_capacity(batches.len());
             for batch in &mut batches {
                 let i = i - arrays.len();
@@ -508,16 +515,10 @@ pub fn concat_batches(
                 new_batches.push(column);
             }
             arrow::compute::concat(&new_batches.iter().map(|c| c.as_ref()).collect::<Vec<_>>())?
-        } else {
-            arrow::compute::concat(
-                &batches
-                    .iter()
-                    .map(|batch| batch.column(i).as_ref())
-                    .collect::<Vec<_>>(),
-            )?
         };
         arrays.push(array);
     }
+    drop(batches);
     RecordBatch::try_new(schema.clone(), arrays)
 }
 

--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -96,8 +96,10 @@ async fn settings(
     settings: web::Json<StreamSettings>,
     req: HttpRequest,
 ) -> Result<HttpResponse, Error> {
-    let (org_id, stream_name) = path.into_inner();
-    let stream_name = format_stream_name(&stream_name);
+    let (org_id, mut stream_name) = path.into_inner();
+    if !config::get_config().common.skip_formatting_bulk_stream_name {
+        stream_name = format_stream_name(&stream_name);
+    }
     let query = web::Query::<HashMap<String, String>>::from_query(req.query_string()).unwrap();
     let stream_type = match get_stream_type_from_request(&query) {
         Ok(v) => {

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -303,12 +303,12 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
 SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, flattened
     FROM file_list 
     FORCE INDEX (file_list_stream_ts_idx) 
-    WHERE stream = ? AND min_ts <= ? AND max_ts >= ?;
+    WHERE stream = ? AND max_ts >= ? AND min_ts <= ?;
                 "#,
             )
             .bind(stream_key)
-            .bind(time_end)
             .bind(time_start)
+            .bind(time_end)
             .fetch_all(&pool)
             .await
         };
@@ -795,7 +795,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
         (
             "file_list",
-            "CREATE INDEX file_list_stream_ts_idx on file_list (stream, min_ts, max_ts);",
+            "CREATE INDEX file_list_stream_ts_idx on file_list (stream, max_ts, min_ts);",
         ),
         (
             "file_list_history",
@@ -803,7 +803,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
         (
             "file_list_history",
-            "CREATE INDEX file_list_history_stream_ts_idx on file_list_history (stream, min_ts, max_ts);",
+            "CREATE INDEX file_list_history_stream_ts_idx on file_list_history (stream, max_ts, min_ts);",
         ),
         (
             "file_list_history",

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -306,12 +306,12 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
                 r#"
 SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, flattened
     FROM file_list 
-    WHERE stream = $1 AND min_ts <= $2 AND max_ts >= $3;
+    WHERE stream = $1 AND max_ts >= $2 AND min_ts <= $3;
                 "#,
             )
             .bind(stream_key)
-            .bind(time_end)
             .bind(time_start)
+            .bind(time_end)
             .fetch_all(&pool)
             .await
         };
@@ -800,7 +800,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
         (
             "file_list",
-            "CREATE INDEX IF NOT EXISTS file_list_stream_ts_idx on file_list (stream, min_ts, max_ts);",
+            "CREATE INDEX IF NOT EXISTS file_list_stream_ts_idx on file_list (stream, max_ts, min_ts);",
         ),
         (
             "file_list_history",
@@ -808,7 +808,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
         (
             "file_list_history",
-            "CREATE INDEX IF NOT EXISTS file_list_history_stream_ts_idx on file_list_history (stream, min_ts, max_ts);",
+            "CREATE INDEX IF NOT EXISTS file_list_history_stream_ts_idx on file_list_history (stream, max_ts, min_ts);",
         ),
         (
             "file_list_history",

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -313,12 +313,12 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
                 r#"
 SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, flattened
     FROM file_list 
-    WHERE stream = $1 AND min_ts <= $2 AND max_ts >= $3;
+    WHERE stream = $1 AND max_ts >= $2 AND min_ts <= $3;
                 "#,
             )
             .bind(stream_key)
-            .bind(time_end)
             .bind(time_start)
+            .bind(time_end)
             .fetch_all(&pool)
             .await
         };
@@ -814,7 +814,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
         (
             "file_list",
-            "CREATE INDEX IF NOT EXISTS file_list_stream_ts_idx on file_list (stream, min_ts, max_ts);",
+            "CREATE INDEX IF NOT EXISTS file_list_stream_ts_idx on file_list (stream, max_ts, min_ts);",
         ),
         (
             "file_list_history",
@@ -822,7 +822,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
         (
             "file_list_history",
-            "CREATE INDEX IF NOT EXISTS file_list_history_stream_ts_idx on file_list_history (stream, min_ts, max_ts);",
+            "CREATE INDEX IF NOT EXISTS file_list_history_stream_ts_idx on file_list_history (stream, max_ts, min_ts);",
         ),
         (
             "file_list_history",

--- a/src/ingester/src/errors.rs
+++ b/src/ingester/src/errors.rs
@@ -100,5 +100,8 @@ pub enum Error {
     TokioJoinError {
         source: tokio::task::JoinError,
     },
+    TokioMpscSendError {
+        source: tokio::sync::mpsc::error::SendError<PathBuf>,
+    },
     MemoryTableOverflowError {},
 }

--- a/src/ingester/src/partition.rs
+++ b/src/ingester/src/partition.rs
@@ -108,7 +108,7 @@ impl Partition {
             };
             // write into parquet buf
             let (bloom_filter_fields, full_text_search_fields) =
-                if self.schema.fields().len() > cfg.limit.file_move_fields_limit {
+                if self.schema.fields().len() >= cfg.limit.file_move_fields_limit {
                     let bloom_filter_fields =
                         infra::schema::get_stream_setting_bloom_filter_fields(self.schema.as_ref())
                             .unwrap();

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -142,7 +142,7 @@ impl Writer {
             .join("logs")
             .join(idx.to_string());
         log::info!(
-            "[INGESTER:WAL] create file: {}/{}/{}/{}.wal",
+            "[INGESTER:MEM] create file: {}/{}/{}/{}.wal",
             wal_dir.display().to_string(),
             &key.org_id,
             &key.stream_type,
@@ -207,7 +207,7 @@ impl Writer {
                 .join("logs")
                 .join(self.idx.to_string());
             log::info!(
-                "[INGESTER:WAL] create file: {}/{}/{}/{}.wal",
+                "[INGESTER:MEM] create file: {}/{}/{}/{}.wal",
                 wal_dir.display().to_string(),
                 &self.key.org_id,
                 &self.key.stream_type,
@@ -233,9 +233,9 @@ impl Writer {
             let path = old_wal.path().clone();
             let path_str = path.display().to_string();
             let table = Arc::new(Immutable::new(self.idx, self.key.clone(), old_mem));
-            log::info!("[INGESTER:WAL] start add to IMMUTABLES, file: {}", path_str,);
+            log::info!("[INGESTER:MEM] start add to IMMUTABLES, file: {}", path_str,);
             IMMUTABLES.write().await.insert(path, table);
-            log::info!("[INGESTER:WAL] dones add to IMMUTABLES, file: {}", path_str);
+            log::info!("[INGESTER:MEM] dones add to IMMUTABLES, file: {}", path_str);
         }
 
         if !check_ttl {

--- a/src/job/compactor.rs
+++ b/src/job/compactor.rs
@@ -40,10 +40,10 @@ pub async fn run() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    let (tx, rx) = mpsc::channel::<(MergeSender, MergeBatch)>(cfg.limit.file_move_thread_num);
+    let (tx, rx) = mpsc::channel::<(MergeSender, MergeBatch)>(cfg.limit.file_merge_thread_num);
     let rx = Arc::new(Mutex::new(rx));
     // start merge workers
-    for thread_id in 0..cfg.limit.file_move_thread_num {
+    for thread_id in 0..cfg.limit.file_merge_thread_num {
         let rx = rx.clone();
         tokio::spawn(async move {
             loop {

--- a/src/job/flatten_compactor.rs
+++ b/src/job/flatten_compactor.rs
@@ -37,10 +37,10 @@ pub async fn run() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    let (tx, rx) = mpsc::channel::<FileKey>(cfg.limit.file_move_thread_num);
+    let (tx, rx) = mpsc::channel::<FileKey>(cfg.limit.file_merge_thread_num);
     let rx = Arc::new(Mutex::new(rx));
     // start merge workers
-    for _ in 0..cfg.limit.file_move_thread_num {
+    for _ in 0..cfg.limit.file_merge_thread_num {
         let rx = rx.clone();
         tokio::spawn(async move {
             loop {

--- a/src/service/compact/file_list.rs
+++ b/src/service/compact/file_list.rs
@@ -224,7 +224,7 @@ async fn merge_file_list(offset: i64) -> Result<(), anyhow::Error> {
     let filter_file_keys: Arc<RwLock<HashMap<String, FileKey>>> =
         Arc::new(RwLock::new(HashMap::new()));
     let semaphore = std::sync::Arc::new(Semaphore::new(
-        config::get_config().limit.file_move_thread_num,
+        config::get_config().limit.file_merge_thread_num,
     ));
     let mut tasks = Vec::new();
     for file in file_list.clone() {

--- a/src/service/compact/flatten.rs
+++ b/src/service/compact/flatten.rs
@@ -44,7 +44,7 @@ use crate::{common::infra::cluster::get_node_from_consistent_hash, service::db};
 static PROCESSING_FILES: Lazy<RwLock<HashSet<String>>> = Lazy::new(|| RwLock::new(HashSet::new()));
 
 pub async fn run_generate(worker_tx: mpsc::Sender<FileKey>) -> Result<(), anyhow::Error> {
-    let semaphore = std::sync::Arc::new(Semaphore::new(get_config().limit.file_move_thread_num));
+    let semaphore = std::sync::Arc::new(Semaphore::new(get_config().limit.file_merge_thread_num));
     let orgs = db::schema::list_organizations_from_cache().await;
     let stream_types = [StreamType::Logs];
     for org_id in orgs {

--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -184,7 +184,7 @@ pub async fn run_merge(
     worker_tx: mpsc::Sender<(merge::MergeSender, merge::MergeBatch)>,
 ) -> Result<(), anyhow::Error> {
     let cfg = get_config();
-    let semaphore = std::sync::Arc::new(Semaphore::new(cfg.limit.file_move_thread_num));
+    let semaphore = std::sync::Arc::new(Semaphore::new(cfg.limit.file_merge_thread_num));
     let orgs = db::schema::list_organizations_from_cache().await;
     let stream_types = [
         StreamType::Logs,


### PR DESCRIPTION
## New environments

- `ZO_COMPACT_FAST_MODE=true`, Enable fast mode compact, will use more memory but faster
- `ZO_FILE_MOVE_THREAD_NUM=0`, threads num for file move on ingester
- `ZO_MEM_DUMP_THREAD_NUM=0`, threads num for memtable dump to disk on ingester
- `ZO_FILE_MERGE_THREAD_NUM=0`, threads num for file merge on compactor

## Update

- Optimize file_list index
- Optimize MemTable dump to disk, use worker and channels
- Optimize compactor merging to reduce memory usage