### PR TITLE
fix: the base_url didnt contain web+base_uri for presigned url

### DIFF
--- a/src/handler/http/request/users/mod.rs
+++ b/src/handler/http/request/users/mod.rs
@@ -329,11 +329,13 @@ pub async fn get_presigned_url(
     let cfg = get_config();
     let time = chrono::Utc::now().timestamp();
     let password_ext_salt = cfg.auth.ext_auth_salt.as_str();
+
+    let base_url = format!("{}{}", cfg.common.web_url, cfg.common.base_uri);
     let url = generate_presigned_url(
         basic_auth.user_id(),
         basic_auth.password().unwrap(),
         password_ext_salt,
-        &cfg.common.web_url,
+        &base_url,
         query.exp_in as i64,
         time,
     );


### PR DESCRIPTION
In case of generating a presigned-url the base url should be a combination of
```
let base_url = format!("{}{}", cfg.common.web_url, cfg.common.base_uri);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved URL construction by introducing a `base_url` variable for better maintainability and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->