### PR TITLE
feat: support formatting large numbers

### DIFF
--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -75,6 +75,14 @@ const units: any = {
     { unit: "TB", divisor: 1024 * 1024 },
     { unit: "PB", divisor: 1024 * 1024 * 1024 },
   ],
+  largeNumbers: [
+    { unit: "", divisor: 1 },
+    { unit: "K", divisor: 1e3 },
+    { unit: "M", divisor: 1e6 },
+    { unit: "B", divisor: 1e9 },
+    { unit: "T", divisor: 1e12 },
+    { unit: "Q", divisor: 1e15 },
+  ],
 };
 
 /**
@@ -145,13 +153,27 @@ export const getUnitValue = (
       };
     }
     case "default":
-    default: {
-      // console.timeEnd("getUnitValue:");
-      return {
-        value: isNaN(value) ? value : (+value)?.toFixed(decimals) ?? 0,
-        unit: "",
-      };
-    }
+      default: {
+        if (isNaN(value)) {
+          return { value, unit: "" };
+        }
+      
+        let unitIndex = units.largeNumbers.length - 1;
+        while (unitIndex > 0 && absValue < units.largeNumbers[unitIndex].divisor) {
+          unitIndex--;
+        }
+      
+        const finalValue = (
+          (sign * absValue) /
+          units.largeNumbers[unitIndex].divisor
+        ).toFixed(decimals);
+        const finalUnit = units.largeNumbers[unitIndex].unit;
+      
+        return {
+          value: finalValue,
+          unit: finalUnit || "",
+        };
+      }      
   }
 };
 

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -153,27 +153,27 @@ export const getUnitValue = (
       };
     }
     case "default":
-      default: {
-        if (isNaN(value)) {
-          return { value, unit: "" };
-        }
+    default: {
+      if (isNaN(value)) {
+        return { value, unit: "" };
+      }
       
-        let unitIndex = units.largeNumbers.length - 1;
-        while (unitIndex > 0 && absValue < units.largeNumbers[unitIndex].divisor) {
-          unitIndex--;
-        }
+      let unitIndex = units.largeNumbers.length - 1;
+      while (unitIndex > 0 && absValue < units.largeNumbers[unitIndex].divisor) {
+        unitIndex--;
+      }
       
-        const finalValue = (
-          (sign * absValue) /
-          units.largeNumbers[unitIndex].divisor
-        ).toFixed(decimals);
-        const finalUnit = units.largeNumbers[unitIndex].unit;
-      
-        return {
-          value: finalValue,
-          unit: finalUnit || "",
-        };
-      }      
+      const finalValue = (
+        (sign * absValue) /
+        units.largeNumbers[unitIndex].divisor
+      ).toFixed(decimals);
+      const finalUnit = units.largeNumbers[unitIndex].unit;
+
+      return {
+        value: finalValue,
+        unit: finalUnit || "",
+      };
+    }      
   }
 };
 

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -173,7 +173,7 @@ export const getUnitValue = (
         value: finalValue,
         unit: finalUnit || "",
       };
-    }      
+    }
   }
 };
 


### PR DESCRIPTION
The default case currently displays numbers as it is. In the case of the Metric visualization, if the query is `count(messages)` it could be a very large number. For example 1 million will be displayed as `1000000.00` with the changes on this PR it will be displayed as `1.00M`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced handling of large numbers in the dashboard, now including units like "Q" for quadrillion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->