### PR TITLE
fix: pass original timestamp for table chart drilldown

### DIFF
--- a/tests/ui-testing/playwright-tests/sanity.spec.js
+++ b/tests/ui-testing/playwright-tests/sanity.spec.js
@@ -875,7 +875,7 @@ test.describe("Sanity testcases", () => {
     await page
       .locator('[data-test="index-dropdown-stream"]')
       .fill("e2e_tabledashboard");
-    await page.getByRole("option", { name: "e2e_tabledashboard" }).click({force:true});
+    await page.getByRole("option", { name: "e2e_tabledashboard" }).click();
     await page.waitForTimeout(5000);
 
     await page

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -913,6 +913,10 @@ export default defineComponent({
         value: null,
       },
       {
+        label: t("dashboard.numbers"),
+        value: "numbers",
+      },
+      {
         label: t("dashboard.bytes"),
         value: "bytes",
       },

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -594,6 +594,7 @@
     "right": "Right",
     "bottom": "Bottom",
     "default": "Default",
+    "numbers": "Numbers",
     "bytes": "Bytes",
     "kilobytes": "Kilobytes (kb)",
     "megabytes": "Megabytes (mb)",

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -109,6 +109,11 @@ export const getUnitValue = (
     return { value: value, unit: "" };
   }
 
+  // if value is missing use - as a placeholder
+  if (isNaN(value) || value == "") {
+    return { value: value == "" ? "-" : value, unit: "" };
+  }
+
   switch (unit) {
     case "numbers":
     case "bytes":
@@ -119,10 +124,6 @@ export const getUnitValue = (
     case "kilobytes":
     case "bps":
     case "megabytes": {
-      if (isNaN(value) || value == "") {
-        return { value: value == "" ? "-" : value, unit: "" };
-      }
-
       // start with last index
       let unitIndex = units[unit].length - 1;
       // while the value is smaller than the divisor

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -75,7 +75,7 @@ const units: any = {
     { unit: "TB", divisor: 1024 * 1024 },
     { unit: "PB", divisor: 1024 * 1024 * 1024 },
   ],
-  largeNumbers: [
+  numbers: [
     { unit: "", divisor: 1 },
     { unit: "K", divisor: 1e3 },
     { unit: "M", divisor: 1e6 },
@@ -110,6 +110,7 @@ export const getUnitValue = (
   }
 
   switch (unit) {
+    case "numbers":
     case "bytes":
     case "seconds":
     case "microseconds":
@@ -118,6 +119,10 @@ export const getUnitValue = (
     case "kilobytes":
     case "bps":
     case "megabytes": {
+      if (isNaN(value) || value == "") {
+        return { value: value == "" ? "-" : value, unit: "" };
+      }
+
       // start with last index
       let unitIndex = units[unit].length - 1;
       // while the value is smaller than the divisor
@@ -158,24 +163,13 @@ export const getUnitValue = (
     }
     case "default":
     default: {
-      if (isNaN(value) || value == "") {
-        return { value: value == "" ? "-" : value, unit: "" };
-      }
-
-      let unitIndex = units.largeNumbers.length - 1;
-      while (unitIndex > 0 && absValue < units.largeNumbers[unitIndex].divisor) {
-        unitIndex--;
-      }
-      
-      const finalValue = (
-        (sign * absValue) /
-        units.largeNumbers[unitIndex].divisor
-      ).toFixed(decimals);
-      const finalUnit = units.largeNumbers[unitIndex].unit;
-
       return {
-        value: finalValue,
-        unit: finalUnit || "",
+        value: isNaN(value)
+          ? value
+          : value == ""
+          ? "-"
+          : (+value)?.toFixed(decimals) ?? 0,
+        unit: "",
       };
     }
   }

--- a/web/src/utils/dashboard/convertTableData.ts
+++ b/web/src/utils/dashboard/convertTableData.ts
@@ -113,7 +113,10 @@ export const convertTableData = (
             }`
           : val;
       };
-    } else if (histogramFields.includes(it.alias)) {
+    }
+
+    // if current field is histogram field then return formatted date
+    if (histogramFields.includes(it.alias)) {
       // if current field is histogram field then return formatted date
       obj["format"] = (val: any) => {
         return formatDate(


### PR DESCRIPTION
- issue while passing timestamp for table chart drilldown.
- use different unit type for large numbers.

![image](https://github.com/openobserve/openobserve/assets/141122205/cefcbdc0-2d19-4401-995b-4ee9ade3a56a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "numbers" option in the ConfigPanel for dashboards.

- **Improvements**
  - Enhanced column formatting to handle histogram fields more effectively.
  - Renamed `largeNumbers` to `numbers` for better clarity in unit handling.

- **Bug Fixes**
  - Improved `getUnitValue` function to check for `NaN` values and empty strings before processing.

- **Localization**
  - Added a new key-value pair `"numbers": "Numbers"` to the English locale.

- **Tests**
  - Removed unnecessary force option from a Playwright test click action to improve test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->