### PR TITLE
fix: include login calls into auditing

### DIFF
--- a/src/handler/http/auth/token.rs
+++ b/src/handler/http/auth/token.rs
@@ -115,6 +115,28 @@ pub async fn token_validator(
     }
 }
 
+#[cfg(feature = "enterprise")]
+pub async fn get_user_name_from_token(auth_str: &str) -> Option<String> {
+    let keys = get_jwks().await;
+    match jwt::verify_decode_token(
+        auth_str.strip_prefix("Bearer").unwrap().trim(),
+        &keys,
+        &O2_CONFIG.dex.client_id,
+        false,
+    )
+    .await
+    {
+        Ok(res) => {
+            if res.0.is_valid {
+                Some(res.0.user_email)
+            } else {
+                None
+            }
+        }
+        Err(_) => None,
+    }
+}
+
 #[cfg(not(feature = "enterprise"))]
 pub async fn token_validator(
     req: ServiceRequest,

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -96,6 +96,8 @@ pub async fn init() -> Result<(), anyhow::Error> {
     }
 
     tokio::task::spawn(async move { usage::run().await });
+    #[cfg(feature = "enterprise")]
+    tokio::task::spawn(async move { usage::run_audit_publish().await });
 
     // initialize metadata watcher
     tokio::task::spawn(async move { db::schema::watch().await });

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -85,6 +85,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
     // check version
     db::version::set().await.expect("db version set failed");
 
+    // Auth auditing should be done by router also
+    #[cfg(feature = "enterprise")]
+    tokio::task::spawn(async move { usage::run_audit_publish().await });
+
     // Router doesn't need to initialize job
     if cluster::is_router(&cluster::LOCAL_NODE_ROLE) {
         return Ok(());
@@ -96,8 +100,6 @@ pub async fn init() -> Result<(), anyhow::Error> {
     }
 
     tokio::task::spawn(async move { usage::run().await });
-    #[cfg(feature = "enterprise")]
-    tokio::task::spawn(async move { usage::run_audit_publish().await });
 
     // initialize metadata watcher
     tokio::task::spawn(async move { db::schema::watch().await });

--- a/src/service/usage/mod.rs
+++ b/src/service/usage/mod.rs
@@ -391,6 +391,26 @@ pub async fn run() {
     }
 }
 
+// Cron job to frequently publish auditted events
+#[cfg(feature = "enterprise")]
+pub async fn run_audit_publish() {
+    use o2_enterprise::enterprise::common::{
+        auditor::publish_existing_audits, infra::config::O2_CONFIG,
+    };
+    if !O2_CONFIG.common.audit_enabled {
+        return;
+    }
+    let mut audit_interval = time::interval(time::Duration::from_secs(
+        O2_CONFIG.common.audit_publish_interval.try_into().unwrap(),
+    ));
+    audit_interval.tick().await; // trigger the first run
+    loop {
+        log::info!("Audit ingestion loop running");
+        audit_interval.tick().await;
+        publish_existing_audits(publish_audit).await;
+    }
+}
+
 #[cfg(feature = "enterprise")]
 pub async fn audit(msg: auditor::AuditMessage) {
     auditor::audit(msg, publish_audit).await;

--- a/src/service/usage/mod.rs
+++ b/src/service/usage/mod.rs
@@ -277,7 +277,7 @@ async fn ingest_usages(curr_usages: Vec<UsageData>) {
         } else {
             format!("Basic {}", &cfg.common.usage_reporting_creds)
         };
-        if let Err(e) = Client::builder()
+        match Client::builder()
             .build()
             .unwrap()
             .post(url)
@@ -287,13 +287,33 @@ async fn ingest_usages(curr_usages: Vec<UsageData>) {
             .send()
             .await
         {
-            log::error!("Error in ingesting usage data to external URL {:?}", e);
-            if &cfg.common.usage_reporting_mode != "both" {
-                // on error in ingesting usage data, push back the data
-                let mut usages = USAGE_DATA.write().await;
-                let mut curr_usages = curr_usages.clone();
-                usages.append(&mut curr_usages);
-                drop(usages);
+            Ok(resp) => {
+                let resp_status = resp.status();
+                if !resp_status.is_success() {
+                    log::error!(
+                        "Error in ingesting usage data to external URL: {}",
+                        resp.text()
+                            .await
+                            .unwrap_or_else(|_| resp_status.to_string())
+                    );
+                    if &cfg.common.usage_reporting_mode != "both" {
+                        // on error in ingesting usage data, push back the data
+                        let mut usages = USAGE_DATA.write().await;
+                        let mut curr_usages = curr_usages.clone();
+                        usages.append(&mut curr_usages);
+                        drop(usages);
+                    }
+                }
+            }
+            Err(e) => {
+                log::error!("Error in ingesting usage data to external URL {:?}", e);
+                if &cfg.common.usage_reporting_mode != "both" {
+                    // on error in ingesting usage data, push back the data
+                    let mut usages = USAGE_DATA.write().await;
+                    let mut curr_usages = curr_usages.clone();
+                    usages.append(&mut curr_usages);
+                    drop(usages);
+                }
             }
         }
     }
@@ -405,7 +425,7 @@ pub async fn run_audit_publish() {
     ));
     audit_interval.tick().await; // trigger the first run
     loop {
-        log::info!("Audit ingestion loop running");
+        log::debug!("Audit ingestion loop running");
         audit_interval.tick().await;
         publish_existing_audits(publish_audit).await;
     }


### PR DESCRIPTION
- [x] Includes the following APIs endpoints in auditing -
- `/auth/login` - If the login is successful, the user email along with the event data (such as response code, path, method, query params and the timestamp) and if it is unsuccessful, it still audits the event, but username will be present only if available.
- `/auth/presigned-url`
- `/auth/login` - `GET` request. Similar to the first `login` endpoint.
- `/config/reload` - Audits this event, but as this is not a protected route, the username will not be present in the audit record.
- `/config/redirect` - Similar to the first `login` endpoint.
- `/config/logout`

- [x] Audit Cron job is run on all the nodes including the router. The interval can be set through `O2_AUDIT_PUBLISH_INTERVAL` env (in seconds).
- [x] In case of remote usage reporing, print the error if response from remote usage url is unsuccessful


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced auditing functionalities for user authentication and authorization in the enterprise version.
  - Added asynchronous task for auditing and publishing tasks within job module.

- **Improvements**
  - Refined error handling in usage data ingestion to better manage success and failure responses.
  
- **Conditional Compilation**
  - Multiple new functionalities and auditing enhancements are now conditionally compiled based on the "enterprise" feature.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->