### PR TITLE
refactor: compactor working with job queue

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -870,6 +870,18 @@ pub struct Compact {
         help = "Enable fast mode compact, will use more memory but faster"
     )]
     pub fast_mode: bool,
+    #[env_config(
+        name = "ZO_COMPACT_BATCH_SIZE",
+        default = 100,
+        help = "Batch size for compact get pending jobs"
+    )]
+    pub batch_size: i64,
+    #[env_config(
+        name = "ZO_COMPACT_JOB_TIMEOUT",
+        default = 600,
+        help = "If a compact job is not finished in this time, it will be marked as failed"
+    )]
+    pub job_timeout: i64,
 }
 
 #[derive(EnvConfig)]
@@ -1263,6 +1275,9 @@ fn check_common_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         return Err(anyhow::anyhow!(
             "Delete files delay is not allowed to be less than 1 hour."
         ));
+    }
+    if cfg.compact.batch_size < 1 {
+        cfg.compact.batch_size = 100;
     }
 
     // If the default scrape interval is less than 5s, raise an error

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -877,11 +877,17 @@ pub struct Compact {
     )]
     pub batch_size: i64,
     #[env_config(
-        name = "ZO_COMPACT_JOB_TIMEOUT",
-        default = 600,
+        name = "ZO_COMPACT_JOB_RUN_TIMEOUT",
+        default = 1800, // 30 minutes
         help = "If a compact job is not finished in this time, it will be marked as failed"
     )]
-    pub job_timeout: i64,
+    pub job_run_timeout: i64,
+    #[env_config(
+        name = "ZO_COMPACT_JOB_CLEAN_WAIT_TIME",
+        default = 86400, // 1 day
+        help = "Clean the jobs which are finished more than this time"
+    )]
+    pub job_clean_wait_time: i64,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -262,7 +262,7 @@ impl<'a> TryFrom<Group<'a>> for String {
         match &g.0 {
             SqlExpr::Identifier(id) => Ok(id.to_string()),
             expr => Err(anyhow::anyhow!(
-                "We only support identifier for order by, got {expr}"
+                "We only support identifier for group by, got {expr}"
             )),
         }
     }

--- a/src/config/src/utils/time.rs
+++ b/src/config/src/utils/time.rs
@@ -35,6 +35,11 @@ static TIME_UNITS: [(char, u64); 7] = [
 ];
 
 #[inline(always)]
+pub fn now_micros() -> i64 {
+    Utc::now().timestamp_micros()
+}
+
+#[inline(always)]
 pub fn parse_i64_to_timestamp_micros(v: i64) -> i64 {
     if v == 0 {
         return Utc::now().timestamp_micros();

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -126,7 +126,7 @@ pub trait FileList: Sync + Send + 'static {
     async fn set_job_done(&self, id: i64) -> Result<()>;
     async fn update_running_jobs(&self, id: i64) -> Result<()>;
     async fn check_running_jobs(&self, before_date: i64) -> Result<()>;
-    async fn clean_jobs(&self, before_date: i64) -> Result<()>;
+    async fn clean_done_jobs(&self, before_date: i64) -> Result<()>;
 }
 
 pub async fn create_table() -> Result<()> {
@@ -342,8 +342,8 @@ pub async fn check_running_jobs(before_date: i64) -> Result<()> {
 }
 
 #[inline]
-pub async fn clean_jobs(before_date: i64) -> Result<()> {
-    CLIENT.clean_jobs(before_date).await
+pub async fn clean_done_jobs(before_date: i64) -> Result<()> {
+    CLIENT.clean_done_jobs(before_date).await
 }
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -120,11 +120,11 @@ pub trait FileList: Sync + Send + 'static {
         org_id: &str,
         stream_type: StreamType,
         stream: &str,
-        date: i64,
         offset: i64,
     ) -> Result<()>;
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<MergeJobRecord>>;
     async fn set_job_done(&self, id: i64) -> Result<()>;
+    async fn update_running_jobs(&self, id: i64) -> Result<()>;
     async fn check_running_jobs(&self, before_date: i64) -> Result<()>;
     async fn clean_jobs(&self, before_date: i64) -> Result<()>;
 }
@@ -311,6 +311,41 @@ pub async fn clear() -> Result<()> {
     CLIENT.clear().await
 }
 
+#[inline]
+pub async fn add_job(
+    org_id: &str,
+    stream_type: StreamType,
+    stream: &str,
+    offset: i64,
+) -> Result<()> {
+    CLIENT.add_job(org_id, stream_type, stream, offset).await
+}
+
+#[inline]
+pub async fn get_pending_jobs(node: &str, limit: i64) -> Result<Vec<MergeJobRecord>> {
+    CLIENT.get_pending_jobs(node, limit).await
+}
+
+#[inline]
+pub async fn set_job_done(id: i64) -> Result<()> {
+    CLIENT.set_job_done(id).await
+}
+
+#[inline]
+pub async fn update_running_jobs(id: i64) -> Result<()> {
+    CLIENT.update_running_jobs(id).await
+}
+
+#[inline]
+pub async fn check_running_jobs(before_date: i64) -> Result<()> {
+    CLIENT.check_running_jobs(before_date).await
+}
+
+#[inline]
+pub async fn clean_jobs(before_date: i64) -> Result<()> {
+    CLIENT.clean_jobs(before_date).await
+}
+
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
 pub struct FileRecord {
     pub stream: String,
@@ -374,17 +409,14 @@ pub struct FileDeletedRecord {
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
 pub struct MergeJobRecord {
     pub id: i64,
-    pub org: String,    // org id
     pub stream: String, // default/logs/default
-    pub date: i64,      // 20240617
     pub offset: i64,    // 1718603746000000
-    pub node: String,   // node name
 }
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
 pub struct MergeJobPendingRecord {
-    pub stream: String,
     pub id: i64,
+    pub stream: String,
     pub num: i64,
 }
 

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -410,7 +410,7 @@ pub struct FileDeletedRecord {
 pub struct MergeJobRecord {
     pub id: i64,
     pub stream: String, // default/logs/default
-    pub offset: i64,    // 1718603746000000
+    pub offsets: i64,   // 1718603746000000
 }
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -604,7 +604,7 @@ UPDATE stream_stats
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
         match sqlx::query(
-            "INSERT IGNORE INTO file_list_job (org, stream, offset, node, updated_at) VALUES (?, ?, ?, '', 0);",
+            "INSERT IGNORE INTO file_list_jobs (org, stream, offset, node, updated_at) VALUES (?, ?, ?, '', 0);",
         )
         .bind(org_id)
         .bind(stream_key)
@@ -737,7 +737,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         Ok(())
     }
 
-    async fn clean_jobs(&self, before_date: i64) -> Result<()> {
+    async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         let ret = sqlx::query(r#"DELETE FROM file_list_jobs WHERE status = ? AND updated_at < ?;"#)
             .bind(super::FileListJobStatus::Done)
@@ -922,7 +922,7 @@ CREATE TABLE IF NOT EXISTS file_list_jobs
     id         BIGINT not null primary key AUTO_INCREMENT,
     org        VARCHAR(100) not null,
     stream     VARCHAR(256) not null,
-    offset     INT not null,
+    offset     BIGINT not null,
     status     INT not null,
     node       VARCHAR(100) not null,
     updated_at BIGINT not null

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -604,11 +604,12 @@ UPDATE stream_stats
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
         match sqlx::query(
-            "INSERT IGNORE INTO file_list_jobs (org, stream, offset, node, updated_at) VALUES (?, ?, ?, '', 0);",
+            "INSERT IGNORE INTO file_list_jobs (org, stream, offsets, status, node, updated_at) VALUES (?, ?, ?, ?, '', 0);",
         )
         .bind(org_id)
         .bind(stream_key)
         .bind(offset)
+        .bind(super::FileListJobStatus::Pending)
         .execute(&pool)
         .await
         {
@@ -922,7 +923,7 @@ CREATE TABLE IF NOT EXISTS file_list_jobs
     id         BIGINT not null primary key AUTO_INCREMENT,
     org        VARCHAR(100) not null,
     stream     VARCHAR(256) not null,
-    offset     BIGINT not null,
+    offsets    BIGINT not null,
     status     INT not null,
     node       VARCHAR(100) not null,
     updated_at BIGINT not null
@@ -992,7 +993,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
         (
             "file_list_jobs",
-            "CREATE UNIQUE INDEX file_list_jobs_stream_offset_idx on file_list_jobs (stream, offset);",
+            "CREATE UNIQUE INDEX file_list_jobs_stream_offsets_idx on file_list_jobs (stream, offsets);",
         ),
         (
             "file_list_jobs",

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -593,6 +593,154 @@ UPDATE stream_stats
     async fn clear(&self) -> Result<()> {
         Ok(())
     }
+
+    async fn add_job(
+        &self,
+        org_id: &str,
+        stream_type: StreamType,
+        stream: &str,
+        date: i64,
+        offset: i64,
+    ) -> Result<()> {
+        let stream_key = format!("{org_id}/{stream_type}/{stream}");
+        let pool = CLIENT.clone();
+        match sqlx::query(
+            "INSERT IGNORE INTO file_list_job (org, stream, date, offset, node, updated_at) VALUES (?, ?, ?, ?, '', 0);",
+        )
+        .bind(org_id)
+        .bind(stream_key)
+        .bind(date)
+        .bind(offset)
+        .execute(&pool)
+        .await
+        {
+            Err(sqlx::Error::Database(e)) => if e.is_unique_violation() {
+                Ok(())
+            } else {
+                Err(Error::Message(e.to_string()))
+            },
+            Err(e) => Err(e.into()),
+            Ok(_) => Ok(()),
+        }
+    }
+
+    async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {
+        let pool = CLIENT.clone();
+        let mut tx = pool.begin().await?;
+        // get pending jobs group by stream and order by num desc
+        let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(
+            r#"
+SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
+    FROM file_list_jobs 
+    WHERE status = ? 
+    GROUP BY stream 
+    ORDER BY num DESC 
+    LIMIT ? 
+    FOR UPDATE;"#,
+        )
+        .bind(super::FileListJobStatus::Pending)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                if let Err(e) = tx.rollback().await {
+                    log::error!(
+                        "[MYSQL] rollback select file_list_jobs pending jobs for update error: {e}"
+                    );
+                }
+                return Err(e.into());
+            }
+        };
+        // update jobs status to running
+        let ids = ret.iter().map(|r| r.id.to_string()).collect::<Vec<_>>();
+        if ids.is_empty() {
+            if let Err(e) = tx.rollback().await {
+                log::error!("[MYSQL] rollback select file_list_jobs pending jobs error: {e}");
+            }
+            return Ok(Vec::new());
+        }
+        let sql = format!(
+            "UPDATE file_list_jobs SET status = ?, node = ?, updated_at = ? WHERE id IN ({});",
+            ids.join(",")
+        );
+        if let Err(e) = sqlx::query(&sql)
+            .bind(super::FileListJobStatus::Running)
+            .bind(node)
+            .bind(config::utils::time::now_micros())
+            .execute(&mut *tx)
+            .await
+        {
+            if let Err(e) = tx.rollback().await {
+                log::error!("[MYSQL] rollback update file_list_jobs status error: {e}");
+            }
+            return Err(e.into());
+        }
+        // get jobs by ids
+        let sql = format!(
+            "SELECT * FROM file_list_jobs WHERE id IN ({});",
+            ids.join(",")
+        );
+        let ret = match sqlx::query_as::<_, super::MergeJobRecord>(&sql)
+            .fetch_all(&mut *tx)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                if let Err(e) = tx.rollback().await {
+                    log::error!("[MYSQL] rollback select file_list_jobs by ids error: {e}");
+                }
+                return Err(e.into());
+            }
+        };
+        if let Err(e) = tx.commit().await {
+            log::error!("[MYSQL] commit select file_list_jobs pending jobs error: {e}");
+            return Err(e.into());
+        }
+        Ok(ret)
+    }
+
+    async fn set_job_done(&self, id: i64) -> Result<()> {
+        let pool = CLIENT.clone();
+        sqlx::query(r#"UPDATE file_list_jobs SET status = ?, updated_at = ? WHERE id = ?;"#)
+            .bind(super::FileListJobStatus::Done)
+            .bind(config::utils::time::now_micros())
+            .bind(id)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
+        let pool = CLIENT.clone();
+        let ret = sqlx::query(
+            r#"UPDATE file_list_jobs SET status = ?, updated_at = ? WHERE status = ? AND updated_at < ?;"#,
+        )
+        .bind(super::FileListJobStatus::Pending)
+        .bind(config::utils::time::now_micros())
+        .bind(super::FileListJobStatus::Running)
+        .bind(before_date)
+        .execute(&pool)
+        .await?;
+        if ret.rows_affected() > 0 {
+            log::warn!("[MYSQL] reset running jobs status to pending");
+        }
+        Ok(())
+    }
+
+    async fn clean_jobs(&self, before_date: i64) -> Result<()> {
+        let pool = CLIENT.clone();
+        let ret = sqlx::query(r#"DELETE FROM file_list_jobs WHERE status = ? AND updated_at < ?;"#)
+            .bind(super::FileListJobStatus::Done)
+            .bind(before_date)
+            .execute(&pool)
+            .await?;
+        if ret.rows_affected() > 0 {
+            log::warn!("[MYSQL] clean done jobs");
+        }
+        Ok(())
+    }
 }
 
 impl MysqlFileList {
@@ -761,6 +909,24 @@ CREATE TABLE IF NOT EXISTS file_list_deleted
 
     sqlx::query(
         r#"
+CREATE TABLE IF NOT EXISTS file_list_jobs
+(
+    id         BIGINT not null primary key AUTO_INCREMENT,
+    org        VARCHAR(100) not null,
+    stream     VARCHAR(256) not null,
+    date       INT not null,
+    offset     INT not null,
+    status     INT not null,
+    node       VARCHAR(100) not null,
+    updated_at BIGINT not null
+);
+        "#,
+    )
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        r#"
 CREATE TABLE IF NOT EXISTS stream_stats
 (
     id       BIGINT not null primary key AUTO_INCREMENT,
@@ -816,6 +982,18 @@ pub async fn create_table_index() -> Result<()> {
         (
             "file_list_deleted",
             "CREATE INDEX file_list_deleted_stream_date_file_idx on file_list_deleted (stream, date, file);",
+        ),
+        (
+            "file_list_jobs",
+            "CREATE UNIQUE INDEX file_list_jobs_stream_offset_idx on file_list_jobs (stream, offset);",
+        ),
+        (
+            "file_list_jobs",
+            "CREATE INDEX file_list_jobs_stream_date_idx on file_list_jobs (stream, date);",
+        ),
+        (
+            "file_list_jobs",
+            "CREATE INDEX file_list_jobs_stream_status_idx on file_list_jobs (status, stream);",
         ),
         (
             "stream_stats",

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -599,17 +599,15 @@ UPDATE stream_stats
         org_id: &str,
         stream_type: StreamType,
         stream: &str,
-        date: i64,
         offset: i64,
     ) -> Result<()> {
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
         match sqlx::query(
-            "INSERT IGNORE INTO file_list_job (org, stream, date, offset, node, updated_at) VALUES (?, ?, ?, ?, '', 0);",
+            "INSERT IGNORE INTO file_list_job (org, stream, offset, node, updated_at) VALUES (?, ?, ?, '', 0);",
         )
         .bind(org_id)
         .bind(stream_key)
-        .bind(date)
         .bind(offset)
         .execute(&pool)
         .await
@@ -712,10 +710,20 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         Ok(())
     }
 
+    async fn update_running_jobs(&self, id: i64) -> Result<()> {
+        let pool = CLIENT.clone();
+        sqlx::query(r#"UPDATE file_list_jobs SET updated_at = ? WHERE id = ?;"#)
+            .bind(config::utils::time::now_micros())
+            .bind(id)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
     async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         let ret = sqlx::query(
-            r#"UPDATE file_list_jobs SET status = ?, updated_at = ? WHERE status = ? AND updated_at < ?;"#,
+            r#"UPDATE file_list_jobs SET status = ?, node = '', updated_at = ? WHERE status = ? AND updated_at < ?;"#,
         )
         .bind(super::FileListJobStatus::Pending)
         .bind(config::utils::time::now_micros())
@@ -914,7 +922,6 @@ CREATE TABLE IF NOT EXISTS file_list_jobs
     id         BIGINT not null primary key AUTO_INCREMENT,
     org        VARCHAR(100) not null,
     stream     VARCHAR(256) not null,
-    date       INT not null,
     offset     INT not null,
     status     INT not null,
     node       VARCHAR(100) not null,
@@ -986,10 +993,6 @@ pub async fn create_table_index() -> Result<()> {
         (
             "file_list_jobs",
             "CREATE UNIQUE INDEX file_list_jobs_stream_offset_idx on file_list_jobs (stream, offset);",
-        ),
-        (
-            "file_list_jobs",
-            "CREATE INDEX file_list_jobs_stream_date_idx on file_list_jobs (stream, date);",
         ),
         (
             "file_list_jobs",

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -608,7 +608,7 @@ UPDATE stream_stats
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
         match sqlx::query(
-            "INSERT INTO file_list_job (org, stream, offset, node, updated_at) VALUES ($1, $2, $3, '', 0) ON CONFLICT DO NOTHING;",
+            "INSERT INTO file_list_jobs (org, stream, offset, node, updated_at) VALUES ($1, $2, $3, '', 0) ON CONFLICT DO NOTHING;",
         )
         .bind(org_id)
         .bind(stream_key)
@@ -741,7 +741,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         Ok(())
     }
 
-    async fn clean_jobs(&self, before_date: i64) -> Result<()> {
+    async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         let ret =
             sqlx::query(r#"DELETE FROM file_list_jobs WHERE status = $1 AND updated_at < $2;"#)
@@ -928,7 +928,7 @@ CREATE TABLE IF NOT EXISTS file_list_jobs
     id         BIGINT GENERATED ALWAYS AS IDENTITY,
     org        VARCHAR(100) not null,
     stream     VARCHAR(256) not null,
-    offset     INT not null,
+    offset     BIGINT not null,
     status     INT not null,
     node       VARCHAR(100) not null,
     updated_at BIGINT not null

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -608,11 +608,12 @@ UPDATE stream_stats
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
         match sqlx::query(
-            "INSERT INTO file_list_jobs (org, stream, offset, node, updated_at) VALUES ($1, $2, $3, '', 0) ON CONFLICT DO NOTHING;",
+            "INSERT INTO file_list_jobs (org, stream, offsets, status, node, updated_at) VALUES ($1, $2, $3, $4, '', 0) ON CONFLICT DO NOTHING;",
         )
         .bind(org_id)
         .bind(stream_key)
         .bind(offset)
+        .bind(super::FileListJobStatus::Pending)
         .execute(&pool)
         .await
         {
@@ -928,7 +929,7 @@ CREATE TABLE IF NOT EXISTS file_list_jobs
     id         BIGINT GENERATED ALWAYS AS IDENTITY,
     org        VARCHAR(100) not null,
     stream     VARCHAR(256) not null,
-    offset     BIGINT not null,
+    offsets    BIGINT not null,
     status     INT not null,
     node       VARCHAR(100) not null,
     updated_at BIGINT not null
@@ -998,7 +999,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
         (
             "file_list_jobs",
-            "CREATE UNIQUE INDEX IF NOT EXISTS file_list_jobs_stream_offset_idx on file_list_jobs (stream, offset);",
+            "CREATE UNIQUE INDEX IF NOT EXISTS file_list_jobs_stream_offsets_idx on file_list_jobs (stream, offsets);",
         ),
         (
             "file_list_jobs",

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -597,6 +597,155 @@ UPDATE stream_stats
     async fn clear(&self) -> Result<()> {
         Ok(())
     }
+
+    async fn add_job(
+        &self,
+        org_id: &str,
+        stream_type: StreamType,
+        stream: &str,
+        date: i64,
+        offset: i64,
+    ) -> Result<()> {
+        let stream_key = format!("{org_id}/{stream_type}/{stream}");
+        let pool = CLIENT.clone();
+        match sqlx::query(
+            "INSERT INTO file_list_job (org, stream, date, offset, node, updated_at) VALUES ($1, $2, $3, $4, '', 0) ON CONFLICT DO NOTHING;",
+        )
+        .bind(org_id)
+        .bind(stream_key)
+        .bind(date)
+        .bind(offset)
+        .execute(&pool)
+        .await
+        {
+            Err(sqlx::Error::Database(e)) => if e.is_unique_violation() {
+                Ok(())
+            } else {
+                Err(Error::Message(e.to_string()))
+            },
+            Err(e) => Err(e.into()),
+            Ok(_) => Ok(()),
+        }
+    }
+
+    async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {
+        let pool = CLIENT.clone();
+        let mut tx = pool.begin().await?;
+        // get pending jobs group by stream and order by num desc
+        let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(
+            r#"
+SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
+    FROM file_list_jobs 
+    WHERE status = $1 
+    GROUP BY stream 
+    ORDER BY num DESC 
+    LIMIT $2 
+    FOR UPDATE;"#,
+        )
+        .bind(super::FileListJobStatus::Pending)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                if let Err(e) = tx.rollback().await {
+                    log::error!(
+                        "[POSTGRES] rollback select file_list_jobs pending jobs for update error: {e}"
+                    );
+                }
+                return Err(e.into());
+            }
+        };
+        // update jobs status to running
+        let ids = ret.iter().map(|r| r.id.to_string()).collect::<Vec<_>>();
+        if ids.is_empty() {
+            if let Err(e) = tx.rollback().await {
+                log::error!("[POSTGRES] rollback select file_list_jobs pending jobs error: {e}");
+            }
+            return Ok(Vec::new());
+        }
+        let sql = format!(
+            "UPDATE file_list_jobs SET status = $1, node = $2, updated_at = $3 WHERE id IN ({});",
+            ids.join(",")
+        );
+        if let Err(e) = sqlx::query(&sql)
+            .bind(super::FileListJobStatus::Running)
+            .bind(node)
+            .bind(config::utils::time::now_micros())
+            .execute(&mut *tx)
+            .await
+        {
+            if let Err(e) = tx.rollback().await {
+                log::error!("[POSTGRES] rollback update file_list_jobs status error: {e}");
+            }
+            return Err(e.into());
+        }
+        // get jobs by ids
+        let sql = format!(
+            "SELECT * FROM file_list_jobs WHERE id IN ({});",
+            ids.join(",")
+        );
+        let ret = match sqlx::query_as::<_, super::MergeJobRecord>(&sql)
+            .fetch_all(&mut *tx)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                if let Err(e) = tx.rollback().await {
+                    log::error!("[POSTGRES] rollback select file_list_jobs by ids error: {e}");
+                }
+                return Err(e.into());
+            }
+        };
+        if let Err(e) = tx.commit().await {
+            log::error!("[POSTGRES] commit select file_list_jobs pending jobs error: {e}");
+            return Err(e.into());
+        }
+        Ok(ret)
+    }
+
+    async fn set_job_done(&self, id: i64) -> Result<()> {
+        let pool = CLIENT.clone();
+        sqlx::query(r#"UPDATE file_list_jobs SET status = $1, updated_at = $2 WHERE id = $3;"#)
+            .bind(super::FileListJobStatus::Done)
+            .bind(config::utils::time::now_micros())
+            .bind(id)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
+        let pool = CLIENT.clone();
+        let ret = sqlx::query(
+            r#"UPDATE file_list_jobs SET status = $1, updated_at = $2 WHERE status = $3 AND updated_at < $4;"#,
+        )
+        .bind(super::FileListJobStatus::Pending)
+        .bind(config::utils::time::now_micros())
+        .bind(super::FileListJobStatus::Running)
+        .bind(before_date)
+        .execute(&pool)
+        .await?;
+        if ret.rows_affected() > 0 {
+            log::warn!("[POSTGRES] reset running jobs status to pending");
+        }
+        Ok(())
+    }
+
+    async fn clean_jobs(&self, before_date: i64) -> Result<()> {
+        let pool = CLIENT.clone();
+        let ret =
+            sqlx::query(r#"DELETE FROM file_list_jobs WHERE status = $1 AND updated_at < $2;"#)
+                .bind(super::FileListJobStatus::Done)
+                .bind(before_date)
+                .execute(&pool)
+                .await?;
+        if ret.rows_affected() > 0 {
+            log::warn!("[POSTGRES] clean done jobs");
+        }
+        Ok(())
+    }
 }
 
 impl PostgresFileList {
@@ -766,6 +915,24 @@ CREATE TABLE IF NOT EXISTS file_list_deleted
 
     sqlx::query(
         r#"
+CREATE TABLE IF NOT EXISTS file_list_jobs
+(
+    id         BIGINT GENERATED ALWAYS AS IDENTITY,
+    org        VARCHAR(100) not null,
+    stream     VARCHAR(256) not null,
+    date       INT not null,
+    offset     INT not null,
+    status     INT not null,
+    node       VARCHAR(100) not null,
+    updated_at BIGINT not null
+);
+        "#,
+    )
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        r#"
 CREATE TABLE IF NOT EXISTS stream_stats
 (
     id       BIGINT GENERATED ALWAYS AS IDENTITY,
@@ -821,6 +988,18 @@ pub async fn create_table_index() -> Result<()> {
         (
             "file_list_deleted",
             "CREATE INDEX IF NOT EXISTS file_list_deleted_stream_date_file_idx on file_list_deleted (stream, date, file);",
+        ),
+        (
+            "file_list_jobs",
+            "CREATE UNIQUE INDEX IF NOT EXISTS file_list_jobs_stream_offset_idx on file_list_jobs (stream, offset);",
+        ),
+        (
+            "file_list_jobs",
+            "CREATE INDEX IF NOT EXISTS file_list_jobs_stream_date_idx on file_list_jobs (stream, date);",
+        ),
+        (
+            "file_list_jobs",
+            "CREATE INDEX IF NOT EXISTS file_list_jobs_stream_status_idx on file_list_jobs (status, stream);",
         ),
         (
             "stream_stats",

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -619,7 +619,7 @@ SELECT stream, MIN(min_ts) as min_ts, MAX(max_ts) as max_ts, COUNT(*) as file_nu
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
         match sqlx::query(
-            "INSERT INTO file_list_job (org, stream, offset, node, updated_at) VALUES ($1, $2, $3, '', 0);",
+            "INSERT INTO file_list_jobs (org, stream, offset, node, updated_at) VALUES ($1, $2, $3, '', 0);",
         )
         .bind(org_id)
         .bind(stream_key)
@@ -756,7 +756,7 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         Ok(())
     }
 
-    async fn clean_jobs(&self, before_date: i64) -> Result<()> {
+    async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
         let ret =
@@ -949,7 +949,7 @@ CREATE TABLE IF NOT EXISTS file_list_jobs
     id         INTEGER not null primary key autoincrement,
     org        VARCHAR not null,
     stream     VARCHAR not null,
-    offset     INT not null,
+    offset     BIGINT not null,
     status     INT not null,
     node       VARCHAR not null,
     updated_at BIGINT not null

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -607,6 +607,160 @@ SELECT stream, MIN(min_ts) as min_ts, MAX(max_ts) as max_ts, COUNT(*) as file_nu
     async fn clear(&self) -> Result<()> {
         Ok(())
     }
+
+    async fn add_job(
+        &self,
+        org_id: &str,
+        stream_type: StreamType,
+        stream: &str,
+        date: i64,
+        offset: i64,
+    ) -> Result<()> {
+        let stream_key = format!("{org_id}/{stream_type}/{stream}");
+        let client = CLIENT_RW.clone();
+        let client = client.lock().await;
+        match sqlx::query(
+            "INSERT INTO file_list_job (org, stream, date, offset, node, updated_at) VALUES ($1, $2, $3, $4, '', 0);",
+        )
+        .bind(org_id)
+        .bind(stream_key)
+        .bind(date)
+        .bind(offset)
+        .execute(&*client)
+        .await
+        {
+            Err(sqlx::Error::Database(e)) => if e.is_unique_violation() {
+                Ok(())
+            } else {
+                Err(Error::Message(e.to_string()))
+            },
+            Err(e) => Err(e.into()),
+            Ok(_) => Ok(()),
+        }
+    }
+
+    async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {
+        let client = CLIENT_RW.clone();
+        let client = client.lock().await;
+        let mut tx = client.begin().await?;
+        // get pending jobs group by stream and order by num desc
+        let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(
+            r#"
+SELECT stream, max(id) as id, COUNT(*) AS num
+    FROM file_list_jobs 
+    WHERE status = $1 
+    GROUP BY stream 
+    ORDER BY num DESC 
+    LIMIT $2 
+    FOR UPDATE;"#,
+        )
+        .bind(super::FileListJobStatus::Pending)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                if let Err(e) = tx.rollback().await {
+                    log::error!(
+                        "[SQLITE] rollback select file_list_jobs pending jobs for update error: {e}"
+                    );
+                }
+                return Err(e.into());
+            }
+        };
+        // update jobs status to running
+        let ids = ret.iter().map(|r| r.id.to_string()).collect::<Vec<_>>();
+        if ids.is_empty() {
+            if let Err(e) = tx.rollback().await {
+                log::error!("[SQLITE] rollback select file_list_jobs pending jobs error: {e}");
+            }
+            return Ok(Vec::new());
+        }
+        let sql = format!(
+            "UPDATE file_list_jobs SET status = $1, node = $2, updated_at = $3 WHERE id IN ({});",
+            ids.join(",")
+        );
+        if let Err(e) = sqlx::query(&sql)
+            .bind(super::FileListJobStatus::Running)
+            .bind(node)
+            .bind(config::utils::time::now_micros())
+            .execute(&mut *tx)
+            .await
+        {
+            if let Err(e) = tx.rollback().await {
+                log::error!("[SQLITE] rollback update file_list_jobs status error: {e}");
+            }
+            return Err(e.into());
+        }
+        // get jobs by ids
+        let sql = format!(
+            "SELECT * FROM file_list_jobs WHERE id IN ({});",
+            ids.join(",")
+        );
+        let ret = match sqlx::query_as::<_, super::MergeJobRecord>(&sql)
+            .fetch_all(&mut *tx)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                if let Err(e) = tx.rollback().await {
+                    log::error!("[SQLITE] rollback select file_list_jobs by ids error: {e}");
+                }
+                return Err(e.into());
+            }
+        };
+        if let Err(e) = tx.commit().await {
+            log::error!("[SQLITE] commit select file_list_jobs pending jobs error: {e}");
+            return Err(e.into());
+        }
+        Ok(ret)
+    }
+
+    async fn set_job_done(&self, id: i64) -> Result<()> {
+        let client = CLIENT_RW.clone();
+        let client = client.lock().await;
+        sqlx::query(r#"UPDATE file_list_jobs SET status = $1, updated_at = $2 WHERE id = $3;"#)
+            .bind(super::FileListJobStatus::Done)
+            .bind(config::utils::time::now_micros())
+            .bind(id)
+            .execute(&*client)
+            .await?;
+        Ok(())
+    }
+
+    async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
+        let client = CLIENT_RW.clone();
+        let client = client.lock().await;
+        let ret = sqlx::query(
+            r#"UPDATE file_list_jobs SET status = $1, updated_at = $2 WHERE status = $3 AND updated_at < $4;"#,
+        )
+        .bind(super::FileListJobStatus::Pending)
+        .bind(config::utils::time::now_micros())
+        .bind(super::FileListJobStatus::Running)
+        .bind(before_date)
+         .execute(&*client)
+        .await?;
+        if ret.rows_affected() > 0 {
+            log::warn!("[SQLITE] reset running jobs status to pending");
+        }
+        Ok(())
+    }
+
+    async fn clean_jobs(&self, before_date: i64) -> Result<()> {
+        let client = CLIENT_RW.clone();
+        let client = client.lock().await;
+        let ret =
+            sqlx::query(r#"DELETE FROM file_list_jobs WHERE status = $1 AND updated_at < $2;"#)
+                .bind(super::FileListJobStatus::Done)
+                .bind(before_date)
+                .execute(&*client)
+                .await?;
+        if ret.rows_affected() > 0 {
+            log::warn!("[SQLITE] clean done jobs");
+        }
+        Ok(())
+    }
 }
 
 impl SqliteFileList {
@@ -781,6 +935,24 @@ CREATE TABLE IF NOT EXISTS file_list_deleted
 
     sqlx::query(
         r#"
+CREATE TABLE IF NOT EXISTS file_list_jobs
+(
+    id         INTEGER not null primary key autoincrement,
+    org        VARCHAR not null,
+    stream     VARCHAR not null,
+    date       INT not null,
+    offset     INT not null,
+    status     INT not null,
+    node       VARCHAR not null,
+    updated_at BIGINT not null
+);
+        "#,
+    )
+    .execute(&*client)
+    .await?;
+
+    sqlx::query(
+        r#"
 CREATE TABLE IF NOT EXISTS stream_stats
 (
     id      INTEGER not null primary key autoincrement,
@@ -835,6 +1007,18 @@ pub async fn create_table_index() -> Result<()> {
         (
             "file_list_deleted",
             "CREATE INDEX IF NOT EXISTS file_list_deleted_stream_date_file_idx on file_list_deleted (stream, date, file);",
+        ),
+        (
+            "file_list_jobs",
+            "CREATE UNIQUE INDEX IF NOT EXISTS file_list_jobs_stream_offset_idx on file_list_jobs (stream, offset);",
+        ),
+        (
+            "file_list_jobs",
+            "CREATE INDEX IF NOT EXISTS file_list_jobs_stream_date_idx on file_list_jobs (stream, date);",
+        ),
+        (
+            "file_list_jobs",
+            "CREATE INDEX IF NOT EXISTS file_list_jobs_stream_status_idx on file_list_jobs (status, stream);",
         ),
         (
             "stream_stats",

--- a/src/job/compactor.rs
+++ b/src/job/compactor.rs
@@ -173,7 +173,7 @@ async fn run_sync_to_db() -> Result<(), anyhow::Error> {
 
 async fn run_check_running_jobs() -> Result<(), anyhow::Error> {
     loop {
-        let timeout = get_config().compact.job_timeout;
+        let timeout = get_config().compact.job_run_timeout;
         time::sleep(time::Duration::from_secs(timeout as u64)).await;
         log::debug!("[COMPACTOR] Running check running jobs");
         let updated_at = config::utils::time::now_micros() - (timeout * 1000 * 1000);
@@ -185,11 +185,10 @@ async fn run_check_running_jobs() -> Result<(), anyhow::Error> {
 
 async fn run_clean_done_jobs() -> Result<(), anyhow::Error> {
     loop {
-        // set clean time to 2 times of job timeout
-        let timeout = get_config().compact.job_timeout * 2;
-        time::sleep(time::Duration::from_secs(timeout as u64)).await;
+        let wait_time = get_config().compact.job_clean_wait_time;
+        time::sleep(time::Duration::from_secs(wait_time as u64)).await;
         log::debug!("[COMPACTOR] Running clean done jobs");
-        let updated_at = config::utils::time::now_micros() - (timeout * 1000 * 1000);
+        let updated_at = config::utils::time::now_micros() - (wait_time * 1000 * 1000);
         if let Err(e) = infra::file_list::clean_done_jobs(updated_at).await {
             log::error!("[COMPACTOR] run clean done jobs error: {e}");
         }

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -73,24 +73,15 @@ pub struct MergeResult {
 
 pub type MergeSender = mpsc::Sender<Result<(usize, FileKey), anyhow::Error>>;
 
-/// compactor run steps on a stream:
-/// 3. get a cluster lock for compactor stream
-/// 4. read last compacted offset: year/month/day/hour
-/// 5. read current hour all files
-/// 6. compact small files to big files -> COMPACTOR_MAX_FILE_SIZE
-/// 7. write to storage
-/// 8. delete small files keys & write big files keys, use transaction
-/// 9. delete small files from storage
-/// 10. update last compacted offset
-/// 11. release cluster lock
-pub async fn merge_by_stream(
-    worker_tx: mpsc::Sender<(MergeSender, MergeBatch)>,
+/// Generate merging job by stream
+/// 1. get offset from db
+/// 2. check if other node is processing
+/// 3. create job or return
+pub async fn generate_job_by_stream(
     org_id: &str,
     stream_type: StreamType,
     stream_name: &str,
 ) -> Result<(), anyhow::Error> {
-    let start = std::time::Instant::now();
-
     // get last compacted offset
     let (mut offset, node) = db::compact::files::get_offset(org_id, stream_type, stream_name).await;
     if !node.is_empty() && LOCAL_NODE_UUID.ne(&node) && get_node_by_uuid(&node).await.is_some() {
@@ -123,9 +114,6 @@ pub async fn merge_by_stream(
 
     // get schema
     let schema = infra::schema::get(org_id, stream_name, stream_type).await?;
-    let stream_settings = unwrap_stream_settings(&schema).unwrap_or_default();
-    let partition_time_level =
-        unwrap_partition_time_level(stream_settings.partition_time_level, stream_type);
     let stream_created = stream::stream_created(&schema).unwrap_or_default();
     if offset == 0 {
         offset = stream_created
@@ -141,31 +129,6 @@ pub async fn merge_by_stream(
         stream_name,
         offset
     );
-
-    let offset = offset;
-    let offset_time: DateTime<Utc> = Utc.timestamp_nanos(offset * 1000);
-    let offset_time_hour = Utc
-        .with_ymd_and_hms(
-            offset_time.year(),
-            offset_time.month(),
-            offset_time.day(),
-            offset_time.hour(),
-            0,
-            0,
-        )
-        .unwrap()
-        .timestamp_micros();
-    let offset_time_day = Utc
-        .with_ymd_and_hms(
-            offset_time.year(),
-            offset_time.month(),
-            offset_time.day(),
-            0,
-            0,
-            0,
-        )
-        .unwrap()
-        .timestamp_micros();
 
     let cfg = get_config();
     // check offset
@@ -204,6 +167,102 @@ pub async fn merge_by_stream(
     {
         return Ok(()); // the time is future, just wait
     }
+
+    // generate merging job
+    if let Err(e) = infra_file_list::add_job(org_id, stream_type, stream_name, offset).await {
+        return Err(anyhow::anyhow!("[COMAPCT] add file_list_job failed: {}", e));
+    }
+
+    // write new offset
+    let offset = offset
+        + Duration::try_seconds(cfg.compact.step_secs)
+            .unwrap()
+            .num_microseconds()
+            .unwrap();
+    db::compact::files::set_offset(
+        org_id,
+        stream_type,
+        stream_name,
+        offset,
+        Some(&LOCAL_NODE_UUID.clone()),
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// compactor run steps on a stream:
+/// 3. get a cluster lock for compactor stream
+/// 4. read last compacted offset: year/month/day/hour
+/// 5. read current hour all files
+/// 6. compact small files to big files -> COMPACTOR_MAX_FILE_SIZE
+/// 7. write to storage
+/// 8. delete small files keys & write big files keys, use transaction
+/// 9. delete small files from storage
+/// 10. update last compacted offset
+/// 11. release cluster lock
+pub async fn merge_by_stream(
+    worker_tx: mpsc::Sender<(MergeSender, MergeBatch)>,
+    org_id: &str,
+    stream_type: StreamType,
+    stream_name: &str,
+    job_id: i64,
+    offset: i64,
+) -> Result<(), anyhow::Error> {
+    let start = std::time::Instant::now();
+
+    // get schema
+    let schema = infra::schema::get(org_id, stream_name, stream_type).await?;
+    let stream_settings = unwrap_stream_settings(&schema).unwrap_or_default();
+    let partition_time_level =
+        unwrap_partition_time_level(stream_settings.partition_time_level, stream_type);
+
+    log::debug!(
+        "[COMPACTOR] merge_by_stream [{}/{}/{}] offset: {}",
+        org_id,
+        stream_type,
+        stream_name,
+        offset
+    );
+
+    let offset_time: DateTime<Utc> = Utc.timestamp_nanos(offset * 1000);
+    let offset_time_hour = Utc
+        .with_ymd_and_hms(
+            offset_time.year(),
+            offset_time.month(),
+            offset_time.day(),
+            offset_time.hour(),
+            0,
+            0,
+        )
+        .unwrap()
+        .timestamp_micros();
+    let offset_time_day = Utc
+        .with_ymd_and_hms(
+            offset_time.year(),
+            offset_time.month(),
+            offset_time.day(),
+            0,
+            0,
+            0,
+        )
+        .unwrap()
+        .timestamp_micros();
+
+    let cfg = get_config();
+    // check offset
+    let time_now: DateTime<Utc> = Utc::now();
+    let time_now_hour = Utc
+        .with_ymd_and_hms(
+            time_now.year(),
+            time_now.month(),
+            time_now.day(),
+            time_now.hour(),
+            0,
+            0,
+        )
+        .unwrap()
+        .timestamp_micros();
 
     // get current hour(day) all files
     let (partition_offset_start, partition_offset_end) =
@@ -267,24 +326,6 @@ pub async fn merge_by_stream(
     );
 
     if files.is_empty() {
-        // this hour is no data, and check if pass allowed_upto, then just write new
-        // offset if offset > 0 && offset_time_hour +
-        // Duration::try_hours(cfg.limit.allowed_upto).unwrap().num_microseconds().unwrap() <
-        // time_now_hour { -- no check it
-        // }
-        let offset = offset
-            + Duration::try_seconds(cfg.compact.step_secs)
-                .unwrap()
-                .num_microseconds()
-                .unwrap();
-        db::compact::files::set_offset(
-            org_id,
-            stream_type,
-            stream_name,
-            offset,
-            Some(&LOCAL_NODE_UUID.clone()),
-        )
-        .await?;
         return Ok(());
     }
 
@@ -375,8 +416,15 @@ pub async fn merge_by_stream(
                 }
             }
             let mut worker_results = Vec::with_capacity(batch_group_len);
+            let mut updated_at = Utc::now().timestamp_micros();
             for _ in 0..batch_group_len {
                 let result = inner_rx.recv().await.unwrap();
+                if Utc::now().timestamp_micros() - updated_at > cfg.compact.job_timeout / 10 {
+                    if let Err(e) = infra_file_list::update_running_jobs(job_id).await {
+                        log::error!("[COMPACT] update_running_jobs failed: {e}");
+                    }
+                    updated_at = Utc::now().timestamp_micros();
+                }
                 worker_results.push(result);
             }
 
@@ -444,21 +492,6 @@ pub async fn merge_by_stream(
     for task in tasks {
         task.await??;
     }
-
-    // write new offset
-    let offset = offset
-        + Duration::try_seconds(cfg.compact.step_secs)
-            .unwrap()
-            .num_microseconds()
-            .unwrap();
-    db::compact::files::set_offset(
-        org_id,
-        stream_type,
-        stream_name,
-        offset,
-        Some(&LOCAL_NODE_UUID.clone()),
-    )
-    .await?;
 
     // update stream stats
     if stream_stats.doc_num != 0 {

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -123,7 +123,7 @@ pub async fn generate_job_by_stream(
     }
 
     log::debug!(
-        "[COMPACTOR] merge_by_stream [{}/{}/{}] offset: {}",
+        "[COMPACTOR] generate_job_by_stream [{}/{}/{}] offset: {}",
         org_id,
         stream_type,
         stream_name,
@@ -428,7 +428,7 @@ pub async fn merge_by_stream(
                 let result = inner_rx.recv().await.unwrap();
                 let now = config::utils::time::now_micros();
                 // convert job_timeout from secs to micros, and check 1/4 of job_timeout
-                if now - updated_at > (cfg.compact.job_timeout * 1000 * 1000 / 4) {
+                if now - updated_at > (cfg.compact.job_run_timeout * 1000 * 1000 / 4) {
                     if let Err(e) = infra_file_list::update_running_jobs(job_id).await {
                         log::error!("[COMPACT] update_running_jobs failed: {e}");
                     }

--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -262,12 +262,12 @@ pub async fn run_merge(
     let semaphore = std::sync::Arc::new(Semaphore::new(cfg.limit.file_merge_thread_num));
     let mut min_offset = std::i64::MAX;
     for job in jobs {
-        if job.offset == 0 {
-            log::error!("[COMPACTOR] merge job offset error: {}", job.offset);
+        if job.offsets == 0 {
+            log::error!("[COMPACTOR] merge job offset error: {}", job.offsets);
             continue;
         }
-        if job.offset < min_offset {
-            min_offset = job.offset;
+        if job.offsets < min_offset {
+            min_offset = job.offsets;
         }
 
         let columns = job.stream.split('/').collect::<Vec<&str>>();
@@ -297,7 +297,7 @@ pub async fn run_merge(
                 stream_type,
                 &stream_name,
                 job.id,
-                job.offset,
+                job.offsets,
             )
             .await
             {

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -915,10 +915,8 @@ export default defineComponent({
       this.customDownloadDialog = true;
     },
     downloadRangeData() {
-      if (
-        this.downloadCustomInitialNumber < 0 ||
-        this.downloadCustomInitialNumber == ""
-      ) {
+      let initNumber = parseInt(this.downloadCustomInitialNumber);
+      if (initNumber < 0) {
         this.$q.notify({
           message: "Initial number must be positive number.",
           color: "negative",
@@ -929,9 +927,7 @@ export default defineComponent({
       }
       // const queryReq = this.buildSearch();
       // console.log(this.searchObj.data.customDownloadQueryObj)
-      this.searchObj.data.customDownloadQueryObj.query.from = parseInt(
-        this.downloadCustomInitialNumber
-      );
+      this.searchObj.data.customDownloadQueryObj.query.from = initNumber;
       this.searchObj.data.customDownloadQueryObj.query.size =
         this.downloadCustomRange;
       searchService


### PR DESCRIPTION
## Working flow
<img width="1138" alt="image" src="https://github.com/openobserve/openobserve/assets/1628250/6eff9c55-1e4e-4ae7-b54c-9ae8c9bed8c8">

- meta(Table): metadata table where the compact offset store in
- file_list_jobs(Table): file list job table
- stream job: used to generate merging job for streams
- merging job: get pending jobs and merge the files
- checking job: reset the jobs which running timeout or the node was dead
- clean job: clean the jobs which already done over 1 day

## New environments

- 