### PR TITLE
fix: partition time level check for compactor job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
+checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
 dependencies = [
  "actix-utils",
  "actix-web",
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb9843d84c775696c37d9a418bbb01b932629d01870722c0f13eb3f95e2536d"
+checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.7.0"
+version = "4.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6316df3fa569627c98b12557a8b6ff0674e5be4bb9b5e4ae2550ddb4964ed6"
+checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -8506,7 +8506,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ strip = false
 codegen-units = 4
 
 [dependencies]
-actix-cors = "0.6"
-actix-http = "3.6"
+actix-cors = "0.7"
+actix-http = "3.8"
 actix-multipart = { version = "0.6", features = ["derive"] }
 actix-web.workspace = true
 actix-web-httpauth = "0.8"
@@ -196,7 +196,7 @@ proto = { path = "src/proto" }
 report_server = { path = "src/report_server" }
 
 ahash = { version = "0.8", features = ["serde"] }
-actix-web = "4.5"
+actix-web = "4.8"
 actix-web-prometheus = { version = "0.1", features = ["process"] }
 anyhow = "1.0"
 arc-swap = "1.7.1"

--- a/src/config/src/utils/inverted_index.rs
+++ b/src/config/src/utils/inverted_index.rs
@@ -40,7 +40,6 @@ pub fn split_token(s: &str, delimiter: &str) -> Vec<String> {
         .collect()
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -54,19 +53,43 @@ mod tests {
     #[test]
     fn test_empty_delimiter() {
         let result = split_token("Hello, world! This is a test.", "");
-        assert_eq!(result, vec!["hello".to_string(), "world".to_string(), "this".to_string(), "test".to_string()]);
+        assert_eq!(
+            result,
+            vec![
+                "hello".to_string(),
+                "world".to_string(),
+                "this".to_string(),
+                "test".to_string()
+            ]
+        );
     }
 
     #[test]
     fn test_non_empty_delimiter() {
         let result = split_token("Hello,world,This,is,a,test", ",");
-        assert_eq!(result, vec!["hello".to_string(), "world".to_string(), "this".to_string(), "test".to_string()]);
+        assert_eq!(
+            result,
+            vec![
+                "hello".to_string(),
+                "world".to_string(),
+                "this".to_string(),
+                "test".to_string()
+            ]
+        );
     }
 
     #[test]
     fn test_mixed_whitespace_and_punctuation() {
         let result = split_token("Hello, world! This - is; a: test.", "");
-        assert_eq!(result, vec!["hello".to_string(), "world".to_string(), "this".to_string(), "test".to_string()]);
+        assert_eq!(
+            result,
+            vec![
+                "hello".to_string(),
+                "world".to_string(),
+                "this".to_string(),
+                "test".to_string()
+            ]
+        );
     }
 
     #[test]
@@ -108,12 +131,28 @@ mod tests {
     #[test]
     fn test_delimiter_as_whitespace() {
         let result = split_token("Hello world This is a test", " ");
-        assert_eq!(result, vec!["hello".to_string(), "world".to_string(), "this".to_string(), "test".to_string()]);
+        assert_eq!(
+            result,
+            vec![
+                "hello".to_string(),
+                "world".to_string(),
+                "this".to_string(),
+                "test".to_string()
+            ]
+        );
     }
 
     #[test]
     fn test_complex_delimiter() {
         let result = split_token("Hello||world||This||is||a||test", "||");
-        assert_eq!(result, vec!["hello".to_string(), "world".to_string(), "this".to_string(), "test".to_string()]);
+        assert_eq!(
+            result,
+            vec![
+                "hello".to_string(),
+                "world".to_string(),
+                "this".to_string(),
+                "test".to_string()
+            ]
+        );
     }
 }


### PR DESCRIPTION
We need check the partition time level with stream type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved token splitting functionality with updated test cases using various delimiters and test strings.

- **Bug Fixes**
  - Enhanced the `run_merge` function logic for better handling of `PartitionTimeLevel` checks.

- **Chores**
  - Updated dependencies for `actix-cors`, `actix-http`, and `actix-web` to the latest versions for improved security and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->