### PR TITLE
perf: increase datafusion target partitions

### DIFF
--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -1219,14 +1219,14 @@ pub async fn register_table(
             let file_format = ParquetFormat::default();
             ListingOptions::new(Arc::new(file_format))
                 .with_file_extension(FileType::PARQUET.get_ext())
-                .with_target_partitions(cfg.limit.cpu_num)
+                .with_target_partitions(cfg.limit.query_thread_num)
                 .with_collect_stat(true)
         }
         FileType::JSON => {
             let file_format = JsonFormat::default();
             ListingOptions::new(Arc::new(file_format))
                 .with_file_extension(FileType::JSON.get_ext())
-                .with_target_partitions(cfg.limit.cpu_num)
+                .with_target_partitions(cfg.limit.query_thread_num)
                 .with_collect_stat(true)
         }
         _ => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved query performance by modifying the logic for setting target partitions in the `register_table` function. The application now uses `cfg.limit.query_thread_num` instead of `cfg.limit.cpu_num`, optimizing the handling of Parquet and JSON file formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->