### PR TITLE
fix: dashboard gauge chart getAxesOnZeroOf issue

### DIFF
--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -344,6 +344,7 @@ export default defineComponent({
         case "h-stacked":
         case "line":
         case "scatter":
+        case "gauge":
         case "table": {
           // return data.value[0].some((it: any) => {return (xAlias.every((x: any) => it[x]) && yAlias.every((y: any) => it[y]))});
           return (
@@ -352,7 +353,6 @@ export default defineComponent({
               yAlias.every((y: any) => data.value[0][0][y]) != null)
           );
         }
-        case "gauge":
         case "metric": {
           return (
             data.value[0]?.length > 1 ||

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -1697,8 +1697,8 @@ export const convertSQLData = async (
   }
 
   //check if is there any data else filter out axis or series data
-  // for metric we does not have data field
-  if (panelSchema.type != "metric") {
+  // for metric, gauge we does not have data field
+  if (!["metric", "gauge"].includes(panelSchema.type)) {
     options.series = options.series.filter((it: any) => it.data?.length);
     if (panelSchema.type == "h-bar" || panelSchema.type == "h-stacked") {
       options.xAxis = options.series.length ? options.xAxis : {};


### PR DESCRIPTION
![image](https://github.com/openobserve/openobserve/assets/141122205/c6753555-469b-432b-a42d-941b94d03827)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rendering logic for gauge and table chart types, ensuring correct display order in dashboards.

- **New Features**
  - Enhanced data filtering for panels, now supporting both "metric" and "gauge" types for more accurate data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->