### PR TITLE
fix: panic when the stream have no pipeline

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -673,8 +673,6 @@ pub struct Common {
     pub show_stream_dates_doc_num: bool,
     #[env_config(name = "ZO_INGEST_BLOCKED_STREAMS", default = "")] // use comma to split
     pub blocked_streams: String,
-    #[env_config(name = "ZO_INGEST_INFER_SCHEMA_PER_REQUEST", default = true)]
-    pub infer_schema_per_request: bool,
     #[env_config(name = "ZO_REPORT_USER_NAME", default = "")]
     pub report_user_name: String,
     #[env_config(name = "ZO_REPORT_USER_PASSWORD", default = "")]

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -518,10 +518,10 @@ pub async fn get_stream_routing(
         "{}/{}/{}",
         &stream_params.org_id, stream_params.stream_type, &stream_params.stream_name,
     )) {
-        let res: Vec<Routing> = pipeline
-            .routing
-            .as_ref()
-            .unwrap()
+        let Some(routing) = pipeline.routing.as_ref() else {
+            return;
+        };
+        let res: Vec<Routing> = routing
             .iter()
             .map(|(k, v)| Routing {
                 destination: k.to_string(),


### PR DESCRIPTION
fixed #3802 , also fixed another panic that user report error:
<img width="699" alt="image" src="https://github.com/openobserve/openobserve/assets/1628250/c142f11f-770c-486f-b10d-a06ddf7b516c">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the `infer_schema_per_request` field from configuration settings.
  - Improved logic for stream routing to handle optional routing configurations more gracefully.
  - Simplified and optimized the `ingest` function for better error handling and data processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->