### PR TITLE
feat: support subquery in same stream

### DIFF
--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -466,6 +466,9 @@ fn parse_expr_for_field(
                 let eq = parse_expr_check_field_name(&ident.value, field);
                 if ident.value == field || (eq && next_op == SqlOperator::Eq) {
                     let val = get_value_from_expr(right);
+                    if matches!(right.as_ref(), SqlExpr::Subquery(_)) {
+                        return Ok(());
+                    }
                     if val.is_none() {
                         return Err(anyhow::anyhow!(
                             "SqlExpr::Identifier: We only support Identifier at the moment"

--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -44,7 +44,7 @@ pub struct Sql {
     pub time_range: Option<(i64, i64)>,
     pub quick_text: Vec<(String, String, SqlOperator)>, // use text line quick filter
     pub field_alias: Vec<(String, String)>,             // alias for select field
-    pub subquery: Option<Query>,                        // subquery in data source
+    pub subquery: Option<String>,                       // subquery in data source
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -163,6 +163,12 @@ impl TryFrom<&Statement> for Sql {
                 fields.extend(where_fields);
                 fields.sort();
                 fields.dedup();
+
+                let subquery = if let Some(subquery) = subquery {
+                    Some(subquery.to_string())
+                } else {
+                    None
+                };
 
                 Ok(Sql {
                     fields,

--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -262,6 +262,12 @@ impl<'a> TryFrom<Source<'a>> for (String, Option<Query>) {
                     }
                 };
 
+                if table_with_joins.len() != 1 {
+                    return Err(anyhow::anyhow!(
+                        "We only support single data source at the moment"
+                    ));
+                }
+
                 let table = &table_with_joins[0];
                 if !table.joins.is_empty() {
                     return Err(anyhow::anyhow!(

--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -662,7 +662,10 @@ fn parse_expr_function(
 
     let args = match &f.args {
         FunctionArguments::None => return Ok(()),
-        FunctionArguments::Subquery(_) => return Ok(()),
+        FunctionArguments::Subquery(_) => {
+            log::error!("We do not support subquery at the moment");
+            return Ok(());
+        }
         FunctionArguments::List(args) => &args.args,
     };
     if args.len() < 2 {

--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -164,11 +164,7 @@ impl TryFrom<&Statement> for Sql {
                 fields.sort();
                 fields.dedup();
 
-                let subquery = if let Some(subquery) = subquery {
-                    Some(subquery.to_string())
-                } else {
-                    None
-                };
+                let subquery = subquery.map(|subquery| subquery.to_string());
 
                 Ok(Sql {
                     fields,

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -751,6 +751,7 @@ async fn merge_grpc_result(
                 &batch,
                 &select_fields,
                 is_final_phase,
+                sql.meta.subquery.is_some()
             ) => {
                 match res {
                     Ok(res) => merge_batch = res,

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -254,7 +254,6 @@ async fn exec_query(
 
     if !fast_mode && (!field_fns.is_empty() || sql.query_fn.is_some()) {
         if let Some(caps) = RE_WHERE.captures(&sql.origin_sql) {
-            println!("***************** {:?}", caps);
             sql_parts.insert(
                 0,
                 sql.origin_sql
@@ -264,7 +263,6 @@ async fn exec_query(
             sql_parts.insert(1, caps.get(1).unwrap().as_str());
         };
     }
-    println!("***************** {:?}", sql_parts);
     // query
     let query = if !&sql.query_context.is_empty() {
         sql.query_context.replace(&sql.stream_name, "tbl").clone()

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -254,6 +254,7 @@ async fn exec_query(
 
     if !fast_mode && (!field_fns.is_empty() || sql.query_fn.is_some()) {
         if let Some(caps) = RE_WHERE.captures(&sql.origin_sql) {
+            println!("***************** {:?}", caps);
             sql_parts.insert(
                 0,
                 sql.origin_sql
@@ -263,7 +264,7 @@ async fn exec_query(
             sql_parts.insert(1, caps.get(1).unwrap().as_str());
         };
     }
-
+    println!("***************** {:?}", sql_parts);
     // query
     let query = if !&sql.query_context.is_empty() {
         sql.query_context.replace(&sql.stream_name, "tbl").clone()

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -675,7 +675,7 @@ fn merge_rewrite_sql(
     is_subquery: bool,
 ) -> Result<String> {
     if is_subquery && !is_final_phase {
-        let sql = rewrite::add_group_by_order_by_field_to_select(&sql)?;
+        let sql = rewrite::add_group_by_order_by_field_to_select(sql)?;
         return Ok(sql.to_string());
     }
 

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -101,7 +101,7 @@ pub async fn sql(
     let cfg = get_config();
     let start = std::time::Instant::now();
     let trace_id = session.id.clone();
-    // let select_wildcard = RE_SELECT_WILDCARD.is_match(sql.origin_sql.as_str());
+    // let select_wildcard = RE_SELECT_WILDCARD.is_match(origin_sql.as_str());
     // let without_optimizer = select_wildcard
     //     && cfg.limit.query_optimization_num_fields > 0
     //     && schema.fields().len() > cfg.limit.query_optimization_num_fields;
@@ -226,10 +226,16 @@ async fn exec_query(
     files: &[FileKey],
     file_type: FileType,
 ) -> Result<Vec<RecordBatch>> {
+    let origin_sql = if sql.meta.subquery.is_some() {
+        let subquery = sql.meta.subquery.as_ref().unwrap().to_string();
+        subquery.replace(&sql.stream_name, "tbl").clone()
+    } else {
+        sql.origin_sql.clone()
+    };
     let start = std::time::Instant::now();
     let trace_id = session.id.clone();
     let cfg = get_config();
-    let select_wildcard = RE_SELECT_WILDCARD.is_match(sql.origin_sql.as_str());
+    let select_wildcard = RE_SELECT_WILDCARD.is_match(origin_sql.as_str());
     let without_optimizer = select_wildcard
         && cfg.limit.query_optimization_num_fields > 0
         && schema.fields().len() > cfg.limit.query_optimization_num_fields;
@@ -247,16 +253,16 @@ async fn exec_query(
     let mut field_fns = vec![];
     let mut sql_parts = vec![];
     for fn_name in crate::common::utils::functions::get_all_transform_keys(&sql.org_id).await {
-        if sql.origin_sql.contains(&format!("{}(", fn_name)) {
+        if origin_sql.contains(&format!("{}(", fn_name)) {
             field_fns.push(fn_name.clone());
         }
     }
 
     if !fast_mode && (!field_fns.is_empty() || sql.query_fn.is_some()) {
-        if let Some(caps) = RE_WHERE.captures(&sql.origin_sql) {
+        if let Some(caps) = RE_WHERE.captures(&origin_sql) {
             sql_parts.insert(
                 0,
-                sql.origin_sql
+                origin_sql
                     .strip_suffix(caps.get(0).unwrap().as_str())
                     .unwrap(),
             );
@@ -281,7 +287,7 @@ async fn exec_query(
             None => sql_parts[0].to_owned(),
         }
     } else {
-        sql.origin_sql.clone()
+        origin_sql.clone()
     };
 
     let mut query = query;
@@ -307,7 +313,7 @@ async fn exec_query(
             log::error!(
                 "[trace_id {trace_id}] query sql execute failed, session: {:?}, sql: {}, err: {:?}",
                 session,
-                sql.origin_sql,
+                origin_sql,
                 e
             );
             return Err(e);
@@ -420,7 +426,7 @@ async fn exec_query(
     let mut where_query = if !sql_parts.is_empty() {
         format!("select * from tbl where {}", &sql_parts[1])
     } else {
-        sql.origin_sql.clone()
+        origin_sql.clone()
     };
     for alias in &sql.meta.field_alias {
         replace_in_query(&alias.1, &mut where_query, true);
@@ -433,7 +439,7 @@ async fn exec_query(
             log::error!(
                 "query sql execute failed, session: {:?}, sql: {}, err: {:?}",
                 session,
-                sql.origin_sql,
+                origin_sql,
                 e
             );
             return Err(e);
@@ -513,6 +519,7 @@ fn replace_in_query(replace_pat: &str, where_query: &mut String, is_alias: bool)
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn merge(
     org_id: &str,
     offset: i64,
@@ -521,6 +528,7 @@ pub async fn merge(
     batches: &[RecordBatch],
     select_fields: &[Arc<Field>],
     is_final_phase: bool, // use to indicate if this is the final phase of merge
+    is_subquery: bool,    // use to indicate if a subquery in from clause
 ) -> Result<Vec<RecordBatch>> {
     if batches.is_empty() {
         return Ok(vec![]);
@@ -556,7 +564,7 @@ pub async fn merge(
         && schema.fields().len() > cfg.limit.query_optimization_num_fields;
 
     // rewrite sql
-    let mut query_sql = match merge_rewrite_sql(sql, schema, is_final_phase) {
+    let mut query_sql = match merge_rewrite_sql(sql, schema, is_final_phase, is_subquery) {
         Ok(sql) => {
             if is_final_phase
                 && offset > 0
@@ -660,7 +668,12 @@ fn merge_write_recordbatch(batches: &[RecordBatch], work_dir: &Directory) -> Res
     Ok(Arc::new(schema))
 }
 
-fn merge_rewrite_sql(sql: &str, schema: Arc<Schema>, is_final_phase: bool) -> Result<String> {
+fn merge_rewrite_sql(
+    sql: &str,
+    schema: Arc<Schema>,
+    is_final_phase: bool,
+    is_subquery: bool,
+) -> Result<String> {
     // special case for count distinct
     if RE_COUNT_DISTINCT.is_match(sql) {
         let sql = rewrite::rewrite_count_distinct_merge_sql(sql)?;
@@ -774,7 +787,9 @@ fn merge_rewrite_sql(sql: &str, schema: Arc<Schema>, is_final_phase: bool) -> Re
     // handle select *
     let mut fields = new_fields;
     if fields.len() == 1 && sel_fields_has_star {
-        sql = rewrite::remove_where_clause(&sql)?;
+        if !is_subquery || is_final_phase {
+            sql = rewrite::remove_where_clause(&sql)?;
+        }
         return Ok(sql);
     }
     if sel_fields_has_star {
@@ -886,7 +901,9 @@ fn merge_rewrite_sql(sql: &str, schema: Arc<Schema>, is_final_phase: bool) -> Re
         }
     }
 
-    sql = rewrite::remove_where_clause(&sql)?;
+    if !is_subquery || is_final_phase {
+        sql = rewrite::remove_where_clause(&sql)?;
+    }
     Ok(sql)
 }
 
@@ -1441,6 +1458,7 @@ mod tests {
             &[batch, batch2],
             &[],
             true,
+            false,
         )
         .await
         .unwrap();

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -774,6 +774,7 @@ fn merge_rewrite_sql(sql: &str, schema: Arc<Schema>, is_final_phase: bool) -> Re
     // handle select *
     let mut fields = new_fields;
     if fields.len() == 1 && sel_fields_has_star {
+        sql = rewrite::remove_where_clause(&sql)?;
         return Ok(sql);
     }
     if sel_fields_has_star {

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -674,6 +674,11 @@ fn merge_rewrite_sql(
     is_final_phase: bool,
     is_subquery: bool,
 ) -> Result<String> {
+    if is_subquery && !is_final_phase {
+        let sql = rewrite::add_group_by_order_by_field_to_select(&sql)?;
+        return Ok(sql.to_string());
+    }
+
     // special case for count distinct
     if RE_COUNT_DISTINCT.is_match(sql) {
         let sql = rewrite::rewrite_count_distinct_merge_sql(sql)?;
@@ -787,9 +792,7 @@ fn merge_rewrite_sql(
     // handle select *
     let mut fields = new_fields;
     if fields.len() == 1 && sel_fields_has_star {
-        if !is_subquery || is_final_phase {
-            sql = rewrite::remove_where_clause(&sql)?;
-        }
+        sql = rewrite::remove_where_clause(&sql)?;
         return Ok(sql);
     }
     if sel_fields_has_star {
@@ -901,9 +904,7 @@ fn merge_rewrite_sql(
         }
     }
 
-    if !is_subquery || is_final_phase {
-        sql = rewrite::remove_where_clause(&sql)?;
-    }
+    sql = rewrite::remove_where_clause(&sql)?;
     Ok(sql)
 }
 

--- a/src/service/search/datafusion/mod.rs
+++ b/src/service/search/datafusion/mod.rs
@@ -30,7 +30,7 @@ mod date_format_udf;
 pub mod exec;
 pub mod match_udf;
 pub mod regexp_udf;
-mod rewrite;
+pub mod rewrite;
 pub mod spath_udf;
 pub mod storage;
 pub mod string_to_array_v2_udf;

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -220,6 +220,7 @@ pub async fn search(
                 &batches,
                 &select_fields,
                 false,
+                sql.meta.subquery.is_some()
             ) => {
                 match result {
                     Ok(res) => merge_batches = res,

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -165,7 +165,7 @@ pub async fn search(
                 let stream_name = match config::meta::sql::Sql::new(&req_query.sql) {
                     Ok(v) => v.source.to_string(),
                     Err(e) => {
-                        log::error!("parse sql error: {:?}", e);
+                        log::error!("report_usage: parse sql error: {:?}", e);
                         "".to_string()
                     }
                 };

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -665,6 +665,12 @@ impl Sql {
             Some(req_query.query_fn.clone())
         };
 
+        // suppport for subquery in from clause
+        if meta.subquery.is_some() {
+            let re = Regex::new(r"(from\s+)\(.*?\)").unwrap();
+            origin_sql = re.replace(origin_sql.as_str(), "${1}tbl").to_string();
+        }
+
         Ok(Sql {
             origin_sql,
             rewrite_sql,

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -134,7 +134,11 @@ impl Sql {
         let mut meta = match MetaSql::new(&origin_sql) {
             Ok(meta) => meta,
             Err(err) => {
-                log::error!("parse sql error: {}, sql: {}", err, origin_sql);
+                log::error!(
+                    "split_sql_token: parse sql error: {}, sql: {}",
+                    err,
+                    origin_sql
+                );
                 return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(origin_sql)));
             }
         };
@@ -590,7 +594,11 @@ impl Sql {
             }
             let sql_meta = MetaSql::new(sql.clone().as_str());
             if sql_meta.is_err() {
-                log::error!("parse sql error: {}, sql: {}", sql_meta.err().unwrap(), sql);
+                log::error!(
+                    "sql_meta: parse sql error: {}, sql: {}",
+                    sql_meta.err().unwrap(),
+                    sql
+                );
                 return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(sql)));
             }
             let sql_meta = sql_meta.unwrap();
@@ -623,7 +631,6 @@ impl Sql {
         }
 
         let sql_meta = MetaSql::new(origin_sql.clone().as_str());
-
         match &sql_meta {
             Ok(sql_meta) => {
                 let mut used_fns = vec![];
@@ -648,7 +655,7 @@ impl Sql {
                 }
             }
             Err(e) => {
-                log::error!("parse sql error: {}, sql: {}", e, origin_sql);
+                log::error!("final sql: parse sql error: {}, sql: {}", e, origin_sql);
                 return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(origin_sql)));
             }
         }

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -404,7 +404,8 @@ impl Sql {
                             .split(" from ")
                             .next()
                             .unwrap_or_default()
-                            .contains('(')))
+                            .contains('('))
+                        && !origin_sql.to_lowercase().contains("distinct"))
             {
                 let sort_by = if req_query.sort_by.is_empty() {
                     meta.order_by = vec![(cfg.common.column_timestamp.to_string(), true)];

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -39,7 +39,10 @@ use proto::cluster_rpc;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::{common::meta::stream::StreamParams, service::search::match_source};
+use crate::{
+    common::meta::stream::StreamParams,
+    service::search::{self, match_source},
+};
 
 const SQL_DELIMITERS: [u8; 12] = [
     b' ', b'*', b'(', b')', b'<', b'>', b',', b';', b'=', b'!', b'\r', b'\n',
@@ -230,8 +233,44 @@ impl Sql {
             return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(origin_sql)));
         }
         origin_sql = re.replace_all(&origin_sql, " FROM tbl ").to_string();
+        // replace table for subquery
+        if meta.subquery.is_some() {
+            meta.subquery = Some(
+                re.replace_all(&meta.subquery.clone().unwrap(), " FROM tbl ")
+                    .to_string(),
+            );
+        }
 
-        // Hack select for _timestamp
+        // remove subquery in from clause
+        if meta.subquery.is_some() {
+            origin_sql =
+                search::datafusion::rewrite::replace_data_source_to_tbl(origin_sql.as_str())?;
+        }
+
+        if meta.subquery.is_some() {
+            // Hack select in subquery for _timestamp, add _timestamp to select clause
+            let re = Regex::new(r"(?i)\b(avg|count|min|max|sum|group_concat)\b").unwrap();
+            let has_aggregate_function = re.is_match(meta.subquery.as_ref().unwrap());
+            if !has_aggregate_function && !RE_ONLY_GROUPBY.is_match(meta.subquery.as_ref().unwrap())
+            {
+                let caps = RE_SELECT_FROM
+                    .captures(meta.subquery.as_ref().unwrap())
+                    .unwrap();
+                let cap_str = caps.get(1).unwrap().as_str();
+                if !cap_str.contains(&cfg.common.column_timestamp) {
+                    meta.subquery = Some(meta.subquery.as_ref().unwrap().replace(
+                        cap_str,
+                        &format!("{}, {}", &cfg.common.column_timestamp, cap_str),
+                    ));
+                }
+            } else {
+                return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(
+                    "Subquery sql current not support aggregate function".to_string(),
+                )));
+            }
+        }
+
+        // Hack select for _timestamp, add _timestamp to select clause
         if !sql_mode.eq(&SqlMode::Full) && meta.order_by.is_empty() && !origin_sql.contains('*') {
             let caps = RE_SELECT_FROM.captures(origin_sql.as_str()).unwrap();
             let cap_str = caps.get(1).unwrap().as_str();
@@ -272,11 +311,17 @@ impl Sql {
             )));
         }
 
-        // Hack time_range for sql
+        // Hack time_range for sql, add time range to where clause
         let meta_time_range_is_empty = meta.time_range.is_none() || meta.time_range == Some((0, 0));
         if meta_time_range_is_empty && (req_time_range.0 > 0 || req_time_range.1 > 0) {
             meta.time_range = Some(req_time_range); // update meta
         };
+
+        let mut rewrite_time_range_sql = origin_sql.clone();
+        if meta.subquery.is_some() {
+            rewrite_time_range_sql = meta.subquery.clone().unwrap();
+        }
+
         if let Some(time_range) = meta.time_range {
             let time_range_sql = if time_range.0 > 0 && time_range.1 > 0 {
                 format!(
@@ -294,7 +339,7 @@ impl Sql {
                 "".to_string()
             };
             if !time_range_sql.is_empty() && meta_time_range_is_empty {
-                match RE_WHERE.captures(origin_sql.as_str()) {
+                match RE_WHERE.captures(rewrite_time_range_sql.as_str()) {
                     Some(caps) => {
                         let mut where_str = caps.get(1).unwrap().as_str().to_string();
                         if !meta.group_by.is_empty() {
@@ -318,22 +363,28 @@ impl Sql {
                                 [0..where_str.to_lowercase().rfind(" offset ").unwrap()]
                                 .to_string();
                         }
-                        let pos_start = origin_sql.find(where_str.as_str()).unwrap();
+                        let pos_start = rewrite_time_range_sql.find(where_str.as_str()).unwrap();
                         let pos_end = pos_start + where_str.len();
-                        origin_sql = format!(
+                        rewrite_time_range_sql = format!(
                             "{}{} AND ({}){}",
-                            &origin_sql[0..pos_start],
+                            &rewrite_time_range_sql[0..pos_start],
                             time_range_sql,
                             where_str,
-                            &origin_sql[pos_end..]
+                            &rewrite_time_range_sql[pos_end..]
                         );
                     }
                     None => {
-                        origin_sql = origin_sql
+                        rewrite_time_range_sql = rewrite_time_range_sql
                             .replace(" FROM tbl", &format!(" FROM tbl WHERE {time_range_sql}"));
                     }
                 };
             }
+        }
+
+        if meta.subquery.is_some() {
+            meta.subquery = Some(rewrite_time_range_sql);
+        } else {
+            origin_sql = rewrite_time_range_sql;
         }
 
         // Hack offset limit and sort by for sql
@@ -664,12 +715,6 @@ impl Sql {
         } else {
             Some(req_query.query_fn.clone())
         };
-
-        // suppport for subquery in from clause
-        if meta.subquery.is_some() {
-            let re = Regex::new(r"(from\s+)\(.*?\)").unwrap();
-            origin_sql = re.replace(origin_sql.as_str(), "${1}tbl").to_string();
-        }
 
         Ok(Sql {
             origin_sql,


### PR DESCRIPTION
close #3837

## Todo

```sql
select a,b from (select a,b,c from tbl) order by _timestamp desc
```
~this case will got error, haven't fix it yet.~ 

this is already fixed.


## Subquery

The current support is two types of subqueries, and the subqueries should be in the same stream.
the first type is a subquery in the `where` clause
```
SELECT k8s_namespace_name, AVG(body_code) AS avg_body_code
FROM default1
WHERE k8s_pod_name IN (
    SELECT k8s_pod_name
    FROM default1
    WHERE k8s_pod_name LIKE 'zinc%'
)
GROUP BY k8s_namespace_name;
```
the second type is a subquery in the `from` clause
```
SELECT k8s_pod_name, body_level_classification
FROM (
    SELECT _timestamp, k8s_pod_name,
           CASE
               WHEN body_level = 'info' THEN 'info'
               ELSE 'error'
           END AS body_level_classification
    FROM default1
) AS classified
WHERE body_level_classification = 'info';
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for subqueries in various SQL operations, including parsing and handling within the application.

- **Bug Fixes**
  - Enhanced error logging messages for better diagnostics during SQL parsing and execution.

- **Improvements**
  - Improved the handling of SQL parsing errors and replacements.
  - Enhanced the control flow to manage subqueries and time range conditions more effectively.

These updates aim to provide greater flexibility in SQL query handling and improve the application's reliability and debuggability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->