### PR TITLE
fix: def val for start_at column

### DIFF
--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -1041,7 +1041,7 @@ CREATE TABLE IF NOT EXISTS stream_stats
 
     // create column started_at for old version <= 0.10.8
     let column = "started_at";
-    let data_type = "BIGINT not null";
+    let data_type = "BIGINT default 0 not null";
     add_column("file_list_jobs", column, data_type).await?;
 
     Ok(())

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -998,7 +998,7 @@ CREATE TABLE IF NOT EXISTS stream_stats
 
     // create column started_at for old version <= 0.10.8
     let column = "started_at";
-    let data_type = "BIGINT not null";
+    let data_type = "BIGINT default 0 not null";
     add_column("file_list_jobs", column, data_type).await?;
 
     Ok(())

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -1006,7 +1006,7 @@ CREATE TABLE IF NOT EXISTS stream_stats
 
     // create column started_at for old version <= 0.10.8
     let column = "started_at";
-    let data_type = "BIGINT not null";
+    let data_type = "BIGINT default 0 not null";
     add_column(&client, "file_list_jobs", column, data_type).await?;
 
     Ok(())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated database schema to ensure default values for `started_at` column in `file_list_jobs` table, preventing issues with missing data in MySQL, PostgreSQL, and SQLite.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->