### PR TITLE
fix: set right partitioning config as default

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -754,11 +754,11 @@ pub struct Limit {
     pub query_timeout: u64,
     #[env_config(name = "ZO_QUERY_DEFAULT_LIMIT", default = 1000)]
     pub query_default_limit: i64,
-    #[env_config(name = "ZO_QUERY_PARTITION_BY_SECS", default = 10)] // seconds
+    #[env_config(name = "ZO_QUERY_PARTITION_BY_SECS", default = 1)] // seconds
     pub query_partition_by_secs: usize,
     #[env_config(name = "ZO_QUERY_PARTITION_MIN_SECS", default = 600)] // seconds
     pub query_partition_min_secs: i64,
-    #[env_config(name = "ZO_QUERY_GROUP_BASE_SPEED", default = 1024)] // MB/s/core
+    #[env_config(name = "ZO_QUERY_GROUP_BASE_SPEED", default = 768)] // MB/s/core
     pub query_group_base_speed: usize,
     #[env_config(name = "ZO_INGEST_ALLOWED_UPTO", default = 5)] // in hours - in past
     pub ingest_allowed_upto: i64,


### PR DESCRIPTION
Set default partitioninig config that is optimized for getting most search results in under 1 second.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Optimized default settings for query partitioning and group base speed, enhancing overall performance and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->