### PR TITLE
feat: original size and compressed size unit in query management

### DIFF
--- a/web/src/components/queries/QueryList.vue
+++ b/web/src/components/queries/QueryList.vue
@@ -46,6 +46,7 @@ import { defineComponent, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { timestampToTimezoneDate } from "@/utils/zincutils";
 import { useStore } from "vuex";
+import { getUnitValue } from "@/utils/dashboard/convertDataIntoUnitValue";
 
 export default defineComponent({
   name: "QueryList",
@@ -129,7 +130,15 @@ export default defineComponent({
 
         return formattedDuration;
       };
+      const originalSizeGB =
+        query?.original_size !== undefined
+          ? getUnitValue(query?.original_size, "megabytes", "", 2)
+          : { value: "", unit: "" };
 
+      const compressedSizeGB =
+        query?.compressed_size !== undefined
+          ? getUnitValue(query?.compressed_size, "megabytes", "", 2)
+          : { value: "", unit: "" };
       const rows: any[] = [
         ["Trace ID", query?.trace_id],
         ["Status", query?.status],
@@ -143,13 +152,19 @@ export default defineComponent({
         ["Query Range", queryRange(query?.start_time, query?.end_time)],
         ["Scan Records", query?.records],
         ["Files", query?.files],
-        ["Original Size", query?.original_size],
-        ["Compressed Size", query?.compressed_size],
+        [
+          "Original Size",
+          originalSizeGB.value ? `${originalSizeGB.value} GB` : "",
+        ],
+        [
+          "Compressed Size",
+          compressedSizeGB.value ? `${compressedSizeGB.value} GB` : "",
+        ],
       ];
-      
+
       return rows;
     };
-    
+
     return {
       queryData,
       t,

--- a/web/src/components/queries/QueryList.vue
+++ b/web/src/components/queries/QueryList.vue
@@ -130,14 +130,14 @@ export default defineComponent({
 
         return formattedDuration;
       };
-      const originalSizeGB =
+      const originalSize =
         query?.original_size !== undefined
-          ? getUnitValue(query?.original_size, "megabytes", "", 2)
+          ? getUnitValue(query?.original_size, "bytes", "", 2)
           : { value: "", unit: "" };
 
-      const compressedSizeGB =
+      const compressedSize =
         query?.compressed_size !== undefined
-          ? getUnitValue(query?.compressed_size, "megabytes", "", 2)
+          ? getUnitValue(query?.compressed_size, "bytes", "", 2)
           : { value: "", unit: "" };
       const rows: any[] = [
         ["Trace ID", query?.trace_id],
@@ -154,11 +154,11 @@ export default defineComponent({
         ["Files", query?.files],
         [
           "Original Size",
-          originalSizeGB.value ? `${originalSizeGB.value} GB` : "",
+          originalSize.value ? `${originalSize.value} ${originalSize.unit}` : "",
         ],
         [
           "Compressed Size",
-          compressedSizeGB.value ? `${compressedSizeGB.value} GB` : "",
+          compressedSize.value ? `${compressedSize.value} ${compressedSize.unit}` : "",
         ],
       ];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved the display of file sizes by formatting `original_size` and `compressed_size` for better readability in the Query List table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->