### PR TITLE
chore: add trace id to cache logs

### DIFF
--- a/src/handler/grpc/request/query_cache.rs
+++ b/src/handler/grpc/request/query_cache.rs
@@ -38,6 +38,7 @@ impl QueryCache for QueryCacheServerImpl {
             req.is_aggregate,
             &req.file_path,
             &req.timestamp_col,
+            &req.trace_id,
         )
         .await
         {

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -285,7 +285,10 @@ pub async fn search(
         })
     }
 
-    log::info!("query deltas are: {:?}", c_resp.deltas);
+    log::info!(
+        "[trace_id {trace_id}]  query deltas are: {:?}",
+        c_resp.deltas
+    );
     // Result caching check ends
     let mut results = Vec::new();
     let mut res = if should_exec_query {
@@ -325,7 +328,7 @@ pub async fn search(
 
         if cfg.common.result_cache_enabled && cfg.common.print_key_sql {
             log::info!(
-                "Query original start time: {}, end time : {}",
+                "[trace_id {trace_id}]  Query original start time: {}, end time : {}",
                 req.query.start_time,
                 req.query.end_time
             );
@@ -346,7 +349,7 @@ pub async fn search(
 
                 if cfg.common.result_cache_enabled && cfg.common.print_key_sql {
                     log::info!(
-                        "Query new start time: {}, end time : {}",
+                        "[trace_id {trace_id}]  Query new start time: {}, end time : {}",
                         req.query.start_time,
                         req.query.end_time
                     );

--- a/src/proto/proto/cluster/querycache.proto
+++ b/src/proto/proto/cluster/querycache.proto
@@ -25,6 +25,7 @@ message QueryCacheRequest {
     string  query_key = 4; 
     string  file_path = 5; 
     string  timestamp_col = 6; 
+    string  trace_id = 7; 
 }
 
 message QueryCacheRes {

--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -168,6 +168,7 @@ pub async fn get_cached_results(
     is_aggregate: bool,
     file_path: &str,
     result_ts_column: &str,
+    trace_id: &str,
 ) -> Option<CachedQueryResponse> {
     let r = QUERY_RESULT_CACHE.read().await;
     let query_key = file_path.replace('/', "_");
@@ -249,7 +250,12 @@ pub async fn get_cached_results(
                             cached_response.hits = to_retain;
                         };
 
-                        log::info!("Get results from disk success for query key: {}", query_key);
+                        log::info!(
+                            "[trace_id {trace_id}] Get results from disk success for query key: {} with start time {} - end time {} ",
+                            query_key,
+                            matching_cache_meta.start_time,
+                            matching_cache_meta.end_time
+                        );
                         Some(CachedQueryResponse {
                             cached_response,
                             deltas,
@@ -262,7 +268,10 @@ pub async fn get_cached_results(
                         })
                     }
                     Err(e) => {
-                        log::error!("Get results from disk failed : {:?}", e);
+                        log::error!(
+                            "[trace_id {trace_id}] Get results from disk failed : {:?}",
+                            e
+                        );
                         None
                     }
                 }

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -72,6 +72,7 @@ pub async fn get_cached_results(
                     query_key,
                     file_path,
                     timestamp_col: result_ts_column,
+                    trace_id:trace_id.clone(),
                 };
 
                 let request = tonic::Request::new(req);
@@ -214,6 +215,7 @@ pub async fn get_cached_results(
         is_aggregate,
         &file_path,
         result_ts_column.as_str(),
+        &trace_id,
     )
     .await
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced traceability by adding `trace_id` support in various search and cache request functions.
  
- **Improvements**
  - Updated logging messages to include `trace_id` for better traceability across services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->