### PR TITLE
fix: inverted index search on longest token of all terms

### DIFF
--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -130,18 +130,17 @@ pub async fn search(
             .map(|t| {
                 let tokens = split_token(t, &cfg.common.inverted_index_split_chars);
                 tokens
-                    .iter()
+                    .into_iter()
                     .max_by_key(|key| key.len())
-                    .unwrap_or(&String::new())
-                    .to_string()
+                    .unwrap_or_default()
             })
             .collect::<HashSet<String>>();
 
         let search_condition = terms
             .iter()
-            .map(|x| format!("term LIKE '%{x}%'"))
-            .collect::<Vec<String>>()
-            .join(" or ");
+            .map(|v| format!("term LIKE '%{v}%'"))
+            .collect::<Vec<_>>()
+            .join(" OR ");
 
         let query = format!(
             "SELECT file_name, term, _count, _timestamp, deleted FROM \"{}\" WHERE {}",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced search functionality to process search terms more efficiently by using the longest token from each term and building a search condition with `or` between terms. This should yield more relevant search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->