### PR TITLE
fix: query management size units initial value unit is in mb not bytes

### DIFF
--- a/web/src/components/queries/QueryList.vue
+++ b/web/src/components/queries/QueryList.vue
@@ -132,12 +132,12 @@ export default defineComponent({
       };
       const originalSize =
         query?.original_size !== undefined
-          ? getUnitValue(query?.original_size, "bytes", "", 2)
+          ? getUnitValue(query?.original_size, "megabytes", "", 2)
           : { value: "", unit: "" };
 
       const compressedSize =
         query?.compressed_size !== undefined
-          ? getUnitValue(query?.compressed_size, "bytes", "", 2)
+          ? getUnitValue(query?.compressed_size, "megabytes", "", 2)
           : { value: "", unit: "" };
       const rows: any[] = [
         ["Trace ID", query?.trace_id],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated display units for original and compressed sizes from bytes to megabytes in the query list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->