### PR TITLE
feat: add `time_wait_in_queue` in search usage reporting

### DIFF
--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -88,6 +88,8 @@ pub struct UsageData {
     pub max_ts: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub search_type: Option<SearchEventType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub took_wait_in_queue: Option<usize>,
 }
 
 #[derive(Hash, PartialEq, Eq)]
@@ -230,6 +232,8 @@ pub struct RequestStats {
     pub search_type: Option<SearchEventType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub took_wait_in_queue: Option<usize>,
 }
 impl Default for RequestStats {
     fn default() -> Self {
@@ -245,6 +249,7 @@ impl Default for RequestStats {
             user_email: None,
             search_type: None,
             trace_id: None,
+            took_wait_in_queue: None,
         }
     }
 }
@@ -263,6 +268,7 @@ impl From<FileMeta> for RequestStats {
             user_email: None,
             search_type: None,
             trace_id: None,
+            took_wait_in_queue: None,
         }
     }
 }

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -453,6 +453,13 @@ pub async fn search(
         cached_ratio: Some(res.cached_ratio),
         search_type,
         trace_id: Some(trace_id.clone()),
+        took_wait_in_queue: if res.took_detail.is_some() {
+            let resp_took = res.took_detail.as_ref().unwrap();
+            // Consider only the cluster wait queue duration
+            Some(resp_took.cluster_wait_queue)
+        } else {
+            None
+        },
         ..Default::default()
     };
     let num_fn = req.query.query_fn.is_some() as u16;
@@ -800,6 +807,17 @@ pub async fn around(
         max_ts: Some(around_end_time),
         cached_ratio: Some(resp.cached_ratio),
         trace_id: Some(trace_id),
+        took_wait_in_queue: match (
+            resp_forward.took_detail.as_ref(),
+            resp_backward.took_detail.as_ref(),
+        ) {
+            (Some(forward_took), Some(backward_took)) => {
+                Some(forward_took.cluster_wait_queue + backward_took.cluster_wait_queue)
+            }
+            (Some(forward_took), None) => Some(forward_took.cluster_wait_queue),
+            (None, Some(backward_took)) => Some(backward_took.cluster_wait_queue),
+            _ => None,
+        },
         ..Default::default()
     };
     let num_fn = req.query.query_fn.is_some() as u16;
@@ -1201,6 +1219,13 @@ async fn values_v1(
         cached_ratio: Some(resp.cached_ratio),
         search_type: Some(SearchEventType::Values),
         trace_id: Some(trace_id),
+        took_wait_in_queue: if resp.took_detail.is_some() {
+            let resp_took = resp.took_detail.as_ref().unwrap();
+            // Consider only the cluster wait queue duration
+            Some(resp_took.cluster_wait_queue)
+        } else {
+            None
+        },
         ..Default::default()
     };
     let num_fn = req.query.query_fn.is_some() as u16;
@@ -1395,6 +1420,13 @@ async fn values_v2(
         cached_ratio: Some(resp.cached_ratio),
         search_type: Some(SearchEventType::Values),
         trace_id: Some(trace_id),
+        took_wait_in_queue: if resp.took_detail.is_some() {
+            let resp_took = resp.took_detail.as_ref().unwrap();
+            // Consider only the cluster wait queue duration
+            Some(resp_took.cluster_wait_queue)
+        } else {
+            None
+        },
         ..Default::default()
     };
     let num_fn = req.query.query_fn.is_some() as u16;

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -182,6 +182,13 @@ pub async fn search(
                     cached_ratio: Some(res.cached_ratio),
                     search_type,
                     trace_id: Some(trace_id),
+                    took_wait_in_queue: if res.took_detail.is_some() {
+                        let resp_took = res.took_detail.as_ref().unwrap();
+                        // Consider only the cluster wait queue duration
+                        Some(resp_took.cluster_wait_queue)
+                    } else {
+                        None
+                    },
                     ..Default::default()
                 };
                 report_request_usage_stats(

--- a/src/service/usage/mod.rs
+++ b/src/service/usage/mod.rs
@@ -102,6 +102,7 @@ pub async fn report_request_usage_stats(
             compressed_size: None,
             search_type: stats.search_type,
             trace_id: None,
+            took_wait_in_queue: stats.took_wait_in_queue,
         });
     };
 
@@ -134,6 +135,7 @@ pub async fn report_request_usage_stats(
         compressed_size: None,
         search_type: stats.search_type,
         trace_id: stats.trace_id,
+        took_wait_in_queue: stats.took_wait_in_queue,
     });
     if !usage.is_empty() {
         publish_usage(usage).await;


### PR DESCRIPTION
Includes `cluster_wait_queue` from response in the usage reporting of search api calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new field `took_wait_in_queue` to track the time spent in the queue for search and request operations.
  - Enhanced search functionality to include detailed queue wait times in the request stats.

- **Improvements**
  - Improved reporting of request usage statistics by including queue wait time for better performance insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->