### PR TITLE
fix: nats reconnection

### DIFF
--- a/src/infra/src/db/etcd.rs
+++ b/src/infra/src/db/etcd.rs
@@ -447,7 +447,7 @@ impl super::Db for Etcd {
                     match client.watch(key.clone(), Some(opt.clone())).await {
                         Ok((watcher, stream)) => (watcher, stream),
                         Err(e) => {
-                            log::error!("watching prefix: {}, error: {}", key, e);
+                            log::error!("[ETCD:watch] prefix: {}, error: {}", key, e);
                             time::sleep(time::Duration::from_secs(1)).await;
                             continue;
                         }
@@ -456,7 +456,7 @@ impl super::Db for Etcd {
                     let resp = match stream.message().await {
                         Ok(resp) => resp,
                         Err(e) => {
-                            log::error!("watching prefix: {}, get message error: {}", key, e);
+                            log::error!("[ETCD:watch] prefix: {}, get message error: {}", key, e);
                             break;
                         }
                     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced logging clarity with `[ETCD:watch]` prefix in error messages for Etcd database operations.
  - Improved error handling and retry logic in Nats database operations for increased reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->