### PR TITLE
fix: error while using arrow_cast with percentile function

### DIFF
--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -898,7 +898,9 @@ fn merge_rewrite_sql(
             fn_name = "sum".to_string();
         }
         if fn_name == "approx_percentile_cont" {
-            let re = Regex::new(r"(?i)approx_percentile_cont\(.*?,\s*(\d+(?:\.\d+)?(?:,\s*\d+)?)\)").unwrap();
+            let re =
+                Regex::new(r"(?i)approx_percentile_cont\(.*?,\s*(\d+(?:\.\d+)?(?:,\s*\d+)?)\)")
+                    .unwrap();
             let percentile = re.captures(field).unwrap().get(1).unwrap().as_str();
             fields[i] = format!(
                 "{fn_name}(\"{}\", {}) {}",

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -898,7 +898,7 @@ fn merge_rewrite_sql(
             fn_name = "sum".to_string();
         }
         if fn_name == "approx_percentile_cont" {
-            let re = Regex::new(r"(?i)approx_percentile_cont\(.*?,\s*(\d+(?:\.\d+)?)\)").unwrap();
+            let re = Regex::new(r"(?i)approx_percentile_cont\(.*?,\s*(\d+(?:\.\d+)?(?:,\s*\d+)?)\)").unwrap();
             let percentile = re.captures(field).unwrap().get(1).unwrap().as_str();
             fields[i] = format!(
                 "{fn_name}(\"{}\", {}) {}",

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -901,7 +901,15 @@ fn merge_rewrite_sql(
             let re =
                 Regex::new(r"(?i)approx_percentile_cont\(.*?,\s*(\d+(?:\.\d+)?(?:,\s*\d+)?)\)")
                     .unwrap();
-            let percentile = re.captures(field).unwrap().get(1).unwrap().as_str();
+            let percentile = match re.captures(field) {
+                Some(caps) => caps.get(1).unwrap().as_str(),
+                None => {
+                    return Err(DataFusionError::Execution(
+                        "Failed to extract percentile value in approx_percentile_cont function"
+                            .to_string(),
+                    ));
+                }
+            };
             fields[i] = format!(
                 "{fn_name}(\"{}\", {}) {}",
                 schema_field, percentile, over_as

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -898,14 +898,8 @@ fn merge_rewrite_sql(
             fn_name = "sum".to_string();
         }
         if fn_name == "approx_percentile_cont" {
-            let percentile = cap
-                .get(2)
-                .unwrap()
-                .as_str()
-                .splitn(2, ',')
-                .last()
-                .unwrap()
-                .trim();
+            let re = Regex::new(r"(?i)approx_percentile_cont\(.*?,\s*(\d+(?:\.\d+)?)\)").unwrap();
+            let percentile = re.captures(field).unwrap().get(1).unwrap().as_str();
             fields[i] = format!(
                 "{fn_name}(\"{}\", {}) {}",
                 schema_field, percentile, over_as


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy for extracting `percentile` values in queries using `"approx_percentile_cont"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->