### PR TITLE
fix: cancel query for super cluster

### DIFF
--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -594,7 +594,11 @@ fn parse_expr_check_field_name(s: &str, field: &str) -> bool {
     if s == field {
         return true;
     }
-    if field == "*" && s != "_all" && s != get_config().common.column_timestamp.clone() {
+    let cfg = get_config();
+    if field == "*"
+        && s != cfg.common.column_all.as_str()
+        && s != cfg.common.column_timestamp.as_str()
+    {
         return true;
     }
 

--- a/src/handler/grpc/request/search/mod.rs
+++ b/src/handler/grpc/request/search/mod.rs
@@ -131,9 +131,23 @@ impl Search for Searcher {
         let trace_id = req.job.as_ref().unwrap().trace_id.to_string();
         #[cfg(feature = "enterprise")]
         if !self.contain_key(&trace_id).await {
+            let req_query = req.query.as_ref().unwrap();
+            let sql = Some(req_query.sql.clone());
+            let start_time = Some(req_query.start_time);
+            let end_time = Some(req_query.end_time);
+            let user_id = req.user_id.clone();
             self.insert(
                 trace_id.clone(),
-                TaskStatus::new(vec![], false, None, None, None, None, None, None),
+                TaskStatus::new(
+                    vec![],
+                    false,
+                    user_id,
+                    Some(org_id.to_string()),
+                    Some(stream_type.to_string()),
+                    sql,
+                    start_time,
+                    end_time,
+                ),
             )
             .await;
         }
@@ -200,9 +214,23 @@ impl Search for Searcher {
         let trace_id = req.job.as_ref().unwrap().trace_id.to_string();
         #[cfg(feature = "enterprise")]
         if !self.contain_key(&trace_id).await {
+            let req_query = req.query.as_ref().unwrap();
+            let sql = Some(req_query.sql.clone());
+            let start_time = Some(req_query.start_time);
+            let end_time = Some(req_query.end_time);
+            let user_id = req.user_id.clone();
             self.insert(
                 trace_id.clone(),
-                TaskStatus::new(vec![], false, None, None, None, None, None, None),
+                TaskStatus::new(
+                    vec![],
+                    false,
+                    user_id,
+                    Some(org_id.to_string()),
+                    Some(stream_type.to_string()),
+                    sql,
+                    start_time,
+                    end_time,
+                ),
             )
             .await;
         }
@@ -288,6 +316,28 @@ impl Search for Searcher {
 
     #[cfg(not(feature = "enterprise"))]
     async fn cancel_query(
+        &self,
+        _req: Request<CancelQueryRequest>,
+    ) -> Result<Response<CancelQueryResponse>, Status> {
+        Err(Status::unimplemented("Not Supported"))
+    }
+
+    #[cfg(feature = "enterprise")]
+    async fn cluster_cancel_query(
+        &self,
+        req: Request<CancelQueryRequest>,
+    ) -> Result<Response<CancelQueryResponse>, Status> {
+        let trace_id = req.into_inner().trace_id;
+        match SearchService::cancel_query("", &trace_id).await {
+            Ok(ret) => Ok(Response::new(CancelQueryResponse {
+                is_success: ret.is_success,
+            })),
+            Err(_) => Ok(Response::new(CancelQueryResponse { is_success: false })),
+        }
+    }
+
+    #[cfg(not(feature = "enterprise"))]
+    async fn cluster_cancel_query(
         &self,
         _req: Request<CancelQueryRequest>,
     ) -> Result<Response<CancelQueryResponse>, Status> {

--- a/src/handler/http/request/search/job.rs
+++ b/src/handler/http/request/search/job.rs
@@ -84,6 +84,9 @@ async fn cancel_query_inner(org_id: &str, trace_ids: &[&str]) -> Result<HttpResp
     }
     let mut res = Vec::with_capacity(trace_ids.len());
     for trace_id in trace_ids {
+        if trace_id.is_empty() {
+            continue;
+        }
         let ret = if O2_CONFIG.super_cluster.enabled {
             o2_enterprise::enterprise::super_cluster::search::cancel_query(org_id, trace_id).await
         } else {

--- a/src/proto/proto/cluster/search.proto
+++ b/src/proto/proto/cluster/search.proto
@@ -13,6 +13,7 @@ service Search {
     rpc ClusterSearch (SearchRequest) returns (SearchResponse) {}
     rpc QueryStatus(QueryStatusRequest) returns (QueryStatusResponse) {}
     rpc CancelQuery(CancelQueryRequest) returns (CancelQueryResponse) {}
+    rpc ClusterCancelQuery(CancelQueryRequest) returns (CancelQueryResponse) {}
 }
 
 // Search request query

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -462,7 +462,10 @@ pub async fn query_status() -> Result<search::QueryStatusResponse, Error> {
 }
 
 #[cfg(feature = "enterprise")]
-pub async fn cancel_query(trace_id: &str) -> Result<search::CancelQueryResponse, Error> {
+pub async fn cancel_query(
+    _org_id: &str,
+    trace_id: &str,
+) -> Result<search::CancelQueryResponse, Error> {
     // get nodes from cluster
     let mut nodes = infra_cluster::get_cached_online_query_nodes()
         .await
@@ -487,8 +490,6 @@ pub async fn cancel_query(trace_id: &str) -> Result<search::CancelQueryResponse,
                 let cfg = get_config();
                 let mut request =
                     tonic::Request::new(proto::cluster_rpc::CancelQueryRequest { trace_id });
-                // request.set_timeout(Duration::from_secs(cfg.grpc.timeout));
-
                 opentelemetry::global::get_text_map_propagator(|propagator| {
                     propagator.inject_context(
                         &tracing::Span::current().context(),
@@ -506,7 +507,7 @@ pub async fn cancel_query(trace_id: &str) -> Result<search::CancelQueryResponse,
                     .await
                     .map_err(|err| {
                         log::error!(
-                            "search->grpc: node: {}, connect err: {:?}",
+                            "grpc_cancel_query: node: {}, connect err: {:?}",
                             &node.grpc_addr,
                             err
                         );
@@ -524,21 +525,22 @@ pub async fn cancel_query(trace_id: &str) -> Result<search::CancelQueryResponse,
                     .accept_compressed(CompressionEncoding::Gzip)
                     .max_decoding_message_size(cfg.grpc.max_message_size * 1024 * 1024)
                     .max_encoding_message_size(cfg.grpc.max_message_size * 1024 * 1024);
-                let response = match client.cancel_query(request).await {
-                    Ok(res) => res.into_inner(),
-                    Err(err) => {
-                        log::error!(
-                            "search->grpc: node: {}, search err: {:?}",
-                            &node.grpc_addr,
-                            err
-                        );
-                        if err.code() == tonic::Code::Internal {
-                            let err = ErrorCodes::from_json(err.message())?;
-                            return Err(Error::ErrorCode(err));
+                let response: cluster_rpc::CancelQueryResponse =
+                    match client.cancel_query(request).await {
+                        Ok(res) => res.into_inner(),
+                        Err(err) => {
+                            log::error!(
+                                "grpc_cancel_query: node: {}, search err: {:?}",
+                                &node.grpc_addr,
+                                err
+                            );
+                            if err.code() == tonic::Code::Internal {
+                                let err = ErrorCodes::from_json(err.message())?;
+                                return Err(Error::ErrorCode(err));
+                            }
+                            return Err(server_internal_error("search node error"));
                         }
-                        return Err(server_internal_error("search node error"));
-                    }
-                };
+                    };
                 Ok(response)
             }
             .instrument(grpc_span),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for canceling queries within a specific organization.
  - Introduced a new RPC method, `ClusterCancelQuery`, for enhanced query management.

- **Enhancements**
  - Improved the `cancel_query` functionality to include organization ID parameters for more targeted query management.
  - Updated error handling and logging for better debugging and user clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->