### PR TITLE
fix: unnecessary null field during compaction

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-03-02
+          toolchain: nightly-2024-07-08
           targets: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-03-02"
+channel = "nightly-2024-07-08"
 components = ["rustfmt", "clippy", "llvm-tools"]

--- a/src/config/src/utils/record_batch_ext.rs
+++ b/src/config/src/utils/record_batch_ext.rs
@@ -508,7 +508,7 @@ pub fn concat_batches(
         )?;
         arrays.push(array);
     }
-    RecordBatch::try_new(schema.clone(), arrays)
+    RecordBatch::try_new(schema, arrays)
 }
 
 // merge record batches, the record batch have same schema

--- a/src/config/src/utils/schema_ext.rs
+++ b/src/config/src/utils/schema_ext.rs
@@ -19,6 +19,7 @@ use std::{
 };
 
 use arrow_schema::{Field, Schema};
+use hashbrown::HashSet;
 
 const HASH_MAP_SIZE: usize = std::mem::size_of::<HashMap<String, String>>();
 
@@ -26,6 +27,7 @@ const HASH_MAP_SIZE: usize = std::mem::size_of::<HashMap<String, String>>();
 pub trait SchemaExt {
     fn to_cloned_fields(&self) -> Vec<Field>;
     fn cloned_from(&self, schema: &Schema) -> Schema;
+    fn retain(&self, fields: HashSet<String>) -> Schema;
     fn hash_key(&self) -> String;
     fn size(&self) -> usize;
     fn simple_fields(&self) -> Vec<(String, String)>;
@@ -50,6 +52,17 @@ impl SchemaExt for Schema {
                 Some(f) => (*f).clone(),
                 None => f.clone(),
             })
+            .collect::<Vec<_>>();
+        Schema::new(fields)
+    }
+
+    // create a new schema with only the fields in the set and keep the order
+    fn retain(&self, fields: HashSet<String>) -> Schema {
+        let fields = self
+            .fields()
+            .iter()
+            .filter(|f| fields.contains(f.name()))
+            .cloned()
             .collect::<Vec<_>>();
         Schema::new(fields)
     }

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -45,8 +45,8 @@ use crate::{
         utils::{
             functions,
             http::{
-                get_or_create_trace_id, get_search_type_from_request,
-                get_stream_type_from_request, get_use_cache_from_request,
+                get_or_create_trace_id, get_search_type_from_request, get_stream_type_from_request,
+                get_use_cache_from_request,
             },
         },
     },

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -36,8 +36,7 @@ use crate::{
         utils::{
             functions,
             http::{
-                get_or_create_trace_id, get_search_type_from_request,
-                get_stream_type_from_request,
+                get_or_create_trace_id, get_search_type_from_request, get_stream_type_from_request,
             },
         },
     },

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -586,13 +586,7 @@ async fn merge_files(
         )
         .await
     } else if stream_type == StreamType::Logs {
-        merge_parquet_files(
-            thread_id,
-            tmp_dir.name(),
-            schema.metadata().clone(),
-            &defined_schema_fields,
-        )
-        .await
+        merge_parquet_files(thread_id, tmp_dir.name(), schema.metadata().clone()).await
     } else {
         merge_parquet_files_by_datafusion(tmp_dir.name(), stream_type, &stream_name, schema.clone())
             .await

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -586,7 +586,13 @@ async fn merge_files(
         )
         .await
     } else if stream_type == StreamType::Logs {
-        merge_parquet_files(thread_id, tmp_dir.name(), schema.clone()).await
+        merge_parquet_files(
+            thread_id,
+            tmp_dir.name(),
+            schema.metadata().clone(),
+            &defined_schema_fields,
+        )
+        .await
     } else {
         merge_parquet_files_by_datafusion(tmp_dir.name(), stream_type, &stream_name, schema.clone())
             .await

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -586,7 +586,7 @@ async fn merge_files(
         )
         .await
     } else if stream_type == StreamType::Logs {
-        merge_parquet_files(thread_id, tmp_dir.name(), schema.metadata().clone()).await
+        merge_parquet_files(thread_id, tmp_dir.name(), schema.clone()).await
     } else {
         merge_parquet_files_by_datafusion(tmp_dir.name(), stream_type, &stream_name, schema.clone())
             .await

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -946,13 +946,10 @@ pub async fn convert_parquet_file(
     let query_sql = format!(
         "SELECT * FROM tbl ORDER BY {} DESC",
         cfg.common.column_timestamp
-    );
-
-    let select_wildcard = RE_SELECT_WILDCARD.is_match(query_sql.as_str());
-    let without_optimizer = select_wildcard;
+    ); //  select_wildcard -> without_optimizer
 
     // query data
-    let ctx = prepare_datafusion_context(None, &SearchType::Normal, without_optimizer).await?;
+    let ctx = prepare_datafusion_context(None, &SearchType::Normal, true).await?;
 
     // Configure listing options
     let listing_options = match file_type {


### PR DESCRIPTION
stop creating null field when merging parquet files during compaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced schema handling to support schema versions and evolution during file merging.
  - Added method to selectively retain fields in schemas.

- **Improvements**
  - Simplified query optimization logic for better performance.
  - Updated Rust toolchain to a newer nightly version for improved development experience.

- **Refactor**
  - Reformatted and consolidated import statements for better code organization.

- **Chores**
  - Updated Rust toolchain configurations in CI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->