### PR TITLE
perf: avoid repartition in file group

### DIFF
--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -1131,8 +1131,8 @@ pub fn create_session_config(
         "datafusion.execution.listing_table_ignore_subdirectory",
         false,
     );
-    config = config.set_bool("datafusion.execution.split_file_groups_by_statistics", true);
     if sort_by_timestamp_desc {
+        config = config.set_bool("datafusion.execution.split_file_groups_by_statistics", true);
         config = config.with_round_robin_repartition(false);
         config = config.with_coalesce_batches(false);
     }

--- a/src/service/search/datafusion/table_provider/mod.rs
+++ b/src/service/search/datafusion/table_provider/mod.rs
@@ -352,8 +352,8 @@ fn repartition_sorted_groups(
         let max_index = find_max_group_index(&groups);
         let max_group = groups.remove(max_index);
 
-        // if the max group has less than 2 files, we don't split it further
-        if max_group.len() <= 2 {
+        // if the max group has less than 3 files, we don't split it further
+        if max_group.len() <= 3 {
             groups.push(max_group);
             break;
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced performance for file group processing by conditionally configuring session settings based on the `sort_by_timestamp_desc` variable.
  - Improved efficiency in file group repartitioning by adjusting the threshold for splitting maximum groups to files less than or equal to 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->