### PR TITLE
fix: histogram time to match partition time range

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1538,13 +1538,11 @@ const useLogs = () => {
         searchObj.data.histogramQuery.query.sql_mode = "full";
 
         searchObj.data.histogramQuery.query.start_time =
-          searchObj.data.datetime.startTime.toString().length > 13
-            ? searchObj.data.datetime.startTime
-            : searchObj.data.datetime.startTime * 1000;
+          queryReq.query.start_time;             
+      
         searchObj.data.histogramQuery.query.end_time =
-          searchObj.data.datetime.endTime.toString().length > 13
-            ? searchObj.data.datetime.endTime
-            : searchObj.data.datetime.endTime * 1000;
+          queryReq.query.end_time;
+   
         delete searchObj.data.histogramQuery.query.quick_mode;
         delete searchObj.data.histogramQuery.query.from;
 

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1537,11 +1537,11 @@ const useLogs = () => {
           searchObj.data.histogramQuery.aggs.histogram;
         searchObj.data.histogramQuery.query.sql_mode = "full";
 
-        searchObj.data.histogramQuery.query.start_time =
-          queryReq.query.start_time;             
+        // searchObj.data.histogramQuery.query.start_time =
+        //   queryReq.query.start_time;             
       
-        searchObj.data.histogramQuery.query.end_time =
-          queryReq.query.end_time;
+        // searchObj.data.histogramQuery.query.end_time =
+        //   queryReq.query.end_time;
    
         delete searchObj.data.histogramQuery.query.quick_mode;
         delete searchObj.data.histogramQuery.query.from;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log search functionality by ensuring accurate assignment of `start_time` and `end_time` values directly from the query request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->