### PR TITLE
fix: inverted index can't get result when the min_timestamp mismatch

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -53,12 +53,15 @@ pub const SIZE_IN_MB: f64 = 1024.0 * 1024.0;
 pub const SIZE_IN_GB: f64 = 1024.0 * 1024.0 * 1024.0;
 pub const PARQUET_BATCH_SIZE: usize = 8 * 1024;
 pub const PARQUET_PAGE_SIZE: usize = 1024 * 1024;
-pub const PARQUET_MAX_ROW_GROUP_SIZE: usize = 1024 * 1024;
+pub const PARQUET_MAX_ROW_GROUP_SIZE: usize = 1024 * 1024; // this can't be change, it will cause segment matching error
+pub const INDEX_SEGMENT_LENGTH: usize = 1024; // this can't be change, it will cause segment matching error
 pub const DEFAULT_BLOOM_FILTER_FPP: f64 = 0.01;
 
 pub const FILE_EXT_JSON: &str = ".json";
 pub const FILE_EXT_ARROW: &str = ".arrow";
 pub const FILE_EXT_PARQUET: &str = ".parquet";
+
+pub const INDEX_FIELD_NAME_FOR_ALL: &str = "_all";
 
 pub const INDEX_MIN_CHAR_LEN: usize = 3;
 
@@ -498,8 +501,6 @@ pub struct Common {
     pub data_dir: String,
     #[env_config(name = "ZO_DATA_WAL_DIR", default = "")] // ./data/openobserve/wal/
     pub data_wal_dir: String,
-    #[env_config(name = "ZO_DATA_IDX_DIR", default = "")] // ./data/openobserve/idx/
-    pub data_idx_dir: String,
     #[env_config(name = "ZO_DATA_STREAM_DIR", default = "")] // ./data/openobserve/stream/
     pub data_stream_dir: String,
     #[env_config(name = "ZO_DATA_DB_DIR", default = "")] // ./data/openobserve/db/
@@ -535,6 +536,8 @@ pub struct Common {
     pub feature_query_infer_schema: bool,
     #[env_config(name = "ZO_FEATURE_QUERY_EXCLUDE_ALL", default = true)]
     pub feature_query_exclude_all: bool,
+    #[env_config(name = "ZO_FEATURE_QUERY_WITHOUT_INDEX", default = false)]
+    pub feature_query_without_index: bool,
     #[env_config(name = "ZO_UI_ENABLED", default = true)]
     pub ui_enabled: bool,
     #[env_config(name = "ZO_UI_SQL_BASE64_ENABLED", default = false)]
@@ -720,8 +723,6 @@ pub struct Limit {
     pub req_json_limit: usize,
     #[env_config(name = "ZO_PAYLOAD_LIMIT", default = 209715200)]
     pub req_payload_limit: usize,
-    #[env_config(name = "ZO_PARQUET_MAX_ROW_GROUP_SIZE", default = 0)] // row count
-    pub parquet_max_row_group_size: usize,
     #[env_config(name = "ZO_MAX_FILE_RETENTION_TIME", default = 600)] // seconds
     pub max_file_retention_time: u64,
     // MB, per log file size limit on disk
@@ -862,11 +863,13 @@ pub struct Compact {
     pub enabled: bool,
     #[env_config(name = "ZO_COMPACT_INTERVAL", default = 60)] // seconds
     pub interval: u64,
+    #[env_config(name = "ZO_COMPACT_STRATEGY", default = "file_time")] // file_size, file_time
+    pub strategy: String,
     #[env_config(name = "ZO_COMPACT_LOOKBACK_HOURS", default = 0)] // hours
     pub lookback_hours: i64,
     #[env_config(name = "ZO_COMPACT_STEP_SECS", default = 3600)] // seconds
     pub step_secs: i64,
-    #[env_config(name = "ZO_COMPACT_SYNC_TO_DB_INTERVAL", default = 1800)] // seconds
+    #[env_config(name = "ZO_COMPACT_SYNC_TO_DB_INTERVAL", default = 600)] // seconds
     pub sync_to_db_interval: u64,
     #[env_config(name = "ZO_COMPACT_MAX_FILE_SIZE", default = 256)] // MB
     pub max_file_size: usize,
@@ -1340,12 +1343,6 @@ fn check_path_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
     if !cfg.common.data_wal_dir.ends_with('/') {
         cfg.common.data_wal_dir = format!("{}/", cfg.common.data_wal_dir);
-    }
-    if cfg.common.data_idx_dir.is_empty() {
-        cfg.common.data_idx_dir = format!("{}idx/", cfg.common.data_dir);
-    }
-    if !cfg.common.data_idx_dir.ends_with('/') {
-        cfg.common.data_idx_dir = format!("{}/", cfg.common.data_idx_dir);
     }
     if cfg.common.data_stream_dir.is_empty() {
         cfg.common.data_stream_dir = format!("{}stream/", cfg.common.data_dir);

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -22,9 +22,9 @@ use proto::cluster_rpc;
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 use utoipa::ToSchema;
 
-use super::usage::Stats;
 use crate::{
     get_config,
+    meta::usage::Stats,
     utils::{
         hash::{gxhash, Sum64},
         json::{self, Map, Value},
@@ -197,6 +197,22 @@ impl From<&String> for QueryPartitionStrategy {
             "file_size" => QueryPartitionStrategy::FileSize,
             "file_hash" => QueryPartitionStrategy::FileHash,
             _ => QueryPartitionStrategy::FileNum,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MergeStrategy {
+    FileSize,
+    FileTime,
+}
+
+impl From<&String> for MergeStrategy {
+    fn from(s: &String) -> Self {
+        match s.to_lowercase().as_str() {
+            "file_size" => MergeStrategy::FileSize,
+            "file_time" => MergeStrategy::FileTime,
+            _ => MergeStrategy::FileSize,
         }
     }
 }

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -203,9 +203,6 @@ pub async fn init() -> Result<(), anyhow::Error> {
         if let Err(e) = std::fs::create_dir_all(&cfg.common.data_wal_dir) {
             log::error!("Failed to create wal dir: {}", e);
         }
-        if let Err(e) = std::fs::create_dir_all(&cfg.common.data_idx_dir) {
-            log::error!("Failed to create wal dir: {}", e);
-        }
     }
 
     tokio::task::spawn(async move { files::run().await });

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -146,8 +146,8 @@ pub async fn search(
             .join(" OR ");
 
         let query = format!(
-            "SELECT file_name, term, _count, _timestamp, deleted FROM \"{}\" WHERE {}",
-            meta.stream_name, search_condition
+            "SELECT file_name, term, _count, deleted, {} FROM \"{}\" WHERE {}",
+            cfg.common.column_timestamp, meta.stream_name, search_condition
         );
 
         // fast_mode is for 1st page optimization

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -107,7 +107,9 @@ pub async fn search(
         partition: 0,
     };
 
-    let is_inverted_index = cfg.common.inverted_index_enabled && !meta.fts_terms.is_empty();
+    let is_inverted_index = cfg.common.inverted_index_enabled
+        && !cfg.common.feature_query_without_index
+        && !meta.fts_terms.is_empty();
 
     log::info!(
         "[trace_id {trace_id}] search: is_agg_query {:?} is_inverted_index {:?}",

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -701,27 +701,6 @@ async fn get_file_list(
     .await
 }
 
-/// get file list from local mutable arrow idx file, each file will be searched
-#[tracing::instrument(name = "service:search:grpc:wal:get_file_list_arrow", skip_all, fields(org_id = sql.org_id, stream_name = sql.stream_name))]
-async fn get_file_list_arrow(
-    trace_id: &str,
-    sql: &Sql,
-    stream_type: StreamType,
-    _partition_time_level: &PartitionTimeLevel,
-    partition_keys: &[StreamPartition],
-) -> Result<Vec<FileKey>, Error> {
-    get_file_list_inner(
-        trace_id,
-        sql,
-        stream_type,
-        _partition_time_level,
-        partition_keys,
-        &get_config().common.data_idx_dir,
-        "arrow",
-    )
-    .await
-}
-
 pub fn adapt_batch(table_schema: &Schema, batch: &RecordBatch) -> RecordBatch {
     let batch_schema = &*batch.schema();
     let batch_cols = batch.columns().to_vec();

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -336,7 +336,10 @@ impl Sql {
             } else {
                 "".to_string()
             };
-            if !time_range_sql.is_empty() && meta_time_range_is_empty {
+            if !time_range_sql.is_empty()
+                && meta_time_range_is_empty
+                && stream_type != StreamType::Index
+            {
                 match RE_WHERE.captures(rewrite_time_range_sql.as_str()) {
                     Some(caps) => {
                         let mut where_str = caps.get(1).unwrap().as_str().to_string();


### PR DESCRIPTION
It will work if we don't add `time range` for query from `inverted index`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new condition to the search functionality to better handle queries without using an index.

- **Improvements**
  - Simplified file management and configuration processes.
  - Enhanced merge strategy options for file handling.
  - Streamlined Parquet writer configuration for consistency.
  - Improved initialization process to avoid unnecessary errors.

- **Bug Fixes**
  - Fixed issues related to directory creation errors during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->