### PR TITLE
fix: added plus sign for getcount call & removed duplicate call from …

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2891,6 +2891,11 @@ const useLogs = () => {
       if (isNaN(endCount)) {
         endCount = 0;
       }
+
+      let plusSign: string = "";
+      if(searchObj.data.queryResults.partitionDetail.partitions.length > 1 && searchObj.meta.showHistogram == false) {
+        plusSign = "+";
+      }
       const title =
         "Showing " +
         startCount +
@@ -2898,10 +2903,12 @@ const useLogs = () => {
         endCount +
         " out of " +
         totalCount.toLocaleString() +
+        plusSign +
         " events in " +
         searchObj.data.queryResults.took +
         " ms. (Scan Size: " +
         formatSizeFromMB(searchObj.data.queryResults.scan_size) +
+        plusSign +
         ")";
       return title;
     } catch (e: any) {
@@ -3166,9 +3173,6 @@ const useLogs = () => {
           if (searchObj.loading == false && searchObj.loadingHistogram == false) {
             searchObj.loading = true;
             await getQueryData(false);
-            generateHistogramData();
-            updateGridColumns();
-            searchObj.meta.histogramDirtyFlag = true;
           }
         }, searchObj.meta.refreshInterval * 1000);
         store.dispatch("setRefreshIntervalID", refreshIntervalID);


### PR DESCRIPTION
issue# 3932

Added plus sign on search data message like `Showing 1 to 250 out of 5,776,398+ events in 249 ms. (Scan Size: 6.19 GB+)`

Removed duplicate call on live reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The log title now conditionally includes a plus sign based on specific criteria for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->