### PR TITLE
fix: avoid otlp tracing being split into parts

### DIFF
--- a/src/handler/grpc/request/search/mod.rs
+++ b/src/handler/grpc/request/search/mod.rs
@@ -111,7 +111,7 @@ impl Default for Searcher {
 
 #[tonic::async_trait]
 impl Search for Searcher {
-    #[tracing::instrument(name = "grpc:search:enter", skip_all, fields(trace_id=req.get_ref().job.as_ref().unwrap().trace_id, org_id = req.get_ref().org_id))]
+    #[tracing::instrument(name = "grpc:search:enter", skip_all, fields(trace_id, org_id = req.get_ref().org_id))]
     async fn search(
         &self,
         req: Request<SearchRequest>,
@@ -194,7 +194,7 @@ impl Search for Searcher {
         }
     }
 
-    #[tracing::instrument(name = "grpc:cluster_search:enter", skip_all, fields(trace_id=req.get_ref().job.as_ref().unwrap().trace_id, org_id = req.get_ref().org_id))]
+    #[tracing::instrument(name = "grpc:cluster_search:enter", skip_all, fields(trace_id, org_id = req.get_ref().org_id))]
     async fn cluster_search(
         &self,
         req: Request<SearchRequest>,

--- a/src/handler/grpc/request/search/mod.rs
+++ b/src/handler/grpc/request/search/mod.rs
@@ -111,7 +111,7 @@ impl Default for Searcher {
 
 #[tonic::async_trait]
 impl Search for Searcher {
-    #[tracing::instrument(name = "grpc:search:enter", skip_all, fields(trace_id, org_id = req.get_ref().org_id))]
+    #[tracing::instrument(name = "grpc:search:enter", skip_all, fields(org_id = req.get_ref().org_id))]
     async fn search(
         &self,
         req: Request<SearchRequest>,
@@ -194,7 +194,7 @@ impl Search for Searcher {
         }
     }
 
-    #[tracing::instrument(name = "grpc:cluster_search:enter", skip_all, fields(trace_id, org_id = req.get_ref().org_id))]
+    #[tracing::instrument(name = "grpc:cluster_search:enter", skip_all, fields(org_id = req.get_ref().org_id))]
     async fn cluster_search(
         &self,
         req: Request<SearchRequest>,

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -167,7 +167,7 @@ pub(crate) async fn create_context(
 #[tracing::instrument(
     name = "promql:search:grpc:storage:get_file_list",
     skip_all,
-    fields(trace_id, org_id, stream_name)
+    fields(org_id, stream_name)
 )]
 async fn get_file_list(
     trace_id: &str,

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -56,7 +56,10 @@ pub async fn get_cached_results(
         let node_addr = node.grpc_addr.clone();
         let grpc_span = info_span!(
             "service:search:cluster:cacher:get_cached_results",
-            trace_id,
+            trace_id = trace_id
+                .split_once('-')
+                .map(|(trace_id, _)| trace_id)
+                .unwrap_or(&trace_id),
             node_id = node.id,
             node_addr = node_addr.as_str(),
         );
@@ -274,7 +277,10 @@ pub async fn delete_cached_results(path: String) -> bool {
 
         let grpc_span = info_span!(
             "service:search:cluster:cacher:delete_cached_results",
-            trace_id,
+            trace_id = trace_id
+                .split_once('-')
+                .map(|(trace_id, _)| trace_id)
+                .unwrap_or(&trace_id),
             node_id = node.id,
             node_addr = node_addr.as_str(),
         );

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -56,10 +56,6 @@ pub async fn get_cached_results(
         let node_addr = node.grpc_addr.clone();
         let grpc_span = info_span!(
             "service:search:cluster:cacher:get_cached_results",
-            trace_id = trace_id
-                .split_once('-')
-                .map(|(trace_id, _)| trace_id)
-                .unwrap_or(&trace_id),
             node_id = node.id,
             node_addr = node_addr.as_str(),
         );
@@ -277,10 +273,6 @@ pub async fn delete_cached_results(path: String) -> bool {
 
         let grpc_span = info_span!(
             "service:search:cluster:cacher:delete_cached_results",
-            trace_id = trace_id
-                .split_once('-')
-                .map(|(trace_id, _)| trace_id)
-                .unwrap_or(&trace_id),
             node_id = node.id,
             node_addr = node_addr.as_str(),
         );

--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -29,7 +29,7 @@ use crate::common::meta::functions::VRLResultResolver;
 #[tracing::instrument(
     name = "service:search:cluster",
     skip(req),
-    fields(trace_id, org_id = req.org_id)
+    fields(org_id = req.org_id)
 )]
 pub async fn search(mut req: cluster_rpc::SearchRequest) -> Result<search::Response> {
     let start = std::time::Instant::now();

--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -29,7 +29,7 @@ use crate::common::meta::functions::VRLResultResolver;
 #[tracing::instrument(
     name = "service:search:cluster",
     skip(req),
-    fields(trace_id = req.job.as_ref().unwrap().trace_id, org_id = req.org_id)
+    fields(trace_id, org_id = req.org_id)
 )]
 pub async fn search(mut req: cluster_rpc::SearchRequest) -> Result<search::Response> {
     let start = std::time::Instant::now();

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -462,10 +462,6 @@ pub async fn search(
         let node_addr = node.grpc_addr.clone();
         let grpc_span = info_span!(
             "service:search:cluster:grpc_search",
-            trace_id = trace_id
-                .split_once('-')
-                .map(|(trace_id, _)| trace_id)
-                .unwrap_or(&trace_id),
             org_id = req.org_id,
             node_id = node.id,
             node_addr = node_addr.as_str(),

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -59,7 +59,7 @@ pub mod super_cluster;
 #[tracing::instrument(
     name = "service:search:cluster:run",
     skip_all,
-    fields(trace_id = req.job.as_ref().unwrap().trace_id, org_id = req.org_id)
+    fields(trace_id, org_id = req.org_id)
 )]
 pub async fn search(
     trace_id: &str,
@@ -462,7 +462,10 @@ pub async fn search(
         let node_addr = node.grpc_addr.clone();
         let grpc_span = info_span!(
             "service:search:cluster:grpc_search",
-            trace_id,
+            trace_id = trace_id
+                .split_once('-')
+                .map(|(trace_id, _)| trace_id)
+                .unwrap_or(&trace_id),
             org_id = req.org_id,
             node_id = node.id,
             node_addr = node_addr.as_str(),

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -59,7 +59,7 @@ pub mod super_cluster;
 #[tracing::instrument(
     name = "service:search:cluster:run",
     skip_all,
-    fields(trace_id, org_id = req.org_id)
+    fields(org_id = req.org_id)
 )]
 pub async fn search(
     trace_id: &str,

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -72,11 +72,6 @@ pub async fn search(
         sql.meta.time_range
     );
 
-    let span_trace_id = trace_id
-        .split_once('-')
-        .map(|(trace_id, _)| trace_id)
-        .unwrap_or(&trace_id);
-
     // search in WAL parquet
     let skip_wal = req.query.as_ref().unwrap().skip_wal;
     let work_group1 = work_group.clone();
@@ -84,7 +79,6 @@ pub async fn search(
     let sql1 = sql.clone();
     let wal_parquet_span = info_span!(
         "service:search:grpc:in_wal_parquet",
-        trace_id = span_trace_id,
         org_id = sql.org_id,
         stream_name = sql.stream_name,
         stream_type = stream_type.to_string(),
@@ -106,7 +100,6 @@ pub async fn search(
     let sql2 = sql.clone();
     let wal_mem_span = info_span!(
         "service:search:grpc:in_wal_memory",
-        trace_id = span_trace_id,
         org_id = sql.org_id,
         stream_name = sql.stream_name,
         stream_type = stream_type.to_string(),
@@ -130,7 +123,6 @@ pub async fn search(
     let file_list: Vec<FileKey> = req.file_list.iter().map(FileKey::from).collect();
     let storage_span = info_span!(
         "service:search:grpc:in_storage",
-        trace_id = span_trace_id,
         org_id = sql.org_id,
         stream_name = sql.stream_name,
         stream_type = stream_type.to_string(),

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -38,7 +38,7 @@ mod wal;
 
 pub type SearchResult = Result<(HashMap<String, Vec<RecordBatch>>, ScanStats), Error>;
 
-#[tracing::instrument(name = "service:search:grpc:search", skip_all, fields(trace_id, org_id = req.org_id))]
+#[tracing::instrument(name = "service:search:grpc:search", skip_all, fields(org_id = req.org_id))]
 pub async fn search(
     req: &cluster_rpc::SearchRequest,
 ) -> Result<cluster_rpc::SearchResponse, Error> {

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -249,10 +249,6 @@ pub async fn search(
 
         let datafusion_span = info_span!(
             "service:search:grpc:storage:datafusion",
-            trace_id = trace_id
-                .split_once('-')
-                .map(|(trace_id, _)| trace_id)
-                .unwrap_or(trace_id),
             org_id = sql.org_id,
             stream_name = sql.stream_name,
             stream_type = stream_type.to_string(),

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -249,7 +249,10 @@ pub async fn search(
 
         let datafusion_span = info_span!(
             "service:search:grpc:storage:datafusion",
-            trace_id,
+            trace_id = trace_id
+                .split_once('-')
+                .map(|(trace_id, _)| trace_id)
+                .unwrap_or(&trace_id),
             org_id = sql.org_id,
             stream_name = sql.stream_name,
             stream_type = stream_type.to_string(),

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -47,7 +47,7 @@ use crate::service::{
 type CachedFiles = (usize, usize);
 
 /// search in remote object storage
-#[tracing::instrument(name = "service:search:grpc:storage:enter", skip_all, fields(trace_id, org_id = sql.org_id, stream_name = sql.stream_name))]
+#[tracing::instrument(name = "service:search:grpc:storage:enter", skip_all, fields(org_id = sql.org_id, stream_name = sql.stream_name))]
 pub async fn search(
     trace_id: &str,
     sql: Arc<Sql>,
@@ -252,7 +252,7 @@ pub async fn search(
             trace_id = trace_id
                 .split_once('-')
                 .map(|(trace_id, _)| trace_id)
-                .unwrap_or(&trace_id),
+                .unwrap_or(trace_id),
             org_id = sql.org_id,
             stream_name = sql.stream_name,
             stream_type = stream_type.to_string(),
@@ -359,7 +359,7 @@ pub async fn search(
     Ok((results, scan_stats))
 }
 
-#[tracing::instrument(name = "service:search:grpc:storage:get_file_list", skip_all, fields(trace_id, org_id = sql.org_id, stream_name = sql.stream_name))]
+#[tracing::instrument(name = "service:search:grpc:storage:get_file_list", skip_all, fields(org_id = sql.org_id, stream_name = sql.stream_name))]
 async fn get_file_list(
     trace_id: &str,
     sql: &Sql,
@@ -408,11 +408,7 @@ async fn get_file_list(
     Ok(files)
 }
 
-#[tracing::instrument(
-    name = "service:search:grpc:storage:cache_parquet_files",
-    skip_all,
-    fields(trace_id)
-)]
+#[tracing::instrument(name = "service:search:grpc:storage:cache_parquet_files", skip_all)]
 async fn cache_parquet_files(
     trace_id: &str,
     files: &[FileKey],

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -280,10 +280,6 @@ pub async fn search_parquet(
 
         let datafusion_span = info_span!(
             "service:search:grpc:wal:parquet:datafusion",
-            trace_id = trace_id
-                .split_once('-')
-                .map(|(trace_id, _)| trace_id)
-                .unwrap_or(trace_id),
             org_id = sql.org_id,
             stream_name = sql.stream_name,
             stream_type = stream_type.to_string(),
@@ -505,10 +501,6 @@ pub async fn search_memtable(
 
         let datafusion_span = info_span!(
             "service:search:grpc:wal:mem:datafusion",
-            trace_id = trace_id
-                .split_once('-')
-                .map(|(trace_id, _)| trace_id)
-                .unwrap_or(trace_id),
             org_id = sql.org_id,
             stream_name = sql.stream_name,
             stream_type = stream_type.to_string(),

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -283,7 +283,7 @@ pub async fn search_parquet(
             trace_id = trace_id
                 .split_once('-')
                 .map(|(trace_id, _)| trace_id)
-                .unwrap_or(&trace_id),
+                .unwrap_or(trace_id),
             org_id = sql.org_id,
             stream_name = sql.stream_name,
             stream_type = stream_type.to_string(),
@@ -508,7 +508,7 @@ pub async fn search_memtable(
             trace_id = trace_id
                 .split_once('-')
                 .map(|(trace_id, _)| trace_id)
-                .unwrap_or(&trace_id),
+                .unwrap_or(trace_id),
             org_id = sql.org_id,
             stream_name = sql.stream_name,
             stream_type = stream_type.to_string(),

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -55,7 +55,7 @@ use crate::{
 };
 
 /// search in local WAL, which haven't been sync to object storage
-#[tracing::instrument(name = "service:search:wal:parquet::enter", skip_all, fields(trace_id, org_id = sql.org_id, stream_name = sql.stream_name))]
+#[tracing::instrument(name = "service:search:wal:parquet::enter", skip_all, fields(org_id = sql.org_id, stream_name = sql.stream_name))]
 pub async fn search_parquet(
     trace_id: &str,
     sql: Arc<Sql>,

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -280,7 +280,10 @@ pub async fn search_parquet(
 
         let datafusion_span = info_span!(
             "service:search:grpc:wal:parquet:datafusion",
-            trace_id,
+            trace_id = trace_id
+                .split_once('-')
+                .map(|(trace_id, _)| trace_id)
+                .unwrap_or(&trace_id),
             org_id = sql.org_id,
             stream_name = sql.stream_name,
             stream_type = stream_type.to_string(),
@@ -502,6 +505,10 @@ pub async fn search_memtable(
 
         let datafusion_span = info_span!(
             "service:search:grpc:wal:mem:datafusion",
+            trace_id = trace_id
+                .split_once('-')
+                .map(|(trace_id, _)| trace_id)
+                .unwrap_or(&trace_id),
             org_id = sql.org_id,
             stream_name = sql.stream_name,
             stream_type = stream_type.to_string(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved tracing instrumentation across various search-related functions by removing the `trace_id` field and refining how `trace_id` is handled in logs.

- **Bug Fixes**
  - Enhanced logging consistency and accuracy by standardizing trace ID processing in `get_file_list`, `search`, `cluster_search`, `search_parquet`, and `search_memtable` functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->