### PR TITLE
fix: use _timestamp in TriggerData for triggers usage

### DIFF
--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -45,6 +45,7 @@ pub enum TriggerDataType {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TriggerData {
+    pub _timestamp: i64,
     pub org: String,
     pub module: TriggerDataType,
     pub key: String,

--- a/src/service/alerts/alert_manager.rs
+++ b/src/service/alerts/alert_manager.rs
@@ -150,6 +150,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
     }
 
     let mut trigger_data_stream = TriggerData {
+        _timestamp: trigger.start_time.unwrap_or_default(),
         org: trigger.org,
         module: TriggerDataType::Alert,
         key: trigger.module_key.clone(),
@@ -298,6 +299,7 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
     }
 
     let mut trigger_data_stream = TriggerData {
+        _timestamp: trigger.start_time.unwrap_or_default(),
         org: trigger.org.clone(),
         module: TriggerDataType::Report,
         key: trigger.module_key.clone(),

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -222,6 +222,7 @@ pub async fn evaluate_trigger(trigger: Option<TriggerAlertData>) {
         );
         let now = Utc::now().timestamp_micros();
         let mut trigger_data_stream = TriggerData {
+            _timestamp: now,
             org: alert.org_id.to_string(),
             module: TriggerDataType::Alert,
             key: module_key.clone(),

--- a/src/service/usage/mod.rs
+++ b/src/service/usage/mod.rs
@@ -346,7 +346,7 @@ async fn ingest_usages(curr_usages: Vec<UsageData>) {
 
 async fn ingest_trigger_usages(curr_usages: Vec<TriggerData>) {
     if curr_usages.is_empty() {
-        log::info!(" Returning as no triggers reported ");
+        log::info!(" Returning as no triggers reported");
         return;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `_timestamp` field to track the timestamp in `TriggerData` for better logging and analysis.

- **Bug Fixes**
  - Corrected a minor formatting issue in a log message for improved readability.

These enhancements will improve data tracking and log clarity for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->