### PR TITLE
fix: invalid peer certificate: UnknownIssuer for report traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
  "proto",
  "rand",
  "regex",
- "reqwest 0.12.4",
+ "reqwest 0.11.27",
  "segment",
  "serde",
  "serde_json",
@@ -5508,7 +5508,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.4",
  "report_server",
- "reqwest 0.12.4",
+ "reqwest 0.11.27",
  "rust-embed-for-web",
  "segment",
  "serde",
@@ -6578,6 +6578,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -6586,10 +6587,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg 0.50.0",
@@ -6636,7 +6639,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.2",
  "winreg 0.52.0",
 ]
 
@@ -7073,12 +7075,12 @@ dependencies = [
 
 [[package]]
 name = "segment"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bdca318192c89bb31bffa2ef8e9e9898bc80f15a78db2fdd41cd051f1b41d01"
+checksum = "12485833e00457a6bbba60397d3f19362751a0caefe27f6755fff1a2be4fd601"
 dependencies = [
  "async-trait",
- "reqwest 0.12.4",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,11 +262,11 @@ rand = "0.8"
 rayon = "1.7.0"
 regex = "1.7"
 regex-syntax = "0.8"
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
   "stream",
 ] }
-segment = "0.2"
+segment = "~0.2.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha256 = "1.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -640,6 +640,11 @@ fn enable_tracing() -> Result<(), anyhow::Error> {
         .with_exporter(
             opentelemetry_otlp::new_exporter()
                 .http()
+                .with_http_client(
+                    reqwest::Client::builder()
+                        .danger_accept_invalid_certs(true)
+                        .build()?,
+                )
                 .with_endpoint(&cfg.common.otel_otlp_url)
                 .with_headers(headers),
         )

--- a/src/service/promql/functions/math_operations.rs
+++ b/src/service/promql/functions/math_operations.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Openobserve.ai and Contributors
+// Copyright 2024 Zinc Labs Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/service/promql/functions/time_operations.rs
+++ b/src/service/promql/functions/time_operations.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Openobserve.ai and Contributors
+// Copyright 2024 Zinc Labs Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/service/promql/name_visitor.rs
+++ b/src/service/promql/name_visitor.rs
@@ -1,3 +1,18 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use std::collections::HashSet;
 
 use promql_parser::{


### PR DESCRIPTION
fixed #3901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `reqwest` dependency version to `0.11` and `segment` dependency to `~0.2.3`.
  
- **Refactor**
  - Enhanced tracing configuration to accept invalid certificates in HTTP client settings.

- **Documentation**
  - Updated licensing information in multiple files to reflect "Zinc Labs Inc."
  - Added GNU Affero General Public License header to specific files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->