### PR TITLE
perf: optimize search partition

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -774,9 +774,7 @@ pub struct Limit {
     #[env_config(name = "ZO_QUERY_DEFAULT_LIMIT", default = 1000)]
     pub query_default_limit: i64,
     #[env_config(name = "ZO_QUERY_PARTITION_BY_SECS", default = 1)] // seconds
-    pub query_partition_by_secs: usize,
-    #[env_config(name = "ZO_QUERY_PARTITION_MIN_SECS", default = 600)] // seconds
-    pub query_partition_min_secs: i64,
+    pub query_partition_by_secs: usize, 
     #[env_config(name = "ZO_QUERY_GROUP_BASE_SPEED", default = 768)] // MB/s/core
     pub query_group_base_speed: usize,
     #[env_config(name = "ZO_INGEST_ALLOWED_UPTO", default = 5)] // in hours - in past

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -774,7 +774,7 @@ pub struct Limit {
     #[env_config(name = "ZO_QUERY_DEFAULT_LIMIT", default = 1000)]
     pub query_default_limit: i64,
     #[env_config(name = "ZO_QUERY_PARTITION_BY_SECS", default = 1)] // seconds
-    pub query_partition_by_secs: usize, 
+    pub query_partition_by_secs: usize,
     #[env_config(name = "ZO_QUERY_GROUP_BASE_SPEED", default = 768)] // MB/s/core
     pub query_group_base_speed: usize,
     #[env_config(name = "ZO_INGEST_ALLOWED_UPTO", default = 5)] // in hours - in past
@@ -1470,9 +1470,6 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
     if cfg.limit.query_partition_by_secs == 0 {
         cfg.limit.query_partition_by_secs = 30;
-    }
-    if cfg.limit.query_partition_min_secs == 0 {
-        cfg.limit.query_partition_min_secs = 600;
     }
     if cfg.limit.query_default_limit == 0 {
         cfg.limit.query_default_limit = 1000;

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -229,7 +229,6 @@ pub async fn get_cached_results(
                 "[CACHE CANDIDATES {trace_id}] get_cached_results->grpc: cache_meta.response_start_time: {}, cache_meta.response_end_time: {}",
                 cache_meta.response_start_time,
                 cache_meta.response_end_time);
-                
 
             cache_meta.response_start_time <= cache_req.q_end_time
                 && cache_meta.response_end_time >= cache_req.q_start_time

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -285,17 +285,11 @@ pub async fn search_partition(
     if part_num * cfg.limit.query_partition_by_secs < total_secs {
         part_num += 1;
     }
-    let mut step = max(
-        Duration::try_seconds(cfg.limit.query_partition_min_secs)
-            .unwrap()
-            .num_microseconds()
-            .unwrap(),
-        (req.end_time - req.start_time) / part_num as i64,
-    );
-    // step must be times of minute
+    let mut step = (req.end_time - req.start_time) / part_num as i64;
+    // step must be times of second
     step = step
         - step
-            % Duration::try_minutes(1)
+            % Duration::try_seconds(1)
                 .unwrap()
                 .num_microseconds()
                 .unwrap();


### PR DESCRIPTION
Optimize search partition and set the minimal partition can be 1 second.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved time calculation in search functionality.
  - Updated data type for time partitioning for better performance.

- **Style**
  - Minor formatting improvements for better readability in search results caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->