### PR TITLE
feat: role-group based node selection

### DIFF
--- a/src/common/infra/cluster/etcd.rs
+++ b/src/common/infra/cluster/etcd.rs
@@ -16,7 +16,7 @@
 use config::{
     cluster::*,
     get_config,
-    meta::cluster::{Node, NodeStatus, Role},
+    meta::cluster::{load_role_group, Node, NodeStatus, Role},
     utils::json,
 };
 use etcd_client::PutOptions;
@@ -145,6 +145,7 @@ async fn register() -> Result<()> {
         status: NodeStatus::Prepare,
         scheduled: true,
         broadcasted: false,
+        role_group: load_role_group(),
     };
     let val = json::to_string(&node).unwrap();
 
@@ -219,6 +220,7 @@ pub(crate) async fn set_status(status: NodeStatus, new_lease_id: bool) -> Result
             status: status.clone(),
             scheduled: true,
             broadcasted: false,
+            role_group: load_role_group(),
         },
     };
     let val = json::to_string(&node).unwrap();

--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -19,7 +19,7 @@ use config::{
     cluster::*,
     get_config, get_instance_id,
     meta::{
-        cluster::{Node, NodeStatus, Role},
+        cluster::{load_role_group, Node, NodeStatus, Role},
         meta_store::MetaStore,
     },
     utils::{hash::Sum64, json},
@@ -207,6 +207,7 @@ pub async fn list_nodes() -> Result<Vec<Node>> {
 
     for item in items {
         let node: Node = json::from_slice(&item)?;
+        log::debug!("node role group: {}", node.role_group);
         nodes.push(node.to_owned());
     }
 
@@ -390,6 +391,7 @@ pub fn load_local_mode_node() -> Node {
         status: NodeStatus::Online,
         scheduled: true,
         broadcasted: false,
+        role_group: load_role_group(),
     }
 }
 

--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -207,7 +207,6 @@ pub async fn list_nodes() -> Result<Vec<Node>> {
 
     for item in items {
         let node: Node = json::from_slice(&item)?;
-        log::debug!("node role group: {}", node.role_group);
         nodes.push(node.to_owned());
     }
 

--- a/src/common/infra/cluster/nats.rs
+++ b/src/common/infra/cluster/nats.rs
@@ -18,7 +18,7 @@ use core::cmp::min;
 use config::{
     cluster::*,
     get_config,
-    meta::cluster::{Node, NodeStatus, Role},
+    meta::cluster::{load_role_group, Node, NodeStatus, Role},
     utils::json,
 };
 use infra::{
@@ -137,6 +137,7 @@ async fn register() -> Result<()> {
         status: NodeStatus::Prepare,
         scheduled: true,
         broadcasted: false,
+        role_group: load_role_group(),
     };
     let val = json::to_vec(&node).unwrap();
 
@@ -198,6 +199,7 @@ pub(crate) async fn set_status(status: NodeStatus) -> Result<()> {
             status: status.clone(),
             scheduled: true,
             broadcasted: false,
+            role_group: load_role_group(),
         },
     };
     let val = json::to_string(&node).unwrap();

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -492,6 +492,12 @@ pub struct Common {
     pub meta_mysql_dsn: String, // mysql://root:12345678@localhost:3306/openobserve
     #[env_config(name = "ZO_NODE_ROLE", default = "all")]
     pub node_role: String,
+    #[env_config(
+        name = "ZO_NODE_ROLE_GROUP",
+        default = "interactive",
+        help = "Role group can be either interactive (default) or background"
+    )]
+    pub node_role_group: String,
     #[env_config(name = "ZO_CLUSTER_NAME", default = "zo1")]
     pub cluster_name: String,
     #[env_config(name = "ZO_INSTANCE_NAME", default = "")]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -494,8 +494,8 @@ pub struct Common {
     pub node_role: String,
     #[env_config(
         name = "ZO_NODE_ROLE_GROUP",
-        default = "interactive",
-        help = "Role group can be either interactive (default) or background"
+        default = "",
+        help = "Role group can be empty (default), interactive, or background"
     )]
     pub node_role_group: String,
     #[env_config(name = "ZO_CLUSTER_NAME", default = "zo1")]

--- a/src/config/src/meta/cluster.rs
+++ b/src/config/src/meta/cluster.rs
@@ -17,6 +17,8 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
+use crate::{config, meta::search::SearchEventType};
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Node {
     pub id: i32,
@@ -31,6 +33,8 @@ pub struct Node {
     pub scheduled: bool,
     #[serde(default)]
     pub broadcasted: bool,
+    #[serde(default)]
+    pub role_group: RoleGroup,
 }
 
 impl Node {
@@ -46,6 +50,7 @@ impl Node {
             status: NodeStatus::Prepare,
             scheduled: false,
             broadcasted: false,
+            role_group: load_role_group(),
         }
     }
 }
@@ -103,4 +108,45 @@ impl std::fmt::Display for Role {
             Role::FlattenCompactor => write!(f, "flatten_compactor"),
         }
     }
+}
+
+/// Categorizes nodes into different groups.
+/// Low-priority tasks -> [Background] nodes
+/// High-priority tasks -> [Interactive] nodes
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub enum RoleGroup {
+    #[default]
+    Interactive,
+    Background,
+}
+
+impl From<&str> for RoleGroup {
+    fn from(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "background" => RoleGroup::Background,
+            _ => RoleGroup::Interactive,
+        }
+    }
+}
+
+impl From<SearchEventType> for RoleGroup {
+    fn from(value: SearchEventType) -> Self {
+        match value {
+            SearchEventType::Reports | SearchEventType::Alerts => RoleGroup::Background,
+            _ => RoleGroup::Interactive,
+        }
+    }
+}
+
+impl std::fmt::Display for RoleGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RoleGroup::Interactive => write!(f, "interactive"),
+            RoleGroup::Background => write!(f, "background"),
+        }
+    }
+}
+
+pub fn load_role_group() -> RoleGroup {
+    RoleGroup::from(config::get_config().common.node_role_group.as_str())
 }

--- a/src/config/src/meta/cluster.rs
+++ b/src/config/src/meta/cluster.rs
@@ -111,11 +111,13 @@ impl std::fmt::Display for Role {
 }
 
 /// Categorizes nodes into different groups.
-/// Low-priority tasks -> [Background] nodes
-/// High-priority tasks -> [Interactive] nodes
+/// None        -> All tasks
+/// Background  -> Low-priority tasks
+/// Interactive -> High-priority tasks
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub enum RoleGroup {
     #[default]
+    None,
     Interactive,
     Background,
 }
@@ -124,7 +126,8 @@ impl From<&str> for RoleGroup {
     fn from(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "background" => RoleGroup::Background,
-            _ => RoleGroup::Interactive,
+            "interactive" => RoleGroup::Interactive,
+            _ => RoleGroup::None,
         }
     }
 }
@@ -141,6 +144,7 @@ impl From<SearchEventType> for RoleGroup {
 impl std::fmt::Display for RoleGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            RoleGroup::None => write!(f, ""),
             RoleGroup::Interactive => write!(f, "interactive"),
             RoleGroup::Background => write!(f, "background"),
         }

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
 use proto::cluster_rpc;
 use serde::{Deserialize, Serialize};
@@ -478,6 +478,7 @@ impl From<Request> for cluster_rpc::SearchRequest {
             timeout: req.timeout,
             work_group: "".to_string(),
             user_id: None,
+            search_event_type: req.search_type.map(|event| event.to_string()),
         }
     }
 }
@@ -531,6 +532,23 @@ impl std::fmt::Display for SearchEventType {
             SearchEventType::Other => write!(f, "Other"),
             SearchEventType::Values => write!(f, "_values"),
             SearchEventType::RUM => write!(f, "RUM"),
+        }
+    }
+}
+
+impl FromStr for SearchEventType {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let s = s.to_lowercase();
+        match s.as_str() {
+            "ui" => Ok(SearchEventType::UI),
+            "dashboards" => Ok(SearchEventType::Dashboards),
+            "reports" => Ok(SearchEventType::Reports),
+            "alerts" => Ok(SearchEventType::Alerts),
+            "values" => Ok(SearchEventType::Values),
+            "other" => Ok(SearchEventType::Other),
+            "rum" => Ok(SearchEventType::RUM),
+            _ => Err(format!("Invalid search event type: {s}")),
         }
     }
 }

--- a/src/proto/proto/cluster/search.proto
+++ b/src/proto/proto/cluster/search.proto
@@ -36,16 +36,17 @@ message SearchQuery {
 
 // Search request
 message SearchRequest {
-    Job                        job = 1;
-    string                  org_id = 2;
-    string             stream_type = 3;
-    SearchType               stype = 4;
-    SearchQuery              query = 5;
-    repeated FileKey     file_list = 6;
-    repeated SearchAggRequest aggs = 7;
-    int64                  timeout = 8;
-    string              work_group = 9;
-    optional string       user_id = 10;
+    Job                            job = 1;
+    string                      org_id = 2;
+    string                 stream_type = 3;
+    SearchType                   stype = 4;
+    SearchQuery                  query = 5;
+    repeated FileKey         file_list = 6;
+    repeated SearchAggRequest     aggs = 7;
+    int64                      timeout = 8;
+    string                  work_group = 9;
+    optional string           user_id = 10;
+    optional string search_event_type = 11;
 }
 
 message SearchResponse {

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -17,7 +17,7 @@ use chrono::Utc;
 use config::{
     get_config,
     meta::{
-        search::{self, SearchEventType},
+        search,
         stream::StreamType,
         usage::{RequestStats, UsageType},
     },

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -56,7 +56,6 @@ pub async fn search(
     user_id: Option<String>,
     in_req: &search::Request,
     use_cache: bool,
-    search_type: Option<SearchEventType>,
 ) -> Result<search::Response, Error> {
     let started_at = Utc::now().timestamp_micros();
     let start = std::time::Instant::now();
@@ -241,7 +240,7 @@ pub async fn search(
         min_ts: Some(req.query.start_time),
         max_ts: Some(req.query.end_time),
         cached_ratio: Some(res.cached_ratio),
-        search_type,
+        search_type: req.search_type,
         trace_id: Some(trace_id.to_string()),
         took_wait_in_queue: if res.took_detail.is_some() {
             let resp_took = res.took_detail.as_ref().unwrap();

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -91,10 +91,11 @@ pub async fn search(
     nodes.dedup_by(|a, b| a.grpc_addr == b.grpc_addr);
     if let Some(search_event_type) = req.search_event_type.clone() {
         nodes.retain(|node| {
-            SearchEventType::from_str(search_event_type.as_str())
-                .map_or(true, |search_event_type| {
-                    RoleGroup::from(search_event_type) == node.role_group
-                })
+            node.role_group == RoleGroup::None
+                || SearchEventType::from_str(search_event_type.as_str())
+                    .map_or(true, |search_event_type| {
+                        RoleGroup::from(search_event_type) == node.role_group
+                    })
         });
     }
     nodes.sort_by_key(|x| x.id);

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{cmp::min, io::Cursor, sync::Arc};
+use std::{cmp::min, io::Cursor, str::FromStr, sync::Arc};
 
 use ::datafusion::arrow::{datatypes::Schema, ipc, record_batch::RecordBatch};
 use async_recursion::async_recursion;
@@ -21,8 +21,8 @@ use config::{
     cluster::{is_ingester, is_querier},
     get_config,
     meta::{
-        cluster::{Node, Role},
-        search::{self, ScanStats},
+        cluster::{Node, Role, RoleGroup},
+        search::{self, ScanStats, SearchEventType},
         stream::{
             FileKey, PartitionTimeLevel, QueryPartitionStrategy, StreamPartition, StreamType,
         },
@@ -89,6 +89,14 @@ pub async fn search(
     // sort nodes by node_id this will improve hit cache ratio
     nodes.sort_by(|a, b| a.grpc_addr.cmp(&b.grpc_addr));
     nodes.dedup_by(|a, b| a.grpc_addr == b.grpc_addr);
+    if let Some(search_event_type) = req.search_event_type.clone() {
+        nodes.retain(|node| {
+            SearchEventType::from_str(search_event_type.as_str())
+                .map_or(true, |search_event_type| {
+                    RoleGroup::from(search_event_type) == node.role_group
+                })
+        });
+    }
     nodes.sort_by_key(|x| x.id);
     let nodes = nodes;
 

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -255,9 +255,6 @@ pub async fn search_partition(
         return Err(Error::Message("no querier node online".to_string()));
     }
     let cpu_cores = nodes.iter().map(|n| n.cpu_num).sum::<u64>() as usize;
-    if nodes.is_empty() {
-        return Err(Error::Message("no querier node online".to_string()));
-    }
 
     let (records, original_size, compressed_size) =
         files


### PR DESCRIPTION
Categorizes nodes into role groups selected to serve different query requests based on query search event type.

--- 
Each node can be configured into different role groups by using the new env:  `ZO_NODE_ROLE_GROUP`
- default: `` (empty: none)
- node for high-priority tasks: `interactive`
- node for low-priority tasks: `background`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `node_role_group` configuration to specify role groups for nodes.
  - Added `SearchEventType` to `SearchRequest` to enhance search capabilities.
  - Implemented `RoleGroup` enum to categorize nodes based on priority.

- **Improvements**
  - Updated node registration and status setting to include `role_group`.
  - Enhanced logging to include node's role group in cluster operations.
  - Streamlined search logic by assigning `search_type` earlier in the request handling process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->