### PR TITLE
fix: delete wal file when stream already deleted

### DIFF
--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -321,6 +321,30 @@ async fn move_files(
     };
     let stream_fields_num = latest_schema.fields().len();
 
+    // check stream is existing
+    if stream_fields_num == 0 {
+        for file in files {
+            log::warn!(
+                "[INGESTER:JOB:{thread_id}] the stream [{}/{}/{}] was deleted, just delete file: {}",
+                &org_id,
+                stream_type,
+                &stream_name,
+                file.key,
+            );
+            if let Err(e) = tokio::fs::remove_file(wal_dir.join(&file.key)).await {
+                log::error!(
+                    "[INGESTER:JOB:{thread_id}] Failed to remove parquet file from disk: {}, {}",
+                    file.key,
+                    e
+                );
+            }
+            // delete metadata from cache
+            WAL_PARQUET_METADATA.write().await.remove(&file.key);
+            PROCESSING_FILES.write().await.remove(&file.key);
+        }
+        return Ok(());
+    }
+
     // log::debug!("[INGESTER:JOB:{thread_id}] start processing for partition: {}", prefix);
 
     let wal_dir = wal_dir.clone();

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -379,6 +379,7 @@
     "labelLogs": "Logs",
     "labelMetrics": "Metrics",
     "labelTraces": "Traces",
+    "labelMetadata": "Metadata",
     "labelIndex": "Index",
     "add": "Add Stream",
     "dataRetention": "Data Retention (in days)",

--- a/web/src/views/LogStream.vue
+++ b/web/src/views/LogStream.vue
@@ -111,7 +111,7 @@ size="sm" color="secondary" />
                     emit-value
                     no-caps
                     class="visual-selection-btn"
-                    style="height: 30px; padding: 4px 12px"
+                    style="height: 30px; margin: 0 2px; padding: 4px 12px"
                     @click="onChangeStreamFilter(visual.value)"
                   >
                     {{ visual.label }}</q-btn
@@ -282,6 +282,7 @@ export default defineComponent({
       { label: t("logStream.labelLogs"), value: "logs" },
       { label: t("logStream.labelMetrics"), value: "metrics" },
       { label: t("logStream.labelTraces"), value: "traces" },
+      { label: t("logStream.labelMetadata"), value: "metadata" },
       { label: t("logStream.labelIndex"), value: "index" },
     ];
     const { getStreams, resetStreams, removeStream } = useStreams();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "metadata" option to the stream selection dropdown.

- **Bug Fixes**
  - Ensured proper cleanup and handling of deleted streams during file processing.

- **Style**
  - Adjusted button styles in the LogStream view.

- **Documentation**
  - Added a new localization key "Metadata" in the English language file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->