### PR TITLE
feat: Introduce otel grpc endpoint to export traces

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -577,12 +577,6 @@ pub struct Common {
     #[env_config(name = "OTEL_OTLP_GRPC_ENDPOINT", default = "")]
     pub otel_otlp_grpc_url: String,
     #[env_config(
-        name = "ZO_TRACING_TYPE_GRPC",
-        default = false,
-        help = "If true, it uses OTEL_OTLP_GRPC_ENDPOINT for trace export."
-    )]
-    pub tracing_type_grpc: bool,
-    #[env_config(
         name = "ZO_TRACING_GRPC_ORGANIZATION",
         default = "",
         help = "Used in metadata when exporting traces to grpc endpoint."

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -574,6 +574,26 @@ pub struct Common {
     pub tracing_search_enabled: bool,
     #[env_config(name = "OTEL_OTLP_HTTP_ENDPOINT", default = "")]
     pub otel_otlp_url: String,
+    #[env_config(name = "OTEL_OTLP_GRPC_ENDPOINT", default = "")]
+    pub otel_otlp_grpc_url: String,
+    #[env_config(
+        name = "ZO_TRACING_TYPE_GRPC",
+        default = false,
+        help = "If true, it uses OTEL_OTLP_GRPC_ENDPOINT for trace export."
+    )]
+    pub tracing_type_grpc: bool,
+    #[env_config(
+        name = "ZO_TRACING_GRPC_ORGANIZATION",
+        default = "",
+        help = "Used in metadata when exporting traces to grpc endpoint."
+    )]
+    pub tracing_grpc_header_org: String,
+    #[env_config(
+        name = "ZO_TRACING_GRPC_STREAM_NAME",
+        default = "",
+        help = "Used in metadata when exporting traces to grpc endpoint."
+    )]
+    pub tracing_grpc_header_stream_name: String,
     #[env_config(name = "ZO_TRACING_HEADER_KEY", default = "Authorization")]
     pub tracing_header_key: String,
     #[env_config(

--- a/src/main.rs
+++ b/src/main.rs
@@ -670,6 +670,7 @@ fn enable_tracing() -> Result<(), anyhow::Error> {
                 .tonic()
                 .with_endpoint(&cfg.common.otel_otlp_grpc_url)
                 .with_metadata(metadata)
+                .with_protocol(opentelemetry_otlp::Protocol::Grpc)
         })
     };
     let tracer = tracer

--- a/src/main.rs
+++ b/src/main.rs
@@ -634,7 +634,7 @@ fn enable_tracing() -> Result<(), anyhow::Error> {
     let cfg = get_config();
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
     let tracer = opentelemetry_otlp::new_pipeline().tracing();
-    let tracer = if !cfg.common.tracing_type_grpc {
+    let tracer = if cfg.common.otel_otlp_grpc_url.is_empty() {
         tracer.with_exporter({
             let mut headers = HashMap::new();
             headers.insert(


### PR DESCRIPTION
Fixes #3940 

## New ENVs:
- `ZO_TRACING_GRPC_ORGANIZATION` - The name of the organization used to ingest traces
- `ZO_TRACING_GRPC_STREAM_NAME` - The stream name to use for trace export.
- `OTEL_OTLP_GRPC_ENDPOINT` - The grpc endpoint to use for trace export. E.g. - `grpc://localhost:5081`. If this is specified, `OTEL_OTLP_HTTP_ENDPOINT` is ignored.

`ZO_TRACING_HEADER_VALUE` can be used for authorization token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added configuration options for GRPC tracing, including URL, type, and header settings.
- **Improvements**
	- Enhanced tracer exporter logic for better configurability based on tracing type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->