### PR TITLE
fix: inverted index search with fast mode

### DIFF
--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -1000,7 +1000,7 @@ async fn get_file_list_by_inverted_index(
     if fast_mode && time_min > 0 && time_max > 0 {
         search_condition = format!(
             "({}) AND max_ts >= {} AND min_ts <= {}",
-            search_condition, time_min, time_max
+            search_condition, time_max, time_min
         );
     }
 


### PR DESCRIPTION
We have a `fast mode` that only return the top N parquet files in the `inverted index` which contains the `term total count > query.limit`. 

But after we remove the `time range` for index query sql, the first terms which `total count > 250` maybe is not in the query time range, then it will cause the real query found nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `fast mode` option to the file search functionality for quicker initial page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->