### PR TITLE
ci: bump datafusion to 40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,8 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9d55a9cd2634818953809f75ebe5248b00dd43c3227efb2a51a2d5feaad54e"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2793,7 +2794,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def66b642959e7f96f5d2da22e1f43d3bd35598f821e5ce351a0553e0f1b7367"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2814,7 +2816,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f104bb9cb44c06c9badf8a0d7e0855e5f7fa5e395b887d7f835e8a9457dc1352"
 dependencies = [
  "tokio",
 ]
@@ -2822,7 +2825,8 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac0fd8b5d80bbca3fc3b6f40da4e9f6907354824ec3b18bbd83fee8cf5c3c3e"
 dependencies = [
  "arrow",
  "chrono",
@@ -2842,7 +2846,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2103d2cc16fb11ef1fa993a6cac57ed5cb028601db4b97566c90e5fa77aa1e68"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2860,7 +2865,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a369332afd0ef5bd565f6db2139fb9f1dfdd0afa75a7f70f000b74208d76994f"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -2885,7 +2891,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92718db1aff70c47e5abf9fc975768530097059e5db7c7b78cd64b5e9a11fc77"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2902,7 +2909,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bb80f46ff3dcf4bb4510209c2ba9b8ce1b716ac8b7bf70c6bf7dca6260c831"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2922,7 +2930,8 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f34692011bec4fdd6fc18c264bf8037b8625d801e6dd8f5111af15cb6d71d3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2941,7 +2950,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45538630defedb553771434a437f7ca8f04b9b3e834344aafacecb27dc65d5e5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2970,7 +2980,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8a72b0ca908e074aaeca52c14ddf5c28d22361e9cb6bc79bb733cd6661b536"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2983,7 +2994,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b504eae6107a342775e22e323e9103f7f42db593ec6103b28605b7b7b1405c4a"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3016,7 +3028,8 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "40.0.0"
-source = "git+https://github.com/apache/datafusion?tag=40.0.0-rc1#4cae81363e29f011c6602a7a7a54e1aaee841046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5db33f323f41b95ae201318ba654a9bf11113e58a51a1dff977b1a836d3d889"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,8 +220,8 @@ chromiumoxide = { git = "https://github.com/mattsse/chromiumoxide", features = [
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 cityhasher = { version = "0.1", default-features = false }
 dashmap = { version = "5.5", features = ["serde"] }
-datafusion = { version = "40", git = "https://github.com/apache/datafusion", tag = "40.0.0-rc1" }
-datafusion-expr = { version = "40", git = "https://github.com/apache/datafusion", tag = "40.0.0-rc1" }
+datafusion = "40"
+datafusion-expr = "40"
 arrow = { version = "52.1.0", features = ["ipc_compression", "prettyprint"] }
 arrow-json = "52.1.0"
 arrow-schema = { version = "52.1.0", features = ["serde"] }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project dependencies to use version numbers instead of git URLs and tags for `datafusion` and `datafusion-expr`. This change ensures more stable and predictable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->