### PR TITLE
fix: Add PRIMARY KEY constraint to tables in postgres

### DIFF
--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -515,7 +515,7 @@ pub async fn create_table() -> Result<()> {
         r#"
 CREATE TABLE IF NOT EXISTS meta
 (
-    id       BIGINT GENERATED ALWAYS AS IDENTITY,
+    id       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     module   VARCHAR(100) not null,
     key1     VARCHAR(256) not null,
     key2     VARCHAR(256) not null,

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -895,7 +895,7 @@ pub async fn create_table() -> Result<()> {
         r#"
 CREATE TABLE IF NOT EXISTS file_list
 (
-    id        BIGINT GENERATED ALWAYS AS IDENTITY,
+    id        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     org       VARCHAR(100) not null,
     stream    VARCHAR(256) not null,
     date      VARCHAR(16)  not null,
@@ -917,7 +917,7 @@ CREATE TABLE IF NOT EXISTS file_list
         r#"
 CREATE TABLE IF NOT EXISTS file_list_history
 (
-    id        BIGINT GENERATED ALWAYS AS IDENTITY,
+    id        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     org       VARCHAR(100) not null,
     stream    VARCHAR(256) not null,
     date      VARCHAR(16)  not null,
@@ -939,7 +939,7 @@ CREATE TABLE IF NOT EXISTS file_list_history
         r#"
 CREATE TABLE IF NOT EXISTS file_list_deleted
 (
-    id         BIGINT GENERATED ALWAYS AS IDENTITY,
+    id         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     org        VARCHAR(100) not null,
     stream     VARCHAR(256) not null,
     date       VARCHAR(16)  not null,
@@ -956,7 +956,7 @@ CREATE TABLE IF NOT EXISTS file_list_deleted
         r#"
 CREATE TABLE IF NOT EXISTS file_list_jobs
 (
-    id         BIGINT GENERATED ALWAYS AS IDENTITY,
+    id         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     org        VARCHAR(100) not null,
     stream     VARCHAR(256) not null,
     offsets    BIGINT not null,
@@ -974,7 +974,7 @@ CREATE TABLE IF NOT EXISTS file_list_jobs
         r#"
 CREATE TABLE IF NOT EXISTS stream_stats
 (
-    id       BIGINT GENERATED ALWAYS AS IDENTITY,
+    id       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     org      VARCHAR(100) not null,
     stream   VARCHAR(256) not null,
     file_num BIGINT not null,

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -47,7 +47,7 @@ impl super::Scheduler for PostgresScheduler {
             r#"
 CREATE TABLE IF NOT EXISTS scheduled_jobs
 (
-    id           BIGINT GENERATED ALWAYS AS IDENTITY,
+    id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     org          VARCHAR(100) not null,
     module       INT not null,
     module_key   VARCHAR(256) not null,

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -90,7 +90,7 @@ pub async fn create_table() -> Result<()> {
         r#"
 CREATE TABLE IF NOT EXISTS schema_history
 (
-    id           BIGINT GENERATED ALWAYS AS IDENTITY,
+    id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     org          VARCHAR(100) not null,
     stream_type  VARCHAR(32)  not null,
     stream_name  VARCHAR(256) not null,


### PR DESCRIPTION
# SUMMARY

Add PRIMARY KEY constraints on `id` field to all tables in `postgres` database.

Tables considered here:
```
meta
file_list
file_list_history
file_list_deleted
file_list_jobs
stream_stats
scheduled_jobs
schema_history
```