### PR TITLE
fix: log result cache ratio to usage & delta scan size

### DIFF
--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -91,6 +91,8 @@ pub struct UsageData {
     pub search_type: Option<SearchEventType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub took_wait_in_queue: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_cache_ratio: Option<usize>,
 }
 
 #[derive(Hash, PartialEq, Eq)]
@@ -245,6 +247,8 @@ pub struct RequestStats {
     pub trace_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub took_wait_in_queue: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_cache_ratio: Option<usize>,
 }
 impl Default for RequestStats {
     fn default() -> Self {
@@ -261,6 +265,7 @@ impl Default for RequestStats {
             search_type: None,
             trace_id: None,
             took_wait_in_queue: None,
+            result_cache_ratio: None,
         }
     }
 }
@@ -280,6 +285,7 @@ impl From<FileMeta> for RequestStats {
             search_type: None,
             trace_id: None,
             took_wait_in_queue: None,
+            result_cache_ratio: None,
         }
     }
 }

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -249,6 +249,7 @@ pub async fn search(
         } else {
             None
         },
+        result_cache_ratio: Some(res.result_cache_ratio),
         ..Default::default()
     };
     let num_fn = req.query.query_fn.is_some() as u16;
@@ -313,7 +314,7 @@ fn merge_response(
         return;
     }
     let cache_hits_len = cache_response.hits.len();
-
+    cache_response.scan_size = 0;
     let mut files_cache_ratio = 0;
     let mut result_cache_len = 0;
     let cache_ts = if cache_response.hits.is_empty() {

--- a/src/service/usage/mod.rs
+++ b/src/service/usage/mod.rs
@@ -103,6 +103,7 @@ pub async fn report_request_usage_stats(
             search_type: stats.search_type,
             trace_id: None,
             took_wait_in_queue: stats.took_wait_in_queue,
+            result_cache_ratio: None,
         });
     };
 
@@ -136,6 +137,7 @@ pub async fn report_request_usage_stats(
         search_type: stats.search_type,
         trace_id: stats.trace_id,
         took_wait_in_queue: stats.took_wait_in_queue,
+        result_cache_ratio: stats.result_cache_ratio,
     });
     if !usage.is_empty() {
         publish_usage(usage).await;

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2186,6 +2186,7 @@ const useLogs = () => {
               searchObj.data.queryResults.aggs = res.data.hits;
               searchObj.data.queryResults.scan_size = res.data.scan_size;
               searchObj.data.queryResults.took += res.data.took;
+              searchObj.data.queryResults.result_cache_ratio += res.data.result_cache_ratio;
               // if (hasAggregationFlag) {
               //   searchObj.data.queryResults.total = res.data.total;
               // }
@@ -2897,6 +2898,8 @@ const useLogs = () => {
       if(searchObj.data.queryResults.partitionDetail.partitions.length > 1 && searchObj.meta.showHistogram == false) {
         plusSign = "+";
       }
+      const scanSizeLabel = searchObj.data.queryResults.result_cache_ratio > 0 ? "Delta Scan Size" : "Scan Size";
+
       const title =
         "Showing " +
         startCount +
@@ -2907,7 +2910,7 @@ const useLogs = () => {
         plusSign +
         " events in " +
         searchObj.data.queryResults.took +
-        " ms. (Scan Size: " +
+        " ms. (+ scanSizeLabel +: " +
         formatSizeFromMB(searchObj.data.queryResults.scan_size) +
         plusSign +
         ")";


### PR DESCRIPTION
- Report delta scan size for UI 
- Report result cache ratio to usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `result_cache_ratio` field to enhance cache performance tracking.
- **Enhancements**
  - Updated search and logging functionalities to incorporate `result_cache_ratio` for more detailed analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->