### PR TITLE
fix: consistent hashing with querier group

### DIFF
--- a/src/common/infra/cluster/etcd.rs
+++ b/src/common/infra/cluster/etcd.rs
@@ -16,7 +16,7 @@
 use config::{
     cluster::*,
     get_config,
-    meta::cluster::{load_role_group, Node, NodeStatus, Role, RoleGroup},
+    meta::cluster::{Node, NodeStatus, Role, RoleGroup},
     utils::json,
 };
 use etcd_client::PutOptions;
@@ -138,19 +138,19 @@ async fn register() -> Result<()> {
     }
 
     // 4. join the cluster
-    let key = format!("{}nodes/{}", &cfg.etcd.prefix, *LOCAL_NODE_UUID);
+    let key = format!("{}nodes/{}", &cfg.etcd.prefix, LOCAL_NODE.uuid);
     let node = Node {
         id: new_node_id,
-        uuid: LOCAL_NODE_UUID.clone(),
+        uuid: LOCAL_NODE.uuid.clone(),
         name: cfg.common.instance_name.clone(),
         http_addr: format!("http://{}:{}", get_local_http_ip(), cfg.http.port),
         grpc_addr: format!("http://{}:{}", get_local_grpc_ip(), cfg.grpc.port),
-        role: LOCAL_NODE_ROLE.clone(),
+        role: LOCAL_NODE.role.clone(),
+        role_group: LOCAL_NODE.role_group,
         cpu_num: cfg.limit.cpu_num as u64,
         status: NodeStatus::Prepare,
         scheduled: true,
         broadcasted: false,
-        role_group: load_role_group(),
     };
     let val = json::to_string(&node).unwrap();
 
@@ -171,7 +171,7 @@ async fn register() -> Result<()> {
     }
 
     let mut w = super::NODES.write().await;
-    w.insert(LOCAL_NODE_UUID.clone(), node.clone());
+    w.insert(LOCAL_NODE.uuid.clone(), node.clone());
     drop(w);
 
     // register node to cluster
@@ -213,7 +213,7 @@ pub(crate) async fn set_offline(new_lease_id: bool) -> Result<()> {
 pub(crate) async fn set_status(status: NodeStatus, new_lease_id: bool) -> Result<()> {
     let cfg = get_config();
     // set node status to online
-    let node = match super::NODES.read().await.get(LOCAL_NODE_UUID.as_str()) {
+    let node = match super::NODES.read().await.get(LOCAL_NODE.uuid.as_str()) {
         Some(node) => {
             let mut val = node.clone();
             val.status = status.clone();
@@ -221,16 +221,16 @@ pub(crate) async fn set_status(status: NodeStatus, new_lease_id: bool) -> Result
         }
         None => Node {
             id: unsafe { LOCAL_NODE_ID },
-            uuid: LOCAL_NODE_UUID.clone(),
+            uuid: LOCAL_NODE.uuid.clone(),
             name: cfg.common.instance_name.clone(),
             http_addr: format!("http://{}:{}", get_local_node_ip(), cfg.http.port),
             grpc_addr: format!("http://{}:{}", get_local_node_ip(), cfg.grpc.port),
-            role: LOCAL_NODE_ROLE.clone(),
+            role: LOCAL_NODE.role.clone(),
+            role_group: LOCAL_NODE.role_group,
             cpu_num: cfg.limit.cpu_num as u64,
             status: status.clone(),
             scheduled: true,
             broadcasted: false,
-            role_group: load_role_group(),
         },
     };
     let val = json::to_string(&node).unwrap();
@@ -252,7 +252,7 @@ pub(crate) async fn set_status(status: NodeStatus, new_lease_id: bool) -> Result
         }
     }
 
-    let key = format!("{}nodes/{}", &cfg.etcd.prefix, *LOCAL_NODE_UUID);
+    let key = format!("{}nodes/{}", &cfg.etcd.prefix, LOCAL_NODE.uuid);
     let opt = PutOptions::new().with_lease(unsafe { LOCAL_NODE_KEY_LEASE_ID });
     let mut client = etcd::get_etcd_client().await.clone();
     if let Err(e) = client.put(key, val, Some(opt)).await {
@@ -264,7 +264,7 @@ pub(crate) async fn set_status(status: NodeStatus, new_lease_id: bool) -> Result
 
 /// Leave cluster
 pub(crate) async fn leave() -> Result<()> {
-    let key = format!("{}nodes/{}", get_config().etcd.prefix, *LOCAL_NODE_UUID);
+    let key = format!("{}nodes/{}", get_config().etcd.prefix, LOCAL_NODE.uuid);
     let mut client = etcd::get_etcd_client().await.clone();
     if let Err(e) = client.delete(key, None).await {
         return Err(Error::Message(format!("leave node error: {}", e)));
@@ -274,7 +274,7 @@ pub(crate) async fn leave() -> Result<()> {
 }
 
 pub(crate) async fn update_local_node(node: &Node) -> Result<()> {
-    let key = format!("{}nodes/{}", get_config().etcd.prefix, *LOCAL_NODE_UUID);
+    let key = format!("{}nodes/{}", get_config().etcd.prefix, LOCAL_NODE.uuid);
     let opt = PutOptions::new().with_lease(unsafe { LOCAL_NODE_KEY_LEASE_ID });
     let val = json::to_string(&node).unwrap();
     let mut client = etcd::get_etcd_client().await.clone();

--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -19,7 +19,7 @@ use config::{
     cluster::*,
     get_config, get_instance_id,
     meta::{
-        cluster::{load_role_group, Node, NodeStatus, Role},
+        cluster::{load_role_group, Node, NodeStatus, Role, RoleGroup},
         meta_store::MetaStore,
     },
     utils::{hash::Sum64, json},
@@ -41,15 +41,22 @@ const HEALTH_CHECK_FAILED_TIMES: usize = 3;
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
 
 static NODES: Lazy<RwAHashMap<String, Node>> = Lazy::new(Default::default);
-static QUERIER_CONSISTENT_HASH: Lazy<RwBTreeMap<u64, String>> = Lazy::new(Default::default);
+static QUERIER_INTERACTIVE_CONSISTENT_HASH: Lazy<RwBTreeMap<u64, String>> =
+    Lazy::new(Default::default);
+static QUERIER_BACKGROUND_CONSISTENT_HASH: Lazy<RwBTreeMap<u64, String>> =
+    Lazy::new(Default::default);
 static COMPACTOR_CONSISTENT_HASH: Lazy<RwBTreeMap<u64, String>> = Lazy::new(Default::default);
 static FLATTEN_COMPACTOR_CONSISTENT_HASH: Lazy<RwBTreeMap<u64, String>> =
     Lazy::new(Default::default);
 static NODES_HEALTH_CHECK: Lazy<RwAHashMap<String, usize>> = Lazy::new(Default::default);
 
-pub async fn add_node_to_consistent_hash(node: &Node, role: &Role) {
+pub async fn add_node_to_consistent_hash(node: &Node, role: &Role, group: Option<RoleGroup>) {
     let mut nodes = match role {
-        Role::Querier => QUERIER_CONSISTENT_HASH.write().await,
+        Role::Querier => match group {
+            Some(RoleGroup::Interactive) => QUERIER_INTERACTIVE_CONSISTENT_HASH.write().await,
+            Some(RoleGroup::Background) => QUERIER_BACKGROUND_CONSISTENT_HASH.write().await,
+            _ => QUERIER_INTERACTIVE_CONSISTENT_HASH.write().await,
+        },
         Role::Compactor => COMPACTOR_CONSISTENT_HASH.write().await,
         Role::FlattenCompactor => FLATTEN_COMPACTOR_CONSISTENT_HASH.write().await,
         _ => return,
@@ -62,9 +69,13 @@ pub async fn add_node_to_consistent_hash(node: &Node, role: &Role) {
     }
 }
 
-pub async fn remove_node_from_consistent_hash(node: &Node, role: &Role) {
+pub async fn remove_node_from_consistent_hash(node: &Node, role: &Role, group: Option<RoleGroup>) {
     let mut nodes = match role {
-        Role::Querier => QUERIER_CONSISTENT_HASH.write().await,
+        Role::Querier => match group {
+            Some(RoleGroup::Interactive) => QUERIER_INTERACTIVE_CONSISTENT_HASH.write().await,
+            Some(RoleGroup::Background) => QUERIER_BACKGROUND_CONSISTENT_HASH.write().await,
+            _ => QUERIER_INTERACTIVE_CONSISTENT_HASH.write().await,
+        },
         Role::Compactor => COMPACTOR_CONSISTENT_HASH.write().await,
         Role::FlattenCompactor => FLATTEN_COMPACTOR_CONSISTENT_HASH.write().await,
         _ => return,
@@ -77,9 +88,17 @@ pub async fn remove_node_from_consistent_hash(node: &Node, role: &Role) {
     }
 }
 
-pub async fn get_node_from_consistent_hash(key: &str, role: &Role) -> Option<String> {
+pub async fn get_node_from_consistent_hash(
+    key: &str,
+    role: &Role,
+    group: Option<RoleGroup>,
+) -> Option<String> {
     let nodes = match role {
-        Role::Querier => QUERIER_CONSISTENT_HASH.read().await,
+        Role::Querier => match group {
+            Some(RoleGroup::Interactive) => QUERIER_INTERACTIVE_CONSISTENT_HASH.read().await,
+            Some(RoleGroup::Background) => QUERIER_BACKGROUND_CONSISTENT_HASH.read().await,
+            _ => QUERIER_INTERACTIVE_CONSISTENT_HASH.read().await,
+        },
         Role::Compactor => COMPACTOR_CONSISTENT_HASH.read().await,
         Role::FlattenCompactor => FLATTEN_COMPACTOR_CONSISTENT_HASH.read().await,
         _ => return None,
@@ -118,9 +137,10 @@ pub async fn register_and_keepalive() -> Result<()> {
         }
         // cache local node
         let node = load_local_mode_node();
-        add_node_to_consistent_hash(&node, &Role::Querier).await;
-        add_node_to_consistent_hash(&node, &Role::Compactor).await;
-        add_node_to_consistent_hash(&node, &Role::FlattenCompactor).await;
+        add_node_to_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Interactive)).await;
+        add_node_to_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Background)).await;
+        add_node_to_consistent_hash(&node, &Role::Compactor, None).await;
+        add_node_to_consistent_hash(&node, &Role::FlattenCompactor, None).await;
         NODES.write().await.insert(LOCAL_NODE_UUID.clone(), node);
         return Ok(());
     }
@@ -242,15 +262,32 @@ async fn watch_node_list() -> Result<()> {
                 }
                 if item_value.status == NodeStatus::Offline {
                     log::info!("[CLUSTER] offline {:?}", item_value);
-                    if is_querier(&item_value.role) {
-                        remove_node_from_consistent_hash(&item_value, &Role::Querier).await;
+                    if item_value.is_interactive_querier() {
+                        remove_node_from_consistent_hash(
+                            &item_value,
+                            &Role::Querier,
+                            Some(RoleGroup::Interactive),
+                        )
+                        .await;
                     }
-                    if is_compactor(&item_value.role) {
-                        remove_node_from_consistent_hash(&item_value, &Role::Compactor).await;
+                    if item_value.is_background_querier() {
+                        remove_node_from_consistent_hash(
+                            &item_value,
+                            &Role::Querier,
+                            Some(RoleGroup::Background),
+                        )
+                        .await;
                     }
-                    if is_flatten_compactor(&item_value.role) {
-                        remove_node_from_consistent_hash(&item_value, &Role::FlattenCompactor)
-                            .await;
+                    if item_value.is_compactor() {
+                        remove_node_from_consistent_hash(&item_value, &Role::Compactor, None).await;
+                    }
+                    if item_value.is_flatten_compactor() {
+                        remove_node_from_consistent_hash(
+                            &item_value,
+                            &Role::FlattenCompactor,
+                            None,
+                        )
+                        .await;
                     }
                     NODES.write().await.remove(item_key);
                     continue;
@@ -282,14 +319,27 @@ async fn watch_node_list() -> Result<()> {
                     }
                 }
                 item_value.broadcasted = true;
-                if is_querier(&item_value.role) {
-                    add_node_to_consistent_hash(&item_value, &Role::Querier).await;
+                if item_value.is_interactive_querier() {
+                    add_node_to_consistent_hash(
+                        &item_value,
+                        &Role::Querier,
+                        Some(RoleGroup::Interactive),
+                    )
+                    .await;
                 }
-                if is_compactor(&item_value.role) {
-                    add_node_to_consistent_hash(&item_value, &Role::Compactor).await;
+                if item_value.is_background_querier() {
+                    add_node_to_consistent_hash(
+                        &item_value,
+                        &Role::Querier,
+                        Some(RoleGroup::Background),
+                    )
+                    .await;
                 }
-                if is_flatten_compactor(&item_value.role) {
-                    add_node_to_consistent_hash(&item_value, &Role::FlattenCompactor).await;
+                if item_value.is_compactor() {
+                    add_node_to_consistent_hash(&item_value, &Role::Compactor, None).await;
+                }
+                if item_value.is_flatten_compactor() {
+                    add_node_to_consistent_hash(&item_value, &Role::FlattenCompactor, None).await;
                 }
                 NODES.write().await.insert(item_key.to_string(), item_value);
             }
@@ -302,14 +352,28 @@ async fn watch_node_list() -> Result<()> {
                     }
                 };
                 log::info!("[CLUSTER] leave {:?}", item_value);
-                if is_querier(&item_value.role) {
-                    remove_node_from_consistent_hash(&item_value, &Role::Querier).await;
+                if item_value.is_interactive_querier() {
+                    remove_node_from_consistent_hash(
+                        &item_value,
+                        &Role::Querier,
+                        Some(RoleGroup::Interactive),
+                    )
+                    .await;
                 }
-                if is_compactor(&item_value.role) {
-                    remove_node_from_consistent_hash(&item_value, &Role::Compactor).await;
+                if item_value.is_background_querier() {
+                    remove_node_from_consistent_hash(
+                        &item_value,
+                        &Role::Querier,
+                        Some(RoleGroup::Background),
+                    )
+                    .await;
                 }
-                if is_flatten_compactor(&item_value.role) {
-                    remove_node_from_consistent_hash(&item_value, &Role::FlattenCompactor).await;
+                if item_value.is_compactor() {
+                    remove_node_from_consistent_hash(&item_value, &Role::Compactor, None).await;
+                }
+                if item_value.is_flatten_compactor() {
+                    remove_node_from_consistent_hash(&item_value, &Role::FlattenCompactor, None)
+                        .await;
                 }
                 NODES.write().await.remove(item_key);
             }
@@ -339,14 +403,27 @@ async fn check_nodes_status(client: &reqwest::Client) -> Result<()> {
                     "[CLUSTER] node {} health check failed 3 times, remove it",
                     node.name
                 );
-                if is_querier(&node.role) {
-                    remove_node_from_consistent_hash(&node, &Role::Querier).await;
+                if node.is_interactive_querier() {
+                    remove_node_from_consistent_hash(
+                        &node,
+                        &Role::Querier,
+                        Some(RoleGroup::Interactive),
+                    )
+                    .await;
                 }
-                if is_compactor(&node.role) {
-                    remove_node_from_consistent_hash(&node, &Role::Compactor).await;
+                if node.is_background_querier() {
+                    remove_node_from_consistent_hash(
+                        &node,
+                        &Role::Querier,
+                        Some(RoleGroup::Background),
+                    )
+                    .await;
                 }
-                if is_flatten_compactor(&node.role) {
-                    remove_node_from_consistent_hash(&node, &Role::FlattenCompactor).await;
+                if node.is_compactor() {
+                    remove_node_from_consistent_hash(&node, &Role::Compactor, None).await;
+                }
+                if node.is_flatten_compactor() {
+                    remove_node_from_consistent_hash(&node, &Role::FlattenCompactor, None).await;
                 }
                 NODES.write().await.remove(&node.uuid);
             }
@@ -413,21 +490,39 @@ pub async fn get_cached_online_ingester_nodes() -> Option<Vec<Node>> {
 }
 
 #[inline]
-pub async fn get_cached_online_querier_nodes() -> Option<Vec<Node>> {
-    get_cached_nodes(|node| {
+pub async fn get_cached_online_querier_nodes(group: Option<RoleGroup>) -> Option<Vec<Node>> {
+    let nodes = get_cached_nodes(|node| {
         node.status == NodeStatus::Online && node.scheduled && is_querier(&node.role)
     })
-    .await
+    .await;
+    filter_nodes_with_group(nodes, group)
 }
 
 #[inline]
-pub async fn get_cached_online_query_nodes() -> Option<Vec<Node>> {
-    get_cached_nodes(|node| {
+pub async fn get_cached_online_query_nodes(group: Option<RoleGroup>) -> Option<Vec<Node>> {
+    let nodes = get_cached_nodes(|node| {
         node.status == NodeStatus::Online
             && node.scheduled
             && (is_querier(&node.role) || is_ingester(&node.role))
     })
-    .await
+    .await;
+    filter_nodes_with_group(nodes, group)
+}
+
+#[inline(always)]
+fn filter_nodes_with_group(
+    nodes: Option<Vec<Node>>,
+    group: Option<RoleGroup>,
+) -> Option<Vec<Node>> {
+    let mut nodes = nodes?;
+    match group {
+        Some(RoleGroup::Interactive) => nodes
+            .retain(|n| n.role_group == RoleGroup::None || n.role_group == RoleGroup::Interactive),
+        Some(RoleGroup::Background) => nodes
+            .retain(|n| n.role_group == RoleGroup::None || n.role_group == RoleGroup::Background),
+        _ => {}
+    };
+    Some(nodes)
 }
 
 #[cfg(test)]
@@ -446,9 +541,9 @@ mod tests {
         set_online(false).await.unwrap();
         leave().await.unwrap();
         assert!(get_cached_online_nodes().await.is_some());
-        assert!(get_cached_online_query_nodes().await.is_some());
+        assert!(get_cached_online_query_nodes(None).await.is_some());
         assert!(get_cached_online_ingester_nodes().await.is_some());
-        assert!(get_cached_online_querier_nodes().await.is_some());
+        assert!(get_cached_online_querier_nodes(None).await.is_some());
     }
 
     #[tokio::test]
@@ -465,21 +560,21 @@ mod tests {
                 role: [Role::Compactor].to_vec(),
                 ..node.clone()
             };
-            add_node_to_consistent_hash(&node_q, &Role::Querier).await;
-            add_node_to_consistent_hash(&node_c, &Role::Compactor).await;
-            add_node_to_consistent_hash(&node_c, &Role::FlattenCompactor).await;
+            add_node_to_consistent_hash(&node_q, &Role::Querier, None).await;
+            add_node_to_consistent_hash(&node_c, &Role::Compactor, None).await;
+            add_node_to_consistent_hash(&node_c, &Role::FlattenCompactor, None).await;
         }
 
         for key in ["test", "test1", "test2", "test3"] {
             println!(
                 "{key}-q: {}",
-                get_node_from_consistent_hash(key, &Role::Querier)
+                get_node_from_consistent_hash(key, &Role::Querier, None)
                     .await
                     .unwrap()
             );
             println!(
                 "{key}-c: {}",
-                get_node_from_consistent_hash(key, &Role::Compactor)
+                get_node_from_consistent_hash(key, &Role::Compactor, None)
                     .await
                     .unwrap()
             );
@@ -515,11 +610,11 @@ mod tests {
         ];
         for key in data {
             assert_eq!(
-                get_node_from_consistent_hash(key.first().unwrap(), &Role::Querier).await,
+                get_node_from_consistent_hash(key.first().unwrap(), &Role::Querier, None).await,
                 Some(key.get(1).unwrap().to_string())
             );
             assert_eq!(
-                get_node_from_consistent_hash(key.first().unwrap(), &Role::Compactor).await,
+                get_node_from_consistent_hash(key.first().unwrap(), &Role::Compactor, None).await,
                 Some(key.get(2).unwrap().to_string())
             );
         }

--- a/src/common/infra/cluster/nats.rs
+++ b/src/common/infra/cluster/nats.rs
@@ -18,7 +18,7 @@ use core::cmp::min;
 use config::{
     cluster::*,
     get_config,
-    meta::cluster::{load_role_group, Node, NodeStatus, Role, RoleGroup},
+    meta::cluster::{Node, NodeStatus, Role, RoleGroup},
     utils::json,
 };
 use infra::{
@@ -130,19 +130,19 @@ async fn register() -> Result<()> {
     }
 
     // 5. join the cluster
-    let key = format!("/nodes/{}", *LOCAL_NODE_UUID);
+    let key = format!("/nodes/{}", LOCAL_NODE.uuid);
     let node = Node {
         id: new_node_id,
-        uuid: LOCAL_NODE_UUID.clone(),
+        uuid: LOCAL_NODE.uuid.clone(),
         name: cfg.common.instance_name.clone(),
         http_addr: format!("http://{}:{}", get_local_http_ip(), cfg.http.port),
         grpc_addr: format!("http://{}:{}", get_local_grpc_ip(), cfg.grpc.port),
-        role: LOCAL_NODE_ROLE.clone(),
+        role: LOCAL_NODE.role.clone(),
+        role_group: LOCAL_NODE.role_group,
         cpu_num: cfg.limit.cpu_num as u64,
         status: NodeStatus::Prepare,
         scheduled: true,
         broadcasted: false,
-        role_group: load_role_group(),
     };
     let val = json::to_vec(&node).unwrap();
 
@@ -163,7 +163,7 @@ async fn register() -> Result<()> {
     }
 
     let mut w = super::NODES.write().await;
-    w.insert(LOCAL_NODE_UUID.clone(), node);
+    w.insert(LOCAL_NODE.uuid.clone(), node);
     drop(w);
 
     // 6. register node to cluster
@@ -192,7 +192,7 @@ pub(crate) async fn set_offline() -> Result<()> {
 pub(crate) async fn set_status(status: NodeStatus) -> Result<()> {
     let cfg = get_config();
     // set node status to online
-    let node = match super::NODES.read().await.get(LOCAL_NODE_UUID.as_str()) {
+    let node = match super::NODES.read().await.get(LOCAL_NODE.uuid.as_str()) {
         Some(node) => {
             let mut val = node.clone();
             val.status = status.clone();
@@ -200,16 +200,16 @@ pub(crate) async fn set_status(status: NodeStatus) -> Result<()> {
         }
         None => Node {
             id: unsafe { LOCAL_NODE_ID },
-            uuid: LOCAL_NODE_UUID.clone(),
+            uuid: LOCAL_NODE.uuid.clone(),
             name: cfg.common.instance_name.clone(),
             http_addr: format!("http://{}:{}", get_local_node_ip(), cfg.http.port),
             grpc_addr: format!("http://{}:{}", get_local_node_ip(), cfg.grpc.port),
-            role: LOCAL_NODE_ROLE.clone(),
+            role: LOCAL_NODE.role.clone(),
+            role_group: LOCAL_NODE.role_group,
             cpu_num: cfg.limit.cpu_num as u64,
             status: status.clone(),
             scheduled: true,
             broadcasted: false,
-            role_group: load_role_group(),
         },
     };
     let val = json::to_string(&node).unwrap();
@@ -218,7 +218,7 @@ pub(crate) async fn set_status(status: NodeStatus) -> Result<()> {
         LOCAL_NODE_STATUS = status;
     }
 
-    let key = format!("/nodes/{}", *LOCAL_NODE_UUID);
+    let key = format!("/nodes/{}", LOCAL_NODE.uuid);
     let client = get_coordinator().await;
     if let Err(e) = client.put(&key, val.into(), NEED_WATCH, None).await {
         return Err(Error::Message(format!("online node error: {}", e)));
@@ -229,7 +229,7 @@ pub(crate) async fn set_status(status: NodeStatus) -> Result<()> {
 
 /// Leave cluster
 pub(crate) async fn leave() -> Result<()> {
-    let key = format!("/nodes/{}", *LOCAL_NODE_UUID);
+    let key = format!("/nodes/{}", LOCAL_NODE.uuid);
     let client = get_coordinator().await;
     if let Err(e) = client.delete(&key, false, NEED_WATCH, None).await {
         return Err(Error::Message(format!("leave node error: {}", e)));
@@ -239,7 +239,7 @@ pub(crate) async fn leave() -> Result<()> {
 }
 
 pub(crate) async fn update_local_node(node: &Node) -> Result<()> {
-    let key = format!("/nodes/{}", *LOCAL_NODE_UUID);
+    let key = format!("/nodes/{}", LOCAL_NODE.uuid);
     let val = json::to_vec(&node).unwrap();
     let client = get_coordinator().await;
     if let Err(e) = client.put(&key, val.into(), NEED_WATCH, None).await {

--- a/src/common/infra/cluster/nats.rs
+++ b/src/common/infra/cluster/nats.rs
@@ -18,7 +18,7 @@ use core::cmp::min;
 use config::{
     cluster::*,
     get_config,
-    meta::cluster::{load_role_group, Node, NodeStatus, Role},
+    meta::cluster::{load_role_group, Node, NodeStatus, Role, RoleGroup},
     utils::json,
 };
 use infra::{
@@ -92,14 +92,19 @@ async fn register() -> Result<()> {
     let mut node_ids = Vec::new();
     let mut w = super::NODES.write().await;
     for node in node_list {
-        if is_querier(&node.role) {
-            super::add_node_to_consistent_hash(&node, &Role::Querier).await;
+        if node.is_interactive_querier() {
+            super::add_node_to_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Interactive))
+                .await;
         }
-        if is_compactor(&node.role) {
-            super::add_node_to_consistent_hash(&node, &Role::Compactor).await;
+        if node.is_background_querier() {
+            super::add_node_to_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Background))
+                .await;
         }
-        if is_flatten_compactor(&node.role) {
-            super::add_node_to_consistent_hash(&node, &Role::FlattenCompactor).await;
+        if node.is_compactor() {
+            super::add_node_to_consistent_hash(&node, &Role::Compactor, None).await;
+        }
+        if node.is_flatten_compactor() {
+            super::add_node_to_consistent_hash(&node, &Role::FlattenCompactor, None).await;
         }
         node_ids.push(node.id);
         w.insert(node.uuid.clone(), node);
@@ -142,14 +147,19 @@ async fn register() -> Result<()> {
     let val = json::to_vec(&node).unwrap();
 
     // cache local node
-    if is_querier(&node.role) {
-        super::add_node_to_consistent_hash(&node, &Role::Querier).await;
+    if node.is_interactive_querier() {
+        super::add_node_to_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Interactive))
+            .await;
     }
-    if is_compactor(&node.role) {
-        super::add_node_to_consistent_hash(&node, &Role::Compactor).await;
+    if node.is_background_querier() {
+        super::add_node_to_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Background))
+            .await;
     }
-    if is_flatten_compactor(&node.role) {
-        super::add_node_to_consistent_hash(&node, &Role::FlattenCompactor).await;
+    if node.is_compactor() {
+        super::add_node_to_consistent_hash(&node, &Role::Compactor, None).await;
+    }
+    if node.is_flatten_compactor() {
+        super::add_node_to_consistent_hash(&node, &Role::FlattenCompactor, None).await;
     }
 
     let mut w = super::NODES.write().await;

--- a/src/common/meta/telemetry.rs
+++ b/src/common/meta/telemetry.rs
@@ -16,10 +16,7 @@
 use std::collections::HashMap;
 
 use config::{
-    cluster::{is_single_node, load_local_node_role},
-    get_config, get_instance_id,
-    utils::json,
-    SIZE_IN_MB, TELEMETRY_CLIENT,
+    cluster::LOCAL_NODE, get_config, get_instance_id, utils::json, SIZE_IN_MB, TELEMETRY_CLIENT,
 };
 use hashbrown::HashSet;
 use infra::{cache::stats, db as infra_db, schema::STREAM_SCHEMAS_LATEST};
@@ -162,8 +159,7 @@ pub async fn add_zo_info(mut data: HashMap<String, json::Value>) -> HashMap<Stri
         }
     }
 
-    let roles = load_local_node_role();
-    if !is_single_node(&roles) {
+    if !LOCAL_NODE.is_single_node() {
         match get_cached_online_nodes().await {
             Some(nodes) => {
                 data.insert("is_HA_mode".to_string(), json::Value::Bool(true));

--- a/src/common/meta/telemetry.rs
+++ b/src/common/meta/telemetry.rs
@@ -170,7 +170,7 @@ pub async fn add_zo_info(mut data: HashMap<String, json::Value>) -> HashMap<Stri
                 data.insert("number_of_nodes".to_string(), nodes.len().into());
                 data.insert(
                     "querier_nodes".to_string(),
-                    crate::common::infra::cluster::get_cached_online_querier_nodes()
+                    crate::common::infra::cluster::get_cached_online_querier_nodes(None)
                         .await
                         .unwrap_or_default()
                         .len()

--- a/src/config/src/cluster.rs
+++ b/src/config/src/cluster.rs
@@ -19,21 +19,41 @@ use once_cell::sync::Lazy;
 
 use crate::{
     get_config, ider,
-    meta::cluster::{NodeStatus, Role},
+    meta::cluster::{Node, NodeStatus, Role, RoleGroup},
 };
 
 pub static mut LOCAL_NODE_ID: i32 = 0;
 pub static mut LOCAL_NODE_KEY_LEASE_ID: i64 = 0;
 pub static mut LOCAL_NODE_STATUS: NodeStatus = NodeStatus::Prepare;
-pub static LOCAL_NODE_UUID: Lazy<String> = Lazy::new(load_local_node_uuid);
-pub static LOCAL_NODE_ROLE: Lazy<Vec<Role>> = Lazy::new(load_local_node_role);
+pub static LOCAL_NODE: Lazy<Node> = Lazy::new(load_local_node);
 
-#[inline(always)]
-pub fn load_local_node_uuid() -> String {
+fn load_local_node() -> Node {
+    Node {
+        uuid: load_local_node_uuid(),
+        role: load_local_node_role(),
+        role_group: load_role_group(),
+        ..Default::default()
+    }
+}
+
+fn load_local_node_uuid() -> String {
     ider::uuid()
 }
 
-#[inline(always)]
+fn load_local_node_role() -> Vec<Role> {
+    get_config()
+        .common
+        .node_role
+        .clone()
+        .split(',')
+        .map(|s| s.parse().unwrap())
+        .collect()
+}
+
+fn load_role_group() -> RoleGroup {
+    RoleGroup::from(get_config().common.node_role_group.as_str())
+}
+
 pub fn get_local_http_ip() -> String {
     let cfg = get_config();
     if !cfg.http.addr.is_empty() {
@@ -43,7 +63,6 @@ pub fn get_local_http_ip() -> String {
     }
 }
 
-#[inline(always)]
 pub fn get_local_grpc_ip() -> String {
     let cfg = get_config();
     if !cfg.grpc.addr.is_empty() {
@@ -53,7 +72,6 @@ pub fn get_local_grpc_ip() -> String {
     }
 }
 
-#[inline(always)]
 pub fn get_local_node_ip() -> String {
     for adapter in get_if_addrs::get_if_addrs().unwrap() {
         if !adapter.is_loopback() && matches!(adapter.ip(), IpAddr::V4(_)) {
@@ -64,52 +82,6 @@ pub fn get_local_node_ip() -> String {
 }
 
 #[inline(always)]
-pub fn load_local_node_role() -> Vec<Role> {
-    get_config()
-        .common
-        .node_role
-        .clone()
-        .split(',')
-        .map(|s| s.parse().unwrap())
-        .collect()
-}
-
-#[inline(always)]
-pub fn is_ingester(role: &[Role]) -> bool {
-    role.contains(&Role::Ingester) || role.contains(&Role::All)
-}
-
-#[inline(always)]
-pub fn is_querier(role: &[Role]) -> bool {
-    role.contains(&Role::Querier) || role.contains(&Role::All)
-}
-
-#[inline(always)]
-pub fn is_compactor(role: &[Role]) -> bool {
-    role.contains(&Role::Compactor) || role.contains(&Role::All)
-}
-
-#[inline(always)]
-pub fn is_flatten_compactor(role: &[Role]) -> bool {
-    role.contains(&Role::FlattenCompactor) || role.contains(&Role::All)
-}
-
-#[inline(always)]
-pub fn is_router(role: &[Role]) -> bool {
-    role.contains(&Role::Router)
-}
-
-#[inline(always)]
-pub fn is_alert_manager(role: &[Role]) -> bool {
-    role.contains(&Role::AlertManager) || role.contains(&Role::All)
-}
-
-#[inline(always)]
-pub fn is_single_node(role: &[Role]) -> bool {
-    role.contains(&Role::All)
-}
-
-#[inline(always)]
 pub fn is_offline() -> bool {
     unsafe { LOCAL_NODE_STATUS == NodeStatus::Offline }
 }
@@ -117,6 +89,7 @@ pub fn is_offline() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::meta::cluster::Role;
 
     #[test]
     fn test_convert_role() {
@@ -131,41 +104,6 @@ mod tests {
         assert_eq!(parse("alertManager"), Role::AlertManager);
         assert_eq!(parse("AlertManager"), Role::AlertManager);
         assert!("alert_manager".parse::<Role>().is_ok());
-    }
-
-    #[test]
-    fn test_is_querier() {
-        assert!(is_querier(&[Role::Querier]));
-        assert!(is_querier(&[Role::All]));
-        assert!(!is_querier(&[Role::Ingester]));
-    }
-
-    #[test]
-    fn test_is_ingester() {
-        assert!(is_ingester(&[Role::Ingester]));
-        assert!(is_ingester(&[Role::All]));
-        assert!(!is_ingester(&[Role::Querier]));
-    }
-
-    #[test]
-    fn test_is_compactor() {
-        assert!(is_compactor(&[Role::Compactor]));
-        assert!(is_compactor(&[Role::All]));
-        assert!(!is_compactor(&[Role::Querier]));
-    }
-
-    #[test]
-    fn test_is_router() {
-        assert!(is_router(&[Role::Router]));
-        assert!(!is_router(&[Role::All]));
-        assert!(!is_router(&[Role::Querier]));
-    }
-
-    #[test]
-    fn test_is_alert_manager() {
-        assert!(is_alert_manager(&[Role::AlertManager]));
-        assert!(is_alert_manager(&[Role::All]));
-        assert!(!is_alert_manager(&[Role::Querier]));
     }
 
     #[test]

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -28,7 +28,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
     // initialize chrome launch options, so that if chrome download is
     // needed, it will happen now and not during serving report API
-    if cluster::is_alert_manager(&cluster::LOCAL_NODE_ROLE) {
+    if cluster::LOCAL_NODE.is_alert_manager() {
         let _ = get_chrome_launch_options().await;
     }
     Ok(())

--- a/src/config/src/meta/cluster.rs
+++ b/src/config/src/meta/cluster.rs
@@ -53,6 +53,32 @@ impl Node {
             role_group: load_role_group(),
         }
     }
+    pub fn is_router(&self) -> bool {
+        self.role.contains(&Role::Router) || self.role.contains(&Role::All)
+    }
+    pub fn is_ingester(&self) -> bool {
+        self.role.contains(&Role::Ingester) || self.role.contains(&Role::All)
+    }
+    pub fn is_querier(&self) -> bool {
+        self.role.contains(&Role::Querier) || self.role.contains(&Role::All)
+    }
+    pub fn is_interactive_querier(&self) -> bool {
+        self.is_querier()
+            && (self.role_group == RoleGroup::None || self.role_group == RoleGroup::Interactive)
+    }
+    pub fn is_background_querier(&self) -> bool {
+        self.is_querier()
+            && (self.role_group == RoleGroup::None || self.role_group == RoleGroup::Background)
+    }
+    pub fn is_compactor(&self) -> bool {
+        self.role.contains(&Role::Compactor) || self.role.contains(&Role::All)
+    }
+    pub fn is_flatten_compactor(&self) -> bool {
+        self.role.contains(&Role::FlattenCompactor) || self.role.contains(&Role::All)
+    }
+    pub fn is_alert_manager(&self) -> bool {
+        self.role.contains(&Role::AlertManager) || self.role.contains(&Role::All)
+    }
 }
 
 impl Default for Node {
@@ -114,7 +140,7 @@ impl std::fmt::Display for Role {
 /// None        -> All tasks
 /// Background  -> Low-priority tasks
 /// Interactive -> High-priority tasks
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub enum RoleGroup {
     #[default]
     None,

--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -17,7 +17,10 @@ use chrono::{Duration, Utc};
 use config::{
     cluster::{is_compactor, is_querier, LOCAL_NODE_ROLE, LOCAL_NODE_UUID},
     get_config,
-    meta::{cluster::Role, stream::FileKey},
+    meta::{
+        cluster::{Role, RoleGroup},
+        stream::FileKey,
+    },
     metrics,
     utils::parquet::read_recordbatch_from_bytes,
 };
@@ -92,7 +95,12 @@ impl Event for Eventer {
         if cfg.memory_cache.cache_latest_files && is_querier(&LOCAL_NODE_ROLE) {
             let mut cached_field_stream = HashSet::new();
             for item in put_items.iter() {
-                let Some(node) = get_node_from_consistent_hash(&item.key, &Role::Querier).await
+                let Some(node) = get_node_from_consistent_hash(
+                    &item.key,
+                    &Role::Querier,
+                    Some(RoleGroup::Interactive),
+                )
+                .await
                 else {
                     continue; // no querier node
                 };

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -24,7 +24,7 @@ use actix_web::{
 };
 use arrow_schema::Schema;
 use config::{
-    cluster::{is_ingester, LOCAL_NODE_ROLE, LOCAL_NODE_UUID},
+    cluster::LOCAL_NODE,
     get_config, get_instance_id,
     meta::cluster::NodeStatus,
     utils::{json, schema_ext::SchemaExt},
@@ -153,7 +153,7 @@ pub async fn healthz() -> Result<HttpResponse, Error> {
 )]
 #[get("/schedulez")]
 pub async fn schedulez() -> Result<HttpResponse, Error> {
-    let node_id = LOCAL_NODE_UUID.clone();
+    let node_id = LOCAL_NODE.uuid.clone();
     let Some(node) = cluster::get_node_by_uuid(&node_id).await else {
         return Ok(HttpResponse::NotFound().json(HealthzResponse {
             status: "not ok".to_string(),
@@ -275,7 +275,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
 pub async fn cache_status() -> Result<HttpResponse, Error> {
     let cfg = get_config();
     let mut stats: HashMap<&str, json::Value> = HashMap::default();
-    stats.insert("LOCAL_NODE_UUID", json::json!(LOCAL_NODE_UUID.clone()));
+    stats.insert("LOCAL_NODE_UUID", json::json!(LOCAL_NODE.uuid.clone()));
     stats.insert("LOCAL_NODE_NAME", json::json!(&cfg.common.instance_name));
     stats.insert("LOCAL_NODE_ROLE", json::json!(&cfg.common.node_role));
     let nodes = cluster::get_cached_online_nodes().await;
@@ -668,7 +668,7 @@ async fn logout(req: actix_web::HttpRequest) -> HttpResponse {
 
 #[put("/enable")]
 async fn enable_node(req: HttpRequest) -> Result<HttpResponse, Error> {
-    let node_id = LOCAL_NODE_UUID.clone();
+    let node_id = LOCAL_NODE.uuid.clone();
     let Some(mut node) = cluster::get_node_by_uuid(&node_id).await else {
         return Ok(MetaHttpResponse::not_found("node not found"));
     };
@@ -687,7 +687,7 @@ async fn enable_node(req: HttpRequest) -> Result<HttpResponse, Error> {
 
 #[put("/flush")]
 async fn flush_node() -> Result<HttpResponse, Error> {
-    if !is_ingester(&LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Ok(MetaHttpResponse::not_found("local node is not an ingester"));
     };
 

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::{cluster, get_config};
+use config::{cluster::LOCAL_NODE, get_config};
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::common::infra::config::O2_CONFIG;
 use tokio::time;
@@ -21,7 +21,7 @@ use tokio::time;
 use crate::service;
 
 pub async fn run() -> Result<(), anyhow::Error> {
-    if !cluster::is_alert_manager(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_alert_manager() {
         return Ok(());
     }
 

--- a/src/job/compactor.rs
+++ b/src/job/compactor.rs
@@ -15,11 +15,7 @@
 
 use std::sync::Arc;
 
-use config::{
-    cluster::{is_compactor, LOCAL_NODE_ROLE},
-    get_config,
-    meta::stream::FileKey,
-};
+use config::{cluster::LOCAL_NODE, get_config, meta::stream::FileKey};
 use tokio::{
     sync::{mpsc, Mutex},
     time,
@@ -31,7 +27,7 @@ use crate::service::compact::{
 };
 
 pub async fn run() -> Result<(), anyhow::Error> {
-    if !is_compactor(&LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_compactor() {
         return Ok(());
     }
 

--- a/src/job/file_list.rs
+++ b/src/job/file_list.rs
@@ -15,12 +15,7 @@
 
 use std::{fs, path::Path};
 
-use config::{
-    cluster::{is_compactor, is_ingester, is_querier, LOCAL_NODE_ROLE},
-    get_config,
-    meta::stream::StreamType,
-    utils::file::scan_files,
-};
+use config::{cluster::LOCAL_NODE, get_config, meta::stream::StreamType, utils::file::scan_files};
 use infra::storage;
 use tokio::time;
 
@@ -42,7 +37,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
 }
 
 pub async fn run_move_file_to_s3() -> Result<(), anyhow::Error> {
-    if !is_ingester(&LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Ok(()); // not an ingester, no need to init job
     }
 
@@ -145,7 +140,7 @@ async fn upload_file(path_str: &str, file_key: &str) -> Result<(), anyhow::Error
 }
 
 async fn _run_sync_s3_to_cache() -> Result<(), anyhow::Error> {
-    if !is_querier(&LOCAL_NODE_ROLE) && !is_compactor(&LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_querier() && !LOCAL_NODE.is_compactor() {
         return Ok(()); // only querier or compactor need to sync
     }
 

--- a/src/job/files/mod.rs
+++ b/src/job/files/mod.rs
@@ -13,7 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::{cluster, ider, meta::stream::StreamType, FILE_EXT_PARQUET};
+use config::{
+    cluster::{is_offline, LOCAL_NODE},
+    ider,
+    meta::stream::StreamType,
+    FILE_EXT_PARQUET,
+};
 use tokio::time;
 
 pub mod broadcast;
@@ -21,7 +26,7 @@ pub mod idx;
 pub mod parquet;
 
 pub async fn run() -> Result<(), anyhow::Error> {
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Ok(()); // not an ingester, no need to init job
     }
 
@@ -34,7 +39,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
 async fn clean_empty_dirs() -> Result<(), anyhow::Error> {
     loop {
-        if cluster::is_offline() {
+        if is_offline() {
             break;
         }
         time::sleep(time::Duration::from_secs(3600)).await;

--- a/src/job/flatten_compactor.rs
+++ b/src/job/flatten_compactor.rs
@@ -15,11 +15,7 @@
 
 use std::sync::Arc;
 
-use config::{
-    cluster::{is_flatten_compactor, LOCAL_NODE_ROLE},
-    get_config,
-    meta::stream::FileKey,
-};
+use config::{cluster::LOCAL_NODE, get_config, meta::stream::FileKey};
 use tokio::{
     sync::{mpsc, Mutex},
     time,
@@ -28,7 +24,7 @@ use tokio::{
 use crate::service::compact;
 
 pub async fn run() -> Result<(), anyhow::Error> {
-    if !is_flatten_compactor(&LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_flatten_compactor() {
         return Ok(());
     }
 

--- a/src/job/metrics.rs
+++ b/src/job/metrics.rs
@@ -16,7 +16,7 @@
 use std::path::Path;
 
 use config::{
-    cluster, get_config,
+    get_config,
     meta::{cluster::Role, stream::StreamType},
     metrics,
     utils::file::scan_files,
@@ -118,27 +118,27 @@ async fn update_metadata_metrics() -> Result<(), anyhow::Error> {
         let nodes = get_cached_online_nodes().await;
         if nodes.is_some() {
             for node in nodes.unwrap() {
-                if cluster::is_ingester(&node.role) {
+                if node.is_ingester() {
                     metrics::META_NUM_NODES
                         .with_label_values(&[Role::Ingester.to_string().as_str()])
                         .inc();
                 }
-                if cluster::is_querier(&node.role) {
+                if node.is_querier() {
                     metrics::META_NUM_NODES
                         .with_label_values(&[Role::Querier.to_string().as_str()])
                         .inc();
                 }
-                if cluster::is_compactor(&node.role) {
+                if node.is_compactor() {
                     metrics::META_NUM_NODES
                         .with_label_values(&[Role::Compactor.to_string().as_str()])
                         .inc();
                 }
-                if cluster::is_router(&node.role) {
+                if node.is_router() {
                     metrics::META_NUM_NODES
                         .with_label_values(&[Role::Router.to_string().as_str()])
                         .inc();
                 }
-                if cluster::is_alert_manager(&node.role) {
+                if node.is_alert_manager() {
                     metrics::META_NUM_NODES
                         .with_label_values(&[Role::AlertManager.to_string().as_str()])
                         .inc();

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::cluster;
+use config::cluster::LOCAL_NODE;
 use infra::file_list as infra_file_list;
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::common::infra::config::O2_CONFIG;
@@ -90,12 +90,12 @@ pub async fn init() -> Result<(), anyhow::Error> {
     tokio::task::spawn(async move { usage::run_audit_publish().await });
 
     // Router doesn't need to initialize job
-    if cluster::is_router(&cluster::LOCAL_NODE_ROLE) {
+    if LOCAL_NODE.is_router() {
         return Ok(());
     }
 
     // telemetry run
-    if cfg.common.telemetry_enabled && cluster::is_querier(&cluster::LOCAL_NODE_ROLE) {
+    if cfg.common.telemetry_enabled && LOCAL_NODE.is_querier() {
         tokio::task::spawn(async move { telemetry::run().await });
     }
 
@@ -114,14 +114,12 @@ pub async fn init() -> Result<(), anyhow::Error> {
     tokio::task::spawn(async move { db::organization::watch().await });
     #[cfg(feature = "enterprise")]
     tokio::task::spawn(async move { db::ofga::watch().await });
-    if cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if LOCAL_NODE.is_ingester() {
         tokio::task::spawn(async move { db::pipelines::watch().await });
     }
 
     #[cfg(feature = "enterprise")]
-    if !cluster::is_compactor(&cluster::LOCAL_NODE_ROLE)
-        || cluster::is_single_node(&cluster::LOCAL_NODE_ROLE)
-    {
+    if !LOCAL_NODE.is_compactor() || LOCAL_NODE.is_single_node() {
         tokio::task::spawn(async move { db::session::watch().await });
     }
 
@@ -157,21 +155,19 @@ pub async fn init() -> Result<(), anyhow::Error> {
     db::syslog::cache_syslog_settings()
         .await
         .expect("syslog settings cache failed");
-    if cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if LOCAL_NODE.is_ingester() {
         db::pipelines::cache().await.expect("syslog cache failed");
     }
 
     // cache file list
     if !cfg.common.meta_store_external {
-        if cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+        if LOCAL_NODE.is_ingester() {
             // load the wal file_list into memory
             db::file_list::local::load_wal_in_cache()
                 .await
                 .expect("load wal file list failed");
         }
-        if cluster::is_querier(&cluster::LOCAL_NODE_ROLE)
-            || cluster::is_compactor(&cluster::LOCAL_NODE_ROLE)
-        {
+        if LOCAL_NODE.is_querier() || LOCAL_NODE.is_compactor() {
             db::file_list::remote::cache("", false)
                 .await
                 .expect("file list remote cache failed");
@@ -191,14 +187,14 @@ pub async fn init() -> Result<(), anyhow::Error> {
     db::ofga::cache().await.expect("ofga model cache failed");
 
     #[cfg(feature = "enterprise")]
-    if !cluster::is_compactor(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_compactor() {
         db::session::cache()
             .await
             .expect("user session cache failed");
     }
 
     // check wal directory
-    if cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if LOCAL_NODE.is_ingester() {
         // create wal dir
         if let Err(e) = std::fs::create_dir_all(&cfg.common.data_wal_dir) {
             log::error!("Failed to create wal dir: {}", e);

--- a/src/job/prom.rs
+++ b/src/job/prom.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::cluster;
+use config::cluster::LOCAL_NODE;
 use hashbrown::HashMap;
 use tokio::time::{self, Duration};
 
@@ -23,7 +23,7 @@ use crate::{
 };
 
 pub async fn run() -> Result<(), anyhow::Error> {
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Ok(()); // not an ingester, no need to init job
     }
 

--- a/src/job/stats.rs
+++ b/src/job/stats.rs
@@ -13,10 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::{
-    cluster::{is_compactor, is_querier},
-    get_config,
-};
+use config::{cluster::LOCAL_NODE, get_config};
 use tokio::time;
 
 use crate::service::{compact::stats::update_stats_from_file_list, db, usage};
@@ -30,7 +27,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
 async fn _usage_report_stats() -> Result<(), anyhow::Error> {
     let cfg = get_config();
-    if !is_compactor(&super::cluster::LOCAL_NODE_ROLE) || !cfg.common.usage_enabled {
+    if !LOCAL_NODE.is_compactor() || !cfg.common.usage_enabled {
         return Ok(());
     }
 
@@ -50,9 +47,7 @@ async fn _usage_report_stats() -> Result<(), anyhow::Error> {
 // get stats from file_list to update stream_stats
 async fn file_list_update_stats() -> Result<(), anyhow::Error> {
     let cfg = get_config();
-    if (cfg.common.meta_store_external || !is_querier(&super::cluster::LOCAL_NODE_ROLE))
-        && !is_compactor(&super::cluster::LOCAL_NODE_ROLE)
-    {
+    if (cfg.common.meta_store_external || !LOCAL_NODE.is_querier()) && !LOCAL_NODE.is_compactor() {
         return Ok(());
     }
 
@@ -80,7 +75,7 @@ async fn file_list_update_stats() -> Result<(), anyhow::Error> {
 }
 
 async fn cache_stream_stats() -> Result<(), anyhow::Error> {
-    if !is_querier(&super::cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_querier() {
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,10 +17,7 @@ use std::{cmp::max, collections::HashMap, net::SocketAddr, str::FromStr, time::D
 
 use actix_web::{dev::ServerHandle, http::KeepAlive, middleware, web, App, HttpServer};
 use actix_web_opentelemetry::RequestTracing;
-use config::{
-    cluster::{is_router, LOCAL_NODE_ROLE},
-    get_config,
-};
+use config::get_config;
 use log::LevelFilter;
 use openobserve::{
     cli::basic::cli,
@@ -202,7 +199,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // gRPC server
     let (grpc_shutudown_tx, grpc_shutdown_rx) = oneshot::channel();
     let (grpc_stopped_tx, grpc_stopped_rx) = oneshot::channel();
-    if is_router(&LOCAL_NODE_ROLE) {
+    if config::cluster::LOCAL_NODE.is_router() {
         init_router_grpc_server(grpc_shutdown_rx, grpc_stopped_tx)?;
     } else {
         init_common_grpc_server(grpc_shutdown_rx, grpc_stopped_tx)?;
@@ -402,7 +399,7 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
         let cfg = get_config();
         log::info!("starting HTTP server at: {}", haddr);
         let mut app = App::new().wrap(prometheus.clone());
-        if is_router(&LOCAL_NODE_ROLE) {
+        if config::cluster::LOCAL_NODE.is_router() {
             let client = awc::Client::builder()
                 .connector(awc::Connector::new().limit(cfg.route.max_connections))
                 .timeout(Duration::from_secs(cfg.route.timeout))
@@ -481,7 +478,7 @@ async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
         let cfg = get_config();
         log::info!("starting HTTP server at: {}", haddr);
         let mut app = App::new().wrap(prometheus.clone());
-        if is_router(&LOCAL_NODE_ROLE) {
+        if config::cluster::LOCAL_NODE.is_router() {
             let client = awc::Client::builder()
                 .connector(awc::Connector::new().limit(cfg.route.max_connections))
                 .timeout(Duration::from_secs(cfg.route.timeout))

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -13,7 +13,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use ::config::{get_config, meta::cluster::Role, utils::rand::get_rand_element};
+use ::config::{
+    get_config,
+    meta::cluster::{Role, RoleGroup},
+    utils::rand::get_rand_element,
+};
 use actix_web::{http::Error, route, web, HttpRequest, HttpResponse};
 
 use crate::common::infra::cluster;
@@ -193,7 +197,7 @@ async fn get_url(path: &str) -> URLDetails {
 
     let nodes = if is_querier_path {
         node_type = Role::Querier;
-        let nodes = cluster::get_cached_online_querier_nodes().await;
+        let nodes = cluster::get_cached_online_querier_nodes(Some(RoleGroup::Interactive)).await;
         if is_fixed_querier_route(path) && nodes.is_some() && !nodes.as_ref().unwrap().is_empty() {
             nodes.map(|v| v.into_iter().take(1).collect())
         } else {

--- a/src/service/compact/flatten.rs
+++ b/src/service/compact/flatten.rs
@@ -21,7 +21,7 @@ use arrow::array::{
 };
 use arrow_schema::{DataType, Field};
 use config::{
-    cluster::LOCAL_NODE_UUID,
+    cluster::LOCAL_NODE,
     get_config,
     meta::{
         cluster::Role,
@@ -75,7 +75,7 @@ pub async fn run_generate(worker_tx: mpsc::Sender<FileKey>) -> Result<(), anyhow
                 else {
                     continue; // no compactor node
                 };
-                if LOCAL_NODE_UUID.ne(&node) {
+                if LOCAL_NODE.uuid.ne(&node) {
                     continue; // not this node
                 }
 

--- a/src/service/compact/flatten.rs
+++ b/src/service/compact/flatten.rs
@@ -70,7 +70,8 @@ pub async fn run_generate(worker_tx: mpsc::Sender<FileKey>) -> Result<(), anyhow
 
                 // check running node
                 let Some(node) =
-                    get_node_from_consistent_hash(&stream_name, &Role::FlattenCompactor).await
+                    get_node_from_consistent_hash(&stream_name, &Role::FlattenCompactor, None)
+                        .await
                 else {
                     continue; // no compactor node
                 };

--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -58,7 +58,7 @@ pub async fn run_retention() -> Result<(), anyhow::Error> {
             let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
             for stream_name in streams {
                 let Some(node) =
-                    get_node_from_consistent_hash(&stream_name, &Role::Compactor).await
+                    get_node_from_consistent_hash(&stream_name, &Role::Compactor, None).await
                 else {
                     continue; // no compactor node
                 };
@@ -103,7 +103,8 @@ pub async fn run_retention() -> Result<(), anyhow::Error> {
         let stream_name = columns[2];
         let retention = columns[3];
 
-        let Some(node) = get_node_from_consistent_hash(stream_name, &Role::Compactor).await else {
+        let Some(node) = get_node_from_consistent_hash(stream_name, &Role::Compactor, None).await
+        else {
             continue; // no compactor node
         };
         if LOCAL_NODE_UUID.ne(&node) {
@@ -150,7 +151,7 @@ pub async fn run_generate_job() -> Result<(), anyhow::Error> {
             let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
             for stream_name in streams {
                 let Some(node) =
-                    get_node_from_consistent_hash(&stream_name, &Role::Compactor).await
+                    get_node_from_consistent_hash(&stream_name, &Role::Compactor, None).await
                 else {
                     continue; // no compactor node
                 };
@@ -237,7 +238,8 @@ pub async fn run_merge(
             unwrap_partition_time_level(stream_setting.partition_time_level, stream_type);
         if partition_time_level == PartitionTimeLevel::Daily || cfg.compact.step_secs < 3600 {
             // check if this stream need process by this node
-            let Some(node) = get_node_from_consistent_hash(&stream_name, &Role::Compactor).await
+            let Some(node) =
+                get_node_from_consistent_hash(&stream_name, &Role::Compactor, None).await
             else {
                 continue; // no compactor node
             };

--- a/src/service/compact/retention.rs
+++ b/src/service/compact/retention.rs
@@ -20,7 +20,7 @@ use std::{
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use config::{
-    cluster::LOCAL_NODE_UUID,
+    cluster::LOCAL_NODE,
     get_config, ider, is_local_disk_storage,
     meta::stream::{FileKey, FileMeta, PartitionTimeLevel, StreamStats, StreamType},
     utils::{json, time::BASE_TIME},
@@ -82,7 +82,7 @@ pub async fn delete_all(
     let lock_key = format!("/compact/retention/{org_id}/{stream_type}/{stream_name}");
     let locker = dist_lock::lock(&lock_key, 0).await?;
     let node = db::compact::retention::get_stream(org_id, stream_type, stream_name, None).await;
-    if !node.is_empty() && LOCAL_NODE_UUID.ne(&node) && get_node_by_uuid(&node).await.is_some() {
+    if !node.is_empty() && LOCAL_NODE.uuid.ne(&node) && get_node_by_uuid(&node).await.is_some() {
         log::error!("[COMPACT] stream {org_id}/{stream_type}/{stream_name} is deleting by {node}");
         dist_lock::unlock(&locker).await?;
         return Ok(()); // not this node, just skip
@@ -94,7 +94,7 @@ pub async fn delete_all(
         stream_type,
         stream_name,
         None,
-        &LOCAL_NODE_UUID.clone(),
+        &LOCAL_NODE.uuid.clone(),
     )
     .await;
     // already bind to this node, we can unlock now
@@ -179,7 +179,7 @@ pub async fn delete_by_date(
     let node =
         db::compact::retention::get_stream(org_id, stream_type, stream_name, Some(date_range))
             .await;
-    if !node.is_empty() && LOCAL_NODE_UUID.ne(&node) && get_node_by_uuid(&node).await.is_some() {
+    if !node.is_empty() && LOCAL_NODE.uuid.ne(&node) && get_node_by_uuid(&node).await.is_some() {
         log::error!(
             "[COMPACT] stream {org_id}/{stream_type}/{stream_name}/{:?} is deleting by {node}",
             date_range
@@ -194,7 +194,7 @@ pub async fn delete_by_date(
         stream_type,
         stream_name,
         Some(date_range),
-        &LOCAL_NODE_UUID.clone(),
+        &LOCAL_NODE.uuid.clone(),
     )
     .await;
     // already bind to this node, we can unlock now

--- a/src/service/db/compact/files.rs
+++ b/src/service/db/compact/files.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::{cluster::LOCAL_NODE_UUID, meta::stream::StreamType, RwAHashMap};
+use config::{cluster::LOCAL_NODE, meta::stream::StreamType, RwAHashMap};
 use once_cell::sync::Lazy;
 
 use crate::service::db;
@@ -55,7 +55,7 @@ pub async fn get_offset(org_id: &str, stream_type: StreamType, stream_name: &str
         (value.parse().unwrap(), String::from(""))
     };
     // only cache the value if it's empty or it's from this node
-    if node.is_empty() || LOCAL_NODE_UUID.eq(&node) {
+    if node.is_empty() || LOCAL_NODE.uuid.eq(&node) {
         let mut w = CACHES.write().await;
         w.insert(key.clone(), (offset, node.clone()));
         drop(w);

--- a/src/service/db/metrics.rs
+++ b/src/service/db/metrics.rs
@@ -16,7 +16,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use config::{cluster::LOCAL_NODE_UUID, utils::json};
+use config::{cluster::LOCAL_NODE, utils::json};
 
 use crate::{
     common::{infra::config::METRIC_CLUSTER_LEADER, meta::prom::ClusterLeader},
@@ -90,7 +90,7 @@ pub async fn watch_prom_cluster_leader() -> Result<(), anyhow::Error> {
                 } else {
                     json::from_slice(&ev.value.unwrap()).unwrap()
                 };
-                if item_value.updated_by != LOCAL_NODE_UUID.to_string() {
+                if item_value.updated_by != LOCAL_NODE.uuid {
                     METRIC_CLUSTER_LEADER
                         .write()
                         .await

--- a/src/service/db/schema.rs
+++ b/src/service/db/schema.rs
@@ -17,7 +17,11 @@ use std::sync::Arc;
 
 use arrow_schema::{Field, Schema};
 use bytes::Bytes;
-use config::{get_config, is_local_disk_storage, meta::stream::StreamType, utils::json};
+use config::{
+    get_config, is_local_disk_storage,
+    meta::{cluster::RoleGroup, stream::StreamType},
+    utils::json,
+};
 use hashbrown::{HashMap, HashSet};
 use infra::{
     cache,
@@ -558,7 +562,9 @@ pub async fn cache_enrichment_tables() -> Result<(), anyhow::Error> {
     // waiting for querier to be ready
     let expect_querier_num = get_config().limit.starting_expect_querier_num;
     loop {
-        let nodes = get_cached_online_querier_nodes().await.unwrap_or_default();
+        let nodes = get_cached_online_querier_nodes(Some(RoleGroup::Interactive))
+            .await
+            .unwrap_or_default();
         if nodes.len() >= expect_querier_num {
             break;
         }

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -23,7 +23,8 @@ use actix_web::{
 use bytes::Bytes;
 use chrono::Utc;
 use config::{
-    cluster, get_config,
+    cluster::LOCAL_NODE,
+    get_config,
     meta::{
         stream::{PartitionTimeLevel, StreamType},
         usage::UsageType,
@@ -65,7 +66,7 @@ pub async fn save_enrichment_data(
     let table_name = table_name.trim();
     let stream_name = &format_stream_name(table_name);
 
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -19,7 +19,7 @@ use config::{
     cluster::LOCAL_NODE_UUID,
     get_config, ider,
     meta::{
-        cluster::Node,
+        cluster::{Node, RoleGroup},
         search::ScanStats,
         stream::{FileKey, FileMeta, PartitionTimeLevel, StreamType},
     },
@@ -73,7 +73,7 @@ pub async fn query(
 
     // cluster mode
     let start: std::time::Instant = std::time::Instant::now();
-    let nodes = cluster::get_cached_online_querier_nodes()
+    let nodes = cluster::get_cached_online_querier_nodes(Some(RoleGroup::Interactive))
         .await
         .unwrap_or_default();
     if nodes.is_empty() {

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -16,7 +16,7 @@
 use std::io::Write;
 
 use config::{
-    cluster::LOCAL_NODE_UUID,
+    cluster::LOCAL_NODE,
     get_config, ider,
     meta::{
         cluster::{Node, RoleGroup},
@@ -171,7 +171,7 @@ pub async fn query(
         return Ok(Vec::new());
     }
     let node = max_id_node.unwrap();
-    if node.uuid.eq(LOCAL_NODE_UUID.as_str()) {
+    if node.uuid.eq(LOCAL_NODE.uuid.as_str()) {
         // local node, no need grpc call
         let files = query_inner(
             org_id,

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -21,7 +21,8 @@ use std::{
 use anyhow::{anyhow, Result};
 use chrono::{Duration, TimeZone, Utc};
 use config::{
-    cluster, get_config,
+    cluster::LOCAL_NODE,
+    get_config,
     meta::{
         stream::{PartitionTimeLevel, PartitioningDetails, Routing, StreamPartition, StreamType},
         usage::{RequestStats, TriggerData, TriggerDataStatus, TriggerDataType},
@@ -411,7 +412,7 @@ pub async fn write_file(
 }
 
 pub fn check_ingestion_allowed(org_id: &str, stream_name: Option<&str>) -> Result<()> {
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Err(anyhow!("not an ingester"));
     }
 

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, io::BufReader, sync::Arc};
 use actix_web::{http, web};
 use anyhow::{anyhow, Result};
 use config::{
-    cluster,
+    cluster::LOCAL_NODE,
     meta::{
         stream::{PartitioningDetails, StreamType},
         usage::UsageType,
@@ -50,7 +50,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
     let start = std::time::Instant::now();
     let started_at = chrono::Utc::now().timestamp_micros();
 
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Err(anyhow::anyhow!("not an ingester"));
     }
 

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -19,7 +19,8 @@ use actix_web::{http, HttpResponse};
 use bytes::BytesMut;
 use chrono::Utc;
 use config::{
-    cluster, get_config,
+    cluster::LOCAL_NODE,
+    get_config,
     meta::{
         stream::{PartitioningDetails, StreamType},
         usage::UsageType,
@@ -61,7 +62,7 @@ pub async fn handle_grpc_request(
     request: ExportMetricsServiceRequest,
     is_grpc: bool,
 ) -> Result<HttpResponse, anyhow::Error> {
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -19,7 +19,8 @@ use actix_web::{http, web, HttpResponse};
 use bytes::BytesMut;
 use chrono::Utc;
 use config::{
-    cluster, get_config,
+    cluster::LOCAL_NODE,
+    get_config,
     meta::{
         stream::{PartitioningDetails, StreamType},
         usage::UsageType,
@@ -79,7 +80,7 @@ pub async fn metrics_json_handler(
     org_id: &str,
     body: web::Bytes,
 ) -> Result<HttpResponse, std::io::Error> {
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -18,7 +18,8 @@ use std::{collections::HashMap, sync::Arc};
 use actix_web::web;
 use chrono::{TimeZone, Utc};
 use config::{
-    cluster, get_config,
+    cluster::LOCAL_NODE,
+    get_config,
     meta::{
         stream::{PartitioningDetails, StreamType},
         usage::UsageType,
@@ -64,7 +65,7 @@ pub async fn remote_write(
 ) -> std::result::Result<(), anyhow::Error> {
     let start = std::time::Instant::now();
     let started_at = Utc::now().timestamp_micros();
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Err(anyhow::anyhow!("not an ingester"));
     }
 
@@ -849,7 +850,7 @@ async fn prom_ha_handler(
             ClusterLeader {
                 name: replica_label.to_owned(),
                 last_received: curr_ts,
-                updated_by: cluster::LOCAL_NODE_UUID.to_string(),
+                updated_by: LOCAL_NODE.uuid.clone(),
             },
         );
         _accept_record = true;

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -21,6 +21,7 @@ use std::{
 use config::{
     ider,
     meta::{
+        cluster::RoleGroup,
         search::ScanStats,
         stream::StreamType,
         usage::{RequestStats, UsageType},
@@ -73,7 +74,9 @@ async fn search_in_cluster(
     let started_at = chrono::Utc::now().timestamp_micros();
 
     // get querier nodes from cluster
-    let mut nodes = cluster::get_cached_online_querier_nodes().await.unwrap();
+    let mut nodes = cluster::get_cached_online_querier_nodes(Some(RoleGroup::Interactive))
+        .await
+        .unwrap();
     // sort nodes by node_id this will improve hit cache ratio
     nodes.sort_by(|a, b| a.grpc_addr.cmp(&b.grpc_addr));
     nodes.dedup_by(|a, b| a.grpc_addr == b.grpc_addr);

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::cluster::{is_querier, LOCAL_NODE_UUID};
+use config::cluster::LOCAL_NODE;
 use infra::errors::{Error, ErrorCodes};
 use proto::cluster_rpc::{self, DeleteResultCacheRequest, QueryCacheRequest};
 use tonic::{codec::CompressionEncoding, metadata::MetadataValue, transport::Channel, Request};
@@ -41,8 +41,8 @@ pub async fn get_cached_results(
 
     nodes.sort_by_key(|x| x.id);
 
-    let local_node = infra_cluster::get_node_by_uuid(LOCAL_NODE_UUID.as_str()).await;
-    nodes.retain(|node| is_querier(&node.role) && !node.uuid.eq(LOCAL_NODE_UUID.as_str()));
+    let local_node = infra_cluster::get_node_by_uuid(LOCAL_NODE.uuid.as_str()).await;
+    nodes.retain(|node| node.is_querier() && !node.uuid.eq(LOCAL_NODE.uuid.as_str()));
 
     let querier_num = nodes.len();
     if querier_num == 0 && local_node.is_none() {
@@ -262,8 +262,8 @@ pub async fn delete_cached_results(path: String) -> bool {
 
     nodes.sort_by_key(|x| x.id);
 
-    let local_node = infra_cluster::get_node_by_uuid(LOCAL_NODE_UUID.as_str()).await;
-    nodes.retain(|node| is_querier(&node.role) && !node.uuid.eq(LOCAL_NODE_UUID.as_str()));
+    let local_node = infra_cluster::get_node_by_uuid(LOCAL_NODE.uuid.as_str()).await;
+    nodes.retain(|node| node.is_querier() && !node.uuid.eq(LOCAL_NODE.uuid.as_str()));
 
     let querier_num = nodes.len();
     if querier_num == 0 && local_node.is_none() {

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -33,7 +33,7 @@ pub async fn get_cached_results(
 ) -> Option<CachedQueryResponse> {
     let start = std::time::Instant::now();
     // get nodes from cluster
-    let mut nodes = infra_cluster::get_cached_online_query_nodes()
+    let mut nodes = infra_cluster::get_cached_online_query_nodes(None)
         .await
         .unwrap();
     nodes.sort_by(|a, b| a.grpc_addr.cmp(&b.grpc_addr));
@@ -254,7 +254,7 @@ pub async fn delete_cached_results(path: String) -> bool {
     let trace_id = path.clone();
     let mut delete_response = true;
     // get nodes from cluster
-    let mut nodes = infra_cluster::get_cached_online_query_nodes()
+    let mut nodes = infra_cluster::get_cached_online_query_nodes(None)
         .await
         .unwrap();
     nodes.sort_by(|a, b| a.grpc_addr.cmp(&b.grpc_addr));

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -18,7 +18,8 @@ use std::{collections::HashSet, sync::Arc};
 use ::datafusion::arrow::{ipc, record_batch::RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use config::{
-    cluster, get_config,
+    cluster::LOCAL_NODE,
+    get_config,
     meta::{
         search::ScanStats,
         stream::{FileKey, StreamType},
@@ -79,7 +80,7 @@ pub async fn search(
     let sql1 = sql.clone();
     let wal_parquet_span = tracing::span::Span::current();
     let task1 = tokio::task::spawn(async move {
-        if cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) && !skip_wal {
+        if LOCAL_NODE.is_ingester() && !skip_wal {
             wal::search_parquet(&trace_id1, sql1, stream_type, &work_group1, timeout)
                 .instrument(wal_parquet_span)
                 .await
@@ -94,7 +95,7 @@ pub async fn search(
     let sql2 = sql.clone();
     let wal_mem_span = tracing::span::Span::current();
     let task2 = tokio::task::spawn(async move {
-        if cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) && !skip_wal {
+        if LOCAL_NODE.is_ingester() && !skip_wal {
             wal::search_memtable(&trace_id2, sql2, stream_type, &work_group2, timeout)
                 .instrument(wal_mem_span)
                 .await

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -19,6 +19,7 @@ use chrono::Duration;
 use config::{
     get_config, ider,
     meta::{
+        cluster::RoleGroup,
         search,
         stream::{FileKey, StreamType},
         usage::{RequestStats, UsageType},
@@ -247,7 +248,7 @@ pub async fn search_partition(
     )
     .await;
 
-    let nodes = infra_cluster::get_cached_online_querier_nodes()
+    let nodes = infra_cluster::get_cached_online_querier_nodes(Some(RoleGroup::Interactive))
         .await
         .unwrap_or_default();
     if nodes.is_empty() {

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -310,7 +310,7 @@ pub async fn search_partition(
 #[cfg(feature = "enterprise")]
 pub async fn query_status() -> Result<search::QueryStatusResponse, Error> {
     // get nodes from cluster
-    let mut nodes = infra_cluster::get_cached_online_query_nodes()
+    let mut nodes = infra_cluster::get_cached_online_query_nodes(None)
         .await
         .unwrap();
     // sort nodes by node_id this will improve hit cache ratio
@@ -466,7 +466,7 @@ pub async fn cancel_query(
     trace_id: &str,
 ) -> Result<search::CancelQueryResponse, Error> {
     // get nodes from cluster
-    let mut nodes = infra_cluster::get_cached_online_query_nodes()
+    let mut nodes = infra_cluster::get_cached_online_query_nodes(None)
         .await
         .unwrap();
     // sort nodes by node_id this will improve hit cache ratio

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -19,7 +19,8 @@ use actix_web::{http, HttpResponse};
 use bytes::BytesMut;
 use chrono::{Duration, Utc};
 use config::{
-    cluster, get_config,
+    cluster::LOCAL_NODE,
+    get_config,
     meta::{
         stream::{PartitionTimeLevel, StreamPartition, StreamType},
         usage::{RequestStats, UsageType},
@@ -75,7 +76,7 @@ pub async fn handle_trace_request(
     let start = std::time::Instant::now();
     let started_at = Utc::now().timestamp_micros();
 
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -18,7 +18,8 @@ use std::{collections::HashMap, io::Error};
 use actix_web::{http, web, HttpResponse};
 use chrono::{Duration, Utc};
 use config::{
-    cluster, get_config,
+    cluster::LOCAL_NODE,
+    get_config,
     meta::{stream::StreamType, usage::UsageType},
     metrics,
     utils::{flatten, json},
@@ -63,7 +64,7 @@ pub async fn traces_json(
     let start = std::time::Instant::now();
     let started_at = Utc::now().timestamp_micros();
 
-    if !cluster::is_ingester(&cluster::LOCAL_NODE_ROLE) {
+    if !LOCAL_NODE.is_ingester() {
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),


### PR DESCRIPTION
- [x] Add two consistent hashing table for `Interactive` and `Background` querier group
- [x] Only cache latest parquet files for `Interactive` queriers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced role groups for nodes in the cluster, enhancing node categorization and management.
 
- **Refactor**
    - Updated node registration logic to include role groups.
    - Replaced `LOCAL_NODE_UUID` with `LOCAL_NODE` for better node management.

- **Bug Fixes**
    - Improved conditions for adding nodes to consistent hashes based on roles and role groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->