### PR TITLE
fix: enable cache by default & scan size lable issue

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -748,7 +748,7 @@ pub struct Common {
     pub traces_span_metrics_channel_buffer: usize,
     #[env_config(
         name = "ZO_RESULT_CACHE_ENABLED",
-        default = "false",
+        default = true,
         help = "Enable result cache for query results"
     )]
     pub result_cache_enabled: bool,

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2898,7 +2898,7 @@ const useLogs = () => {
       if(searchObj.data.queryResults.partitionDetail.partitions.length > 1 && searchObj.meta.showHistogram == false) {
         plusSign = "+";
       }
-      const scanSizeLabel = searchObj.data.queryResults.result_cache_ratio > 0 ? "Delta Scan Size" : "Scan Size";
+      const scanSizeLabel =  (searchObj.data.queryResults.result_cache_ratio !== undefined && searchObj.data.queryResults.result_cache_ratio > 0)? "Delta Scan Size" : "Scan Size";
 
       const title =
         "Showing " +


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled result caching by default, improving query result retrieval time.

- **Enhancements**
  - Refined label assignment logic to consider the `result_cache_ratio`, ensuring more accurate and meaningful labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->