### PR TITLE
feat: add `apply_before_flattening` option to function StreamOrder

### DIFF
--- a/src/common/meta/functions.rs
+++ b/src/common/meta/functions.rs
@@ -66,6 +66,7 @@ pub struct StreamTransform {
     #[serde(default)]
     pub is_removed: bool,
     #[serde(default)]
+    #[serde(rename = "applyBeforeFlattening")]
     pub apply_before_flattening: bool,
 }
 

--- a/src/common/meta/functions.rs
+++ b/src/common/meta/functions.rs
@@ -49,6 +49,8 @@ pub struct StreamOrder {
     pub stream_type: StreamType,
     #[serde(default)]
     pub is_removed: bool,
+    #[serde(default)]
+    pub apply_before_flattening: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
@@ -63,6 +65,8 @@ pub struct StreamTransform {
     pub stream_type: StreamType,
     #[serde(default)]
     pub is_removed: bool,
+    #[serde(default)]
+    pub apply_before_flattening: bool,
 }
 
 impl PartialEq for StreamTransform {
@@ -86,6 +90,7 @@ impl Transform {
                     order: stream.order,
                     stream_type: stream.stream_type,
                     is_removed: stream.is_removed,
+                    apply_before_flattening: stream.apply_before_flattening,
                 })
             }
         }
@@ -159,6 +164,7 @@ mod tests {
                 order: 1,
                 stream_type: StreamType::Logs,
                 is_removed: false,
+                apply_before_flattening: false,
             }]),
         };
 

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -292,6 +292,7 @@ pub async fn add_function_to_stream(
         if let Some(existing) = val.iter_mut().find(|x| x.stream == stream_order.stream) {
             existing.is_removed = false;
             existing.order = stream_order.order;
+            existing.apply_before_flattening = stream_order.apply_before_flattening;
         } else {
             val.push(stream_order);
         }

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -382,6 +382,7 @@ mod tests {
                 stream_type: StreamType::Logs,
                 order: 0,
                 is_removed: false,
+                apply_before_flattening: false,
             }]),
         };
 

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -289,7 +289,9 @@ pub async fn add_function_to_stream(
     stream_order.stream_type = stream_type;
 
     if let Some(mut val) = existing_fn.streams {
-        if let Some(existing) = val.iter_mut().find(|x| x.stream == stream_order.stream) {
+        if let Some(existing) = val.iter_mut().find(|x| {
+            x.stream == stream_order.stream && x.stream_type.eq(&stream_order.stream_type)
+        }) {
             existing.is_removed = false;
             existing.order = stream_order.order;
             existing.apply_before_flattening = stream_order.apply_before_flattening;

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -221,7 +221,7 @@ pub async fn list_stream_functions(
 
 pub async fn delete_stream_function(
     org_id: &str,
-    _stream_type: StreamType,
+    stream_type: StreamType,
     stream_name: &str,
     fn_name: &str,
 ) -> Result<HttpResponse, Error> {
@@ -237,7 +237,7 @@ pub async fn delete_stream_function(
 
     if let Some(ref mut val) = existing_fn.streams {
         for stream in val.iter_mut() {
-            if stream.stream == stream_name {
+            if stream.stream == stream_name && stream.stream_type == stream_type {
                 stream.is_removed = true;
                 stream.order = 0;
                 break;

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -340,8 +340,8 @@ pub fn register_stream_functions(
 
     if let Some(transforms) = STREAM_FUNCTIONS.get(&key) {
         (before_local_trans, after_local_trans) = (*transforms.list)
-            .to_vec()
-            .into_iter()
+            .iter()
+            .cloned()
             .partition(|elem| elem.apply_before_flattening);
         before_local_trans.sort_by(|a, b| a.order.cmp(&b.order));
         after_local_trans.sort_by(|a, b| a.order.cmp(&b.order));

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -134,7 +134,8 @@ pub fn apply_vrl_fn(
 
 pub async fn get_stream_functions<'a>(
     streams: &[StreamParams],
-    stream_functions_map: &mut HashMap<String, Vec<StreamTransform>>,
+    stream_before_functions_map: &mut HashMap<String, Vec<StreamTransform>>,
+    stream_after_functions_map: &mut HashMap<String, Vec<StreamTransform>>,
     stream_vrl_map: &mut HashMap<String, VRLResultResolver>,
 ) {
     for stream in streams {
@@ -142,12 +143,14 @@ pub async fn get_stream_functions<'a>(
             "{}/{}/{}",
             stream.org_id, stream.stream_type, stream.stream_name
         );
-        if stream_functions_map.contains_key(&key) {
+        if stream_after_functions_map.contains_key(&key)
+            || stream_before_functions_map.contains_key(&key)
+        {
             return;
         }
         //   let mut _local_trans: Vec<StreamTransform> = vec![];
         // let local_stream_vrl_map;
-        let (_local_trans, local_stream_vrl_map) =
+        let (before_local_trans, after_local_trans, local_stream_vrl_map) =
             crate::service::ingestion::register_stream_functions(
                 &stream.org_id,
                 &stream.stream_type,
@@ -155,7 +158,8 @@ pub async fn get_stream_functions<'a>(
             );
         stream_vrl_map.extend(local_stream_vrl_map);
 
-        stream_functions_map.insert(key, _local_trans);
+        stream_before_functions_map.insert(key.clone(), before_local_trans);
+        stream_after_functions_map.insert(key, after_local_trans);
     }
 }
 
@@ -324,15 +328,24 @@ pub fn register_stream_functions(
     org_id: &str,
     stream_type: &StreamType,
     stream_name: &str,
-) -> (Vec<StreamTransform>, HashMap<String, VRLResultResolver>) {
-    let mut local_trans = vec![];
+) -> (
+    Vec<StreamTransform>,
+    Vec<StreamTransform>,
+    HashMap<String, VRLResultResolver>,
+) {
+    let mut before_local_trans = vec![];
+    let mut after_local_trans = vec![];
     let mut stream_vrl_map: HashMap<String, VRLResultResolver> = HashMap::new();
     let key = format!("{}/{}/{}", org_id, stream_type, stream_name);
 
     if let Some(transforms) = STREAM_FUNCTIONS.get(&key) {
-        local_trans = (*transforms.list).to_vec();
-        local_trans.sort_by(|a, b| a.order.cmp(&b.order));
-        for trans in &local_trans {
+        (before_local_trans, after_local_trans) = (*transforms.list)
+            .to_vec()
+            .into_iter()
+            .partition(|elem| elem.apply_before_flattening);
+        before_local_trans.sort_by(|a, b| a.order.cmp(&b.order));
+        after_local_trans.sort_by(|a, b| a.order.cmp(&b.order));
+        for trans in before_local_trans.iter().chain(after_local_trans.iter()) {
             let func_key = format!("{}/{}", &stream_name, trans.transform.name);
             if let Ok(vrl_runtime_config) = compile_vrl_function(&trans.transform.function, org_id)
             {
@@ -352,7 +365,7 @@ pub fn register_stream_functions(
         }
     }
 
-    (local_trans, stream_vrl_map)
+    (before_local_trans, after_local_trans, stream_vrl_map)
 }
 
 pub fn apply_stream_functions(

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -310,7 +310,7 @@ pub async fn ingest(
                 json::Value::Number(timestamp.into()),
             );
 
-            let fns_length = stream_after_functions_map
+            let fns_length = stream_before_functions_map
                 .get(&key)
                 .map(|v| v.len())
                 .unwrap_or_default()

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -314,7 +314,6 @@ pub fn apply_functions<'a>(
     runtime: &mut Runtime,
 ) -> Result<json::Value> {
     let cfg = get_config();
-    log::info!("item printing: {:#?}", item);
     let mut value = item;
     if !before_local_trans.is_empty() {
         value = crate::service::ingestion::apply_stream_functions(
@@ -327,7 +326,6 @@ pub fn apply_functions<'a>(
         )?;
     }
     value = flatten::flatten_with_level(value, cfg.limit.ingest_flatten_level)?;
-    log::info!("item printing after flattening: {:#?}", value);
 
     if !after_local_trans.is_empty() {
         value = crate::service::ingestion::apply_stream_functions(

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -69,11 +69,12 @@ pub async fn ingest(
 
     // Start Register Transforms for stream
     let mut runtime = crate::service::ingestion::init_functions_runtime();
-    let (local_trans, stream_vrl_map) = crate::service::ingestion::register_stream_functions(
-        org_id,
-        &StreamType::Logs,
-        &stream_name,
-    );
+    let (before_local_trans, after_local_trans, stream_vrl_map) =
+        crate::service::ingestion::register_stream_functions(
+            org_id,
+            &StreamType::Logs,
+            &stream_name,
+        );
     // End Register Transforms for stream
 
     let mut stream_params = vec![StreamParams::new(org_id, &stream_name, StreamType::Logs)];
@@ -195,7 +196,8 @@ pub async fn ingest(
         // Start row based transform
         let mut res = match apply_functions(
             item,
-            &local_trans,
+            &before_local_trans,
+            &after_local_trans,
             &stream_vrl_map,
             org_id,
             &stream_name,
@@ -234,7 +236,7 @@ pub async fn ingest(
             .entry(stream_name.clone())
             .or_insert((Vec::new(), None));
         ts_data.push((timestamp, local_val));
-        *fn_num = need_usage_report.then_some(local_trans.len());
+        *fn_num = need_usage_report.then_some(before_local_trans.len() + after_local_trans.len());
     }
 
     // if no data, fast return
@@ -304,18 +306,32 @@ pub async fn ingest(
 
 pub fn apply_functions<'a>(
     item: json::Value,
-    local_trans: &[StreamTransform],
+    before_local_trans: &[StreamTransform],
+    after_local_trans: &[StreamTransform],
     stream_vrl_map: &'a HashMap<String, VRLResultResolver>,
     org_id: &'a str,
     stream_name: &'a str,
     runtime: &mut Runtime,
 ) -> Result<json::Value> {
     let cfg = get_config();
-    let mut value = flatten::flatten_with_level(item, cfg.limit.ingest_flatten_level)?;
-
-    if !local_trans.is_empty() {
+    log::info!("item printing: {:#?}", item);
+    let mut value = item;
+    if !before_local_trans.is_empty() {
         value = crate::service::ingestion::apply_stream_functions(
-            local_trans,
+            before_local_trans,
+            value,
+            stream_vrl_map,
+            org_id,
+            stream_name,
+            runtime,
+        )?;
+    }
+    value = flatten::flatten_with_level(value, cfg.limit.ingest_flatten_level)?;
+    log::info!("item printing after flattening: {:#?}", value);
+
+    if !after_local_trans.is_empty() {
+        value = crate::service::ingestion::apply_stream_functions(
+            after_local_trans,
             value,
             stream_vrl_map,
             org_id,

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -348,16 +348,14 @@ fn apply_func(
     metric_name: &str,
     value: json::Value,
 ) -> Result<json::Value> {
-    let (mut before_local_trans, mut after_local_trans, stream_vrl_map) =
-        crate::service::ingestion::register_stream_functions(
-            org_id,
-            &StreamType::Metrics,
-            metric_name,
-        );
+    let (_, local_trans, stream_vrl_map) = crate::service::ingestion::register_stream_functions(
+        org_id,
+        &StreamType::Metrics,
+        metric_name,
+    );
 
-    before_local_trans.append(&mut after_local_trans);
     crate::service::ingestion::apply_stream_functions(
-        &before_local_trans,
+        &local_trans,
         value,
         &stream_vrl_map,
         org_id,

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -348,14 +348,16 @@ fn apply_func(
     metric_name: &str,
     value: json::Value,
 ) -> Result<json::Value> {
-    let (local_tans, stream_vrl_map) = crate::service::ingestion::register_stream_functions(
-        org_id,
-        &StreamType::Metrics,
-        metric_name,
-    );
+    let (mut before_local_trans, mut after_local_trans, stream_vrl_map) =
+        crate::service::ingestion::register_stream_functions(
+            org_id,
+            &StreamType::Metrics,
+            metric_name,
+        );
 
+    before_local_trans.append(&mut after_local_trans);
     crate::service::ingestion::apply_stream_functions(
-        &local_tans,
+        &before_local_trans,
         value,
         &stream_vrl_map,
         org_id,

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -218,7 +218,6 @@ pub async fn handle_grpc_request(
                     }
                 }
                 for mut rec in records {
-                    // TODO: What to do here?
                     // flattening
                     rec = flatten::flatten(rec)?;
 

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -145,7 +145,7 @@ pub async fn handle_grpc_request(
                 // End get stream alert
 
                 // Start Register Transforms for stream
-                let (mut local_trans, mut stream_vrl_map) =
+                let (_, mut local_trans, mut stream_vrl_map) =
                     crate::service::ingestion::register_stream_functions(
                         org_id,
                         &StreamType::Metrics,
@@ -218,6 +218,7 @@ pub async fn handle_grpc_request(
                     }
                 }
                 for mut rec in records {
+                    // TODO: What to do here?
                     // flattening
                     rec = flatten::flatten(rec)?;
 
@@ -266,7 +267,7 @@ pub async fn handle_grpc_request(
                         // End get stream alert
 
                         // Start Register Transforms for stream
-                        (local_trans, stream_vrl_map) =
+                        (_, local_trans, stream_vrl_map) =
                             crate::service::ingestion::register_stream_functions(
                                 org_id,
                                 &StreamType::Metrics,

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -220,7 +220,7 @@ pub async fn metrics_json_handler(
                     // End get stream alert
 
                     // Start Register Transforms for stream
-                    let (mut local_trans, mut stream_vrl_map) =
+                    let (_, mut local_trans, mut stream_vrl_map) =
                         crate::service::ingestion::register_stream_functions(
                             org_id,
                             &StreamType::Metrics,
@@ -299,6 +299,7 @@ pub async fn metrics_json_handler(
                     }
 
                     for mut rec in records {
+                        // TODO: What to do here?
                         // flattening
                         rec = flatten::flatten(rec).expect("failed to flatten");
                         // get json object
@@ -348,7 +349,7 @@ pub async fn metrics_json_handler(
                             // End get stream alert
 
                             // Start Register Transforms for stream
-                            (local_trans, stream_vrl_map) =
+                            (_, local_trans, stream_vrl_map) =
                                 crate::service::ingestion::register_stream_functions(
                                     org_id,
                                     &StreamType::Metrics,

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -299,7 +299,6 @@ pub async fn metrics_json_handler(
                     }
 
                     for mut rec in records {
-                        // TODO: What to do here?
                         // flattening
                         rec = flatten::flatten(rec).expect("failed to flatten");
                         // get json object

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -298,13 +298,12 @@ pub async fn remote_write(
             let mut runtime = crate::service::ingestion::init_functions_runtime();
 
             // Start Register Transforms for stream
-            let (mut local_trans, mut after_local_trans, stream_vrl_map) =
+            let (_, local_trans, stream_vrl_map) =
                 crate::service::ingestion::register_stream_functions(
                     org_id,
                     &StreamType::Metrics,
                     &metric_name,
                 );
-            local_trans.append(&mut after_local_trans);
 
             stream_transform_map.insert(metric_name.to_owned(), local_trans.clone());
             // End Register Transforms for stream

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -298,12 +298,13 @@ pub async fn remote_write(
             let mut runtime = crate::service::ingestion::init_functions_runtime();
 
             // Start Register Transforms for stream
-            let (local_trans, stream_vrl_map) =
+            let (mut local_trans, mut after_local_trans, stream_vrl_map) =
                 crate::service::ingestion::register_stream_functions(
                     org_id,
                     &StreamType::Metrics,
                     &metric_name,
                 );
+            local_trans.append(&mut after_local_trans);
 
             stream_transform_map.insert(metric_name.to_owned(), local_trans.clone());
             // End Register Transforms for stream

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -102,11 +102,12 @@ pub async fn traces_json(
 
     // Start Register Transforms for stream
     let mut runtime = crate::service::ingestion::init_functions_runtime();
-    let (local_trans, stream_vrl_map) = crate::service::ingestion::register_stream_functions(
-        org_id,
-        &StreamType::Traces,
-        &traces_stream_name,
-    );
+    let (before_local_trans, after_local_trans, stream_vrl_map) =
+        crate::service::ingestion::register_stream_functions(
+            org_id,
+            &StreamType::Traces,
+            &traces_stream_name,
+        );
     // End Register Transforms for stream
 
     let body: json::Value = match json::from_slice(body.as_ref()) {
@@ -264,15 +265,31 @@ pub async fn traces_json(
 
                     let mut value: json::Value = json::to_value(local_val).unwrap();
 
+                    // Start row based transform
+                    if !before_local_trans.is_empty() {
+                        value = crate::service::ingestion::apply_stream_functions(
+                            &before_local_trans,
+                            value,
+                            &stream_vrl_map,
+                            org_id,
+                            &traces_stream_name,
+                            &mut runtime,
+                        )
+                        .map_err(|e| {
+                            std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+                        })?;
+                    }
+                    // End row based transform
+
                     // JSON Flattening
                     value = flatten::flatten(value).map_err(|e| {
                         std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
                     })?;
 
                     // Start row based transform
-                    if !local_trans.is_empty() {
+                    if !after_local_trans.is_empty() {
                         value = crate::service::ingestion::apply_stream_functions(
-                            &local_trans,
+                            &after_local_trans,
                             value,
                             &stream_vrl_map,
                             org_id,

--- a/web/src/components/functions/AssociatedStreamFunction.vue
+++ b/web/src/components/functions/AssociatedStreamFunction.vue
@@ -114,6 +114,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <q-td key="order" :props="props">
                       {{ props.row.order }}
                     </q-td>
+                    <q-td key="applyBeforeFlattening" :props="props">
+                      <q-toggle
+                        data-test="stream-association-applyBeforeFlattening-toggle"
+                        class="q-mt-sm"
+                        v-model="props.row.applyBeforeFlattening"
+                        @update:model-value="
+                          updateAssociatedFunctions(props.row)
+                        "
+                      />
+                    </q-td>
                     <q-td key="actions" :props="props">
                       <q-btn
                         data-test="stream-association-delete-function-btn"
@@ -152,6 +162,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       ></q-select>
                     </q-td>
                     <q-td></q-td>
+                    <q-td> </q-td>
                     <q-td></q-td>
                   </q-tr>
                 </template>
@@ -373,6 +384,14 @@ export default defineComponent({
         sortable: true,
       },
       {
+        name: "applyBeforeFlattening",
+        field: "applyBeforeFlattening",
+        label: "Apply Before Flattening",
+        align: "left",
+        sortable: true,
+        style: "width: 180px",
+      },
+      {
         name: "actions",
         field: "actions",
         label: t("user.actions"),
@@ -483,6 +502,10 @@ export default defineComponent({
           store.state.selectedOrganization.identifier
         )
         .then((res: any) => {
+          res.data.list.forEach((element: any) => {
+            element.applyBeforeFlattening =
+              element.applyBeforeFlattening || false;
+          });
           allFunctionsList.value = res.data?.list || [];
           filterFunctions.value = res.data?.list || [];
         })
@@ -557,6 +580,10 @@ export default defineComponent({
         )
         .then((res: any) => {
           functionsList.value = res.data?.list || [];
+          functionsList.value.forEach((element: any) => {
+            element.applyBeforeFlattening =
+              element.applyBeforeFlattening || false;
+          });
         })
         .catch((err) => {
           $q.notify({
@@ -673,6 +700,20 @@ export default defineComponent({
       }
     });
 
+    const updateAssociatedFunctions = (_function: any) => {
+      jsTransformService
+        .apply_stream_function(
+          store.state.selectedOrganization.identifier,
+          expandedRow.value.name,
+          expandedRow.value.stream_type,
+          _function.name,
+          _function
+        )
+        .then((res) => {
+          console.log(res);
+        });
+    };
+
     return {
       t,
       qTable,
@@ -724,6 +765,7 @@ export default defineComponent({
       getImageURL,
       loadingFunctions,
       verifyOrganizationStatus,
+      updateAssociatedFunctions,
     };
   },
   computed: {

--- a/web/src/components/functions/AssociatedStreamFunction.vue
+++ b/web/src/components/functions/AssociatedStreamFunction.vue
@@ -710,7 +710,10 @@ export default defineComponent({
           _function
         )
         .then((res) => {
-          console.log(res);
+          getStreamFunctions(
+            expandedRow.value.name,
+            expandedRow.value.stream_type
+          );
         });
     };
 

--- a/web/src/components/functions/AssociatedStreamFunction.vue
+++ b/web/src/components/functions/AssociatedStreamFunction.vue
@@ -421,7 +421,7 @@ export default defineComponent({
           return column.name !== "applyBeforeFlattening";
         }
         return true;
-      });
+      }) as QTableProps["columns"];
     });
 
     const getLogStream = () => {

--- a/web/src/components/functions/AssociatedStreamFunction.vue
+++ b/web/src/components/functions/AssociatedStreamFunction.vue
@@ -114,7 +114,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <q-td key="order" :props="props">
                       {{ props.row.order }}
                     </q-td>
-                    <q-td key="applyBeforeFlattening" :props="props">
+                    <q-td
+                      v-if="expandedRow.stream_type === 'logs'"
+                      key="applyBeforeFlattening"
+                      :props="props"
+                    >
                       <q-toggle
                         data-test="stream-association-applyBeforeFlattening-toggle"
                         class="q-mt-sm"
@@ -275,7 +279,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, onActivated, onMounted, watch } from "vue";
+import {
+  defineComponent,
+  ref,
+  onActivated,
+  onMounted,
+  watch,
+  computed,
+} from "vue";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import { useQuasar, type QTableProps } from "quasar";
@@ -362,43 +373,6 @@ export default defineComponent({
     const addFunctionInProgressLoading = ref(false);
     const { getStreams } = useStreams();
 
-    const functionsColumns = ref<QTableProps["columns"]>([
-      {
-        name: "#",
-        label: "#",
-        field: "#",
-        align: "left",
-      },
-      {
-        name: "name",
-        field: "name",
-        label: t("logStream.name"),
-        align: "left",
-        sortable: true,
-      },
-      {
-        name: "order",
-        field: "order",
-        label: "Order",
-        align: "left",
-        sortable: true,
-      },
-      {
-        name: "applyBeforeFlattening",
-        field: "applyBeforeFlattening",
-        label: "Apply Before Flattening",
-        align: "left",
-        sortable: true,
-        style: "width: 180px",
-      },
-      {
-        name: "actions",
-        field: "actions",
-        label: t("user.actions"),
-        align: "left",
-      },
-    ]);
-
     let deleteStreamName = "";
     let deleteStreamType = "";
     const loadingFunctions = ref(false);
@@ -406,6 +380,49 @@ export default defineComponent({
     const allFunctionsList = ref([]);
     const selectedFunction = ref<any | null>(null);
     const filterFunctions = ref([]);
+
+    const functionsColumns = computed(() => {
+      return [
+        {
+          name: "#",
+          label: "#",
+          field: "#",
+          align: "left",
+        },
+        {
+          name: "name",
+          field: "name",
+          label: t("logStream.name"),
+          align: "left",
+          sortable: true,
+        },
+        {
+          name: "order",
+          field: "order",
+          label: "Order",
+          align: "left",
+          sortable: true,
+        },
+        {
+          name: "applyBeforeFlattening",
+          field: "applyBeforeFlattening",
+          label: "Apply Before Flattening",
+          align: "left",
+          sortable: true,
+        },
+        {
+          name: "actions",
+          field: "actions",
+          label: t("user.actions"),
+          align: "left",
+        },
+      ].filter((column) => {
+        if (expandedRow.value.stream_type !== "logs") {
+          return column.name !== "applyBeforeFlattening";
+        }
+        return true;
+      });
+    });
 
     const getLogStream = () => {
       if (store.state.selectedOrganization != null) {


### PR DESCRIPTION
Fixes #3994 #4012 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `applyBeforeFlattening` toggle in the `AssociatedStreamFunction.vue` component for stream functions.
  - Enhanced ingestion functionality to support transformations before and after the flattening of data.

- **Bug Fixes**
  - Improved JSON flattening and transformation logic in multiple ingestion functions.

- **Refactor**
  - Updated function signatures and variable assignments to incorporate new transformation logic across various modules and handlers.
  - Refactored the `functionsColumns` definition to dynamically include the `applyBeforeFlattening` column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->