### PR TITLE
fix: result cache panic when there is no _timestamp

### DIFF
--- a/src/service/search/cache/result_utils.rs
+++ b/src/service/search/cache/result_utils.rs
@@ -69,12 +69,15 @@ const AGGREGATE_UDF_LIST: [&str; 7] = [
 ];
 
 pub fn get_ts_value(ts_column: &str, record: &json::Value) -> i64 {
-    match record.get(ts_column).unwrap() {
-        serde_json::Value::String(ts) => {
-            parse_str_to_timestamp_micros_as_option(ts.as_str()).unwrap()
-        }
-        serde_json::Value::Number(ts) => ts.as_i64().unwrap(),
-        _ => 0_i64,
+    match record.get(ts_column) {
+        None => 0_i64,
+        Some(ts) => match ts {
+            serde_json::Value::String(ts) => {
+                parse_str_to_timestamp_micros_as_option(ts.as_str()).unwrap()
+            }
+            serde_json::Value::Number(ts) => ts.as_i64().unwrap(),
+            _ => 0_i64,
+        },
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of missing timestamp keys in search results to prevent potential application crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->