### PR TITLE
test: e2e quick mode without timestamp

### DIFF
--- a/tests/ui-testing/playwright-tests/logsquickmode.spec.js
+++ b/tests/ui-testing/playwright-tests/logsquickmode.spec.js
@@ -313,7 +313,12 @@ test.describe("Logs Quickmode testcases", () => {
       .click({
         force: true,
       });
-      await page.locator('[data-test="log-table-column-0-\\@timestamp"]').click();
+      await expect(
+        page
+          .locator('[data-test="log-table-column-0-source"]')
+          .getByText(/_timestamp/)
+          .first()
+      ).toBeVisible();
 
  });
 });

--- a/tests/ui-testing/playwright-tests/logsquickmode.spec.js
+++ b/tests/ui-testing/playwright-tests/logsquickmode.spec.js
@@ -289,4 +289,31 @@ test.describe("Logs Quickmode testcases", () => {
         )
     ).toBeVisible();
   });
+
+  test("should display results without adding timestamp in quick mode", async ({
+    page,
+  }) => {
+  
+    await page.locator('[data-cy="index-field-search-input"]').clear();
+    await page
+      .locator('[data-cy="index-field-search-input"]')
+      .fill("kubernetes_pod_id");
+    await page.waitForTimeout(2000);
+    await page
+      .locator(
+        '[data-test="log-search-index-list-interesting-kubernetes_pod_id-field-btn"]'
+      )
+      .last()
+      .click({
+        force: true,
+      });
+    await page.locator('[aria-label="SQL Mode"] > .q-toggle__inner').click();
+    await page
+      .locator('[data-cy="search-bar-refresh-button"] > .q-btn__content')
+      .click({
+        force: true,
+      });
+      await page.locator('[data-test="log-table-column-0-\\@timestamp"]').click();
+
+ });
 });

--- a/web/src/components/ingestion/traces/OpenTelemetry.vue
+++ b/web/src/components/ingestion/traces/OpenTelemetry.vue
@@ -77,7 +77,7 @@ export default defineComponent({
       tls: url.protocol === "https:" ? "On" : "Off",
     };
 
-    const copyHTTPTracesContentURL = `${endpoint.value.url}/api/${store.state.selectedOrganization.identifier}/traces`;
+    const copyHTTPTracesContentURL = `${endpoint.value.url}/api/${store.state.selectedOrganization.identifier}`;
     const copyHTTPTracesContentPasscode = `Basic [BASIC_PASSCODE]`;
     const copyGRPCTracesContent = `endpoint: ${endpoint.value.host}
 headers: 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated URL generation for copying HTTP traces content in OpenTelemetry component to improve accuracy.

- **Tests**
  - Added a new test case to verify the display of results without timestamps in quick mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->