### PR TITLE
fix: #3630 solved cmd + enter issue

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,6 +29,7 @@
         "marked": "^13.0.2",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.45",
+        "monaco-editor-vue": "^1.0.10",
         "node-polyfill-webpack-plugin": "^4.0.0",
         "node-sql-parser": "^5.2.0",
         "quasar": "^2.16.6",
@@ -40,7 +41,6 @@
         "vue-drag-resize": "^1.5.4",
         "vue-draggable-next": "^2.2.1",
         "vue-i18n": "^9.13.1",
-        "vue-monaco-singleline": "^1.1.1",
         "vue-router": "^4.4.0",
         "vue3-grid-layout": "^1.0.0",
         "vuex": "^4.1.0"
@@ -5446,17 +5446,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/core-js": {
-      "version": "3.37.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -15809,57 +15798,6 @@
       },
       "peerDependencies": {
         "vue": "^3.0.0"
-      }
-    },
-    "node_modules/vue-monaco-singleline": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vue-monaco-singleline/-/vue-monaco-singleline-1.1.1.tgz",
-      "integrity": "sha512-zRZQCLi73VAtIdtdr8asUPOzh9gNx/TMvxMPAeWps8gHD596zqqPg4PGgP5ovNHuUaIwLmZcyYtuB8DqHSz/BQ==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^3.6.5",
-        "monaco-editor-vue": "^1.0.10",
-        "vue": "^2.6.11"
-      }
-    },
-    "node_modules/vue-monaco-singleline/node_modules/@vue/compiler-sfc": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-      "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
-      "dependencies": {
-        "@babel/parser": "^7.23.5",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
-      },
-      "optionalDependencies": {
-        "prettier": "^1.18.2 || ^2.0.0"
-      }
-    },
-    "node_modules/vue-monaco-singleline/node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/vue-monaco-singleline/node_modules/vue": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-      "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
-      "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-sfc": "2.7.16",
-        "csstype": "^3.1.0"
       }
     },
     "node_modules/vue-router": {

--- a/web/package.json
+++ b/web/package.json
@@ -54,7 +54,7 @@
     "vue-drag-resize": "^1.5.4",
     "vue-draggable-next": "^2.2.1",
     "vue-i18n": "^9.13.1",
-    "vue-monaco-singleline": "^1.1.1",
+    "monaco-editor-vue": "^1.0.10",
     "vue-router": "^4.4.0",
     "vue3-grid-layout": "^1.0.0",
     "vuex": "^4.1.0"

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -507,6 +507,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               v-model:query="searchObj.data.query"
               :keywords="autoCompleteKeywords"
               :suggestions="autoCompleteSuggestions"
+              @keydown.ctrl.enter="handleRunQueryFn"
               @update:query="updateQueryValue"
               @run-query="handleRunQueryFn"
               :class="
@@ -538,6 +539,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     : ''
                 "
                 language="ruby"
+                @keydown.ctrl.enter="handleRunQueryFn"
                 @focus="searchObj.meta.functionEditorPlaceholderFlag = false"
                 @blur="searchObj.meta.functionEditorPlaceholderFlag = true"
               />


### PR DESCRIPTION
Removed Monoco-single-line dependency
When user clicks on Ctrl + enter (windows) or Cmd  + enter (max) in query mode or vrl function editor 
run query runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a keyboard shortcut (Ctrl + Enter) in the Search Bar for executing queries, enhancing user experience and interactivity.

- **Dependency Updates**
  - Updated the dependency from `vue-monaco-singleline` to `monaco-editor-vue`, which may introduce new features and optimizations for the Monaco Editor integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->