### PR TITLE
feat: add OR operation for Query Conditions in Alert module

### DIFF
--- a/src/common/meta/alerts/mod.rs
+++ b/src/common/meta/alerts/mod.rs
@@ -111,11 +111,29 @@ pub struct QueryCondition {
     #[serde(default)]
     #[serde(rename = "type")]
     pub query_type: QueryType,
-    pub conditions: Option<Vec<Condition>>,
+    pub conditions: Option<ConditionList>,
     pub sql: Option<String>,
     pub promql: Option<String>,              // (cpu usage / cpu total)
     pub promql_condition: Option<Condition>, // value >= 80
     pub aggregation: Option<Aggregation>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+#[serde(untagged)]
+pub enum ConditionList {
+    OrNode {
+        or: Vec<ConditionList>,
+    },
+    AndNode {
+        and: Vec<ConditionList>,
+    },
+    NotNode {
+        not: Box<ConditionList>,
+    },
+    /// This variant handles data serialized in `Vec<Condition>`
+    /// where all conditions are evaluated as conjunction
+    LegacyConditions(Vec<ConditionList>),
+    EndCondition(Condition),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
@@ -263,5 +281,195 @@ impl std::fmt::Display for Operator {
             Operator::Contains => write!(f, "contains"),
             Operator::NotContains => write!(f, "not contains"),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_backcompat_condition_list() {
+        let backcompat_condition_list = r#"[
+        {
+            "column": "level",
+            "operator": "=",
+            "value": "error",
+            "ignore_case": false
+        },
+        {
+            "column": "job",
+            "operator": "=",
+            "value": "something",
+            "ignore_case": false
+        }
+        ]"#;
+        let expected_legacy_condition_list: ConditionList =
+            serde_json::from_str(backcompat_condition_list).unwrap();
+        assert_eq!(
+            expected_legacy_condition_list,
+            ConditionList::LegacyConditions(vec![
+                ConditionList::EndCondition(Condition {
+                    column: "level".into(),
+                    operator: Operator::EqualTo,
+                    value: Value::String("error".into()),
+                    ignore_case: false,
+                }),
+                ConditionList::EndCondition(Condition {
+                    column: "job".to_string(),
+                    operator: Operator::EqualTo,
+                    value: Value::String("something".into()),
+                    ignore_case: false,
+                })
+            ])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_not_condition_list() {
+        let and_condition_list = r#"{
+            "not: {
+                "and": [
+                    {
+                        "column": "level",
+                        "operator": "=",
+                        "value": "error",
+                        "ignore_case": false
+                    },
+                    {
+                        "column": "job",
+                        "operator": "=",
+                        "value": "something",
+                        "ignore_case": false
+                    }
+                ]
+            }
+        }"#;
+        let expected_not_condition_list: ConditionList =
+            serde_json::from_str(and_condition_list).unwrap();
+        assert_eq!(
+            expected_not_condition_list,
+            ConditionList::NotNode {
+                not: {
+                    Box::new(ConditionList::AndNode {
+                        and: vec![
+                            ConditionList::EndCondition(Condition {
+                                column: "level".into(),
+                                operator: Operator::EqualTo,
+                                value: Value::String("error".into()),
+                                ignore_case: false,
+                            }),
+                            ConditionList::EndCondition(Condition {
+                                column: "job".to_string(),
+                                operator: Operator::EqualTo,
+                                value: Value::String("something".into()),
+                                ignore_case: false,
+                            }),
+                        ],
+                    })
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_deserialize_simple_condition_list() {
+        let and_condition_list = r#"{
+        "and": [
+        {
+            "column": "level",
+            "operator": "=",
+            "value": "error",
+            "ignore_case": false
+        },
+        {
+            "column": "job",
+            "operator": "=",
+            "value": "something",
+            "ignore_case": false
+        }
+        ]}"#;
+        let expected_and_condition_list: ConditionList =
+            serde_json::from_str(and_condition_list).unwrap();
+        assert_eq!(
+            expected_and_condition_list,
+            ConditionList::AndNode {
+                and: vec![
+                    ConditionList::EndCondition(Condition {
+                        column: "level".into(),
+                        operator: Operator::EqualTo,
+                        value: Value::String("error".into()),
+                        ignore_case: false,
+                    }),
+                    ConditionList::EndCondition(Condition {
+                        column: "job".to_string(),
+                        operator: Operator::EqualTo,
+                        value: Value::String("something".into()),
+                        ignore_case: false,
+                    })
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn test_deserialize_complex_condition_list() {
+        let complex_condition_list = r#"{
+        "or": [
+            {
+                "and": [
+                    {
+                        "column": "column1",
+                        "operator": "=",
+                        "value": "value1",
+                        "ignore_case": true
+                    },
+                    {
+                        "column": "level",
+                        "operator": "=",
+                        "value": "error",
+                        "ignore_case": false
+                    }
+                ]
+            },
+            {
+                "column": "column3",
+                "operator": ">",
+                "value": "value3",
+                "ignore_case": false
+            }
+        ]
+        }"#;
+        let expected_complex_condition_list: ConditionList =
+            serde_json::from_str(complex_condition_list).unwrap();
+        assert_eq!(
+            expected_complex_condition_list,
+            ConditionList::OrNode {
+                or: vec![
+                    ConditionList::AndNode {
+                        and: vec![
+                            ConditionList::EndCondition(Condition {
+                                column: "column1".into(),
+                                operator: Operator::EqualTo,
+                                value: Value::String("value1".into()),
+                                ignore_case: true,
+                            }),
+                            ConditionList::EndCondition(Condition {
+                                column: "level".to_string(),
+                                operator: Operator::EqualTo,
+                                value: Value::String("error".into()),
+                                ignore_case: false,
+                            })
+                        ]
+                    },
+                    ConditionList::EndCondition(Condition {
+                        column: "column3".to_string(),
+                        operator: Operator::GreaterThan,
+                        value: Value::String("value3".into()),
+                        ignore_case: false,
+                    })
+                ]
+            }
+        );
     }
 }

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use actix_web::http;
-use arrow_schema::DataType;
+use arrow_schema::{DataType, Schema};
 use chrono::{Duration, Local, TimeZone, Utc};
 use config::{
     get_config, ider,
@@ -39,8 +39,8 @@ use crate::{
         meta::{
             alerts::{
                 destinations::{DestinationType, DestinationWithTemplate, HTTPType},
-                AggFunction, Alert, AlertFrequencyType, Condition, Operator, QueryCondition,
-                QueryType,
+                AggFunction, Alert, AlertFrequencyType, Condition, ConditionList, Operator,
+                QueryCondition, QueryType,
             },
             authz::Authz,
         },
@@ -330,13 +330,8 @@ impl QueryCondition {
             return Ok(None);
         }
         let conditions = self.conditions.as_ref().unwrap();
-        if conditions.is_empty() {
+        if !conditions.evaluate(row).await {
             return Ok(None);
-        }
-        for condition in conditions.iter() {
-            if !condition.evaluate(row).await {
-                return Ok(None);
-            }
         }
         Ok(Some(vec![row.to_owned()]))
     }
@@ -490,6 +485,84 @@ impl QueryCondition {
     }
 }
 
+impl ConditionList {
+    /// Evaluate Row against preset conditions
+    #[async_recursion::async_recursion]
+    pub async fn evaluate(&self, row: &Map<String, Value>) -> bool {
+        match self {
+            ConditionList::OrNode { or: conditions } => {
+                let mut eval = false;
+                for condition in conditions {
+                    eval = eval || condition.evaluate(row).await
+                }
+                eval
+            }
+            ConditionList::AndNode { and: conditions }
+            | ConditionList::LegacyConditions(conditions) => {
+                let mut eval = false;
+                for condition in conditions {
+                    eval = eval && condition.evaluate(row).await
+                }
+                eval
+            }
+            ConditionList::NotNode { not: conditions } => !conditions.evaluate(row).await,
+            ConditionList::EndCondition(condition) => condition.evaluate(row).await,
+        }
+    }
+
+    /// Returns end node count of a Condition list
+    #[async_recursion::async_recursion]
+    pub async fn len(&self) -> u32 {
+        match self {
+            ConditionList::OrNode { or: conditions }
+            | ConditionList::LegacyConditions(conditions)
+            | ConditionList::AndNode { and: conditions } => {
+                let mut count = 0;
+                for condition in conditions.iter() {
+                    count += condition.len().await
+                }
+                count
+            }
+            ConditionList::NotNode { not: inner } => inner.len().await,
+            ConditionList::EndCondition(_) => 1,
+        }
+    }
+
+    /// Converts Condition list to SQL query as per schema
+    #[async_recursion::async_recursion]
+    pub async fn to_sql(&self, schema: &Schema) -> Result<String, anyhow::Error> {
+        match self {
+            ConditionList::OrNode { or: conditions } => {
+                let mut cond_sql_list = Vec::new();
+                for condition in conditions.iter() {
+                    cond_sql_list.push(condition.to_sql(schema).await?);
+                }
+                Ok(format!("({})", cond_sql_list.join(" OR ")))
+            }
+            ConditionList::LegacyConditions(conditions)
+            | ConditionList::AndNode { and: conditions } => {
+                let mut cond_sql_list = Vec::new();
+                for condition in conditions.iter() {
+                    cond_sql_list.push(condition.to_sql(schema).await?);
+                }
+                Ok(format!("({})", cond_sql_list.join(" AND ")))
+            }
+            ConditionList::NotNode { not: inner } => {
+                Ok(format!("NOT ({})", inner.to_sql(schema).await?))
+            }
+            ConditionList::EndCondition(node) => {
+                let data_type = match schema.field_with_name(&node.column) {
+                    Ok(field) => field.data_type(),
+                    Err(_) => {
+                        return Err(anyhow::anyhow!("Column {} not found", &node.column,));
+                    }
+                };
+                build_expr(node, "", data_type)
+            }
+        }
+    }
+}
+
 impl Condition {
     pub async fn evaluate(&self, row: &Map<String, Value>) -> bool {
         let val = match row.get(&self.column) {
@@ -556,31 +629,19 @@ impl Condition {
     }
 }
 
-async fn build_sql(alert: &Alert, conditions: &[Condition]) -> Result<String, anyhow::Error> {
+async fn build_sql(alert: &Alert, conditions: &ConditionList) -> Result<String, anyhow::Error> {
     let schema = infra::schema::get(&alert.org_id, &alert.stream_name, alert.stream_type).await?;
-    let mut wheres = Vec::with_capacity(conditions.len());
-    for cond in conditions.iter() {
-        let data_type = match schema.field_with_name(&cond.column) {
-            Ok(field) => field.data_type(),
-            Err(_) => {
-                return Err(anyhow::anyhow!(
-                    "Column {} not found on stream {}",
-                    &cond.column,
-                    &alert.stream_name
-                ));
-            }
-        };
-        let expr = build_expr(cond, "", data_type)?;
-        wheres.push(expr);
-    }
-    let where_sql = if !wheres.is_empty() {
-        format!("WHERE {}", wheres.join(" AND "))
-    } else {
-        String::new()
-    };
+    let where_sql = conditions.to_sql(&schema).await.map_err(|err| {
+        anyhow::anyhow!(
+            "Error building SQL on stream {}: {}",
+            &alert.stream_name,
+            err
+        )
+    })?;
+
     if alert.query_condition.aggregation.is_none() {
         return Ok(format!(
-            "SELECT * FROM \"{}\" {}",
+            "SELECT * FROM \"{}\" WHERE {}",
             alert.stream_name, where_sql
         ));
     }


### PR DESCRIPTION
This PR introduces a new enum `ConditionList` which allows setting complex conditions with grouping. It also takes care of backwards compatibility with its LegacyConditions variant which will be treated as a list of conditions which will be evaluated with AND operator.

Fixed #3047 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced query condition management with a more structured representation, allowing for complex logical combinations (AND, OR, NOT).
  - Introduced a new `ConditionList` that supports various condition types and simplifies evaluation and SQL query generation.

- **Bug Fixes**
  - Ensured backward compatibility with legacy data formats through comprehensive deserialization tests.

- **Refactor**
  - Simplified the evaluation logic in `QueryCondition` to improve clarity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->