### PR TITLE
fix: panic when the parentSpanId is null

### DIFF
--- a/src/config/src/utils/json.rs
+++ b/src/config/src/utils/json.rs
@@ -82,6 +82,8 @@ pub fn get_string_value(value: &Value) -> String {
         value.as_f64().unwrap_or_default().to_string()
     } else if value.is_boolean() {
         value.as_bool().unwrap_or_default().to_string()
+    } else if value.is_null() {
+        "".to_string()
     } else {
         value.to_string()
     }

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -22,7 +22,10 @@ use config::{
     get_config,
     meta::{stream::StreamType, usage::UsageType},
     metrics,
-    utils::{flatten, json},
+    utils::{
+        flatten,
+        json::{self, get_string_value},
+    },
 };
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use prost::Message;
@@ -184,15 +187,8 @@ pub async fn traces_json(
                         span.get("traceId").unwrap().as_str().unwrap().to_string();
 
                     let mut span_ref = HashMap::new();
-                    if span.get("parentSpanId").is_some() {
-                        span_ref.insert(
-                            PARENT_SPAN_ID.to_string(),
-                            span.get("parentSpanId")
-                                .unwrap()
-                                .as_str()
-                                .unwrap()
-                                .to_string(),
-                        );
+                    if let Some(v) = span.get("parentSpanId") {
+                        span_ref.insert(PARENT_SPAN_ID.to_string(), get_string_value(v));
                         span_ref.insert(PARENT_TRACE_ID.to_string(), trace_id.clone());
                         span_ref
                             .insert(REF_TYPE.to_string(), format!("{:?}", SpanRefType::ChildOf));

--- a/src/service/traces/otlp_http.rs
+++ b/src/service/traces/otlp_http.rs
@@ -22,10 +22,7 @@ use config::{
     get_config,
     meta::{stream::StreamType, usage::UsageType},
     metrics,
-    utils::{
-        flatten,
-        json::{self, get_string_value},
-    },
+    utils::{flatten, json},
 };
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use prost::Message;
@@ -188,7 +185,7 @@ pub async fn traces_json(
 
                     let mut span_ref = HashMap::new();
                     if let Some(v) = span.get("parentSpanId") {
-                        span_ref.insert(PARENT_SPAN_ID.to_string(), get_string_value(v));
+                        span_ref.insert(PARENT_SPAN_ID.to_string(), json::get_string_value(v));
                         span_ref.insert(PARENT_TRACE_ID.to_string(), trace_id.clone());
                         span_ref
                             .insert(REF_TYPE.to_string(), format!("{:?}", SpanRefType::ChildOf));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of `parentSpanId` in span data, reducing potential runtime errors and enhancing code reliability.
	- Enhanced robustness of the `get_string_value` function to consistently return a string representation when handling `null` inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->