### PR TITLE
fix: added wrong _timestamp with distinct

### DIFF
--- a/src/service/search/cache/result_utils.rs
+++ b/src/service/search/cache/result_utils.rs
@@ -35,6 +35,9 @@ pub fn is_aggregate_query(query: &str) -> Result<bool, sqlparser::parser::Parser
 
 fn is_aggregate_in_select(query: Box<Query>) -> bool {
     if let SetExpr::Select(ref select) = *query.body {
+        if select.distinct.is_some() {
+            return true;
+        }
         for select_item in &select.projection {
             if let SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, alias: _ } =
                 select_item


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced query handling to recognize aggregate queries that utilize the `DISTINCT` keyword, improving correctness and efficiency in query processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->