### PR TITLE
fix: remove ZO_BLOOM_FILTER_ON_ALL_FIELDS

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -558,8 +558,6 @@ pub struct Common {
     pub bloom_filter_enabled: bool,
     #[env_config(name = "ZO_BLOOM_FILTER_DISABLED_ON_SEARCH", default = false)]
     pub bloom_filter_disabled_on_search: bool,
-    #[env_config(name = "ZO_BLOOM_FILTER_ON_ALL_FIELDS", default = false)]
-    pub bloom_filter_on_all_fields: bool,
     #[env_config(name = "ZO_BLOOM_FILTER_DEFAULT_FIELDS", default = "")]
     pub bloom_filter_default_fields: String,
     #[env_config(

--- a/src/config/src/utils/parquet.rs
+++ b/src/config/src/utils/parquet.rs
@@ -75,25 +75,10 @@ pub fn new_parquet_writer<'a>(
         bf_ndv = max(1000, bf_ndv / cfg.common.bloom_filter_ndv_ratio);
     }
     if cfg.common.bloom_filter_enabled {
-        // if bloom_filter_on_all_fields is true, then use all string fields
-        let fields = if cfg.common.bloom_filter_on_all_fields {
-            schema
-                .fields()
-                .iter()
-                .filter(|f| {
-                    f.data_type() == &arrow::datatypes::DataType::Utf8
-                        && !SQL_FULL_TEXT_SEARCH_FIELDS.contains(f.name())
-                        && !full_text_search_fields.contains(f.name())
-                })
-                .map(|f| f.name().to_string())
-                .collect::<Vec<_>>()
-        } else {
-            let mut fields = bloom_filter_fields.to_vec();
-            fields.extend(BLOOM_FILTER_DEFAULT_FIELDS.clone());
-            fields.sort();
-            fields.dedup();
-            fields
-        };
+        let mut fields = bloom_filter_fields.to_vec();
+        fields.extend(BLOOM_FILTER_DEFAULT_FIELDS.clone());
+        fields.sort();
+        fields.dedup();
         for field in fields {
             writer_props = writer_props
                 .set_column_bloom_filter_enabled(field.as_str().into(), true)


### PR DESCRIPTION
`ZO_BLOOM_FILTER_ON_ALL_FIELDS` will huge increase parquet file size and memory usage when the fields num over 1000 in a stream. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified configuration for bloom filters by removing the `bloom_filter_on_all_fields` option.
  
- **Bug Fixes**
	- Streamlined logic in the bloom filter configuration handling, ensuring consistent field processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->