### PR TITLE
fix: convert `[:?#\s'"&%]` characters into `_` while saving alert/report/destination/template names

### DIFF
--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use schema::migrate_resource_names;
 use version_compare::Version;
 
 pub mod dashboards;
@@ -44,6 +45,11 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
         upgrade_092_093().await?;
     }
 
+    let v01010 = Version::from("0.10.9").unwrap();
+    if old_ver < v01010 {
+        upgrade_0109_01010().await?;
+    }
+
     Ok(())
 }
 
@@ -60,6 +66,12 @@ async fn upgrade_052_053() -> Result<(), anyhow::Error> {
 async fn upgrade_092_093() -> Result<(), anyhow::Error> {
     // migration schema
     schema::run().await?;
+
+    Ok(())
+}
+
+async fn upgrade_0109_01010() -> Result<(), anyhow::Error> {
+    migrate_resource_names().await?;
 
     Ok(())
 }

--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -25,6 +25,7 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
     let old_ver = Version::from(old_ver).unwrap();
     let new_ver = Version::from(new_ver).unwrap();
     let zero = Version::from("v0.0.0").unwrap();
+    log::info!("old_ver: {:#?}", old_ver);
     if old_ver == zero {
         // new install
         return Ok(());
@@ -45,8 +46,10 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
         upgrade_092_093().await?;
     }
 
+    log::info!("before checking migration version");
     let v0109 = Version::from("0.10.9").unwrap();
     if old_ver < v0109 {
+        log::info!("here in the check");
         upgrade_0108_0109().await?;
     }
 

--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -31,6 +31,11 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
         return Ok(());
     }
     if old_ver >= new_ver {
+        log::info!(
+            "old version {} is equal to new version {}",
+            old_ver,
+            new_ver
+        );
         return Ok(());
     }
 

--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -47,7 +47,7 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
     }
 
     log::info!("before checking migration version");
-    let v0109 = Version::from("0.10.9").unwrap();
+    let v0109 = Version::from("v0.10.9").unwrap();
     if old_ver < v0109 {
         log::info!("here in the check");
         upgrade_0108_0109().await?;

--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -31,11 +31,6 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
         return Ok(());
     }
     if old_ver >= new_ver {
-        log::info!(
-            "old version {} is equal to new version {}",
-            old_ver,
-            new_ver
-        );
         return Ok(());
     }
 
@@ -49,13 +44,6 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
     let v093 = Version::from("v0.9.3").unwrap();
     if old_ver < v093 {
         upgrade_092_093().await?;
-    }
-
-    let v0109 = Version::from("v0.10.9").unwrap();
-    // The below migration requires ofga init ready, but on Router node,
-    // we don't initialize ofga, hence the migration should not run on router
-    if old_ver < v0109 && !LOCAL_NODE.is_router() {
-        upgrade_0108_0109().await?;
     }
 
     Ok(())
@@ -78,8 +66,11 @@ async fn upgrade_092_093() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-async fn upgrade_0108_0109() -> Result<(), anyhow::Error> {
-    migrate_resource_names().await?;
-
+pub async fn upgrade_resource_names() -> Result<(), anyhow::Error> {
+    // The below migration requires ofga init ready, but on Router node,
+    // we don't initialize ofga, hence the migration should not run on router
+    if !LOCAL_NODE.is_router() {
+        migrate_resource_names().await?;
+    }
     Ok(())
 }

--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use config::cluster::LOCAL_NODE;
 use schema::migrate_resource_names;
 use version_compare::Version;
 
@@ -25,7 +26,6 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
     let old_ver = Version::from(old_ver).unwrap();
     let new_ver = Version::from(new_ver).unwrap();
     let zero = Version::from("v0.0.0").unwrap();
-    log::info!("old_ver: {:#?}", old_ver);
     if old_ver == zero {
         // new install
         return Ok(());
@@ -46,10 +46,10 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
         upgrade_092_093().await?;
     }
 
-    log::info!("before checking migration version");
     let v0109 = Version::from("v0.10.9").unwrap();
-    if old_ver < v0109 {
-        log::info!("here in the check");
+    // The below migration requires ofga init ready, but on Router node,
+    // we don't initialize ofga, hence the migration should not run on router
+    if old_ver < v0109 && !LOCAL_NODE.is_router() {
         upgrade_0108_0109().await?;
     }
 

--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -45,9 +45,9 @@ pub async fn check_upgrade(old_ver: &str, new_ver: &str) -> Result<(), anyhow::E
         upgrade_092_093().await?;
     }
 
-    let v01010 = Version::from("0.10.9").unwrap();
-    if old_ver < v01010 {
-        upgrade_0109_01010().await?;
+    let v0109 = Version::from("0.10.9").unwrap();
+    if old_ver < v0109 {
+        upgrade_0108_0109().await?;
     }
 
     Ok(())
@@ -70,7 +70,7 @@ async fn upgrade_092_093() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-async fn upgrade_0109_01010() -> Result<(), anyhow::Error> {
+async fn upgrade_0108_0109() -> Result<(), anyhow::Error> {
     migrate_resource_names().await?;
 
     Ok(())

--- a/src/common/migration/schema.rs
+++ b/src/common/migration/schema.rs
@@ -297,11 +297,7 @@ async fn need_meta_resource_name_migration() -> bool {
             let val_str = std::str::from_utf8(&val).unwrap();
             let old_meta_migration_ver =
                 Version::from(val_str).unwrap_or(Version::from("v0.0.0").unwrap());
-            if old_meta_migration_ver < Version::from("v0.0.1").unwrap() {
-                true
-            } else {
-                false
-            }
+            old_meta_migration_ver < Version::from("v0.0.1").unwrap()
         }
         Err(_) => true,
     }
@@ -327,7 +323,7 @@ async fn migrate_report_names() -> Result<(), anyhow::Error> {
             #[cfg(feature = "enterprise")]
             get_ownership_tuple(keys[0], "reports", &report.name, &mut write_tuples);
             // First create an report copy with formatted report name
-            match db::dashboards::reports::set(keys[0], &mut report, true).await {
+            match db::dashboards::reports::set(keys[0], &report, true).await {
                 // Delete report with unsupported report name
                 Ok(_) => {
                     if let Err(e) = db::dashboards::reports::delete(keys[0], report_name).await {

--- a/src/common/migration/schema.rs
+++ b/src/common/migration/schema.rs
@@ -243,6 +243,7 @@ pub async fn migrate_resource_names() -> Result<(), anyhow::Error> {
         }
         false => {
             log::info!("Resource name migration already done");
+            dist_lock::unlock(&locker).await?;
             return Ok(());
         }
     }

--- a/src/common/migration/schema.rs
+++ b/src/common/migration/schema.rs
@@ -33,7 +33,7 @@ use crate::{
     common::{
         infra::config::VERSION,
         meta::{
-            alerts::{destinations::Destination, templates::Template, Alert},
+            alerts::{alert::Alert, destinations::Destination, templates::Template},
             dashboards::reports::Report,
         },
         utils::auth::{into_ofga_supported_format, is_ofga_unsupported},
@@ -513,12 +513,19 @@ async fn migrate_alert_names() -> Result<(), anyhow::Error> {
             // updating the destinations of the alert.
             alert.destinations = destinations;
             // First create an alert copy with formatted alert name
-            match db::alerts::set(keys[0], StreamType::from(keys[1]), keys[2], &alert, create).await
+            match db::alerts::alert::set(
+                keys[0],
+                StreamType::from(keys[1]),
+                keys[2],
+                &alert,
+                create,
+            )
+            .await
             {
                 // Delete alert with unsupported alert name
                 Ok(_) => {
                     if create
-                        && db::alerts::delete(
+                        && db::alerts::alert::delete(
                             keys[0],
                             StreamType::from(keys[1]),
                             keys[2],

--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -18,6 +18,8 @@ use argon2::{password_hash::SaltString, Algorithm, Argon2, Params, PasswordHashe
 use base64::Engine;
 use config::utils::json;
 use futures::future::{ready, Ready};
+use once_cell::sync::Lazy;
+use regex::Regex;
 
 #[cfg(feature = "enterprise")]
 use crate::common::infra::config::USER_SESSIONS;
@@ -31,6 +33,8 @@ use crate::common::{
         user::{AuthTokens, UserRole},
     },
 };
+
+pub static RE_OFGA_UNSUPPORTED_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[:#?\s]").unwrap());
 
 pub(crate) fn get_hash(pass: &str, salt: &str) -> String {
     let key = format!("{pass}{salt}");

--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -36,6 +36,14 @@ use crate::common::{
 
 pub static RE_OFGA_UNSUPPORTED_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[:#?\s]").unwrap());
 
+pub fn into_ofga_supported_format(name: &str) -> String {
+    RE_OFGA_UNSUPPORTED_NAME.replace_all(name, "_").to_string()
+}
+
+pub fn is_ofga_unsupported(name: &str) -> bool {
+    RE_OFGA_UNSUPPORTED_NAME.is_match(name)
+}
+
 pub(crate) fn get_hash(pass: &str, salt: &str) -> String {
     let key = format!("{pass}{salt}");
     let hash = PASSWORD_HASH.get(&key);

--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -34,9 +34,10 @@ use crate::common::{
     },
 };
 
-pub static RE_OFGA_UNSUPPORTED_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[:#?\s%&]+").unwrap());
+pub static RE_OFGA_UNSUPPORTED_NAME: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"[:#?\s'"%&]+"#).unwrap());
 static RE_SPACE_AROUND: Lazy<Regex> = Lazy::new(|| {
-    let char_pattern = r"[^a-zA-Z0-9:#?&%\s]";
+    let char_pattern = r#"[^a-zA-Z0-9:#?'"&%\s]"#;
     let pattern = format!(r"(\s+{char_pattern}\s+)|(\s+{char_pattern})|({char_pattern}\s+)");
     Regex::new(&pattern).unwrap()
 });

--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -43,14 +43,16 @@ static RE_SPACE_AROUND: Lazy<Regex> = Lazy::new(|| {
 
 pub fn into_ofga_supported_format(name: &str) -> String {
     // remove spaces around special characters
-    let result = RE_OFGA_UNSUPPORTED_NAME.replace_all(name, |caps: &regex::Captures| {
+    let result = RE_SPACE_AROUND.replace_all(name, |caps: &regex::Captures| {
         caps.iter()
             .find_map(|m| m)
             .map(|m| m.as_str().trim())
             .unwrap_or("")
             .to_string()
     });
-    RE_OFGA_UNSUPPORTED_NAME.replace_all(name, "_").to_string()
+    RE_OFGA_UNSUPPORTED_NAME
+        .replace_all(&result, "_")
+        .to_string()
 }
 
 pub fn is_ofga_unsupported(name: &str) -> bool {

--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -34,7 +34,7 @@ use crate::common::{
     },
 };
 
-pub static RE_OFGA_UNSUPPORTED_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[:#?\s]").unwrap());
+pub static RE_OFGA_UNSUPPORTED_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[:#?\s]+").unwrap());
 
 pub fn into_ofga_supported_format(name: &str) -> String {
     RE_OFGA_UNSUPPORTED_NAME.replace_all(name, "_").to_string()

--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -34,9 +34,22 @@ use crate::common::{
     },
 };
 
-pub static RE_OFGA_UNSUPPORTED_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[:#?\s]+").unwrap());
+pub static RE_OFGA_UNSUPPORTED_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[:#?\s%&]+").unwrap());
+static RE_SPACE_AROUND: Lazy<Regex> = Lazy::new(|| {
+    let char_pattern = r"[^a-zA-Z0-9:#?&%\s]";
+    let pattern = format!(r"(\s+{char_pattern}\s+)|(\s+{char_pattern})|({char_pattern}\s+)");
+    Regex::new(&pattern).unwrap()
+});
 
 pub fn into_ofga_supported_format(name: &str) -> String {
+    // remove spaces around special characters
+    let result = RE_OFGA_UNSUPPORTED_NAME.replace_all(name, |caps: &regex::Captures| {
+        caps.iter()
+            .find_map(|m| m)
+            .map(|m| m.as_str().trim())
+            .unwrap_or("")
+            .to_string()
+    });
     RE_OFGA_UNSUPPORTED_NAME.replace_all(name, "_").to_string()
 }
 

--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -87,8 +87,15 @@ impl super::Db for MysqlDb {
             .await
         {
             Ok(v) => v,
-            Err(_) => {
-                return Err(Error::from(DbError::KeyNotExists(key.to_string())));
+            Err(e) => {
+                if let sqlx::Error::RowNotFound = e {
+                    return Err(Error::from(DbError::KeyNotExists(key.to_string())));
+                } else {
+                    return Err(Error::from(DbError::DBOperError(
+                        e.to_string(),
+                        key.to_string(),
+                    )));
+                }
             }
         };
         Ok(Bytes::from(value))

--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -411,6 +411,8 @@ impl super::Db for MysqlDb {
         }
 
         let (module, key1, key2) = super::parse_key(key);
+        // Escape ' (single quote) character with ''
+        let (key1, key2) = (key1.replace("'", "''"), key2.replace("'", "''"));
         let sql = if with_prefix {
             if key1.is_empty() {
                 format!(r#"DELETE FROM meta WHERE module = '{}';"#, module)

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -86,8 +86,15 @@ impl super::Db for PostgresDb {
             .await
         {
             Ok(v) => v,
-            Err(_) => {
-                return Err(Error::from(DbError::KeyNotExists(key.to_string())));
+            Err(e) => {
+                if let sqlx::Error::RowNotFound = e {
+                    return Err(Error::from(DbError::KeyNotExists(key.to_string())));
+                } else {
+                    return Err(Error::from(DbError::DBOperError(
+                        e.to_string(),
+                        key.to_string(),
+                    )));
+                }
             }
         };
         Ok(Bytes::from(value))

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -349,6 +349,8 @@ impl super::Db for PostgresDb {
         }
 
         let (module, key1, key2) = super::parse_key(key);
+        // Escape ' (single quote) character with ''
+        let (key1, key2) = (key1.replace("'", "''"), key2.replace("'", "''"));
         let sql = if with_prefix {
             if key1.is_empty() {
                 format!(r#"DELETE FROM meta WHERE module = '{}';"#, module)

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -201,8 +201,15 @@ impl super::Db for SqliteDb {
         .await
         {
             Ok(v) => v,
-            Err(_) => {
-                return Err(Error::from(DbError::KeyNotExists(key.to_string())));
+            Err(e) => {
+                if let sqlx::Error::RowNotFound = e {
+                    return Err(Error::from(DbError::KeyNotExists(key.to_string())));
+                } else {
+                    return Err(Error::from(DbError::DBOperError(
+                        e.to_string(),
+                        key.to_string(),
+                    )));
+                }
             }
         };
         Ok(Bytes::from(value))

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -497,6 +497,8 @@ impl super::Db for SqliteDb {
         }
 
         let (module, key1, key2) = super::parse_key(key);
+        // Escape ' (single quote) character with ''
+        let (key1, key2) = (key1.replace("'", "''"), key2.replace("'", "''"));
         let sql = if with_prefix {
             if key1.is_empty() {
                 format!(r#"DELETE FROM meta WHERE module = '{}';"#, module)

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,6 +216,10 @@ async fn main() -> Result<(), anyhow::Error> {
                 panic!("migrate dashboards failed: {}", e);
             }
 
+            migration::upgrade_resource_names()
+                .await
+                .expect("migrate resource names into supported ofga format failed");
+
             // ingester init
             if let Err(e) = ingester::init().await {
                 job_init_tx.send(false).ok();

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -43,7 +43,7 @@ use crate::{
             authz::Authz,
             stream::StreamParams,
         },
-        utils::auth::{remove_ownership, set_ownership},
+        utils::auth::{is_ofga_unsupported, remove_ownership, set_ownership},
     },
     service::{
         alerts::{build_sql, destinations},
@@ -62,6 +62,13 @@ pub async fn save(
         alert.name = name.to_string();
     }
     alert.name = alert.name.trim().to_string();
+
+    // Don't allow the characters not supported by ofga
+    if is_ofga_unsupported(&alert.name) {
+        return Err(anyhow::anyhow!(
+            "Alert name cannot contain ':', '#', '?', '&', '%', quotes and space characters"
+        ));
+    }
     alert.org_id = org_id.to_string();
     let stream_type = alert.stream_type;
     alert.stream_name = stream_name.to_string();

--- a/src/service/alerts/destinations.rs
+++ b/src/service/alerts/destinations.rs
@@ -63,10 +63,12 @@ pub async fn save(
         destination.name = name.to_string();
     }
     destination.name = destination.name.trim().to_string();
-    // Replace the characters not supported by ofga with '_'
-    destination.name = RE_OFGA_UNSUPPORTED_NAME
-        .replace_all(&destination.name, "_")
-        .to_string();
+    // Don't allow the characters not supported by ofga
+    if is_ofga_unsupported(&destination.name) {
+        return Err(anyhow::anyhow!(
+            "Alert destination name cannot contain ':', '#', '?' and space characters"
+        ));
+    }
     if destination.name.is_empty() {
         return Err((
             http::StatusCode::BAD_REQUEST,

--- a/src/service/alerts/destinations.rs
+++ b/src/service/alerts/destinations.rs
@@ -22,7 +22,7 @@ use crate::{
             alerts::destinations::{Destination, DestinationType, DestinationWithTemplate},
             authz::Authz,
         },
-        utils::auth::{remove_ownership, set_ownership, RE_OFGA_UNSUPPORTED_NAME},
+        utils::auth::{is_ofga_unsupported, remove_ownership, set_ownership},
     },
     service::db,
 };
@@ -65,8 +65,11 @@ pub async fn save(
     destination.name = destination.name.trim().to_string();
     // Don't allow the characters not supported by ofga
     if is_ofga_unsupported(&destination.name) {
-        return Err(anyhow::anyhow!(
-            "Alert destination name cannot contain ':', '#', '?' and space characters"
+        return Err((
+            http::StatusCode::BAD_REQUEST,
+            anyhow::anyhow!(
+                "Alert destination name cannot contain ':', '#', '?' and space characters"
+            ),
         ));
     }
     if destination.name.is_empty() {

--- a/src/service/alerts/destinations.rs
+++ b/src/service/alerts/destinations.rs
@@ -22,7 +22,7 @@ use crate::{
             alerts::destinations::{Destination, DestinationType, DestinationWithTemplate},
             authz::Authz,
         },
-        utils::auth::{remove_ownership, set_ownership},
+        utils::auth::{remove_ownership, set_ownership, RE_OFGA_UNSUPPORTED_NAME},
     },
     service::db,
 };
@@ -63,6 +63,10 @@ pub async fn save(
         destination.name = name.to_string();
     }
     destination.name = destination.name.trim().to_string();
+    // Replace the characters not supported by ofga with '_'
+    destination.name = RE_OFGA_UNSUPPORTED_NAME
+        .replace_all(&destination.name, "_")
+        .to_string();
     if destination.name.is_empty() {
         return Err((
             http::StatusCode::BAD_REQUEST,

--- a/src/service/alerts/destinations.rs
+++ b/src/service/alerts/destinations.rs
@@ -68,7 +68,7 @@ pub async fn save(
         return Err((
             http::StatusCode::BAD_REQUEST,
             anyhow::anyhow!(
-                "Alert destination name cannot contain ':', '#', '?' and space characters"
+                "Alert destination name cannot contain ':', '#', '?', '&', '%', quotes and space characters"
             ),
         ));
     }

--- a/src/service/alerts/templates.rs
+++ b/src/service/alerts/templates.rs
@@ -19,7 +19,7 @@ use crate::{
     common::{
         infra::config::ALERTS_DESTINATIONS,
         meta::{alerts::templates::Template, authz::Authz},
-        utils::auth::{remove_ownership, set_ownership, RE_OFGA_UNSUPPORTED_NAME},
+        utils::auth::{is_ofga_unsupported, remove_ownership, set_ownership},
     },
     service::db,
 };

--- a/src/service/alerts/templates.rs
+++ b/src/service/alerts/templates.rs
@@ -19,7 +19,7 @@ use crate::{
     common::{
         infra::config::ALERTS_DESTINATIONS,
         meta::{alerts::templates::Template, authz::Authz},
-        utils::auth::{remove_ownership, set_ownership},
+        utils::auth::{remove_ownership, set_ownership, RE_OFGA_UNSUPPORTED_NAME},
     },
     service::db,
 };
@@ -37,6 +37,10 @@ pub async fn save(
         template.name = name.to_owned();
     }
     template.name = template.name.trim().to_string();
+    // Replace the characters not supported by ofga with '_'
+    template.name = RE_OFGA_UNSUPPORTED_NAME
+        .replace_all(&template.name, "_")
+        .to_string();
     if template.name.is_empty() {
         return Err(anyhow::anyhow!("Alert template name is required"));
     }

--- a/src/service/alerts/templates.rs
+++ b/src/service/alerts/templates.rs
@@ -37,10 +37,12 @@ pub async fn save(
         template.name = name.to_owned();
     }
     template.name = template.name.trim().to_string();
-    // Replace the characters not supported by ofga with '_'
-    template.name = RE_OFGA_UNSUPPORTED_NAME
-        .replace_all(&template.name, "_")
-        .to_string();
+    // Don't allow the characters not supported by ofga
+    if is_ofga_unsupported(&template.name) {
+        return Err(anyhow::anyhow!(
+            "Alert template name cannot contain ':', '#', '?' and space characters"
+        ));
+    }
     if template.name.is_empty() {
         return Err(anyhow::anyhow!("Alert template name is required"));
     }

--- a/src/service/alerts/templates.rs
+++ b/src/service/alerts/templates.rs
@@ -40,7 +40,7 @@ pub async fn save(
     // Don't allow the characters not supported by ofga
     if is_ofga_unsupported(&template.name) {
         return Err(anyhow::anyhow!(
-            "Alert template name cannot contain ':', '#', '?' and space characters"
+            "Alert template name cannot contain ':', '#', '?', '&', '%', quotes and space characters"
         ));
     }
     if template.name.is_empty() {

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -36,9 +36,7 @@ use crate::{
                 ReportFrequencyType, ReportTimerangeType,
             },
         },
-        utils::auth::{
-            is_ofga_unsupported, remove_ownership, set_ownership, RE_OFGA_UNSUPPORTED_NAME,
-        },
+        utils::auth::{is_ofga_unsupported, remove_ownership, set_ownership},
     },
     service::db,
 };

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -36,7 +36,9 @@ use crate::{
                 ReportFrequencyType, ReportTimerangeType,
             },
         },
-        utils::auth::{remove_ownership, set_ownership, RE_OFGA_UNSUPPORTED_NAME},
+        utils::auth::{
+            is_ofga_unsupported, remove_ownership, set_ownership, RE_OFGA_UNSUPPORTED_NAME,
+        },
     },
     service::db,
 };
@@ -67,10 +69,13 @@ pub async fn save(
     if !name.is_empty() {
         report.name = name.to_string();
     }
-    // Replace the characters not supported by ofga with '_'
-    report.name = RE_OFGA_UNSUPPORTED_NAME
-        .replace_all(&report.name, "_")
-        .to_string();
+
+    // Don't allow the characters not supported by ofga
+    if is_ofga_unsupported(&report.name) {
+        return Err(anyhow::anyhow!(
+            "Report name cannot contain ':', '#', '?' and space characters"
+        ));
+    }
     if report.name.is_empty() {
         return Err(anyhow::anyhow!("Report name is required"));
     }

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -36,7 +36,7 @@ use crate::{
                 ReportFrequencyType, ReportTimerangeType,
             },
         },
-        utils::auth::{remove_ownership, set_ownership},
+        utils::auth::{remove_ownership, set_ownership, RE_OFGA_UNSUPPORTED_NAME},
     },
     service::db,
 };
@@ -67,6 +67,10 @@ pub async fn save(
     if !name.is_empty() {
         report.name = name.to_string();
     }
+    // Replace the characters not supported by ofga with '_'
+    report.name = RE_OFGA_UNSUPPORTED_NAME
+        .replace_all(&report.name, "_")
+        .to_string();
     if report.name.is_empty() {
         return Err(anyhow::anyhow!("Report name is required"));
     }

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -71,7 +71,7 @@ pub async fn save(
     // Don't allow the characters not supported by ofga
     if is_ofga_unsupported(&report.name) {
         return Err(anyhow::anyhow!(
-            "Report name cannot contain ':', '#', '?' and space characters"
+            "Report name cannot contain ':', '#', '?', '&', '%', quotes and space characters"
         ));
     }
     if report.name.is_empty() {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -44,7 +44,7 @@ pub mod users;
 
 const MAX_KEY_LENGTH: usize = 100;
 
-static RE_CORRECT_STREAM_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^a-zA-Z0-9_:]+").unwrap());
+static RE_CORRECT_STREAM_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^a-zA-Z0-9_]+").unwrap());
 
 // format partition key
 pub fn format_partition_key(input: &str) -> String {

--- a/web/src/services/alert_destination.ts
+++ b/web/src/services/alert_destination.ts
@@ -17,30 +17,27 @@ import http from "./http";
 
 const destination = {
   create: ({ org_identifier, destination_name, data }: any) => {
-    return http().post(
-      `/api/${org_identifier}/alerts/destinations`,
-      data
-    );
+    return http().post(`/api/${org_identifier}/alerts/destinations`, data);
   },
   update: ({ org_identifier, destination_name, data }: any) => {
     return http().put(
-      `/api/${org_identifier}/alerts/destinations/${destination_name}`,
-      data
+      `/api/${org_identifier}/alerts/destinations/${encodeURIComponent(destination_name)}`,
+      data,
     );
   },
   list: ({ org_identifier, page_num, page_size, desc, sort_by }: any) => {
     return http().get(
-      `/api/${org_identifier}/alerts/destinations?page_num=${page_num}&page_size=${page_size}&sort_by=${sort_by}&desc=${desc}`
+      `/api/${org_identifier}/alerts/destinations?page_num=${page_num}&page_size=${page_size}&sort_by=${sort_by}&desc=${desc}`,
     );
   },
   get_by_name: ({ org_identifier, destination_name }: any) => {
     return http().get(
-      `/api/${org_identifier}/alerts/destinations/${destination_name}`
+      `/api/${org_identifier}/alerts/destinations/${encodeURIComponent(destination_name)}`,
     );
   },
   delete: ({ org_identifier, destination_name }: any) => {
     return http().delete(
-      `/api/${org_identifier}/alerts/destinations/${destination_name}`
+      `/api/${org_identifier}/alerts/destinations/${encodeURIComponent(destination_name)}`,
     );
   },
 };

--- a/web/src/services/alert_templates.ts
+++ b/web/src/services/alert_templates.ts
@@ -21,8 +21,8 @@ const template = {
   },
   update: ({ org_identifier, template_name, data }: any) => {
     return http().put(
-      `/api/${org_identifier}/alerts/templates/${template_name}`,
-      data
+      `/api/${org_identifier}/alerts/templates/${encodeURIComponent(template_name)}`,
+      data,
     );
   },
   list: ({ org_identifier }: any) => {
@@ -30,12 +30,12 @@ const template = {
   },
   get_by_name: ({ org_identifier, template_name }: any) => {
     return http().get(
-      `/api/${org_identifier}/alerts/templates/${template_name}`
+      `/api/${org_identifier}/alerts/templates/${encodeURIComponent(template_name)}`,
     );
   },
   delete: ({ org_identifier, template_name }: any) => {
     return http().delete(
-      `/api/${org_identifier}/alerts/templates/${template_name}`
+      `/api/${org_identifier}/alerts/templates/${encodeURIComponent(template_name)}`,
     );
   },
 };

--- a/web/src/services/alerts.ts
+++ b/web/src/services/alerts.ts
@@ -22,50 +22,50 @@ const alerts = {
     sort_by: string,
     desc: boolean,
     name: string,
-    org_identifier: string
+    org_identifier: string,
   ) => {
     return http().get(
-      `/api/${org_identifier}/alerts?page_num=${page_num}&page_size=${page_size}&sort_by=${sort_by}&desc=${desc}&name=${name}`
+      `/api/${org_identifier}/alerts?page_num=${page_num}&page_size=${page_size}&sort_by=${sort_by}&desc=${desc}&name=${name}`,
     );
   },
   create: (
     org_identifier: string,
     stream_name: string,
     stream_type: string,
-    data: any
+    data: any,
   ) => {
     return http().post(
       `/api/${org_identifier}/${stream_name}/alerts?type=${stream_type}`,
-      data
+      data,
     );
   },
   update: (
     org_identifier: string,
     stream_name: string,
     stream_type: string,
-    data: any
+    data: any,
   ) => {
     return http().put(
-      `/api/${org_identifier}/${stream_name}/alerts/${data.name}?type=${stream_type}`,
-      data
+      `/api/${org_identifier}/${stream_name}/alerts/${encodeURIComponent(data.name)}?type=${stream_type}`,
+      data,
     );
   },
   get_with_name: (
     org_identifier: string,
     stream_name: string,
-    alert_name: string
+    alert_name: string,
   ) => {
     return http().get(
-      `/api/${org_identifier}/${stream_name}/alerts/${alert_name}`
+      `/api/${org_identifier}/${stream_name}/alerts/${encodeURIComponent(alert_name)}`,
     );
   },
   delete: (
     org_identifier: string,
     stream_name: string,
     alert_name: string,
-    type: string
+    type: string,
   ) => {
-    let url = `/api/${org_identifier}/${stream_name}/alerts/${alert_name}`;
+    let url = `/api/${org_identifier}/${stream_name}/alerts/${encodeURIComponent(alert_name)}`;
     if (type != "") {
       url += "?type=" + type;
     }
@@ -76,9 +76,9 @@ const alerts = {
     stream_name: string,
     alert_name: string,
     enable: boolean,
-    stream_type: string
+    stream_type: string,
   ) => {
-    const url = `/api/${org_identifier}/${stream_name}/alerts/${alert_name}/enable?value=${enable}&type=${stream_type}`;
+    const url = `/api/${org_identifier}/${stream_name}/alerts/${encodeURIComponent(alert_name)}/enable?value=${enable}&type=${stream_type}`;
     return http().put(url);
   },
 
@@ -86,9 +86,9 @@ const alerts = {
     org_identifier: string,
     stream_name: string,
     alert_name: string,
-    stream_type: string
+    stream_type: string,
   ) => {
-    const url = `/api/${org_identifier}/${stream_name}/alerts/${alert_name}/preview?type=${stream_type}`;
+    const url = `/api/${org_identifier}/${stream_name}/alerts/${encodeURIComponent(alert_name)}/preview?type=${stream_type}`;
     return http().get(url);
   },
 };

--- a/web/src/services/reports.ts
+++ b/web/src/services/reports.ts
@@ -28,30 +28,36 @@ const reports = {
     return http().get(`/api/${org_identifier}/reports`);
   },
   getReport: (org_identifier: string, reportName: string) => {
-    return http().get(`/api/${org_identifier}/reports/${reportName}`);
+    return http().get(
+      `/api/${org_identifier}/reports/${encodeURIComponent(reportName)}`,
+    );
   },
   createReport: (org_identifier: string, payload: any) => {
     return http().post(`/api/${org_identifier}/reports`, payload);
   },
   updateReport: (org_identifier: string, payload: any) => {
     return http().put(
-      `/api/${org_identifier}/reports/${payload.name}`,
-      payload
+      `/api/${org_identifier}/reports/${encodeURIComponent(payload.name)}`,
+      payload,
     );
   },
   deleteReport: (org_identifier: string, reportName: string) => {
-    return http().delete(`/api/${org_identifier}/reports/${reportName}`);
+    return http().delete(
+      `/api/${org_identifier}/reports/${encodeURIComponent(reportName)}`,
+    );
   },
   triggerReport: (org_identifier: string, reportName: string) => {
-    return http().put(`/api/${org_identifier}/reports/${reportName}/trigger`);
+    return http().put(
+      `/api/${org_identifier}/reports/${encodeURIComponent(reportName)}/trigger`,
+    );
   },
   toggleReportState: (
     org_identifier: string,
     reportName: string,
-    state: boolean
+    state: boolean,
   ) => {
     return http().put(
-      `/api/${org_identifier}/reports/${reportName}/enable?value=${state}`
+      `/api/${org_identifier}/reports/${encodeURIComponent(reportName)}/enable?value=${state}`,
     );
   },
 };


### PR DESCRIPTION
- Convert `[:?#\s'"&%]` characters into `_`
- Migration for updating existing alerts/destinations/templates/reports with name containing the above characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced initialization process with better tuple management for data migration.
	- Added conditional execution for migration processes based on node type and version.
	- Introduced new functions to validate and format names according to OFGA requirements.
	- Improved handling of destination, alert, and report names in API interactions for better compliance.

- **Bug Fixes**
	- URL parameters are now properly encoded to prevent malformed API requests.

- **Documentation**
	- Improved error handling and logging for migration processes for better visibility.

- **Style**
	- Minor formatting improvements for better code readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->