### PR TITLE
chore: Bump Node.js to v18.20.4

### DIFF
--- a/deploy/build/Dockerfile
+++ b/deploy/build/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.19.0-bookworm AS webBuilder
+FROM public.ecr.aws/docker/library/node:18.20.4-bookworm AS webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.aarch64
+++ b/deploy/build/Dockerfile.aarch64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.19.0-bookworm AS webBuilder
+FROM public.ecr.aws/docker/library/node:18.20.4-bookworm AS webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.amd64
+++ b/deploy/build/Dockerfile.amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.19.0-bookworm AS webBuilder
+FROM public.ecr.aws/docker/library/node:18.20.4-bookworm AS webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.profiling.amd64
+++ b/deploy/build/Dockerfile.profiling.amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.19.0-bookworm AS webBuilder
+FROM public.ecr.aws/docker/library/node:18.20.4-bookworm AS webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tag-debug.aarch64
+++ b/deploy/build/Dockerfile.tag-debug.aarch64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.19.0-bookworm AS webBuilder
+FROM public.ecr.aws/docker/library/node:18.20.4-bookworm AS webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tag-debug.amd64
+++ b/deploy/build/Dockerfile.tag-debug.amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.19.0-bookworm AS webBuilder
+FROM public.ecr.aws/docker/library/node:18.20.4-bookworm AS webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tag-simd.amd64
+++ b/deploy/build/Dockerfile.tag-simd.amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.19.0-bookworm AS webBuilder
+FROM public.ecr.aws/docker/library/node:18.20.4-bookworm AS webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tag.aarch64
+++ b/deploy/build/Dockerfile.tag.aarch64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.19.0-bookworm AS webBuilder
+FROM public.ecr.aws/docker/library/node:18.20.4-bookworm AS webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tag.amd64
+++ b/deploy/build/Dockerfile.tag.amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.19.0-bookworm AS webBuilder
+FROM public.ecr.aws/docker/library/node:18.20.4-bookworm AS webBuilder
 WORKDIR /web
 COPY ./web /web/
 

--- a/deploy/build/Dockerfile.tokio-console.amd64
+++ b/deploy/build/Dockerfile.tokio-console.amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/node:18.19.0-bookworm AS webBuilder
+FROM public.ecr.aws/docker/library/node:18.20.4-bookworm AS webBuilder
 WORKDIR /web
 COPY ./web /web/
 


### PR DESCRIPTION
This will take care of fixing over +10 CVE's that have been announced between versions v18.19.0 and v18.20.4

Release notes: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the Node.js base image across various build configurations, potentially enhancing application performance and security with new features and bug fixes.

- **Bug Fixes**
	- The upgrade may resolve previously existing bugs through improvements in the newer Node.js version. 

- **Chores**
	- Updated base image references to ensure the application runs on the latest stable Node.js environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->