### PR TITLE
fix: histogram will be updated when run query button will be pressed …

### DIFF
--- a/src/service/alerts/alert_manager.rs
+++ b/src/service/alerts/alert_manager.rs
@@ -44,7 +44,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
     )
     .await?;
 
-    log::debug!("Pulled {} jobs from scheduler", triggers.len());
+    log::info!("Pulled {} jobs from scheduler", triggers.len());
 
     for trigger in triggers {
         tokio::task::spawn(async move {
@@ -127,6 +127,13 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
 
     // evaluate alert
     let ret = alert.evaluate(None).await?;
+    if ret.is_some() {
+        log::info!(
+            "Alert conditions satisfied, org: {}, module_key: {}",
+            &new_trigger.org,
+            &new_trigger.module_key
+        );
+    }
     if ret.is_some() && alert.trigger_condition.silence > 0 {
         new_trigger.next_run_at += Duration::try_minutes(alert.trigger_condition.silence)
             .unwrap()

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -97,6 +97,7 @@ const defaultObject = {
     logsVisualizeToggle: "logs",
     refreshInterval: <number>0,
     refreshIntervalLabel: "Off",
+    refreshHistogram: false,
     showFields: true,
     showQuery: true,
     showHistogram: true,
@@ -1655,7 +1656,7 @@ const useLogs = () => {
 
         if (
           (searchObj.data.queryResults.aggs == undefined &&
-            searchObj.data.resultGrid.currentPage == 1 &&
+            searchObj.meta.refreshHistogram == true &&
             searchObj.loadingHistogram == false &&
             searchObj.meta.showHistogram == true &&
             searchObj.data.stream.selectedStream.length <= 1 &&
@@ -1665,8 +1666,9 @@ const useLogs = () => {
             searchObj.meta.showHistogram == true &&
             searchObj.meta.sqlMode == false &&
             searchObj.data.stream.selectedStream.length <= 1 &&
-            searchObj.data.resultGrid.currentPage == 1)
+            searchObj.meta.refreshHistogram == true)
         ) {
+          searchObj.meta.refreshHistogram = false;
           if (searchObj.data.queryResults.hits.length > 0) {
             await getHistogramQueryData(searchObj.data.histogramQuery);
           }
@@ -3379,6 +3381,7 @@ const useLogs = () => {
   const handleRunQuery = async () => {
     try {
       searchObj.loading = true;
+      searchObj.meta.refreshHistogram = true;
       initialQueryPayload.value = null;
       searchObj.data.queryResults.aggs = null;
       // searchObj.data.histogram.chartParams.title = ""

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -515,6 +515,7 @@ export default defineComponent({
       // if search tab
       if (searchObj.meta.logsVisualizeToggle == "logs") {
         const queryParams: any = router.currentRoute.value.query;
+        searchObj.meta.refreshHistogram = true;
 
         const isStreamChanged =
           queryParams.stream_type !== searchObj.data.stream.streamType ||
@@ -552,6 +553,7 @@ export default defineComponent({
       if (searchObj.meta.logsVisualizeToggle == "logs") {
         // searchObj.loading = true;
         searchObj.meta.pageType = "logs";
+        searchObj.meta.refreshHistogram = true;
         if (
           config.isEnterprise == "true" &&
           store.state.zoConfig.super_cluster_enabled


### PR DESCRIPTION
…or page refresh will be done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `refreshHistogram` property to improve histogram management within the logs component.
	- Enhanced the logs visualization to refresh the histogram in real-time when toggling log views.

- **Bug Fixes**
	- Corrected conditions for refreshing the histogram to ensure data accuracy based on user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->