### PR TITLE
chore: modify roadmap and cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ OpenObserve is available in three different editions:
 | Query management | ❌ | ✅ | ❌ |
 | Workload management (QoS) | ❌ | ✅ | ❌ |
 | Audit trail | ❌ | ✅ | ❌ |
+| Ability to influence roadmap | ❌ | ✅ | ✅ on enterprise plan |
 | License | AGPL | Enterprise | Cloud |
 | Support | Community | Enterprise | Cloud |
-| Cost | Free | Paid | Paid |
-
+| Cost | Free | If self hosted, free for up to 200 GB/Day data ingested <br> Paid thereafter  | Free 200 GB/Month data ingested <br> Paid thereafter |
 
 
 ## 📷 Screenshots


### PR DESCRIPTION
Modified ability to influence OpenObserve roadmap and cost details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to influence the product roadmap for enterprise plan users.

- **Documentation**
	- Updated the feature comparison table to enhance clarity on pricing and features across different hosting options.
	- Specified that the self-hosted option is free for up to 200 GB of data ingested per day and outlined the free tier for the Cloud option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->