### PR TITLE
fix: rum token invalid when user update

### DIFF
--- a/src/service/db/user.rs
+++ b/src/service/db/user.rs
@@ -52,7 +52,6 @@ pub async fn get_by_token(
     let user = match org_id {
         None => ROOT_USER.get("root").map(|v| v.clone()),
         Some(org_id) => USERS_RUM_TOKEN
-            .clone()
             .get(&format!("{org_id}/{token}"))
             .map(|v| v.clone()),
     };
@@ -123,9 +122,7 @@ pub async fn set(user: &DBUser) -> Result<(), anyhow::Error> {
         );
 
         if let Some(rum_token) = &org.rum_token {
-            USERS_RUM_TOKEN
-                .clone()
-                .insert(format!("{}/{}", org.name.clone(), rum_token), user);
+            USERS_RUM_TOKEN.insert(format!("{}/{}", org.name.clone(), rum_token), user);
         }
     }
     Ok(())
@@ -183,7 +180,7 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                 // Invalidate the entire RUM-TOKEN-CACHE
                 for (_, user) in USERS.clone() {
                     if user.email.eq(item_key) {
-                        USERS_RUM_TOKEN.clone().remove(&format!(
+                        USERS_RUM_TOKEN.remove(&format!(
                             "{}/{}",
                             user.org,
                             user.rum_token.as_ref().unwrap()
@@ -200,9 +197,7 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                     };
                     USERS.insert(format!("{}/{}", user.org, item_key), user.clone());
                     if let Some(rum_token) = &user.rum_token {
-                        USERS_RUM_TOKEN
-                            .clone()
-                            .insert(format!("{}/{}", user.org, rum_token), user);
+                        USERS_RUM_TOKEN.insert(format!("{}/{}", user.org, rum_token), user);
                     }
                 }
 
@@ -213,9 +208,7 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                     }
                     USERS.insert(format!("{}/{}", user.org, item_key), user.clone());
                     if let Some(rum_token) = &user.rum_token {
-                        USERS_RUM_TOKEN
-                            .clone()
-                            .insert(format!("{}/{}", user.org, rum_token), user);
+                        USERS_RUM_TOKEN.insert(format!("{}/{}", user.org, rum_token), user);
                     }
                 }
             }
@@ -225,7 +218,7 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                     if user.email.eq(item_key) {
                         USERS.remove(&format!("{}/{}", user.org, user.email));
                         // Invalidate the entire RUM-TOKEN-CACHE
-                        USERS_RUM_TOKEN.clone().remove(&format!(
+                        USERS_RUM_TOKEN.remove(&format!(
                             "{}/{}",
                             user.org,
                             user.rum_token.as_ref().unwrap()
@@ -255,9 +248,7 @@ pub async fn cache() -> Result<(), anyhow::Error> {
             }
             USERS.insert(format!("{}/{}", user.org, user.email), user.clone());
             if let Some(rum_token) = &user.rum_token {
-                USERS_RUM_TOKEN
-                    .clone()
-                    .insert(format!("{}/{}", user.org, rum_token), user);
+                USERS_RUM_TOKEN.insert(format!("{}/{}", user.org, rum_token), user);
             }
         }
 
@@ -268,9 +259,7 @@ pub async fn cache() -> Result<(), anyhow::Error> {
             }
             USERS.insert(format!("{}/{}", user.org, user.email), user.clone());
             if let Some(rum_token) = &user.rum_token {
-                USERS_RUM_TOKEN
-                    .clone()
-                    .insert(format!("{}/{}", user.org, rum_token), user);
+                USERS_RUM_TOKEN.insert(format!("{}/{}", user.org, rum_token), user);
             }
         }
     }

--- a/src/service/db/user.rs
+++ b/src/service/db/user.rs
@@ -50,8 +50,11 @@ pub async fn get_by_token(
     token: &str,
 ) -> Result<Option<User>, anyhow::Error> {
     let user = match org_id {
-        None => ROOT_USER.get("root"),
-        Some(org_id) => USERS_RUM_TOKEN.get(&format!("{org_id}/{token}")),
+        None => ROOT_USER.get("root").map(|v| v.clone()),
+        Some(org_id) => USERS_RUM_TOKEN
+            .clone()
+            .get(&format!("{org_id}/{token}"))
+            .map(|v| v.clone()),
     };
 
     if let Some(user) = user {
@@ -177,6 +180,17 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                 };
 
                 let users = item_value.get_all_users();
+                // Invalidate the entire RUM-TOKEN-CACHE
+                for (_, user) in USERS.clone() {
+                    if user.email.eq(item_key) {
+                        USERS_RUM_TOKEN.clone().remove(&format!(
+                            "{}/{}",
+                            user.org,
+                            user.rum_token.as_ref().unwrap()
+                        ));
+                    }
+                }
+
                 #[cfg(not(feature = "enterprise"))]
                 for mut user in users {
                     if user.role.eq(&UserRole::Root) {
@@ -184,7 +198,12 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                     } else {
                         user.role = UserRole::Admin;
                     };
-                    USERS.insert(format!("{}/{}", user.org, item_key), user);
+                    USERS.insert(format!("{}/{}", user.org, item_key), user.clone());
+                    if let Some(rum_token) = &user.rum_token {
+                        USERS_RUM_TOKEN
+                            .clone()
+                            .insert(format!("{}/{}", user.org, rum_token), user);
+                    }
                 }
 
                 #[cfg(feature = "enterprise")]
@@ -192,21 +211,27 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                     if user.role.eq(&UserRole::Root) {
                         ROOT_USER.insert("root".to_string(), user.clone());
                     }
-                    USERS.insert(format!("{}/{}", user.org, item_key), user);
+                    USERS.insert(format!("{}/{}", user.org, item_key), user.clone());
+                    if let Some(rum_token) = &user.rum_token {
+                        USERS_RUM_TOKEN
+                            .clone()
+                            .insert(format!("{}/{}", user.org, rum_token), user);
+                    }
                 }
-                // Invalidate the entire RUM-TOKEN-CACHE
-                USERS_RUM_TOKEN.clear();
             }
             db::Event::Delete(ev) => {
                 let item_key = ev.key.strip_prefix(key).unwrap();
-                for user in USERS.clone() {
-                    if user.1.email.eq(item_key) {
-                        USERS.remove(&format!("{}/{}", user.1.org, user.1.email));
-                        break;
+                for (_, user) in USERS.clone() {
+                    if user.email.eq(item_key) {
+                        USERS.remove(&format!("{}/{}", user.org, user.email));
+                        // Invalidate the entire RUM-TOKEN-CACHE
+                        USERS_RUM_TOKEN.clone().remove(&format!(
+                            "{}/{}",
+                            user.org,
+                            user.rum_token.as_ref().unwrap()
+                        ));
                     }
                 }
-                // Invalidate the entire RUM-TOKEN-CACHE
-                USERS_RUM_TOKEN.clear();
             }
             db::Event::Empty => {}
         }

--- a/src/service/organization.rs
+++ b/src/service/organization.rs
@@ -151,7 +151,7 @@ async fn update_passcode_inner(
 
         // Invalidate the local cache
         let org_to_update = &existing_org[0];
-        USERS_RUM_TOKEN.clone().remove(&format!(
+        USERS_RUM_TOKEN.remove(&format!(
             "{}/{}",
             org_to_update.name,
             org_to_update.rum_token.as_deref().unwrap_or_default()
@@ -165,7 +165,7 @@ async fn update_passcode_inner(
         let existing_org = orgs.first().unwrap().clone();
 
         let org_to_update = &existing_org;
-        USERS_RUM_TOKEN.clone().remove(&format!(
+        USERS_RUM_TOKEN.remove(&format!(
             "{}/{}",
             org_to_update.name,
             org_to_update.rum_token.as_deref().unwrap_or_default()


### PR DESCRIPTION
When user update we `clean` the `USER_RUM_TOKEN` and in the next we never set `{DEFAULT_ORG}/{token}` back to `USER_RUM_TOKEN`, so the RUM ingestion report token not found for root user.

The solution is we don't `clean` the tokens, just `remove` the token which already invalid. also will add  `{DEFAULT_ORG}/{token}` if it is root user when we fetch data from db.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced user data retrieval and caching mechanisms to improve performance and reliability.
  
- **Bug Fixes**
  - Improved cache invalidation logic to prevent stale data from persisting.
  
- **Performance Improvements**
  - Streamlined operations for managing user tokens and reduced unnecessary memory usage during cache management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->