### PR TITLE
fix: do not allow `*` in first column of alert and report cron expression and introduce vrl in alerts

### DIFF
--- a/src/common/meta/alerts/mod.rs
+++ b/src/common/meta/alerts/mod.rs
@@ -50,6 +50,8 @@ pub struct Alert {
     /// Timezone offset in minutes.
     /// The negative secs means the Western Hemisphere
     pub tz_offset: i32,
+    #[serde(default)]
+    pub vrl_function: Option<String>,
 }
 
 impl PartialEq for Alert {
@@ -76,6 +78,7 @@ impl Default for Alert {
             description: "".to_string(),
             enabled: false,
             tz_offset: 0, // UTC
+            vrl_function: None,
         }
     }
 }

--- a/src/common/meta/alerts/mod.rs
+++ b/src/common/meta/alerts/mod.rs
@@ -50,8 +50,6 @@ pub struct Alert {
     /// Timezone offset in minutes.
     /// The negative secs means the Western Hemisphere
     pub tz_offset: i32,
-    #[serde(default)]
-    pub vrl_function: Option<String>,
 }
 
 impl PartialEq for Alert {
@@ -78,7 +76,6 @@ impl Default for Alert {
             description: "".to_string(),
             enabled: false,
             tz_offset: 0, // UTC
-            vrl_function: None,
         }
     }
 }
@@ -119,6 +116,8 @@ pub struct QueryCondition {
     pub promql: Option<String>,              // (cpu usage / cpu total)
     pub promql_condition: Option<Condition>, // value >= 80
     pub aggregation: Option<Aggregation>,
+    #[serde(default)]
+    pub vrl_function: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -112,6 +112,22 @@ pub async fn save(
         return Err(anyhow::anyhow!("Alert name cannot contain '/'"));
     }
 
+    if let Some(vrl) = alert.query_condition.vrl_function.as_ref() {
+        match base64::decode_url(vrl) {
+            Ok(vrl) => {
+                if !vrl.ends_with('.') {
+                    let vrl = base64::encode_url(&format!("{vrl} \n ."));
+                    alert.query_condition.vrl_function = Some(vrl);
+                }
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "Error decoding vrl function for alert: {e}"
+                ));
+            }
+        }
+    }
+
     // before saving alert check alert destination
     if alert.destinations.is_empty() {
         return Err(anyhow::anyhow!("Alert destinations is required"));

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -442,7 +442,7 @@ impl QueryCondition {
         };
 
         // fire the query
-        let req = config::meta::search::Request {
+        let req: config::meta::search::Request = config::meta::search::Request {
             query: config::meta::search::Query {
                 sql: sql.clone(),
                 from: 0,
@@ -458,7 +458,7 @@ impl QueryCondition {
                 query_type: "".to_string(),
                 track_total_hits: false,
                 uses_zo_fn: false,
-                query_fn: None,
+                query_fn: alert.vrl_function.clone(),
                 skip_wal: false,
             },
             encoding: config::meta::search::RequestEncoding::Empty,

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -469,7 +469,18 @@ impl QueryCondition {
                 query_type: "".to_string(),
                 track_total_hits: false,
                 uses_zo_fn: false,
-                query_fn: alert.query_condition.vrl_function.clone(),
+                query_fn: if alert.query_condition.vrl_function.is_some() {
+                    match base64::decode_url(alert.query_condition.vrl_function.as_ref().unwrap()) {
+                        Ok(query_fn) => Some(query_fn),
+                        Err(e) => {
+                            return Err(anyhow::anyhow!(
+                                "Error decoding alert vrl query function: {e}"
+                            ));
+                        }
+                    }
+                } else {
+                    None
+                },
                 skip_wal: false,
             },
             encoding: config::meta::search::RequestEncoding::Empty,

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -469,7 +469,7 @@ impl QueryCondition {
                 query_type: "".to_string(),
                 track_total_hits: false,
                 uses_zo_fn: false,
-                query_fn: alert.vrl_function.clone(),
+                query_fn: alert.query_condition.vrl_function.clone(),
                 skip_wal: false,
             },
             encoding: config::meta::search::RequestEncoding::Empty,

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -119,7 +119,6 @@ pub async fn search(
         && !req_clusters.is_empty()
         && (req_clusters == vec!["local"] || req_clusters == vec![config::get_cluster_name()]);
 
-    log::info!("in_req for search, {:#?}", in_req.query.query_fn);
     let mut req: cluster_rpc::SearchRequest = in_req.to_owned().into();
     req.job.as_mut().unwrap().trace_id = trace_id.clone();
     req.org_id = org_id.to_string();

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -119,6 +119,7 @@ pub async fn search(
         && !req_clusters.is_empty()
         && (req_clusters == vec!["local"] || req_clusters == vec![config::get_cluster_name()]);
 
+    log::info!("in_req for search, {:#?}", in_req.query.query_fn);
     let mut req: cluster_rpc::SearchRequest = in_req.to_owned().into();
     req.job.as_mut().unwrap().trace_id = trace_id.clone();
     req.org_id = org_id.to_string();

--- a/web/src/components/alerts/ScheduledAlert.vue
+++ b/web/src/components/alerts/ScheduledAlert.vue
@@ -57,19 +57,24 @@
 
       <div class="flex">
         <template v-if="tab === 'sql'">
-          <query-editor
-            data-test="scheduled-alert-sql-editor"
-            ref="queryEditorRef"
-            editor-id="alerts-query-editor"
-            class="monaco-editor q-mb-md"
-            v-model:query="query"
-            :class="
-              query == '' && queryEditorPlaceholderFlag ? 'empty-query' : ''
-            "
-            @update:query="updateQueryValue"
-            @focus="queryEditorPlaceholderFlag = false"
-            @blur="queryEditorPlaceholderFlag = true"
-          />
+          <div>
+            <query-editor
+              data-test="scheduled-alert-sql-editor"
+              ref="queryEditorRef"
+              editor-id="alerts-query-editor"
+              class="monaco-editor"
+              v-model:query="query"
+              :class="
+                query == '' && queryEditorPlaceholderFlag ? 'empty-query' : ''
+              "
+              @update:query="updateQueryValue"
+              @focus="queryEditorPlaceholderFlag = false"
+              @blur="onBlurQueryEditor"
+            />
+            <div class="text-negative q-mb-xs" style="height: 21px">
+              <span v-show="!isValidSqlQuery"> Invalid SQL Query</span>
+            </div>
+          </div>
         </template>
         <template v-if="tab === 'promql'">
           <query-editor
@@ -713,6 +718,8 @@ import {
 } from "@quasar/extras/material-icons-outlined";
 import { useStore } from "vuex";
 import { getImageURL } from "@/utils/zincutils";
+import useQuery from "@/composables/useQuery";
+import searchService from "@/services/search";
 
 const QueryEditor = defineAsyncComponent(
   () => import("@/components/QueryEditor.vue"),
@@ -731,6 +738,7 @@ const props = defineProps([
   "promql_condition",
   "vrl_function",
   "showVrlFunction",
+  "isValidSqlQuery",
 ]);
 
 const emits = defineEmits([
@@ -746,6 +754,7 @@ const emits = defineEmits([
   "update:promql_condition",
   "update:vrl_function",
   "update:showVrlFunction",
+  "validate-sql",
 ]);
 
 const { t } = useI18n();
@@ -962,6 +971,12 @@ const filterFunctionOptions = (val: string, update: any) => {
     });
   });
 };
+
+const onBlurQueryEditor = () => {
+  queryEditorPlaceholderFlag.value = true;
+  emits("validate-sql");
+};
+
 defineExpose({
   tab,
 });

--- a/web/src/components/alerts/ScheduledAlert.vue
+++ b/web/src/components/alerts/ScheduledAlert.vue
@@ -63,7 +63,12 @@
             editor-id="alerts-query-editor"
             class="monaco-editor q-mb-md"
             v-model:query="query"
+            :class="
+              query == '' && queryEditorPlaceholderFlag ? 'empty-query' : ''
+            "
             @update:query="updateQueryValue"
+            @focus="queryEditorPlaceholderFlag = false"
+            @blur="queryEditorPlaceholderFlag = true"
           />
         </template>
         <template v-if="tab === 'promql'">
@@ -117,8 +122,14 @@
             editor-id="fnEditor"
             class="monaco-editor"
             v-model:query="vrlFunctionContent"
-            :class="vrlFunctionContent == '' ? 'empty-function' : ''"
+            :class="
+              vrlFunctionContent == '' && functionEditorPlaceholderFlag
+                ? 'empty-function'
+                : ''
+            "
             language="ruby"
+            @focus="functionEditorPlaceholderFlag = false"
+            @blur="functionEditorPlaceholderFlag = true"
           />
         </div>
       </div>
@@ -749,6 +760,10 @@ const tab = ref(props.query_type || "custom");
 
 const store = useStore();
 
+const functionEditorPlaceholderFlag = ref(true);
+
+const queryEditorPlaceholderFlag = ref(true);
+
 const metricFunctions = ["p50", "p75", "p90", "p95", "p99"];
 const regularFunctions = ["avg", "max", "min", "sum", "count"];
 
@@ -987,6 +1002,18 @@ defineExpose({
     &.icon-dark {
       filter: none !important;
     }
+  }
+
+  .empty-query .monaco-editor-background {
+    background-image: url("../../assets/images/common/query-editor.png");
+    background-repeat: no-repeat;
+    background-size: 115px;
+  }
+
+  .empty-function .monaco-editor-background {
+    background-image: url("../../assets/images/common/vrl-function.png");
+    background-repeat: no-repeat;
+    background-size: 170px;
   }
 }
 </style>

--- a/web/src/components/alerts/ScheduledAlert.vue
+++ b/web/src/components/alerts/ScheduledAlert.vue
@@ -97,7 +97,6 @@
                 hide-selected
                 menu-anchor="top left"
                 fill-input
-                @filter="filterFunctionOptions"
                 option-label="label"
                 option-value="value"
                 @update:modelValue="onFunctionSelect"

--- a/web/src/components/alerts/ScheduledAlert.vue
+++ b/web/src/components/alerts/ScheduledAlert.vue
@@ -97,8 +97,9 @@
                 hide-selected
                 menu-anchor="top left"
                 fill-input
-                option-label="label"
-                option-value="value"
+                option-label="name"
+                option-value="name"
+                @filter="filterFunctionOptions"
                 @update:modelValue="onFunctionSelect"
                 style="width: 100%"
               >
@@ -108,26 +109,6 @@
                   </q-item>
                 </template>
               </q-select>
-              <q-btn
-                no-caps
-                padding="xs"
-                class=""
-                size="sm"
-                flat
-                icon="info_outline"
-                data-test="dashboard-addpanel-config-drilldown-info"
-              >
-                <q-tooltip
-                  class="bg-grey-8"
-                  anchor="bottom middle"
-                  self="top right"
-                  max-width="250px"
-                >
-                  To use extracted VRL fields in the chart, write a VRL function
-                  and click on the Apply button. The fields will be extracted,
-                  allowing you to use them to build the chart.
-                </q-tooltip>
-              </q-btn>
             </div>
           </div>
           <query-editor
@@ -844,19 +825,20 @@ const getDefaultPromqlCondition = () => {
 };
 
 const onFunctionSelect = (_function: any) => {
-  selectedFunction.value = _function.value;
+  selectedFunction.value = _function.name;
   vrlFunctionContent.value = _function.function;
 };
 
-const functionOptions = computed(() => {
-  return store.state.organizationData.functions.map((fn: any) => {
-    return {
-      ...fn,
-      value: fn.name,
-      label: fn.name,
-    };
-  });
-});
+const functionsList = computed(() => store.state.organizationData.functions);
+
+const functionOptions = ref<any[]>([]);
+
+watch(
+  () => functionsList.value,
+  (functions: any[]) => {
+    functionOptions.value = [...functions];
+  },
+);
 
 const vrlFunctionContent = computed({
   get() {
@@ -956,6 +938,14 @@ const filterNumericColumns = (val: string, update: Function) => {
 const updateAggregationToggle = () => {
   _isAggregationEnabled.value =
     tab.value === "custom" && props.isAggregationEnabled;
+};
+
+const filterFunctionOptions = (val: string, update: any) => {
+  update(() => {
+    functionOptions.value = functionsList.value.filter((fn: any) => {
+      return fn.name.toLowerCase().indexOf(val.toLowerCase()) > -1;
+    });
+  });
 };
 defineExpose({
   tab,

--- a/web/src/composables/useQuery.ts
+++ b/web/src/composables/useQuery.ts
@@ -150,36 +150,41 @@ const useQuery = () => {
           sql: 'select *[QUERY_FUNCTIONS] from "[INDEX_NAME]" [WHERE_CLAUSE]',
           start_time: (new Date().getTime() - 900000) * 1000,
           end_time: new Date().getTime() * 1000,
-          from: data.from,
-          size: data.size,
+          from: data.from || 0,
+          size: data.size || 100,
         },
         aggs: {
           histogram:
             "select histogram(" +
-            data.timestamp_column +
+            (data?.timestamp_column ||
+              store.state.zoConfig.timestamp_column ||
+              "_timestamp") +
             ", '[INTERVAL]') AS zo_sql_key, count(*) AS zo_sql_num from query GROUP BY zo_sql_key ORDER BY zo_sql_key",
         },
       };
 
       req.aggs.histogram = req.aggs.histogram.replaceAll(
         "[INTERVAL]",
-        data.timeInterval
+        data.timeInterval,
       );
 
       req.query.sql = req.query.sql.replaceAll(
         "[QUERY_FUNCTIONS]",
-        data.parsedQuery?.queryFunctions || ""
+        data.parsedQuery?.queryFunctions || "",
       );
 
       req.query.sql = req.query.sql.replaceAll("[INDEX_NAME]", data.streamName);
 
       req.query.sql = req.query.sql.replaceAll(
         "[WHERE_CLAUSE]",
-        data.parsedQuery?.whereClause || ""
+        data.parsedQuery?.whereClause || "",
       );
 
-      req.query.start_time = data.timestamps.startTime;
-      req.query.end_time = data.timestamps.endTime;
+      if (data?.timestamps?.startTime)
+        req.query.start_time = data.timestamps.startTime;
+
+      if (data?.timestamps?.endTime)
+        req.query.end_time = data.timestamps.endTime;
 
       if (store.state.zoConfig.sql_base64_enabled) {
         req["encoding"] = "base64";

--- a/web/src/composables/useQuery.ts
+++ b/web/src/composables/useQuery.ts
@@ -4,18 +4,18 @@ import { b64EncodeUnicode } from "@/utils/zincutils";
 import { onBeforeMount } from "vue";
 
 interface BuildQueryPayload {
-  from: number;
-  size: number;
-  timestamp_column: string;
-  timestamps: {
+  from?: number;
+  size?: number;
+  timestamp_column?: string;
+  timestamps?: {
     startTime: number | "Invalid Date";
     endTime: number | "Invalid Date";
   };
-  timeInterval: string;
+  timeInterval?: string;
   sqlMode: boolean;
-  currentPage: number;
-  selectedStream: string;
-  parsedQuery: {
+  currentPage?: number;
+  selectedStream?: string;
+  parsedQuery?: {
     queryFunctions: string;
     whereClause: string;
     limit: number;


### PR DESCRIPTION
- Replace first column `*` with the current second in cron expression while saving report and alerts
- Introduce vrl functions in alerts. The new field `vrl_function` in alert payload stores the vrl function in the alert in base64 encoded format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional field for alerts to allow the association of VRL functions.
	- Enhanced scheduling for alerts and reports by dynamically modifying cron expressions to include the current second.
	- Added a VRL function editor in the Scheduled Alert component for improved query editing, with toggles for enhanced user interactivity.
	- Improved query construction with optional parameters and enhanced error handling for timestamp handling.

- **Bug Fixes**
	- Improved robustness of the alert and report scheduling systems with better handling of cron expressions.
	- Enhanced error handling for decoding failures related to VRL functions in alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->