### PR TITLE
fix: #4098 loading icon stops when error in values api

### DIFF
--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -977,11 +977,16 @@ export default defineComponent({
                 }
               }
             })
+            .catch((err: any) => {
+              fieldValues.value[name]["isLoading"] = false;
+            })
             .finally(() => {
               if (countTotal == 0) fieldValues.value[name]["isLoading"] = false;
             });
         });
       } catch (err) {
+        fieldValues.value[name]["isLoading"] = false;
+
         console.log(err);
         $q.notify({
           type: "negative",


### PR DESCRIPTION
This PR fixes #4098  so when there is an error in values api then the spinner / loading icon will be stopped and as well as it shows no value found 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Enhanced error handling in the IndexList component to ensure accurate loading states during asynchronous operations, preventing indefinite loading indicators and improving overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->