### PR TITLE
fix: request timeout after an error happened

### DIFF
--- a/src/common/utils/http.rs
+++ b/src/common/utils/http.rs
@@ -19,8 +19,7 @@ use std::{
     net::{AddrParseError, IpAddr, SocketAddr},
 };
 
-use actix_http::header::HeaderName;
-use actix_web::web::Query;
+use actix_web::{http::header::HeaderName, web::Query};
 use awc::http::header::HeaderMap;
 use config::meta::{search::SearchEventType, stream::StreamType};
 use opentelemetry::{global, propagation::Extractor, trace::TraceContextExt};

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -146,7 +146,7 @@ async fn check_keepalive(
     let mut resp = next.call(req).await?;
     if resp.status() != StatusCode::OK {
         resp.headers_mut().insert(
-            header::HeaderName::from_static("Connection"),
+            header::HeaderName::from_static("connection"),
             header::HeaderValue::from_static("close"),
         );
     }

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -16,11 +16,10 @@
 use std::{rc::Rc, str::FromStr};
 
 use actix_cors::Cors;
-use actix_http::header::HeaderName;
 use actix_web::{
     body::MessageBody,
     dev::{Service, ServiceRequest, ServiceResponse},
-    http::header,
+    http::{header, StatusCode},
     middleware, web, HttpRequest, HttpResponse,
 };
 use actix_web_httpauth::middleware::HttpAuthentication;
@@ -55,7 +54,7 @@ fn get_cors() -> Rc<Cors> {
             header::AUTHORIZATION,
             header::ACCEPT,
             header::CONTENT_TYPE,
-            HeaderName::from_lowercase(b"traceparent").unwrap(),
+            header::HeaderName::from_lowercase(b"traceparent").unwrap(),
         ])
         .allow_any_origin()
         .supports_credentials()
@@ -138,6 +137,20 @@ async fn audit_middleware(
     next: Next<impl MessageBody>,
 ) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
     next.call(req).await
+}
+
+async fn check_keepalive(
+    req: ServiceRequest,
+    next: Next<impl MessageBody>,
+) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
+    let mut resp = next.call(req).await?;
+    if resp.status() != StatusCode::OK {
+        resp.headers_mut().insert(
+            header::HeaderName::from_static("Connection"),
+            header::HeaderValue::from_static("close"),
+        );
+    }
+    Ok(resp)
 }
 
 /// This is a very trivial proxy to overcome the cors errors while
@@ -311,6 +324,7 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
 
     cfg.service(
         web::scope("/api")
+            .wrap(from_fn(check_keepalive))
             .wrap(from_fn(audit_middleware))
             .wrap(HttpAuthentication::with_fn(
                 super::auth::validator::oo_validator,

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -19,7 +19,7 @@ use actix_cors::Cors;
 use actix_web::{
     body::MessageBody,
     dev::{Service, ServiceRequest, ServiceResponse},
-    http::{header, StatusCode},
+    http::{header, ConnectionType, StatusCode},
     middleware, web, HttpRequest, HttpResponse,
 };
 use actix_web_httpauth::middleware::HttpAuthentication;
@@ -147,7 +147,7 @@ async fn check_keepalive(
     if resp.status() >= StatusCode::BAD_REQUEST {
         resp.response_mut()
             .head_mut()
-            .set_connection_type(actix_http::ConnectionType::Close);
+            .set_connection_type(ConnectionType::Close);
     }
     Ok(resp)
 }


### PR DESCRIPTION
We found router has a lot of timeout that is because we enabled `keep-alive` for http connection and reusing connection for multiple request.

But there is a issue if there is one request got `401` error then this connection never reply again, so the next request on this connection will timeout.

**The solution is:**

Add a middleware to check the response status add `Connection: close` if the status is not `200`.

**Tips:**

First, this solution can force close the connection, it is right.

Second, the router use the connection in concurrency, so, it means, still some request will got problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities by adding an optional `o2_request_id` parameter across multiple request handling functions for better traceability.
	- Introduced a unique request ID for specific requests to improve monitoring and debugging.

- **Bug Fixes**
	- Improved handling of incoming requests by modifying signature parameters to ensure proper processing.

- **Documentation**
	- Updated comments and logging statements for clarity regarding the new request ID tracking and logging enhancements.

- **Chores**
	- Cleaned up import statements across various files for better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->