### PR TITLE
fix: added back interesting field icon and eye icon on _timestamp column

### DIFF
--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -159,7 +159,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   <span class="float-right">
                     <q-icon
                       :data-test="`log-search-index-list-interesting-${props.row.name}-field-btn`"
-                      v-if="searchObj.meta.quickMode && props.row.name != store.state.zoConfig.timestamp_column"
+                      v-if="searchObj.meta.quickMode"
                       :name="
                         props.row.isInterestingField ? 'info' : 'info_outline'
                       "
@@ -192,7 +192,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     v-if="
                       !searchObj.data.stream.selectedFields.includes(
                         props.row.name
-                      ) && props.row.name != store.state.zoConfig.timestamp_column
+                      )
                     "
                     :name="outlinedVisibility"
                     style="margin-right: 0.375rem"
@@ -205,7 +205,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     v-if="
                       searchObj.data.stream.selectedFields.includes(
                         props.row.name
-                      ) && props.row.name != store.state.zoConfig.timestamp_column
+                      )
                     "
                     :name="outlinedVisibilityOff"
                     style="margin-right: 0.375rem"
@@ -215,7 +215,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   />
                   <q-icon
                     :data-test="`log-search-index-list-interesting-${props.row.name}-field-btn`"
-                    v-if="searchObj.meta.quickMode && props.row.name != store.state.zoConfig.timestamp_column"
+                    v-if="searchObj.meta.quickMode"
                     :name="
                       props.row.isInterestingField ? 'info' : 'info_outline'
                     "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced icon visibility in the logs plugin when `quickMode` is enabled, making it easier for users to identify relevant fields across different views. 
- **Bug Fixes**
	- Streamlined conditions for icon rendering, improving the responsiveness and user interface behavior of the logs display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->