### PR TITLE
fix: use next cron timestamp after silence period

### DIFF
--- a/src/service/alerts/alert_manager.rs
+++ b/src/service/alerts/alert_manager.rs
@@ -141,10 +141,23 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         );
     }
     if ret.is_some() && alert.trigger_condition.silence > 0 {
-        new_trigger.next_run_at += Duration::try_minutes(alert.trigger_condition.silence)
-            .unwrap()
-            .num_microseconds()
-            .unwrap();
+        if alert.trigger_condition.frequency_type == AlertFrequencyType::Cron {
+            let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;
+            let silence =
+                Utc::now() + Duration::try_minutes(alert.trigger_condition.silence).unwrap();
+            let silence = silence.with_timezone(
+                FixedOffset::east_opt(alert.tz_offset * 60)
+                    .as_ref()
+                    .unwrap(),
+            );
+            // Check for the cron timestamp after the silence period
+            new_trigger.next_run_at = schedule.after(&silence).next().unwrap().timestamp_micros();
+        } else {
+            new_trigger.next_run_at += Duration::try_minutes(alert.trigger_condition.silence)
+                .unwrap()
+                .num_microseconds()
+                .unwrap();
+        }
         new_trigger.is_silenced = true;
     } else if alert.trigger_condition.frequency_type == AlertFrequencyType::Cron {
         let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;


### PR DESCRIPTION
Fixes #4155 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of alert triggers for `Cron` frequency types, allowing for more accurate scheduling after silence periods.
- **Bug Fixes**
	- Enhanced functionality for alert rescheduling, ensuring alerts are appropriately silenced and triggered based on their defined schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->