### PR TITLE
fix: plan error in some case

### DIFF
--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -60,6 +60,7 @@ pub async fn search(
 
     // Result caching check start
     let mut origin_sql = in_req.query.sql.clone();
+    origin_sql = origin_sql.replace('\n', " ");
     let is_aggregate = is_aggregate_query(&origin_sql).unwrap_or_default();
     let parsed_sql = match config::meta::sql::Sql::new(&origin_sql) {
         Ok(v) => v,

--- a/src/service/search/datafusion/plan.rs
+++ b/src/service/search/datafusion/plan.rs
@@ -128,7 +128,15 @@ pub fn get_final_plan(
     ))
 }
 
-pub fn get_without_dist_plan(
+pub fn get_empty_partial_plan(plan: &Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    if plan.name() == "ProjectionExec" {
+        get_empty_partial_plan(plan.children().first().unwrap())
+    } else {
+        plan.clone()
+    }
+}
+
+pub fn get_empty_final_plan(
     plan: &Arc<dyn ExecutionPlan>,
     data: &[Vec<RecordBatch>],
     batch_size: usize,


### PR DESCRIPTION
Fix this sql can't work:
```sql
SELECT 
    concat(spath(array_element(cast_to_arr(phases), 1), 'elapsedTime'), ':', spath(array_element(cast_to_arr(phases), 1), 'startTime')) as field_1,
    concat(spath(array_element(cast_to_arr(phases), 2), 'elapsedTime'), ':', spath(array_element(cast_to_arr(phases), 2), 'startTime')) as field_2,
    concat(spath(array_element(cast_to_arr(phases), 3), 'elapsedTime'), ':', spath(array_element(cast_to_arr(phases), 3), 'startTime')) as field_3 
FROM "default1"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced SQL query handling by normalizing newline characters to spaces, improving robustness and reducing potential parsing errors.
	- Introduced new functions for improved execution plan handling: `get_empty_partial_plan` and `get_empty_final_plan`, facilitating more efficient management of execution plans.
  
- **Bug Fixes**
	- Streamlined error handling in query execution by standardizing the retrieval of final plans, ensuring consistent behavior across execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->