### PR TITLE
fix: ingestion time of enrichement table

### DIFF
--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -106,19 +106,7 @@ pub async fn save_enrichment_data(
 
     let mut records = vec![];
     let mut records_size = 0;
-    let timestamp = if !append_data {
-        Utc::now().timestamp_micros()
-    } else {
-        let schema = stream_schema_map.get(stream_name).unwrap();
-        schema
-            .schema()
-            .metadata()
-            .get("created_at")
-            .unwrap()
-            .parse::<i64>()
-            .unwrap()
-    };
-
+    let timestamp = Utc::now().timestamp_micros();
     for mut json_record in payload {
         json_record.insert(
             get_config().common.column_timestamp.clone(),


### PR DESCRIPTION
We can always use `NOW` as the ingestion time, then we can compact the files in this stream, also we use the `BASE_TIME` and `NOW` as time range to query data, it should be fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the logic for saving enrichment data to consistently use the current timestamp, simplifying data handling.

- **Impact**
	- This change may affect how historical timestamps are processed, ensuring all records reflect the current time moving forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->