### PR TITLE
fix: for enrichment table use orginal timestamp

### DIFF
--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -121,16 +121,11 @@ pub async fn save_enrichment_data(
 
     let mut records = vec![];
     let mut records_size = 0;
-
+    let timestamp = Utc::now().timestamp_micros();
     for mut json_record in payload {
-        let timestamp = if json_record.contains_key(&get_config().common.column_timestamp) {
-            json_record
-                .get(&get_config().common.column_timestamp)
-                .unwrap()
-                .as_i64()
-                .unwrap_or_else(|| Utc::now().timestamp_micros())
-        } else {
-            Utc::now().timestamp_micros()
+        let timestamp = match json_record.get(&get_config().common.column_timestamp) {
+            Some(v) => v.as_i64().unwrap_or(timestamp),
+            None => timestamp,
         };
 
         json_record.insert(

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -127,7 +127,6 @@ pub async fn save_enrichment_data(
             Some(v) => v.as_i64().unwrap_or(timestamp),
             None => timestamp,
         };
-
         json_record.insert(
             get_config().common.column_timestamp.clone(),
             json::Value::Number(timestamp.into()),

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -121,8 +121,18 @@ pub async fn save_enrichment_data(
 
     let mut records = vec![];
     let mut records_size = 0;
-    let timestamp = Utc::now().timestamp_micros();
+
     for mut json_record in payload {
+        let timestamp = if json_record.contains_key(&get_config().common.column_timestamp) {
+            json_record
+                .get(&get_config().common.column_timestamp)
+                .unwrap()
+                .as_i64()
+                .unwrap_or_else(|| Utc::now().timestamp_micros() as i64)
+        } else {
+            Utc::now().timestamp_micros() as i64
+        };
+
         json_record.insert(
             get_config().common.column_timestamp.clone(),
             json::Value::Number(timestamp.into()),

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -128,9 +128,9 @@ pub async fn save_enrichment_data(
                 .get(&get_config().common.column_timestamp)
                 .unwrap()
                 .as_i64()
-                .unwrap_or_else(|| Utc::now().timestamp_micros() as i64)
+                .unwrap_or_else(|| Utc::now().timestamp_micros())
         } else {
-            Utc::now().timestamp_micros() as i64
+            Utc::now().timestamp_micros()
         };
 
         json_record.insert(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced timestamp handling for JSON records, allowing the use of user-provided timestamps while ensuring a valid one is assigned.

- **Bug Fixes**
	- Improved robustness and adaptability of timestamp generation for varying input data in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->