### PR TITLE
chore: wording change "logs" to "data"

### DIFF
--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -685,7 +685,7 @@
     "scheduledAlert": "Scheduled alerts",
     "rtAlert": "Real time alerts",
     "noData": "No Data Ingested",
-    "findIngestion": "Find how to ingest logs >>",
+    "findIngestion": "Find how to ingest data >>",
     "ingestionMsg": "Looks like you have not ingested any data to selected organization, there are various ways in which data can be ingested, like fluentbit.",
     "inestedInSearch": "Try Log Search",
     "searchInDemoOrg": "You can explore search capbilities by switching to demo organization, to switch to demo organization, select 'Demo Organization' using organization dropdown on top.We keep ingesting dummy data to Demo Organization."


### PR DESCRIPTION
Changes the word `logs` to `data` to better reflect the data ingest options (it isn't all about logs).

<img width="418" alt="Screenshot 2024-08-12 at 8 18 14 PM" src="https://github.com/user-attachments/assets/2e21b0e4-7051-4ff0-aceb-8a3d0e3fbe71">

<img width="418" alt="Screenshot 2024-08-12 at 8 18 30 PM" src="https://github.com/user-attachments/assets/f5027b99-b2af-4c07-8170-01844ccfcdb5">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated language localization for improved clarity, changing the ingestion prompt from "logs" to "data".
  
- **Chores**
	- Added a newline at the end of the localization file for better formatting compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->