### PR TITLE
fix: auto order by clause removed for sql mode

### DIFF
--- a/tests/ui-testing/playwright-tests/logspage.spec.js
+++ b/tests/ui-testing/playwright-tests/logspage.spec.js
@@ -366,7 +366,7 @@ test.describe("Logs UI testcases", () => {
 
     // Assert that the SQL query is visible
     const expectedQuery =
-      'SELECT * FROM "e2e_automate" ORDER BY _timestamp DESC';
+      'SELECT * FROM "e2e_automate"';
     const text = await page.evaluate(() => {
       const editor = document
         .querySelector('[data-test="logs-search-bar-query-editor"]')

--- a/tests/ui-testing/playwright-tests/logsquickmode.spec.js
+++ b/tests/ui-testing/playwright-tests/logsquickmode.spec.js
@@ -185,7 +185,7 @@ test.describe("Logs Quickmode testcases", () => {
       .click();
     await page.locator('[aria-label="SQL Mode"] > .q-toggle__inner').click();
     await expect(
-      page.locator('[data-test="logs-search-bar-query-editor"]').locator('text=kubernetes_pod_id FROM "e2e_automate" ORDER BY _timestamp DESC')
+      page.locator('[data-test="logs-search-bar-query-editor"]').locator('text=kubernetes_pod_id FROM "e2e_automate"')
     ).toBeVisible();
 
 
@@ -274,7 +274,7 @@ test.describe("Logs Quickmode testcases", () => {
       page
         .locator('[data-test="logs-search-bar-query-editor"]')
         .locator(
-          'text=SELECT kubernetes_pod_id FROM "e2e_automate" ORDER BY _timestamp DESC'
+          'text=SELECT kubernetes_pod_id FROM "e2e_automate"'
         )
     ).toBeVisible();
   });

--- a/tests/ui-testing/playwright-tests/sanity.spec.js
+++ b/tests/ui-testing/playwright-tests/sanity.spec.js
@@ -137,7 +137,7 @@ test.describe("Sanity testcases", () => {
     await expect(
       page
         .locator('[data-test="logs-search-bar-query-editor"]')
-        .getByText(/_timestamp/)
+        .getByText(/job/)
         .first()
     ).toBeVisible();
   });

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -734,12 +734,13 @@ export default defineComponent({
             }
           }
 
-          searchObj.data.query = addOrderByToQuery(
-            searchObj.data.query,
-            store.state.zoConfig.timestamp_column,
-            "DESC",
-            searchObj.data.stream.selectedStream.join(","),
-          );
+          // Removed order by as it creating problem while clicking on the URL generated from the Alert. It's appending order by and that is causing issue if _timestamp column not added in select clause
+          // searchObj.data.query = addOrderByToQuery(
+          //   searchObj.data.query,
+          //   store.state.zoConfig.timestamp_column,
+          //   "DESC",
+          //   searchObj.data.stream.selectedStream.join(","),
+          // );
 
           searchObj.data.editorValue = searchObj.data.query;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted search functionality to prevent issues with results sorting when clicking on alert-generated URLs.

- **Improvements**
	- Modified control flow to enhance the stability of the search results display.
	- Updated test cases to reflect changes in query visibility conditions, allowing for broader match criteria.
	- Simplified test queries by removing unnecessary ordering, improving test flexibility.
	- Shifted focus of sanity test from `_timestamp` to `job`, aligning with changes in expected UI output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->