### PR TITLE
fix: apply functions for routed streams

### DIFF
--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -149,7 +149,8 @@ pub async fn get_stream_functions<'a>(
         if stream_after_functions_map.contains_key(&key)
             || stream_before_functions_map.contains_key(&key)
         {
-            return;
+            // functions for this stream already fetched
+            continue;
         }
         //   let mut _local_trans: Vec<StreamTransform> = vec![];
         // let local_stream_vrl_map;

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -314,7 +314,7 @@ pub async fn ingest(
             );
 
             let fns_length = stream_before_functions_map
-                .get(&routed_stream_name)
+                .get(&main_stream_key)
                 .map(|v| v.len())
                 .unwrap_or_default()
                 + stream_after_functions_map

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -165,9 +165,9 @@ pub async fn ingest(
         } else {
             next_line_is_data = false;
 
-            let key = format!("{org_id}/{}/{stream_name}", StreamType::Logs);
+            let main_stream_key = format!("{org_id}/{}/{stream_name}", StreamType::Logs);
             // Start row based transform before flattening the value
-            if let Some(transforms) = stream_before_functions_map.get(&key) {
+            if let Some(transforms) = stream_before_functions_map.get(&main_stream_key) {
                 if !transforms.is_empty() {
                     let mut ret_value = value.clone();
                     ret_value = crate::service::ingestion::apply_stream_functions(
@@ -201,6 +201,7 @@ pub async fn ingest(
             // JSON Flattening
             let mut value = flatten::flatten_with_level(value, cfg.limit.ingest_flatten_level)?;
 
+            let mut routed_stream_name = stream_name.clone();
             // Start re-routing if exists
             if let Some(routing) = stream_routing_map.get(&stream_name) {
                 if !routing.is_empty() {
@@ -214,13 +215,15 @@ pub async fn ingest(
                             }
                         }
                         if is_routed && !val.is_empty() {
-                            stream_name = route.destination.clone();
+                            routed_stream_name = route.destination.clone();
                             break;
                         }
                     }
                 }
             }
             // End re-routing
+
+            let key = format!("{org_id}/{}/{routed_stream_name}", StreamType::Logs);
 
             // Start row based transform
             if let Some(transforms) = stream_after_functions_map.get(&key) {
@@ -231,14 +234,14 @@ pub async fn ingest(
                         ret_value,
                         &stream_vrl_map,
                         org_id,
-                        &stream_name,
+                        &routed_stream_name,
                         &mut runtime,
                     )?;
 
                     if ret_value.is_null() || !ret_value.is_object() {
                         bulk_res.errors = true;
                         add_record_status(
-                            stream_name.clone(),
+                            routed_stream_name.clone(),
                             &doc_id,
                             action.clone(),
                             Some(value),
@@ -265,7 +268,7 @@ pub async fn ingest(
                 local_val.insert("_id".to_string(), json::Value::String(doc_id.to_owned()));
             }
 
-            if let Some(fields) = user_defined_schema_map.get(&stream_name) {
+            if let Some(fields) = user_defined_schema_map.get(&routed_stream_name) {
                 local_val = crate::service::logs::refactor_map(local_val, fields);
             }
 
@@ -276,7 +279,7 @@ pub async fn ingest(
                     Err(_e) => {
                         bulk_res.errors = true;
                         add_record_status(
-                            stream_name.clone(),
+                            routed_stream_name.clone(),
                             &doc_id,
                             action.clone(),
                             Some(value),
@@ -295,7 +298,7 @@ pub async fn ingest(
                 bulk_res.errors = true;
                 let failure_reason = Some(get_upto_discard_error().to_string());
                 add_record_status(
-                    stream_name.clone(),
+                    routed_stream_name.clone(),
                     &doc_id,
                     action.clone(),
                     Some(value),
@@ -311,7 +314,7 @@ pub async fn ingest(
             );
 
             let fns_length = stream_before_functions_map
-                .get(&key)
+                .get(&routed_stream_name)
                 .map(|v| v.len())
                 .unwrap_or_default()
                 + stream_after_functions_map
@@ -320,7 +323,7 @@ pub async fn ingest(
                     .unwrap_or_default();
 
             let (ts_data, fn_num) = json_data_by_stream
-                .entry(stream_name.clone())
+                .entry(routed_stream_name.clone())
                 .or_insert((Vec::new(), None));
             ts_data.push((timestamp, local_val));
             *fn_num = Some(fns_length);

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -62,7 +62,7 @@ pub async fn ingest(
     let mut need_usage_report = true;
 
     // check stream
-    let mut stream_name = if cfg.common.skip_formatting_stream_name {
+    let stream_name = if cfg.common.skip_formatting_stream_name {
         get_formatted_stream_name(StreamParams::new(org_id, in_stream_name, StreamType::Logs))
             .await?
     } else {

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -36,6 +36,7 @@ use prost::Message;
 
 use crate::{
     common::meta::{
+        functions::{StreamTransform, VRLResultResolver},
         ingestion::{IngestionStatus, StreamStatus},
         stream::StreamParams,
     },
@@ -71,15 +72,10 @@ pub async fn handle_grpc_request(
     let min_ts = (Utc::now() - Duration::try_hours(cfg.limit.ingest_allowed_upto).unwrap())
         .timestamp_micros();
 
-    // Start Register Transforms for stream
     let mut runtime = crate::service::ingestion::init_functions_runtime();
-    let (before_local_trans, after_local_trans, stream_vrl_map) =
-        crate::service::ingestion::register_stream_functions(
-            org_id,
-            &StreamType::Logs,
-            &stream_name,
-        );
-    // End Register Transforms for stream
+    let mut stream_vrl_map: HashMap<String, VRLResultResolver> = HashMap::new();
+    let mut stream_before_functions_map: HashMap<String, Vec<StreamTransform>> = HashMap::new();
+    let mut stream_after_functions_map: HashMap<String, Vec<StreamTransform>> = HashMap::new();
 
     let mut stream_params = vec![StreamParams::new(org_id, &stream_name, StreamType::Logs)];
 
@@ -110,6 +106,16 @@ pub async fn handle_grpc_request(
     )
     .await;
     // End get user defined schema
+
+    // Start Register functions for stream
+    crate::service::ingestion::get_stream_functions(
+        &stream_params,
+        &mut stream_before_functions_map,
+        &mut stream_after_functions_map,
+        &mut stream_vrl_map,
+    )
+    .await;
+    // End Register functions for index
 
     let mut stream_status = StreamStatus::new(&stream_name);
     let mut json_data_by_stream = HashMap::new();
@@ -196,19 +202,22 @@ pub async fn handle_grpc_request(
                                 .into();
                     }
                 };
+                let main_stream_key = format!("{org_id}/{}/{stream_name}", StreamType::Logs);
 
-                // Start row based transform
-                if !before_local_trans.is_empty() {
-                    rec = crate::service::ingestion::apply_stream_functions(
-                        &before_local_trans,
-                        rec,
-                        &stream_vrl_map,
-                        org_id,
-                        &stream_name,
-                        &mut runtime,
-                    )?;
+                // Start row based transform before flattening the value
+                if let Some(transforms) = stream_before_functions_map.get(&main_stream_key) {
+                    if !transforms.is_empty() {
+                        rec = crate::service::ingestion::apply_stream_functions(
+                            transforms,
+                            rec,
+                            &stream_vrl_map,
+                            org_id,
+                            &stream_name,
+                            &mut runtime,
+                        )?;
+                    }
                 }
-                // end row based transform
+                // end row based transformation
 
                 // flattening
                 rec = flatten::flatten_with_level(rec, cfg.limit.ingest_flatten_level)?;
@@ -235,19 +244,13 @@ pub async fn handle_grpc_request(
                 }
                 // End re-routing
 
-                let mut function_no = before_local_trans.len() + after_local_trans.len();
+                let key = format!("{org_id}/{}/{routed_stream_name}", StreamType::Logs);
+
                 // Start row based transform
-                if routed_stream_name.ne(&stream_name) {
-                    let (_, after_local_trans, stream_vrl_map) =
-                        crate::service::ingestion::register_stream_functions(
-                            org_id,
-                            &StreamType::Logs,
-                            &routed_stream_name,
-                        );
-                    function_no = before_local_trans.len() + after_local_trans.len();
-                    if !after_local_trans.is_empty() {
+                if let Some(transforms) = stream_after_functions_map.get(&key) {
+                    if !transforms.is_empty() {
                         rec = crate::service::ingestion::apply_stream_functions(
-                            &after_local_trans,
+                            transforms,
                             rec,
                             &stream_vrl_map,
                             org_id,
@@ -255,15 +258,6 @@ pub async fn handle_grpc_request(
                             &mut runtime,
                         )?;
                     }
-                } else if !after_local_trans.is_empty() {
-                    rec = crate::service::ingestion::apply_stream_functions(
-                        &after_local_trans,
-                        rec,
-                        &stream_vrl_map,
-                        org_id,
-                        &routed_stream_name,
-                        &mut runtime,
-                    )?;
                 }
                 // end row based transform
 
@@ -277,6 +271,14 @@ pub async fn handle_grpc_request(
                     local_val = crate::service::logs::refactor_map(local_val, fields);
                 }
 
+                let function_no = stream_before_functions_map
+                    .get(&main_stream_key)
+                    .map(|v| v.len())
+                    .unwrap_or_default()
+                    + stream_after_functions_map
+                        .get(&key)
+                        .map(|v| v.len())
+                        .unwrap_or_default();
                 let (ts_data, fn_num) = json_data_by_stream
                     .entry(routed_stream_name.clone())
                     .or_insert((Vec::new(), None));


### PR DESCRIPTION
Fixes #4129 

- Current workflow for the pipelining -
ingestion to the main stream -> apply functions of main stream with `apply_before_flattening` flag -> flatten data -> routing -> apply rest of the functions of the routed stream. `apply_before_flattening` functions will be ignored for the routed stream because data is already flattened before routing.
- Fix of bug: For non-bulk apis for log ingestion, if the first record is routed (i.e. the routing condition matched), the rest of the records also are routed even if the condition does not match.
- Fix of bug: For json log ingestion, routing was happening before flattening of stream data, this PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced stream processing functionality with improved control flow and routing logic.
	- Introduced structured management of stream transformations using HashMaps for better clarity and maintainability.

- **Bug Fixes**
	- Improved robustness of stream processing by ensuring all relevant streams are processed without premature termination.

- **Chores**
	- Renamed variables for clarity regarding their roles in stream processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->