### PR TITLE
feat: impl #4200 support skip format stream name

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -719,8 +719,6 @@ pub struct Common {
     pub schema_cache_compress_enabled: bool,
     #[env_config(name = "ZO_SKIP_FORMAT_STREAM_NAME", default = false)]
     pub skip_formatting_stream_name: bool,
-    #[env_config(name = "ZO_SKIP_FORMAT_BULK_STREAM_NAME", default = false)]
-    pub skip_formatting_bulk_stream_name: bool,
     #[env_config(name = "ZO_BULK_RESPONSE_INCLUDE_ERRORS_ONLY", default = false)]
     pub bulk_api_response_errors_only: bool,
     #[env_config(name = "ZO_ALLOW_USER_DEFINED_SCHEMAS", default = false)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -717,6 +717,8 @@ pub struct Common {
     pub report_server_skip_tls_verify: bool,
     #[env_config(name = "ZO_SCHEMA_CACHE_COMPRESS_ENABLED", default = false)]
     pub schema_cache_compress_enabled: bool,
+    #[env_config(name = "ZO_SKIP_FORMAT_STREAM_NAME", default = false)]
+    pub skip_formatting_stream_name: bool,
     #[env_config(name = "ZO_SKIP_FORMAT_BULK_STREAM_NAME", default = false)]
     pub skip_formatting_bulk_stream_name: bool,
     #[env_config(name = "ZO_BULK_RESPONSE_INCLUDE_ERRORS_ONLY", default = false)]

--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -97,7 +97,7 @@ async fn settings(
     req: HttpRequest,
 ) -> Result<HttpResponse, Error> {
     let (org_id, mut stream_name) = path.into_inner();
-    if !config::get_config().common.skip_formatting_bulk_stream_name {
+    if !config::get_config().common.skip_formatting_stream_name {
         stream_name = format_stream_name(&stream_name);
     }
     let query = web::Query::<HashMap<String, String>>::from_query(req.query_string()).unwrap();

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -102,7 +102,7 @@ pub async fn ingest(
             }
             (action, stream_name, doc_id) = ret.unwrap();
 
-            if !cfg.common.skip_formatting_bulk_stream_name {
+            if !cfg.common.skip_formatting_stream_name {
                 stream_name = format_stream_name(&stream_name);
             }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -13,8 +13,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use infra::errors::Result;
 use once_cell::sync::Lazy;
 use regex::Regex;
+
+use crate::common::meta::stream::StreamParams;
 
 pub mod alerts;
 pub mod compact;
@@ -58,6 +61,17 @@ pub fn format_partition_key(input: &str) -> String {
         }
     }
     output
+}
+
+// format stream name
+pub async fn get_formatted_stream_name(params: StreamParams) -> Result<String> {
+    let stream_name = params.stream_name.to_string();
+    let schema = infra::schema::get_cache(&params.org_id, &stream_name, params.stream_type).await?;
+    Ok(if schema.fields_map().is_empty() {
+        format_stream_name(&stream_name)
+    } else {
+        stream_name
+    })
 }
 
 // format stream name


### PR DESCRIPTION
impl #4200 

If you want to keep old stream name, just set the new ENV:

```
ZO_SKIP_FORMAT_STREAM_NAME=true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new configuration option to control stream name formatting behavior.
  - Added an asynchronous function to enhance the functionality of stream name formatting based on schema.

- **Improvements**
  - Stream name handling is now more flexible, allowing conditional formatting based on the new configuration setting.
  - Updated logic for ingesting functions to utilize the new configuration for better stream name processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->