### PR TITLE
refactor: follow OTel service semconv naming

### DIFF
--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -49,6 +49,7 @@ use crate::{
 };
 
 const SERVICE_NAME: &str = "service.name";
+const SERVICE_PREFIX: &str = "service.";
 const SERVICE: &str = "service";
 
 pub async fn logs_proto_handler(
@@ -186,27 +187,13 @@ pub async fn logs_json_handler(
                 let attributes = resource.get("attributes").unwrap().as_array().unwrap();
                 for res_attr in attributes {
                     let local_attr = res_attr.as_object().unwrap();
-                    if local_attr
-                        .get("key")
-                        .unwrap()
-                        .as_str()
-                        .unwrap()
-                        .eq(SERVICE_NAME)
-                    {
-                        let loc_service_name =
-                            local_attr.get("value").unwrap().as_object().unwrap();
-                        for item in loc_service_name {
-                            service_att_map.insert(SERVICE_NAME.to_string(), item.1.clone());
-                        }
+                    let res_attr_key = local_attr.get("key").unwrap().as_str().unwrap();
+                    let res_attr_value = get_val_for_attr(local_attr.get("value").unwrap());
+                    if res_attr_key.starts_with(SERVICE_PREFIX) {
+                        service_att_map.insert(res_attr_key.to_string(), res_attr_value);
                     } else {
-                        service_att_map.insert(
-                            format!(
-                                "{}_{}",
-                                SERVICE,
-                                local_attr.get("key").unwrap().as_str().unwrap()
-                            ),
-                            get_val_for_attr(local_attr.get("value").unwrap()),
-                        );
+                        service_att_map
+                            .insert(format!("{}_{}", SERVICE, res_attr_key), res_attr_value);
                     }
                 }
             }

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -64,6 +64,7 @@ const PARENT_SPAN_ID: &str = "reference.parent_span_id";
 const PARENT_TRACE_ID: &str = "reference.parent_trace_id";
 const REF_TYPE: &str = "reference.ref_type";
 const SERVICE_NAME: &str = "service.name";
+const SERVICE_PREFIX: &str = "service.";
 const SERVICE: &str = "service";
 const BLOCK_FIELDS: [&str; 4] = ["_timestamp", "duration", "start_time", "end_time"];
 
@@ -131,17 +132,16 @@ pub async fn handle_trace_request(
         let resource = res_span.resource.unwrap();
 
         for res_attr in resource.attributes {
-            if res_attr.key.eq(SERVICE_NAME) {
-                let loc_service_name = get_val(&res_attr.value.as_ref());
-                if let Some(name) = loc_service_name.as_str() {
-                    service_name = name.to_string();
-                    service_att_map.insert(res_attr.key, loc_service_name);
+            let res_attr_value = get_val(&res_attr.value.as_ref());
+            if res_attr.key.starts_with(SERVICE_PREFIX) {
+                if res_attr.key.eq(SERVICE_NAME)
+                    && let Some(service_name_value) = res_attr_value.as_str()
+                {
+                    service_name = service_name_value.to_string();
                 }
+                service_att_map.insert(res_attr.key, loc_service_name);
             } else {
-                service_att_map.insert(
-                    format!("{}.{}", SERVICE, res_attr.key),
-                    get_val(&res_attr.value.as_ref()),
-                );
+                service_att_map.insert(format!("{}.{}", SERVICE, res_attr.key), res_attr_value);
             }
         }
         let inst_resources = res_span.scope_spans;


### PR DESCRIPTION
According to the [Otel Service Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/attributes-registry/service/), attributes like `service.instance.id`, `service.namespace`, and `service.version` should not have the `service.` prefix added.

So we should avoid adding the `service.` prefix to any attributes that already start with `service.`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced processing of service attributes for logs and traces, allowing broader attribute handling.
	- Improved logic for extracting and inserting service attributes, making it more adaptable and readable.

- **Bug Fixes**
	- Streamlined control flow for handling service names and attributes, reducing redundancy and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->