### PR TITLE
fix: merge plan panic

### DIFF
--- a/src/handler/grpc/request/ingest.rs
+++ b/src/handler/grpc/request/ingest.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use actix_web::http::StatusCode;
 use async_trait::async_trait;
 use config::utils::json;
 use proto::cluster_rpc::{ingest_server::Ingest, IngestionRequest, IngestionResponse, StreamType};
@@ -64,35 +65,35 @@ impl Ingest for Ingester {
                             })
                             .collect()
                     });
-                crate::service::enrichment_table::save_enrichment_data(
+                match crate::service::enrichment_table::save_enrichment_data(
                     &org_id,
                     &stream_name,
                     json_records,
                     true,
                 )
                 .await
-                .map_or_else(
-                    |e| {
-                        Err(anyhow::anyhow!(
-                            "Internal gPRC ingestion service errors saving enrichment data: {}",
-                            e.to_string()
-                        ))
-                    },
-                    |res| {
-                        if res.status().as_u16() != 200 {
+                {
+                    Err(e) => Err(anyhow::anyhow!(
+                        "Internal gPRC ingestion service errors saving enrichment data: {}",
+                        e.to_string()
+                    )),
+                    Ok(res) => {
+                        if res.status() != StatusCode::OK {
+                            let status: StatusCode = res.status();
                             log::error!(
-                                "Internal gPRC ingestion service errors saving enrichment data: {:?}",
-                                res
+                                "Internal gPRC ingestion service errors saving enrichment data: code: {}, body: {:?}",
+                                status,
+                                res.into_body()
                             );
                             Err(anyhow::anyhow!(
-                                "Internal gPRC ingestion service errors saving enrichment data: {}",
-                                res.error().map_or("".to_string(), |err| err.to_string())
+                                "Internal gPRC ingestion service errors saving enrichment data: http code {}",
+                                status
                             ))
                         } else {
                             Ok(())
                         }
-                    },
-                )
+                    }
+                }
             }
             _ => Err(anyhow::anyhow!(
                 "Internal gPRC ingestion service currently only supports Logs and EnrichmentTables",

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -565,60 +565,70 @@ async fn handle_derived_stream_triggers(
             .into_iter()
             .map(json::Value::Object)
             .collect::<Vec<_>>();
-        // Ingest result into destination stream
-        let (org_id, stream_name, stream_type): (String, String, i32) = {
-            (
-                derived_stream.destination.org_id.into(),
-                derived_stream.destination.stream_name.into(),
-                cluster_rpc::StreamType::from(derived_stream.destination.stream_type).into(),
-            )
-        };
-        let req = cluster_rpc::IngestionRequest {
-            org_id: org_id.clone(),
-            stream_name: stream_name.clone(),
-            stream_type,
-            data: Some(cluster_rpc::IngestionData::from(local_val)),
-            ingestion_type: Some(cluster_rpc::IngestionType::Json.into()), /* TODO(taiming): finalize IngestionType for derived_stream */
-        };
-        match ingestion_service::ingest(&org_id, req).await {
-            Ok(resp) if resp.status_code == 200 => {
-                log::info!(
-                    "DerivedStream result ingested to destination {org_id}/{stream_name}/{stream_type}",
-                );
-                db::scheduler::update_trigger(new_trigger).await?;
-            }
-            error => {
-                let err = error.map_or_else(|e| e.to_string(), |resp| resp.message);
-                log::error!(
-                    "Error in ingesting DerivedStream result to destination {:?}, org: {}, module_key: {}",
-                    err,
-                    new_trigger.org,
-                    new_trigger.module_key
-                );
-                if trigger.retries + 1 >= get_config().limit.scheduler_max_retries {
-                    // It has been tried the maximum time, just update the
-                    // next_run_at to the next expected trigger time
-                    log::debug!(
-                        "This DerivedStream trigger: {}/{} has reached maximum retries",
-                        &new_trigger.org,
-                        &new_trigger.module_key
+        if local_val.is_empty() {
+            log::debug!(
+                "DerivedStream conditions not satisfied, org: {}, module_key: {}",
+                &new_trigger.org,
+                &new_trigger.module_key
+            );
+            db::scheduler::update_trigger(new_trigger).await?;
+            trigger_data_stream.status = TriggerDataStatus::Completed;
+        } else {
+            // Ingest result into destination stream
+            let (org_id, stream_name, stream_type): (String, String, i32) = {
+                (
+                    derived_stream.destination.org_id.into(),
+                    derived_stream.destination.stream_name.into(),
+                    cluster_rpc::StreamType::from(derived_stream.destination.stream_type).into(),
+                )
+            };
+            let req = cluster_rpc::IngestionRequest {
+                org_id: org_id.clone(),
+                stream_name: stream_name.clone(),
+                stream_type,
+                data: Some(cluster_rpc::IngestionData::from(local_val)),
+                ingestion_type: Some(cluster_rpc::IngestionType::Json.into()), /* TODO(taiming): finalize IngestionType for derived_stream */
+            };
+            match ingestion_service::ingest(&org_id, req).await {
+                Ok(resp) if resp.status_code == 200 => {
+                    log::info!(
+                        "DerivedStream result ingested to destination {org_id}/{stream_name}/{stream_type}",
                     );
                     db::scheduler::update_trigger(new_trigger).await?;
-                } else {
-                    // Otherwise update its status only
-                    db::scheduler::update_status(
-                        &new_trigger.org,
-                        new_trigger.module,
-                        &new_trigger.module_key,
-                        db::scheduler::TriggerStatus::Waiting,
-                        trigger.retries + 1,
-                    )
-                    .await?;
                 }
-                trigger_data_stream.status = TriggerDataStatus::Failed;
-                trigger_data_stream.error = Some(format!(
-                    "error saving enrichment table for DerivedStream: {err}"
-                ));
+                error => {
+                    let err = error.map_or_else(|e| e.to_string(), |resp| resp.message);
+                    log::error!(
+                        "Error in ingesting DerivedStream result to destination {:?}, org: {}, module_key: {}",
+                        err,
+                        new_trigger.org,
+                        new_trigger.module_key
+                    );
+                    if trigger.retries + 1 >= get_config().limit.scheduler_max_retries {
+                        // It has been tried the maximum time, just update the
+                        // next_run_at to the next expected trigger time
+                        log::debug!(
+                            "This DerivedStream trigger: {}/{} has reached maximum retries",
+                            &new_trigger.org,
+                            &new_trigger.module_key
+                        );
+                        db::scheduler::update_trigger(new_trigger).await?;
+                    } else {
+                        // Otherwise update its status only
+                        db::scheduler::update_status(
+                            &new_trigger.org,
+                            new_trigger.module,
+                            &new_trigger.module_key,
+                            db::scheduler::TriggerStatus::Waiting,
+                            trigger.retries + 1,
+                        )
+                        .await?;
+                    }
+                    trigger_data_stream.status = TriggerDataStatus::Failed;
+                    trigger_data_stream.error = Some(format!(
+                        "error saving enrichment table for DerivedStream: {err}"
+                    ));
+                }
             }
         }
     } else {

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -42,7 +42,7 @@ use infra::{
 };
 
 use crate::{
-    common::meta::{self, http::HttpResponse as MetaHttpResponse, stream::SchemaRecords},
+    common::meta::{http::HttpResponse as MetaHttpResponse, stream::SchemaRecords},
     service::{
         compact::retention,
         db::{self, enrichment_table},
@@ -172,12 +172,10 @@ pub async fn save_enrichment_data(
     }
 
     if records.is_empty() {
-        return Ok(
-            HttpResponse::BadRequest().json(meta::http::HttpResponse::error(
-                http::StatusCode::BAD_REQUEST.into(),
-                "No records to ingest for look up table".to_string(),
-            )),
-        );
+        return Ok(HttpResponse::Ok().json(MetaHttpResponse::error(
+            StatusCode::OK.into(),
+            "Saved enrichment table".to_string(),
+        )));
     }
 
     let schema = stream_schema_map

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -28,7 +28,7 @@ use config::{
         },
     },
     metrics,
-    utils::{inverted_index::split_token, json, record_batch_ext::format_recordbatch_by_schema},
+    utils::{inverted_index::split_token, json},
     INDEX_FIELD_NAME_FOR_ALL, QUERY_WITH_NO_LIMIT,
 };
 use hashbrown::{HashMap, HashSet};
@@ -49,7 +49,12 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::{
     common::infra::cluster as infra_cluster,
-    service::{file_list, search::sql::RE_SELECT_WILDCARD},
+    service::{
+        file_list,
+        search::{
+            generate_search_schema, generate_select_start_search_schema, sql::RE_SELECT_WILDCARD,
+        },
+    },
 };
 
 pub mod cacher;
@@ -705,74 +710,25 @@ async fn merge_grpc_result(
         }
     }
 
-    // convert select field to schema::Field
-    let select_fields = sql
-        .meta
-        .fields
-        .iter()
-        .filter_map(|f| {
-            sql.schema
-                .field_with_name(f)
-                .ok()
-                .map(|f| Arc::new(f.clone()))
-        })
-        .collect::<Vec<_>>();
-
-    // format recordbatch with same schema
-    let mut schema_latest = Arc::new(sql.schema.clone());
+    // get the using schema
     let select_wildcard = RE_SELECT_WILDCARD.is_match(sql.origin_sql.as_str());
-    if !batches.is_empty() {
-        let mut schema = batches[0].schema();
-        let schema_fields = schema
-            .fields()
-            .iter()
-            .map(|f| f.name())
-            .collect::<HashSet<_>>();
-        let mut new_fields = HashSet::new();
-        let mut need_format = false;
-        if select_wildcard {
-            for field in select_fields {
-                if !schema_fields.contains(field.name()) {
-                    new_fields.insert(field.clone());
-                    need_format = true;
-                }
-            }
-        }
-        for batch in batches.iter() {
-            if batch.num_rows() == 0 {
-                continue;
-            }
-            if batch.schema().fields() != schema.fields() {
-                need_format = true;
-            }
-            for field in batch.schema().fields() {
-                if !schema_fields.contains(field.name()) {
-                    new_fields.insert(field.clone());
-                }
-            }
-        }
-        drop(schema_fields);
-        if !new_fields.is_empty() {
-            need_format = true;
-            let new_schema = Schema::new(new_fields.into_iter().collect::<Vec<_>>());
-            schema =
-                Arc::new(Schema::try_merge(vec![schema.as_ref().clone(), new_schema]).unwrap());
-        }
-        if need_format {
-            let mut new_batches = Vec::new();
-            for batch in batches {
-                if batch.num_rows() == 0 {
-                    continue;
-                }
-                new_batches.push(format_recordbatch_by_schema(schema.clone(), batch));
-            }
-            batches = new_batches;
-        }
-        // reset schema_latest only when select wildcard
-        if select_wildcard {
-            schema_latest = schema.clone();
-        }
+    let schema_latest = Arc::new(sql.schema.clone());
+    let stream_settings = unwrap_stream_settings(&schema_latest).unwrap_or_default();
+    let defined_schema_fields = stream_settings.defined_schema_fields.unwrap_or_default();
+    let mut schema_latest_map = HashMap::with_capacity(schema_latest.fields().len());
+    for field in schema_latest.fields() {
+        schema_latest_map.insert(field.name(), field);
     }
+    let (schema_latest, _) = if select_wildcard {
+        generate_select_start_search_schema(
+            &sql,
+            schema_latest.clone(),
+            &schema_latest_map,
+            &defined_schema_fields,
+        )?
+    } else {
+        generate_search_schema(&sql, schema_latest.clone(), &schema_latest_map)?
+    };
 
     // only final phase need merge partitions
     if !is_final_phase {

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -16,6 +16,7 @@
 use std::sync::Arc;
 
 use ::datafusion::arrow::{ipc, record_batch::RecordBatch};
+use arrow_schema::Schema;
 use config::{
     cluster::LOCAL_NODE,
     get_config,
@@ -23,8 +24,10 @@ use config::{
         search::ScanStats,
         stream::{FileKey, StreamType},
     },
+    utils::record_batch_ext::format_recordbatch_by_schema,
 };
 use futures::future::try_join_all;
+use hashbrown::HashSet;
 use infra::errors::{Error, ErrorCodes};
 use proto::cluster_rpc;
 use tracing::Instrument;
@@ -137,6 +140,47 @@ pub async fn search(
         results.extend(batches.into_iter().flatten().filter(|v| v.num_rows() > 0));
     }
 
+    // format recordbatch with same schema
+    if !results.is_empty() {
+        let mut schema = results[0].schema();
+        let schema_fields = schema
+            .fields()
+            .iter()
+            .map(|f| f.name())
+            .collect::<HashSet<_>>();
+        let mut new_fields = HashSet::new();
+        let mut need_format = false;
+        for batch in results.iter() {
+            if batch.num_rows() == 0 {
+                continue;
+            }
+            if batch.schema().fields() != schema.fields() {
+                need_format = true;
+            }
+            for field in batch.schema().fields() {
+                if !schema_fields.contains(field.name()) {
+                    new_fields.insert(field.clone());
+                }
+            }
+        }
+        drop(schema_fields);
+        if !new_fields.is_empty() {
+            need_format = true;
+            let new_schema = Schema::new(new_fields.into_iter().collect::<Vec<_>>());
+            schema =
+                Arc::new(Schema::try_merge(vec![schema.as_ref().clone(), new_schema]).unwrap());
+        }
+        if need_format {
+            let mut new_batches = Vec::new();
+            for batch in results {
+                if batch.num_rows() == 0 {
+                    continue;
+                }
+                new_batches.push(format_recordbatch_by_schema(schema.clone(), batch));
+            }
+            results = new_batches;
+        }
+    }
     log::info!("[trace_id {trace_id}] in node merge task finish");
 
     // clear session data

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -228,6 +228,7 @@ pub async fn search(
             .cloned()
             .unwrap_or_default();
         let schema = schema.with_metadata(std::collections::HashMap::new());
+        let schema = Arc::new(schema);
         let sql = sql.clone();
         let session = config::meta::search::Session {
             id: format!("{trace_id}-{ver}"),
@@ -245,12 +246,12 @@ pub async fn search(
         let (schema, diff_fields) = if select_wildcard {
             generate_select_start_search_schema(
                 &sql,
-                &schema,
+                schema.clone(),
                 &schema_latest_map,
                 &defined_schema_fields,
             )?
         } else {
-            generate_search_schema(&sql, &schema, &schema_latest_map)?
+            generate_search_schema(&sql, schema.clone(), &schema_latest_map)?
         };
 
         let datafusion_span = info_span!(

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -245,6 +245,7 @@ pub async fn search_parquet(
         let schema = schema_versions[ver]
             .clone()
             .with_metadata(std::collections::HashMap::new());
+        let schema = Arc::new(schema);
         let sql = sql.clone();
         let session = config::meta::search::Session {
             id: format!("{trace_id}-wal-{ver}"),
@@ -262,12 +263,12 @@ pub async fn search_parquet(
         let (schema, diff_fields) = if select_wildcard {
             generate_select_start_search_schema(
                 &sql,
-                &schema,
+                schema.clone(),
                 &schema_latest_map,
                 &defined_schema_fields,
             )?
         } else {
-            generate_search_schema(&sql, &schema, &schema_latest_map)?
+            generate_search_schema(&sql, schema.clone(), &schema_latest_map)?
         };
 
         let datafusion_span = info_span!(
@@ -469,12 +470,12 @@ pub async fn search_memtable(
         let (schema, diff_fields) = if select_wildcard {
             generate_select_start_search_schema(
                 &sql,
-                &schema,
+                schema.clone(),
                 &schema_latest_map,
                 &defined_schema_fields,
             )?
         } else {
-            generate_search_schema(&sql, &schema, &schema_latest_map)?
+            generate_search_schema(&sql, schema.clone(), &schema_latest_map)?
         };
 
         for batch in record_batches.iter_mut() {


### PR DESCRIPTION
## merge plan panic

The reason is in some case the plan is difference. if there is only one partition and that is a simple query then there is no `sort` and simple add a new `Projection` plan, and it is difference with other nodes which have multiple partitions, then the merge got RecordBatch mismatch.

The solution have two:
- Format all the RecordBatch before merge using the Schema from partial plan. 
    - I used it in this PR
- Use `EmptyTable` to generate plan then we can guarantee the plan is same, then replace the `EmptyTable` to `MemoryTable` or `ParquetTable` in different node based on the data. 
    - We will use this in the next big release

By the way:

Also updated a logic of derived schema

- [x] If the evolution has no record will not fire the ingestion grpc request or will got error and retry, i also update the log to print the error information.