### PR TITLE
fix: use last triggered time for derived stream period to prevent missing data

### DIFF
--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -116,6 +116,7 @@ pub struct Trigger {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_time: Option<i64>,
     pub retries: i32,
+    pub data: String,
 }
 
 /// Initializes the scheduler - creates table and index

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -225,7 +225,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         let pool = CLIENT.clone();
         sqlx::query(
             r#"UPDATE scheduled_jobs
-SET status = ?, retries = ?, next_run_at = ?, is_realtime = ?, is_silenced = ?
+SET status = ?, retries = ?, next_run_at = ?, is_realtime = ?, is_silenced = ?, data = ?
 WHERE org = ? AND module_key = ? AND module = ?;"#,
         )
         .bind(trigger.status)
@@ -233,6 +233,7 @@ WHERE org = ? AND module_key = ? AND module = ?;"#,
         .bind(trigger.next_run_at)
         .bind(trigger.is_realtime)
         .bind(trigger.is_silenced)
+        .bind(&trigger.data)
         .bind(&trigger.org)
         .bind(&trigger.module_key)
         .bind(&trigger.module)
@@ -480,7 +481,7 @@ async fn add_data_column() -> Result<()> {
     log::info!("[MYSQL] Adding data column to scheduled_jobs table");
     let pool = CLIENT.clone();
     if let Err(e) =
-        sqlx::query(r#"ALTER TABLE scheduled_jobs ADD COLUMN data TEXT NOT NULL DEFAULT '';"#)
+        sqlx::query(r#"ALTER TABLE scheduled_jobs ADD COLUMN data TEXT NOT NULL DEFAULT ('');"#)
             .execute(&pool)
             .await
     {

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -58,12 +58,21 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     end_time     BIGINT,
     retries      INT not null,
     next_run_at  BIGINT not null,
-    created_at   TIMESTAMP default CURRENT_TIMESTAMP
+    created_at   TIMESTAMP default CURRENT_TIMESTAMP,
+    data         LONGTEXT not null
 );
             "#,
         )
         .execute(&pool)
         .await?;
+
+        // create data column for old version <= 0.10.9
+        let has_data_column = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='scheduled_jobs' AND column_name='data';")
+            .fetch_one(&pool)
+            .await?;
+        if has_data_column == 0 {
+            add_data_column().await?;
+        }
         Ok(())
     }
 
@@ -119,8 +128,8 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
 
         if let Err(e) = sqlx::query(
             r#"
-INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ? , ?);
+INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time, data)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ? , ?, ?);
         "#,
         )
         .bind(&trigger.org)
@@ -133,6 +142,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         .bind(trigger.next_run_at)
         .bind(0)
         .bind(0)
+        .bind(&trigger.data)
         .execute(&mut *tx)
         .await
         {
@@ -464,4 +474,21 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
 
         Ok(())
     }
+}
+
+async fn add_data_column() -> Result<()> {
+    log::info!("[MYSQL] Adding data column to scheduled_jobs table");
+    let pool = CLIENT.clone();
+    if let Err(e) =
+        sqlx::query(r#"ALTER TABLE scheduled_jobs ADD COLUMN data TEXT NOT NULL DEFAULT '';"#)
+            .execute(&pool)
+            .await
+    {
+        if !e.to_string().contains("Duplicate column name") {
+            // Check for the specific MySQL error code for duplicate column
+            log::error!("[MYSQL] Unexpected error in adding column: {}", e);
+            return Err(e.into());
+        }
+    }
+    Ok(())
 }

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -58,12 +58,21 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     end_time     BIGINT,
     retries      INT not null,
     next_run_at  BIGINT not null,
-    created_at   TIMESTAMP default CURRENT_TIMESTAMP
+    created_at   TIMESTAMP default CURRENT_TIMESTAMP,
+    data         TEXT not null
 );
             "#,
         )
         .execute(&pool)
         .await?;
+
+        // create start_dt column for old version <= 0.9.2
+        let has_data_column = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='scheduled_jobs' AND column_name='data';")
+            .fetch_one(&pool)
+            .await?;
+        if has_data_column == 0 {
+            add_data_column().await?;
+        }
         Ok(())
     }
 
@@ -116,8 +125,8 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs WHERE module = $1;"#,
 
         if let Err(e) = sqlx::query(
             r#"
-INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time, data)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
     ON CONFLICT DO NOTHING;
         "#,
         )
@@ -131,6 +140,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         .bind(trigger.next_run_at)
         .bind(0)
         .bind(0)
+        .bind(&trigger.data)
         .execute(&mut *tx)
         .await
         {
@@ -426,4 +436,19 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs;"#,
 
         Ok(())
     }
+}
+
+async fn add_data_column() -> Result<()> {
+    log::info!("[POSTGRES] Adding data column to scheduled_jobs table");
+    let pool = CLIENT.clone();
+    if let Err(e) = sqlx::query(
+        r#"ALTER TABLE scheduled_jobs ADD COLUMN IF NOT EXISTS data TEXT NOT NULL DEFAULT '';"#,
+    )
+    .execute(&pool)
+    .await
+    {
+        log::error!("[POSTGRES] Error in adding column data: {}", e);
+        return Err(e.into());
+    }
+    Ok(())
 }

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -223,14 +223,15 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         let pool = CLIENT.clone();
         sqlx::query(
             r#"UPDATE scheduled_jobs
-SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5
-WHERE org = $6 AND module_key = $7 AND module = $8;"#,
+SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5, data = $6
+WHERE org = $7 AND module_key = $8 AND module = $9;"#,
         )
         .bind(trigger.status)
         .bind(trigger.retries)
         .bind(trigger.next_run_at)
         .bind(trigger.is_realtime)
         .bind(trigger.is_silenced)
+        .bind(&trigger.data)
         .bind(&trigger.org)
         .bind(&trigger.module_key)
         .bind(&trigger.module)

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -16,7 +16,7 @@
 use async_trait::async_trait;
 use chrono::Duration;
 use config::utils::json;
-use sqlx::Row;
+use sqlx::{Pool, Row, Sqlite};
 
 use super::{Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
 use crate::{
@@ -62,12 +62,16 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     end_time     BIGINT,
     retries      INT not null,
     next_run_at  BIGINT not null,
-    created_at   TIMESTAMP default CURRENT_TIMESTAMP
+    created_at   TIMESTAMP default CURRENT_TIMESTAMP,
+    data         TEXT not null
 );
             "#,
         )
         .execute(&*client)
         .await?;
+
+        // Add data column for old version <= 0.10.9
+        add_data_column(&client).await?;
         Ok(())
     }
 
@@ -117,8 +121,8 @@ SELECT COUNT(*) as num FROM scheduled_jobs WHERE module = $1;"#,
 
         if let Err(e) = sqlx::query(
             r#"
-INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time, data)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
     ON CONFLICT DO NOTHING;
         "#,
         )
@@ -132,6 +136,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         .bind(trigger.next_run_at)
         .bind(0)
         .bind(0)
+        .bind(&trigger.data)
         .execute(&mut *tx)
         .await
         {
@@ -435,4 +440,21 @@ SELECT COUNT(*) as num FROM scheduled_jobs;"#,
 
         Ok(())
     }
+}
+
+async fn add_data_column(client: &Pool<Sqlite>) -> Result<()> {
+    // Attempt to add the column, ignoring the error if the column already exists
+    if let Err(e) =
+        sqlx::query(r#"ALTER TABLE scheduled_jobs ADD COLUMN data TEXT NOT NULL DEFAULT '';"#)
+            .execute(client)
+            .await
+    {
+        // Check if the error is about the duplicate column
+        if !e.to_string().contains("duplicate column name") {
+            // If the error is not about the duplicate column, return it
+            return Err(e.into());
+        }
+    }
+
+    Ok(())
 }

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -234,14 +234,15 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         let client = client.lock().await;
         sqlx::query(
             r#"UPDATE scheduled_jobs
-SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5
-WHERE org = $6 AND module_key = $7 AND module = $8;"#,
+SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5, data = $6
+WHERE org = $7 AND module_key = $8 AND module = $9;"#,
         )
         .bind(&trigger.status)
         .bind(trigger.retries)
         .bind(trigger.next_run_at)
         .bind(trigger.is_realtime)
         .bind(trigger.is_silenced)
+        .bind(&trigger.data)
         .bind(&trigger.org)
         .bind(&trigger.module_key)
         .bind(&trigger.module)

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -337,6 +337,7 @@ impl Alert {
                     &self.get_stream_params(),
                     &self.trigger_condition,
                     &self.query_condition,
+                    None,
                 )
                 .await
         }

--- a/src/service/alerts/derived_streams.rs
+++ b/src/service/alerts/derived_streams.rs
@@ -120,7 +120,7 @@ pub async fn save(
     }
 
     // test derived_stream
-    if let Err(e) = &derived_stream.evaluate(None).await {
+    if let Err(e) = &derived_stream.evaluate(None, None).await {
         return Err(anyhow::anyhow!(
             "DerivedStream not saved due to failed test run caused by {}",
             e.to_string()
@@ -185,12 +185,18 @@ impl DerivedStreamMeta {
     pub async fn evaluate(
         &self,
         row: Option<&Map<String, Value>>,
+        start_time: Option<i64>,
     ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error> {
         if self.is_real_time {
             self.query_condition.evaluate_realtime(row).await
         } else {
             self.query_condition
-                .evaluate_scheduled(&self.source, &self.trigger_condition, &self.query_condition)
+                .evaluate_scheduled(
+                    &self.source,
+                    &self.trigger_condition,
+                    &self.query_condition,
+                    start_time,
+                )
                 .await
         }
     }

--- a/src/service/alerts/derived_streams.rs
+++ b/src/service/alerts/derived_streams.rs
@@ -15,7 +15,7 @@
 
 use std::str::FromStr;
 
-use chrono::{Duration, Utc};
+use chrono::Utc;
 use config::{
     get_config,
     utils::json::{Map, Value},
@@ -128,11 +128,7 @@ pub async fn save(
     };
 
     // Save the trigger to db
-    let next_run_at = Utc::now().timestamp_micros()
-        + Duration::try_minutes(derived_stream.trigger_condition.frequency)
-            .unwrap()
-            .num_microseconds()
-            .unwrap();
+    let next_run_at = Utc::now().timestamp_micros();
     let trigger = db::scheduler::Trigger {
         org: derived_stream.source.org_id.to_string(),
         module: db::scheduler::TriggerModule::DerivedStream,

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -72,6 +72,7 @@ impl QueryCondition {
         stream_param: &StreamParams,
         trigger_condition: &TriggerCondition,
         query_condition: &QueryCondition,
+        start_time: Option<i64>,
     ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error> {
         let now = Utc::now().timestamp_micros();
         let sql = match self.query_type {
@@ -98,11 +99,14 @@ impl QueryCondition {
                 if v.is_empty() {
                     return Ok((None, now));
                 }
-                let start = now
-                    - Duration::try_minutes(trigger_condition.period)
+                let start = if start_time.is_some() {
+                    start_time.unwrap()
+                } else {
+                    now - Duration::try_minutes(trigger_condition.period)
                         .unwrap()
                         .num_microseconds()
-                        .unwrap();
+                        .unwrap()
+                };
                 let end = now;
                 let condition = self.promql_condition.as_ref().unwrap();
                 let req = promql::MetricsQueryRequest {
@@ -182,11 +186,14 @@ impl QueryCondition {
                 } else {
                     std::cmp::max(100, trigger_condition.threshold)
                 },
-                start_time: now
-                    - Duration::try_minutes(trigger_condition.period)
+                start_time: if start_time.is_some() {
+                    start_time.unwrap()
+                } else {
+                    now - Duration::try_minutes(trigger_condition.period)
                         .unwrap()
                         .num_microseconds()
-                        .unwrap(),
+                        .unwrap()
+                },
                 end_time: now,
                 sort_by: None,
                 quick_mode: false,

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -99,8 +99,8 @@ impl QueryCondition {
                 if v.is_empty() {
                     return Ok((None, now));
                 }
-                let start = if start_time.is_some() {
-                    start_time.unwrap()
+                let start = if let Some(start_time) = start_time {
+                    start_time
                 } else {
                     now - Duration::try_minutes(trigger_condition.period)
                         .unwrap()
@@ -186,8 +186,8 @@ impl QueryCondition {
                 } else {
                     std::cmp::max(100, trigger_condition.threshold)
                 },
-                start_time: if start_time.is_some() {
-                    start_time.unwrap()
+                start_time: if let Some(start_time) = start_time {
+                    start_time
                 } else {
                     now - Duration::try_minutes(trigger_condition.period)
                         .unwrap()

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -520,10 +520,10 @@ async fn handle_derived_stream_triggers(
         None
     } else {
         let last_data: Result<DerivedTriggerData, json::Error> = json::from_str(&trigger.data);
-        if last_data.is_err() {
-            None
+        if let Ok(last_data) = last_data {
+            Some(last_data.period_end_time + 1)
         } else {
-            Some(last_data.unwrap().period_end_time + 1)
+            None
         }
     };
     let mut new_trigger = db::scheduler::Trigger {
@@ -593,14 +593,14 @@ async fn handle_derived_stream_triggers(
         is_realtime: trigger.is_realtime,
         is_silenced: trigger.is_silenced,
         status: TriggerDataStatus::Completed,
-        start_time: if start_time.is_none() {
+        start_time: if let Some(start_time) = start_time {
+            start_time
+        } else {
             end_time
                 - Duration::try_minutes(derived_stream.trigger_condition.period)
                     .unwrap()
                     .num_microseconds()
                     .unwrap()
-        } else {
-            start_time.unwrap()
         },
         end_time: trigger.end_time.unwrap_or_default(),
         retries: trigger.retries,

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -645,7 +645,7 @@ async fn handle_derived_stream_triggers(
                             &new_trigger.org,
                             new_trigger.module,
                             &new_trigger.module_key,
-                            db::scheduler::TriggerStatus::Waiting,
+                            db::scheduler::TriggerStatus::Waiting, // TODO: update data
                             trigger.retries + 1,
                         )
                         .await?;

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -593,7 +593,15 @@ async fn handle_derived_stream_triggers(
         is_realtime: trigger.is_realtime,
         is_silenced: trigger.is_silenced,
         status: TriggerDataStatus::Completed,
-        start_time: trigger.start_time.unwrap_or_default(),
+        start_time: if start_time.is_none() {
+            end_time
+                - Duration::try_minutes(derived_stream.trigger_condition.period)
+                    .unwrap()
+                    .num_microseconds()
+                    .unwrap()
+        } else {
+            start_time.unwrap()
+        },
         end_time: trigger.end_time.unwrap_or_default(),
         retries: trigger.retries,
         error: None,

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -530,6 +530,7 @@ async fn handle_derived_stream_triggers(
         next_run_at: Utc::now().timestamp_micros(),
         is_silenced: false,
         status: db::scheduler::TriggerStatus::Waiting,
+        retries: 0,
         ..trigger.clone()
     };
 

--- a/src/service/db/scheduler.rs
+++ b/src/service/db/scheduler.rs
@@ -18,11 +18,17 @@ use infra::{
     errors::Result,
     scheduler::{self as infra_scheduler},
 };
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "enterprise")]
 use {
     infra::errors::Error, o2_enterprise::enterprise::common::infra::config::O2_CONFIG,
     o2_enterprise::enterprise::super_cluster,
 };
+
+#[derive(Default, Serialize, Deserialize, Debug)]
+pub struct DerivedTriggerData {
+    pub period_end_time: i64,
+}
 
 #[inline]
 pub async fn push(trigger: Trigger) -> Result<()> {


### PR DESCRIPTION
Fixes #4241 

- Adds a new `data` column to `scheduled_jobs` table for the purpose of storing different data as required by different modules.
- Uses the last end time of stream as the start time of derived stream calculation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new `data` field to the `Trigger` structure, allowing for additional information storage in scheduled jobs.
	- Introduced a new `DerivedTriggerData` struct for improved data handling within the scheduler module.
	- Enhanced job evaluation and query conditions with new optional `start_time` parameters for greater flexibility.

- **Bug Fixes**
	- Improved error handling for database schema changes to maintain backward compatibility with older versions.

- **Refactor**
	- Simplified logic within various functions to improve code clarity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->