### PR TITLE
fix: use empty table for generate plan

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -14,3 +14,5 @@ use_field_init_shorthand = true
 use_try_shorthand = true
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
+
+ignore = ["src/proto/src/generated/*.rs"]

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -5,7 +5,8 @@ pub struct EmptyRequest {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EmptyResponse {}
-#[derive(Eq, serde::Serialize)]
+#[derive(Eq)]
+#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptor {
@@ -14,7 +15,8 @@ pub struct FileDescriptor {
     #[prost(enumeration = "StreamType", tag = "2")]
     pub file_type: i32,
 }
-#[derive(Eq, serde::Serialize)]
+#[derive(Eq)]
+#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileMeta {
@@ -32,7 +34,8 @@ pub struct FileMeta {
     pub compressed_size: i64,
 }
 /// Job information for a request
-#[derive(Eq, serde::Serialize)]
+#[derive(Eq)]
+#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Job {
@@ -45,7 +48,8 @@ pub struct Job {
     #[prost(int32, tag = "4")]
     pub partition: i32,
 }
-#[derive(Eq, serde::Serialize)]
+#[derive(Eq)]
+#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScanStats {
@@ -69,14 +73,16 @@ pub struct ScanStats {
     #[prost(int64, tag = "8")]
     pub idx_scan_size: i64,
 }
-#[derive(Eq, serde::Serialize)]
+#[derive(Eq)]
+#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileList {
     #[prost(message, repeated, tag = "1")]
     pub items: ::prost::alloc::vec::Vec<FileKey>,
 }
-#[derive(Eq, serde::Serialize)]
+#[derive(Eq)]
+#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileKey {
@@ -170,7 +176,8 @@ impl SearchType {
 /// Generated client implementations.
 pub mod event_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct EventClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -209,13 +216,14 @@ pub mod event_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
-                    Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                    >,
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             EventClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -254,14 +262,19 @@ pub mod event_client {
             &mut self,
             request: impl tonic::IntoRequest<super::FileList>,
         ) -> std::result::Result<tonic::Response<super::EmptyResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cluster.Event/SendFileList");
+            let path = http::uri::PathAndQuery::from_static(
+                "/cluster.Event/SendFileList",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("cluster.Event", "SendFileList"));
@@ -304,7 +317,10 @@ pub mod event_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -360,16 +376,21 @@ pub mod event_server {
                 "/cluster.Event/SendFileList" => {
                     #[allow(non_camel_case_types)]
                     struct SendFileListSvc<T: Event>(pub Arc<T>);
-                    impl<T: Event> tonic::server::UnaryService<super::FileList> for SendFileListSvc<T> {
+                    impl<T: Event> tonic::server::UnaryService<super::FileList>
+                    for SendFileListSvc<T> {
                         type Response = super::EmptyResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FileList>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Event>::send_file_list(&inner, request).await };
+                            let fut = async move {
+                                <T as Event>::send_file_list(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -396,14 +417,18 @@ pub mod event_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -458,7 +483,8 @@ pub struct FileListQueryRequest {
 /// Generated client implementations.
 pub mod filelist_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct FilelistClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -497,13 +523,14 @@ pub mod filelist_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
-                    Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                    >,
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             FilelistClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -542,34 +569,38 @@ pub mod filelist_client {
             &mut self,
             request: impl tonic::IntoRequest<super::EmptyRequest>,
         ) -> std::result::Result<tonic::Response<super::MaxIdResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/cluster.Filelist/MaxID");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("cluster.Filelist", "MaxID"));
+            req.extensions_mut().insert(GrpcMethod::new("cluster.Filelist", "MaxID"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn query(
             &mut self,
             request: impl tonic::IntoRequest<super::FileListQueryRequest>,
         ) -> std::result::Result<tonic::Response<super::FileList>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/cluster.Filelist/Query");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("cluster.Filelist", "Query"));
+            req.extensions_mut().insert(GrpcMethod::new("cluster.Filelist", "Query"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -578,8 +609,7 @@ pub mod filelist_client {
 pub mod filelist_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with
-    /// FilelistServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with FilelistServer.
     #[async_trait]
     pub trait Filelist: Send + Sync + 'static {
         async fn max_id(
@@ -614,7 +644,10 @@ pub mod filelist_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -670,15 +703,21 @@ pub mod filelist_server {
                 "/cluster.Filelist/MaxID" => {
                     #[allow(non_camel_case_types)]
                     struct MaxIDSvc<T: Filelist>(pub Arc<T>);
-                    impl<T: Filelist> tonic::server::UnaryService<super::EmptyRequest> for MaxIDSvc<T> {
+                    impl<T: Filelist> tonic::server::UnaryService<super::EmptyRequest>
+                    for MaxIDSvc<T> {
                         type Response = super::MaxIdResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::EmptyRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { <T as Filelist>::max_id(&inner, request).await };
+                            let fut = async move {
+                                <T as Filelist>::max_id(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -708,15 +747,23 @@ pub mod filelist_server {
                 "/cluster.Filelist/Query" => {
                     #[allow(non_camel_case_types)]
                     struct QuerySvc<T: Filelist>(pub Arc<T>);
-                    impl<T: Filelist> tonic::server::UnaryService<super::FileListQueryRequest> for QuerySvc<T> {
+                    impl<
+                        T: Filelist,
+                    > tonic::server::UnaryService<super::FileListQueryRequest>
+                    for QuerySvc<T> {
                         type Response = super::FileList;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FileListQueryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { <T as Filelist>::query(&inner, request).await };
+                            let fut = async move {
+                                <T as Filelist>::query(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -743,14 +790,18 @@ pub mod filelist_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -902,7 +953,8 @@ pub struct MetricsWalFile {
 /// Generated client implementations.
 pub mod metrics_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct MetricsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -941,13 +993,14 @@ pub mod metrics_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
-                    Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                    >,
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             MetricsClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -985,37 +1038,45 @@ pub mod metrics_client {
         pub async fn query(
             &mut self,
             request: impl tonic::IntoRequest<super::MetricsQueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::MetricsQueryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::MetricsQueryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/cluster.Metrics/Query");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("cluster.Metrics", "Query"));
+            req.extensions_mut().insert(GrpcMethod::new("cluster.Metrics", "Query"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn wal_file(
             &mut self,
             request: impl tonic::IntoRequest<super::MetricsWalFileRequest>,
-        ) -> std::result::Result<tonic::Response<super::MetricsWalFileResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::MetricsWalFileResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/cluster.Metrics/WalFile");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("cluster.Metrics", "WalFile"));
+            req.extensions_mut().insert(GrpcMethod::new("cluster.Metrics", "WalFile"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1024,18 +1085,23 @@ pub mod metrics_client {
 pub mod metrics_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with
-    /// MetricsServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MetricsServer.
     #[async_trait]
     pub trait Metrics: Send + Sync + 'static {
         async fn query(
             &self,
             request: tonic::Request<super::MetricsQueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::MetricsQueryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::MetricsQueryResponse>,
+            tonic::Status,
+        >;
         async fn wal_file(
             &self,
             request: tonic::Request<super::MetricsWalFileRequest>,
-        ) -> std::result::Result<tonic::Response<super::MetricsWalFileResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::MetricsWalFileResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct MetricsServer<T: Metrics> {
@@ -1060,7 +1126,10 @@ pub mod metrics_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1116,15 +1185,23 @@ pub mod metrics_server {
                 "/cluster.Metrics/Query" => {
                     #[allow(non_camel_case_types)]
                     struct QuerySvc<T: Metrics>(pub Arc<T>);
-                    impl<T: Metrics> tonic::server::UnaryService<super::MetricsQueryRequest> for QuerySvc<T> {
+                    impl<
+                        T: Metrics,
+                    > tonic::server::UnaryService<super::MetricsQueryRequest>
+                    for QuerySvc<T> {
                         type Response = super::MetricsQueryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MetricsQueryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { <T as Metrics>::query(&inner, request).await };
+                            let fut = async move {
+                                <T as Metrics>::query(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1154,16 +1231,23 @@ pub mod metrics_server {
                 "/cluster.Metrics/WalFile" => {
                     #[allow(non_camel_case_types)]
                     struct WalFileSvc<T: Metrics>(pub Arc<T>);
-                    impl<T: Metrics> tonic::server::UnaryService<super::MetricsWalFileRequest> for WalFileSvc<T> {
+                    impl<
+                        T: Metrics,
+                    > tonic::server::UnaryService<super::MetricsWalFileRequest>
+                    for WalFileSvc<T> {
                         type Response = super::MetricsWalFileResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MetricsWalFileRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Metrics>::wal_file(&inner, request).await };
+                            let fut = async move {
+                                <T as Metrics>::wal_file(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1190,14 +1274,18 @@ pub mod metrics_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -1285,7 +1373,8 @@ pub struct SearchRequest {
     #[prost(string, optional, tag = "11")]
     pub search_event_type: ::core::option::Option<::prost::alloc::string::String>,
 }
-#[derive(Eq, serde::Serialize)]
+#[derive(Eq)]
+#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchResponse {
@@ -1418,7 +1507,8 @@ impl WorkGroup {
 /// Generated client implementations.
 pub mod search_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SearchClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1457,13 +1547,14 @@ pub mod search_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
-                    Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                    >,
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             SearchClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1502,31 +1593,38 @@ pub mod search_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SearchRequest>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/cluster.Search/Search");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("cluster.Search", "Search"));
+            req.extensions_mut().insert(GrpcMethod::new("cluster.Search", "Search"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn cluster_search(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchRequest>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cluster.Search/ClusterSearch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/cluster.Search/ClusterSearch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("cluster.Search", "ClusterSearch"));
@@ -1535,16 +1633,23 @@ pub mod search_client {
         pub async fn query_status(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryStatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryStatusResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::QueryStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cluster.Search/QueryStatus");
+            let path = http::uri::PathAndQuery::from_static(
+                "/cluster.Search/QueryStatus",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("cluster.Search", "QueryStatus"));
@@ -1553,16 +1658,23 @@ pub mod search_client {
         pub async fn cancel_query(
             &mut self,
             request: impl tonic::IntoRequest<super::CancelQueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::CancelQueryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CancelQueryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cluster.Search/CancelQuery");
+            let path = http::uri::PathAndQuery::from_static(
+                "/cluster.Search/CancelQuery",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("cluster.Search", "CancelQuery"));
@@ -1571,16 +1683,23 @@ pub mod search_client {
         pub async fn cluster_cancel_query(
             &mut self,
             request: impl tonic::IntoRequest<super::CancelQueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::CancelQueryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CancelQueryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cluster.Search/ClusterCancelQuery");
+            let path = http::uri::PathAndQuery::from_static(
+                "/cluster.Search/ClusterCancelQuery",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("cluster.Search", "ClusterCancelQuery"));
@@ -1592,8 +1711,7 @@ pub mod search_client {
 pub mod search_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with
-    /// SearchServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with SearchServer.
     #[async_trait]
     pub trait Search: Send + Sync + 'static {
         async fn search(
@@ -1607,15 +1725,24 @@ pub mod search_server {
         async fn query_status(
             &self,
             request: tonic::Request<super::QueryStatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryStatusResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::QueryStatusResponse>,
+            tonic::Status,
+        >;
         async fn cancel_query(
             &self,
             request: tonic::Request<super::CancelQueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::CancelQueryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CancelQueryResponse>,
+            tonic::Status,
+        >;
         async fn cluster_cancel_query(
             &self,
             request: tonic::Request<super::CancelQueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::CancelQueryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CancelQueryResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SearchServer<T: Search> {
@@ -1640,7 +1767,10 @@ pub mod search_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1696,15 +1826,21 @@ pub mod search_server {
                 "/cluster.Search/Search" => {
                     #[allow(non_camel_case_types)]
                     struct SearchSvc<T: Search>(pub Arc<T>);
-                    impl<T: Search> tonic::server::UnaryService<super::SearchRequest> for SearchSvc<T> {
+                    impl<T: Search> tonic::server::UnaryService<super::SearchRequest>
+                    for SearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { <T as Search>::search(&inner, request).await };
+                            let fut = async move {
+                                <T as Search>::search(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1734,16 +1870,21 @@ pub mod search_server {
                 "/cluster.Search/ClusterSearch" => {
                     #[allow(non_camel_case_types)]
                     struct ClusterSearchSvc<T: Search>(pub Arc<T>);
-                    impl<T: Search> tonic::server::UnaryService<super::SearchRequest> for ClusterSearchSvc<T> {
+                    impl<T: Search> tonic::server::UnaryService<super::SearchRequest>
+                    for ClusterSearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Search>::cluster_search(&inner, request).await };
+                            let fut = async move {
+                                <T as Search>::cluster_search(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1773,16 +1914,23 @@ pub mod search_server {
                 "/cluster.Search/QueryStatus" => {
                     #[allow(non_camel_case_types)]
                     struct QueryStatusSvc<T: Search>(pub Arc<T>);
-                    impl<T: Search> tonic::server::UnaryService<super::QueryStatusRequest> for QueryStatusSvc<T> {
+                    impl<
+                        T: Search,
+                    > tonic::server::UnaryService<super::QueryStatusRequest>
+                    for QueryStatusSvc<T> {
                         type Response = super::QueryStatusResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::QueryStatusRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Search>::query_status(&inner, request).await };
+                            let fut = async move {
+                                <T as Search>::query_status(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1812,16 +1960,23 @@ pub mod search_server {
                 "/cluster.Search/CancelQuery" => {
                     #[allow(non_camel_case_types)]
                     struct CancelQuerySvc<T: Search>(pub Arc<T>);
-                    impl<T: Search> tonic::server::UnaryService<super::CancelQueryRequest> for CancelQuerySvc<T> {
+                    impl<
+                        T: Search,
+                    > tonic::server::UnaryService<super::CancelQueryRequest>
+                    for CancelQuerySvc<T> {
                         type Response = super::CancelQueryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CancelQueryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Search>::cancel_query(&inner, request).await };
+                            let fut = async move {
+                                <T as Search>::cancel_query(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1851,11 +2006,15 @@ pub mod search_server {
                 "/cluster.Search/ClusterCancelQuery" => {
                     #[allow(non_camel_case_types)]
                     struct ClusterCancelQuerySvc<T: Search>(pub Arc<T>);
-                    impl<T: Search> tonic::server::UnaryService<super::CancelQueryRequest>
-                        for ClusterCancelQuerySvc<T>
-                    {
+                    impl<
+                        T: Search,
+                    > tonic::server::UnaryService<super::CancelQueryRequest>
+                    for ClusterCancelQuerySvc<T> {
                         type Response = super::CancelQueryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CancelQueryRequest>,
@@ -1890,14 +2049,18 @@ pub mod search_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -1996,7 +2159,8 @@ impl IngestionType {
 /// Generated client implementations.
 pub mod ingest_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct IngestClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -2035,13 +2199,14 @@ pub mod ingest_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
-                    Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                    >,
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             IngestClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2079,18 +2244,23 @@ pub mod ingest_client {
         pub async fn ingest(
             &mut self,
             request: impl tonic::IntoRequest<super::IngestionRequest>,
-        ) -> std::result::Result<tonic::Response<super::IngestionResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::IngestionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/cluster.Ingest/Ingest");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("cluster.Ingest", "Ingest"));
+            req.extensions_mut().insert(GrpcMethod::new("cluster.Ingest", "Ingest"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -2099,14 +2269,16 @@ pub mod ingest_client {
 pub mod ingest_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with
-    /// IngestServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with IngestServer.
     #[async_trait]
     pub trait Ingest: Send + Sync + 'static {
         async fn ingest(
             &self,
             request: tonic::Request<super::IngestionRequest>,
-        ) -> std::result::Result<tonic::Response<super::IngestionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::IngestionResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct IngestServer<T: Ingest> {
@@ -2131,7 +2303,10 @@ pub mod ingest_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2187,15 +2362,21 @@ pub mod ingest_server {
                 "/cluster.Ingest/Ingest" => {
                     #[allow(non_camel_case_types)]
                     struct IngestSvc<T: Ingest>(pub Arc<T>);
-                    impl<T: Ingest> tonic::server::UnaryService<super::IngestionRequest> for IngestSvc<T> {
+                    impl<T: Ingest> tonic::server::UnaryService<super::IngestionRequest>
+                    for IngestSvc<T> {
                         type Response = super::IngestionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::IngestionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { <T as Ingest>::ingest(&inner, request).await };
+                            let fut = async move {
+                                <T as Ingest>::ingest(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2222,14 +2403,18 @@ pub mod ingest_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -2284,7 +2469,8 @@ pub struct UsageResponse {
 /// Generated client implementations.
 pub mod usage_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct UsageClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -2323,13 +2509,14 @@ pub mod usage_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
-                    Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                    >,
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             UsageClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2368,17 +2555,21 @@ pub mod usage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UsageRequest>,
         ) -> std::result::Result<tonic::Response<super::UsageResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cluster.Usage/ReportUsage");
+            let path = http::uri::PathAndQuery::from_static(
+                "/cluster.Usage/ReportUsage",
+            );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("cluster.Usage", "ReportUsage"));
+            req.extensions_mut().insert(GrpcMethod::new("cluster.Usage", "ReportUsage"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -2418,7 +2609,10 @@ pub mod usage_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2474,16 +2668,21 @@ pub mod usage_server {
                 "/cluster.Usage/ReportUsage" => {
                     #[allow(non_camel_case_types)]
                     struct ReportUsageSvc<T: Usage>(pub Arc<T>);
-                    impl<T: Usage> tonic::server::UnaryService<super::UsageRequest> for ReportUsageSvc<T> {
+                    impl<T: Usage> tonic::server::UnaryService<super::UsageRequest>
+                    for ReportUsageSvc<T> {
                         type Response = super::UsageResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UsageRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Usage>::report_usage(&inner, request).await };
+                            let fut = async move {
+                                <T as Usage>::report_usage(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2510,14 +2709,18 @@ pub mod usage_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -2628,7 +2831,8 @@ pub struct DeleteResultCacheResponse {
 /// Generated client implementations.
 pub mod query_cache_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct QueryCacheClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -2667,13 +2871,14 @@ pub mod query_cache_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
-                    Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                    >,
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             QueryCacheClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2711,16 +2916,23 @@ pub mod query_cache_client {
         pub async fn get_cached_result(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryCacheRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryCacheResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::QueryCacheResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cluster.QueryCache/GetCachedResult");
+            let path = http::uri::PathAndQuery::from_static(
+                "/cluster.QueryCache/GetCachedResult",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("cluster.QueryCache", "GetCachedResult"));
@@ -2729,38 +2941,50 @@ pub mod query_cache_client {
         pub async fn get_multiple_cached_result(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryCacheRequest>,
-        ) -> std::result::Result<tonic::Response<super::MultiQueryCacheResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::MultiQueryCacheResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/cluster.QueryCache/GetMultipleCachedResult");
+            let path = http::uri::PathAndQuery::from_static(
+                "/cluster.QueryCache/GetMultipleCachedResult",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cluster.QueryCache",
-                "GetMultipleCachedResult",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("cluster.QueryCache", "GetMultipleCachedResult"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn delete_result_cache(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteResultCacheRequest>,
-        ) -> std::result::Result<tonic::Response<super::DeleteResultCacheResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteResultCacheResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/cluster.QueryCache/DeleteResultCache");
+            let path = http::uri::PathAndQuery::from_static(
+                "/cluster.QueryCache/DeleteResultCache",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("cluster.QueryCache", "DeleteResultCache"));
@@ -2772,22 +2996,30 @@ pub mod query_cache_client {
 pub mod query_cache_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with
-    /// QueryCacheServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryCacheServer.
     #[async_trait]
     pub trait QueryCache: Send + Sync + 'static {
         async fn get_cached_result(
             &self,
             request: tonic::Request<super::QueryCacheRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryCacheResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::QueryCacheResponse>,
+            tonic::Status,
+        >;
         async fn get_multiple_cached_result(
             &self,
             request: tonic::Request<super::QueryCacheRequest>,
-        ) -> std::result::Result<tonic::Response<super::MultiQueryCacheResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::MultiQueryCacheResponse>,
+            tonic::Status,
+        >;
         async fn delete_result_cache(
             &self,
             request: tonic::Request<super::DeleteResultCacheRequest>,
-        ) -> std::result::Result<tonic::Response<super::DeleteResultCacheResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteResultCacheResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct QueryCacheServer<T: QueryCache> {
@@ -2812,7 +3044,10 @@ pub mod query_cache_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2868,11 +3103,15 @@ pub mod query_cache_server {
                 "/cluster.QueryCache/GetCachedResult" => {
                     #[allow(non_camel_case_types)]
                     struct GetCachedResultSvc<T: QueryCache>(pub Arc<T>);
-                    impl<T: QueryCache> tonic::server::UnaryService<super::QueryCacheRequest>
-                        for GetCachedResultSvc<T>
-                    {
+                    impl<
+                        T: QueryCache,
+                    > tonic::server::UnaryService<super::QueryCacheRequest>
+                    for GetCachedResultSvc<T> {
                         type Response = super::QueryCacheResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::QueryCacheRequest>,
@@ -2910,18 +3149,26 @@ pub mod query_cache_server {
                 "/cluster.QueryCache/GetMultipleCachedResult" => {
                     #[allow(non_camel_case_types)]
                     struct GetMultipleCachedResultSvc<T: QueryCache>(pub Arc<T>);
-                    impl<T: QueryCache> tonic::server::UnaryService<super::QueryCacheRequest>
-                        for GetMultipleCachedResultSvc<T>
-                    {
+                    impl<
+                        T: QueryCache,
+                    > tonic::server::UnaryService<super::QueryCacheRequest>
+                    for GetMultipleCachedResultSvc<T> {
                         type Response = super::MultiQueryCacheResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::QueryCacheRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as QueryCache>::get_multiple_cached_result(&inner, request).await
+                                <T as QueryCache>::get_multiple_cached_result(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2952,18 +3199,23 @@ pub mod query_cache_server {
                 "/cluster.QueryCache/DeleteResultCache" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteResultCacheSvc<T: QueryCache>(pub Arc<T>);
-                    impl<T: QueryCache> tonic::server::UnaryService<super::DeleteResultCacheRequest>
-                        for DeleteResultCacheSvc<T>
-                    {
+                    impl<
+                        T: QueryCache,
+                    > tonic::server::UnaryService<super::DeleteResultCacheRequest>
+                    for DeleteResultCacheSvc<T> {
                         type Response = super::DeleteResultCacheResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeleteResultCacheRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as QueryCache>::delete_result_cache(&inner, request).await
+                                <T as QueryCache>::delete_result_cache(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2991,14 +3243,18 @@ pub mod query_cache_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }

--- a/src/proto/src/generated/prometheus.rs
+++ b/src/proto/src/generated/prometheus.rs
@@ -16,9 +16,8 @@ pub struct MetricMetadata {
 }
 /// Nested message and enum types in `MetricMetadata`.
 pub mod metric_metadata {
+    #[derive(serde::Deserialize, serde::Serialize)]
     #[derive(
-        serde::Deserialize,
-        serde::Serialize,
         Clone,
         Copy,
         Debug,
@@ -27,7 +26,7 @@ pub mod metric_metadata {
         Hash,
         PartialOrd,
         Ord,
-        ::prost::Enumeration,
+        ::prost::Enumeration
     )]
     #[repr(i32)]
     pub enum MetricType {
@@ -164,7 +163,17 @@ pub struct Histogram {
 }
 /// Nested message and enum types in `Histogram`.
 pub mod histogram {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum ResetHint {
         /// Need to test for a counter reset explicitly.
@@ -283,7 +292,17 @@ pub struct LabelMatcher {
 }
 /// Nested message and enum types in `LabelMatcher`.
 pub mod label_matcher {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Type {
         Eq = 0,
@@ -360,7 +379,17 @@ pub struct Chunk {
 /// Nested message and enum types in `Chunk`.
 pub mod chunk {
     /// We require this to match chunkenc.Encoding.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Encoding {
         Unknown = 0,
@@ -418,20 +447,29 @@ pub struct ReadRequest {
     pub queries: ::prost::alloc::vec::Vec<Query>,
     /// accepted_response_types allows negotiating the content type of the response.
     ///
-    /// Response types are taken from the list in the FIFO order. If no response type in
-    /// `accepted_response_types` is implemented by server, error is returned.
-    /// For request that do not contain `accepted_response_types` field the SAMPLES response type
-    /// will be used.
+    /// Response types are taken from the list in the FIFO order. If no response type in `accepted_response_types` is
+    /// implemented by server, error is returned.
+    /// For request that do not contain `accepted_response_types` field the SAMPLES response type will be used.
     #[prost(enumeration = "read_request::ResponseType", repeated, tag = "2")]
     pub accepted_response_types: ::prost::alloc::vec::Vec<i32>,
 }
 /// Nested message and enum types in `ReadRequest`.
 pub mod read_request {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum ResponseType {
-        /// Server will return a single ReadResponse message with matched series that includes list
-        /// of raw samples. It's recommended to use streamed response types instead.
+        /// Server will return a single ReadResponse message with matched series that includes list of raw samples.
+        /// It's recommended to use streamed response types instead.
         ///
         /// Response headers:
         /// Content-Type: "application/x-protobuf"
@@ -496,17 +534,15 @@ pub struct QueryResult {
     pub timeseries: ::prost::alloc::vec::Vec<TimeSeries>,
 }
 /// ChunkedReadResponse is a response when response_type equals STREAMED_XOR_CHUNKS.
-/// We strictly stream full series after series, optionally split by time. This means that a single
-/// frame can contain partition of the single series, but once a new series is started to be
-/// streamed it means that no more chunks will be sent for previous one. Series are returned sorted
-/// in the same way TSDB block are internally.
+/// We strictly stream full series after series, optionally split by time. This means that a single frame can contain
+/// partition of the single series, but once a new series is started to be streamed it means that no more chunks will
+/// be sent for previous one. Series are returned sorted in the same way TSDB block are internally.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChunkedReadResponse {
     #[prost(message, repeated, tag = "1")]
     pub chunked_series: ::prost::alloc::vec::Vec<ChunkedSeries>,
-    /// query_index represents an index of the query from ReadRequest.queries these chunks relates
-    /// to.
+    /// query_index represents an index of the query from ReadRequest.queries these chunks relates to.
     #[prost(int64, tag = "2")]
     pub query_index: i64,
 }

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -38,10 +38,7 @@ use crate::{
     common::meta::stream::StreamParams,
     service::{
         db, file_list,
-        search::{
-            datafusion::{exec::register_table, file_type::FileType},
-            match_source,
-        },
+        search::{datafusion::exec::register_table, match_source},
     },
 };
 
@@ -166,7 +163,6 @@ pub(crate) async fn create_context(
         schema.clone(),
         stream_name,
         &files,
-        FileType::PARQUET,
         HashMap::default(),
         false,
         &[],

--- a/src/service/promql/search/grpc/wal.rs
+++ b/src/service/promql/search/grpc/wal.rs
@@ -45,10 +45,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use crate::{
     common::infra::cluster::{get_cached_online_ingester_nodes, get_internal_grpc_token},
     service::search::{
-        datafusion::{
-            exec::{prepare_datafusion_context, register_table},
-            file_type::FileType,
-        },
+        datafusion::exec::{prepare_datafusion_context, register_table},
         MetadataMap,
     },
 };
@@ -189,7 +186,6 @@ pub(crate) async fn create_context(
         schema.clone(),
         stream_name,
         &[],
-        FileType::PARQUET,
         hashbrown::HashMap::default(),
         false,
         &[],

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -33,6 +33,7 @@ use datafusion::{
         datatypes::{DataType, Schema},
         record_batch::RecordBatch,
     },
+    catalog::TableProvider,
     common::{tree_node::TreeNode, Column},
     datasource::{
         empty::EmptyTable,
@@ -62,7 +63,12 @@ use super::{
     udf::transform_udf::get_all_transform,
 };
 use crate::service::search::{
-    datafusion::{plan::UpdateOffsetExec, ExtLimit},
+    datafusion::{
+        physical_plan::{empty_exec::NewEmptyExec, NewEmptyExecVisitor, ReplaceTableScanExec},
+        plan::UpdateOffsetExec,
+        table_provider::empty_table::NewEmptyTable,
+        ExtLimit,
+    },
     sql::{Sql, RE_SELECT_WILDCARD},
 };
 
@@ -82,47 +88,64 @@ pub async fn sql(
         return Ok(vec![]);
     }
 
+    let cfg = get_config();
     let start = std::time::Instant::now();
     let trace_id = session.id.clone();
-    let mut ctx = if !file_type.eq(&FileType::ARROW) {
-        register_table(
-            session,
-            schema.clone(),
-            "tbl",
-            files,
-            file_type.clone(),
-            rules.clone(),
-            false,
-            &sql.meta.order_by,
-            Some(sql.meta.limit as usize),
-        )
-        .await?
-    } else {
-        let ctx = prepare_datafusion_context(
-            session.work_group.clone(),
-            &session.search_type,
-            false,
-            false,
-            session.target_partitions,
-            None,
-        )
-        .await?;
-        let record_batches = in_records_batches.unwrap();
-        let mem_table = Arc::new(NewMemTable::try_new(
-            schema.clone(),
-            vec![record_batches],
-            rules.clone(),
-        )?);
-        // Register the MemTable as a table in the DataFusion context
-        ctx.register_table("tbl", mem_table)?;
-        ctx
-    };
+    let origin_sql: &str = sql.origin_sql.as_ref();
+
+    // Hack for limit 0
+    if origin_sql.ends_with("LIMIT 0") {
+        return Ok(vec![]);
+    }
+
+    // only sort by timestamp desc
+    let sort_by_timestamp_desc = sql.meta.order_by.len() == 1
+        && sql.meta.order_by[0].0 == cfg.common.column_timestamp
+        && sql.meta.order_by[0].1;
+
+    let mut ctx = prepare_datafusion_context(
+        session.work_group.clone(),
+        &session.search_type,
+        false,
+        sort_by_timestamp_desc,
+        session.target_partitions,
+        Some(sql.meta.limit as usize),
+    )
+    .await?;
 
     // register UDF
     register_udf(&mut ctx, &sql.org_id).await;
 
+    // create table
+    let real_table: Arc<dyn TableProvider> = if !file_type.eq(&FileType::ARROW) {
+        let mut table = create_parquet_table(
+            session,
+            schema.clone(),
+            files,
+            rules.clone(),
+            &sql.meta.order_by,
+        )
+        .await?;
+
+        if session.storage_type != StorageType::Tmpfs {
+            table = table.with_cache(ctx.runtime_env().cache_manager.get_file_statistic_cache());
+        }
+        Arc::new(table) as _
+    } else {
+        let record_batches = in_records_batches.unwrap();
+        Arc::new(NewMemTable::try_new(
+            schema.clone(),
+            vec![record_batches],
+            rules.clone(),
+        )?)
+    };
+
+    // register empty table
+    let empty_table = NewEmptyTable::new("tbl", schema.clone()).with_partitions(cfg.limit.cpu_num);
+    ctx.register_table("tbl", Arc::new(empty_table))?;
+
     // query sql
-    let result = exec_query(&ctx, session, sql).await?;
+    let result = exec_query(&ctx, session, sql, real_table).await?;
 
     // drop table
     ctx.deregister_table("tbl")?;
@@ -138,6 +161,7 @@ async fn exec_query(
     ctx: &SessionContext,
     session: &SearchSession,
     sql: &Arc<Sql>,
+    table: Arc<dyn TableProvider>,
 ) -> Result<Vec<Vec<RecordBatch>>> {
     let sql: &str = sql.origin_sql.as_ref();
     let start = std::time::Instant::now();
@@ -147,11 +171,6 @@ async fn exec_query(
     // Debug SQL
     if cfg.common.print_key_sql {
         log::info!("[trace_id {trace_id}] Query sql: {}", sql);
-    }
-
-    // Hack for limit 0
-    if sql.ends_with("LIMIT 0") {
-        return Ok(vec![]);
     }
 
     let plan = ctx.state().create_logical_plan(sql).await?;
@@ -173,12 +192,41 @@ async fn exec_query(
         println!("{}", plan);
     }
 
-    let partial_paln = match super::plan::get_partial_plan(&physical_plan)? {
+    let partial_plan = match super::plan::get_partial_plan(&physical_plan)? {
         Some(plan) => plan,
         None => super::plan::get_empty_partial_plan(&physical_plan),
     };
+
+    // replace table scan exec
+    let mut empty_exec_visitor = NewEmptyExecVisitor::new();
+    partial_plan.visit(&mut empty_exec_visitor)?;
+    let empty_exec = match empty_exec_visitor.get_data() {
+        Some(v) => match v.as_any().downcast_ref::<NewEmptyExec>() {
+            Some(v) => v,
+            None => {
+                return Err(DataFusionError::Execution(
+                    "Failed to downcast NewEmptyExec".to_string(),
+                ));
+            }
+        },
+        None => {
+            return Ok(vec![]);
+        }
+    };
+    let table_scan_exec = table
+        .scan(
+            &ctx.state(),
+            empty_exec.projection(),
+            empty_exec.filters(),
+            empty_exec.limit(),
+        )
+        .await?;
+
+    let mut replace_table_visitor = ReplaceTableScanExec::new(table_scan_exec);
+    let partial_plan = partial_plan.rewrite(&mut replace_table_visitor)?.data;
+
     if cfg.common.print_key_sql {
-        let plan = datafusion::physical_plan::displayable(partial_paln.as_ref())
+        let plan = datafusion::physical_plan::displayable(partial_plan.as_ref())
             .set_show_schema(false)
             .indent(false)
             .to_string();
@@ -188,7 +236,7 @@ async fn exec_query(
         println!("{}", plan);
     }
 
-    let data = match collect_partitioned(partial_paln, ctx.task_ctx()).await {
+    let data = match collect_partitioned(partial_plan, ctx.task_ctx()).await {
         Ok(v) => v,
         Err(e) => {
             log::error!(
@@ -680,7 +728,6 @@ pub async fn register_table(
     schema: Arc<Schema>,
     table_name: &str,
     files: &[FileKey],
-    file_type: FileType,
     rules: HashMap<String, DataType>,
     without_optimizer: bool,
     sort_key: &[(String, bool)],
@@ -701,28 +748,40 @@ pub async fn register_table(
     )
     .await?;
 
-    // Configure listing options
-    let mut listing_options = match file_type {
-        FileType::PARQUET => {
-            let file_format = ParquetFormat::default();
-            ListingOptions::new(Arc::new(file_format))
-                .with_file_extension(FileType::PARQUET.get_ext())
-                .with_target_partitions(ctx.state().config().target_partitions())
-                .with_collect_stat(true)
-        }
-        FileType::JSON => {
-            let file_format = JsonFormat::default();
-            ListingOptions::new(Arc::new(file_format))
-                .with_file_extension(FileType::JSON.get_ext())
-                .with_target_partitions(ctx.state().config().target_partitions())
-                .with_collect_stat(true)
-        }
-        _ => {
-            return Err(DataFusionError::Execution(format!(
-                "Unsupported file type scheme {file_type:?}",
-            )));
-        }
+    let mut table =
+        create_parquet_table(session, schema.clone(), files, rules.clone(), sort_key).await?;
+    if session.storage_type != StorageType::Tmpfs {
+        table = table.with_cache(ctx.runtime_env().cache_manager.get_file_statistic_cache());
+    }
+    ctx.register_table(table_name, Arc::new(table))?;
+
+    Ok(ctx)
+}
+
+pub async fn create_parquet_table(
+    session: &SearchSession,
+    schema: Arc<Schema>,
+    files: &[FileKey],
+    rules: HashMap<String, DataType>,
+    sort_key: &[(String, bool)],
+) -> Result<NewListingTable> {
+    let cfg = get_config();
+    let target_partitions = if session.target_partitions == 0 {
+        cfg.limit.cpu_num
+    } else {
+        std::cmp::max(DATAFUSION_MIN_PARTITION, session.target_partitions)
     };
+
+    // only sort by timestamp desc
+    let sort_by_timestamp_desc =
+        sort_key.len() == 1 && sort_key[0].0 == cfg.common.column_timestamp && sort_key[0].1;
+
+    // Configure listing options
+    let file_format = ParquetFormat::default();
+    let mut listing_options = ListingOptions::new(Arc::new(file_format))
+        .with_file_extension(FileType::PARQUET.get_ext())
+        .with_target_partitions(target_partitions)
+        .with_collect_stat(true);
 
     if sort_by_timestamp_desc {
         // specify sort columns for parquet file
@@ -748,7 +807,8 @@ pub async fn register_table(
         format!("tmpfs:///{}/", session.id)
     } else {
         return Err(DataFusionError::Execution(format!(
-            "Unsupported file type scheme {file_type:?}",
+            "Unsupported storage_type {:?}",
+            session.storage_type,
         )));
     };
     let prefix = match ListingTableUrl::parse(prefix) {
@@ -761,40 +821,27 @@ pub async fn register_table(
     };
 
     let mut config = ListingTableConfig::new(prefix).with_listing_options(listing_options);
-    if cfg.common.feature_query_infer_schema
-        && (cfg.limit.query_optimization_num_fields > 0
-            && schema.fields().len() > cfg.limit.query_optimization_num_fields)
-    {
-        config = config.infer_schema(&ctx.state()).await?;
+    let timestamp_field = schema.field_with_name(&cfg.common.column_timestamp);
+    let schema = if timestamp_field.is_ok() && timestamp_field.unwrap().is_nullable() {
+        let new_fields = schema
+            .fields()
+            .iter()
+            .map(|x| {
+                if x.name() == &cfg.common.column_timestamp {
+                    Arc::new(Field::new(
+                        cfg.common.column_timestamp.clone(),
+                        DataType::Int64,
+                        false,
+                    ))
+                } else {
+                    x.clone()
+                }
+            })
+            .collect::<Vec<_>>();
+        Arc::new(Schema::new(new_fields))
     } else {
-        let timestamp_field = schema.field_with_name(&cfg.common.column_timestamp);
-        let schema = if timestamp_field.is_ok() && timestamp_field.unwrap().is_nullable() {
-            let new_fields = schema
-                .fields()
-                .iter()
-                .map(|x| {
-                    if x.name() == &cfg.common.column_timestamp {
-                        Arc::new(Field::new(
-                            cfg.common.column_timestamp.clone(),
-                            DataType::Int64,
-                            false,
-                        ))
-                    } else {
-                        x.clone()
-                    }
-                })
-                .collect::<Vec<_>>();
-            Arc::new(Schema::new(new_fields))
-        } else {
-            schema
-        };
-        config = config.with_schema(schema);
-    }
-    let mut table = NewListingTable::try_new(config, rules)?;
-    if session.storage_type != StorageType::Tmpfs {
-        table = table.with_cache(ctx.runtime_env().cache_manager.get_file_statistic_cache());
-    }
-    ctx.register_table(table_name, Arc::new(table))?;
-
-    Ok(ctx)
+        schema
+    };
+    config = config.with_schema(schema);
+    NewListingTable::try_new(config, rules)
 }

--- a/src/service/search/datafusion/mod.rs
+++ b/src/service/search/datafusion/mod.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 
 pub mod exec;
 pub mod file_type;
+pub mod physical_plan;
 pub mod plan;
 pub mod storage;
 pub mod table_provider;

--- a/src/service/search/datafusion/physical_plan/empty_exec.rs
+++ b/src/service/search/datafusion/physical_plan/empty_exec.rs
@@ -1,0 +1,201 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{any::Any, sync::Arc};
+
+use datafusion::{
+    arrow::{array::RecordBatch, datatypes::SchemaRef},
+    common::{internal_err, Result, Statistics},
+    execution::{SendableRecordBatchStream, TaskContext},
+    physical_expr::{EquivalenceProperties, Partitioning},
+    physical_plan::{
+        common, memory::MemoryStream, DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan,
+        PlanProperties,
+    },
+    prelude::Expr,
+};
+
+/// Execution plan for empty relation with produce_one_row=false
+#[derive(Debug)]
+pub struct NewEmptyExec {
+    name: String,      // table name
+    schema: SchemaRef, // The schema for the produced row
+    partitions: usize, // Number of partitions
+    cache: PlanProperties,
+    projection: Option<Vec<usize>>,
+    filters: Vec<Expr>,
+    limit: Option<usize>,
+}
+
+impl NewEmptyExec {
+    /// Create a new NewEmptyExec
+    pub fn new(
+        name: &str,
+        schema: SchemaRef,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Self {
+        let cache = Self::compute_properties(Arc::clone(&schema), 1);
+        NewEmptyExec {
+            name: name.to_string(),
+            schema,
+            partitions: 1,
+            cache,
+            projection: projection.cloned(),
+            filters: filters.to_owned(),
+            limit,
+        }
+    }
+
+    /// Create a new NewEmptyExec with specified partition number
+    pub fn with_partitions(mut self, partitions: usize) -> Self {
+        self.partitions = partitions;
+        // Changing partitions may invalidate output partitioning, so update it:
+        let output_partitioning = Self::output_partitioning_helper(self.partitions);
+        self.cache = self.cache.with_partitioning(output_partitioning);
+        self
+    }
+
+    fn data(&self) -> Result<Vec<RecordBatch>> {
+        Ok(vec![])
+    }
+
+    fn output_partitioning_helper(n_partitions: usize) -> Partitioning {
+        Partitioning::UnknownPartitioning(n_partitions)
+    }
+
+    /// This function creates the cache object that stores the plan properties such as schema,
+    /// equivalence properties, ordering, partitioning, etc.
+    fn compute_properties(schema: SchemaRef, n_partitions: usize) -> PlanProperties {
+        let eq_properties = EquivalenceProperties::new(schema);
+        let output_partitioning = Self::output_partitioning_helper(n_partitions);
+        PlanProperties::new(
+            eq_properties,
+            // Output Partitioning
+            output_partitioning,
+            // Execution Mode
+            ExecutionMode::Bounded,
+        )
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn projection(&self) -> Option<&Vec<usize>> {
+        self.projection.as_ref()
+    }
+
+    pub fn filters(&self) -> &[Expr] {
+        &self.filters
+    }
+
+    pub fn limit(&self) -> Option<usize> {
+        self.limit
+    }
+}
+
+impl DisplayAs for NewEmptyExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                let name_string = format!("name={:?}", self.name);
+                let projection_string = format!(
+                    ", projection={:?}",
+                    self.schema
+                        .fields()
+                        .iter()
+                        .map(|f| f.name())
+                        .collect::<Vec<_>>()
+                );
+                let filters_string = format!(
+                    ", filters={:?}",
+                    self.filters
+                        .iter()
+                        .map(|f| f.to_string())
+                        .collect::<Vec<_>>()
+                );
+                let limit_string = self
+                    .limit
+                    .map_or_else(|| "".to_string(), |l| format!(", limit={}", l));
+
+                write!(f, "NewEmptyExec: ")?;
+                write!(
+                    f,
+                    "{}{}{}{}",
+                    name_string, projection_string, filters_string, limit_string
+                )
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for NewEmptyExec {
+    fn name(&self) -> &'static str {
+        "NewEmptyExec"
+    }
+
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        if partition >= self.partitions {
+            return internal_err!(
+                "NewEmptyExec invalid partition {} (expected less than {})",
+                partition,
+                self.partitions
+            );
+        }
+
+        Ok(Box::pin(MemoryStream::try_new(
+            self.data()?,
+            Arc::clone(&self.schema),
+            None,
+        )?))
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        let batch = self
+            .data()
+            .expect("Create empty RecordBatch should not fail");
+        Ok(common::compute_record_batch_statistics(
+            &[batch],
+            &self.schema,
+            None,
+        ))
+    }
+}

--- a/src/service/search/datafusion/physical_plan/mod.rs
+++ b/src/service/search/datafusion/physical_plan/mod.rs
@@ -1,0 +1,90 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use datafusion::{
+    common::{
+        tree_node::{Transformed, TreeNodeRecursion, TreeNodeRewriter, TreeNodeVisitor},
+        Result,
+    },
+    physical_plan::ExecutionPlan,
+};
+
+pub mod empty_exec;
+
+pub struct NewEmptyExecVisitor {
+    data: Option<Arc<dyn ExecutionPlan>>,
+}
+
+impl NewEmptyExecVisitor {
+    pub fn new() -> Self {
+        Self { data: None }
+    }
+
+    pub fn get_data(&self) -> Option<&Arc<dyn ExecutionPlan>> {
+        self.data.as_ref()
+    }
+}
+
+impl Default for NewEmptyExecVisitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'n> TreeNodeVisitor<'n> for NewEmptyExecVisitor {
+    type Node = Arc<dyn ExecutionPlan>;
+
+    fn f_up(&mut self, node: &'n Self::Node) -> Result<TreeNodeRecursion> {
+        if node.name() == "NewEmptyExec" {
+            self.data = Some(node.clone());
+            Ok(TreeNodeRecursion::Stop)
+        } else {
+            Ok(TreeNodeRecursion::Continue)
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub struct ReplaceTableScanExec {
+    input: Arc<dyn ExecutionPlan>,
+}
+
+impl ReplaceTableScanExec {
+    #[allow(dead_code)]
+    pub fn new(input: Arc<dyn ExecutionPlan>) -> Self {
+        Self { input }
+    }
+}
+
+impl TreeNodeRewriter for ReplaceTableScanExec {
+    type Node = Arc<dyn ExecutionPlan>;
+
+    fn f_up(&mut self, node: Self::Node) -> Result<Transformed<Self::Node>> {
+        let name = node.name().to_string();
+        let mut transformed = if name == "NewEmptyExec" {
+            Transformed::yes(self.input.clone())
+        } else {
+            Transformed::no(node)
+        };
+        if name == "NewEmptyExec" {
+            transformed.tnr = TreeNodeRecursion::Stop;
+        } else {
+            transformed.tnr = TreeNodeRecursion::Continue;
+        }
+        Ok(transformed)
+    }
+}

--- a/src/service/search/datafusion/table_provider/empty_table.rs
+++ b/src/service/search/datafusion/table_provider/empty_table.rs
@@ -34,15 +34,17 @@ pub struct NewEmptyTable {
     name: String,
     schema: SchemaRef,
     partitions: usize,
+    is_memtable: bool,
 }
 
 impl NewEmptyTable {
     /// Initialize a new `EmptyTable` from a schema.
-    pub fn new(name: &str, schema: SchemaRef) -> Self {
+    pub fn new(name: &str, schema: SchemaRef, is_memtable: bool) -> Self {
         Self {
             name: name.to_string(),
             schema,
             partitions: 1,
+            is_memtable,
         }
     }
 
@@ -77,8 +79,15 @@ impl TableProvider for NewEmptyTable {
         // even though there is no data, projections apply
         let projected_schema = project_schema(&self.schema, projection)?;
         Ok(Arc::new(
-            NewEmptyExec::new(&self.name, projected_schema, projection, filters, limit)
-                .with_partitions(self.partitions),
+            NewEmptyExec::new(
+                &self.name,
+                projected_schema,
+                projection,
+                filters,
+                limit,
+                self.is_memtable,
+            )
+            .with_partitions(self.partitions),
         ))
     }
 

--- a/src/service/search/datafusion/table_provider/empty_table.rs
+++ b/src/service/search/datafusion/table_provider/empty_table.rs
@@ -1,0 +1,91 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{any::Any, sync::Arc};
+
+use async_trait::async_trait;
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    catalog::Session,
+    common::{project_schema, Result},
+    datasource::{TableProvider, TableType},
+    logical_expr::TableProviderFilterPushDown,
+    physical_plan::ExecutionPlan,
+    prelude::Expr,
+};
+
+use crate::service::search::datafusion::physical_plan::empty_exec::NewEmptyExec;
+
+/// An empty plan that is useful for testing and generating plans
+/// without mapping them to actual data.
+pub struct NewEmptyTable {
+    name: String,
+    schema: SchemaRef,
+    partitions: usize,
+}
+
+impl NewEmptyTable {
+    /// Initialize a new `EmptyTable` from a schema.
+    pub fn new(name: &str, schema: SchemaRef) -> Self {
+        Self {
+            name: name.to_string(),
+            schema,
+            partitions: 1,
+        }
+    }
+
+    /// Creates a new EmptyTable with specified partition number.
+    pub fn with_partitions(mut self, partitions: usize) -> Self {
+        self.partitions = partitions;
+        self
+    }
+}
+
+#[async_trait]
+impl TableProvider for NewEmptyTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // even though there is no data, projections apply
+        let projected_schema = project_schema(&self.schema, projection)?;
+        Ok(Arc::new(
+            NewEmptyExec::new(&self.name, projected_schema, projection, filters, limit)
+                .with_partitions(self.partitions),
+        ))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+    }
+}

--- a/src/service/search/datafusion/table_provider/mod.rs
+++ b/src/service/search/datafusion/table_provider/mod.rs
@@ -62,6 +62,7 @@ use hashbrown::HashMap;
 use helpers::*;
 use object_store::ObjectStore;
 
+pub mod empty_table;
 mod helpers;
 pub mod memtable;
 


### PR DESCRIPTION
fix the search case:
```sql
SELECT 'abc-services' as _stream_name,_timestamp, log, ext1,ext3 FROM "default5" ORDER BY _timestamp DESC
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new execution plan `NewEmptyExec` for handling empty datasets in DataFusion.
	- Added table provider `NewEmptyTable` for creating placeholder tables without actual data.
	- Enhanced SQL execution with new table provider functionalities and improved error handling.

- **Bug Fixes**
	- Improved handling of edge cases related to empty datasets and varying storage types.

- **Refactor**
	- Streamlined import statements and function signatures for improved clarity.

- **Documentation**
	- Updated comments and module structure for better organization and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->