### PR TITLE
feat: add last_triggered_at, owner, last_edited_by, updated_at fields in alerts

### DIFF
--- a/src/common/meta/alerts/alert.rs
+++ b/src/common/meta/alerts/alert.rs
@@ -49,6 +49,8 @@ pub struct Alert {
     /// Timezone offset in minutes.
     /// The negative secs means the Western Hemisphere
     pub tz_offset: i32,
+    #[serde(default)]
+    pub last_triggered_at: Option<i64>,
 }
 
 impl PartialEq for Alert {
@@ -75,6 +77,7 @@ impl Default for Alert {
             description: "".to_string(),
             enabled: false,
             tz_offset: 0, // UTC
+            last_triggered_at: None,
         }
     }
 }

--- a/src/common/meta/alerts/alert.rs
+++ b/src/common/meta/alerts/alert.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use chrono::{DateTime, FixedOffset};
 use config::meta::stream::StreamType;
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
@@ -51,6 +52,13 @@ pub struct Alert {
     pub tz_offset: i32,
     #[serde(default)]
     pub last_triggered_at: Option<i64>,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = String, format = DateTime)]
+    pub updated_at: Option<DateTime<FixedOffset>>,
+    #[serde(default)]
+    pub last_edited_by: Option<String>,
 }
 
 impl PartialEq for Alert {
@@ -78,6 +86,9 @@ impl Default for Alert {
             enabled: false,
             tz_offset: 0, // UTC
             last_triggered_at: None,
+            owner: None,
+            updated_at: None,
+            last_edited_by: None,
         }
     }
 }

--- a/src/handler/http/request/dashboards/reports.rs
+++ b/src/handler/http/request/dashboards/reports.rs
@@ -18,7 +18,10 @@ use std::{collections::HashMap, io::Error};
 use actix_web::{delete, get, http, post, put, web, HttpRequest, HttpResponse};
 
 use crate::{
-    common::meta::{dashboards::reports::Report, http::HttpResponse as MetaHttpResponse},
+    common::{
+        meta::{dashboards::reports::Report, http::HttpResponse as MetaHttpResponse},
+        utils::auth::UserEmail,
+    },
     service::dashboards::reports,
 };
 
@@ -50,9 +53,13 @@ use crate::{
 pub async fn create_report(
     path: web::Path<String>,
     report: web::Json<Report>,
+    user_email: UserEmail,
 ) -> Result<HttpResponse, Error> {
     let org_id = path.into_inner();
-    match reports::save(&org_id, "", report.into_inner(), true).await {
+
+    let mut report = report.into_inner();
+    report.owner = user_email.user_id;
+    match reports::save(&org_id, "", report, true).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Report saved")),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }
@@ -84,9 +91,12 @@ pub async fn create_report(
 async fn update_report(
     path: web::Path<(String, String)>,
     report: web::Json<Report>,
+    user_email: UserEmail,
 ) -> Result<HttpResponse, Error> {
     let (org_id, name) = path.into_inner();
-    match reports::save(&org_id, &name, report.into_inner(), false).await {
+    let mut report = report.into_inner();
+    report.last_edited_by = user_email.user_id;
+    match reports::save(&org_id, &name, report, false).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Report saved")),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -75,10 +75,12 @@ pub async fn save(
     alert.row_template = alert.row_template.trim().to_string();
 
     match db::alerts::alert::get(org_id, stream_type, stream_name, &alert.name).await {
-        Ok(Some(_)) => {
+        Ok(Some(old_alert)) => {
             if create {
                 return Err(anyhow::anyhow!("Alert already exists"));
             }
+            alert.last_triggered_at = old_alert.last_triggered_at;
+            alert.owner = old_alert.owner;
         }
         Ok(None) => {
             if !create {

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -86,12 +86,13 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
     );
     let columns = trigger.module_key.split('/').collect::<Vec<&str>>();
     assert_eq!(columns.len(), 3);
-    let org_id = &trigger.org;
+    let org_id = trigger.org.clone();
     let stream_type: StreamType = columns[0].into();
     let stream_name = columns[1];
     let alert_name = columns[2];
     let is_realtime = trigger.is_realtime;
     let is_silenced = trigger.is_silenced;
+    let triggered_at = trigger.start_time.unwrap_or_default();
 
     if is_realtime && is_silenced {
         log::debug!(
@@ -111,7 +112,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         return Ok(());
     }
 
-    let alert = match super::alert::get(org_id, stream_type, stream_name, alert_name).await? {
+    let alert = match super::alert::get(&org_id, stream_type, stream_name, alert_name).await? {
         Some(alert) => alert,
         None => {
             return Err(anyhow::anyhow!(
@@ -186,7 +187,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
     }
 
     let mut trigger_data_stream = TriggerData {
-        _timestamp: trigger.start_time.unwrap_or_default(),
+        _timestamp: triggered_at,
         org: trigger.org,
         module: TriggerDataType::Alert,
         key: trigger.module_key.clone(),
@@ -272,6 +273,31 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         trigger_data_stream.status = TriggerDataStatus::ConditionNotSatisfied;
     }
 
+    // Check if the alert has been disabled in the mean time
+    let mut old_alert =
+        match super::alert::get(&org_id, stream_type, stream_name, alert_name).await? {
+            Some(alert) => alert,
+            None => {
+                return Err(anyhow::anyhow!(
+                    "alert not found: {}/{}/{}/{}",
+                    org_id,
+                    stream_name,
+                    stream_type,
+                    alert_name
+                ));
+            }
+        };
+    old_alert.last_triggered_at = Some(triggered_at);
+    if let Err(e) = db::alerts::alert::set_without_updating_trigger(
+        &org_id,
+        stream_type,
+        stream_name,
+        &old_alert,
+    )
+    .await
+    {
+        log::error!("Failed to update alert: {alert_name} after trigger: {e}",);
+    }
     // publish the triggers as stream
     publish_triggers_usage(trigger_data_stream).await;
 
@@ -358,8 +384,9 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         }
     }
 
+    let triggered_at = trigger.start_time.unwrap_or_default();
     let mut trigger_data_stream = TriggerData {
-        _timestamp: trigger.start_time.unwrap_or_default(),
+        _timestamp: triggered_at,
         org: trigger.org.clone(),
         module: TriggerDataType::Report,
         key: trigger.module_key.clone(),
@@ -373,7 +400,6 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         error: None,
     };
 
-    let now = Utc::now().timestamp_micros();
     match report.send_subscribers().await {
         Ok(_) => {
             log::info!("Report {} sent to destination", report_name);
@@ -414,13 +440,13 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         }
     }
 
-    report.last_triggered_at = Some(now);
     // Check if the report has been disabled in the mean time
-    let old_report = db::dashboards::reports::get(org_id, report_name).await?;
-    if !old_report.enabled {
-        report.enabled = old_report.enabled;
+    let mut old_report = db::dashboards::reports::get(org_id, report_name).await?;
+    if old_report.enabled {
+        old_report.enabled = report.enabled;
     }
-    let result = db::dashboards::reports::set_without_updating_trigger(org_id, &report).await;
+    old_report.last_triggered_at = Some(triggered_at);
+    let result = db::dashboards::reports::set_without_updating_trigger(org_id, &old_report).await;
     if result.is_err() {
         log::error!(
             "Failed to update report: {report_name} after trigger: {}",

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -31,9 +31,12 @@ use crate::{
     common::{
         meta::{
             authz::Authz,
-            dashboards::reports::{
-                HttpReportPayload, Report, ReportDashboard, ReportDestination, ReportEmailDetails,
-                ReportFrequencyType, ReportTimerangeType,
+            dashboards::{
+                datetime_now,
+                reports::{
+                    HttpReportPayload, Report, ReportDashboard, ReportDestination,
+                    ReportEmailDetails, ReportFrequencyType, ReportTimerangeType,
+                },
             },
         },
         utils::auth::{is_ofga_unsupported, remove_ownership, set_ownership},
@@ -100,10 +103,13 @@ pub async fn save(
     }
 
     match db::dashboards::reports::get(org_id, &report.name).await {
-        Ok(_) => {
+        Ok(old_report) => {
             if create {
                 return Err(anyhow::anyhow!("Report already exists"));
             }
+            report.last_triggered_at = old_report.last_triggered_at;
+            report.owner = old_report.owner;
+            report.updated_at = Some(datetime_now());
         }
         Err(_) => {
             if !create {

--- a/src/service/db/alerts/alert.rs
+++ b/src/service/db/alerts/alert.rs
@@ -89,6 +89,27 @@ pub async fn set(
     }
 }
 
+pub async fn set_without_updating_trigger(
+    org_id: &str,
+    stream_type: StreamType,
+    stream_name: &str,
+    alert: &Alert,
+) -> Result<String, anyhow::Error> {
+    let schedule_key = format!("{stream_type}/{stream_name}/{}", alert.name);
+    let key = format!("/alerts/{org_id}/{}", &schedule_key);
+    match db::put(
+        &key,
+        json::to_vec(alert).unwrap().into(),
+        db::NEED_WATCH,
+        None,
+    )
+    .await
+    {
+        Ok(_) => Ok(schedule_key),
+        Err(e) => Err(anyhow::anyhow!("{e}")),
+    }
+}
+
 pub async fn delete(
     org_id: &str,
     stream_type: StreamType,


### PR DESCRIPTION
Addresses #4273 

- Adds `last_triggered_at`, `owner`, `updated_at` and `last_edited_by` fields (similar to Reports) to Alerts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced alert and report management with additional metadata fields for tracking last triggered times, owners, and edit history.
  - Introduced user identification in report creation and updates for better ownership tracking.
  
- **Bug Fixes**
  - Improved logic for saving alerts and reports to accurately reflect their statuses and metadata during creation and updates.
  
- **Documentation**
  - Restructured import organization for improved clarity and maintainability in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->