### PR TITLE
fix: do not allow `SELECT *` in alert query

### DIFF
--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -48,6 +48,7 @@ use crate::{
     service::{
         alerts::{build_sql, destinations},
         db,
+        search::sql::RE_ONLY_SELECT,
     },
 };
 
@@ -186,6 +187,13 @@ pub async fn save(
                 || alert.query_condition.sql.as_ref().unwrap().is_empty()
             {
                 return Err(anyhow::anyhow!("Alert with SQL mode should have a query"));
+            }
+            if alert.query_condition.sql.is_some()
+                && RE_ONLY_SELECT.is_match(alert.query_condition.sql.as_ref().unwrap())
+            {
+                return Err(anyhow::anyhow!(
+                    "Alert with SQL can not contain SELECT * in the SQL query"
+                ));
             }
         }
         QueryType::PromQL => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced validation for alert creation to prevent the use of "SELECT *" in SQL queries, improving data integrity and security during the alert setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->