### PR TITLE
fix: add histogram interval for multi result cache

### DIFF
--- a/src/infra/src/cache/meta.rs
+++ b/src/infra/src/cache/meta.rs
@@ -15,7 +15,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ResultCacheMeta {
     pub start_time: i64,
     pub end_time: i64,

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -368,6 +368,7 @@ fn merge_response(
         cache_response.scan_size += res.scan_size;
         cache_response.took += res.took;
         files_cache_ratio += res.cached_ratio;
+        cache_response.histogram_interval = res.histogram_interval;
 
         result_cache_len += res.total;
 

--- a/src/service/search/cache/multi.rs
+++ b/src/service/search/cache/multi.rs
@@ -220,11 +220,14 @@ async fn recursive_process_multiple_metas(
                 let remaining_metas: Vec<ResultCacheMeta> = sorted_metas.clone()
                     .into_iter()
                     .filter(|meta| {
-                        meta.end_time <= largest_meta.start_time || meta.start_time >= largest_meta.end_time
+                       !largest_meta.eq(meta) &&  (meta.end_time <= largest_meta.start_time || meta.start_time >= largest_meta.end_time)
                     })
                     .collect();
-
-                let _ = recursive_process_multiple_metas(&remaining_metas[..], trace_id, cache_req, results, query_key, file_path).await;
+                if !remaining_metas.is_empty() {
+                     return Ok(());
+                };
+                let _ = recursive_process_multiple_metas(&remaining_metas[..], trace_id, cache_req, results, query_key, file_path).await;                    
     }
     Ok(())
 }
+

--- a/src/service/search/cluster/cache_multi.rs
+++ b/src/service/search/cluster/cache_multi.rs
@@ -264,11 +264,15 @@ fn recursive_process_muliple_metas(
         let remaining_metas: Vec<_> = sorted_metas
             .into_iter()
             .filter(|meta| {
-                meta.response_end_time <= largest_meta.response_start_time
-                    || meta.response_start_time >= largest_meta.response_end_time
+                !(largest_meta.response_start_time == meta.response_start_time
+                    && meta.response_end_time <= largest_meta.response_end_time)
+                    && (meta.response_end_time <= largest_meta.response_start_time
+                        || meta.response_start_time >= largest_meta.response_end_time)
             })
             .collect();
-
+        if remaining_metas.is_empty() {
+            return;
+        }
         recursive_process_muliple_metas(&remaining_metas, cache_req, results);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `ResultCacheMeta` struct to support equality comparisons, improving filtering and duplicate checks.
	- Updated response merging to account for histogram intervals in cache responses.
	- Improved filtering logic to optimize processing of metadata, including early returns for empty collections.

- **Bug Fixes**
	- Refined logic to ensure correct filtering based on response times for metadata processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->