### PR TITLE
fix: duplicate records when using result cache

### DIFF
--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -158,7 +158,12 @@ pub async fn check_cache(
 
         multi_res.sort_by_key(|meta| meta.response_start_time);
 
-        let deltas = calculate_deltas_multi(&multi_res, req.query.start_time, req.query.end_time);
+        let deltas = calculate_deltas_multi(
+            &multi_res,
+            req.query.start_time,
+            req.query.end_time,
+            discard_interval,
+        );
 
         for res in multi_res {
             if res.has_cached_data {
@@ -571,6 +576,7 @@ fn calculate_deltas_multi(
     results: &[CachedQueryResponse],
     start_time: i64,
     end_time: i64,
+    histogram_interval: i64,
 ) -> Vec<QueryDelta> {
     let mut deltas = Vec::new();
 
@@ -584,11 +590,23 @@ fn calculate_deltas_multi(
             meta.response_end_time,
             meta.cached_response.hits.len()
         );
+
+        let delta_end_time = if current_end_time != start_time && histogram_interval > 0 {
+            // If there is a histogram interval, we need to adjust the end time to the nearest
+            // interval
+            let mut end_time = meta.response_start_time;
+            if end_time % histogram_interval != 0 {
+                end_time = end_time - (end_time % histogram_interval);
+            }
+            end_time
+        } else {
+            meta.response_start_time
+        };
         if meta.response_start_time > current_end_time {
             // There is a gap (delta) between current coverage and the next meta
             deltas.push(QueryDelta {
                 delta_start_time: current_end_time,
-                delta_end_time: meta.response_start_time,
+                delta_end_time,
                 delta_removed_hits: false,
             });
         }

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -405,12 +405,6 @@ fn sort_response(is_descending: bool, cache_response: &mut search::Response, ts_
             .hits
             .sort_by_key(|a| get_ts_value(ts_column, a));
     }
-    // Deduplicate the hits by ts_column
-    let mut seen = hashbrown::HashSet::new();
-    cache_response.hits.retain(|hit| {
-        let ts_value = get_ts_value(ts_column, hit);
-        seen.insert(ts_value)
-    });
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -405,6 +405,12 @@ fn sort_response(is_descending: bool, cache_response: &mut search::Response, ts_
             .hits
             .sort_by_key(|a| get_ts_value(ts_column, a));
     }
+    // Deduplicate the hits by ts_column
+    let mut seen = hashbrown::HashSet::new();
+    cache_response.hits.retain(|hit| {
+        let ts_value = get_ts_value(ts_column, hit);
+        seen.insert(ts_value)
+    });
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Fixes : https://github.com/openobserve/openobserve/issues/4274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced search response quality by implementing a deduplication step, ensuring unique entries based on timestamps in the search results.
	- Improved delta calculations in the caching mechanism with new parameters for granular control over time intervals, enhancing the accuracy of cached data responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->