### PR TITLE
fix: always return single partition for ResultArray VRL

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -329,6 +329,8 @@ pub struct SearchPartitionRequest {
     pub regions: Vec<String>,
     #[serde(default)]
     pub clusters: Vec<String>,
+    #[serde(default)]
+    pub query_fn: Option<String>,
 }
 
 impl SearchPartitionRequest {
@@ -553,6 +555,8 @@ pub struct MultiSearchPartitionRequest {
     pub regions: Vec<String>,
     #[serde(default)]
     pub clusters: Vec<String>,
+    #[serde(default)]
+    pub query_fn: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, ToSchema)]

--- a/src/service/search/cache/multi.rs
+++ b/src/service/search/cache/multi.rs
@@ -226,8 +226,7 @@ async fn recursive_process_multiple_metas(
                 if !remaining_metas.is_empty() {
                      return Ok(());
                 };
-                let _ = recursive_process_multiple_metas(&remaining_metas[..], trace_id, cache_req, results, query_key, file_path).await;                    
+                let _ = recursive_process_multiple_metas(&remaining_metas[..], trace_id, cache_req, results, query_key, file_path).await;
     }
     Ok(())
 }
-

--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -25,16 +25,10 @@ use config::{
     },
 };
 use infra::errors::{Error, ErrorCodes, Result};
-use once_cell::sync::Lazy;
 use proto::cluster_rpc;
-use regex::Regex;
 use vector_enrichment::TableRegistry;
 
 use crate::common::meta::functions::VRLResultResolver;
-
-// Checks for #ResultArray#
-pub static RESULT_ARRAY: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?m)^#[ \s]*Result[ \s]*Array[ \s]*#$").unwrap());
 
 #[tracing::instrument(
     name = "service:search:cluster",
@@ -83,9 +77,9 @@ pub async fn search(mut req: cluster_rpc::SearchRequest) -> Result<search::Respo
             // compile vrl function & apply the same before returning the response
             let input_fn = query_fn.trim();
 
-            let apply_over_hits = RESULT_ARRAY.is_match(input_fn);
+            let apply_over_hits = super::super::RESULT_ARRAY.is_match(input_fn);
             if apply_over_hits {
-                query_fn = RESULT_ARRAY.replace(input_fn, "").to_string();
+                query_fn = super::super::RESULT_ARRAY.replace(input_fn, "").to_string();
             }
             let mut runtime = crate::common::utils::functions::init_vrl_runtime();
             let program =


### PR DESCRIPTION
impl #4289

the search partition API request also added a new attribute `query_fn`, like this:

```json
{
	"sql": "SELECT histogram(_timestamp) AS xyz, _timestamp FROM default5 GROUP BY _timestamp ORDER BY _timestamp DESC LIMIT 10000",
	"start_time": 1724129780000000,
	"end_time":  1725080137000000,
	"query_fn": "#ResultArray#\nabc"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional field `query_fn` for enhanced search functionality in search requests.
	- Updated search methods to incorporate the `query_fn`, allowing for more complex query handling.

- **Bug Fixes**
	- Improved regex handling by referencing a globally defined regex pattern, ensuring consistent application across modules.

- **Style**
	- Cleaned up code formatting for better readability without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->