### PR TITLE
feat: destination-less report

### DIFF
--- a/src/common/meta/dashboards/reports.rs
+++ b/src/common/meta/dashboards/reports.rs
@@ -211,3 +211,10 @@ pub struct HttpReportPayload {
     pub dashboards: Vec<ReportDashboard>,
     pub email_details: ReportEmailDetails,
 }
+
+#[derive(Debug, Clone)]
+pub struct ReportListFilters {
+    pub dashboard: Option<String>,
+    pub folder: Option<String>,
+    pub destination_less: Option<bool>,
+}

--- a/src/handler/http/request/dashboards/reports.rs
+++ b/src/handler/http/request/dashboards/reports.rs
@@ -19,7 +19,10 @@ use actix_web::{delete, get, http, post, put, web, HttpRequest, HttpResponse};
 
 use crate::{
     common::{
-        meta::{dashboards::reports::Report, http::HttpResponse as MetaHttpResponse},
+        meta::{
+            dashboards::reports::{Report, ReportListFilters},
+            http::HttpResponse as MetaHttpResponse,
+        },
         utils::auth::UserEmail,
     },
     service::dashboards::reports,
@@ -118,14 +121,34 @@ async fn update_report(
     ),
 )]
 #[get("/{org_id}/reports")]
-async fn list_reports(org_id: web::Path<String>, _req: HttpRequest) -> Result<HttpResponse, Error> {
+async fn list_reports(org_id: web::Path<String>, req: HttpRequest) -> Result<HttpResponse, Error> {
     let org_id = org_id.into_inner();
+    let query = web::Query::<HashMap<String, String>>::from_query(req.query_string()).unwrap();
+
+    let folder = query
+        .get("folder_id")
+        .and_then(|field| Some(field.to_owned()));
+    let dashboard = query
+        .get("dashboard_id")
+        .and_then(|field| Some(field.to_owned()));
+    let destination_less =
+        query
+            .get("destination_less")
+            .and_then(|field| match field.parse::<bool>() {
+                Ok(value) => Some(value),
+                Err(_) => None,
+            });
+    let filters = ReportListFilters {
+        folder,
+        dashboard,
+        destination_less,
+    };
 
     let mut _permitted = None;
     // Get List of allowed objects
     #[cfg(feature = "enterprise")]
     {
-        let user_id = _req.headers().get("user_id").unwrap();
+        let user_id = req.headers().get("user_id").unwrap();
         match crate::handler::http::auth::validator::list_objects_for_user(
             &org_id,
             user_id.to_str().unwrap(),
@@ -146,7 +169,7 @@ async fn list_reports(org_id: web::Path<String>, _req: HttpRequest) -> Result<Ht
         // Get List of allowed objects ends
     }
 
-    match reports::list(&org_id, _permitted).await {
+    match reports::list(&org_id, filters, _permitted).await {
         Ok(data) => Ok(MetaHttpResponse::json(data)),
         Err(e) => Ok(MetaHttpResponse::bad_request(e)),
     }

--- a/src/handler/http/request/dashboards/reports.rs
+++ b/src/handler/http/request/dashboards/reports.rs
@@ -125,12 +125,8 @@ async fn list_reports(org_id: web::Path<String>, req: HttpRequest) -> Result<Htt
     let org_id = org_id.into_inner();
     let query = web::Query::<HashMap<String, String>>::from_query(req.query_string()).unwrap();
 
-    let folder = query
-        .get("folder_id")
-        .and_then(|field| Some(field.to_owned()));
-    let dashboard = query
-        .get("dashboard_id")
-        .and_then(|field| Some(field.to_owned()));
+    let folder = query.get("folder_id").map(|field| field.to_owned());
+    let dashboard = query.get("dashboard_id").map(|field| field.to_owned());
     let destination_less =
         query
             .get("destination_less")

--- a/src/handler/http/request/dashboards/reports.rs
+++ b/src/handler/http/request/dashboards/reports.rs
@@ -127,13 +127,12 @@ async fn list_reports(org_id: web::Path<String>, req: HttpRequest) -> Result<Htt
 
     let folder = query.get("folder_id").map(|field| field.to_owned());
     let dashboard = query.get("dashboard_id").map(|field| field.to_owned());
-    let destination_less =
-        query
-            .get("destination_less")
-            .and_then(|field| match field.parse::<bool>() {
-                Ok(value) => Some(value),
-                Err(_) => None,
-            });
+    let destination_less = query
+        .get("cache")
+        .and_then(|field| match field.parse::<bool>() {
+            Ok(value) => Some(value),
+            Err(_) => None,
+        });
     let filters = ReportListFilters {
         folder,
         dashboard,

--- a/src/report_server/src/models.rs
+++ b/src/report_server/src/models.rs
@@ -17,6 +17,12 @@ pub struct EmailDetails {
     pub dashb_url: String,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum ReportType {
+    PDF,
+    Cache,
+}
+
 #[derive(Serialize, Debug, Deserialize, Clone)]
 pub struct Report {
     pub dashboards: Vec<ReportDashboard>,

--- a/src/report_server/src/models.rs
+++ b/src/report_server/src/models.rs
@@ -17,7 +17,7 @@ pub struct EmailDetails {
     pub dashb_url: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ReportType {
     PDF,
     Cache,

--- a/src/report_server/src/report.rs
+++ b/src/report_server/src/report.rs
@@ -349,13 +349,11 @@ pub async fn generate_report(
     // Convert the page into pdf
     let pdf_data = match report_type {
         ReportType::PDF => {
-            let pdf = page
-                .pdf(PrintToPdfParams {
-                    landscape: Some(true),
-                    ..Default::default()
-                })
-                .await?;
-            pdf
+            page.pdf(PrintToPdfParams {
+                landscape: Some(true),
+                ..Default::default()
+            })
+            .await?
         }
         // No need to capture pdf when report type is cache
         ReportType::Cache => vec![],

--- a/src/report_server/src/report.rs
+++ b/src/report_server/src/report.rs
@@ -222,7 +222,7 @@ pub async fn generate_report(
 
     // dashboard link in the email should contain data of the same period as the report
     let (dashb_url, email_dashb_url) = match timerange.range_type {
-        ReportTimerangeType::Relative => {
+        models::ReportTimerangeType::Relative => {
             let period = &timerange.period;
             let (time_duration, time_unit) = period.split_at(period.len() - 1);
             let dashb_url = format!(
@@ -275,7 +275,7 @@ pub async fn generate_report(
             );
             (dashb_url, email_dashb_url)
         }
-        ReportTimerangeType::Absolute => {
+        models::ReportTimerangeType::Absolute => {
             let url = format!(
                 "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype=reports&from={}&to={}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
                 &timerange.from, &timerange.to
@@ -368,10 +368,10 @@ pub async fn generate_report(
 }
 
 /// Sends emails to the [`Report`] recepients. Currently only one pdf data is supported.
-async fn send_email(
+pub async fn send_email(
     pdf_data: &[u8],
-    email_details: EmailDetails,
-    config: SmtpConfig,
+    email_details: models::EmailDetails,
+    config: models::SmtpConfig,
 ) -> Result<(), anyhow::Error> {
     let mut recepients = vec![];
     for recepient in &email_details.recepients {
@@ -422,7 +422,7 @@ async fn send_email(
 
 pub async fn wait_for_panel_data_load(page: &Page) -> Result<Duration, anyhow::Error> {
     let start = std::time::Instant::now();
-    let timeout = std::time::Duration::from_secs(CONFIG.chrome.chrome_sleep_secs.into());
+    let timeout = std::time::Duration::from_secs(get_config().chrome.chrome_sleep_secs.into());
     loop {
         if page
             .find_element("span#dashboardVariablesAndPanelsDataLoaded")

--- a/src/report_server/src/report.rs
+++ b/src/report_server/src/report.rs
@@ -219,6 +219,10 @@ pub async fn generate_report(
     sleep(Duration::from_secs(5)).await;
 
     let timerange = &dashboard.timerange;
+    let search_type = match report_type.clone() {
+        ReportType::Cache => "ui",
+        _ => "reports",
+    };
 
     // dashboard link in the email should contain data of the same period as the report
     let (dashb_url, email_dashb_url) = match timerange.range_type {
@@ -226,7 +230,7 @@ pub async fn generate_report(
             let period = &timerange.period;
             let (time_duration, time_unit) = period.split_at(period.len() - 1);
             let dashb_url = format!(
-                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype=reports&period={period}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
+                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype={search_type}&period={period}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
             );
             log::debug!("dashb_url for dashboard {folder_id}/{dashboard_id}: {dashb_url}");
 
@@ -277,7 +281,7 @@ pub async fn generate_report(
         }
         models::ReportTimerangeType::Absolute => {
             let url = format!(
-                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype=reports&from={}&to={}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
+                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype={search_type}&from={}&to={}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
                 &timerange.from, &timerange.to
             );
             log::debug!("dashb_url for dashboard {folder_id}/{dashboard_id}: {url}");

--- a/src/report_server/src/report.rs
+++ b/src/report_server/src/report.rs
@@ -19,7 +19,7 @@ use lettre::{
 use once_cell::sync::Lazy;
 use tokio::time::{sleep, Duration};
 
-use crate::models;
+use crate::models::{self, ReportType};
 
 static CHROME_LAUNCHER_OPTIONS: tokio::sync::OnceCell<BrowserConfig> =
     tokio::sync::OnceCell::const_new();
@@ -143,6 +143,7 @@ pub async fn generate_report(
     user_pass: &str,
     web_url: &str,
     timezone: &str,
+    report_type: ReportType,
 ) -> Result<(Vec<u8>, String), anyhow::Error> {
     let dashboard_id = &dashboard.dashboard;
     let folder_id = &dashboard.folder;
@@ -172,30 +173,46 @@ pub async fn generate_report(
         }
     });
 
-    log::debug!("Navigating to web url: {}", &web_url);
+    log::info!("Navigating to web url: {web_url}/login?login_as_internal_user=true");
     let page = browser
         .new_page(&format!("{web_url}/login?login_as_internal_user=true"))
         .await?;
     page.disable_log().await?;
-    log::debug!("headless: new page created");
+    log::info!("headless: new page created");
+    sleep(Duration::from_secs(5)).await;
 
-    page.find_element("input[type='email']")
-        .await?
-        .click()
-        .await?
-        .type_str(user_id)
-        .await?;
-    log::debug!("headless: email input filled");
+    match page.find_element("input[type='email']").await {
+        Ok(elem) => {
+            elem.click().await?.type_str(user_id).await?;
+        }
+        Err(e) => {
+            let page_url = page.url().await;
+            return Err(anyhow::anyhow!(
+                "Error finding email input box: current url: {:#?} error: {e}",
+                page_url
+            ));
+        }
+    }
+    log::info!("headless: email input filled");
 
-    page.find_element("input[type='password']")
-        .await?
-        .click()
-        .await?
-        .type_str(user_pass)
-        .await?
-        .press_key("Enter")
-        .await?;
-    log::debug!("headless: password input filled");
+    match page.find_element("input[type='password']").await {
+        Ok(elem) => {
+            elem.click()
+                .await?
+                .type_str(user_pass)
+                .await?
+                .press_key("Enter")
+                .await?;
+        }
+        Err(e) => {
+            let page_url = page.url().await;
+            return Err(anyhow::anyhow!(
+                "Error finding password input box: current url: {:#?} error: {e}",
+                page_url
+            ));
+        }
+    }
+    log::info!("headless: password input filled");
 
     // Does not seem to work for single page client application
     page.wait_for_navigation().await?;
@@ -205,7 +222,7 @@ pub async fn generate_report(
 
     // dashboard link in the email should contain data of the same period as the report
     let (dashb_url, email_dashb_url) = match timerange.range_type {
-        models::ReportTimerangeType::Relative => {
+        ReportTimerangeType::Relative => {
             let period = &timerange.period;
             let (time_duration, time_unit) = period.split_at(period.len() - 1);
             let dashb_url = format!(
@@ -258,7 +275,7 @@ pub async fn generate_report(
             );
             (dashb_url, email_dashb_url)
         }
-        models::ReportTimerangeType::Absolute => {
+        ReportTimerangeType::Absolute => {
             let url = format!(
                 "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype=reports&from={}&to={}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
                 &timerange.from, &timerange.to
@@ -269,54 +286,80 @@ pub async fn generate_report(
         }
     };
 
-    log::debug!("headless: going to dash url");
+    log::info!("headless: navigating to organization: {web_url}/?org_identifier={org_id}");
     // First navigate to the correct org
     page.goto(&format!("{web_url}/?org_identifier={org_id}"))
         .await?;
     page.wait_for_navigation().await?;
     sleep(Duration::from_secs(2)).await;
-    log::debug!("headless: navigated to the org_id: {org_id}");
 
-    page.goto(&dashb_url).await?;
-    log::debug!("headless: going to dash url");
+    log::info!("headless: navigated to the organization {org_id}");
+    log::info!("headless: navigating to dashboard url {dashb_url}");
+
+    if let Err(e) = page.goto(&dashb_url).await {
+        let page_url = page.url().await;
+        log::error!(
+            "Error navigating to dashboard url {dashb_url}: current uri: {:#?} error: {e}",
+            page_url
+        );
+        return Err(anyhow::anyhow!("{e}"));
+    }
 
     // Wait for navigation does not really wait until it is fully loaded
     page.wait_for_navigation().await?;
 
-    log::debug!("waiting for data to load for dashboard {dashboard_id}");
+    log::info!("waiting for data to load for dashboard {dashboard_id}");
 
     // If the span element is not rendered yet, capture whatever is loaded till now
-    if let Err(e) = wait_for_panel_data_load(&page).await {
-        log::error!(
-            "[REPORT] error occurred while finding the span element for dashboard {dashboard_id}:{e}"
-        );
-    } else {
-        log::info!("[REPORT] all panel data loaded for report dashboard: {dashboard_id}");
+    match wait_for_panel_data_load(&page).await {
+        Err(e) => {
+            log::error!(
+                "[REPORT] error finding the span element for dashboard {dashboard_id}: {e}"
+            );
+            log::info!("[REPORT] proceeding with whatever data is loaded until now");
+        }
+        Ok(dur) => {
+            log::info!(
+                "[REPORT] all panel data loaded for report dashboard: {dashboard_id} in {} seconds",
+                dur.as_secs_f64()
+            );
+        }
     }
 
     if let Err(e) = page.find_element("main").await {
+        let page_url = page.url().await;
         browser.close().await?;
         handle.await?;
         return Err(anyhow::anyhow!(
-            "[REPORT] main element not rendered yet for dashboard {dashboard_id}: {e}"
+            "[REPORT] main html element not rendered yet for dashboard {dashboard_id}; most likely login failed: current url: {:#?} error: {e}",
+            page_url
         ));
     }
     if let Err(e) = page.find_element("div.displayDiv").await {
+        let page_url = page.url().await;
         browser.close().await?;
         handle.await?;
         return Err(anyhow::anyhow!(
-            "[REPORT] div.displayDiv element not rendered yet for dashboard {dashboard_id}: {e}"
+            "[REPORT] div.displayDiv element not rendered yet for dashboard {dashboard_id}: current url: {:#?} error: {e}",
+            page_url
         ));
     }
 
     // Last two elements loaded means atleast the metric components have loaded.
     // Convert the page into pdf
-    let pdf_data = page
-        .pdf(PrintToPdfParams {
-            landscape: Some(true),
-            ..Default::default()
-        })
-        .await?;
+    let pdf_data = match report_type {
+        ReportType::PDF => {
+            let pdf = page
+                .pdf(PrintToPdfParams {
+                    landscape: Some(true),
+                    ..Default::default()
+                })
+                .await?;
+            pdf
+        }
+        // No need to capture pdf when report type is cache
+        ReportType::Cache => vec![],
+    };
 
     browser.close().await?;
     handle.await?;
@@ -325,10 +368,10 @@ pub async fn generate_report(
 }
 
 /// Sends emails to the [`Report`] recepients. Currently only one pdf data is supported.
-pub async fn send_email(
+async fn send_email(
     pdf_data: &[u8],
-    email_details: models::EmailDetails,
-    config: models::SmtpConfig,
+    email_details: EmailDetails,
+    config: SmtpConfig,
 ) -> Result<(), anyhow::Error> {
     let mut recepients = vec![];
     for recepient in &email_details.recepients {
@@ -350,10 +393,9 @@ pub async fn send_email(
     let email = email
         .multipart(
             MultiPart::mixed()
-                .singlepart(SinglePart::html(email_details.message))
                 .singlepart(SinglePart::html(format!(
-                    "<p><a href='{}' target='_blank'>Link to dashboard</a></p>",
-                    email_details.dashb_url
+                    "{}\n\n<p><a href='{}' target='_blank'>Link to dashboard</a></p>",
+                    email_details.message, email_details.dashb_url
                 )))
                 .singlepart(
                     // Only supports PDF for now, attach the PDF
@@ -378,21 +420,22 @@ pub async fn send_email(
     }
 }
 
-pub async fn wait_for_panel_data_load(page: &Page) -> Result<(), anyhow::Error> {
+pub async fn wait_for_panel_data_load(page: &Page) -> Result<Duration, anyhow::Error> {
     let start = std::time::Instant::now();
-    let timeout = std::time::Duration::from_secs(get_config().chrome.chrome_sleep_secs.into());
+    let timeout = std::time::Duration::from_secs(CONFIG.chrome.chrome_sleep_secs.into());
     loop {
         if page
             .find_element("span#dashboardVariablesAndPanelsDataLoaded")
             .await
             .is_ok()
         {
-            return Ok(());
+            return Ok(start.elapsed());
         }
 
         if start.elapsed() >= timeout {
             return Err(anyhow::anyhow!(
-                "span element indicator for data load not rendered yet"
+                "Dashboard data not completely loaded yet in {} seconds",
+                start.elapsed().as_secs_f64()
             ));
         }
 

--- a/src/report_server/src/router.rs
+++ b/src/report_server/src/router.rs
@@ -4,7 +4,7 @@ use actix_web::{get, http::StatusCode, put, web, HttpRequest, HttpResponse as Ac
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    models,
+    models::{self, ReportType},
     report::{generate_report, send_email, SMTP_CLIENT},
 };
 
@@ -66,6 +66,11 @@ pub async fn send_report(
     };
 
     let cfg = config::get_config();
+    let report_type = if report.email_details.recepients.is_empty() {
+        ReportType::Cache
+    } else {
+        ReportType::PDF
+    };
     let (pdf_data, email_dashboard_url) = match generate_report(
         &report.dashboards[0],
         &org_id,
@@ -73,6 +78,7 @@ pub async fn send_report(
         &cfg.report_server.user_password,
         &report.email_details.dashb_url,
         timezone,
+        report_type.clone(),
     )
     .await
     {
@@ -83,6 +89,13 @@ pub async fn send_report(
                 .json(HttpResponse::internal_server_error(e.to_string())));
         }
     };
+
+    if report_type == ReportType::Cache {
+        log::info!("Dashboard data cached by report {report_name}");
+        return Ok(ActixHttpResponse::Ok().json(HttpResponse::success(format!(
+            "dashboard data cached by report {report_name}"
+        ))));
+    }
 
     match send_email(
         &pdf_data,

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -341,7 +341,6 @@ impl Report {
         for recepient in &self.destinations {
             match recepient {
                 ReportDestination::Email(email) => recepients.push(email),
-                _ => {}
             }
         }
 

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -486,6 +486,11 @@ async fn generate_report(
     tokio::time::sleep(Duration::from_secs(5)).await;
 
     let timerange = &dashboard.timerange;
+    let search_type = if no_of_recepients == 0 {
+        "ui"
+    } else {
+        "reports"
+    };
 
     // dashboard link in the email should contain data of the same period as the report
     let (dashb_url, email_dashb_url) = match timerange.range_type {
@@ -493,7 +498,7 @@ async fn generate_report(
             let period = &timerange.period;
             let (time_duration, time_unit) = period.split_at(period.len() - 1);
             let dashb_url = format!(
-                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype=reports&period={period}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
+                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype={search_type}&period={period}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
             );
 
             let time_duration: i64 = time_duration.parse()?;
@@ -543,7 +548,7 @@ async fn generate_report(
         }
         ReportTimerangeType::Absolute => {
             let url = format!(
-                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype=reports&from={}&to={}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
+                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype={search_type}&from={}&to={}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
                 &timerange.from, &timerange.to
             );
             (url.clone(), url)

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -205,8 +205,7 @@ pub async fn list(
                         if report
                             .dashboards
                             .iter()
-                            .find(|&x| x.dashboard.eq(dashboard_id))
-                            .is_none()
+                            .any(|x| x.dashboard.eq(dashboard_id))
                         {
                             should_include = false;
                         }
@@ -214,9 +213,9 @@ pub async fn list(
                     if let Some(destination_less) = destination_less.as_ref() {
                         // destination_less = true -> push only if the report is destination-less
                         // destination_less = false -> push only if the report has destinations
-                        if *destination_less && !report.destinations.is_empty() {
-                            should_include = false;
-                        } else if !*destination_less && report.destinations.is_empty() {
+                        if (*destination_less && !report.destinations.is_empty())
+                            || (!*destination_less && report.destinations.is_empty())
+                        {
                             should_include = false;
                         }
                     }


### PR DESCRIPTION
Destination less report for caching purpose.
- [x] Empty destination array is supported for caching purpose. If destinations array is empty it only spawns a chromium and loads the dashboard, does not capture pdf.
- [x] For Cache type reports, it uses ui search type so that the dashboard queries land on only the interactive node and not in the background node.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new filtering system for reports, allowing users to specify criteria such as dashboard and folder.
	- Added support for two report types: PDF and Cache, enhancing report generation options.
	- Enhanced report generation functionality to include dynamic handling based on report type and recipient count.

- **Bug Fixes**
	- Improved error handling and logging for report generation processes.

- **Documentation**
	- Updated documentation to reflect new parameters and functionalities in report handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->