### PR TITLE
fix: keep tcp connections alive for syslog

### DIFF
--- a/src/handler/tcp_udp/mod.rs
+++ b/src/handler/tcp_udp/mod.rs
@@ -59,7 +59,6 @@ pub async fn udp_server(socket: UdpSocket) {
 pub async fn tcp_server(listener: TcpListener) {
     let sender = BROADCASTER.read().await;
     let mut tcp_receiver_rx = sender.subscribe();
-    let mut buf_tcp = vec![0u8; 1460];
     loop {
         let (mut stream, _) = match listener.accept().await {
             Ok(val) => val,
@@ -68,16 +67,32 @@ pub async fn tcp_server(listener: TcpListener) {
                 continue;
             }
         };
-
-        match stream.peer_addr() {
-            Ok(addr) => {
+        tokio::task::spawn(async move {
+            let mut buf_tcp = vec![0u8; 1460];
+            let peer_addr = match stream.peer_addr() {
+                Ok(addr) => addr,
+                Err(e) => {
+                    log::error!("Error while reading peer_addr from TCP stream: {}", e);
+                    return;
+                }
+            };
+            log::info!("spawned new syslog tcp receiver for peer {}", peer_addr);
+            loop {
+                // TODO: properly handle large size reads
                 let len = match stream.read(&mut buf_tcp).await {
                     Ok(val) => val,
                     Err(e) => {
                         log::error!("Error while reading from TCP stream: {}", e);
-                        continue;
+                        return;
                     }
                 };
+                if len == 0 {
+                    // technically len==0 does not mean stream has closed,
+                    // but we assume that, as otherwise we can keep looping
+                    // in case the other end closes the socket
+                    log::info!("received 0 bytes, closing for peer {}", peer_addr);
+                    return;
+                }
                 let message = BytesMut::from(&buf_tcp[..len]);
                 let input_str = match String::from_utf8(message.to_vec()) {
                     Ok(val) => val,
@@ -87,19 +102,15 @@ pub async fn tcp_server(listener: TcpListener) {
                     }
                 };
                 if input_str != STOP_SRV {
-                    let _ = syslog::ingest(&input_str, addr).await;
+                    let _ = syslog::ingest(&input_str, peer_addr).await;
                 }
-                if let Ok(val) = tcp_receiver_rx.try_recv() {
-                    if !val {
-                        log::warn!("TCP server - received the stop signal, exiting.");
-                        drop(listener);
-                        break;
-                    }
-                };
             }
-            Err(e) => {
-                log::error!("Error while writing to TCP stream: {}", e);
-                continue;
+        });
+        if let Ok(val) = tcp_receiver_rx.try_recv() {
+            if !val {
+                log::warn!("TCP server - received the stop signal, exiting.");
+                drop(listener);
+                break;
             }
         };
     }


### PR DESCRIPTION
fixes #4067

In the existing implementation, we would drop the stream after reading from it once. This caused issues with rsyslod, as it reuses the same connection socket for sending logs. Existing implementation would cause it to error on second attempt to send logs, re-connect and send the logs in this new connection. As the error itself would be logged as a syslog, that would also get sent to openobserve, causing a lot of noise in logs.

This PR spawns a task for each received tcp connection, and the task keeps reading from the same socket till receiving 0 bytes.

No changes for udp, as it is not connection oriented, each udp packet is supposed to be independent, and thus I don't think there is any issue of socket getting closed or such.

Also, need to test if `syslog::ingest` is ok to be called in a multi-thread context, I haven't tested with a lot of syslog connections, but seemed to work fine with 1/2 syslog connections.