### PR TITLE
feat: added last triggered , owner , cloning in alerts page

### DIFF
--- a/web/src/components/alerts/AddAlert.vue
+++ b/web/src/components/alerts/AddAlert.vue
@@ -750,10 +750,9 @@ export default defineComponent({
       isFetchingStreams.value = true;
       return getStreams(formData.value.stream_type, false)
         .then((res: any) => {
-          console.log(res,"res")
+
           streams.value[formData.value.stream_type] = res.list;
           schemaList.value = res.list;
-          console.log(indexOptions,"index")
           indexOptions.value = res.list.map((data: any) => {
             return data.name;
           });

--- a/web/src/components/alerts/AddAlert.vue
+++ b/web/src/components/alerts/AddAlert.vue
@@ -750,8 +750,10 @@ export default defineComponent({
       isFetchingStreams.value = true;
       return getStreams(formData.value.stream_type, false)
         .then((res: any) => {
+          console.log(res,"res")
           streams.value[formData.value.stream_type] = res.list;
           schemaList.value = res.list;
+          console.log(indexOptions,"index")
           indexOptions.value = res.list.map((data: any) => {
             return data.name;
           });

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -640,7 +640,6 @@ export default defineComponent({
       }
       catch(e){
         showForm.value = true;
-        console.log(e)
       $q.notify({
               type: "negative",
               message: e.data.message,
@@ -761,7 +760,6 @@ export default defineComponent({
       return filteredOptions;
     };
     const updateStreamName = (selectedOption)=> {
-      console.log("selectedOption", selectedOption);
     toBeClonestreamName.value = selectedOption;
   }
     const updateStreams = (resetStream = true) => {
@@ -785,7 +783,6 @@ export default defineComponent({
         .then((res: any) => {
           streams.value[toBeClonestreamType.value] = res.list;
           schemaList.value = res.list;
-          console.log(indexOptions,"index")
           indexOptions.value = res.list.map((data: any) => {
             return data.name;
           });

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -251,7 +251,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             label="Stream Name"
             :options="streamNames"
             @change="updateStreamName"
-            @update:model-value="changeStreamName(toBeCloneStreamName)"
             @filter="filterStreams"
           />
           <q-btn type="submit" class="q-ma-md" color="primary" label="Submit" />
@@ -603,12 +602,14 @@ export default defineComponent({
     const submitForm = () =>{
       const alertToBeCloned = alerts.value.find((alert) => alert.uuid === toBeCloneUUID.value)
       alertToBeCloned.name = toBeCloneAlertName.value;
+      alertToBeCloned.stream_name = toBeClonestreamName.value;
+      alertToBeCloned.stream_type = toBeClonestreamType.value;
 
       try{
         alertsService.create(
             store.state.selectedOrganization.identifier,
-            toBeClonestreamName.value.value,
-            toBeClonestreamType.value,
+            alertToBeCloned.stream_name,
+            alertToBeCloned.stream_type,
             alertToBeCloned,
           ).then((res) => {
             if (res.data.code == 200) {
@@ -763,10 +764,6 @@ export default defineComponent({
       console.log("selectedOption", selectedOption);
     toBeClonestreamName.value = selectedOption;
   }
-  const changeStreamName = (name) =>{
-
-    console.log(toBeClonestreamName.value)
-  }
     const updateStreams = (resetStream = true) => {
       if (resetStream) toBeClonestreamName.value = "";
       if (streams.value[toBeClonestreamType.value]) {
@@ -799,11 +796,7 @@ export default defineComponent({
         .finally(() => (isFetchingStreams.value = false));
     };
     const filterStreams = (val: string, update: any) => {
-      streamNames.value = filterColumns(indexOptions.value, val, update).map((option) => ({
-        value: option,
-        label: option,
-      }));
-      console.log(streamNames.value.length,"streamNames")
+      streamNames.value = filterColumns(indexOptions.value, val, update)
     };
 
     const toggleAlertState = (row: any) => {
@@ -852,7 +845,6 @@ export default defineComponent({
       confirmDelete,
       selectedDelete,
       updateStreams,
-      changeStreamName,
       updateStreamName,
       getAlerts,
       pagination,

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -583,7 +583,7 @@ export default defineComponent({
       maxRecordToReturn.value = val;
     };
     
-    function convertUnixToQuasarFormat(unixMicroseconds) {
+    function convertUnixToQuasarFormat(unixMicroseconds : any) {
       if(!unixMicroseconds) return "";
         const unixSeconds = unixMicroseconds / 1e6;
         const dateToFormat = new Date(unixSeconds * 1000);
@@ -594,16 +594,26 @@ export default defineComponent({
     const addAlert = () => {
       showAddAlertDialog.value = true;
     };
-    const duplicateAlert = (row) =>{
+
+    const duplicateAlert = (row : any) =>{
       toBeCloneUUID.value = row.uuid
       toBeCloneAlertName.value = row.name;
       showForm.value = true;
     }
     const submitForm = () =>{
-      const alertToBeCloned = alerts.value.find((alert) => alert.uuid === toBeCloneUUID.value)
-      alertToBeCloned.name = toBeCloneAlertName.value;
-      alertToBeCloned.stream_name = toBeClonestreamName.value;
-      alertToBeCloned.stream_type = toBeClonestreamType.value;
+      const alertToBeCloned = alerts.value.find((alert) => alert.uuid === toBeCloneUUID.value) as Alert;
+
+      if (!alertToBeCloned) {
+        $q.notify({
+          type: "negative",
+          message: "Alert not found",
+          timeout: 2000,
+        });
+        return;
+      }
+        alertToBeCloned.name = toBeCloneAlertName.value;
+        alertToBeCloned.stream_name = toBeClonestreamName.value;
+        alertToBeCloned.stream_type = toBeClonestreamType.value;
 
       try{
         alertsService.create(
@@ -628,8 +638,7 @@ export default defineComponent({
               });
             }
           })
-          .catch((e) => {
-            console.error(e);
+          .catch((e: any) => {
             $q.notify({
               type: "negative",
               message: e.response.data.message,
@@ -638,7 +647,7 @@ export default defineComponent({
           });
 
       }
-      catch(e){
+      catch(e : any) {
         showForm.value = true;
       $q.notify({
               type: "negative",
@@ -759,7 +768,7 @@ export default defineComponent({
       });
       return filteredOptions;
     };
-    const updateStreamName = (selectedOption)=> {
+    const updateStreamName = (selectedOption : any)=> {
     toBeClonestreamName.value = selectedOption;
   }
     const updateStreams = (resetStream = true) => {

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -233,7 +233,7 @@ import {
 import type { Ref } from "vue";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
-import { QTable, useQuasar, type QTableProps } from "quasar";
+import { QTable, date, useQuasar, type QTableProps } from "quasar";
 import { useI18n } from "vue-i18n";
 import QTablePagination from "@/components/shared/grid/Pagination.vue";
 import alertsService from "@/services/alerts";
@@ -330,6 +330,13 @@ export default defineComponent({
         sortable: true,
       },
       {
+        name: "owner",
+        field: "owner",
+        label: t("alerts.owner"),
+        align: "center",
+        sortable: true,
+      },
+      {
         name: "conditions",
         field: "conditions",
         label: t("alerts.condition"),
@@ -342,6 +349,13 @@ export default defineComponent({
         label: t("alerts.description"),
         align: "center",
         sortable: false,
+      },
+      {
+        name: "last_triggered_at",
+        field: "last_triggered_at",
+        label: t("alerts.lastTriggered"),
+        align: "left",
+        sortable: true,
       },
       {
         name: "actions",
@@ -403,6 +417,8 @@ export default defineComponent({
               conditions: conditions,
               description: data.description,
               uuid: data.uuid,
+              owner: data.owner,
+              last_triggered_at:convertUnixToQuasarFormat(data.last_triggered_at),
             };
           });
           alertsRows.value.forEach((alert: AlertListItem) => {
@@ -501,6 +517,15 @@ export default defineComponent({
     const changeMaxRecordToReturn = (val: any) => {
       maxRecordToReturn.value = val;
     };
+    
+    function convertUnixToQuasarFormat(unixMicroseconds) {
+      if(!unixMicroseconds) return "";
+        const unixSeconds = unixMicroseconds / 1e6;
+        const dateToFormat = new Date(unixSeconds * 1000);
+        const formattedDate = dateToFormat.toISOString();
+        return date.formatDate(formattedDate, "YYYY-MM-DDTHH:mm:ssZ");
+}
+
     const addAlert = () => {
       showAddAlertDialog.value = true;
     };

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -130,6 +130,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               @click="showAddUpdateFn(props)"
             ></q-btn>
             <q-btn
+                icon="content_copy"
+                :title="t('dashboard.duplicate')"
+                class="q-ml-xs"
+                padding="sm"
+                unelevated
+                size="sm"
+                round
+                flat
+                @click.stop="duplicateAlert(props.row)"
+                data-test="dashboard-duplicate"
+              ></q-btn>
+            <q-btn
               :data-test="`alert-list-${props.row.name}-delete-alert`"
               :icon="outlinedDelete"
               class="q-ml-xs"
@@ -218,6 +230,43 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       @update:cancel="confirmDelete = false"
       v-model="confirmDelete"
     />
+    <template>
+  <q-dialog class="q-pa-md"  v-model="showForm" persistent>
+    <q-card>
+      <q-card-section>
+        <div class="text-h6">Duplicate Alert</div>
+      </q-card-section>
+      <q-card-section>
+        <q-form @submit="submitForm">
+          <q-input v-model="toBeCloneAlertName" label="Alert Name" />
+          <q-select
+            v-model="toBeClonestreamType"
+            label="Stream Type"
+            :options="streamTypes"
+            @update:model-value="updateStreams()"
+          />
+          <q-select
+            v-model="toBeClonestreamName"
+            :loading="isFetchingStreams"
+            label="Stream Name"
+            :options="streamNames"
+            @change="updateStreamName"
+            @update:model-value="changeStreamName(toBeCloneStreamName)"
+            @filter="filterStreams"
+          />
+          <q-btn type="submit" class="q-ma-md" color="primary" label="Submit" />
+          <q-btn
+            type="button"
+            color="negative"
+            label="Cancel"
+            v-close-popup
+          />
+        </q-form>
+      </q-card-section>
+    </q-card>
+  </q-dialog>
+</template>
+
   </div>
 </template>
 
@@ -233,6 +282,8 @@ import {
 import type { Ref } from "vue";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
+import useStreams from "@/composables/useStreams";
+
 import { QTable, date, useQuasar, type QTableProps } from "quasar";
 import { useI18n } from "vue-i18n";
 import QTablePagination from "@/components/shared/grid/Pagination.vue";
@@ -279,12 +330,27 @@ export default defineComponent({
     const alerts: Ref<Alert[]> = ref([]);
     const alertsRows: Ref<AlertListItem[]> = ref([]);
     const formData: Ref<Alert | {}> = ref({});
+    const toBeClonedAlert: Ref<Alert | {}> = ref({});
     const showAddAlertDialog: any = ref(false);
     const qTable: Ref<InstanceType<typeof QTable> | null> = ref(null);
     const selectedDelete: any = ref(null);
     const isUpdated: any = ref(false);
     const confirmDelete = ref<boolean>(false);
     const splitterModel = ref(220);
+    const showForm  = ref(false);
+    const indexOptions = ref([]);
+    const schemaList = ref([]);
+    const streams: any = ref({});
+    const isFetchingStreams = ref(false);
+
+    const { getStreams } = useStreams();
+
+      const toBeCloneAlertName  = ref ("");
+      const toBeCloneUUID = ref("");
+      const toBeClonestreamType =  ref('');
+      const toBeClonestreamName =  ref('');
+      const streamTypes =  ref(['logs', 'metrics', 'traces']);
+      const streamNames  :  Ref<string[]> =  ref([]);
     const alertStateLoadingMap: Ref<{ [key: string]: boolean }> = ref({});
     const folders = ref([
       {
@@ -529,6 +595,59 @@ export default defineComponent({
     const addAlert = () => {
       showAddAlertDialog.value = true;
     };
+    const duplicateAlert = (row) =>{
+      toBeCloneUUID.value = row.uuid
+      toBeCloneAlertName.value = row.name;
+      showForm.value = true;
+    }
+    const submitForm = () =>{
+      const alertToBeCloned = alerts.value.find((alert) => alert.uuid === toBeCloneUUID.value)
+      alertToBeCloned.name = toBeCloneAlertName.value;
+
+      try{
+        alertsService.create(
+            store.state.selectedOrganization.identifier,
+            toBeClonestreamName.value.value,
+            toBeClonestreamType.value,
+            alertToBeCloned,
+          ).then((res) => {
+            if (res.data.code == 200) {
+              $q.notify({
+                type: "positive",
+                message: "Duplicated Alert",
+                timeout: 2000,
+              });
+              showForm.value = false;
+              getAlerts();
+            } else {
+              $q.notify({
+                type: "negative",
+                message: res.data.message,
+                timeout: 2000,
+              });
+            }
+          })
+          .catch((e) => {
+            console.error(e);
+            $q.notify({
+              type: "negative",
+              message: e.response.data.message,
+              timeout: 2000,
+            }); 
+          });
+
+      }
+      catch(e){
+        showForm.value = true;
+        console.log(e)
+      $q.notify({
+              type: "negative",
+              message: e.data.message,
+              timeout: 2000,
+            });
+      }
+
+    }
     const showAddUpdateFn = (props: any) => {
       formData.value = alerts.value.find(
         (alert: any) => alert.uuid === props.row?.uuid
@@ -624,6 +743,68 @@ export default defineComponent({
       selectedDelete.value = props.row;
       confirmDelete.value = true;
     };
+    const filterColumns = (options: any[], val: String, update: Function) => {
+      let filteredOptions: any[] = [];
+      if (val === "") {
+        update(() => {
+          filteredOptions = [...options];
+        });
+        return filteredOptions;
+      }
+      update(() => {
+        const value = val.toLowerCase();
+        filteredOptions = options.filter(
+          (column: any) => column.toLowerCase().indexOf(value) > -1,
+        );
+      });
+      return filteredOptions;
+    };
+    const updateStreamName = (selectedOption)=> {
+      console.log("selectedOption", selectedOption);
+    toBeClonestreamName.value = selectedOption;
+  }
+  const changeStreamName = (name) =>{
+
+    console.log(toBeClonestreamName.value)
+  }
+    const updateStreams = (resetStream = true) => {
+      if (resetStream) toBeClonestreamName.value = "";
+      if (streams.value[toBeClonestreamType.value]) {
+        schemaList.value = streams.value[toBeClonestreamType.value];
+        indexOptions.value = streams.value[toBeClonestreamType.value].map(
+          (data: any) => {
+            return data.name;
+          },
+        );
+        updateStreamName(toBeClonestreamName.value);
+
+        return;
+      }
+
+      if (!toBeClonestreamType) return Promise.resolve();
+
+      isFetchingStreams.value = true;
+      return getStreams (toBeClonestreamType.value, false)
+        .then((res: any) => {
+          streams.value[toBeClonestreamType.value] = res.list;
+          schemaList.value = res.list;
+          console.log(indexOptions,"index")
+          indexOptions.value = res.list.map((data: any) => {
+            return data.name;
+          });
+
+          return Promise.resolve();
+        })
+        .catch(() => Promise.reject())
+        .finally(() => (isFetchingStreams.value = false));
+    };
+    const filterStreams = (val: string, update: any) => {
+      streamNames.value = filterColumns(indexOptions.value, val, update).map((option) => ({
+        value: option,
+        label: option,
+      }));
+      console.log(streamNames.value.length,"streamNames")
+    };
 
     const toggleAlertState = (row: any) => {
       alertStateLoadingMap.value[row.uuid] = true;
@@ -670,6 +851,9 @@ export default defineComponent({
       hideForm,
       confirmDelete,
       selectedDelete,
+      updateStreams,
+      changeStreamName,
+      updateStreamName,
       getAlerts,
       pagination,
       resultTotal,
@@ -681,9 +865,24 @@ export default defineComponent({
       isUpdated,
       showAddUpdateFn,
       showDeleteDialogFn,
+      duplicateAlert,
       changePagination,
       maxRecordToReturn,
       showAddAlertDialog,
+      showForm,
+      toBeCloneAlertName,
+      toBeCloneUUID,
+      toBeClonestreamType,
+      toBeClonestreamName,
+      streamTypes,
+      filterColumns,
+      filterStreams,
+      streamNames,
+      submitForm,
+      schemaList,
+      indexOptions,
+      streams,
+      isFetchingStreams,
       changeMaxRecordToReturn,
       outlinedDelete,
       filterQuery: ref(""),

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -131,7 +131,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             ></q-btn>
             <q-btn
                 icon="content_copy"
-                :title="t('dashboard.duplicate')"
+                :title="t('alerts.clone')"
                 class="q-ml-xs"
                 padding="sm"
                 unelevated
@@ -139,7 +139,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 round
                 flat
                 @click.stop="duplicateAlert(props.row)"
-                data-test="dashboard-duplicate"
+                data-test="alert-clone"
               ></q-btn>
             <q-btn
               :data-test="`alert-list-${props.row.name}-delete-alert`"
@@ -234,7 +234,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <q-dialog class="q-pa-md"  v-model="showForm" persistent>
     <q-card>
       <q-card-section>
-        <div class="text-h6">Duplicate Alert</div>
+        <div class="text-h6">Clone Alert</div>
       </q-card-section>
       <q-card-section>
         <q-form @submit="submitForm">
@@ -615,7 +615,7 @@ export default defineComponent({
             if (res.data.code == 200) {
               $q.notify({
                 type: "positive",
-                message: "Duplicated Alert",
+                message:  "Alert Cloned Successfully",
                 timeout: 2000,
               });
               showForm.value = false;

--- a/web/src/components/reports/ReportList.vue
+++ b/web/src/components/reports/ReportList.vue
@@ -175,7 +175,7 @@ import {
   outlinedPause,
   outlinedPlayArrow,
 } from "@quasar/extras/material-icons-outlined";
-import { useQuasar, type QTableProps } from "quasar";
+import { useQuasar, date, type QTableProps } from "quasar";
 import { useI18n } from "vue-i18n";
 import reports from "@/services/reports";
 import { cloneDeep } from "lodash-es";
@@ -239,12 +239,26 @@ const columns: any = ref<QTableProps["columns"]>([
     sortable: true,
   },
   {
+    name: "owner",
+    field: "owner",
+    label: t("alerts.owner"),
+    align: "center",
+    sortable: true,
+    },
+  {
     name: "description",
     field: "description",
     label: t("alerts.description"),
     align: "center",
     sortable: false,
   },
+  {
+    name: "last_triggered_at",
+    field: "lastTriggeredAt",
+    label: t("alerts.lastTriggered"),
+    align: "left",
+    sortable: true,
+    },
   {
     name: "actions",
     field: "actions",
@@ -270,6 +284,7 @@ onBeforeMount(() => {
       reportsTableRows.value = res.data.map((report: any, index: number) => ({
         "#": index + 1,
         ...report,
+        lastTriggeredAt: convertUnixToQuasarFormat(report.lastTriggeredAt),
       }));
       resultTotal.value = reportsTableRows.value.length;
     })
@@ -291,6 +306,13 @@ const changePagination = (val: { label: string; value: any }) => {
   pagination.value.rowsPerPage = val.value;
   reportListTableRef.value?.setPagination(pagination.value);
 };
+function convertUnixToQuasarFormat(unixMicroseconds) {
+  if(!unixMicroseconds) return "";
+    const unixSeconds = unixMicroseconds / 1e6;
+    const dateToFormat = new Date(unixSeconds * 1000);
+    const formattedDate = dateToFormat.toISOString();
+    return date.formatDate(formattedDate, "YYYY-MM-DDTHH:mm:ssZ");
+}
 
 const filterData = (rows: any, terms: any) => {
   var filtered = [];

--- a/web/src/components/reports/ReportList.vue
+++ b/web/src/components/reports/ReportList.vue
@@ -306,7 +306,7 @@ const changePagination = (val: { label: string; value: any }) => {
   pagination.value.rowsPerPage = val.value;
   reportListTableRef.value?.setPagination(pagination.value);
 };
-function convertUnixToQuasarFormat(unixMicroseconds) {
+function convertUnixToQuasarFormat(unixMicroseconds : any) {
   if(!unixMicroseconds) return "";
     const unixSeconds = unixMicroseconds / 1e6;
     const dateToFormat = new Date(unixSeconds * 1000);

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -791,7 +791,9 @@
     "groupBy": "Group by",
     "row": "Row Template",
     "preview": "Preview",
-    "crontitle": "Enable Cron"
+    "crontitle": "Enable Cron",
+    "lastTriggered":"Last Triggered At",
+    "owner": "Owner"
   },
   "alert_templates": {
     "header": "Templates",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -750,6 +750,7 @@
     "header": "Alerts",
     "add": "Add alert",
     "edit": "Edit",
+    "clone": "Clone alert",
     "search": "Search alert",
     "name": "Name",
     "save": "Save",


### PR DESCRIPTION
1.added last_triggered_at, owner , in both alerts page and reports page
2. cloning of alerts is introduced where user can clone alerts and have a option to edit alertname , streamname, streamtype

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a cloning feature for alerts, allowing users to duplicate alerts directly from the alert list.
	- Added new columns in the reports table for "owner" and "last triggered at," enhancing data visibility.

- **Bug Fixes**
	- Improved date formatting for the "last_triggered_at" column to ensure accurate display.

- **Documentation**
	- Updated English localization to include new terms related to alert cloning and report attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->