### PR TITLE
feat: impl union plan for single node

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -607,6 +607,10 @@ mod tests {
             ["test2", "node-q-0", "node-c-2"],
             ["test3", "node-q-7", "node-c-3"],
         ];
+
+        remove_node_from_consistent_hash(&node, &Role::Querier, None).await;
+        remove_node_from_consistent_hash(&node, &Role::Compactor, None).await;
+        remove_node_from_consistent_hash(&node, &Role::FlattenCompactor, None).await;
         for key in data {
             assert_eq!(
                 get_node_from_consistent_hash(key.first().unwrap(), &Role::Querier, None).await,

--- a/src/common/infra/mod.rs
+++ b/src/common/infra/mod.rs
@@ -34,7 +34,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     };
     cache_instance_id(&instance_id);
 
-    wal::init().await?;
+    wal::init()?;
     // because of asynchronous, we need to wait for a while
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 

--- a/src/common/infra/wal.rs
+++ b/src/common/infra/wal.rs
@@ -37,8 +37,12 @@ use crate::common::meta::stream::StreamParams;
 static MANAGER: Lazy<Manager> = Lazy::new(Manager::new);
 
 // SEARCHING_FILES for searching files, in use, should not move to s3
-static SEARCHING_FILES: Lazy<tokio::sync::RwLock<SearchingFileLocker>> =
-    Lazy::new(|| tokio::sync::RwLock::new(SearchingFileLocker::new()));
+static SEARCHING_FILES: Lazy<parking_lot::RwLock<SearchingFileLocker>> =
+    Lazy::new(|| parking_lot::RwLock::new(SearchingFileLocker::new()));
+
+// SEARCHING_REQUESTS for searching requests, in use, should not move to s3
+static SEARCHING_REQUESTS: Lazy<parking_lot::RwLock<HashMap<String, Vec<String>>>> =
+    Lazy::new(Default::default);
 
 type RwData = RwLock<HashMap<String, Arc<RwFile>>>;
 
@@ -94,9 +98,9 @@ pub struct RwFile {
     expired: i64,
 }
 
-pub async fn init() -> Result<(), anyhow::Error> {
+pub fn init() -> Result<(), anyhow::Error> {
     _ = MANAGER.data.len();
-    _ = SEARCHING_FILES.read().await.len();
+    _ = SEARCHING_FILES.read().len();
     Ok(())
 }
 
@@ -373,23 +377,39 @@ impl RwFile {
     }
 }
 
-pub async fn lock_files(files: &[String]) {
-    let mut locker = SEARCHING_FILES.write().await;
+pub fn lock_files(files: &[String]) {
+    let mut locker = SEARCHING_FILES.write();
     for file in files.iter() {
         locker.lock(file.clone());
     }
 }
 
-pub async fn release_files(files: &[String]) {
-    let mut locker = SEARCHING_FILES.write().await;
+pub fn release_files(files: &[String]) {
+    let mut locker = SEARCHING_FILES.write();
     for file in files.iter() {
         locker.release(file);
     }
     locker.shrink_to_fit();
 }
 
-pub async fn lock_files_exists(file: &str) -> bool {
-    SEARCHING_FILES.read().await.exist(file)
+pub fn lock_files_exists(file: &str) -> bool {
+    SEARCHING_FILES.read().exist(file)
+}
+
+pub fn lock_request(trace_id: &str, files: &[String]) {
+    let mut locker = SEARCHING_REQUESTS.write();
+    locker.insert(trace_id.to_string(), files.to_vec());
+}
+
+pub fn release_request(trace_id: &str) {
+    log::info!("[trace_id {}] release_request for wal files", trace_id);
+    let mut locker = SEARCHING_REQUESTS.write();
+    let files = locker.remove(trace_id);
+    locker.shrink_to_fit();
+    drop(locker);
+    if let Some(files) = files {
+        release_files(&files);
+    }
 }
 
 #[cfg(test)]

--- a/src/handler/grpc/request/metrics/querier.rs
+++ b/src/handler/grpc/request/metrics/querier.rs
@@ -184,7 +184,7 @@ impl Metrics for MetricsQuerier {
                     .to_string()
             })
             .collect::<Vec<_>>();
-        wal::lock_files(&files).await;
+        wal::lock_files(&files);
 
         for file in files.iter() {
             // check time range by filename
@@ -199,7 +199,7 @@ impl Metrics for MetricsQuerier {
                     file_min_ts,
                     file_max_ts
                 );
-                wal::release_files(&[file.clone()]).await;
+                wal::release_files(&[file.clone()]);
                 continue;
             }
             // filter by partition keys
@@ -222,7 +222,7 @@ impl Metrics for MetricsQuerier {
             )
             .await
             {
-                wal::release_files(&[file.clone()]).await;
+                wal::release_files(&[file.clone()]);
                 continue;
             }
             // check time range by parquet metadata
@@ -257,7 +257,7 @@ impl Metrics for MetricsQuerier {
         }
 
         // release all files
-        wal::release_files(&files).await;
+        wal::release_files(&files);
 
         // append arrow files
         resp.files.extend(arrow_files);

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -445,7 +445,7 @@ async fn move_files(
         // check if allowed to delete the file
         for file in new_file_list.iter() {
             loop {
-                if wal::lock_files_exists(&file.key).await {
+                if wal::lock_files_exists(&file.key) {
                     log::warn!(
                         "[INGESTER:JOB:{thread_id}] the file is still in use, waiting for a few ms: {}",
                         file.key

--- a/src/service/search/cluster/grpc.rs
+++ b/src/service/search/cluster/grpc.rs
@@ -16,7 +16,9 @@
 use std::sync::Arc;
 
 use arrow::ipc;
-use config::meta::stream::StreamType;
+use arrow_schema::Schema;
+use config::{meta::stream::StreamType, utils::record_batch_ext::format_recordbatch_by_schema};
+use hashbrown::HashSet;
 use infra::errors::Result;
 use proto::cluster_rpc;
 
@@ -49,8 +51,62 @@ pub async fn search(mut req: cluster_rpc::SearchRequest) -> Result<cluster_rpc::
     );
 
     // handle query function
-    let (merge_results, scan_stats, _, is_partial, idx_took) =
+    let (mut merge_results, scan_stats, _, is_partial, idx_took) =
         super::search(&trace_id, sql.clone(), req).await?;
+
+    // format recordbatch with same schema
+    let merge_schema = merge_results
+        .iter()
+        .filter_map(|v| {
+            if v.num_rows() > 0 {
+                Some(v.schema())
+            } else {
+                None
+            }
+        })
+        .next()
+        .unwrap_or_else(|| Arc::new(Schema::empty()));
+    if !merge_schema.fields().is_empty() {
+        let mut schema = merge_schema.clone();
+        let schema_fields = schema
+            .fields()
+            .iter()
+            .map(|f| f.name())
+            .collect::<HashSet<_>>();
+        let mut new_fields = HashSet::new();
+        let mut need_format = false;
+        for batch in merge_results.iter() {
+            if batch.num_rows() == 0 {
+                continue;
+            }
+            if batch.schema().fields() != schema.fields() {
+                need_format = true;
+            }
+            for field in batch.schema().fields() {
+                if !schema_fields.contains(field.name()) {
+                    new_fields.insert(field.clone());
+                }
+            }
+        }
+        drop(schema_fields);
+        if !new_fields.is_empty() {
+            need_format = true;
+            let new_schema = Schema::new(new_fields.into_iter().collect::<Vec<_>>());
+            schema =
+                Arc::new(Schema::try_merge(vec![schema.as_ref().clone(), new_schema]).unwrap());
+        }
+        if need_format {
+            let mut new_batches = Vec::new();
+            for batch in merge_results {
+                if batch.num_rows() == 0 {
+                    continue;
+                }
+                new_batches.push(format_recordbatch_by_schema(schema.clone(), batch));
+            }
+            merge_results = new_batches;
+        }
+    }
+    log::info!("[trace_id {trace_id}] in cluster leader merge task finish");
 
     // final result
     let mut hits_buf = Vec::new();

--- a/src/service/search/cluster/grpc.rs
+++ b/src/service/search/cluster/grpc.rs
@@ -52,7 +52,13 @@ pub async fn search(mut req: cluster_rpc::SearchRequest) -> Result<cluster_rpc::
 
     // handle query function
     let (mut merge_results, scan_stats, _, is_partial, idx_took) =
-        super::search(&trace_id, sql.clone(), req).await?;
+        match super::search(&trace_id, sql.clone(), req).await {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("[trace_id {trace_id}] grpc->cluster_search: err: {:?}", e);
+                return Err(e);
+            }
+        };
 
     // format recordbatch with same schema
     let merge_schema = merge_results

--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -56,7 +56,13 @@ pub async fn search(mut req: cluster_rpc::SearchRequest) -> Result<search::Respo
 
     // handle query function
     let (merge_batches, scan_stats, took_wait, is_partial, idx_took) =
-        super::search(&trace_id, sql.clone(), req).await?;
+        match super::search(&trace_id, sql.clone(), req).await {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("[trace_id {trace_id}] http->search: err: {:?}", e);
+                return Err(e);
+            }
+        };
 
     // final result
     let mut result = search::Response::new(sql.meta.offset, sql.meta.limit);

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -715,7 +715,14 @@ async fn merge_grpc_result(
             let reader = ipc::reader::FileReader::try_new(buf, None).unwrap();
             let batch = reader
                 .into_iter()
-                .map(std::result::Result::unwrap)
+                .map(|v| match v {
+                    Ok(v) => v,
+                    Err(e) => {
+                        panic!(
+                            "[trace_id {trace_id}] search->merge_grpc_result: read ipc error: {e}"
+                        );
+                    }
+                })
                 .collect::<Vec<_>>();
             batches.push(batch);
         }

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -701,7 +701,7 @@ async fn merge_grpc_result(
 ) -> Result<(Vec<RecordBatch>, ScanStats, bool)> {
     // merge multiple instances data
     let mut scan_stats = search::ScanStats::new();
-    let mut batches: Vec<RecordBatch> = Vec::new();
+    let mut batches: Vec<Vec<RecordBatch>> = Vec::new();
     let mut is_partial = false;
     for (_, resp) in results {
         if resp.is_partial {
@@ -717,7 +717,7 @@ async fn merge_grpc_result(
                 .into_iter()
                 .map(std::result::Result::unwrap)
                 .collect::<Vec<_>>();
-            batches.extend(batch);
+            batches.push(batch);
         }
     }
 
@@ -733,18 +733,13 @@ async fn merge_grpc_result(
     let (schema_latest, _) = if select_wildcard {
         generate_select_start_search_schema(
             &sql,
-            schema_latest.clone(),
+            schema_latest.as_ref(),
             &schema_latest_map,
             &defined_schema_fields,
         )?
     } else {
-        generate_search_schema(&sql, schema_latest.clone(), &schema_latest_map)?
+        generate_search_schema(&sql, schema_latest.as_ref(), &schema_latest_map)?
     };
-
-    // only final phase need merge partitions
-    if !is_final_phase {
-        return Ok((batches, scan_stats, is_partial));
-    }
 
     #[cfg(feature = "enterprise")]
     let (abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
@@ -761,38 +756,71 @@ async fn merge_grpc_result(
         return Err(Error::ErrorCode(ErrorCodes::SearchCancelQuery(err)));
     }
 
-    let merge_batch;
-    tokio::select! {
-        res = super::datafusion::exec::merge_partitions(
-            &sql.org_id,
-            sql.meta.offset,
-            sql.meta.limit,
-            &sql.origin_sql,
-            schema_latest,
-            batches,
-        ) => {
-            match res {
-                Ok(res) => merge_batch = res,
-                Err(err) => {
-                    log::error!("[trace_id {trace_id}] search->cluster: merge partitions error: {err}");
-                    return Err(Error::ErrorCode(ErrorCodes::ServerInternalError(
-                        err.to_string(),
-                    )));
+    if !is_final_phase {
+        let merge_batch;
+        tokio::select! {
+            res = super::datafusion::exec::merge_partitions_cluster(
+                &sql.org_id,
+                sql.meta.offset,
+                sql.meta.limit,
+                &sql.origin_sql,
+                schema_latest,
+                batches,
+            ) => {
+                match res {
+                    Ok(res) => merge_batch = res,
+                    Err(err) => {
+                        log::error!("[trace_id {trace_id}] search->cluster: merge super cluster partitions error: {err}");
+                        return Err(Error::ErrorCode(ErrorCodes::ServerInternalError(
+                            err.to_string(),
+                        )));
+                    }
                 }
             }
+            _ = async {
+                #[cfg(feature = "enterprise")]
+                let _ = abort_receiver.await;
+                #[cfg(not(feature = "enterprise"))]
+                futures::future::pending::<()>().await;
+            } => {
+                log::info!("[trace_id {trace_id}] search->cluster: super cluster merge task is cancel");
+                return Err(Error::ErrorCode(ErrorCodes::SearchCancelQuery(format!("[trace_id {trace_id}] search->cluster: super cluster follow cluster merge task is cancel"))));
+            }
         }
-        _ = async {
-            #[cfg(feature = "enterprise")]
-            let _ = abort_receiver.await;
-            #[cfg(not(feature = "enterprise"))]
-            futures::future::pending::<()>().await;
-        } => {
-            log::info!("[trace_id {trace_id}] search->cluster: final merge task is cancel");
-            return Err(Error::ErrorCode(ErrorCodes::SearchCancelQuery(format!("[trace_id {trace_id}] search->cluster: final merge task is cancel"))));
+        Ok((merge_batch, scan_stats, is_partial))
+    } else {
+        let merge_batch;
+        tokio::select! {
+            res = super::datafusion::exec::merge_partitions(
+                &sql.org_id,
+                sql.meta.offset,
+                sql.meta.limit,
+                &sql.origin_sql,
+                schema_latest,
+                batches,
+            ) => {
+                match res {
+                    Ok(res) => merge_batch = res,
+                    Err(err) => {
+                        log::error!("[trace_id {trace_id}] search->cluster: merge partitions error: {err}");
+                        return Err(Error::ErrorCode(ErrorCodes::ServerInternalError(
+                            err.to_string(),
+                        )));
+                    }
+                }
+            }
+            _ = async {
+                #[cfg(feature = "enterprise")]
+                let _ = abort_receiver.await;
+                #[cfg(not(feature = "enterprise"))]
+                futures::future::pending::<()>().await;
+            } => {
+                log::info!("[trace_id {trace_id}] search->cluster: final merge task is cancel");
+                return Err(Error::ErrorCode(ErrorCodes::SearchCancelQuery(format!("[trace_id {trace_id}] search->cluster: final merge task is cancel"))));
+            }
         }
+        Ok((merge_batch, scan_stats, is_partial))
     }
-
-    Ok((merge_batch, scan_stats, is_partial))
 }
 
 #[tracing::instrument(skip(sql), fields(org_id = sql.org_id, stream_name = sql.stream_name))]

--- a/src/service/search/datafusion/physical_plan/empty_exec.rs
+++ b/src/service/search/datafusion/physical_plan/empty_exec.rs
@@ -38,6 +38,7 @@ pub struct NewEmptyExec {
     projection: Option<Vec<usize>>,
     filters: Vec<Expr>,
     limit: Option<usize>,
+    sorted_by_time: bool,
 }
 
 impl NewEmptyExec {
@@ -48,9 +49,9 @@ impl NewEmptyExec {
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
-        is_memtable: bool,
+        sorted_by_time: bool,
     ) -> Self {
-        let cache = Self::compute_properties(Arc::clone(&schema), 1, is_memtable);
+        let cache = Self::compute_properties(Arc::clone(&schema), 1, sorted_by_time);
         NewEmptyExec {
             name: name.to_string(),
             schema,
@@ -59,6 +60,7 @@ impl NewEmptyExec {
             projection: projection.cloned(),
             filters: filters.to_owned(),
             limit,
+            sorted_by_time,
         }
     }
 
@@ -84,11 +86,11 @@ impl NewEmptyExec {
     fn compute_properties(
         schema: SchemaRef,
         n_partitions: usize,
-        is_memtable: bool,
+        sorted_by_time: bool,
     ) -> PlanProperties {
         let timestamp_column = config::get_config().common.column_timestamp.clone();
         let index = schema.index_of(&timestamp_column);
-        let eq_properties = if is_memtable {
+        let eq_properties = if !sorted_by_time {
             EquivalenceProperties::new(schema)
         } else {
             match index {
@@ -155,12 +157,21 @@ impl DisplayAs for NewEmptyExec {
                 let limit_string = self
                     .limit
                     .map_or_else(|| "".to_string(), |l| format!(", limit={}", l));
+                let sorted_by_time_string = if self.sorted_by_time {
+                    ", sorted_by_time=true"
+                } else {
+                    ""
+                };
 
                 write!(f, "NewEmptyExec: ")?;
                 write!(
                     f,
-                    "{}{}{}{}",
-                    name_string, projection_string, filters_string, limit_string
+                    "{}{}{}{}{}",
+                    name_string,
+                    projection_string,
+                    filters_string,
+                    limit_string,
+                    sorted_by_time_string
                 )
             }
         }

--- a/src/service/search/datafusion/physical_plan/empty_exec.rs
+++ b/src/service/search/datafusion/physical_plan/empty_exec.rs
@@ -234,3 +234,21 @@ impl ExecutionPlan for NewEmptyExec {
         ))
     }
 }
+
+// add some unit tests here
+#[cfg(test)]
+mod tests {
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    use super::*;
+
+    #[test]
+    fn test_new_empty_exec() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let exec = NewEmptyExec::new("test", schema, None, &[], None, false);
+        assert_eq!(exec.name(), "test");
+        assert_eq!(exec.projection(), None);
+        assert_eq!(exec.filters().len(), 0);
+        assert_eq!(exec.limit(), None);
+    }
+}

--- a/src/service/search/datafusion/plan.rs
+++ b/src/service/search/datafusion/plan.rs
@@ -37,7 +37,7 @@ pub fn get_partial_plan(
     if children.is_empty() {
         return Ok(None);
     }
-    if children.len() > 1 {
+    if plan.name() != "UnionExec" && children.len() > 1 {
         return Err(datafusion::error::DataFusionError::NotImplemented(
             "ExecutionPlan with multiple children".to_string(),
         ));
@@ -161,18 +161,18 @@ pub fn get_empty_final_plan(
 }
 
 /// Rewriter to update the offset and limit of a GlobalLimitExec node
-pub(crate) struct UpdateOffsetExec {
+pub(crate) struct UpdateOffsetRewrite {
     offset: usize,
     limit: usize,
 }
 
-impl UpdateOffsetExec {
+impl UpdateOffsetRewrite {
     pub fn new(offset: usize, limit: usize) -> Self {
         Self { offset, limit }
     }
 }
 
-impl TreeNodeRewriter for UpdateOffsetExec {
+impl TreeNodeRewriter for UpdateOffsetRewrite {
     type Node = Arc<dyn ExecutionPlan>;
 
     fn f_down(

--- a/src/service/search/datafusion/table_provider/empty_table.rs
+++ b/src/service/search/datafusion/table_provider/empty_table.rs
@@ -34,17 +34,17 @@ pub struct NewEmptyTable {
     name: String,
     schema: SchemaRef,
     partitions: usize,
-    is_memtable: bool,
+    sorted_by_time: bool,
 }
 
 impl NewEmptyTable {
     /// Initialize a new `EmptyTable` from a schema.
-    pub fn new(name: &str, schema: SchemaRef, is_memtable: bool) -> Self {
+    pub fn new(name: &str, schema: SchemaRef, sorted_by_time: bool) -> Self {
         Self {
             name: name.to_string(),
             schema,
             partitions: 1,
-            is_memtable,
+            sorted_by_time,
         }
     }
 
@@ -85,7 +85,7 @@ impl TableProvider for NewEmptyTable {
                 projection,
                 filters,
                 limit,
-                self.is_memtable,
+                self.sorted_by_time,
             )
             .with_partitions(self.partitions),
         ))

--- a/src/service/search/datafusion/table_provider/mod.rs
+++ b/src/service/search/datafusion/table_provider/mod.rs
@@ -65,6 +65,7 @@ use object_store::ObjectStore;
 pub mod empty_table;
 mod helpers;
 pub mod memtable;
+pub mod uniontable;
 
 pub(crate) struct NewListingTable {
     table_paths: Vec<ListingTableUrl>,

--- a/src/service/search/datafusion/table_provider/uniontable.rs
+++ b/src/service/search/datafusion/table_provider/uniontable.rs
@@ -1,0 +1,75 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{any::Any, sync::Arc};
+
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use datafusion::{
+    catalog::Session,
+    common::Result,
+    datasource::TableProvider,
+    logical_expr::{Expr, TableProviderFilterPushDown, TableType},
+    physical_plan::{union::UnionExec, ExecutionPlan},
+};
+
+pub(crate) struct NewUnionTable {
+    schema: SchemaRef,
+    tables: Vec<Arc<dyn TableProvider>>,
+}
+
+impl NewUnionTable {
+    /// Create a new in-memory table from the provided schema and record batches
+    pub fn try_new(schema: SchemaRef, tables: Vec<Arc<dyn TableProvider>>) -> Result<Self> {
+        Ok(Self { schema, tables })
+    }
+}
+
+#[async_trait]
+impl TableProvider for NewUnionTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let mut table_plans = Vec::new();
+        for table in self.tables.iter() {
+            let plan = table.scan(state, projection, filters, limit).await?;
+            table_plans.push(plan);
+        }
+        Ok(Arc::new(UnionExec::new(table_plans)))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+    }
+}

--- a/src/service/search/datafusion/table_provider/uniontable.rs
+++ b/src/service/search/datafusion/table_provider/uniontable.rs
@@ -22,7 +22,7 @@ use datafusion::{
     common::Result,
     datasource::TableProvider,
     logical_expr::{Expr, TableProviderFilterPushDown, TableType},
-    physical_plan::{union::UnionExec, ExecutionPlan},
+    physical_plan::{empty::EmptyExec, union::UnionExec, ExecutionPlan},
 };
 
 pub(crate) struct NewUnionTable {
@@ -58,6 +58,12 @@ impl TableProvider for NewUnionTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        if self.tables.is_empty() {
+            return Ok(Arc::new(EmptyExec::new(self.schema())));
+        }
+        if self.tables.len() == 1 {
+            return self.tables[0].scan(state, projection, filters, limit).await;
+        }
         let mut table_plans = Vec::new();
         for table in self.tables.iter() {
             let plan = table.scan(state, projection, filters, limit).await?;

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -118,9 +118,11 @@ pub async fn search(
 
     // search in WAL parquet
     let skip_wal = req.query.as_ref().unwrap().skip_wal;
+    let wal_lock_files;
     if LOCAL_NODE.is_ingester() && !skip_wal {
-        let (tbls, stats) =
+        let (tbls, stats, lock_files) =
             wal::search_parquet(&trace_id, sql.clone(), stream_type, &work_group).await?;
+        wal_lock_files = lock_files;
         tables.extend(tbls);
         scan_stats.add(&stats);
     }

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -227,8 +227,19 @@ pub async fn search(
     };
 
     // format recordbatch with same schema
-    if !results.is_empty() {
-        let mut schema = results[0].schema();
+    let merge_schema = results
+        .iter()
+        .filter_map(|v| {
+            if v.num_rows() > 0 {
+                Some(v.schema())
+            } else {
+                None
+            }
+        })
+        .next()
+        .unwrap_or_else(|| Arc::new(Schema::empty()));
+    if !merge_schema.fields().is_empty() {
+        let mut schema = merge_schema.clone();
         let schema_fields = schema
             .fields()
             .iter()

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -173,6 +173,20 @@ pub async fn search(
         )));
     }
 
+    if tables.is_empty() {
+        return Ok(cluster_rpc::SearchResponse {
+            job: req.job.clone(),
+            took: start.elapsed().as_millis() as i32,
+            idx_took: 0,
+            from: sql.meta.offset as i32,
+            size: sql.meta.limit as i32,
+            total: 0,
+            hits: vec![],
+            scan_stats: Some(cluster_rpc::ScanStats::from(&scan_stats)),
+            is_partial: false,
+        });
+    }
+
     let ret = tokio::select! {
         ret = exec::sql(&session, &sql, tables) => {
             match ret {

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -13,31 +13,39 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
-use ::datafusion::arrow::{ipc, record_batch::RecordBatch};
+use ::datafusion::{arrow::ipc, catalog::TableProvider, error::DataFusionError};
 use arrow_schema::Schema;
 use config::{
     cluster::LOCAL_NODE,
     get_config,
     meta::{
-        search::ScanStats,
+        search::{ScanStats, SearchType, StorageType},
         stream::{FileKey, StreamType},
     },
     utils::record_batch_ext::format_recordbatch_by_schema,
 };
-use futures::future::try_join_all;
-use hashbrown::HashSet;
-use infra::errors::{Error, ErrorCodes};
+use hashbrown::{HashMap, HashSet};
+use infra::{
+    errors::{Error, ErrorCodes},
+    schema::unwrap_stream_settings,
+};
 use proto::cluster_rpc;
-use tracing::Instrument;
 
 use super::datafusion;
-use crate::service::db;
+use crate::service::{
+    db,
+    search::{
+        datafusion::exec,
+        generate_search_schema, generate_select_start_search_schema,
+        sql::{Sql, RE_SELECT_WILDCARD},
+    },
+};
 mod storage;
 mod wal;
 
-pub type SearchResult = Result<(Vec<Vec<RecordBatch>>, ScanStats), Error>;
+pub type SearchTable = Result<(Vec<Arc<dyn TableProvider>>, ScanStats), Error>;
 
 #[tracing::instrument(name = "service:search:grpc:search", skip_all, fields(org_id = req.org_id))]
 pub async fn search(
@@ -48,6 +56,7 @@ pub async fn search(
     let stream_type = StreamType::from(req.stream_type.as_str());
     let work_group = req.work_group.clone();
 
+    let cfg = get_config();
     let trace_id = Arc::new(req.job.as_ref().unwrap().trace_id.to_string());
     let timeout = if req.timeout > 0 {
         req.timeout as u64
@@ -73,72 +82,135 @@ pub async fn search(
         sql.meta.time_range
     );
 
-    // search in WAL parquet
-    let skip_wal = req.query.as_ref().unwrap().skip_wal;
-    let work_group1 = work_group.clone();
-    let trace_id1 = trace_id.clone();
-    let sql1 = sql.clone();
-    let wal_parquet_span = tracing::span::Span::current();
-    let task1 = tokio::task::spawn(async move {
-        if LOCAL_NODE.is_ingester() && !skip_wal {
-            wal::search_parquet(&trace_id1, sql1, stream_type, &work_group1, timeout)
-                .instrument(wal_parquet_span)
-                .await
-        } else {
-            Ok((vec![], ScanStats::default()))
-        }
+    // set target partitions based on cache type
+    // construct latest schema map
+    let schema_latest = infra::schema::get(&sql.org_id, &sql.stream_name, stream_type)
+        .await
+        .map_err(|e| Error::ErrorCode(ErrorCodes::ServerInternalError(e.to_string())))?;
+    let mut schema_latest_map = HashMap::with_capacity(schema_latest.fields().len());
+    for field in schema_latest.fields() {
+        schema_latest_map.insert(field.name(), field);
+    }
+    let stream_settings = unwrap_stream_settings(&schema_latest).unwrap_or_default();
+    let defined_schema_fields = stream_settings.defined_schema_fields.unwrap_or_default();
+
+    let select_wildcard = RE_SELECT_WILDCARD.is_match(sql.origin_sql.as_str());
+
+    let (schema, _) = if select_wildcard {
+        generate_select_start_search_schema(
+            &sql,
+            &schema_latest,
+            &schema_latest_map,
+            &defined_schema_fields,
+        )?
+    } else {
+        generate_search_schema(&sql, &schema_latest, &schema_latest_map)?
+    };
+
+    let sql = Arc::new(Sql {
+        schema: schema.as_ref().clone(),
+        ..sql.as_ref().clone()
     });
 
+    // get all tables
+    let mut tables = Vec::new();
+    let mut scan_stats = ScanStats::new();
+
+    // search in WAL parquet
+    let skip_wal = req.query.as_ref().unwrap().skip_wal;
+    if LOCAL_NODE.is_ingester() && !skip_wal {
+        let (tbls, stats) =
+            wal::search_parquet(&trace_id, sql.clone(), stream_type, &work_group).await?;
+        tables.extend(tbls);
+        scan_stats.add(&stats);
+    }
+
     // search in WAL memory
-    let work_group2 = work_group.clone();
-    let trace_id2 = trace_id.clone();
-    let sql2 = sql.clone();
-    let wal_mem_span = tracing::span::Span::current();
-    let task2 = tokio::task::spawn(async move {
-        if LOCAL_NODE.is_ingester() && !skip_wal {
-            wal::search_memtable(&trace_id2, sql2, stream_type, &work_group2, timeout)
-                .instrument(wal_mem_span)
-                .await
-        } else {
-            Ok((vec![], ScanStats::default()))
-        }
-    });
+    if LOCAL_NODE.is_ingester() && !skip_wal {
+        let (tbls, stats) = wal::search_memtable(&trace_id, sql.clone(), stream_type).await?;
+        tables.extend(tbls);
+        scan_stats.add(&stats);
+    }
 
     // search in object storage
     let req_stype = req.stype;
-    let work_group3 = work_group.clone();
-    let trace_id3 = trace_id.clone();
-    let sql3 = sql.clone();
-    let file_list: Vec<FileKey> = req.file_list.iter().map(FileKey::from).collect();
-    let storage_span = tracing::span::Span::current();
-    let task3 = tokio::task::spawn(async move {
-        if req_stype == cluster_rpc::SearchType::WalOnly as i32 {
-            Ok((vec![], ScanStats::default()))
-        } else {
-            storage::search(
-                &trace_id3,
-                sql3,
-                &file_list,
-                stream_type,
-                &work_group3,
-                timeout,
-            )
-            .instrument(storage_span)
-            .await
-        }
-    });
-
-    // merge result
-    let mut results = Vec::new();
-    let mut scan_stats = ScanStats::new();
-    let tasks = try_join_all(vec![task1, task2, task3])
-        .await
-        .map_err(|e| Error::ErrorCode(ErrorCodes::ServerInternalError(e.to_string())))?;
-    for task in tasks {
-        let (batches, stats) = task?;
+    if req_stype != cluster_rpc::SearchType::WalOnly as i32 {
+        let file_list: Vec<FileKey> = req.file_list.iter().map(FileKey::from).collect();
+        let (tbls, stats) =
+            storage::search(&trace_id, sql.clone(), &file_list, stream_type, &work_group).await?;
+        tables.extend(tbls);
         scan_stats.add(&stats);
-        results.extend(batches.into_iter().flatten().filter(|v| v.num_rows() > 0));
     }
+
+    let session = config::meta::search::Session {
+        id: trace_id.to_string(),
+        storage_type: StorageType::Memory,
+        search_type: if !sql.meta.group_by.is_empty() {
+            SearchType::Aggregation
+        } else {
+            SearchType::Normal
+        },
+        work_group: Some(work_group.to_string()),
+        target_partitions: cfg.limit.cpu_num,
+    };
+
+    // run and get the RecordBatch
+    #[cfg(feature = "enterprise")]
+    let (abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
+    #[cfg(feature = "enterprise")]
+    if crate::service::search::SEARCH_SERVER
+        .insert_sender(trace_id, abort_sender)
+        .await
+        .is_err()
+    {
+        log::info!(
+            "[trace_id {}] search->storage: search canceled before call search->storage",
+            session.id
+        );
+        return Err(Error::Message(format!(
+            "[trace_id {}] search->storage: search canceled before call search->storage",
+            session.id
+        )));
+    }
+
+    let ret = tokio::select! {
+        ret = exec::sql(&session, &sql, tables) => {
+            match ret {
+                Ok(ret) => Ok(ret),
+                Err(err) => {
+                    log::error!("[trace_id {}] search->storage: datafusion execute error: {}", session.id, err);
+                    Err(err)
+                }
+            }
+        },
+        _ = tokio::time::sleep(Duration::from_secs(timeout)) => {
+            log::error!("[trace_id {}] search->storage: search timeout", session.id);
+            Err(DataFusionError::ResourcesExhausted(format!(
+                "[trace_id {}] search->storage: task timeout", session.id
+            )))
+        },
+        _ = async {
+            #[cfg(feature = "enterprise")]
+            let _ = abort_receiver.await;
+            #[cfg(not(feature = "enterprise"))]
+            futures::future::pending::<()>().await;
+        } => {
+            log::info!("[trace_id {}] search->storage: search canceled", session.id);
+            Err( DataFusionError::Execution(format!(
+                "[trace_id {}] search->storage: task is cancel", session.id
+            )))
+        }
+    };
+
+    let mut results = match ret {
+        Ok(v) => v,
+        Err(err) => match err {
+            DataFusionError::ResourcesExhausted(e) => {
+                return Err(Error::ErrorCode(ErrorCodes::SearchTimeout(e)));
+            }
+            _ => return Err(err.into()),
+        },
+    };
 
     // format recordbatch with same schema
     if !results.is_empty() {

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -159,7 +159,7 @@ pub async fn search(
     let (abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
     #[cfg(feature = "enterprise")]
     if crate::service::search::SEARCH_SERVER
-        .insert_sender(trace_id, abort_sender)
+        .insert_sender(&trace_id, abort_sender)
         .await
         .is_err()
     {

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -21,22 +21,20 @@ use config::{
         search::{ScanStats, SearchType, StorageType},
         stream::{FileKey, PartitionTimeLevel, StreamPartition, StreamType},
     },
-    utils::schema_ext::SchemaExt,
 };
-use futures::future::try_join_all;
 use hashbrown::HashMap;
 use infra::{
     cache::file_data,
     errors::{Error, ErrorCodes},
     schema::{unwrap_partition_time_level, unwrap_stream_settings},
 };
-use tokio::{sync::Semaphore, time::Duration};
-use tracing::{info_span, Instrument};
+use tokio::sync::Semaphore;
+use tracing::Instrument;
 
 use crate::service::{
     db, file_list,
     search::{
-        datafusion::{exec, file_type::FileType},
+        datafusion::exec,
         generate_search_schema, generate_select_start_search_schema,
         sql::{Sql, RE_SELECT_WILDCARD},
     },
@@ -52,8 +50,7 @@ pub async fn search(
     file_list: &[FileKey],
     stream_type: StreamType,
     work_group: &str,
-    timeout: u64,
-) -> super::SearchResult {
+) -> super::SearchTable {
     let enter_span = tracing::span::Span::current();
     log::info!("[trace_id {trace_id}] search->storage: enter");
     let schema_latest = infra::schema::get(&sql.org_id, &sql.stream_name, stream_type)
@@ -219,15 +216,12 @@ pub async fn search(
     }
     let select_wildcard = RE_SELECT_WILDCARD.is_match(sql.origin_sql.as_str());
 
-    let mut tasks = Vec::new();
+    let mut tables = Vec::new();
     for (ver, files) in files_group {
+        if files.is_empty() {
+            continue;
+        }
         let schema = schema_versions[ver].clone();
-        let schema_dt = schema
-            .metadata()
-            .get("start_dt")
-            .cloned()
-            .unwrap_or_default();
-        let schema = schema.with_metadata(std::collections::HashMap::new());
         let schema = Arc::new(schema);
         let sql = sql.clone();
         let session = config::meta::search::Session {
@@ -246,109 +240,21 @@ pub async fn search(
         let (schema, diff_fields) = if select_wildcard {
             generate_select_start_search_schema(
                 &sql,
-                schema.clone(),
+                schema.as_ref(),
                 &schema_latest_map,
                 &defined_schema_fields,
             )?
         } else {
-            generate_search_schema(&sql, schema.clone(), &schema_latest_map)?
+            generate_search_schema(&sql, schema.as_ref(), &schema_latest_map)?
         };
 
-        let datafusion_span = info_span!(
-            "service:search:grpc:storage:datafusion",
-            org_id = sql.org_id,
-            stream_name = sql.stream_name,
-            stream_type = stream_type.to_string(),
-        );
-
-        #[cfg(feature = "enterprise")]
-        let (abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
-        #[cfg(feature = "enterprise")]
-        if crate::service::search::SEARCH_SERVER
-            .insert_sender(trace_id, abort_sender)
-            .await
-            .is_err()
-        {
-            log::info!(
-                "[trace_id {}] search->storage: search canceled before call search->storage",
-                session.id
-            );
-            return Err(Error::Message(format!(
-                "[trace_id {}] search->storage: search canceled before call search->storage",
-                session.id
-            )));
-        }
-
-        let task = tokio::task::spawn(
-            async move {
-                tokio::select! {
-                    ret = exec::sql(
-                        &session,
-                        schema.clone(),
-                        diff_fields,
-                        &sql,
-                        &files,
-                        None,
-                        FileType::PARQUET,
-                    ) => {
-                        match ret {
-                            Ok(ret) => Ok(ret),
-                            Err(err) => {
-                                log::error!("[trace_id {}] search->storage: datafusion execute error: {}", session.id, err);
-                                if err.to_string().contains("Invalid comparison operation") {
-                                    // print the session_id, schema, sql, files
-                                    let schema_version = format!("{}/{}/{}/{}", &sql.org_id, &stream_type, &sql.stream_name, schema_dt);
-                                    let schema_fiels = schema.as_ref().simple_fields();
-                                    let files = files.iter().map(|f| f.key.as_str()).collect::<Vec<_>>();
-                                    log::error!("[trace_id {}] search->storage: schema and parquet mismatch, version: {}, schema: {:?}, files: {:?}", 
-                                        session.id, schema_version, schema_fiels, files);
-                                }
-                                Err(err)
-                            }
-                        }
-                    },
-                    _ = tokio::time::sleep(Duration::from_secs(timeout)) => {
-                        log::error!("[trace_id {}] search->storage: search timeout", session.id);
-                        Err(datafusion::error::DataFusionError::ResourcesExhausted(format!(
-                            "[trace_id {}] search->storage: task timeout", session.id
-                        )))
-                    },
-                    _ = async {
-                        #[cfg(feature = "enterprise")]
-                        let _ = abort_receiver.await;
-                        #[cfg(not(feature = "enterprise"))]
-                        futures::future::pending::<()>().await;
-                    } => {
-                        log::info!("[trace_id {}] search->storage: search canceled", session.id);
-                        Err(datafusion::error::DataFusionError::Execution(format!(
-                            "[trace_id {}] search->storage: task is cancel", session.id
-                        )))
-                    }
-                }
-            }
-            .instrument(datafusion_span),
-        );
-
-        tasks.push(task);
+        let table =
+            exec::create_parquet_table(&session, schema, &files, diff_fields, &sql.meta.order_by)
+                .await?;
+        tables.push(Arc::new(table) as Arc<dyn datafusion::datasource::TableProvider>);
     }
 
-    let mut results = vec![];
-    let task_results = try_join_all(tasks)
-        .await
-        .map_err(|e| Error::ErrorCode(ErrorCodes::ServerInternalError(e.to_string())))?;
-    for ret in task_results {
-        match ret {
-            Ok(v) => results.extend(v),
-            Err(err) => match err {
-                datafusion::error::DataFusionError::ResourcesExhausted(e) => {
-                    return Err(Error::ErrorCode(ErrorCodes::SearchTimeout(e)));
-                }
-                _ => return Err(err.into()),
-            },
-        };
-    }
-
-    Ok((results, scan_stats))
+    Ok((tables, scan_stats))
 }
 
 #[tracing::instrument(name = "service:search:grpc:storage:get_file_list", skip_all, fields(org_id = sql.org_id, stream_name = sql.stream_name))]

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -28,22 +28,20 @@ use config::{
     },
 };
 use datafusion::arrow::{datatypes::Schema, record_batch::RecordBatch};
-use futures::{future::try_join_all, StreamExt};
+use futures::StreamExt;
 use hashbrown::HashMap;
 use infra::{
     errors::{Error, ErrorCodes},
     schema::{unwrap_partition_time_level, unwrap_stream_settings},
 };
 use ingester::WAL_PARQUET_METADATA;
-use tokio::time::Duration;
-use tracing::{info_span, Instrument};
 
 use crate::{
     common::infra::wal,
     service::{
         db, file_list,
         search::{
-            datafusion::{exec, file_type::FileType},
+            datafusion::{exec, table_provider::memtable::NewMemTable},
             generate_search_schema, generate_select_start_search_schema,
             sql::{Sql, RE_SELECT_WILDCARD},
         },
@@ -57,8 +55,7 @@ pub async fn search_parquet(
     sql: Arc<Sql>,
     stream_type: StreamType,
     work_group: &str,
-    timeout: u64,
-) -> super::SearchResult {
+) -> super::SearchTable {
     let schema_latest = match infra::schema::get(&sql.org_id, &sql.stream_name, stream_type).await {
         Ok(schema) => schema,
         Err(err) => {
@@ -240,8 +237,11 @@ pub async fn search_parquet(
     }
     let select_wildcard = RE_SELECT_WILDCARD.is_match(sql.origin_sql.as_str());
 
-    let mut tasks = Vec::new();
+    let mut tables = Vec::new();
     for (ver, files) in files_group {
+        if files.is_empty() {
+            continue;
+        }
         let schema = schema_versions[ver]
             .clone()
             .with_metadata(std::collections::HashMap::new());
@@ -263,114 +263,24 @@ pub async fn search_parquet(
         let (schema, diff_fields) = if select_wildcard {
             generate_select_start_search_schema(
                 &sql,
-                schema.clone(),
+                schema.as_ref(),
                 &schema_latest_map,
                 &defined_schema_fields,
             )?
         } else {
-            generate_search_schema(&sql, schema.clone(), &schema_latest_map)?
+            generate_search_schema(&sql, schema.as_ref(), &schema_latest_map)?
         };
 
-        let datafusion_span = info_span!(
-            "service:search:grpc:wal:parquet:datafusion",
-            org_id = sql.org_id,
-            stream_name = sql.stream_name,
-            stream_type = stream_type.to_string(),
-        );
-
-        #[cfg(feature = "enterprise")]
-        let (abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
-        #[cfg(feature = "enterprise")]
-        if crate::service::search::SEARCH_SERVER
-            .insert_sender(trace_id, abort_sender)
-            .await
-            .is_err()
-        {
-            log::info!(
-                "[trace_id {}] wal->parquet->search: search canceled before call wal->parquet->search",
-                session.id
-            );
-            return Err(Error::Message(format!(
-                "[trace_id {}] wal->parquet->search: search canceled before call wal->parquet->search",
-                session.id
-            )));
-        }
-
-        let task = tokio::task::spawn(
-            async move {
-                tokio::select! {
-                    ret = exec::sql(
-                        &session,
-                        schema,
-                        diff_fields,
-                        &sql,
-                        &files,
-                        None,
-                        FileType::PARQUET,
-                    ) => ret,
-                    _ = tokio::time::sleep(Duration::from_secs(timeout)) => {
-                        log::error!("[trace_id {}] wal->parquet->search: search timeout", session.id);
-                        Err(datafusion::error::DataFusionError::ResourcesExhausted(format!(
-                            "[trace_id {}] wal->parquet->search: task timeout", session.id
-                        )))
-                    },
-                    _ = async {
-                        #[cfg(feature = "enterprise")]
-                        let _ = abort_receiver.await;
-                        #[cfg(not(feature = "enterprise"))]
-                        futures::future::pending::<()>().await;
-                    } => {
-                        log::info!("[trace_id {}] wal->parquet->search: search canceled", session.id);
-                        Err(datafusion::error::DataFusionError::Execution(format!(
-                            "[trace_id {}] wal->parquet->search: task is cancel", session.id
-                        )))
-                    }
-                }
-            }
-            .instrument(datafusion_span),
-        );
-
-        tasks.push(task);
+        let table =
+            exec::create_parquet_table(&session, schema, &files, diff_fields, &sql.meta.order_by)
+                .await?;
+        tables.push(Arc::new(table) as Arc<dyn datafusion::datasource::TableProvider>);
     }
 
-    let task_results = match try_join_all(tasks).await {
-        Ok(v) => v,
-        Err(e) => {
-            // release all files
-            wal::release_files(&lock_files).await;
-            return Err(Error::ErrorCode(ErrorCodes::ServerInternalError(
-                e.to_string(),
-            )));
-        }
-    };
-
-    let mut results = vec![];
-    for ret in task_results {
-        match ret {
-            Ok(v) => {
-                results.extend(v);
-            }
-            Err(err) => {
-                // release all files
-                wal::release_files(&lock_files).await;
-                log::error!(
-                    "[trace_id {trace_id}] wal->parquet->search: datafusion execute error: {}",
-                    err
-                );
-                match err {
-                    datafusion::error::DataFusionError::ResourcesExhausted(e) => {
-                        return Err(Error::ErrorCode(ErrorCodes::SearchTimeout(e)));
-                    }
-                    _ => return Err(err.into()),
-                }
-            }
-        };
-    }
-
-    // release all files
+    // TODO: release all files
     wal::release_files(&lock_files).await;
 
-    Ok((results, scan_stats))
+    Ok((tables, scan_stats))
 }
 
 /// search in local WAL, which haven't been sync to object storage
@@ -379,9 +289,7 @@ pub async fn search_memtable(
     trace_id: &str,
     sql: Arc<Sql>,
     stream_type: StreamType,
-    work_group: &str,
-    timeout: u64,
-) -> super::SearchResult {
+) -> super::SearchTable {
     let schema_latest = infra::schema::get(&sql.org_id, &sql.stream_name, stream_type)
         .await
         .unwrap_or(Schema::empty());
@@ -451,123 +359,44 @@ pub async fn search_memtable(
     }
     let select_wildcard = RE_SELECT_WILDCARD.is_match(sql.origin_sql.as_str());
 
-    let mut tasks = Vec::new();
-    for (ver, (schema, mut record_batches)) in batch_groups.into_iter().enumerate() {
+    // only sort by timestamp desc
+    let sort_by_timestamp_desc = sql.meta.order_by.len() == 1
+        && sql.meta.order_by[0].0 == cfg.common.column_timestamp
+        && sql.meta.order_by[0].1;
+
+    let mut tables = Vec::new();
+    for (schema, mut record_batches) in batch_groups {
+        if record_batches.is_empty() {
+            continue;
+        }
         let sql = sql.clone();
-        let session = config::meta::search::Session {
-            id: format!("{trace_id}-mem-{ver}"),
-            storage_type: StorageType::Tmpfs,
-            search_type: if !sql.meta.group_by.is_empty() {
-                SearchType::Aggregation
-            } else {
-                SearchType::Normal
-            },
-            work_group: Some(work_group.to_string()),
-            target_partitions: 0,
-        };
 
         // cacluate the diff between latest schema and group schema
         let (schema, diff_fields) = if select_wildcard {
             generate_select_start_search_schema(
                 &sql,
-                schema.clone(),
+                schema.as_ref(),
                 &schema_latest_map,
                 &defined_schema_fields,
             )?
         } else {
-            generate_search_schema(&sql, schema.clone(), &schema_latest_map)?
+            generate_search_schema(&sql, schema.as_ref(), &schema_latest_map)?
         };
 
         for batch in record_batches.iter_mut() {
             *batch = adapt_batch(&schema, batch);
         }
 
-        let datafusion_span = info_span!(
-            "service:search:grpc:wal:mem:datafusion",
-            org_id = sql.org_id,
-            stream_name = sql.stream_name,
-            stream_type = stream_type.to_string(),
-        );
-
-        #[cfg(feature = "enterprise")]
-        let (abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
-        #[cfg(feature = "enterprise")]
-        if crate::service::search::SEARCH_SERVER
-            .insert_sender(trace_id, abort_sender)
-            .await
-            .is_err()
-        {
-            log::info!(
-                "[trace_id {}] wal->mem->search: search canceled before call wal->mem->search",
-                session.id
-            );
-            return Err(Error::Message(format!(
-                "[trace_id {}] wal->mem->search: search canceled before call wal->mem->search",
-                session.id
-            )));
-        }
-
-        let task = tokio::task::spawn(
-            async move {
-                let files = vec![];
-                tokio::select! {
-                    ret = exec::sql(
-                        &session,
-                        schema,
-                        diff_fields,
-                        &sql,
-                        &files,
-                        Some(record_batches),
-                        FileType::ARROW,
-                    ) => ret,
-                    _ = tokio::time::sleep(Duration::from_secs(timeout)) => {
-                        log::error!("[trace_id {}] wal->mem->search: search timeout", session.id);
-                        Err(datafusion::error::DataFusionError::ResourcesExhausted(format!(
-                            "[trace_id {}] wal->mem->search: task timeout", session.id
-                        )))
-                    },
-                    _ = async {
-                        #[cfg(feature = "enterprise")]
-                        let _ = abort_receiver.await;
-                        #[cfg(not(feature = "enterprise"))]
-                        futures::future::pending::<()>().await;
-                    } => {
-                        log::info!("[trace_id {}] wal->mem->search: search canceled", session.id);
-                        Err(datafusion::error::DataFusionError::Execution(format!(
-                            "[trace_id {}] wal->mem->search: task is cancel", session.id
-                        )))
-                    }
-                }
-            }
-            .instrument(datafusion_span),
-        );
-
-        tasks.push(task);
+        let table = Arc::new(NewMemTable::try_new(
+            schema,
+            vec![record_batches],
+            diff_fields,
+            sort_by_timestamp_desc,
+        )?);
+        tables.push(table as _);
     }
 
-    let mut results = vec![];
-    let task_results = try_join_all(tasks)
-        .await
-        .map_err(|e| Error::ErrorCode(ErrorCodes::ServerInternalError(e.to_string())))?;
-    for ret in task_results {
-        match ret {
-            Ok(v) => results.extend(v),
-            Err(err) => {
-                log::error!(
-                    "[trace_id {trace_id}] wal->mem->search: datafusion execute error: {}",
-                    err
-                );
-                match err {
-                    datafusion::error::DataFusionError::ResourcesExhausted(e) => {
-                        return Err(Error::ErrorCode(ErrorCodes::SearchTimeout(e)));
-                    }
-                    _ => return Err(err.into()),
-                }
-            }
-        };
-    }
-
-    Ok((results, scan_stats))
+    Ok((tables, scan_stats))
 }
 
 #[tracing::instrument(name = "service:search:grpc:wal:get_file_list_inner", skip_all, fields(org_id = sql.org_id, stream_name = sql.stream_name))]

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -896,6 +896,25 @@ fn generate_used_fields_in_query(sql: &Arc<sql::Sql>) -> Vec<String> {
     used_fields.into_iter().collect()
 }
 
+// generate parquet file search schema
+fn generate_search_schema_diff(
+    schema: &Schema,
+    schema_latest_map: &HashMap<&String, &Arc<Field>>,
+) -> Result<HashMap<String, DataType>, Error> {
+    // cacluate the diff between latest schema and group schema
+    let mut diff_fields = HashMap::new();
+
+    for field in schema.fields().iter() {
+        if let Some(latest_field) = schema_latest_map.get(field.name()) {
+            if field.data_type() != latest_field.data_type() {
+                diff_fields.insert(field.name().clone(), latest_field.data_type().clone());
+            }
+        }
+    }
+
+    Ok(diff_fields)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -773,7 +773,7 @@ impl<'a> opentelemetry::propagation::Injector for MetadataMap<'a> {
 // generate parquet file search schema
 fn generate_search_schema(
     sql: &Arc<sql::Sql>,
-    schema: Arc<Schema>,
+    schema: &Schema,
     schema_latest_map: &HashMap<&String, &Arc<Field>>,
 ) -> Result<(Arc<Schema>, HashMap<String, DataType>), Error> {
     // cacluate the diff between latest schema and group schema
@@ -821,7 +821,7 @@ fn generate_search_schema(
 // generate parquet file search schema
 fn generate_select_start_search_schema(
     sql: &Arc<sql::Sql>,
-    schema: Arc<Schema>,
+    schema: &Schema,
     schema_latest_map: &HashMap<&String, &Arc<Field>>,
     defined_schema_fields: &[String],
 ) -> Result<(Arc<Schema>, HashMap<String, DataType>), Error> {
@@ -872,12 +872,9 @@ fn generate_select_start_search_schema(
         Arc::new(Schema::new(new_fields))
     } else if !new_fields.is_empty() {
         let new_schema = Schema::new(new_fields);
-        Arc::new(Schema::try_merge(vec![
-            schema.as_ref().to_owned(),
-            new_schema,
-        ])?)
+        Arc::new(Schema::try_merge(vec![schema.to_owned(), new_schema])?)
     } else {
-        schema.clone()
+        Arc::new(schema.clone())
     };
     Ok((schema, diff_fields))
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,7 +16,7 @@
 #[cfg(test)]
 mod tests {
     use core::time;
-    use std::{env, fs, str, sync::Once, thread};
+    use std::{env, fs, net::SocketAddr, str, sync::Once, thread};
 
     use actix_web::{http::header::ContentType, test, web, App};
     use bytes::{Bytes, BytesMut};
@@ -24,10 +24,12 @@ mod tests {
     use config::{get_config, utils::json};
     use openobserve::{
         common::meta::dashboards::{v1, Dashboard, Dashboards},
-        handler::http::router::*,
+        handler::{grpc::auth::check_auth, http::router::*},
+        service::search::SEARCH_SERVER,
     };
     use prost::Message;
-    use proto::prometheus_rpc;
+    use proto::{cluster_rpc::search_server::SearchServer, prometheus_rpc};
+    use tonic::codec::CompressionEncoding;
 
     static START: Once = Once::new();
 
@@ -40,7 +42,7 @@ mod tests {
             env::set_var("ZO_FILE_PUSH_INTERVAL", "1");
             env::set_var("ZO_PAYLOAD_LIMIT", "209715200");
             env::set_var("ZO_JSON_LIMIT", "209715200");
-            env::set_var("ZO_TIME_STAMP_COL", "_timestamp");
+            env::set_var("ZO_RESULT_CACHE_ENABLED", "false");
 
             env_logger::init_from_env(
                 env_logger::Env::new().default_filter_or(&get_config().log.level),
@@ -52,6 +54,30 @@ mod tests {
             "Authorization",
             "Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=",
         )
+    }
+
+    async fn init_grpc_server() -> Result<(), anyhow::Error> {
+        let cfg = get_config();
+        let ip = if !cfg.grpc.addr.is_empty() {
+            cfg.grpc.addr.clone()
+        } else {
+            "0.0.0.0".to_string()
+        };
+        let gaddr: SocketAddr = format!("{}:{}", ip, cfg.grpc.port).parse()?;
+        let search_svc = SearchServer::new(SEARCH_SERVER.clone())
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip)
+            .max_decoding_message_size(cfg.grpc.max_message_size * 1024 * 1024)
+            .max_encoding_message_size(cfg.grpc.max_message_size * 1024 * 1024);
+
+        log::info!("starting gRPC server at {}", gaddr);
+        tonic::transport::Server::builder()
+            .layer(tonic::service::interceptor(check_auth))
+            .add_service(search_svc)
+            .serve(gaddr)
+            .await
+            .expect("gRPC server init failed");
+        Ok(())
     }
 
     async fn e2e_100_tear_down() {
@@ -66,6 +92,13 @@ mod tests {
             .unwrap_or_else(|e| log::info!("Error deleting local dir: {}", e));
 
         setup();
+
+        // start gRPC server
+        tokio::task::spawn(async move {
+            init_grpc_server()
+                .await
+                .expect("router gRPC server init failed");
+        });
 
         // register node
         openobserve::common::infra::cluster::register_and_keepalive()
@@ -107,12 +140,9 @@ mod tests {
         e2e_remove_stream_function().await;
         e2e_delete_function().await;
 
-        // FIXME: Revise and restore the e2e tests for search API calls.
-        // They have been broken by https://github.com/openobserve/openobserve/pull/570
-        //
-        // // search
-        // e2e_search().await;
-        // e2e_search_around().await;
+        // search
+        e2e_search().await;
+        e2e_search_around().await;
 
         // users
         e2e_post_user().await;
@@ -1308,6 +1338,8 @@ mod tests {
             .set_payload(body_str)
             .to_request();
         let resp = test::call_service(&app, req).await;
+        println!("{:?}", resp.status());
+        println!("{:?}", resp.response().body());
         assert!(resp.status().is_success());
     }
 


### PR DESCRIPTION
related #4355  #4356
this pr fixes the sort issue, 
the issue is when we have more than one filegroup in a single querier node, and at the top of the partial plan is a `SortMerge` operator, the result sometimes will out of order; this pr fix this by using a single union plan in a querier node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced search functionality with improved error handling and dynamic management of schemas.
	- Introduced mechanisms for consistent formatting of query results based on schema variations.
	- Added new types for granular search operations and improved handling of search configurations.
	- Introduced a new boolean field `sorted_by_time` for better control over execution logic in search operations.
	- Added a new asynchronous function for initializing the gRPC server in the test environment.

- **Bug Fixes**
	- Improved error visibility and logging for search operations, ensuring better clarity during failures.

- **Refactor**
	- Streamlined the search process by restructuring batch handling and control flow for different processing phases.
	- Simplified schema management and reduced complexity in the asynchronous handling of search results.
	- Transitioned from asynchronous to synchronous operations in key functions for improved performance.
	- Enhanced testing framework to better simulate gRPC interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->