### PR TITLE
fix: use original stream name to lookup post-flatten-function

### DIFF
--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -176,7 +176,6 @@ pub async fn ingest(
                 return Err(anyhow::anyhow!("Failed processing: {:?}", e));
             }
         };
-        let mut routed_stream_name = stream_name.clone();
 
         if let Some(extend) = extend_json.as_ref() {
             for (key, val) in extend.iter() {
@@ -193,7 +192,7 @@ pub async fn ingest(
                     transforms,
                     &stream_vrl_map,
                     org_id,
-                    &routed_stream_name,
+                    &stream_name,
                     &mut runtime,
                 ) {
                     Ok(res) => res,
@@ -211,6 +210,7 @@ pub async fn ingest(
         let item = flatten::flatten_with_level(item, cfg.limit.ingest_flatten_level)?;
 
         // Start re-routing if exists
+        let mut routed_stream_name = stream_name.clone();
         if let Some(routings) = stream_routing_map.get(&routed_stream_name) {
             if !routings.is_empty() {
                 for route in routings {
@@ -231,7 +231,7 @@ pub async fn ingest(
         }
         // End re-routing
 
-        let key = format!("{org_id}/{}/{routed_stream_name}", StreamType::Logs);
+        let key = format!("{org_id}/{}/{stream_name}", StreamType::Logs);
         // Start row based transform
         let mut res = if let Some(transforms) = stream_after_functions_map.get(&key) {
             match apply_functions(
@@ -239,7 +239,7 @@ pub async fn ingest(
                 transforms,
                 &stream_vrl_map,
                 org_id,
-                &routed_stream_name,
+                &stream_name,
                 &mut runtime,
             ) {
                 Ok(res) => res,


### PR DESCRIPTION
## Summary

This fixes the bug described in issue #4357 in which post-flatten-functions were not applied to data being routed to a destination route. Please see that issue for more details about the observed behavior of the bug and a description of the proposed solution that this PR implements.

I believe that the bug occurred because post-flatten-function lookup was performed using a mutable `routed_stream_name` which was mutated from the original stream name to the name of a destination stream if the data matched the conditions of some route. This PR updates the post-flatten-function lookup logic to always use the original stream name, just as the pre-flatten-function lookup logic always uses the original stream name.

## Additional notes

As mentioned in #4357 ...

> we still need to define the actual desired and expected behavior. I can see two different, and both reasonable, definitions for the desired behavior:
>
> 1. Pre and post-flattening functions associated with an original stream are ONLY applied to data that will be routed to the original stream as its final destination.
>
> ...
>
> 2. Pre and post-flattening functions associated with an original stream are applied BOTH to data that will be routed to the original stream AND to downstream destination streams.

In this PR I am assuming that Option 2 is the desired behavior. Please let me know if that's not the case and I can update this PR to implement the behavior described in Option 1 instead.