### PR TITLE
fix: when updating alert first check, if the scheduled_job exist or not

### DIFF
--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -127,7 +127,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
 
     let mut new_trigger = db::scheduler::Trigger {
         next_run_at: Utc::now().timestamp_micros(),
-        is_realtime: false,
+        is_realtime: alert.is_real_time,
         is_silenced: false,
         status: db::scheduler::TriggerStatus::Waiting,
         retries: 0,


### PR DESCRIPTION
Fixes #4360 

In case some `scheduled_job` records (required for alerts to get scheduled properly) are missing for some alerts, they can be recreated by simply disabling and enabling it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Improvements**
	- Enhanced error logging for trigger updates and creations, providing clearer context with the inclusion of the `schedule_key`.
	- Improved robustness of trigger management logic, facilitating easier diagnosis of issues related to alert triggers.
	- Increased flexibility in alert handling by dynamically setting the `is_realtime` property based on the alert's characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->