### PR TITLE
fix: args of histogram( ) or any function to be added to interesting fields in quick mode

### DIFF
--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -1168,12 +1168,20 @@ export default defineComponent({
       data.forEach((item) => {
         if (item.expr && item.expr.column) {
           columnNames.push(item.expr.column);
-        } else if (item.expr && item.expr.args && item.expr.args.expr) {
+        } 
+        else if (item.expr && item.expr.args && item.expr.args.expr) {
           if (item.expr.args.expr.column) {
             columnNames.push(item.expr.args.expr.column);
           } else if (item.expr.args.expr.value) {
             columnNames.push(item.expr.args.expr.value);
           }
+        }
+        else if(item.expr && item.expr.name && item.expr.type ==="function"){
+          item.expr.args.value.map((val) => {
+            if (val.type === "column_ref") {
+              columnNames.push(val.column);
+            }
+          })
         }
       });
       return columnNames;
@@ -1239,6 +1247,7 @@ export default defineComponent({
                 }
               }
               useLocalInterestingFields(localFields);
+
             }
           }
 


### PR DESCRIPTION
This PR fixes #4363 
1. This fix adds the args of any function to interesting fields.
2. This fix also ensures that not only single arg but also able to add multiple args to the interesting fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the search bar functionality to support a broader range of expression types, improving the extraction of column names from function expressions.
  
- **Style**
  - Minor formatting adjustments made for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->