### PR TITLE
fix: remove alert evaluation on save and do not store alert vrl containing only "."

### DIFF
--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -209,10 +209,12 @@ pub async fn save(
         }
     }
 
-    // test the alert
-    if let Err(e) = &alert.evaluate(None).await {
-        return Err(anyhow::anyhow!("Alert test failed: {}", e));
-    }
+    // Commented intentionally - in case the alert period is big and there
+    // is huge amount of data within the time period, the below can timeout and return error.
+    // // test the alert
+    // if let Err(e) = &alert.evaluate(None).await {
+    //     return Err(anyhow::anyhow!("Alert test failed: {}", e));
+    // }
 
     // save the alert
     match db::alerts::alert::set(org_id, stream_type, stream_name, &alert, create).await {

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -127,7 +127,8 @@ pub async fn save(
                 if !vrl.is_empty() && !vrl.ends_with('.') {
                     let vrl = base64::encode_url(&format!("{vrl} \n ."));
                     alert.query_condition.vrl_function = Some(vrl);
-                } else if vrl.is_empty() {
+                } else if vrl.is_empty() || vrl.eq(".") {
+                    // In case the vrl contains only ".", no need to save it
                     alert.query_condition.vrl_function = None;
                 }
             }


### PR DESCRIPTION
Fixes #4388 

- If the VRL function in alert contains only '.', no need to store the VRL function in the alert
- Remove alert evaluation in backend while saving alert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved logic for saving alerts by preventing the assignment of non-meaningful values (specifically a single period) to alert conditions, enhancing data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->