### PR TITLE
feat: add `last_satisfied_at` field in alerts

### DIFF
--- a/src/common/meta/alerts/alert.rs
+++ b/src/common/meta/alerts/alert.rs
@@ -53,6 +53,8 @@ pub struct Alert {
     #[serde(default)]
     pub last_triggered_at: Option<i64>,
     #[serde(default)]
+    pub last_satisfied_at: Option<i64>,
+    #[serde(default)]
     pub owner: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = String, format = DateTime)]
@@ -89,6 +91,7 @@ impl Default for Alert {
             owner: None,
             updated_at: None,
             last_edited_by: None,
+            last_satisfied_at: None,
         }
     }
 }

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -205,6 +205,11 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         error: None,
     };
 
+    let last_satisfied_at = if ret.is_some() {
+        Some(triggered_at)
+    } else {
+        None
+    };
     // send notification
     if let Some(data) = ret {
         let vars = get_row_column_map(&data);
@@ -288,6 +293,9 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
             }
         };
     old_alert.last_triggered_at = Some(triggered_at);
+    if let Some(last_satisfied_at) = last_satisfied_at {
+        old_alert.last_satisfied_at = Some(last_satisfied_at);
+    }
     if let Err(e) = db::alerts::alert::set_without_updating_trigger(
         &org_id,
         stream_type,

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -457,6 +457,13 @@ export default defineComponent({
         sortable: true,
       },
       {
+        name: "last_satisfied_at",
+        field: "last_satisfied_at",
+        label: t("alerts.lastSatisfied"),
+        align: "left",
+        sortable: true,
+      },
+      {
         name: "actions",
         field: "actions",
         label: t("alerts.actions"),
@@ -518,6 +525,7 @@ export default defineComponent({
               uuid: data.uuid,
               owner: data.owner,
               last_triggered_at:convertUnixToQuasarFormat(data.last_triggered_at),
+              last_satisfied_at:convertUnixToQuasarFormat(data.last_satisfied_at),
             };
           });
           alertsRows.value.forEach((alert: AlertListItem) => {

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -795,6 +795,7 @@
     "preview": "Preview",
     "crontitle": "Enable Cron",
     "lastTriggered":"Last Triggered At",
+    "lastSatisfied":"Last Satisfied At",
     "owner": "Owner"
   },
   "alert_templates": {


### PR DESCRIPTION
The `last_satisfied_at` field in the alert tracks when the alert condition last met. This is in UTC microseconds.
This PR fixes the issue in #4379 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Introduced a new timestamp field to track when alerts were last satisfied.
	- Enhanced alert handling logic to manage and update satisfaction timestamps effectively.
	- Added a new column in the Alert List to display the last satisfied timestamp for alerts.
	- Improved localization support by adding a label for the last satisfied timestamp.

- **Bug Fixes**
	- Improved accuracy in alert state management by ensuring timestamps are recorded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->