### PR TITLE
fix: Logs cancel query issue

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1702,7 +1702,9 @@ const useLogs = () => {
               if (isTimestampASC(parsedSQL?.orderby) && partitions.length > 1) {
                 partitions.reverse();
               }
+
               await generateHistogramSkeleton();
+
               for (const partition of partitions) {
                 searchObj.data.histogramQuery.query.start_time = partition[0];
                 searchObj.data.histogramQuery.query.end_time = partition[1];
@@ -2999,13 +3001,8 @@ const useLogs = () => {
           });
         }
       } else {
-        // searchObj.data.stream.selectedFields.forEach((field: any) => {
-        if (
-          searchObj.data.stream.selectedFields.includes(
-            store.state.zoConfig.timestamp_column,
-          )
-        ) {
-          searchObj.data.resultGrid.columns.push({
+        if (searchObj.data.hasSearchDataTimestampField == true) {
+          searchObj.data.resultGrid.columns.unshift({
             name: store.state.zoConfig.timestamp_column,
             id: store.state.zoConfig.timestamp_column,
             accessorFn: (row: any) =>
@@ -3026,7 +3023,7 @@ const useLogs = () => {
             sortable: true,
             enableResizing: false,
             meta: {
-              closable: true,
+              closable: false,
               showWrap: false,
               wrapContent: false,
             },

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2329,16 +2329,15 @@ const useLogs = () => {
 
   const getHistogramQueryData = (queryReq: any) => {
     return new Promise((resolve, reject) => {
-      if (
-        searchObj.data.isOperationCancelled &&
-        searchObj.data.histogram?.xData?.length == 0
-      ) {
+      if (searchObj.data.isOperationCancelled) {
         searchObj.loadingHistogram = false;
         searchObj.data.isOperationCancelled = false;
 
-        notificationMsg.value = "Search query was cancelled";
-        searchObj.data.histogram.errorMsg = "Search query was cancelled";
-        searchObj.data.histogram.errorDetail = "Search query was cancelled";
+        if (!searchObj.data.histogram?.xData?.length) {
+          notificationMsg.value = "Search query was cancelled";
+          searchObj.data.histogram.errorMsg = "Search query was cancelled";
+          searchObj.data.histogram.errorDetail = "Search query was cancelled";
+        }
         return;
       }
 
@@ -2430,13 +2429,6 @@ const useLogs = () => {
                 notificationMsg.value += " TraceID:" + trace_id;
                 trace_id = "";
               }
-            }
-
-            if (err?.request?.status >= 429) {
-              notificationMsg.value = err?.response?.data?.message;
-              searchObj.data.histogram.errorMsg = err?.response?.data?.message;
-              searchObj.data.histogram.errorDetail =
-                err?.response?.data?.error_detail;
             }
 
             reject(false);

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -252,31 +252,30 @@ export default defineComponent({
       ] = [newColSizes];
     },
     handleColumnOrderUpdate(newColOrder: string[], columns: any[]) {
-      // Here we are checking if the columns are default columns
+      // Here we are checking if the columns are default columns ( _timestamp and source)
       // As there can be case where user can have column with source like default source column
       // So checking enableResizing as well as its off for default column
       // If default columns not saving in colOrder
-      if (
-        newColOrder.length === 2 &&
-        newColOrder[0] === this.store.state.zoConfig.timestamp_column &&
-        newColOrder[1] === "source"
-      ) {
+      const updatedColOrder = [...newColOrder];
+
+      if (updatedColOrder[0] === this.store.state.zoConfig.timestamp_column)
+        updatedColOrder.splice(0, 1);
+
+      const sourceOrderIndex = updatedColOrder.indexOf("source");
+
+      if (sourceOrderIndex > -1) {
         const sourceColIndex = columns.findIndex(
           (col: any) => col.name === "source",
         );
 
         if (columns[sourceColIndex].enableResizing === false) {
-          this.searchObj.data.resultGrid.colOrder[
-            this.searchObj.data.stream.selectedStream
-          ] = [];
-
-          return;
+          updatedColOrder.splice(sourceOrderIndex, 1);
         }
       }
 
       this.searchObj.data.resultGrid.colOrder[
         this.searchObj.data.stream.selectedStream
-      ] = [...newColOrder];
+      ] = [...updatedColOrder];
     },
 
     getPageData(actionType: string) {

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -473,6 +473,7 @@ const table = useVueTable({
     },
   },
   onSortingChange: setSorting,
+  enableSorting: false,
   getCoreRowModel: getCoreRowModel(),
   getSortedRowModel: getSortedRowModel(),
   defaultColumn: {

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -685,18 +685,8 @@ defineExpose({
 }
 
 .resizer.isResizing {
-  background: blue;
+  background: $primary;
   opacity: 1;
-}
-
-@media (hover: hover) {
-  .resizer {
-    opacity: 0;
-  }
-
-  *:hover > .resizer {
-    opacity: 1;
-  }
 }
 
 .container {


### PR DESCRIPTION
fix #4344 
    1. Sometimes user has to click cancel query multiple times for the query to get cancelled
    2. Add Column and expand log, click on column header. Now when we expand any row, it does not expands at desired 
    position

Reverted the previous timestamp column functionality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced asynchronous loading for the QueryEditor component to improve initial load times in the JsonPreview.
	- Enhanced column order handling in SearchResult for more dynamic adjustments based on default columns.

- **Bug Fixes**
	- Added error handling in the getNestedJson function to improve robustness against unexpected input.

- **Style**
	- Updated the background color of the table resizer for better visual consistency.

- **Chores**
	- Disabled sorting functionality by default in the table component to streamline user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->