### PR TITLE
fix: improve triggers reporting, update trigger status if alert query is invalid

### DIFF
--- a/src/handler/http/request/alerts/alert.rs
+++ b/src/handler/http/request/alerts/alert.rs
@@ -59,6 +59,8 @@ pub async fn save_alert(
     alert.owner = Some(user_email.user_id.clone());
     alert.last_edited_by = Some(user_email.user_id);
     alert.updated_at = Some(datetime_now());
+    alert.last_triggered_at = None;
+    alert.last_satisfied_at = None;
 
     match alert::save(&org_id, &stream_name, "", alert, true).await {
         Ok(_) => Ok(MetaHttpResponse::ok("Alert saved")),

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -81,6 +81,7 @@ pub async fn save(
                 return Err(anyhow::anyhow!("Alert already exists"));
             }
             alert.last_triggered_at = old_alert.last_triggered_at;
+            alert.last_satisfied_at = old_alert.last_satisfied_at;
             alert.owner = old_alert.owner;
         }
         Ok(None) => {


### PR DESCRIPTION
- Fixes #4394
- When cloning alert, don't copy `last_satisfied_at`, `last_triggered_at`

When the alert query is invalid, the scheduler stops processing the alert and returns, but the error message is not reported in the triggers usage stream. This PR fixes that.

When the alert query is invalid, it will be retried again and again (default maximum number of retries is `3`). After that, the associated `scheduled_jobs` record will be automatically removed from the table and hence the alert will not be triggered anymore.

In order to schedule the alert again, the user needs to update the query and again save it, it will start scheduling again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced alert handling logic for improved robustness and clarity.
	- Introduced structured handling of alert data with better error management.
	- Added initialization of `last_triggered_at` and `last_satisfied_at` fields to ensure clear state management for alerts.

- **Bug Fixes**
	- Improved error handling for alert evaluation, ensuring accurate status updates for alert triggers.
	- Enhanced state preservation for alerts by updating the `last_satisfied_at` timestamp during saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->