### PR TITLE
fix: wrong timeseries hover issue for dashboard

### DIFF
--- a/web/src/components/dashboards/panels/ChartRenderer.vue
+++ b/web/src/components/dashboards/panels/ChartRenderer.vue
@@ -233,7 +233,7 @@ export default defineComponent({
       }
 
       // set current hovered series name in state
-      hoveredSeriesState?.value?.setHoveredSeriesName(params?.seriesName);
+      hoveredSeriesState?.value?.setHoveredSeriesName(params?.seriesName ?? "");
 
       // Below logic is to scroll legend upto current series index
       // which creates wrong legend highlight issue in tooltip
@@ -316,9 +316,9 @@ export default defineComponent({
       });
 
       chart?.on("legendselectchanged", legendSelectChangedFn);
-      chart?.on("downplay", (params: any) => {
+      chart?.on("highlight", (params: any) => {
         // reset hovered series name on downplay
-        hoveredSeriesState?.value?.setHoveredSeriesName("");
+        // hoveredSeriesState?.value?.setHoveredSeriesName("");
 
         // downplay event will only called by currently hovered panel else it will go into infinite loop
         // and chart must be timeseries chart


### PR DESCRIPTION
- #4365 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved stability of chart interactions by ensuring the hovered series name defaults to an empty string when not available.
	- Enhanced user experience with updated event handling, renaming the event listener from "downplay" to "highlight" for clearer interaction feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->