### PR TITLE
fix: saved views columns not getting restored

### DIFF
--- a/tests/ui-testing/playwright-tests/logsqueries.spec.js
+++ b/tests/ui-testing/playwright-tests/logsqueries.spec.js
@@ -180,7 +180,7 @@ test.describe("Logs Queries testcases", () => {
 
                 force: true
               });
-    await page.locator('[data-cy="logs-search-bar-reset-filters-btn"]').first().click({
+    await page.locator('[data-cy="logs-search-bar-reset-filters-btn"]').click({
       force: true
     });
     await page.waitForTimeout(5000);

--- a/tests/ui-testing/playwright-tests/logsqueries.spec.js
+++ b/tests/ui-testing/playwright-tests/logsqueries.spec.js
@@ -180,7 +180,7 @@ test.describe("Logs Queries testcases", () => {
 
                 force: true
               });
-    await page.getByText(/Reset Filters/).first().click({
+    await page.locator('[data-cy="logs-search-bar-reset-filters-btn"]').first().click({
       force: true
     });
     await page.waitForTimeout(5000);

--- a/tests/ui-testing/playwright-tests/logsqueries.spec.js
+++ b/tests/ui-testing/playwright-tests/logsqueries.spec.js
@@ -180,7 +180,7 @@ test.describe("Logs Queries testcases", () => {
 
                 force: true
               });
-    await page.locator('[data-cy="logs-search-bar-reset-filters-btn"]').click({
+    await page.locator('[data-test="logs-search-bar-reset-filters-btn"]').click({
       force: true
     });
     await page.waitForTimeout(5000);

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -121,7 +121,8 @@
     "cancel": "Cancel query",
     "viewTrace": "View Trace",
     "flattened": "Flattened",
-    "unflattened": "Unflattened"
+    "unflattened": "Unflattened",
+    "resetFilters": "Reset Filters"
   },
   "menu": {
     "home": "Home",

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -63,11 +63,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         />
         <q-btn
           data-test="logs-search-bar-reset-filters-btn"
-          label="Reset Filters"
+          :title="t('search.resetFilters')"
           no-caps
           size="sm"
           icon="restart_alt"
-          class="q-pr-sm q-pl-xs reset-filters q-ml-xs"
+          class="tw-flex tw-justify-center tw-items-center reset-filters q-ml-xs"
           @click="resetFilters"
         />
         <syntax-guide
@@ -1739,13 +1739,11 @@ export default defineComponent({
             store.dispatch("setSavedViewFlag", true);
             const extractedObj = res.data.data;
 
+            // Resetting columns as its not required in searchObj
+            // As we reassign columns from selectedFields and search results
+            extractedObj.data.resultGrid.columns = [];
+
             // Add colOrder to searchObj if saved view don't have colOrder property in resultGrid
-            if (!extractedObj.data.resultGrid.hasOwnProperty("colOrder")) {
-              extractedObj.data.resultGrid.colOrder = {};
-              extractedObj.data.resultGrid.colOrder[
-                extractedObj.data.stream.selectedStream
-              ] = [];
-            }
 
             if (extractedObj.data?.timezone) {
               store.dispatch("setTimezone", extractedObj.data.timezone);
@@ -2746,6 +2744,15 @@ export default defineComponent({
   padding-bottom: 1px;
   height: 100%;
   overflow: visible;
+
+  .reset-filters {
+    width: 32px;
+    height: 32px;
+
+    .q-icon {
+      margin-right: 0;
+    }
+  }
 
   #logsQueryEditor,
   #fnEditor {

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -1743,8 +1743,6 @@ export default defineComponent({
             // As we reassign columns from selectedFields and search results
             extractedObj.data.resultGrid.columns = [];
 
-            // Add colOrder to searchObj if saved view don't have colOrder property in resultGrid
-
             if (extractedObj.data?.timezone) {
               store.dispatch("setTimezone", extractedObj.data.timezone);
             }

--- a/web/src/plugins/logs/SyntaxGuide.vue
+++ b/web/src/plugins/logs/SyntaxGuide.vue
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     flat
     class="q-ml-xs q-pa-xs syntax-guide-button"
     :class="sqlmode ? 'sql-mode' : 'normal-mode'"
-    :label="t('search.syntaxGuideLabel')"
+    :title="t('search.syntaxGuideLabel')"
     icon="help"
   >
     <q-menu :class="store.state.theme == 'dark' ? 'theme-dark' : 'theme-light'">
@@ -36,18 +36,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div class="syntax-guide-text">
               <ul class="guide-list">
                 <li>
-                  For inverted index search of value 'error' use 
-                  <span class="bg-highlight">match_all('error')</span> 
+                  For inverted index search of value 'error' use
+                  <span class="bg-highlight">match_all('error')</span>
                   in query editor. Search terms are case-insensitive.
                 </li>
                 <li>
-                  For full text search of value 'error' use 
-                  <span class="bg-highlight"
-                    >match_all_raw('error')</span
-                  >
+                  For full text search of value 'error' use
+                  <span class="bg-highlight">match_all_raw('error')</span>
                 </li>
                 <li>
-                  For case-insensitive full text search of value 'error' use 
+                  For case-insensitive full text search of value 'error' use
                   <span class="bg-highlight"
                     >match_all_raw_ignore_case('error')</span
                   >
@@ -100,21 +98,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div class="syntax-guide-text">
               <ul class="guide-list">
                 <li>
-                  For inverted index search of value 'error' use 
+                  For inverted index search of value 'error' use
                   <span class="bg-highlight"
                     >SELECT * FROM <b>stream</b> WHERE match_all('error')</span
                   >
                   in query editor. Search terms are case-insensitive.
                 </li>
                 <li>
-                  For full text search of value 'error' use 
+                  For full text search of value 'error' use
                   <span class="bg-highlight"
                     >SELECT * FROM <b>stream</b> WHERE
                     match_all_raw('error')</span
                   >
                 </li>
                 <li>
-                  For case-insensitive full text search of value 'error' use 
+                  For case-insensitive full text search of value 'error' use
                   <span class="bg-highlight"
                     >SELECT * FROM <b>stream</b> WHERE
                     match_all_raw_ignore_case('error')</span
@@ -206,13 +204,10 @@ export default defineComponent({
 .syntax-guide-button {
   cursor: pointer;
   text-transform: capitalize;
-  padding: 5px 5px;
+  width: 32px;
+  height: 32px;
   font-weight: bold;
   border: 1px solid rgba(89, 96, 178, 0.3);
-}
-
-.normal-mode {
-  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .sql-mode {

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -276,7 +276,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   '-' +
                   cell.column.columnDef.id
                 "
-                class="tw-py-1 tw-px-2 tw-items-center tw-justify-start tw-relative table-cell"
+                class="tw-py-none tw-px-2 tw-items-center tw-justify-start tw-relative table-cell"
                 :style="{
                   width:
                     cell.column.columnDef.id !== 'source'
@@ -284,7 +284,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       : wrap
                         ? width - 260 - 12 + 'px'
                         : 'auto',
-                  height: wrap ? '100%' : '26px',
+                  height: wrap ? '100%' : '20px',
                 }"
                 :class="[
                   columnOrder.includes('source') && !wrap
@@ -566,7 +566,6 @@ const setExpandedRows = () => {
 };
 
 const copyLogToClipboard = (value: any) => {
-  emits("copy", value);
 };
 const addSearchTerm = (value: string) => {
   emits("addSearchTerm", value);

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -566,6 +566,7 @@ const setExpandedRows = () => {
 };
 
 const copyLogToClipboard = (value: any) => {
+  emits("copy", value, false);
 };
 const addSearchTerm = (value: string) => {
   emits("addSearchTerm", value);


### PR DESCRIPTION
fix #4396 
1. Saved view columns not getting restored
2. Removed labels from Reset Filters and Syntax Guide buttons
3. Reduced table row height to 20px
4. Table column value getting copied as JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a "Reset Filters" option to enhance user interface functionality.
- **User Interface Improvements**
	- Updated the search bar to use localized titles for better internationalization.
	- Enhanced the syntax guide button's tooltip presentation and improved readability through formatting adjustments.
	- Modified button styles for consistency and layout improvements in the syntax guide.
- **Styling Changes**
	- Adjusted table cell padding and height for a more compact layout in the logs table.
- **Testing Enhancements**
	- Improved UI testing robustness by updating the method for locating the "Reset Filters" button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->