### PR TITLE
feat: add force quick mode

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -899,6 +899,8 @@ pub struct Limit {
     pub query_optimization_num_fields: usize,
     #[env_config(name = "ZO_QUICK_MODE_ENABLED", default = false)]
     pub quick_mode_enabled: bool,
+    #[env_config(name = "ZO_QUICK_MODE_FORCE_ENABLED", default = false)]
+    pub quick_mode_force_enabled: bool,
     #[env_config(name = "ZO_QUICK_MODE_NUM_FIELDS", default = 500)]
     pub quick_mode_num_fields: usize,
     #[env_config(name = "ZO_QUICK_MODE_STRATEGY", default = "")]

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -290,7 +290,8 @@ impl Sql {
 
         // Hack for quick_mode
         // replace `select *` to `select f1,f2,f3`
-        if req_query.quick_mode
+        if (req_query.quick_mode
+            || cfg.limit.quick_mode_force_enabled)
             && schema_fields.len() > cfg.limit.quick_mode_num_fields
             && RE_ONLY_SELECT.is_match(&origin_sql)
         {


### PR DESCRIPTION
For our cloud we can set these ENV:
```
ZO_QUICK_MODE_FORCE_ENABLED=true
ZO_QUICK_MODE_NUM_FIELDS=100
```

Then the stream over 100 fields will force limit to first 100 fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to force quick mode on for enhanced control over query settings.
	- Expanded conditions for activating quick mode in SQL queries, allowing for more flexible query handling.

These changes improve user experience by providing additional configuration capabilities and enhancing the performance of SQL queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->