### PR TITLE
feat: add URI query fields for alert list filtering

### DIFF
--- a/src/common/meta/alerts/alert.rs
+++ b/src/common/meta/alerts/alert.rs
@@ -95,3 +95,9 @@ impl Default for Alert {
         }
     }
 }
+
+#[derive(Clone, Debug, Default)]
+pub struct AlertListFilter {
+    pub enabled: Option<bool>,
+    pub owner: Option<String>,
+}

--- a/src/handler/http/request/alerts/alert.rs
+++ b/src/handler/http/request/alerts/alert.rs
@@ -20,7 +20,9 @@ use actix_web::{delete, get, http, post, put, web, HttpRequest, HttpResponse};
 use crate::{
     common::{
         meta::{
-            alerts::alert::Alert, dashboards::datetime_now, http::HttpResponse as MetaHttpResponse,
+            alerts::alert::{Alert, AlertListFilter},
+            dashboards::datetime_now,
+            http::HttpResponse as MetaHttpResponse,
         },
         utils::{auth::UserEmail, http::get_stream_type_from_request},
     },
@@ -136,7 +138,26 @@ async fn list_stream_alerts(
             return Ok(MetaHttpResponse::bad_request(e));
         }
     };
-    match alert::list(&org_id, stream_type, Some(stream_name.as_str()), None).await {
+    let user_filter = query.get("owner").map(|v| v.to_string());
+    let enabled_filter = query
+        .get("enabled")
+        .and_then(|field| match field.parse::<bool>() {
+            Ok(value) => Some(value),
+            Err(_) => None,
+        });
+    let alert_filter = AlertListFilter {
+        owner: user_filter,
+        enabled: enabled_filter,
+    };
+    match alert::list(
+        &org_id,
+        stream_type,
+        Some(stream_name.as_str()),
+        None,
+        alert_filter,
+    )
+    .await
+    {
         Ok(mut data) => {
             // Hack for frequency: convert seconds to minutes
             for alert in data.iter_mut() {
@@ -167,14 +188,15 @@ async fn list_stream_alerts(
     )
 )]
 #[get("/{org_id}/alerts")]
-async fn list_alerts(path: web::Path<String>, _req: HttpRequest) -> Result<HttpResponse, Error> {
+async fn list_alerts(path: web::Path<String>, req: HttpRequest) -> Result<HttpResponse, Error> {
     let org_id = path.into_inner();
+    let query = web::Query::<HashMap<String, String>>::from_query(req.query_string()).unwrap();
 
     let mut _alert_list_from_rbac = None;
     // Get List of allowed objects
     #[cfg(feature = "enterprise")]
     {
-        let user_id = _req.headers().get("user_id").unwrap();
+        let user_id = req.headers().get("user_id").unwrap();
         match crate::handler::http::auth::validator::list_objects_for_user(
             &org_id,
             user_id.to_str().unwrap(),
@@ -195,7 +217,29 @@ async fn list_alerts(path: web::Path<String>, _req: HttpRequest) -> Result<HttpR
         // Get List of allowed objects ends
     }
 
-    match alert::list(&org_id, None, None, _alert_list_from_rbac).await {
+    let user_filter = query.get("owner").map(|v| v.to_string());
+    let enabled_filter = query
+        .get("enabled")
+        .and_then(|field| match field.parse::<bool>() {
+            Ok(value) => Some(value),
+            Err(_) => None,
+        });
+    let stream_type_filter = get_stream_type_from_request(&query).unwrap_or_default();
+    let stream_name_filter = query.get("stream_name").map(|v| v.as_str());
+
+    let alert_filter = AlertListFilter {
+        owner: user_filter,
+        enabled: enabled_filter,
+    };
+    match alert::list(
+        &org_id,
+        stream_type_filter,
+        stream_name_filter,
+        _alert_list_from_rbac,
+        alert_filter,
+    )
+    .await
+    {
         Ok(mut data) => {
             // Hack for frequency: convert seconds to minutes
             for alert in data.iter_mut() {

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -845,7 +845,7 @@ export default defineComponent({
         return;
       }
 
-      if (!toBeClonestreamType) return Promise.resolve();
+      if (!toBeClonestreamType.value) return Promise.resolve();
 
       isFetchingStreams.value = true;
       return getStreams(toBeClonestreamType.value, false)
@@ -949,7 +949,24 @@ export default defineComponent({
         var filtered = [];
         terms = terms.toLowerCase();
         for (var i = 0; i < rows.length; i++) {
-          if (rows[i]["name"].toLowerCase().includes(terms)) {
+          if (
+            rows[i]["name"].toLowerCase().includes(terms) ||
+            (rows[i]["stream_name"] != null &&
+              rows[i]["stream_name"].toLowerCase().includes(terms)) ||
+            (rows[i]["owner"] != null &&
+              rows[i]["owner"].toLowerCase().includes(terms)) ||
+            (rows[i]["enabled"] != null &&
+              rows[i]["enabled"].toString().toLowerCase().includes(terms)) ||
+            (rows[i]["alert_type"] != null &&
+              rows[i]["alert_type"].toString().toLowerCase().includes(terms)) ||
+            (rows[i]["stream_type"] != null &&
+              rows[i]["stream_type"]
+                .toString()
+                .toLowerCase()
+                .includes(terms)) ||
+            (rows[i]["description"] != null &&
+              rows[i]["description"].toString().toLowerCase().includes(terms))
+          ) {
             filtered.push(rows[i]);
           }
         }


### PR DESCRIPTION
Added `owner` and `enabled` URI query parameter for the `{org_id}/alerts` and `{org}/{stream_name}/alerts` `GET` APIs. E.g. - `{org}/alerts?owner=user@user.com&enabled=true`.

Fixes #4273 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new filtering capability for alerts, allowing users to filter by owner and enabled status.
	- Added a new structure, `AlertListFilter`, to manage alert filtering criteria.

- **Improvements**
	- Enhanced alert retrieval functions to support user-defined query parameters for more granular control over alert listings, improving the overall usability of the alert system.
	- Expanded filtering logic in the AlertList component for a more comprehensive search capability within the alert list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->