### PR TITLE
fix: realtime alert can't be trigger

### DIFF
--- a/src/common/meta/dashboards/v5/mod.rs
+++ b/src/common/meta/dashboards/v5/mod.rs
@@ -160,7 +160,6 @@ pub enum AggregationFunc {
 pub enum PanelFilter {
     #[serde(rename = "condition")]
     Condition(FilterCondition),
-
     #[serde(rename = "group")]
     Group(GroupType),
 }

--- a/src/common/meta/dashboards/v5/mod.rs
+++ b/src/common/meta/dashboards/v5/mod.rs
@@ -160,7 +160,7 @@ pub enum AggregationFunc {
 pub enum PanelFilter {
     #[serde(rename = "condition")]
     Condition(FilterCondition),
-    
+
     #[serde(rename = "group")]
     Group(GroupType),
 }

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -457,8 +457,8 @@ pub async fn send_http_notification(
     let resp = req.body(msg.clone()).send().await?;
     let resp_status = resp.status();
     let resp_body = resp.text().await?;
-    log::info!(
-        "Alert sent to {} with status {}, body: {:?}",
+    log::debug!(
+        "Alert sent to destination {} with status: {}, body: {:?}",
         dest.url,
         resp_status,
         resp_body,

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -455,12 +455,20 @@ pub async fn send_http_notification(
     }
 
     let resp = req.body(msg.clone()).send().await?;
-    if !resp.status().is_success() {
+    let resp_status = resp.status();
+    let resp_body = resp.text().await?;
+    log::info!(
+        "Alert sent to {} with status {}, body: {:?}",
+        dest.url,
+        resp_status,
+        resp_body,
+    );
+    if !resp_status.is_success() {
         log::error!("Alert body: {}", msg);
         return Err(anyhow::anyhow!(
-            "sent error status: {}, err: {:?}",
-            resp.status(),
-            resp.bytes().await
+            "sent error status: {}, err: {}",
+            resp_status,
+            resp_body
         ));
     }
 

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -222,6 +222,7 @@ pub async fn evaluate_trigger(trigger: Option<TriggerAlertData>) {
     if trigger.is_none() {
         return;
     }
+    log::info!("Evaluating trigger: {:?}", trigger);
     let trigger = trigger.unwrap();
     let mut trigger_usage_reports = vec![];
     for (alert, val) in trigger.iter() {

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -213,19 +213,20 @@ pub async fn get_stream_alerts(
             })
             .cloned()
             .collect::<Vec<_>>();
-
+        if alerts.is_empty() {
+            return;
+        }
         stream_alerts_map.insert(key, alerts);
     }
 }
 
-pub async fn evaluate_trigger(trigger: Option<TriggerAlertData>) {
-    if trigger.is_none() {
+pub async fn evaluate_trigger(triggers: TriggerAlertData) {
+    if triggers.is_empty() {
         return;
     }
-    log::debug!("Evaluating trigger: {:?}", trigger);
-    let trigger = trigger.unwrap();
+    log::debug!("Evaluating triggers: {:?}", triggers);
     let mut trigger_usage_reports = vec![];
-    for (alert, val) in trigger.iter() {
+    for (alert, val) in triggers.iter() {
         let module_key = format!(
             "{}/{}/{}",
             &alert.stream_type, &alert.stream_name, &alert.name

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -222,7 +222,7 @@ pub async fn evaluate_trigger(trigger: Option<TriggerAlertData>) {
     if trigger.is_none() {
         return;
     }
-    log::info!("Evaluating trigger: {:?}", trigger);
+    log::debug!("Evaluating trigger: {:?}", trigger);
     let trigger = trigger.unwrap();
     let mut trigger_usage_reports = vec![];
     for (alert, val) in trigger.iter() {

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -368,7 +368,9 @@ async fn write_logs(
                         trigger_alerts.push((alert.clone(), v));
                     }
                 }
-                trigger = Some(trigger_alerts);
+                if !trigger_alerts.is_empty() {
+                    trigger = Some(trigger_alerts);
+                }
             }
         }
         // end check for alert triggers

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -455,7 +455,9 @@ pub async fn handle_grpc_request(
 
     // only one trigger per request, as it updates etcd
     for (_, entry) in stream_trigger_map {
-        evaluate_trigger(entry).await;
+        if let Some(entry) = entry {
+            evaluate_trigger(entry).await;
+        }
     }
 
     let res = ExportMetricsServiceResponse {

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -533,7 +533,9 @@ pub async fn metrics_json_handler(
 
     // only one trigger per request, as it updates etcd
     for (_, entry) in stream_trigger_map {
-        evaluate_trigger(entry).await;
+        if let Some(entry) = entry {
+            evaluate_trigger(entry).await;
+        }
     }
 
     let res = ExportMetricsServiceResponse {

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -459,7 +459,9 @@ pub async fn remote_write(
 
     // only one trigger per request, as it updates etcd
     for (_, entry) in stream_trigger_map {
-        evaluate_trigger(entry).await;
+        if let Some(entry) = entry {
+            evaluate_trigger(entry).await;
+        }
     }
 
     metrics::HTTP_RESPONSE_TIME

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -538,7 +538,9 @@ async fn write_traces(
                         trigger_alerts.push((alert.clone(), v));
                     }
                 }
-                trigger = Some(trigger_alerts);
+                if !trigger_alerts.is_empty() {
+                    trigger = Some(trigger_alerts);
+                }
             }
         }
         // End check for alert trigger

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -453,7 +453,6 @@ async fn write_traces(
 
     // Start get stream alerts
     let mut stream_alerts_map: HashMap<String, Vec<Alert>> = HashMap::new();
-    let mut trigger: Option<TriggerAlertData> = None;
     crate::service::ingestion::get_stream_alerts(
         &[StreamParams {
             org_id: org_id.to_owned().into(),
@@ -463,6 +462,14 @@ async fn write_traces(
         &mut stream_alerts_map,
     )
     .await;
+    let cur_stream_alerts = stream_alerts_map.get(&format!(
+        "{}/{}/{}",
+        org_id,
+        StreamType::Traces,
+        stream_name
+    ));
+    let mut triggers: TriggerAlertData =
+        Vec::with_capacity(cur_stream_alerts.map_or(0, |v| v.len()));
     // End get stream alert
 
     // Start check for schema
@@ -529,17 +536,12 @@ async fn write_traces(
         }));
 
         // Start check for alert trigger
-        if trigger.is_none() && !stream_alerts_map.is_empty() {
-            let key = format!("{}/{}/{}", &org_id, StreamType::Traces, stream_name);
-            if let Some(alerts) = stream_alerts_map.get(&key) {
-                let mut trigger_alerts: TriggerAlertData = Vec::new();
+        if let Some(alerts) = cur_stream_alerts {
+            if triggers.len() < alerts.len() {
                 for alert in alerts {
                     if let Ok((Some(v), _)) = alert.evaluate(Some(&record_val)).await {
-                        trigger_alerts.push((alert.clone(), v));
+                        triggers.push((alert.clone(), v));
                     }
-                }
-                if !trigger_alerts.is_empty() {
-                    trigger = Some(trigger_alerts);
                 }
             }
         }
@@ -588,7 +590,7 @@ async fn write_traces(
     }
 
     // only one trigger per request
-    evaluate_trigger(trigger).await;
+    evaluate_trigger(triggers).await;
 
     Ok(req_stats)
 }


### PR DESCRIPTION
- [x] realtime alert can't be trigger
- [x] multiple realtime alert on same stream should can trigger all of them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced logging and error handling for alert notifications, providing clearer insights into delivery status and response content.
	- Improved logging for the trigger evaluation process, enhancing traceability and monitoring capabilities without altering existing functionality.
	- Added safety checks to prevent runtime errors when processing optional entries in trigger evaluations.
	- Optimized logic in log writing functions to prevent unnecessary assignments when there are no alerts to trigger.
- **Style**
	- Minor formatting change in the `PanelFilter` enum for improved readability without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->