### PR TITLE
fix: Monaco editor border issue

### DIFF
--- a/web/src/components/QueryEditor.vue
+++ b/web/src/components/QueryEditor.vue
@@ -359,6 +359,7 @@ export default defineComponent({
 
 <style lang="scss">
 .logs-query-editor {
+  --vscode-focusBorder: gray !important;
   .monaco-editor,
   .monaco-editor .monaco-editor {
     padding: 0px 0px 0px 0px !important;

--- a/web/src/components/QueryEditor.vue
+++ b/web/src/components/QueryEditor.vue
@@ -359,7 +359,7 @@ export default defineComponent({
 
 <style lang="scss">
 .logs-query-editor {
-  --vscode-focusBorder: gray !important;
+  --vscode-focusBorder: #515151 !important;
   .monaco-editor,
   .monaco-editor .monaco-editor {
     padding: 0px 0px 0px 0px !important;

--- a/web/src/components/alerts/ScheduledAlert.vue
+++ b/web/src/components/alerts/ScheduledAlert.vue
@@ -872,7 +872,9 @@ defineExpose({
   .monaco-editor {
     width: 500px !important;
     height: 100px !important;
-    border: 1px solid $border-color;
+    border: 1px solid ;
+   --vscode-focusBorder: slate !important;
+
   }
 
   .q-btn {

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -365,7 +365,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   @click.prevent.stop="
                     copyLogToClipboard(
                       column.prop(row, column.name).toString(),
-                      false
                     )
                   "
                   title="Copy"

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -365,6 +365,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   @click.prevent.stop="
                     copyLogToClipboard(
                       column.prop(row, column.name).toString(),
+                      false
                     )
                   "
                   title="Copy"


### PR DESCRIPTION
1. This PR Fixes the monaco editor blue border issue in the logs page as well as in the alerts page 
first issue of #4427  will be solved
2. copy clipboard  in the results page simply copying so this PR fixes that
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new CSS variable for improved focus border styling in the Query Editor and Scheduled Alert components, enhancing visual clarity.
  
- **Style**
	- Updated border styles in the Scheduled Alert component for a more flexible and simplified appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->