### PR TITLE
fix: use ofga mapping in tuple object type for search permission checking

### DIFF
--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -186,6 +186,8 @@ pub async fn search(
     // Check permissions on stream
     #[cfg(feature = "enterprise")]
     {
+        use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+
         use crate::common::{
             infra::config::USERS,
             utils::auth::{is_root_user, AuthExtractor},
@@ -194,6 +196,7 @@ pub async fn search(
         if !is_root_user(&user_id) {
             let user: meta::user::User =
                 USERS.get(&format!("{org_id}/{}", user_id)).unwrap().clone();
+            let stream_type_str = stream_type.to_string();
 
             if user.is_external
                 && !crate::handler::http::auth::validator::check_permissions(
@@ -201,7 +204,13 @@ pub async fn search(
                     AuthExtractor {
                         auth: "".to_string(),
                         method: "GET".to_string(),
-                        o2_type: format!("{}:{}", stream_type, stream_name),
+                        o2_type: format!(
+                            "{}:{}",
+                            OFGA_MODELS
+                                .get(stream_type_str.as_str())
+                                .map_or(stream_type_str.as_str(), |model| model.key),
+                            stream_name
+                        ),
                         org_id: org_id.clone(),
                         bypass_check: false,
                         parent_id: "".to_string(),

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -173,6 +173,8 @@ pub async fn search_multi(
         // Check permissions on stream
         #[cfg(feature = "enterprise")]
         {
+            use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+
             use crate::common::{
                 infra::config::USERS,
                 utils::auth::{is_root_user, AuthExtractor},
@@ -181,6 +183,7 @@ pub async fn search_multi(
             if !is_root_user(user_id) {
                 let user: meta::user::User =
                     USERS.get(&format!("{org_id}/{user_id}")).unwrap().clone();
+                let stream_type_str = stream_type.to_string();
 
                 if user.is_external
                     && !crate::handler::http::auth::validator::check_permissions(
@@ -188,7 +191,13 @@ pub async fn search_multi(
                         AuthExtractor {
                             auth: "".to_string(),
                             method: "GET".to_string(),
-                            o2_type: format!("{}:{}", stream_type, resp.stream_name),
+                            o2_type: format!(
+                                "{}:{}",
+                                OFGA_MODELS
+                                    .get(stream_type_str.as_str())
+                                    .map_or(stream_type_str.as_str(), |model| model.key),
+                                resp.stream_name
+                            ),
                             org_id: org_id.clone(),
                             bypass_check: false,
                             parent_id: "".to_string(),

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -149,6 +149,8 @@ pub async fn get_latest_traces(
 
     #[cfg(feature = "enterprise")]
     {
+        use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+
         use crate::common::{
             infra::config::USERS,
             utils::auth::{is_root_user, AuthExtractor},
@@ -159,6 +161,7 @@ pub async fn get_latest_traces(
                 .get(&format!("{org_id}/{}", user_id.to_str().unwrap()))
                 .unwrap()
                 .clone();
+            let stream_type_str = StreamType::Traces.to_string();
 
             if user.is_external
                 && !crate::handler::http::auth::validator::check_permissions(
@@ -166,7 +169,13 @@ pub async fn get_latest_traces(
                     AuthExtractor {
                         auth: "".to_string(),
                         method: "GET".to_string(),
-                        o2_type: format!("{}:{}", StreamType::Traces, stream_name),
+                        o2_type: format!(
+                            "{}:{}",
+                            OFGA_MODELS
+                                .get(stream_type_str.as_str())
+                                .map_or(stream_type_str.as_str(), |model| model.key),
+                            stream_name
+                        ),
                         org_id: org_id.clone(),
                         bypass_check: false,
                         parent_id: "".to_string(),


### PR DESCRIPTION
Fixes #4455 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced authorization checks for `query`, `query_range`, and `series` functions to dynamically reflect stream types.
	- Improved permission validation logic in the `search` and `search_multi` functions, allowing for more accurate access control based on user roles and stream types.
	- Updated logic in the `get_latest_traces` function to refine the construction of the `o2_type` field for better permission checks.

- **Bug Fixes**
	- Corrected the mapping of stream types to model keys, enhancing security and accuracy in permission checks.

- **Chores**
	- Added necessary imports for `OFGA_MODELS` to support new permission logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->