### PR TITLE
fix: Query Editor rendering issue in logs page

### DIFF
--- a/web/src/components/QueryEditor.vue
+++ b/web/src/components/QueryEditor.vue
@@ -125,7 +125,7 @@ export default defineComponent({
       });
     };
 
-    const setupEditor = () => {
+    const setupEditor = async () => {
       monaco.editor.defineTheme("myCustomTheme", {
         base: "vs", // can also be vs-dark or hc-black
         inherit: true, // can also be false to completely replace the builtin rules
@@ -142,12 +142,22 @@ export default defineComponent({
 
       registerAutoCompleteProvider();
 
-      const editorElement = document.getElementById(props.editorId);
+      let editorElement = document.getElementById(props.editorId);
+      let retryCount = 0;
+      const maxRetries = 5;
+
+      // Retry mechanism to ensure the editor element is found
+      while (!editorElement && retryCount < maxRetries) {
+        await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for 100ms
+        editorElement = document.getElementById(props.editorId);
+        retryCount++;
+      }
 
       if (!editorElement) {
-        console.error("Query Editor element not found");
+        console.error("Query Editor element not found after retries");
         return;
       }
+
       if (editorElement && editorElement?.hasChildNodes()) return;
 
       editorObj = monaco.editor.create(editorElement as HTMLElement, {
@@ -262,7 +272,11 @@ export default defineComponent({
     onActivated(async () => {
       provider.value?.dispose();
       registerAutoCompleteProvider();
-      editorObj?.layout();
+
+      if (!editorObj) {
+        setupEditor();
+        editorObj?.layout();
+      }
     });
 
     onDeactivated(() => {

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -2951,7 +2951,7 @@ export default defineComponent({
   }
 
   .query-editor-container {
-    height: calc(100% - 30px) !important;
+    height: calc(100% - 35px) !important;
   }
 
   .logs-auto-refresh-interval {

--- a/web/src/styles/app.scss
+++ b/web/src/styles/app.scss
@@ -114,3 +114,8 @@
     max-width: 96%;
   }
 }
+
+.monaco-editor {
+  outline-width: 0px;
+  outline-style: none;
+}


### PR DESCRIPTION
#4427 
Editor goes unresponsive intermittently and user unable to see the query in query editor
When we refresh logs page and switch to other page before rendering of logs page. Sometimes editor element fails to mount and it tries to access it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved initialization process for the Query Editor, allowing for better handling of DOM readiness.
	- Enhanced reliability of the editor layout through lifecycle checks.

- **Style**
	- Increased height of the query editor container for improved content display.
	- Removed outline from the Monaco editor for better visual integration.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->