### PR TITLE
fix: vrl as query UDF

### DIFF
--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -101,7 +101,7 @@ pub async fn sql(
     .await?;
 
     // register UDF
-    register_udf(&mut ctx, &sql.org_id).await;
+    register_udf(&mut ctx, &sql.org_id)?;
     datafusion_functions_json::register_all(&mut ctx)?;
 
     // register empty table
@@ -239,7 +239,7 @@ pub async fn merge_partitions(
         prepare_datafusion_context(None, &SearchType::Normal, false, false, 0, None).await?;
 
     // register UDF
-    register_udf(&mut ctx, org_id).await;
+    register_udf(&mut ctx, org_id)?;
     datafusion_functions_json::register_all(&mut ctx)?;
 
     // Debug SQL
@@ -373,7 +373,8 @@ pub async fn merge_partitions_cluster(
         prepare_datafusion_context(None, &SearchType::Normal, false, false, 0, None).await?;
 
     // register UDF
-    register_udf(&mut ctx, org_id).await;
+    register_udf(&mut ctx, org_id)?;
+    datafusion_functions_json::register_all(&mut ctx)?;
 
     // Debug SQL
     let cfg = get_config();
@@ -796,7 +797,7 @@ pub async fn prepare_datafusion_context(
     }
 }
 
-async fn register_udf(ctx: &mut SessionContext, _org_id: &str) {
+fn register_udf(ctx: &mut SessionContext, org_id: &str) -> Result<()> {
     ctx.register_udf(super::udf::match_udf::MATCH_UDF.clone());
     ctx.register_udf(super::udf::match_udf::MATCH_IGNORE_CASE_UDF.clone());
     ctx.register_udf(super::udf::regexp_udf::REGEX_MATCH_UDF.clone());
@@ -818,12 +819,12 @@ async fn register_udf(ctx: &mut SessionContext, _org_id: &str) {
         super::udaf::percentile_cont::PercentileCont::new(),
     ));
 
-    {
-        let udf_list = get_all_transform(_org_id).await;
-        for udf in udf_list {
-            ctx.register_udf(udf.clone());
-        }
+    let udf_list = get_all_transform(org_id)?;
+    for udf in udf_list {
+        ctx.register_udf(udf.clone());
     }
+
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/service/search/datafusion/udf/transform_udf.rs
+++ b/src/service/search/datafusion/udf/transform_udf.rs
@@ -18,77 +18,50 @@ use std::{collections::BTreeMap, sync::Arc};
 use config::utils::json;
 use datafusion::{
     arrow::{
-        array::{Array, ArrayRef, StringArray, StructArray},
-        datatypes::{DataType, Field, Fields},
+        array::{Array, ArrayRef, StringArray},
+        datatypes::DataType,
     },
+    error::Result,
     logical_expr::{ColumnarValue, ScalarUDF, Volatility},
     prelude::create_udf,
 };
-use hashbrown::HashMap;
 use vector_enrichment::TableRegistry;
-use vrl::compiler::{runtime::Runtime, CompilationResult, Program, TargetValueRef, VrlRuntime};
+use vrl::compiler::{runtime::Runtime, TargetValueRef, VrlRuntime};
 
 use crate::{common::infra::config::QUERY_FUNCTIONS, service::ingestion::compile_vrl_function};
 
-type FnType = Arc<
-    dyn Fn(&[ColumnarValue]) -> Result<ColumnarValue, datafusion::error::DataFusionError>
-        + Sync
-        + Send,
->;
+type FnType = Arc<dyn Fn(&[ColumnarValue]) -> Result<ColumnarValue> + Sync + Send>;
 
-fn create_user_df(
-    fn_name: &str,
-    num_args: u8,
-    pow_scalar: FnType,
-    mut output_cols: Vec<String>,
-) -> ScalarUDF {
+fn create_user_df(fn_name: &str, num_args: u8, pow_scalar: FnType) -> ScalarUDF {
     let mut input_vec = vec![];
     for _i in 0..num_args {
         input_vec.push(DataType::Utf8);
     }
-    if output_cols.is_empty() {
-        create_udf(
-            fn_name,
-            input_vec,
-            Arc::new(DataType::Utf8),
-            Volatility::Immutable,
-            pow_scalar,
-        )
-    } else {
-        let mut output_type: Vec<Field> = vec![];
-        output_cols.sort();
-        for col in output_cols {
-            output_type.push(Field::new(col, DataType::Utf8, false));
-        }
-        create_udf(
-            fn_name,
-            input_vec,
-            Arc::new(DataType::Struct(output_type.into())),
-            Volatility::Immutable,
-            pow_scalar,
-        )
-    }
+    create_udf(
+        fn_name,
+        input_vec,
+        Arc::new(DataType::Utf8),
+        Volatility::Immutable,
+        pow_scalar,
+    )
 }
 
-pub async fn get_all_transform(org_id: &str) -> Vec<datafusion::logical_expr::ScalarUDF> {
-    let mut udf;
+pub fn get_all_transform(org_id: &str) -> Result<Vec<ScalarUDF>> {
     let mut udf_list = Vec::new();
     for transform in QUERY_FUNCTIONS.clone().iter() {
         let key = transform.key();
         // do not register ingest_time transforms
         if key.contains(org_id) {
-            udf = get_udf_vrl(
+            udf_list.push(get_udf_vrl(
                 transform.name.to_owned(),
                 transform.function.to_owned().as_str(),
                 &transform.params,
                 transform.num_args,
                 org_id,
-            );
-
-            udf_list.push(udf);
+            )?);
         }
     }
-    udf_list
+    Ok(udf_list)
 }
 
 fn get_udf_vrl(
@@ -97,33 +70,17 @@ fn get_udf_vrl(
     params: &str,
     num_args: u8,
     org_id: &str,
-) -> datafusion::logical_expr::ScalarUDF {
-    let local_fn_name = fn_name;
+) -> Result<ScalarUDF> {
     let local_func = func.trim().to_owned();
     let local_fn_params = params.to_owned();
     let local_org_id = org_id.to_owned();
 
-    // pre computation stage
-    let in_params = local_fn_params.split(',').collect::<Vec<&str>>();
-    let mut in_obj_str = String::from("");
-    for param in in_params {
-        in_obj_str.push_str(&format!(" {} = \"{}\" \n", param, ""));
-    }
-    in_obj_str.push_str(&format!(" \n {}", &local_func));
-    let res_cols = match compile_vrl_function(&in_obj_str, &local_org_id) {
-        Ok(res) => res.fields,
-        Err(_) => vec![],
-    };
-    // end pre computation stage
-
-    let pow_calc = Arc::new(move |args: &[ColumnarValue]| {
+    let vrl_calc = Arc::new(move |args: &[ColumnarValue]| {
         let args = ColumnarValue::values_to_arrays(args)?;
         let len = args[0].len();
         let in_params = local_fn_params.split(',').collect::<Vec<&str>>();
-        let mut is_multi_value = false;
         let mut res_data_vec = vec![];
         let mut runtime = crate::common::utils::functions::init_vrl_runtime();
-        let mut col_val_map: HashMap<String, Vec<String>> = HashMap::new();
 
         for i in 0..len {
             let mut obj_str = String::from("");
@@ -133,98 +90,30 @@ fn get_udf_vrl(
                     .downcast_ref::<StringArray>()
                     .expect("cast failed");
                 obj_str.push_str(&format!(
-                    " {} = \"{}\" \n",
+                    " .{} = \"{}\" \n",
                     in_params.get(j).unwrap(),
                     col.value(i)
                 ));
             }
             obj_str.push_str(&format!(" \n {}", &local_func));
-            if let Ok(mut res) = compile_vrl_function(&obj_str, &local_org_id) {
+            if let Ok(res) = compile_vrl_function(&obj_str, &local_org_id) {
                 let registry = res.config.get_custom::<TableRegistry>().unwrap();
                 registry.finish_load();
                 let result = apply_vrl_fn(&mut runtime, res.program);
                 if result != json::Value::Null {
-                    if let Some(res_map) = result.as_object() {
-                        is_multi_value = true;
-                        res.fields.sort();
-                        for col in res.fields {
-                            let field_builder = col_val_map.entry(col.to_string()).or_default();
-                            if res_map.contains_key(&col) {
-                                field_builder
-                                    .insert(i, json::get_string_value(res_map.get(&col).unwrap()));
-                            } else {
-                                field_builder.insert(i, "".to_string());
-                            }
-                        }
-                    } else {
-                        res_data_vec.insert(i, json::get_string_value(&result));
-                    }
+                    res_data_vec.insert(i, json::get_string_value(&result));
+                } else {
+                    res_data_vec.insert(i, "".to_string());
                 }
+            } else {
+                res_data_vec.insert(i, "".to_string());
             }
         }
-        if is_multi_value {
-            let mut data_vec = vec![];
-            for (k, v) in col_val_map {
-                data_vec.push((
-                    Field::new(k, DataType::Utf8, false),
-                    Arc::new(StringArray::from(v)) as ArrayRef,
-                ));
-            }
-            data_vec.sort_by(|a, b| a.0.name().cmp(b.0.name()));
-
-            let fields: Fields = data_vec
-                .iter()
-                .map(|x| x.0.clone())
-                .collect::<Vec<Field>>()
-                .into();
-            let array_ref = data_vec.iter().map(|x| x.1.clone()).collect();
-            let result = StructArray::new(fields, array_ref, None);
-            Ok(ColumnarValue::from(Arc::new(result) as ArrayRef))
-        } else {
-            let result = StringArray::from(res_data_vec);
-            Ok(ColumnarValue::from(Arc::new(result) as ArrayRef))
-        }
-
-        // `Ok` because no error occurred during the calculation (we should add
-        // one if exponent was [0, 1[ and the base < 0 because that panics!)
-        // `Arc` because arrays are immutable, thread-safe, trait objects.
+        let result = StringArray::from(res_data_vec);
+        Ok(ColumnarValue::from(Arc::new(result) as ArrayRef))
     });
-    // the function above expects an `ArrayRef`, but DataFusion may pass a scalar to
-    // a UDF. thus, we use `make_scalar_function` to decorare the closure so
-    // that it can handle both Arrays and Scalar values.
-    let pow_scalar = pow_calc;
 
-    // Next:
-    // * give it a name so that it shows nicely when the plan is printed
-    // * declare what input it expects
-    // * declare its return type
-
-    let pow_udf = create_user_df(local_fn_name.as_str(), num_args, pow_scalar, res_cols);
-    pow_udf
-}
-
-pub fn _compile_vrl_function(func: &str) -> Option<(Program, Vec<String>)> {
-    let mut fields = vec![];
-    let result = vrl::compiler::compile(func, &vrl::stdlib::all());
-    match result {
-        Ok(CompilationResult {
-            program,
-            warnings: _,
-            config: _,
-        }) => {
-            let state = program.initial_type_state();
-            if let Some(ext) = state.external.target_kind().as_object() {
-                for k in ext.known().keys() {
-                    fields.push(k.to_string());
-                }
-            }
-            Some((program, fields))
-        }
-        Err(e) => {
-            log::info!("Error compiling vrl {:?}", e);
-            None
-        }
-    }
+    Ok(create_user_df(fn_name.as_str(), num_args, vrl_calc))
 }
 
 pub fn apply_vrl_fn(runtime: &mut Runtime, program: vrl::compiler::Program) -> json::Value {
@@ -252,7 +141,11 @@ pub fn apply_vrl_fn(runtime: &mut Runtime, program: vrl::compiler::Program) -> j
 #[cfg(test)]
 mod tests {
     use datafusion::{
-        arrow::{array::Int64Array, datatypes::Schema, record_batch::RecordBatch},
+        arrow::{
+            array::Int64Array,
+            datatypes::{Field, Schema},
+            record_batch::RecordBatch,
+        },
         datasource::MemTable,
         prelude::SessionContext,
     };
@@ -261,13 +154,7 @@ mod tests {
 
     #[tokio::test]
     async fn vrl_udf_test() {
-        // let sql = "select temp.d['account_id'] as acc , temp.pod_id ,temp.lua_test
-        // from (select *, vrltest(log) ,luaconcat(log,pod_id) as lua_test from t) as
-        // temp"; let sql = "select vrltest(log)['account_id']  from (select *,
-        // vrltest(log) ,luaconcat(log,pod_id) as lua_test from t) as temp";
-
-        // !!!TODO: fix this test
-        let sql = "select * from t";
+        let sql = "select pod_id, vrltest(log) from t";
 
         // define a schema.
         let schema = Arc::new(Schema::new(vec![
@@ -279,7 +166,12 @@ mod tests {
         let batch = RecordBatch::try_new(
             schema.clone(),
             vec![
-                Arc::new(StringArray::from(vec!["2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA", "2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA", "2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA", "2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA"])),
+                Arc::new(StringArray::from(vec![
+                    "2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA",
+                    "2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA", 
+                    "2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA", 
+                    "2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA",
+                ])),
                 Arc::new(Int64Array::from(vec![1, 2, 1, 2])),
             ],
         )
@@ -287,11 +179,12 @@ mod tests {
 
         let vrl_udf = get_udf_vrl(
             "vrltest".to_string(),
-            " . = parse_aws_vpc_flow_log!(col1) \n .http_code=200 \n .",
+            " . = parse_aws_vpc_flow_log!(.col1) \n .http_code=200 \n .",
             "col1",
             1,
             "org1",
-        );
+        )
+        .unwrap();
 
         // declare a new context. In spark API, this corresponds to a new spark
         // SQLsession


### PR DESCRIPTION
fix #4462

Now you can use VRL function as query UDF. for example:

create one function:

- Name: `test_abc`
- Param: `value`

```
if .value == "abc" {
    . = true
} else {
    . = false
}
.
```

then we can query like this:
```sql
select test_abc(field) as abc from default
```

Also you can create a function with two params:

- Name: `test_eq`
- Params: `v1, v2`

```
if .v1 == .v2 {
    . = true
} else {
    . = false
}
.
```

Then we can query like this:
```sql
select test_eq(field1, field2) as val from default
```

## Also need to know:
- If you create function from query, the param only one and the name is `row`.
- The input field value will convert to `string` also the return always `string`.