### PR TITLE
fix: Logs table UI fixes

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1343,7 +1343,7 @@ $navbarHeight: 64px;
 
   .thirdlevel {
     .field-list-collapse-btn {
-      z-index: 9;
+      z-index: 99;
       position: absolute;
       top: 5px;
       font-size: 12px !important;

--- a/web/src/plugins/logs/JsonPreview.vue
+++ b/web/src/plugins/logs/JsonPreview.vue
@@ -256,7 +256,7 @@ export default {
     const nestedJson = ref("");
 
     const copyLogToClipboard = () => {
-      emit("copy", props.value);
+      emit("copy", props.value, true);
     };
     const addSearchTerm = (value: string) => {
       emit("addSearchTerm", value);

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       class="tw-w-full tw-table-auto"
       :style="{
         minWidth: '100%',
-        minHeight: totalSize + 'px',
         ...columnSizeVars,
         width: !defaultColumns
           ? table.getCenterTotalSize() + 'px'

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -300,14 +300,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         : 'auto',
                   height: wrap ? '100%' : '20px',
                 }"
-                :class="[
-                  columnOrder.includes('source') && !wrap
-                    ? 'tw-table-cell'
-                    : 'tw-block',
-                  !wrap &&
-                    'tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap',
-                  wrap && ' tw-break-words',
-                ]"
+                :class="tableCellClass"
+                @mouseover="handleCellMouseOver(cell)"
+                @mouseleave="handleCellMouseLeave()"
               >
                 <q-btn
                   v-if="cellIndex == 0"
@@ -324,17 +319,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   @click.capture.stop="handleExpandRow(virtualRow.index)"
                 ></q-btn>
 
-                <cell-actions
-                  v-if="
-                    (cell.column.columnDef.meta as any)?.closable &&
-                    (cell.row.original as any)[cell.column.id]
-                  "
-                  :column="cell.column"
-                  :row="cell.row.original as any"
-                  @copy="copyLogToClipboard"
-                  @add-search-term="addSearchTerm"
-                  @add-field-to-table="addFieldToTable"
-                />
+                <template
+                  v-if="activeCellActionId === `${cell.id}_${cell.column.id}`"
+                >
+                  <cell-actions
+                    v-if="
+                      (cell.column.columnDef.meta as any)?.closable &&
+                      (cell.row.original as any)[cell.column.id]
+                    "
+                    :column="cell.column"
+                    :row="cell.row.original as any"
+                    @copy="copyLogToClipboard"
+                    @add-search-term="addSearchTerm"
+                    @add-field-to-table="addFieldToTable"
+                  />
+                </template>
+
                 <FlexRender
                   :render="cell.column.columnDef.cell"
                   :props="cell.getContext()"
@@ -358,7 +358,6 @@ import {
   useVueTable,
   getCoreRowModel,
   getSortedRowModel,
-  isFunction,
 } from "@tanstack/vue-table";
 import JsonPreview from "./JsonPreview.vue";
 import { useStore } from "vuex";
@@ -449,6 +448,8 @@ const tableRows = ref(props.rows);
 
 const isFunctionErrorOpen = ref(false);
 
+const activeCellActionId = ref("");
+
 watch(
   () => props.columns,
   async (newVal) => {
@@ -488,6 +489,12 @@ watch(
     emits("update:columnOrder", columnOrder.value, props.columns);
   },
 );
+
+const tableCellClass = computed(() => [
+  hasDefaultSourceColumn.value && !props.wrap ? "tw-table-cell" : "tw-block",
+  !props.wrap && "tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap",
+  props.wrap && "tw-break-words",
+]);
 
 const table = useVueTable({
   get data() {
@@ -534,6 +541,10 @@ watch(columnSizeVars, (newColSizes) => {
 onMounted(() => {
   setExpandedRows();
 });
+
+const hasDefaultSourceColumn = computed(
+  () => props.defaultColumns && columnOrder.value.includes("source"),
+);
 
 const updateTableWidth = async () => {
   tableRowSize.value = tableBodyRef?.value?.children[0]?.scrollWidth;
@@ -582,7 +593,7 @@ const rowVirtualizerOptions = computed(() => {
     count: formattedRows.value.length,
     getScrollElement: () => parentRef.value,
     estimateSize: () => 20,
-    overscan: 10,
+    overscan: 80,
     measureElement:
       typeof window !== "undefined" &&
       navigator.userAgent.indexOf("Firefox") === -1
@@ -712,6 +723,28 @@ const handleDataRowClick = (row: any, index: number) => {
 const expandFunctionError = () => {
   isFunctionErrorOpen.value = !isFunctionErrorOpen.value;
 };
+// Specific function that updates the active cell action ID
+const updateActiveCell = (cell?: { id: string; column: { id: string } }) => {
+  console.log("cell", activeCellActionId.value);
+  if (!cell) {
+    activeCellActionId.value = "";
+  } else {
+    activeCellActionId.value = `${cell.id}_${cell.column.id}`;
+    console.log("cell", activeCellActionId.value);
+  }
+};
+
+// Debounced version of the function
+const debounceCellAction = debounce(updateActiveCell, 500);
+
+// Event handlers for mouse over and mouse leave
+const handleCellMouseOver = (cell: { id: string; column: { id: string } }) => {
+  debounceCellAction(cell);
+};
+
+const handleCellMouseLeave = () => {
+  activeCellActionId.value = "";
+};
 
 defineExpose({
   parentRef,
@@ -802,13 +835,9 @@ td {
 }
 
 .table-cell {
-  .table-cell-actions {
-    visibility: hidden !important;
-  }
-
   &:hover {
     .table-cell-actions {
-      visibility: visible !important;
+      display: block !important;
     }
   }
 }

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -22,6 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :style="{
         minWidth: '100%',
         ...columnSizeVars,
+        minHeight: totalSize + 'px',
+
         width: !defaultColumns
           ? table.getCenterTotalSize() + 'px'
           : wrap
@@ -31,7 +33,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             : '100%',
       }"
     >
-      <thead class="tw-sticky tw-top-0 tw-z-50">
+      <thead
+        class="tw-sticky tw-top-0 tw-z-50"
+        style="max-height: 44px; height: 22px"
+      >
         <vue-draggable
           v-model="columnOrder"
           v-for="headerGroup in table.getHeaderGroups()"
@@ -578,12 +583,6 @@ const rowVirtualizerOptions = computed(() => {
     count: formattedRows.value.length,
     getScrollElement: () => parentRef.value,
     estimateSize: () => 20,
-    overscan: 5,
-    measureElement:
-      typeof window !== "undefined" &&
-      navigator.userAgent.indexOf("Firefox") === -1
-        ? (element: any) => element?.getBoundingClientRect().height
-        : undefined,
   };
 });
 
@@ -601,8 +600,8 @@ const setExpandedRows = () => {
   });
 };
 
-const copyLogToClipboard = (value: any) => {
-  emits("copy", value, false);
+const copyLogToClipboard = (value: any, copyAsJson: boolean = true) => {
+  emits("copy", value, copyAsJson);
 };
 const addSearchTerm = (value: string) => {
   emits("addSearchTerm", value);

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -23,7 +23,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         minWidth: '100%',
         ...columnSizeVars,
         minHeight: totalSize + 'px',
-
         width: !defaultColumns
           ? table.getCenterTotalSize() + 'px'
           : wrap
@@ -583,6 +582,12 @@ const rowVirtualizerOptions = computed(() => {
     count: formattedRows.value.length,
     getScrollElement: () => parentRef.value,
     estimateSize: () => 20,
+    overscan: 10,
+    measureElement:
+      typeof window !== "undefined" &&
+      navigator.userAgent.indexOf("Firefox") === -1
+        ? (element: any) => element?.getBoundingClientRect().height
+        : undefined,
   };
 });
 

--- a/web/src/plugins/logs/data-table/CellActions.vue
+++ b/web/src/plugins/logs/data-table/CellActions.vue
@@ -61,7 +61,7 @@ const store = useStore();
 const emit = defineEmits(["copy", "addSearchTerm", "addFieldToTable"]);
 
 const copyLogToClipboard = (value: any) => {
-  emit("copy", value);
+  emit("copy", value, false);
 };
 const addSearchTerm = (value: string) => {
   emit("addSearchTerm", value);


### PR DESCRIPTION
#4427 
1.  Copy to clipboard is broken
2.  When pagination not displayed, source and arrow overlaps
3.  On logs page table header extends a lot vertically as a gray box and only a few logs are displayed after a lot of scroll. (checked on Linux+Firefox)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced copy functionality for log entries, allowing for more nuanced handling of copy actions.
	- Introduced tracking for the currently active cell action, improving user interaction.
- **Improvements**
	- Increased visibility of the collapse button for better user interaction.
	- Reinstated minimum height for the table to improve visual consistency across varying content sizes.
	- Updated table header styles for improved presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->