### PR TITLE
fix: list only permitted for enrichment tables list

### DIFF
--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -339,14 +339,19 @@ async fn list(org_id: web::Path<String>, req: HttpRequest) -> impl Responder {
     // Get List of allowed objects
     #[cfg(feature = "enterprise")]
     {
+        use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+
         let user_id = req.headers().get("user_id").unwrap();
         if let Some(s_type) = &stream_type {
-            if !s_type.eq(&StreamType::EnrichmentTables) && !s_type.eq(&StreamType::Metadata) {
+            if !s_type.eq(&StreamType::Metadata) {
+                let stream_type_str = s_type.to_string();
                 match crate::handler::http::auth::validator::list_objects_for_user(
                     &org_id,
                     user_id.to_str().unwrap(),
                     "GET",
-                    &s_type.to_string(),
+                    OFGA_MODELS
+                        .get(stream_type_str.as_str())
+                        .map_or(stream_type_str.as_str(), |model| model.key),
                 )
                 .await
                 {

--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -343,26 +343,24 @@ async fn list(org_id: web::Path<String>, req: HttpRequest) -> impl Responder {
 
         let user_id = req.headers().get("user_id").unwrap();
         if let Some(s_type) = &stream_type {
-            if !s_type.eq(&StreamType::Metadata) {
-                let stream_type_str = s_type.to_string();
-                match crate::handler::http::auth::validator::list_objects_for_user(
-                    &org_id,
-                    user_id.to_str().unwrap(),
-                    "GET",
-                    OFGA_MODELS
-                        .get(stream_type_str.as_str())
-                        .map_or(stream_type_str.as_str(), |model| model.key),
-                )
-                .await
-                {
-                    Ok(stream_list) => {
-                        _stream_list_from_rbac = stream_list;
-                    }
-                    Err(e) => {
-                        return Ok(crate::common::meta::http::HttpResponse::forbidden(
-                            e.to_string(),
-                        ));
-                    }
+            let stream_type_str = s_type.to_string();
+            match crate::handler::http::auth::validator::list_objects_for_user(
+                &org_id,
+                user_id.to_str().unwrap(),
+                "GET",
+                OFGA_MODELS
+                    .get(stream_type_str.as_str())
+                    .map_or(stream_type_str.as_str(), |model| model.key),
+            )
+            .await
+            {
+                Ok(stream_list) => {
+                    _stream_list_from_rbac = stream_list;
+                }
+                Err(e) => {
+                    return Ok(crate::common::meta::http::HttpResponse::forbidden(
+                        e.to_string(),
+                    ));
                 }
             }
         }

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -180,6 +180,21 @@ impl Metadata for DistinctValues {
                 .await
                 .map_err(|v| Error::Message(v.to_string()))?;
         }
+        #[cfg(feature = "enterprise")]
+        {
+            use o2_enterprise::enterprise::{
+                common::infra::config::O2_CONFIG,
+                openfga::authorizer::authz::set_ownership_if_not_exists,
+            };
+
+            if O2_CONFIG.openfga.enabled {
+                set_ownership_if_not_exists(
+                    org_id,
+                    &format!("{}:{}", StreamType::Metadata, STREAM_NAME),
+                )
+                .await;
+            }
+        }
         Ok(())
     }
 

--- a/src/service/metadata/trace_list_index.rs
+++ b/src/service/metadata/trace_list_index.rs
@@ -126,6 +126,22 @@ impl Metadata for TraceListIndex {
             log::error!("[TraceListIndex] error while syncing writer: {}", e);
         }
 
+        #[cfg(feature = "enterprise")]
+        {
+            use o2_enterprise::enterprise::{
+                common::infra::config::O2_CONFIG,
+                openfga::authorizer::authz::set_ownership_if_not_exists,
+            };
+
+            if O2_CONFIG.openfga.enabled {
+                set_ownership_if_not_exists(
+                    org_id,
+                    &format!("{}:{}", StreamType::Metadata, STREAM_NAME),
+                )
+                .await;
+            }
+        }
+
         Ok(())
     }
     async fn flush(&self) -> infra::errors::Result<()> {

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -77,6 +77,10 @@ pub async fn get_streams(
         .unwrap_or_default();
 
     let filtered_indices = if let Some(s_type) = stream_type {
+        let s_type = match s_type {
+            StreamType::EnrichmentTables => "enrichment_table".to_string(),
+            _ => s_type.to_string(),
+        };
         match permitted_streams {
             Some(permitted_streams) => {
                 if permitted_streams.contains(&format!("{}:_all_{}", s_type, org_id)) {


### PR DESCRIPTION
- [x] Enrichment tables are not listed correctly with RBAC.
- [x] Create ofga ownership for metadata streams
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of stream types for improved flexibility and functionality.
	- Introduced enterprise-level ownership management features for metadata handling in the context of the enterprise feature.

- **Bug Fixes**
	- Streamlined logic for retrieving model keys associated with stream types, ensuring more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->