### PR TITLE
fix: dashboard cache issues

### DIFF
--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -533,7 +533,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :disable="
           dashboardPanelData.data.queries[
             dashboardPanelData.layout.currentQueryIndex
-          ].fields.breakdown.length == 0
+          ]?.fields?.breakdown?.length == 0
         "
         data-test="dashboard-config-top_results"
         ><template v-slot:label>
@@ -585,7 +585,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :disable="
             dashboardPanelData.data.queries[
               dashboardPanelData.layout.currentQueryIndex
-            ].fields.breakdown.length == 0
+            ].fields?.breakdown?.length == 0
           "
         />
 


### PR DESCRIPTION
- pass old selected variable values on edit panel discard/save to use cache.
- Config showing blank on Auto mode [#4493  ]
- When sharing the dashboard link with an absolute time using the apply button, the shared link changes the absolute time to relative time and shows the default value [#4493 ]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced handling of route query parameters in the Add Panel component for improved navigation and data management.
	- Introduced a reactive variable to store query parameters on component mount, ensuring they are preserved for later use.

- **Bug Fixes**
	- Improved error handling in the Config Panel by implementing optional chaining to prevent runtime errors related to undefined properties.

- **Improvements**
	- Refined logic for returning query parameters based on value types, enhancing clarity and functionality in the Add Panel component.
	- Added safety checks in the updateDateTime function to prevent errors when accessing the date picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->