### PR TITLE
fix: Can't enable a partition key after disable it

### DIFF
--- a/web/src/composables/useStreams.ts
+++ b/web/src/composables/useStreams.ts
@@ -453,8 +453,8 @@ const useStreams = () => {
       return objA === objB;
     }
 
-    const keysA = Object.keys(objA).filter((key: string) => key !== "disabled");
-    const keysB = Object.keys(objB).filter((key: string) => key !== "disabled");
+    const keysA = Object.keys(objA)
+    const keysB = Object.keys(objB)
 
     if (keysA.length !== keysB.length) return false;
 
@@ -517,8 +517,13 @@ const useStreams = () => {
         const result: any = compareArrays(previousArray, currentArray);
         add = result.add;
         remove = result.remove;
-
-        remove = remove.filter((item: any) => item.disabled !== true);
+        remove = remove.filter((item: any) => {
+          const isInAdd = add.some((addItem: any) => addItem.field === item.field);
+        
+          // Only keep in `remove` if not in `add` and `disabled` is false
+          return !isInAdd && item.disabled === false;
+        });
+        
       } else {
         // For other attributes, do a simple array comparison
         add = currentArray.filter((item: any) => !previousArray.includes(item));


### PR DESCRIPTION
this PR can fix the issue with #4487 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced logic for filtering keys in the stream comparison, allowing for more nuanced handling of disabled items.
- **Bug Fixes**
	- Improved management of the `remove` array to ensure proper retention of items based on their presence in the `add` array.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->