### PR TITLE
fix: dashboard show time range differ warning when cache data is used

### DIFF
--- a/web/src/components/dashboards/PanelContainer.vue
+++ b/web/src/components/dashboards/PanelContainer.vue
@@ -109,6 +109,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
           </q-tooltip>
         </q-btn>
+        <q-btn
+          v-if="isCachedDataDifferWithCurrentTimeRange"
+          :icon="outlinedRunningWithErrors"
+          flat
+          size="xs"
+          padding="2px"
+          data-test="dashboard-panel-is-cached-data-differ-with-current-time-range-warning"
+        >
+          <q-tooltip anchor="bottom right" self="top right">
+            <div style="white-space: pre-wrap">
+              The data shown is cached and is differed from the selected time
+              range.
+            </div>
+          </q-tooltip>
+        </q-btn>
         <span v-if="lastTriggeredAt && !viewOnly" class="lastRefreshedAt">
           <span class="lastRefreshedAtIcon">🕑</span
           ><RelativeTime
@@ -214,6 +229,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       @metadata-update="metaDataValue"
       @result-metadata-update="handleResultMetadataUpdate"
       @last-triggered-at-update="handleLastTriggeredAtUpdate"
+      @is-cached-data-differ-with-current-time-range-update="
+        handleIsCachedDataDifferWithCurrentTimeRangeUpdate
+      "
       @updated:data-zoom="$emit('updated:data-zoom', $event)"
       @update:initial-variable-values="
         (...args) => $emit('update:initial-variable-values', ...args)
@@ -258,7 +276,10 @@ import { useRoute, useRouter } from "vue-router";
 import { addPanel } from "@/utils/commons";
 import { useQuasar } from "quasar";
 import ConfirmDialog from "../ConfirmDialog.vue";
-import { outlinedWarning } from "@quasar/extras/material-icons-outlined";
+import {
+  outlinedWarning,
+  outlinedRunningWithErrors,
+} from "@quasar/extras/material-icons-outlined";
 import SinglePanelMove from "@/components/dashboards/settings/SinglePanelMove.vue";
 import RelativeTime from "@/components/common/RelativeTime.vue";
 import { getFunctionErrorMessage } from "@/utils/zincutils";
@@ -340,6 +361,14 @@ export default defineComponent({
     const lastTriggeredAt = ref(null);
     const handleLastTriggeredAtUpdate = (data: any) => {
       lastTriggeredAt.value = data;
+    };
+
+    // to store and show warning if the cached data is different with current time range
+    const isCachedDataDifferWithCurrentTimeRange: any = ref(false);
+    const handleIsCachedDataDifferWithCurrentTimeRangeUpdate = (
+      isDiffer: boolean,
+    ) => {
+      isCachedDataDifferWithCurrentTimeRange.value = isDiffer;
     };
 
     const showText = ref(false);
@@ -451,10 +480,13 @@ export default defineComponent({
       deletePanelDialog,
       isCurrentlyHoveredPanel,
       outlinedWarning,
+      outlinedRunningWithErrors,
       store,
       metaDataValue,
       handleResultMetadataUpdate,
       handleLastTriggeredAtUpdate,
+      isCachedDataDifferWithCurrentTimeRange,
+      handleIsCachedDataDifferWithCurrentTimeRangeUpdate,
       lastTriggeredAt,
       maxQueryRange,
       metaData,

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -233,6 +233,7 @@ export default defineComponent({
     "metadata-update",
     "result-metadata-update",
     "last-triggered-at-update",
+    "is-cached-data-differ-with-current-time-range-update",
     "update:initialVariableValues",
     "updated:vrlFunctionFieldList",
   ],
@@ -265,6 +266,7 @@ export default defineComponent({
       metadata,
       resultMetaData,
       lastTriggeredAt,
+      isCachedDataDifferWithCurrentTimeRange,
       searchRequestTraceIds,
     } = usePanelDataLoader(
       panelSchema,
@@ -411,6 +413,13 @@ export default defineComponent({
 
     watch(lastTriggeredAt, () => {
       emit("last-triggered-at-update", lastTriggeredAt.value);
+    });
+
+    watch(isCachedDataDifferWithCurrentTimeRange, () => {
+      emit(
+        "is-cached-data-differ-with-current-time-range-update",
+        isCachedDataDifferWithCurrentTimeRange.value,
+      );
     });
 
     const handleNoData = (panelType: any) => {

--- a/web/src/composables/dashboard/usePanelCache.ts
+++ b/web/src/composables/dashboard/usePanelCache.ts
@@ -78,12 +78,13 @@ export const usePanelCache = (
     }
   };
 
-  const savePanelCache = (key: any, data: any) => {
+  const savePanelCache = (key: any, data: any, cacheTimeRange: any) => {
     createNestedPathsIfRequired();
 
     cache[folderId][dashboardId][panelId] = {
       key: JSON.parse(JSON.stringify(key)), // deep copy key,
       value: JSON.parse(JSON.stringify(data)), // deep copy data
+      cacheTimeRange: JSON.parse(JSON.stringify(cacheTimeRange)),
     };
   };
 

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -93,6 +93,7 @@ export const usePanelDataLoader = (
     },
     resultMetaData: [] as any,
     lastTriggeredAt: null as any,
+    isCachedDataDifferWithCurrentTimeRange: false,
     searchRequestTraceIds: <string[]>[],
   });
 
@@ -103,7 +104,14 @@ export const usePanelDataLoader = (
   const isVisible: any = ref(false);
 
   const saveCurrentStateToCache = () => {
-    savePanelCache(getCacheKey(), { ...toRaw(state) });
+    savePanelCache(
+      getCacheKey(),
+      { ...toRaw(state) },
+      {
+        start_time: selectedTimeObj?.value?.start_time?.getTime(),
+        end_time: selectedTimeObj?.value?.end_time?.getTime(),
+      },
+    );
   };
 
   // currently dependent variables data
@@ -344,6 +352,7 @@ export const usePanelDataLoader = (
       runCount++;
 
       state.loading = true;
+      state.isCachedDataDifferWithCurrentTimeRange = false;
 
       // Check if the query type is "promql"
       if (panelSchema.value.queryType == "promql") {
@@ -1363,6 +1372,15 @@ export const usePanelDataLoader = (
 
       // set that the cache is restored
       isRestoredFromCache = true;
+
+      // if selected time range is not matched with the cache time range
+      if (
+        selectedTimeObj?.value?.end_time -
+          selectedTimeObj?.value?.start_time !==
+        cache?.cacheTimeRange?.end_time - cache?.cacheTimeRange?.start_time
+      ) {
+        state.isCachedDataDifferWithCurrentTimeRange = true;
+      }
 
       log("usePanelDataLoader: panelcache: panel data loaded from cache");
     }

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -215,7 +215,7 @@ export const convertSQLData = async (
     );
   };
 
-  const noValueConfigOption = panelSchema.config?.no_value_replacement;
+  const noValueConfigOption = panelSchema?.config?.no_value_replacement ?? "";
 
   const processedData = processData(searchQueryData, panelSchema);
 
@@ -317,9 +317,7 @@ export const convertSQLData = async (
         };
         if (!currentData) {
           keys.forEach((key) => {
-            if (key !== timeKey)
-              nullEntry[key] =
-                noValueConfigOption === undefined ? null : noValueConfigOption;
+            if (key !== timeKey) nullEntry[key] = noValueConfigOption;
           });
         }
 
@@ -338,10 +336,7 @@ export const convertSQLData = async (
 
             keys.forEach((key) => {
               if (key !== timeKey && key !== uniqueKey) {
-                nullEntry[key] =
-                  noValueConfigOption === undefined
-                    ? null
-                    : noValueConfigOption;
+                nullEntry[key] = noValueConfigOption;
               }
             });
 


### PR DESCRIPTION
- dashboard show time range differ warning when cache data is used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a button to notify users when displayed data is cached and differs from the selected time range.
	- Added a new event to handle updates regarding cached data differences in the dashboard components.

- **Enhancements**
	- Improved caching mechanism to include time range specifications for better data management.
	- Enhanced responsiveness of components to changes in cached data states.

- **Bug Fixes**
	- Streamlined handling of null values in configuration options to prevent undefined values from affecting logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->