### PR TITLE
fix: use browser.wait() after browser.close()

### DIFF
--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -39,6 +39,8 @@ pub enum TriggerDataStatus {
 pub enum TriggerDataType {
     #[serde(rename = "report")]
     Report,
+    #[serde(rename = "cached_report")]
+    CachedReport,
     #[serde(rename = "alert")]
     Alert,
     #[serde(rename = "derived_stream")]

--- a/src/report_server/src/report.rs
+++ b/src/report_server/src/report.rs
@@ -333,6 +333,7 @@ pub async fn generate_report(
     if let Err(e) = page.find_element("main").await {
         let page_url = page.url().await;
         browser.close().await?;
+        browser.wait().await?;
         handle.await?;
         return Err(anyhow::anyhow!(
             "[REPORT] main html element not rendered yet for dashboard {dashboard_id}; most likely login failed: current url: {:#?} error: {e}",
@@ -342,6 +343,7 @@ pub async fn generate_report(
     if let Err(e) = page.find_element("div.displayDiv").await {
         let page_url = page.url().await;
         browser.close().await?;
+        browser.wait().await?;
         handle.await?;
         return Err(anyhow::anyhow!(
             "[REPORT] div.displayDiv element not rendered yet for dashboard {dashboard_id}: current url: {:#?} error: {e}",
@@ -364,6 +366,7 @@ pub async fn generate_report(
     };
 
     browser.close().await?;
+    browser.wait().await?;
     handle.await?;
     log::debug!("done with headless browser");
     Ok((pdf_data, email_dashb_url))

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -423,7 +423,11 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
     let mut trigger_data_stream = TriggerData {
         _timestamp: triggered_at,
         org: trigger.org.clone(),
-        module: TriggerDataType::Report,
+        module: if report.destinations.is_empty() {
+            TriggerDataType::CachedReport
+        } else {
+            TriggerDataType::Report
+        },
         key: trigger.module_key.clone(),
         next_run_at: new_trigger.next_run_at,
         is_realtime: trigger.is_realtime,

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -582,6 +582,7 @@ async fn generate_report(
 
     if let Err(e) = page.find_element("main").await {
         browser.close().await?;
+        browser.wait().await?;
         handle.await?;
         return Err(anyhow::anyhow!(
             "[REPORT] main element not rendered yet for dashboard {dashboard_id}: {e}"
@@ -589,6 +590,7 @@ async fn generate_report(
     }
     if let Err(e) = page.find_element("div.displayDiv").await {
         browser.close().await?;
+        browser.wait().await?;
         handle.await?;
         return Err(anyhow::anyhow!(
             "[REPORT] div.displayDiv element not rendered yet for dashboard {dashboard_id}: {e}"
@@ -609,6 +611,7 @@ async fn generate_report(
     };
 
     browser.close().await?;
+    browser.wait().await?;
     handle.await?;
     log::debug!("done with headless browser");
     Ok((pdf_data, email_dashb_url))

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -205,7 +205,7 @@ pub async fn list(
                         if report
                             .dashboards
                             .iter()
-                            .any(|x| x.dashboard.eq(dashboard_id))
+                            .any(|x| !x.dashboard.eq(dashboard_id))
                         {
                             should_include = false;
                         }

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -115,6 +115,8 @@ pub async fn save(
         Err(_) => {
             if !create {
                 return Err(anyhow::anyhow!("Report not found"));
+            } else {
+                report.last_triggered_at = None;
             }
         }
     }


### PR DESCRIPTION
- After calling `browser.close()`, `browser.wait()` needs to be called to avoid various zombie processes and close the browser properly.
- In triggers usage report, this uses `cached_report` as module type for destination-less reports.
- For list reports api, filter reports based on dashboard id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `CachedReport` variant to enhance report handling capabilities.

- **Improvements**
	- Enhanced error handling and control flow in report generation to ensure browser operations complete before closure.
	- Improved logic for differentiating between cached and standard report triggers based on destination presence.

These updates aim to increase the reliability and functionality of report generation within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->