### PR TITLE
fix: nats lock with node id

### DIFF
--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -747,7 +747,7 @@ impl Locker {
             let expiration = expiration.parse::<i64>().unwrap();
             if (expiration < chrono::Utc::now().timestamp_micros())
                 || (ret_parts.len() == 3 // Backward compatibility: previous values only have 2 parts
-                    && node_ids.is_some_and(|node_ids| !node_ids.contains(ret_parts[2])))
+                    && node_ids.is_some_and(|node_ids| !node_ids.contains(ret_parts[1])))
             {
                 if let Err(err) = bucket.purge(&key).await {
                     log::error!("nats purge lock for key: {}, error: {}", self.key, err);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for backward compatibility checks in the Locker implementation, enhancing the accuracy of data interpretation during purge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->