### PR TITLE
fix: showing not found error in preview while selecting some streams

### DIFF
--- a/web/src/components/alerts/AddAlert.vue
+++ b/web/src/components/alerts/AddAlert.vue
@@ -883,7 +883,7 @@ export default defineComponent({
 
       if (!isAggregationEnabled.value) {
         query +=
-          ` COUNT(*) as zo_sql_val FROM ${formData.value.stream_name} ` +
+          ` COUNT(*) as zo_sql_val FROM \"${formData.value.stream_name}\" ` +
           whereClause +
           " GROUP BY zo_sql_key ORDER BY zo_sql_key ASC";
       } else {
@@ -919,18 +919,18 @@ export default defineComponent({
         if (isAggValid) {
           if (percentileFunctions[aggFn]) {
             query +=
-              ` approx_percentile_cont(${column}, ${percentileFunctions[aggFn]}) as zo_sql_val ${concatGroupBy} FROM ${formData.value.stream_name} ` +
+              ` approx_percentile_cont(${column}, ${percentileFunctions[aggFn]}) as zo_sql_val ${concatGroupBy} FROM \"${formData.value.stream_name}\" ` +
               whereClause +
               ` GROUP BY zo_sql_key ${groupByAlias} ORDER BY zo_sql_key ASC`;
           } else {
             query +=
-              ` ${aggFn}(${column}) as zo_sql_val ${concatGroupBy} FROM ${formData.value.stream_name} ` +
+              ` ${aggFn}(${column}) as zo_sql_val ${concatGroupBy} FROM \"${formData.value.stream_name}\" ` +
               whereClause +
               ` GROUP BY zo_sql_key ${groupByAlias} ORDER BY zo_sql_key ASC`;
           }
         } else {
           query +=
-            ` COUNT(*) as zo_sql_val ${concatGroupBy} FROM ${formData.value.stream_name} ` +
+            ` COUNT(*) as zo_sql_val ${concatGroupBy} FROM \"${formData.value.stream_name}\" ` +
             whereClause +
             ` GROUP BY zo_sql_key ${groupByAlias} ORDER BY zo_sql_key ASC`;
         }
@@ -947,6 +947,7 @@ export default defineComponent({
       }
     };
     const getParser = (sqlQuery: string) => {
+      
       try {
         // As default is a reserved keyword in sql-parser, we are replacing it with default1
         const regex = /\bdefault\b/g;


### PR DESCRIPTION
This PR adds "" around stream name to pass any keyword that has been used as a stream name 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved SQL query handling in the Add Alert feature to prevent syntax errors and enhance security against injection vulnerabilities.

- **Style**
	- Enhanced code readability with minor formatting adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->