### PR TITLE
perf: use buffer write for wal

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -521,10 +521,6 @@ pub struct Common {
     pub data_db_dir: String,
     #[env_config(name = "ZO_DATA_CACHE_DIR", default = "")] // ./data/openobserve/cache/
     pub data_cache_dir: String,
-    #[env_config(name = "ZO_WAL_MEMORY_MODE_ENABLED", default = false)]
-    pub wal_memory_mode_enabled: bool,
-    #[env_config(name = "ZO_WAL_LINE_MODE_ENABLED", default = true)]
-    pub wal_line_mode_enabled: bool,
     #[env_config(name = "ZO_COLUMN_TIMESTAMP", default = "_timestamp")]
     pub column_timestamp: String,
     // TODO: should rename to column_all
@@ -827,6 +823,8 @@ pub struct Limit {
     pub mem_table_bucket_num: usize,
     #[env_config(name = "ZO_MEM_PERSIST_INTERVAL", default = 5)] // seconds
     pub mem_persist_interval: u64,
+    #[env_config(name = "ZO_WAL_WRITE_BUFFER_SIZE", default = 16384)] // 16 KB
+    pub wal_write_buffer_size: usize,
     #[env_config(name = "ZO_FILE_PUSH_INTERVAL", default = 10)] // seconds
     pub file_push_interval: u64,
     #[env_config(name = "ZO_FILE_PUSH_LIMIT", default = 0)] // files
@@ -1625,6 +1623,11 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
     if cfg.limit.mem_table_bucket_num == 0 {
         cfg.limit.mem_table_bucket_num = 1;
+    }
+
+    // wal
+    if cfg.limit.wal_write_buffer_size < 4096 {
+        cfg.limit.wal_write_buffer_size = 4096;
     }
 
     // check query settings

--- a/src/ingester/src/partition.rs
+++ b/src/ingester/src/partition.rs
@@ -208,6 +208,7 @@ impl Partition {
             f.write_all(&buf_parquet)
                 .await
                 .context(WriteFileSnafu { path: path.clone() })?;
+            drop(f);
 
             // set parquet metadata cache
             let mut file_key = path.clone();

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -158,6 +158,7 @@ impl Writer {
                     &key.stream_type,
                     wal_id,
                     cfg.limit.max_file_size_on_disk as u64,
+                    cfg.limit.wal_write_buffer_size,
                 )
                 .expect("wal file create error"),
             )),
@@ -219,6 +220,7 @@ impl Writer {
                 &self.key.stream_type,
                 wal_id,
                 cfg.limit.max_file_size_on_disk as u64,
+                cfg.limit.wal_write_buffer_size,
             )
             .context(WalSnafu)?;
             let old_wal = std::mem::replace(&mut *wal, new_wal);
@@ -253,7 +255,7 @@ impl Writer {
 
     pub async fn close(&self) -> Result<()> {
         // rotation wal
-        let wal = self.wal.lock().await;
+        let mut wal = self.wal.lock().await;
         wal.sync().context(WalSnafu)?;
         let path = wal.path().clone();
         drop(wal);
@@ -270,7 +272,7 @@ impl Writer {
     }
 
     pub async fn sync(&self) -> Result<()> {
-        let wal = self.wal.lock().await;
+        let mut wal = self.wal.lock().await;
         wal.sync().context(WalSnafu)
     }
 

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -438,7 +438,7 @@ pub async fn write_file(
         tasks.push(task);
     }
 
-    let task_results = try_join_all(tasks).await?;
+    let task_results = try_join_all(tasks).await.unwrap();
     for task in task_results {
         match task {
             Ok((entry_records, entry_size)) => {

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -30,7 +30,9 @@ use config::{
     utils::{flatten, json::*},
     SIZE_IN_MB,
 };
+use futures::future::try_join_all;
 use proto::cluster_rpc::IngestionType;
+use tokio::sync::Semaphore;
 use vector_enrichment::TableRegistry;
 use vrl::{
     compiler::{runtime::Runtime, CompilationResult, TargetValueRef},
@@ -402,31 +404,53 @@ pub async fn write_file(
     buf: HashMap<String, SchemaRecords>,
 ) -> RequestStats {
     let mut req_stats = RequestStats::default();
+    let cfg = get_config();
+    let mut tasks = Vec::with_capacity(buf.len());
+    let semaphore = std::sync::Arc::new(Semaphore::new(cfg.limit.file_move_thread_num));
     for (hour_key, entry) in buf {
         if entry.records.is_empty() {
             continue;
         }
-        let entry_records = entry.records.len();
-        if let Err(e) = writer
-            .write(
-                entry.schema,
-                ingester::Entry {
-                    stream: Arc::from(stream_name),
-                    schema_key: Arc::from(entry.schema_key.as_str()),
-                    partition_key: Arc::from(hour_key.as_str()),
-                    data: entry.records,
-                    data_size: entry.records_size,
-                },
-                false,
-            )
-            .await
-        {
-            log::error!("ingestion write file error: {}", e);
-        }
-
-        req_stats.size += entry.records_size as f64 / SIZE_IN_MB;
-        req_stats.records += entry_records as i64;
+        let writer = Arc::clone(writer);
+        let stream_name = stream_name.to_string();
+        let permit = semaphore.clone().acquire_owned().await.unwrap();
+        let task = tokio::task::spawn(async move {
+            let entry_records = entry.records.len();
+            if let Err(e) = writer
+                .write(
+                    entry.schema,
+                    ingester::Entry {
+                        stream: Arc::from(stream_name),
+                        schema_key: Arc::from(entry.schema_key.as_str()),
+                        partition_key: Arc::from(hour_key.as_str()),
+                        data: entry.records,
+                        data_size: entry.records_size,
+                    },
+                    false,
+                )
+                .await
+            {
+                log::error!("ingestion write file error: {}", e);
+            }
+            drop(permit);
+            Ok((entry_records, entry.records_size)) as Result<(usize, usize)>
+        });
+        tasks.push(task);
     }
+
+    let task_results = try_join_all(tasks).await?;
+    for task in task_results {
+        match task {
+            Ok((entry_records, entry_size)) => {
+                req_stats.size += entry_size as f64 / SIZE_IN_MB;
+                req_stats.records += entry_records as i64;
+            }
+            Err(e) => {
+                log::error!("ingestion write file error: {}", e);
+            }
+        }
+    }
+
     req_stats
 }
 

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -337,7 +337,7 @@ pub async fn handle_grpc_request(
     let ep = if is_grpc {
         "/grpc/otlp/logs"
     } else {
-        "/api/oltp/v1/logs"
+        "/api/otlp/v1/logs"
     };
     // metric + data usage
     let took_time = start.elapsed().as_secs_f64();

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -455,7 +455,7 @@ pub async fn logs_json_handler(
     let took_time = start.elapsed().as_secs_f64();
     metrics::HTTP_RESPONSE_TIME
         .with_label_values(&[
-            "/api/oltp/v1/logs",
+            "/api/otlp/v1/logs",
             metric_rpt_status_code,
             org_id,
             &stream_name,
@@ -464,7 +464,7 @@ pub async fn logs_json_handler(
         .observe(took_time);
     metrics::HTTP_INCOMING_REQUESTS
         .with_label_values(&[
-            "/api/oltp/v1/logs",
+            "/api/otlp/v1/logs",
             metric_rpt_status_code,
             org_id,
             &stream_name,

--- a/src/wal/benches/write.rs
+++ b/src/wal/benches/write.rs
@@ -21,12 +21,15 @@ pub fn write_benchmark(c: &mut Criterion) {
     let dir = tempdir().unwrap();
     let dir = dir.path();
     let mut group = c.benchmark_group("wal/write");
-    for entry_size in [256, 1024, 4096, 16384, 1024 * 1024] {
-        let mut writer = Writer::new(dir, "org", "stream", entry_size as u64, 1024_1024).unwrap();
-        let data = vec![42u8; entry_size];
-        group.bench_function(BenchmarkId::from_parameter(entry_size), |b| {
-            b.iter(|| writer.write(black_box(&data), true));
-        });
+    for buf_size in [4096, 8192, 16384, 32768] {
+        for entry_size in [4096, 16384, 32768, 65536] {
+            let mut writer =
+                Writer::new(dir, "org", "stream", entry_size as u64, 1024_1024, buf_size).unwrap();
+            let data = vec![42u8; entry_size];
+            group.bench_function(BenchmarkId::new(buf_size.to_string(), entry_size), |b| {
+                b.iter(|| writer.write(black_box(&data), true));
+            });
+        }
     }
     group.finish();
 }

--- a/src/wal/tests/wal.rs
+++ b/src/wal/tests/wal.rs
@@ -21,7 +21,7 @@ fn wal() {
     let entry_num = 100;
     let dir = tempdir().unwrap();
     let dir = dir.path();
-    let mut writer = Writer::new(dir, "org", "stream", 1, 1024_1024).unwrap();
+    let mut writer = Writer::new(dir, "org", "stream", 1, 1024_1024, 8 * 1024).unwrap();
     for i in 0..entry_num {
         let data = format!("hello world {}", i);
         writer.write(data.as_bytes(), true).unwrap();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable write buffer size for write-ahead logging (WAL) operations.
	- Enhanced asynchronous processing for ingestion tasks, improving performance and responsiveness.
  
- **Bug Fixes**
	- Corrected API endpoint paths to align with OpenTelemetry Protocol (OTLP) standards.

- **Refactor**
	- Improved resource management by ensuring file handles are released after use.
	- Enhanced the `Writer` struct to utilize a buffered writer for more efficient file operations.

- **Tests**
	- Updated benchmarking logic to allow for comprehensive performance testing of the `Writer` under various configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->