### PR TITLE
fix: stream status incorrect

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -173,7 +173,7 @@ pub async fn register_and_keepalive() -> Result<()> {
             panic!("Local mode only support NODE_ROLE=all");
         }
         // cache local node
-        let node = load_local_mode_node();
+        let node = load_local_node();
         add_node_to_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Interactive)).await;
         add_node_to_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Background)).await;
         add_node_to_consistent_hash(&node, &Role::Compactor, None).await;
@@ -491,24 +491,6 @@ pub async fn get_cached_nodes(cond: fn(&Node) -> bool) -> Option<Vec<Node>> {
 }
 
 #[inline(always)]
-pub fn load_local_mode_node() -> Node {
-    let cfg = get_config();
-    Node {
-        id: 1,
-        uuid: LOCAL_NODE.uuid.clone(),
-        name: cfg.common.instance_name.clone(),
-        http_addr: format!("http://127.0.0.1:{}", cfg.http.port),
-        grpc_addr: format!("http://127.0.0.1:{}", cfg.grpc.port),
-        role: [Role::All].to_vec(),
-        role_group: RoleGroup::None,
-        cpu_num: cfg.limit.cpu_num as u64,
-        status: NodeStatus::Online,
-        scheduled: true,
-        broadcasted: false,
-    }
-}
-
-#[inline(always)]
 pub async fn get_node_by_uuid(uuid: &str) -> Option<Node> {
     NODES.read().await.get(uuid).cloned()
 }
@@ -585,7 +567,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_consistent_hashing() {
-        let node = load_local_mode_node();
+        let node = load_local_node();
         for i in 0..10 {
             let node_q = Node {
                 name: format!("node-q-{i}").to_string(),

--- a/src/config/src/cluster.rs
+++ b/src/config/src/cluster.rs
@@ -27,12 +27,20 @@ pub static mut LOCAL_NODE_KEY_LEASE_ID: i64 = 0;
 pub static mut LOCAL_NODE_STATUS: NodeStatus = NodeStatus::Prepare;
 pub static LOCAL_NODE: Lazy<Node> = Lazy::new(load_local_node);
 
-fn load_local_node() -> Node {
+pub fn load_local_node() -> Node {
+    let cfg = get_config();
     Node {
+        id: 1,
         uuid: load_local_node_uuid(),
         role: load_local_node_role(),
         role_group: load_role_group(),
-        ..Default::default()
+        name: cfg.common.instance_name.clone(),
+        http_addr: format!("http://127.0.0.1:{}", cfg.http.port),
+        grpc_addr: format!("http://127.0.0.1:{}", cfg.grpc.port),
+        cpu_num: cfg.limit.cpu_num as u64,
+        status: NodeStatus::Online,
+        scheduled: true,
+        broadcasted: false,
     }
 }
 


### PR DESCRIPTION
fixed #3935 

If your steam stats is incorrect, please upgrade the this version and reset the stream stats once.
```
./openobserve reset -c stream-stats
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `load_local_node` function to provide detailed initialization of Node instances based on configuration settings.
  
- **Bug Fixes**
	- Improved efficiency and accuracy in managing stream statistics across MySQL, PostgreSQL, and SQLite databases by streamlining update processes and ensuring data integrity.

- **Refactor**
	- Simplified function names and logic related to loading local node configurations and handling stream statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->