### PR TITLE
fix: stream stats incorrect

### DIFF
--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -322,6 +322,18 @@ impl StreamStats {
             self.compressed_size = 0.0;
         }
     }
+
+    pub fn format_by(&mut self, stats: &StreamStats) {
+        self.file_num = stats.file_num;
+        self.doc_num = stats.doc_num;
+        self.storage_size = stats.storage_size;
+        self.compressed_size = stats.compressed_size;
+        self.doc_time_min = self.doc_time_min.min(stats.doc_time_min);
+        self.doc_time_max = self.doc_time_max.max(stats.doc_time_max);
+        if self.doc_time_min == 0 {
+            self.doc_time_min = stats.doc_time_min;
+        }
+    }
 }
 
 impl From<&str> for StreamStats {

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -305,24 +305,6 @@ impl StreamStats {
         }
     }
 
-    pub fn add_stream_stats(&mut self, stats: &StreamStats) {
-        self.file_num = max(0, self.file_num + stats.file_num);
-        self.doc_num = max(0, self.doc_num + stats.doc_num);
-        self.doc_time_min = self.doc_time_min.min(stats.doc_time_min);
-        self.doc_time_max = self.doc_time_max.max(stats.doc_time_max);
-        self.storage_size += stats.storage_size;
-        self.compressed_size += stats.compressed_size;
-        if self.doc_time_min == 0 {
-            self.doc_time_min = stats.doc_time_min;
-        }
-        if self.storage_size < 0.0 {
-            self.storage_size = 0.0;
-        }
-        if self.compressed_size < 0.0 {
-            self.compressed_size = 0.0;
-        }
-    }
-
     pub fn format_by(&mut self, stats: &StreamStats) {
         self.file_num = stats.file_num;
         self.doc_num = stats.doc_num;

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -477,10 +477,15 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         let mut new_streams = Vec::new();
         let mut update_streams = Vec::with_capacity(streams.len());
         for (stream_key, item) in streams {
-            if old_stats.get(stream_key).is_none() {
-                new_streams.push(stream_key);
-            }
-            update_streams.push((stream_key, item));
+            let mut stats = match old_stats.get(stream_key) {
+                Some(s) => s.to_owned(),
+                None => {
+                    new_streams.push(stream_key);
+                    StreamStats::default()
+                }
+            };
+            stats.format_by(item); // format stats
+            update_streams.push((stream_key, stats));
         }
 
         let mut tx = pool.begin().await?;

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -487,10 +487,15 @@ SELECT stream, MIN(min_ts) as min_ts, MAX(max_ts) as max_ts, COUNT(*) as file_nu
         let mut new_streams = Vec::new();
         let mut update_streams = Vec::with_capacity(streams.len());
         for (stream_key, item) in streams {
-            if old_stats.get(stream_key).is_none() {
-                new_streams.push(stream_key);
-            }
-            update_streams.push((stream_key, item));
+            let mut stats = match old_stats.get(stream_key) {
+                Some(s) => s.to_owned(),
+                None => {
+                    new_streams.push(stream_key);
+                    StreamStats::default()
+                }
+            };
+            stats.format_by(item); // format stats
+            update_streams.push((stream_key, stats));
         }
 
         let client = CLIENT_RW.clone();


### PR DESCRIPTION
fixed #3935 

If your steam stats is incorrect, please upgrade the this version and reset the stream stats once.
```
./openobserve reset -c stream-stats
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to directly update stream statistics, simplifying the management of data.
  
- **Bug Fixes**
	- Enhanced logic for handling stream statistics across various database systems, ensuring all streams are processed efficiently and correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->