### PR TITLE
fix: fixed trace span start time issue

### DIFF
--- a/web/src/composables/shared/router.ts
+++ b/web/src/composables/shared/router.ts
@@ -120,9 +120,6 @@ const useRoutes = () => {
       path: "traces/trace-details",
       name: "traceDetails",
       component: TraceDetails,
-      meta: {
-        keepAlive: true,
-      },
       beforeEnter(to: any, from: any, next: any) {
         routeGuard(to, from, next);
       },

--- a/web/src/plugins/traces/SpanBlock.vue
+++ b/web/src/plugins/traces/SpanBlock.vue
@@ -193,7 +193,7 @@ export default defineComponent({
 
     const isSpanSelected = computed(() => {
       return searchObj.data.traceDetails.expandedSpans.includes(
-        props.span.spanId
+        props.span.spanId,
       );
     });
 
@@ -211,7 +211,7 @@ export default defineComponent({
         (
           (props.span?.durationMs / props.baseTracePosition?.durationMs) *
           100
-        ).toFixed(2)
+        ).toFixed(2),
       );
     };
 
@@ -220,24 +220,38 @@ export default defineComponent({
     });
 
     watch(
-      () => props.span.startTimeMs + props.baseTracePosition["startTimeMs"],
+      () => props.span.startTimeMs,
       () => {
         leftPosition.value = getLeftPosition();
-      }
+      },
+      {
+        immediate: true,
+      },
+    );
+
+    watch(
+      () => props.baseTracePosition,
+      () => {
+        leftPosition.value = getLeftPosition();
+      },
+      {
+        immediate: true,
+        deep: true,
+      },
     );
 
     watch(
       () => props.span?.durationMs + props.baseTracePosition?.durationMs,
       () => {
         spanWidth.value = getSpanWidth();
-      }
+      },
     );
 
     watch(
       () => spanBlockWidth.value + leftPosition.value + spanWidth.value,
       (val) => {
         durationStyle.value = getDurationStyle();
-      }
+      },
     );
 
     const getDurationStyle = () => {
@@ -283,7 +297,7 @@ export default defineComponent({
       } else {
         searchObj.data.traceDetails.expandedSpans =
           searchObj.data.traceDetails.expandedSpans.filter(
-            (val) => props.span.spanId !== val
+            (val) => props.span.spanId !== val,
           );
       }
     };

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -426,24 +426,27 @@ export default defineComponent({
 
     const showTraceDetails = ref(false);
 
-    onActivated(() => {
-      const params = router.currentRoute.value.query;
+    // Disabled for now
+    // onActivated(() => {
+    //   const params = router.currentRoute.value.query;
 
-      // If selected trace is different from the one in the URL, reset the trace details
-      // If there is no selected trace, then also reset the trace details
+    //   // If selected trace is different from the one in the URL, reset the trace details
+    //   // If there is no selected trace, then also reset the trace details
 
-      if (
-        (searchObj.data.traceDetails.selectedTrace &&
-          params.trace_id !==
-            searchObj.data.traceDetails.selectedTrace?.trace_id) ||
-        !searchObj.data.traceDetails.selectedTrace
-      ) {
-        resetTraceDetails();
-        setupTraceDetails();
-      }
-    });
+    //   if (
+    //     (searchObj.data.traceDetails.selectedTrace &&
+    //       params.trace_id !==
+    //         searchObj.data.traceDetails.selectedTrace?.trace_id) ||
+    //     !searchObj.data.traceDetails.selectedTrace
+    //   ) {
+    //     resetTraceDetails();
+    //     console.log("resetTraceDetails >>>>>>>>>>>>>");
+    //     setupTraceDetails();
+    //   }
+    // });
 
     onBeforeMount(async () => {
+      resetTraceDetails();
       setupTraceDetails();
     });
 
@@ -458,24 +461,26 @@ export default defineComponent({
       },
     );
 
-    watch(
-      () => router.currentRoute.value.query.trace_id,
-      (_new, _old) => {
-        // If trace_id changes, reset the trace details
-        if (
-          _new &&
-          _new !== _old &&
-          _new !== searchObj.data.traceDetails.selectedTrace?.trace_id
-        ) {
-          resetTraceDetails();
-          setupTraceDetails();
-          const params = router.currentRoute.value.query;
-          if (params.span_id) {
-            updateSelectedSpan(params.span_id as string);
-          }
-        }
-      },
-    );
+    // Disabled for now
+    // watch(
+    //   () => router.currentRoute.value.query.trace_id,
+    //   (_new, _old) => {
+    //     // If trace_id changes, reset the trace details
+    //     if (
+    //       _new &&
+    //       _old &&
+    //       _new !== _old &&
+    //       _new !== searchObj.data.traceDetails.selectedTrace?.trace_id
+    //     ) {
+    //       resetTraceDetails();
+    //       // setupTraceDetails();
+    //       const params = router.currentRoute.value.query;
+    //       if (params.span_id) {
+    //         updateSelectedSpan(params.span_id as string);
+    //       }
+    //     }
+    //   },
+    // );
 
     const backgroundStyle = computed(() => {
       return {
@@ -524,15 +529,15 @@ export default defineComponent({
       }
     });
 
-    watch(
-      () => spanList.value.length,
-      () => {
-        if (spanList.value.length) {
-          buildTracesTree();
-        } else traceTree.value = [];
-      },
-      { immediate: true },
-    );
+    // watch(
+    //   () => spanList.value.length,
+    //   () => {
+    //     if (spanList.value.length) {
+    //       buildTracesTree();
+    //     } else traceTree.value = [];
+    //   },
+    //   { immediate: true },
+    // );
 
     const isSidebarOpen = computed(() => {
       return searchObj.data.traceDetails.showSpanDetails;


### PR DESCRIPTION
#4477 

1. Removed  keep alive from TraceDetails component
2. Fixed calculation of span block left position

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved responsiveness of the SpanBlock component to prop changes.
	- Introduced a new watcher for base trace position updates.

- **Bug Fixes**
	- Adjusted route configuration for traceDetails to improve state management when navigating away.

- **Chores**
	- Temporarily disabled automatic handling of trace details in the TraceDetails component for debugging purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->