### PR TITLE
fix: add max_lifetime for db connection pool

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -776,7 +776,7 @@ pub struct Common {
     pub use_multi_result_cache: bool,
     #[env_config(
         name = "ZO_RESULT_CACHE_SELECTION_STRATEGY",
-        default = "both",
+        default = "overlap",
         help = "Strategy to use for result cache, default is both , possible value - both,overlap , duration"
     )]
     pub result_cache_selection_strategy: String,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -927,9 +927,15 @@ pub struct Limit {
     #[env_config(name = "ZO_QUICK_MODE_FILE_LIST_INTERVAL", default = 300)] // seconds
     pub quick_mode_file_list_interval: i64,
     #[env_config(name = "ZO_META_CONNECTION_POOL_MIN_SIZE", default = 0)] // number of connections
-    pub sql_min_db_connections: u32,
+    pub sql_db_connections_min: u32,
     #[env_config(name = "ZO_META_CONNECTION_POOL_MAX_SIZE", default = 0)] // number of connections
-    pub sql_max_db_connections: u32,
+    pub sql_db_connections_max: u32,
+    #[env_config(
+        name = "ZO_META_CONNECTION_POOL_MAX_LIFETIME",
+        default = 0,
+        help = "Seconds, Maximum lifetime of individual connections."
+    )]
+    pub sql_db_connections_max_lifetime: u64,
     #[env_config(
         name = "ZO_META_TRANSACTION_RETRIES",
         default = 3,
@@ -1304,16 +1310,16 @@ pub fn init() -> Config {
         cfg.limit.file_push_limit = 10000;
     }
 
-    if cfg.limit.sql_min_db_connections == 0 {
-        cfg.limit.sql_min_db_connections = cpu_num as u32
+    if cfg.limit.sql_db_connections_min == 0 {
+        cfg.limit.sql_db_connections_min = cpu_num as u32
     }
 
-    if cfg.limit.sql_max_db_connections == 0 {
-        cfg.limit.sql_max_db_connections = cfg.limit.sql_min_db_connections * 2
+    if cfg.limit.sql_db_connections_max == 0 {
+        cfg.limit.sql_db_connections_max = cfg.limit.sql_db_connections_min * 2
     }
 
     if cfg.limit.consistent_hash_vnodes == 0 {
-        cfg.limit.consistent_hash_vnodes = 3;
+        cfg.limit.consistent_hash_vnodes = 100;
     }
 
     // check common config

--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -36,9 +36,17 @@ fn connect() -> Pool<MySql> {
         .expect("mysql connect options create failed")
         .disable_statement_logging();
 
+    let max_lifetime = if cfg.limit.sql_db_connections_max_lifetime > 0 {
+        Some(std::time::Duration::from_secs(
+            cfg.limit.sql_db_connections_max_lifetime,
+        ))
+    } else {
+        None
+    };
     MySqlPoolOptions::new()
-        .min_connections(cfg.limit.sql_min_db_connections)
-        .max_connections(cfg.limit.sql_max_db_connections)
+        .min_connections(cfg.limit.sql_db_connections_min)
+        .max_connections(cfg.limit.sql_db_connections_max)
+        .max_lifetime(max_lifetime)
         .connect_lazy_with(db_opts)
 }
 

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -36,9 +36,17 @@ fn connect() -> Pool<Postgres> {
         .expect("postgres connect options create failed")
         .disable_statement_logging();
 
+    let max_lifetime = if cfg.limit.sql_db_connections_max_lifetime > 0 {
+        Some(std::time::Duration::from_secs(
+            cfg.limit.sql_db_connections_max_lifetime,
+        ))
+    } else {
+        None
+    };
     PgPoolOptions::new()
-        .min_connections(cfg.limit.sql_min_db_connections)
-        .max_connections(cfg.limit.sql_max_db_connections)
+        .min_connections(cfg.limit.sql_db_connections_min)
+        .max_connections(cfg.limit.sql_db_connections_max)
+        .max_lifetime(max_lifetime)
         .connect_lazy_with(db_opts)
 }
 

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -80,9 +80,18 @@ fn connect_ro() -> Pool<Sqlite> {
         .busy_timeout(Duration::from_secs(30))
         // .disable_statement_logging()
         .read_only(true);
+
+    let max_lifetime = if cfg.limit.sql_db_connections_max_lifetime > 0 {
+        Some(std::time::Duration::from_secs(
+            cfg.limit.sql_db_connections_max_lifetime,
+        ))
+    } else {
+        None
+    };
     SqlitePoolOptions::new()
-        .min_connections(cfg.limit.sql_min_db_connections)
-        .max_connections(cfg.limit.sql_max_db_connections)
+        .min_connections(cfg.limit.sql_db_connections_min)
+        .max_connections(cfg.limit.sql_db_connections_max)
+        .max_lifetime(max_lifetime)
         .acquire_timeout(Duration::from_secs(30))
         .connect_lazy_with(db_opts)
 }


### PR DESCRIPTION
Add a new ENV `ZO_META_CONNECTION_POOL_MAX_LIFETIME` default is `0`, you can set it by seconds.

For example. you want the max life time is 2 hours:
```
ZO_META_CONNECTION_POOL_MAX_LIFETIME=7200
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter for maximum lifetime of database connections.
	- Enhanced connection management for MySQL, PostgreSQL, and SQLite with configurable connection lifetimes.

- **Improvements**
	- Renamed connection parameters for clarity and consistency across the application.
	- Updated default behavior for result caching and consistent hashing for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->