### PR TITLE
perf: use cache for gRPC channel

### DIFF
--- a/src/router/grpc/ingest/mod.rs
+++ b/src/router/grpc/ingest/mod.rs
@@ -13,67 +13,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::{utils::rand::get_rand_element, RwAHashMap};
-use once_cell::sync::Lazy;
-use tonic::{transport::Channel, Status};
-
-use crate::common::infra::cluster;
-
 pub mod logs;
 pub mod metrics;
 pub mod traces;
-
-static CHANNELS: Lazy<RwAHashMap<String, Channel>> = Lazy::new(Default::default);
-
-pub(crate) async fn get_ingester_channel() -> Result<Channel, tonic::Status> {
-    let grpc_addr = get_rand_ingester_addr().await?;
-    // cache hit
-    let r = CHANNELS.read().await;
-    if let Some(channel) = r.get(&grpc_addr) {
-        return Ok(channel.clone());
-    }
-    drop(r);
-
-    // cache miss, connect to ingester
-    let channel = Channel::from_shared(grpc_addr.clone())
-        .unwrap()
-        .connect_timeout(std::time::Duration::from_secs(
-            config::get_config().grpc.connect_timeout,
-        ))
-        .connect()
-        .await
-        .map_err(|err| {
-            log::error!(
-                "[ROUTER] grpc->ingest: node: {}, connect err: {:?}",
-                &grpc_addr,
-                err
-            );
-            Status::internal("connect querier error".to_string())
-        })?;
-    let mut w = CHANNELS.write().await;
-    w.insert(grpc_addr, channel.clone());
-    drop(w);
-
-    Ok(channel)
-}
-
-async fn get_rand_ingester_addr() -> Result<String, tonic::Status> {
-    let cfg = config::get_config();
-    let nodes = cluster::get_cached_online_ingester_nodes().await;
-    if nodes.is_none() || nodes.as_ref().unwrap().is_empty() {
-        if !cfg.route.ingester_srv_url.is_empty() {
-            Ok(format!(
-                "http://{}:{}",
-                cfg.route.ingester_srv_url, cfg.grpc.port
-            ))
-        } else {
-            Err(tonic::Status::internal(
-                "No online ingester nodes".to_string(),
-            ))
-        }
-    } else {
-        let nodes = nodes.unwrap();
-        let node = get_rand_element(&nodes);
-        Ok(node.grpc_addr.to_string())
-    }
-}

--- a/src/service/grpc.rs
+++ b/src/service/grpc.rs
@@ -1,0 +1,82 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use config::{utils::rand::get_rand_element, RwAHashMap};
+use once_cell::sync::Lazy;
+use tonic::{transport::Channel, Status};
+
+use crate::common::infra::cluster;
+
+static CHANNELS: Lazy<RwAHashMap<String, Channel>> = Lazy::new(Default::default);
+
+pub(crate) async fn get_ingester_channel() -> Result<(String, Channel), tonic::Status> {
+    let grpc_addr = get_rand_ingester_addr().await?;
+    get_cached_channel(&grpc_addr)
+        .await
+        .map(|channel| (grpc_addr, channel))
+}
+
+async fn get_rand_ingester_addr() -> Result<String, tonic::Status> {
+    let cfg = config::get_config();
+    let nodes = cluster::get_cached_online_ingester_nodes().await;
+    if nodes.is_none() || nodes.as_ref().unwrap().is_empty() {
+        if !cfg.route.ingester_srv_url.is_empty() {
+            Ok(format!(
+                "http://{}:{}",
+                cfg.route.ingester_srv_url, cfg.grpc.port
+            ))
+        } else {
+            Err(tonic::Status::internal(
+                "No online ingester nodes".to_string(),
+            ))
+        }
+    } else {
+        let nodes = nodes.unwrap();
+        let node = get_rand_element(&nodes);
+        Ok(node.grpc_addr.to_string())
+    }
+}
+
+pub(crate) async fn get_cached_channel(grpc_addr: &str) -> Result<Channel, tonic::Status> {
+    // cache hit
+    let r = CHANNELS.read().await;
+    if let Some(channel) = r.get(grpc_addr) {
+        return Ok(channel.clone());
+    }
+    drop(r);
+
+    // cache miss, connect to ingester
+    let channel = create_channel(grpc_addr).await?;
+    let mut w = CHANNELS.write().await;
+    w.insert(grpc_addr.to_string(), channel.clone());
+    drop(w);
+
+    Ok(channel.clone())
+}
+
+async fn create_channel(grpc_addr: &str) -> Result<Channel, tonic::Status> {
+    let channel = Channel::from_shared(grpc_addr.to_string())
+        .unwrap()
+        .connect_timeout(std::time::Duration::from_secs(
+            config::get_config().grpc.connect_timeout,
+        ))
+        .connect()
+        .await
+        .map_err(|err| {
+            log::error!("gRPC node: {}, connect err: {:?}", &grpc_addr, err);
+            Status::internal("connect to gRPC node error".to_string())
+        })?;
+    Ok(channel)
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -28,6 +28,7 @@ pub mod enrichment_table;
 pub mod exporter;
 pub mod file_list;
 pub mod functions;
+pub mod grpc;
 pub mod ingestion;
 pub mod kv;
 pub mod logs;

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -34,7 +34,6 @@ use proto::cluster_rpc;
 use tonic::{
     codec::CompressionEncoding,
     metadata::{MetadataKey, MetadataValue},
-    transport::Channel,
     Request,
 };
 use tracing::{info_span, Instrument};
@@ -43,6 +42,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use crate::{
     common::infra::cluster,
     service::{
+        grpc::get_cached_channel,
         promql::{micros, value::*, MetricsQueryRequest, DEFAULT_LOOKBACK},
         search::{server_internal_error, MetadataMap},
         usage::report_request_usage_stats,
@@ -178,23 +178,17 @@ async fn search_in_cluster(
                 let token: MetadataValue<_> = cluster::get_internal_grpc_token()
                     .parse()
                     .map_err(|_| Error::Message("invalid token".to_string()))?;
-                let channel = Channel::from_shared(node_addr)
-                    .unwrap()
-                    .connect_timeout(std::time::Duration::from_secs(cfg.grpc.connect_timeout))
-                    .connect()
-                    .await
-                    .map_err(|err| {
-                        log::error!(
-                            "promql->search->grpc: node: {}, connect err: {:?}",
-                            &node.grpc_addr,
-                            err
-                        );
-                        server_internal_error("connect search node error")
-                    })?;
-
-                    let mut client = cluster_rpc::metrics_client::MetricsClient::with_interceptor(
-                        channel,
-                        move |mut req: Request<()>| {
+                let channel = get_cached_channel(&node_addr).await.map_err(|err| {
+                    log::error!(
+                        "promql->search->grpc: node: {}, connect err: {:?}",
+                        &node.grpc_addr,
+                        err
+                    );
+                    server_internal_error("connect search node error")
+                })?;
+                let mut client = cluster_rpc::metrics_client::MetricsClient::with_interceptor(
+                    channel,
+                    move |mut req: Request<()>| {
                         req.metadata_mut().insert("authorization", token.clone());
                         req.metadata_mut()
                             .insert(org_header_key.clone(), org_id.clone());

--- a/src/service/search/cluster/cache_multi.rs
+++ b/src/service/search/cluster/cache_multi.rs
@@ -18,12 +18,15 @@ use std::str::FromStr;
 use config::{cluster::LOCAL_NODE, get_config};
 use infra::errors::{Error, ErrorCodes};
 use proto::cluster_rpc::{self, QueryCacheRequest};
-use tonic::{codec::CompressionEncoding, metadata::MetadataValue, transport::Channel, Request};
+use tonic::{codec::CompressionEncoding, metadata::MetadataValue, Request};
 use tracing::{info_span, Instrument};
 
 use crate::{
     common::meta::search::{CacheQueryRequest, CachedQueryResponse, ResultCacheSelectionStrategy},
-    service::search::infra_cluster,
+    service::{
+        grpc::get_cached_channel,
+        search::{infra_cluster, server_internal_error},
+    },
 };
 
 #[tracing::instrument(name = "service:search:cluster:cacher:get_cached_results", skip_all)]
@@ -93,19 +96,14 @@ pub async fn get_cached_results(
                 let token: MetadataValue<_> = infra_cluster::get_internal_grpc_token()
                     .parse()
                     .map_err(|_| Error::Message("invalid token".to_string()))?;
-                let channel = Channel::from_shared(node_addr)
-                    .unwrap()
-                    .connect_timeout(std::time::Duration::from_secs(cfg.grpc.connect_timeout))
-                    .connect()
-                    .await
-                    .map_err(|err| {
-                        log::error!(
-                            "[trace_id {trace_id}] get_cached_results->grpc: node: {}, connect err: {:?}",
-                            &node.grpc_addr,
-                            err
-                        );
-                        super::super::server_internal_error("connect search node error")
-                    })?;
+                let channel = get_cached_channel(&node_addr).await.map_err(|err| {
+                    log::error!(
+                        "[trace_id {trace_id}] get_cached_results->grpc: node: {}, connect err: {:?}",
+                        &node.grpc_addr,
+                        err
+                    );
+                    server_internal_error("connect search node error")
+                })?;
                 let mut client =
                     cluster_rpc::query_cache_client::QueryCacheClient::with_interceptor(
                         channel,

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -16,12 +16,15 @@
 use config::cluster::LOCAL_NODE;
 use infra::errors::{Error, ErrorCodes};
 use proto::cluster_rpc::{self, DeleteResultCacheRequest, QueryCacheRequest};
-use tonic::{codec::CompressionEncoding, metadata::MetadataValue, transport::Channel, Request};
+use tonic::{codec::CompressionEncoding, metadata::MetadataValue, Request};
 use tracing::{info_span, Instrument};
 
 use crate::{
     common::meta::search::{CacheQueryRequest, CachedQueryResponse},
-    service::search::infra_cluster,
+    service::{
+        grpc::get_cached_channel,
+        search::{infra_cluster, server_internal_error},
+    },
 };
 
 #[tracing::instrument(name = "service:search:cluster:cacher:get_cached_results", skip_all)]
@@ -92,19 +95,14 @@ pub async fn get_cached_results(
                 let token: MetadataValue<_> = infra_cluster::get_internal_grpc_token()
                     .parse()
                     .map_err(|_| Error::Message("invalid token".to_string()))?;
-                let channel = Channel::from_shared(node_addr)
-                    .unwrap()
-                    .connect_timeout(std::time::Duration::from_secs(cfg.grpc.connect_timeout))
-                    .connect()
-                    .await
-                    .map_err(|err| {
-                        log::error!(
-                            "[trace_id {trace_id}] get_cached_results->grpc: node: {}, connect err: {:?}",
-                            &node.grpc_addr,
-                            err
-                        );
-                        super::super::server_internal_error("connect search node error")
-                    })?;
+                let channel = get_cached_channel(&node_addr).await.map_err(|err| {
+                    log::error!(
+                        "[trace_id {trace_id}] get_cached_results->grpc: node: {}, connect err: {:?}",
+                        &node.grpc_addr,
+                        err
+                    );
+                    server_internal_error("connect search node error")
+                })?;
                 let mut client =
                     cluster_rpc::query_cache_client::QueryCacheClient::with_interceptor(
                         channel,
@@ -309,19 +307,14 @@ pub async fn delete_cached_results(path: String) -> bool {
                 let token: MetadataValue<_> = infra_cluster::get_internal_grpc_token()
                     .parse()
                     .map_err(|_| Error::Message("invalid token".to_string()))?;
-                let channel = Channel::from_shared(node_addr)
-                    .unwrap()
-                    .connect_timeout(std::time::Duration::from_secs(cfg.grpc.connect_timeout))
-                    .connect()
-                    .await
-                    .map_err(|err| {
-                        log::error!(
-                            "[trace_id {trace_id}] delete_cached_results->grpc: node: {}, connect err: {:?}",
-                            &node.grpc_addr,
-                            err
-                        );
-                        super::super::server_internal_error("connect search node error")
-                    })?;
+                let channel = get_cached_channel(&node_addr).await.map_err(|err| {
+                    log::error!(
+                        "[trace_id {trace_id}] delete_cached_results->grpc: node: {}, connect err: {:?}",
+                        &node.grpc_addr,
+                        err
+                    );
+                    server_internal_error("connect search node error")
+                })?;
                 let mut client =
                     cluster_rpc::query_cache_client::QueryCacheClient::with_interceptor(
                         channel,

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -41,7 +41,6 @@ use proto::cluster_rpc;
 use tonic::{
     codec::CompressionEncoding,
     metadata::{MetadataKey, MetadataValue},
-    transport::Channel,
     Request,
 };
 use tracing::{info_span, Instrument};
@@ -51,8 +50,10 @@ use crate::{
     common::infra::cluster as infra_cluster,
     service::{
         file_list,
+        grpc::get_cached_channel,
         search::{
-            generate_search_schema, generate_select_start_search_schema, sql::RE_SELECT_WILDCARD,
+            generate_search_schema, generate_select_start_search_schema, server_internal_error,
+            sql::RE_SELECT_WILDCARD,
         },
     },
 };
@@ -432,15 +433,10 @@ pub async fn search(
                 let token: MetadataValue<_> = infra_cluster::get_internal_grpc_token()
                     .parse()
                     .map_err(|_| Error::Message("invalid token".to_string()))?;
-                let channel = Channel::from_shared(node_addr)
-                    .unwrap()
-                    .connect_timeout(std::time::Duration::from_secs(cfg.grpc.connect_timeout))
-                    .connect()
-                    .await
-                    .map_err(|err| {
-                        log::error!("[trace_id {trace_id}] search->grpc: node: {}, connect err: {:?}", &node.grpc_addr, err);
-                        super::server_internal_error("connect search node error")
-                    })?;
+                let channel = get_cached_channel(&node_addr).await.map_err(|err| {
+                    log::error!("[trace_id {trace_id}] search->grpc: node: {}, connect err: {:?}", &node.grpc_addr, err);
+                    server_internal_error("connect search node error")
+                })?;
                 let mut client = cluster_rpc::search_client::SearchClient::with_interceptor(
                     channel,
                     move |mut req: Request<()>| {

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -392,19 +392,14 @@ pub async fn query_status() -> Result<search::QueryStatusResponse, Error> {
                 let token: MetadataValue<_> = infra_cluster::get_internal_grpc_token()
                     .parse()
                     .map_err(|_| Error::Message("invalid token".to_string()))?;
-                let channel = Channel::from_shared(node_addr)
-                    .unwrap()
-                    .connect_timeout(std::time::Duration::from_secs(cfg.grpc.connect_timeout))
-                    .connect()
-                    .await
-                    .map_err(|err| {
-                        log::error!(
-                            "search->grpc: node: {}, connect err: {:?}",
-                            &node.grpc_addr,
-                            err
-                        );
-                        server_internal_error("connect search node error")
-                    })?;
+                let channel = get_cached_channel(&node_addr).await.map_err(|err| {
+                    log::error!(
+                        "search->grpc: node: {}, connect err: {:?}",
+                        &node.grpc_addr,
+                        err
+                    );
+                    server_internal_error("connect search node error")
+                })?;
                 let mut client = cluster_rpc::search_client::SearchClient::with_interceptor(
                     channel,
                     move |mut req: Request<()>| {
@@ -555,19 +550,14 @@ pub async fn cancel_query(
                 let token: MetadataValue<_> = infra_cluster::get_internal_grpc_token()
                     .parse()
                     .map_err(|_| Error::Message("invalid token".to_string()))?;
-                let channel = Channel::from_shared(node_addr)
-                    .unwrap()
-                    .connect_timeout(std::time::Duration::from_secs(cfg.grpc.connect_timeout))
-                    .connect()
-                    .await
-                    .map_err(|err| {
-                        log::error!(
-                            "grpc_cancel_query: node: {}, connect err: {:?}",
-                            &node.grpc_addr,
-                            err
-                        );
-                        server_internal_error("connect search node error")
-                    })?;
+                let channel = get_cached_channel(&node_addr).await.map_err(|err| {
+                    log::error!(
+                        "search->cancel_query: node: {}, connect err: {:?}",
+                        &node.grpc_addr,
+                        err
+                    );
+                    server_internal_error("connect search node error")
+                })?;
                 let mut client = cluster_rpc::search_client::SearchClient::with_interceptor(
                     channel,
                     move |mut req: Request<()>| {

--- a/src/service/usage/ingestion_service.rs
+++ b/src/service/usage/ingestion_service.rs
@@ -21,7 +21,7 @@ use tonic::{
     Request,
 };
 
-use crate::{common::infra::cluster, router::grpc::ingest::get_ingester_channel};
+use crate::{common::infra::cluster, service::grpc::get_ingester_channel};
 
 pub async fn ingest(
     dest_org_id: &str,
@@ -36,7 +36,7 @@ pub async fn ingest(
     let token: MetadataValue<_> = cluster::get_internal_grpc_token()
         .parse()
         .map_err(|_| Error::msg("invalid token".to_string()))?;
-    let channel = get_ingester_channel().await?;
+    let (addr, channel) = get_ingester_channel().await?;
     let mut client = cluster_rpc::usage_client::UsageClient::with_interceptor(
         channel,
         move |mut req: Request<()>| {
@@ -54,11 +54,17 @@ pub async fn ingest(
     let res: cluster_rpc::UsageResponse = match client.report_usage(req).await {
         Ok(res) => res.into_inner(),
         Err(err) => {
-            log::error!("[UsageReport] export partial_success response: {:?}", err);
+            log::error!(
+                "[UsageReport] export partial_success node: {addr}, response: {:?}",
+                err
+            );
             if err.code() == tonic::Code::Internal {
                 return Err(err.into());
             }
-            return Err(Error::msg("ingest node error"));
+            return Err(Error::msg(format!(
+                "Ingest node {addr}, response error: {}",
+                err
+            )));
         }
     };
     Ok(res)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities by including ingester addresses in error messages across various services.
	- Introduced a caching mechanism for gRPC channels to improve performance and reduce overhead during connections.

- **Bug Fixes**
	- Improved error handling in the ingestion service by providing clearer context in logs related to specific ingester nodes.

- **Refactor**
	- Streamlined gRPC channel management by centralizing connection logic into a new `get_cached_channel` function.
	- Refactored multiple services to utilize the new channel management approach, enhancing code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->