### PR TITLE
fix: alert improvements

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -894,7 +894,7 @@ pub struct Limit {
     pub keep_alive: u64,
     #[env_config(name = "ZO_ACTIX_SHUTDOWN_TIMEOUT", default = 10)] // seconds
     pub http_shutdown_timeout: u64,
-    #[env_config(name = "ZO_ALERT_SCHEDULE_INTERVAL", default = 60)] // seconds
+    #[env_config(name = "ZO_ALERT_SCHEDULE_INTERVAL", default = 10)] // seconds
     pub alert_schedule_interval: i64,
     #[env_config(name = "ZO_ALERT_SCHEDULE_CONCURRENCY", default = 5)]
     pub alert_schedule_concurrency: i64,

--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -61,6 +61,7 @@ pub struct TriggerData {
     pub end_time: i64,
     pub retries: i32,
     pub error: Option<String>,
+    pub success_response: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -66,7 +66,8 @@ pub async fn run() -> Result<(), anyhow::Error> {
 }
 
 async fn run_schedule_jobs() -> Result<(), anyhow::Error> {
-    let mut interval = time::interval(time::Duration::from_secs(10));
+    let interval = get_config().limit.alert_schedule_interval;
+    let mut interval = time::interval(time::Duration::from_secs(interval as u64));
     interval.tick().await; // trigger the first run
     loop {
         interval.tick().await;

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -66,7 +66,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
 }
 
 async fn run_schedule_jobs() -> Result<(), anyhow::Error> {
-    let mut interval = time::interval(time::Duration::from_secs(30));
+    let mut interval = time::interval(time::Duration::from_secs(10));
     interval.tick().await; // trigger the first run
     loop {
         interval.tick().await;

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -111,7 +111,7 @@ pub async fn save(
     } else if alert.trigger_condition.frequency == 0 {
         // default frequency is 60 seconds
         alert.trigger_condition.frequency =
-            std::cmp::max(10, get_config().limit.alert_schedule_interval);
+            std::cmp::max(60, get_config().limit.alert_schedule_interval);
     }
 
     if alert.name.is_empty() || alert.stream_name.is_empty() {

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -234,10 +234,10 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
     if let Some(data) = ret {
         let vars = get_row_column_map(&data);
         let (alert_start_time, alert_end_time) =
-            get_alert_start_end_time(&vars, alert.trigger_condition.period);
+            get_alert_start_end_time(&vars, alert.trigger_condition.period, end_time);
         trigger_data_stream.start_time = alert_start_time;
         trigger_data_stream.end_time = alert_end_time;
-        match alert.send_notification(&data).await {
+        match alert.send_notification(&data, end_time).await {
             Ok((true, _)) => {
                 log::info!(
                     "Alert notification sent, org: {}, module_key: {}",

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -251,7 +251,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
             error: None,
             success_response: None,
         };
-        match alert.send_notification(val, now).await {
+        match alert.send_notification(val, now, None).await {
             Err(e) => {
                 log::error!("Failed to send notification: {}", e);
                 trigger_data_stream.status = TriggerDataStatus::Failed;

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -250,7 +250,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
             retries: 0,
             error: None,
         };
-        if let Err(e) = alert.send_notification(val).await {
+        if let Err(e) = alert.send_notification(val, now).await {
             log::error!("Failed to send notification: {}", e);
             trigger_data_stream.status = TriggerDataStatus::Failed;
             trigger_data_stream.error = Some(format!("error sending notification for alert: {e}"));

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -249,41 +249,56 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
             end_time: 0,
             retries: 0,
             error: None,
+            success_response: None,
         };
-        if let Err(e) = alert.send_notification(val, now).await {
-            log::error!("Failed to send notification: {}", e);
-            trigger_data_stream.status = TriggerDataStatus::Failed;
-            trigger_data_stream.error = Some(format!("error sending notification for alert: {e}"));
-        } else if alert.trigger_condition.silence > 0 {
-            log::debug!(
-                "Realtime alert {}/{}/{}/{} triggered successfully, hence applying silence period",
-                &alert.org_id,
-                &alert.stream_type,
-                &alert.stream_name,
-                &alert.name
-            );
-
-            let next_run_at = Utc::now().timestamp_micros()
-                + Duration::try_minutes(alert.trigger_condition.silence)
-                    .unwrap()
-                    .num_microseconds()
-                    .unwrap();
-            // After the notification is sent successfully, we need to update
-            // the silence period of the trigger
-            if let Err(e) = db::scheduler::update_trigger(db::scheduler::Trigger {
-                org: alert.org_id.to_string(),
-                module: db::scheduler::TriggerModule::Alert,
-                module_key,
-                is_silenced: true,
-                is_realtime: true,
-                next_run_at,
-                ..Default::default()
-            })
-            .await
-            {
-                log::error!("Failed to update trigger: {}", e);
+        match alert.send_notification(val, now).await {
+            Err(e) => {
+                log::error!("Failed to send notification: {}", e);
+                trigger_data_stream.status = TriggerDataStatus::Failed;
+                trigger_data_stream.error =
+                    Some(format!("error sending notification for alert: {e}"));
             }
-            trigger_data_stream.next_run_at = next_run_at;
+            Ok((success_msg, error_msg)) => {
+                let success_msg = success_msg.trim().to_owned();
+                let error_msg = error_msg.trim().to_owned();
+                if !error_msg.is_empty() {
+                    trigger_data_stream.error = Some(error_msg);
+                }
+                if !success_msg.is_empty() {
+                    trigger_data_stream.success_response = Some(success_msg);
+                }
+                if alert.trigger_condition.silence > 0 {
+                    log::debug!(
+                        "Realtime alert {}/{}/{}/{} triggered successfully, hence applying silence period",
+                        &alert.org_id,
+                        &alert.stream_type,
+                        &alert.stream_name,
+                        &alert.name
+                    );
+
+                    let next_run_at = Utc::now().timestamp_micros()
+                        + Duration::try_minutes(alert.trigger_condition.silence)
+                            .unwrap()
+                            .num_microseconds()
+                            .unwrap();
+                    // After the notification is sent successfully, we need to update
+                    // the silence period of the trigger
+                    if let Err(e) = db::scheduler::update_trigger(db::scheduler::Trigger {
+                        org: alert.org_id.to_string(),
+                        module: db::scheduler::TriggerModule::Alert,
+                        module_key,
+                        is_silenced: true,
+                        is_realtime: true,
+                        next_run_at,
+                        ..Default::default()
+                    })
+                    .await
+                    {
+                        log::error!("Failed to update trigger: {}", e);
+                    }
+                    trigger_data_stream.next_run_at = next_run_at;
+                }
+            }
         }
         trigger_data_stream.end_time = Utc::now().timestamp_micros();
         // Let all the alerts send notifications first

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -378,7 +378,7 @@ async fn write_logs(
                     if evaluated_alerts.contains(&key) {
                         continue;
                     }
-                    if let Ok((Some(v), _)) = alert.evaluate(Some(&record_val)).await {
+                    if let Ok((Some(v), _)) = alert.evaluate(Some(&record_val), None).await {
                         triggers.push((alert.clone(), v));
                         evaluated_alerts.insert(key);
                     }

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -373,7 +373,8 @@ pub async fn handle_grpc_request(
                         if let Some(alerts) = stream_alerts_map.get(&key) {
                             let mut trigger_alerts: TriggerAlertData = Vec::new();
                             for alert in alerts {
-                                if let Ok((Some(v), _)) = alert.evaluate(Some(val_map)).await {
+                                if let Ok((Some(v), _)) = alert.evaluate(Some(val_map), None).await
+                                {
                                     trigger_alerts.push((alert.clone(), v));
                                 }
                             }

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -456,7 +456,9 @@ pub async fn metrics_json_handler(
                             if let Some(alerts) = stream_alerts_map.get(&key) {
                                 let mut trigger_alerts: TriggerAlertData = Vec::new();
                                 for alert in alerts {
-                                    if let Ok((Some(v), _)) = alert.evaluate(Some(val_map)).await {
+                                    if let Ok((Some(v), _)) =
+                                        alert.evaluate(Some(val_map), None).await
+                                    {
                                         trigger_alerts.push((alert.clone(), v));
                                     }
                                 }

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -405,7 +405,7 @@ pub async fn remote_write(
                 if let Some(alerts) = stream_alerts_map.get(&key) {
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
                     for alert in alerts {
-                        if let Ok((Some(v), _)) = alert.evaluate(Some(val_map)).await {
+                        if let Ok((Some(v), _)) = alert.evaluate(Some(val_map), None).await {
                             trigger_alerts.push((alert.clone(), v));
                         }
                     }

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -619,7 +619,7 @@ async fn write_traces(
                     if evaluated_alerts.contains(&key) {
                         continue;
                     }
-                    if let Ok((Some(v), _)) = alert.evaluate(Some(&record_val)).await {
+                    if let Ok((Some(v), _)) = alert.evaluate(Some(&record_val), None).await {
                         triggers.push((alert.clone(), v));
                         evaluated_alerts.insert(key);
                     }


### PR DESCRIPTION
- [x] When an alert is evaluated, if the evaluated records don't contain the timestamp column, the alert start time and end time calculation is little inaccurate. This PR improves this part by using the original end time (used by the querier), when there is no timestamp column.
- [x] Reduce alert run interval
- [x] When error occurs while sending alert to destinations, we already store the error in the `error` field of the triggers stream, in this pr, we are storing the success response as well in the `triggers` stream. The `success_response` field in the triggers stream is a string which looks like - `destination {dest_name} sent status: {response status}, body: {response body}` and is joined with `; ` in case there are success response for multiple destinations.
- [x] Use the end time of the last trigger data to evaluate the alert. This is done to tackle the case when because of the delay in processing of triggers by alert manager, some data go missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced alert notifications with improved timing accuracy based on data processing context.
	- Introduced a new optional field for tracking operation success in alert triggers.
	- Alerts will now be triggered more frequently, every 10 seconds instead of every minute.

- **Bug Fixes**
	- Updated notification logic to ensure proper handling of timestamps, improving reliability.
	- Improved feedback mechanism for alert notifications, capturing success and error messages effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->