### PR TITLE
fix: origin field should not be select

### DIFF
--- a/src/service/search/datafusion/optimizer/rewrite_match.rs
+++ b/src/service/search/datafusion/optimizer/rewrite_match.rs
@@ -141,6 +141,11 @@ impl TreeNodeRewriter for MatchToFullTextMatch {
                         });
                         expr_list.push(new_expr);
                     }
+                    if expr_list.is_empty() {
+                        return Err(DataFusionError::Internal(
+                            infra::errors::ErrorCodes::FullTextSearchFieldNotFound.to_string(),
+                        ));
+                    }
                     let new_expr = disjunction(expr_list).unwrap();
                     Ok(Transformed::yes(new_expr))
                 } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced schema handling to exclude the `_original` column when using the `SELECT *` query, improving data retrieval accuracy.
  
- **Bug Fixes**
	- Improved error handling in the full-text search implementation to ensure robust expression rewriting, raising errors when no valid expressions are generated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->