### PR TITLE
feat: add without connection pool mode for router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,9 +1150,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "awc"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6b67e44fb95d1dc9467e3930383e115f9b4ed60ca689db41409284e967a12d"
+checksum = "79049b2461279b886e46f1107efc347ebecc7b88d74d023dda010551a124967b"
 dependencies = [
  "actix-codec",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ anyhow.workspace = true
 argon2.workspace = true
 async-trait.workspace = true
 async-recursion.workspace = true
-awc = "3.4"
+awc = "3.5"
 base64.workspace = true
 bitvec.workspace = true
 blake3 = { version = "1.4", features = ["rayon"] }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -469,6 +469,8 @@ pub struct Route {
     pub timeout: u64,
     #[env_config(name = "ZO_ROUTE_MAX_CONNECTIONS", default = 1024)]
     pub max_connections: usize,
+    #[env_config(name = "ZO_ROUTE_CONNECTION_POOL_DISABLED", default = false)]
+    pub connection_pool_disabled: bool,
     // zo1-openobserve-ingester.ziox-dev.svc.cluster.local
     #[env_config(name = "ZO_INGESTER_SERVICE_URL", default = "")]
     pub ingester_srv_url: String,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -766,7 +766,7 @@ pub struct Common {
     pub traces_span_metrics_channel_buffer: usize,
     #[env_config(
         name = "ZO_RESULT_CACHE_ENABLED",
-        default = true,
+        default = false,
         help = "Enable result cache for query results"
     )]
     pub result_cache_enabled: bool,

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -143,8 +143,9 @@ async fn check_keepalive(
     req: ServiceRequest,
     next: Next<impl MessageBody>,
 ) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
+    let req_conn_type = req.head().connection_type();
     let mut resp = next.call(req).await?;
-    if resp.status() >= StatusCode::BAD_REQUEST {
+    if resp.status() >= StatusCode::BAD_REQUEST || req_conn_type == ConnectionType::Close {
         resp.response_mut()
             .head_mut()
             .set_connection_type(ConnectionType::Close);

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -164,9 +164,11 @@ async fn dispatch(
             .timeout(std::time::Duration::from_secs(cfg.route.timeout))
             .disable_redirects()
             .finish();
-        let req = client.request_from(new_url.value.clone(), req.head());
-        let req = req.insert_header((awc::http::header::CONNECTION, "close"));
-        req.send_stream(payload).await
+        client
+            .request_from(new_url.value.clone(), req.head())
+            .insert_header((awc::http::header::CONNECTION, "close"))
+            .send_stream(payload)
+            .await
     } else {
         client
             .request_from(new_url.value.clone(), req.head())

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -158,10 +158,22 @@ async fn dispatch(
     }
 
     // send query
-    let resp = client
-        .request_from(new_url.value.clone(), req.head())
-        .send_stream(payload)
-        .await;
+    let cfg = get_config();
+    let resp = if cfg.route.connection_pool_disabled {
+        let client = awc::Client::builder()
+            .timeout(std::time::Duration::from_secs(cfg.route.timeout))
+            .disable_redirects()
+            .finish();
+        client
+            .request_from(new_url.value.clone(), req.head())
+            .send_stream(payload)
+            .await
+    } else {
+        client
+            .request_from(new_url.value.clone(), req.head())
+            .send_stream(payload)
+            .await
+    };
     if let Err(e) = resp {
         log::error!(
             "dispatch: {}, error: {}, took: {} ms",

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -163,12 +163,10 @@ async fn dispatch(
         let client = awc::Client::builder()
             .timeout(std::time::Duration::from_secs(cfg.route.timeout))
             .disable_redirects()
-            .add_default_header((awc::http::header::CONNECTION, "close"))
             .finish();
-        client
-            .request_from(new_url.value.clone(), req.head())
-            .send_stream(payload)
-            .await
+        let req = client.request_from(new_url.value.clone(), req.head());
+        let req = req.insert_header((awc::http::header::CONNECTION, "close"));
+        req.send_stream(payload).await
     } else {
         client
             .request_from(new_url.value.clone(), req.head())

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -163,6 +163,7 @@ async fn dispatch(
         let client = awc::Client::builder()
             .timeout(std::time::Duration::from_secs(cfg.route.timeout))
             .disable_redirects()
+            .add_default_header((awc::http::header::CONNECTION, "close"))
             .finish();
         client
             .request_from(new_url.value.clone(), req.head())


### PR DESCRIPTION
Add new ENV to control if disable connection pool of router
```
ZO_ROUTE_CONNECTION_POOL_DISABLED=false
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration option to enable or disable connection pooling via the `ZO_ROUTE_CONNECTION_POOL_DISABLED` environment variable.
	- Added a new logic structure for handling HTTP requests based on connection pool settings, allowing for more flexible client configurations.

- **Bug Fixes**
	- Enhanced connection management by updating the conditions for closing connections based on request types and response statuses.

- **Chores**
	- Updated the `awc` dependency version from `3.4` to `3.5`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->