### PR TITLE
fix: compactor with puffin

### DIFF
--- a/src/infra/src/storage/mod.rs
+++ b/src/infra/src/storage/mod.rs
@@ -100,7 +100,12 @@ pub async fn del(files: &[&str]) -> Result<(), anyhow::Error> {
                     log::debug!("Deleted object: {}", file);
                 }
                 Err(e) => {
-                    log::error!("Failed to delete object: {:?}", e);
+                    // TODO: need a better solution for identifying the error
+                    if file.ends_with(".puffin") {
+                        // ignore puffin file deletion error
+                    } else {
+                        log::error!("Failed to delete object: {:?}", e);
+                    }
                 }
             }
         })


### PR DESCRIPTION
fixed #4614

The reason is when we delete a parquet file we need to delete the related puffin file. but we have no puffin file list, we don't know if the parquet generated puffin file. 

Now i just skip the error. but we need a better solution:

Maybe we need log the puffin file into `file_list`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during object deletion by selectively ignoring errors for ".puffin" files, enhancing user experience by reducing unnecessary error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->