### PR TITLE
feat: check indices exists before running create index commands

### DIFF
--- a/src/infra/src/db/mod.rs
+++ b/src/infra/src/db/mod.rs
@@ -36,7 +36,7 @@ pub static NO_NEED_WATCH: bool = false;
 static DEFAULT: OnceCell<Box<dyn Db>> = OnceCell::const_new();
 static CLUSTER_COORDINATOR: OnceCell<Box<dyn Db>> = OnceCell::const_new();
 static SUPER_CLUSTER: OnceCell<Box<dyn Db>> = OnceCell::const_new();
-static INDICES: OnceCell<HashSet<DBIndex>> = OnceCell::const_new();
+pub static INDICES: OnceCell<HashSet<DBIndex>> = OnceCell::const_new();
 
 pub async fn get_db() -> &'static Box<dyn Db> {
     DEFAULT.get_or_init(default).await
@@ -237,12 +237,12 @@ pub struct MetaRecord {
 }
 
 #[derive(Hash, Clone, Eq, PartialEq)]
-struct DBIndex {
-    name: String,
-    table: String,
+pub struct DBIndex {
+    pub name: String,
+    pub table: String,
 }
 
-async fn cache_indices_mysql(pool: &Pool<MySql>) -> HashSet<DBIndex> {
+pub async fn cache_indices_mysql(pool: &Pool<MySql>) -> HashSet<DBIndex> {
     let sql = r#"SELECT INDEX_NAME,TABLE_NAME FROM information_schema.statistics;"#;
     let res = sqlx::query_as::<_, (String, String)>(&sql)
         .fetch_all(pool)
@@ -256,7 +256,7 @@ async fn cache_indices_mysql(pool: &Pool<MySql>) -> HashSet<DBIndex> {
     }
 }
 
-async fn cache_indices_pg(pool: &Pool<Postgres>) -> HashSet<DBIndex> {
+pub async fn cache_indices_pg(pool: &Pool<Postgres>) -> HashSet<DBIndex> {
     let sql = r#"SELECT indexname, tablename FROM pg_indexes;"#;
     let res = sqlx::query_as::<_, (String, String)>(&sql)
         .fetch_all(pool)
@@ -270,7 +270,7 @@ async fn cache_indices_pg(pool: &Pool<Postgres>) -> HashSet<DBIndex> {
     }
 }
 
-async fn cache_indices_sqlite(pool: &Pool<Sqlite>) -> HashSet<DBIndex> {
+pub async fn cache_indices_sqlite(pool: &Pool<Sqlite>) -> HashSet<DBIndex> {
     let sql = r#"SELECT name,tbl_name FROM sqlite_master where type = 'index';"#;
     let res = sqlx::query_as::<_, (String, String)>(&sql)
         .fetch_all(pool)

--- a/src/infra/src/db/mod.rs
+++ b/src/infra/src/db/mod.rs
@@ -244,7 +244,7 @@ pub struct DBIndex {
 
 pub async fn cache_indices_mysql(pool: &Pool<MySql>) -> HashSet<DBIndex> {
     let sql = r#"SELECT INDEX_NAME,TABLE_NAME FROM information_schema.statistics;"#;
-    let res = sqlx::query_as::<_, (String, String)>(&sql)
+    let res = sqlx::query_as::<_, (String, String)>(sql)
         .fetch_all(pool)
         .await;
     match res {
@@ -258,7 +258,7 @@ pub async fn cache_indices_mysql(pool: &Pool<MySql>) -> HashSet<DBIndex> {
 
 pub async fn cache_indices_pg(pool: &Pool<Postgres>) -> HashSet<DBIndex> {
     let sql = r#"SELECT indexname, tablename FROM pg_indexes;"#;
-    let res = sqlx::query_as::<_, (String, String)>(&sql)
+    let res = sqlx::query_as::<_, (String, String)>(sql)
         .fetch_all(pool)
         .await;
     match res {
@@ -272,7 +272,7 @@ pub async fn cache_indices_pg(pool: &Pool<Postgres>) -> HashSet<DBIndex> {
 
 pub async fn cache_indices_sqlite(pool: &Pool<Sqlite>) -> HashSet<DBIndex> {
     let sql = r#"SELECT name,tbl_name FROM sqlite_master where type = 'index';"#;
-    let res = sqlx::query_as::<_, (String, String)>(&sql)
+    let res = sqlx::query_as::<_, (String, String)>(sql)
         .fetch_all(pool)
         .await;
     match res {

--- a/src/infra/src/db/mod.rs
+++ b/src/infra/src/db/mod.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -35,7 +35,6 @@ pub static NO_NEED_WATCH: bool = false;
 static DEFAULT: OnceCell<Box<dyn Db>> = OnceCell::const_new();
 static CLUSTER_COORDINATOR: OnceCell<Box<dyn Db>> = OnceCell::const_new();
 static SUPER_CLUSTER: OnceCell<Box<dyn Db>> = OnceCell::const_new();
-static INDICES: OnceCell<HashSet<DBIndex>> = OnceCell::const_new();
 
 pub async fn get_db() -> &'static Box<dyn Db> {
     DEFAULT.get_or_init(default).await

--- a/src/infra/src/db/mod.rs
+++ b/src/infra/src/db/mod.rs
@@ -19,7 +19,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use config::{get_config, meta::meta_store::MetaStore};
 use hashbrown::HashMap;
-use sqlx::{MySql, Pool, Postgres, Sqlite};
 use tokio::sync::{mpsc, OnceCell};
 
 use crate::errors::{DbError, Error, Result};
@@ -240,48 +239,6 @@ pub struct MetaRecord {
 pub struct DBIndex {
     pub name: String,
     pub table: String,
-}
-
-pub async fn cache_indices_mysql(pool: &Pool<MySql>) -> HashSet<DBIndex> {
-    let sql = r#"SELECT INDEX_NAME,TABLE_NAME FROM information_schema.statistics;"#;
-    let res = sqlx::query_as::<_, (String, String)>(sql)
-        .fetch_all(pool)
-        .await;
-    match res {
-        Ok(r) => r
-            .into_iter()
-            .map(|(name, table)| DBIndex { name, table })
-            .collect(),
-        Err(_) => HashSet::new(),
-    }
-}
-
-pub async fn cache_indices_pg(pool: &Pool<Postgres>) -> HashSet<DBIndex> {
-    let sql = r#"SELECT indexname, tablename FROM pg_indexes;"#;
-    let res = sqlx::query_as::<_, (String, String)>(sql)
-        .fetch_all(pool)
-        .await;
-    match res {
-        Ok(r) => r
-            .into_iter()
-            .map(|(name, table)| DBIndex { name, table })
-            .collect(),
-        Err(_) => HashSet::new(),
-    }
-}
-
-pub async fn cache_indices_sqlite(pool: &Pool<Sqlite>) -> HashSet<DBIndex> {
-    let sql = r#"SELECT name,tbl_name FROM sqlite_master where type = 'index';"#;
-    let res = sqlx::query_as::<_, (String, String)>(sql)
-        .fetch_all(pool)
-        .await;
-    match res {
-        Ok(r) => r
-            .into_iter()
-            .map(|(name, table)| DBIndex { name, table })
-            .collect(),
-        Err(_) => HashSet::new(),
-    }
 }
 
 #[cfg(test)]

--- a/src/infra/src/db/mod.rs
+++ b/src/infra/src/db/mod.rs
@@ -35,7 +35,7 @@ pub static NO_NEED_WATCH: bool = false;
 static DEFAULT: OnceCell<Box<dyn Db>> = OnceCell::const_new();
 static CLUSTER_COORDINATOR: OnceCell<Box<dyn Db>> = OnceCell::const_new();
 static SUPER_CLUSTER: OnceCell<Box<dyn Db>> = OnceCell::const_new();
-pub static INDICES: OnceCell<HashSet<DBIndex>> = OnceCell::const_new();
+static INDICES: OnceCell<HashSet<DBIndex>> = OnceCell::const_new();
 
 pub async fn get_db() -> &'static Box<dyn Db> {
     DEFAULT.get_or_init(default).await
@@ -236,9 +236,9 @@ pub struct MetaRecord {
 }
 
 #[derive(Hash, Clone, Eq, PartialEq)]
-pub struct DBIndex {
-    pub name: String,
-    pub table: String,
+struct DBIndex {
+    name: String,
+    table: String,
 }
 
 #[cfg(test)]

--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -24,12 +24,13 @@ use sqlx::{
     mysql::{MySqlConnectOptions, MySqlPoolOptions},
     ConnectOptions, MySql, Pool,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, OnceCell};
 
-use super::{DBIndex, INDICES};
+use super::DBIndex;
 use crate::errors::*;
 
 pub static CLIENT: Lazy<Pool<MySql>> = Lazy::new(connect);
+static INDICES: OnceCell<HashSet<DBIndex>> = OnceCell::const_new();
 
 fn connect() -> Pool<MySql> {
     let cfg = config::get_config();

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -51,7 +51,7 @@ fn connect() -> Pool<Postgres> {
         .connect_lazy_with(db_opts)
 }
 
-pub async fn cache_indices(pool: &Pool<Postgres>) -> HashSet<DBIndex> {
+async fn cache_indices(pool: &Pool<Postgres>) -> HashSet<DBIndex> {
     let sql = r#"SELECT indexname, tablename FROM pg_indexes;"#;
     let res = sqlx::query_as::<_, (String, String)>(sql)
         .fetch_all(pool)
@@ -540,7 +540,6 @@ impl super::Db for PostgresDb {
 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
-    let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
 
     // create table
     _ = sqlx::query(
@@ -568,48 +567,30 @@ CREATE TABLE IF NOT EXISTS meta
     }
 
     // create table index
-    if !indices.contains(&DBIndex {
-        name: "meta_module_idx".into(),
-        table: "meta".into(),
-    }) {
-        create_index_item("CREATE INDEX IF NOT EXISTS meta_module_idx on meta (module);").await?;
-    }
-    if !indices.contains(&DBIndex {
-        name: "meta_module_key1_idx".into(),
-        table: "meta".into(),
-    }) {
-        create_index_item(
-            "CREATE INDEX IF NOT EXISTS meta_module_key1_idx on meta (module, key1);",
-        )
-        .await?;
-    }
-    if !indices.contains(&DBIndex {
-        name: "meta_module_start_dt_idx".into(),
-        table: "meta".into(),
-    }) {
-        create_index_item(
-        "CREATE UNIQUE INDEX IF NOT EXISTS meta_module_start_dt_idx on meta (module, key1, key2, start_dt);",
+    create_index(&pool, "meta_module_idx", "meta", false, &["module"]).await?;
+    create_index(
+        &pool,
+        "meta_module_key1_idx",
+        "meta",
+        false,
+        &["module", "key1"],
     )
     .await?;
-    }
+    create_index(
+        &pool,
+        "meta_module_start_dt_idx",
+        "meta",
+        true,
+        &["module", "key1", "key2", "start_dt"],
+    )
+    .await?;
 
-    Ok(())
-}
-
-async fn create_index_item(sql: &str) -> Result<()> {
-    let pool = CLIENT.clone();
-    if let Err(e) = sqlx::query(sql).execute(&pool).await {
-        log::error!("[POSTGRES] create table meta index error: {}", e);
-        return Err(e.into());
-    }
     Ok(())
 }
 
 async fn add_start_dt_column() -> Result<()> {
     let pool = CLIENT.clone();
     let mut tx = pool.begin().await?;
-    let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
-
     if let Err(e) = sqlx::query(
         r#"ALTER TABLE meta ADD COLUMN IF NOT EXISTS start_dt BIGINT NOT NULL DEFAULT 0;"#,
     )
@@ -622,47 +603,19 @@ async fn add_start_dt_column() -> Result<()> {
         }
         return Err(e.into());
     }
+    tx.commit().await?;
 
     // Proceed to drop the index if it exists and create a new one if it does not exist
-    if indices.contains(&DBIndex {
-        name: "meta_module_start_dt_idx".into(),
-        table: "meta".into(),
-    }) {
-        if let Err(e) = sqlx::query(
-        r#"CREATE UNIQUE INDEX IF NOT EXISTS meta_module_start_dt_idx ON meta (module, key1, key2, start_dt);"#
+    create_index(
+        &pool,
+        "meta_module_start_dt_idx",
+        "meta",
+        true,
+        &["module", "key1", "key2", "start_dt"],
     )
-    .execute(&mut *tx)
-    .await {
-        log::error!("[POSTGRES] Error in adding index meta_module_start_dt_idx: {}", e);
-        if let Err(e) = tx.rollback().await {
-            log::error!("[POSTGRES] Error in rolling back transaction: {}", e);
-        }
-        return Err(e.into());
-    }
-    }
-    if indices.contains(&DBIndex {
-        name: "meta_module_key2_idx".into(),
-        table: "meta".into(),
-    }) {
-        if let Err(e) = sqlx::query(r#"DROP INDEX IF EXISTS meta_module_key2_idx;"#)
-            .execute(&mut *tx)
-            .await
-        {
-            log::error!(
-                "[POSTGRES] Error in dropping index meta_module_key2_idx: {}",
-                e
-            );
-            if let Err(e) = tx.rollback().await {
-                log::error!("[POSTGRES] Error in rolling back transaction: {}", e);
-            }
-            return Err(e.into());
-        }
-    }
+    .await?;
+    delete_index(&pool, "meta_module_key2_idx", "meta").await?;
 
-    if let Err(e) = tx.commit().await {
-        log::info!("[POSTGRES] Error in committing transaction: {}", e);
-        return Err(e.into());
-    };
     Ok(())
 }
 
@@ -689,5 +642,48 @@ async fn create_meta_backup() -> Result<()> {
         );
         return Err(e.into());
     }
+    Ok(())
+}
+
+pub async fn create_index(
+    client: &Pool<Postgres>,
+    idx_name: &str,
+    table: &str,
+    unique: bool,
+    fields: &[&str],
+) -> Result<()> {
+    let indices = INDICES.get_or_init(|| cache_indices(client)).await;
+    if indices.contains(&DBIndex {
+        name: idx_name.into(),
+        table: table.into(),
+    }) {
+        return Ok(());
+    }
+    let unique_str = if unique { "UNIQUE" } else { "" };
+    log::info!("[POSTGRES] creating index {} on table {}", idx_name, table);
+    let sql = format!(
+        "CREATE {} INDEX IF NOT EXISTS {} ON {} ({});",
+        unique_str,
+        idx_name,
+        table,
+        fields.join(",")
+    );
+    sqlx::query(&sql).execute(client).await?;
+    log::info!("[POSTGRES] index {} created successfully", idx_name);
+    Ok(())
+}
+
+pub async fn delete_index(client: &Pool<Postgres>, idx_name: &str, table: &str) -> Result<()> {
+    let indices = INDICES.get_or_init(|| cache_indices(client)).await;
+    if !indices.contains(&DBIndex {
+        name: idx_name.into(),
+        table: table.into(),
+    }) {
+        return Ok(());
+    }
+    log::info!("[POSTGRES] deleting index {} on table {}", idx_name, table);
+    let sql = format!("DROP INDEX IF EXISTS {};", idx_name,);
+    sqlx::query(&sql).execute(client).await?;
+    log::info!("[POSTGRES] index {} deleted successfully", idx_name);
     Ok(())
 }

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -24,12 +24,13 @@ use sqlx::{
     postgres::{PgConnectOptions, PgPoolOptions},
     ConnectOptions, Pool, Postgres,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, OnceCell};
 
-use super::{DBIndex, INDICES};
+use super::DBIndex;
 use crate::errors::*;
 
 pub static CLIENT: Lazy<Pool<Postgres>> = Lazy::new(connect);
+static INDICES: OnceCell<HashSet<DBIndex>> = OnceCell::const_new();
 
 fn connect() -> Pool<Postgres> {
     let cfg = config::get_config();

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -27,9 +27,9 @@ use sqlx::{
     },
     Pool, Sqlite,
 };
-use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::sync::{mpsc, Mutex, OnceCell, RwLock};
 
-use super::{DBIndex, INDICES};
+use super::DBIndex;
 use crate::{
     db::{Event, EventData},
     errors::*,
@@ -38,6 +38,8 @@ use crate::{
 pub static CLIENT_RO: Lazy<Pool<Sqlite>> = Lazy::new(connect_ro);
 pub static CLIENT_RW: Lazy<Arc<Mutex<Pool<Sqlite>>>> =
     Lazy::new(|| Arc::new(Mutex::new(connect_rw())));
+static INDICES: OnceCell<HashSet<DBIndex>> = OnceCell::const_new();
+
 pub static CHANNEL: Lazy<SqliteDbChannel> = Lazy::new(SqliteDbChannel::new);
 
 static WATCHERS: Lazy<RwLock<FxIndexMap<String, EventChannel>>> =

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -97,7 +97,7 @@ fn connect_ro() -> Pool<Sqlite> {
         .connect_lazy_with(db_opts)
 }
 
-pub async fn cache_indices(pool: &Pool<Sqlite>) -> HashSet<DBIndex> {
+async fn cache_indices(pool: &Pool<Sqlite>) -> HashSet<DBIndex> {
     let sql = r#"SELECT name,tbl_name FROM sqlite_master where type = 'index';"#;
     let res = sqlx::query_as::<_, (String, String)>(sql)
         .fetch_all(pool)
@@ -700,7 +700,6 @@ impl super::Db for SqliteDb {
 async fn create_table() -> Result<()> {
     let client = CLIENT_RW.clone();
     let client = client.lock().await;
-    let indices = INDICES.get_or_init(|| cache_indices(&client)).await;
     // create table
     sqlx::query(
         r#"
@@ -722,39 +721,28 @@ CREATE TABLE IF NOT EXISTS meta
     add_start_dt_column(&client).await?;
 
     // create table index
-    if !indices.contains(&DBIndex {
-        name: "meta_module_idx".into(),
-        table: "meta".into(),
-    }) {
-        sqlx::query(r#"CREATE INDEX IF NOT EXISTS meta_module_idx on meta (module);"#)
-            .execute(&*client)
-            .await?;
-    }
-    if !indices.contains(&DBIndex {
-        name: "meta_module_key1_idx".into(),
-        table: "meta".into(),
-    }) {
-        sqlx::query(r#"CREATE INDEX IF NOT EXISTS meta_module_key1_idx on meta (module, key1);"#)
-            .execute(&*client)
-            .await?;
-    }
-
-    if !indices.contains(&DBIndex {
-        name: "meta_module_start_dt_idx".into(),
-        table: "meta".into(),
-    }) {
-        sqlx::query(
-            r#"CREATE UNIQUE INDEX IF NOT EXISTS meta_module_start_dt_idx on meta (module, key1, key2, start_dt);"#,
-        )
-        .execute(&*client)
-        .await?;
-    }
+    create_index(&client, "meta_module_idx", "meta", false, &["module"]).await?;
+    create_index(
+        &client,
+        "meta_module_key1_idx",
+        "meta",
+        false,
+        &["module", "key1"],
+    )
+    .await?;
+    create_index(
+        &client,
+        "meta_module_start_dt_idx",
+        "meta",
+        true,
+        &["module", "key1", "key2", "start_dt"],
+    )
+    .await?;
 
     Ok(())
 }
 
 async fn add_start_dt_column(client: &Pool<Sqlite>) -> Result<()> {
-    let indices = INDICES.get_or_init(|| cache_indices(client)).await;
     // Attempt to add the column, ignoring the error if the column already exists
     if let Err(e) =
         sqlx::query(r#"ALTER TABLE meta ADD COLUMN start_dt INTEGER NOT NULL DEFAULT 0;"#)
@@ -769,24 +757,15 @@ async fn add_start_dt_column(client: &Pool<Sqlite>) -> Result<()> {
     }
 
     // Proceed to drop the index if it exists and create a new one if it does not exist
-    if !indices.contains(&DBIndex {
-        name: "meta_module_start_dt_idx".into(),
-        table: "meta".into(),
-    }) {
-        sqlx::query(
-            r#"CREATE UNIQUE INDEX IF NOT EXISTS meta_module_start_dt_idx ON meta (module, key1, key2, start_dt);"#
-        )
-        .execute(client)
-        .await?;
-    }
-    if indices.contains(&DBIndex {
-        name: "meta_module_key2_idx".into(),
-        table: "meta".into(),
-    }) {
-        sqlx::query(r#"DROP INDEX IF EXISTS meta_module_key2_idx;"#)
-            .execute(client)
-            .await?;
-    }
+    create_index(
+    client,
+        "meta_module_start_dt_idx",
+        "meta",
+        true,
+        &["module", "key1", "key2", "start_dt"],
+    )
+    .await?;
+    delete_index(client, "meta_module_key2_idx", "meta").await?;
     Ok(())
 }
 
@@ -812,5 +791,48 @@ async fn create_meta_backup(client: &Pool<Sqlite>) -> Result<()> {
         );
         return Err(e.into());
     }
+    Ok(())
+}
+
+pub async fn create_index(
+    client: &Pool<Sqlite>,
+    idx_name: &str,
+    table: &str,
+    unique: bool,
+    fields: &[&str],
+) -> Result<()> {
+    let indices = INDICES.get_or_init(|| cache_indices(client)).await;
+    if indices.contains(&DBIndex {
+        name: idx_name.into(),
+        table: table.into(),
+    }) {
+        return Ok(());
+    }
+    let unique_str = if unique { "UNIQUE" } else { "" };
+    log::info!("[SQLITE] creating index {} on table {}", idx_name, table);
+    let sql = format!(
+        "CREATE {} INDEX IF NOT EXISTS {} ON {} ({});",
+        unique_str,
+        idx_name,
+        table,
+        fields.join(",")
+    );
+    sqlx::query(&sql).execute(client).await?;
+    log::info!("[SQLITE] index {} created successfully", idx_name);
+    Ok(())
+}
+
+pub async fn delete_index(client: &Pool<Sqlite>, idx_name: &str, table: &str) -> Result<()> {
+    let indices = INDICES.get_or_init(|| cache_indices(client)).await;
+    if !indices.contains(&DBIndex {
+        name: idx_name.into(),
+        table: table.into(),
+    }) {
+        return Ok(());
+    }
+    log::info!("[SQLITE] deleting index {} on table {}", idx_name, table);
+    let sql = format!("DROP INDEX IF EXISTS {};", idx_name,);
+    sqlx::query(&sql).execute(client).await?;
+    log::info!("[SQLITE] index {}deleted successfully", idx_name);
     Ok(())
 }

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -686,7 +686,7 @@ impl super::Db for SqliteDb {
 async fn create_table() -> Result<()> {
     let client = CLIENT_RW.clone();
     let client = client.lock().await;
-    let indices = INDICES.get_or_init(|| cache_indices_sqlite(&*client)).await;
+    let indices = INDICES.get_or_init(|| cache_indices_sqlite(&client)).await;
     // create table
     sqlx::query(
         r#"

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -25,7 +25,10 @@ use hashbrown::HashMap;
 use sqlx::{Executor, MySql, QueryBuilder, Row};
 
 use crate::{
-    db::{cache_indices_mysql, mysql::CLIENT, DBIndex, INDICES},
+    db::{
+        mysql::{cache_indices, CLIENT},
+        DBIndex, INDICES,
+    },
     errors::{DbError, Error, Result},
 };
 
@@ -1192,9 +1195,9 @@ CREATE TABLE IF NOT EXISTS stream_stats
 
 pub async fn create_table_index() -> Result<()> {
     let pool = CLIENT.clone();
-    let indices = INDICES.get_or_init(|| cache_indices_mysql(&pool)).await;
-    // TODO(YJDoc2) create a unified way for creating all kinds of index, use this common check there,
-    // and use that instead of doing queries like this
+    let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
+    // TODO(YJDoc2) create a unified way for creating all kinds of index, use this common check
+    // there, and use that instead of doing queries like this
     let sqls = vec![
         (
             "file_list_org_idx",

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -1224,7 +1224,7 @@ pub async fn create_table_index() -> Result<()> {
         ("stream_stats_org_idx", "stream_stats", &["org"]),
     ];
     for (idx, table, fields) in indices {
-        create_index(&pool, idx, table, false, fields).await?;
+        create_index(idx, table, false, fields).await?;
     }
 
     let unique_indices: Vec<(&str, &str, &[&str])> = vec![
@@ -1241,12 +1241,11 @@ pub async fn create_table_index() -> Result<()> {
         ("stream_stats_stream_idx", "stream_stats", &["stream"]),
     ];
     for (idx, table, fields) in unique_indices {
-        create_index(&pool, idx, table, true, fields).await?;
+        create_index(idx, table, true, fields).await?;
     }
 
     // This is special case where we want to MAKE the index unique if it is not
     let res = create_index(
-        &pool,
         "file_list_stream_file_idx",
         "file_list",
         true,
@@ -1289,7 +1288,6 @@ pub async fn create_table_index() -> Result<()> {
         );
         // create index again
         create_index(
-            &pool,
             "file_list_stream_file_idx",
             "file_list",
             true,

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -25,10 +25,7 @@ use hashbrown::HashMap;
 use sqlx::{Executor, MySql, QueryBuilder, Row};
 
 use crate::{
-    db::{
-        mysql::{cache_indices, CLIENT},
-        DBIndex, INDICES,
-    },
+    db::mysql::{create_index, CLIENT},
     errors::{DbError, Error, Result},
 };
 
@@ -1195,124 +1192,111 @@ CREATE TABLE IF NOT EXISTS stream_stats
 
 pub async fn create_table_index() -> Result<()> {
     let pool = CLIENT.clone();
-    let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
-    // TODO(YJDoc2) create a unified way for creating all kinds of index, use this common check
-    // there, and use that instead of doing queries like this
-    let sqls = vec![
-        (
-            "file_list_org_idx",
-            "file_list",
-            "CREATE INDEX file_list_org_idx on file_list (org);",
-        ),
+
+    let indices: Vec<(&str, &str, &[&str])> = vec![
+        ("file_list_org_idx", "file_list", &["org"]),
         (
             "file_list_stream_ts_idx",
             "file_list",
-            "CREATE INDEX file_list_stream_ts_idx on file_list (stream, max_ts, min_ts);",
+            &["stream", "max_ts", "min_ts"],
         ),
-        (
-            "file_list_history_org_idx",
-            "file_list_history",
-            "CREATE INDEX file_list_history_org_idx on file_list_history (org);",
-        ),
+        ("file_list_history_org_idx", "file_list_history", &["org"]),
         (
             "file_list_history_stream_ts_idx",
             "file_list_history",
-            "CREATE INDEX file_list_history_stream_ts_idx on file_list_history (stream, max_ts, min_ts);",
-        ),
-        (
-            "file_list_history_stream_file_idx",
-            "file_list_history",
-            "CREATE UNIQUE INDEX file_list_history_stream_file_idx on file_list_history (stream, date, file);",
+            &["stream", "max_ts", "min_ts"],
         ),
         (
             "file_list_deleted_created_at_idx",
             "file_list_deleted",
-            "CREATE INDEX file_list_deleted_created_at_idx on file_list_deleted (org, created_at);",
+            &["org", "created_at"],
         ),
         (
             "file_list_deleted_stream_date_file_idx",
             "file_list_deleted",
-            "CREATE INDEX file_list_deleted_stream_date_file_idx on file_list_deleted (stream, date, file);",
-        ),
-        (
-            "file_list_jobs_stream_offsets_idx",
-            "file_list_jobs",
-            "CREATE UNIQUE INDEX file_list_jobs_stream_offsets_idx on file_list_jobs (stream, offsets);",
+            &["stream", "date", "file"],
         ),
         (
             "file_list_jobs_stream_status_idx",
             "file_list_jobs",
-            "CREATE INDEX file_list_jobs_stream_status_idx on file_list_jobs (status, stream);",
+            &["status", "stream"],
         ),
-        (
-            "stream_stats_org_idx",
-            "stream_stats",
-            "CREATE INDEX stream_stats_org_idx on stream_stats (org);",
-        ),
-        (
-            "stream_stats_stream_idx",
-            "stream_stats",
-            "CREATE UNIQUE INDEX stream_stats_stream_idx on stream_stats (stream);",
-        ),
+        ("stream_stats_org_idx", "stream_stats", &["org"]),
     ];
-    for (idx, table, sql) in sqls {
-        if indices.contains(&DBIndex {
-            name: idx.into(),
-            table: table.into(),
-        }) {
-            continue;
-        }
-        if let Err(e) = sqlx::query(sql).execute(&pool).await {
-            if e.to_string().contains("Duplicate key") {
-                // index already exists
-                continue;
-            }
-            log::error!("[MYSQL] create table {} index error: {}", table, e);
-            return Err(e.into());
-        }
+    for (idx, table, fields) in indices {
+        create_index(&pool, idx, table, false, fields).await?;
     }
 
-    // create UNIQUE index for file_list
-    if !indices.contains(&DBIndex {
-        name: "file_list_stream_file_idx".into(),
-        table: "file_list".into(),
-    }) {
-        let unique_index_sql =
-            r#"CREATE UNIQUE INDEX file_list_stream_file_idx on file_list (stream, date, file);"#;
-        if let Err(e) = sqlx::query(unique_index_sql).execute(&pool).await {
-            if e.to_string().contains("Duplicate key") {
-                return Ok(()); // index already exists
-            } else if e.to_string().contains("Duplicate entry") {
-                log::warn!("[MYSQL] starting delete duplicate records");
-                // delete duplicate records
-                let ret = sqlx::query(
+    let unique_indices: Vec<(&str, &str, &[&str])> = vec![
+        (
+            "file_list_history_stream_file_idx",
+            "file_list_history",
+            &["stream", "date", "file"],
+        ),
+        (
+            "file_list_jobs_stream_offsets_idx",
+            "file_list_jobs",
+            &["stream", "offsets"],
+        ),
+        ("stream_stats_stream_idx", "stream_stats", &["stream"]),
+    ];
+    for (idx, table, fields) in unique_indices {
+        create_index(&pool, idx, table, true, fields).await?;
+    }
+
+    // This is special case where we want to MAKE the index unique if it is not
+    let res = create_index(
+        &pool,
+        "file_list_stream_file_idx",
+        "file_list",
+        true,
+        &["stream", "date", "file"],
+    )
+    .await;
+    if let Err(e) = res {
+        if !e.to_string().contains("Duplicate entry") {
+            return Err(e);
+        }
+
+        log::warn!("[MYSQL] starting delete duplicate records");
+        // delete duplicate records
+        let ret = sqlx::query(
                 r#"SELECT stream, date, file, min(id) as id FROM file_list GROUP BY stream, date, file HAVING COUNT(*) > 1;"#,
             ).fetch_all(&pool).await?;
-                log::warn!("[MYSQL] total: {} duplicate records", ret.len());
-                for (i, r) in ret.iter().enumerate() {
-                    let stream = r.get::<String, &str>("stream");
-                    let date = r.get::<String, &str>("date");
-                    let file = r.get::<String, &str>("file");
-                    let id = r.get::<i64, &str>("id");
-                    sqlx::query(
-                    r#"DELETE FROM file_list WHERE id != ? AND stream = ? AND date = ? AND file = ?;"#,
-                ).bind(id).bind(stream).bind(date).bind(file).execute(&pool).await?;
-                    if i / 1000 == 0 {
-                        log::warn!("[MYSQL] delete duplicate records: {}/{}", i, ret.len());
-                    }
-                }
-                log::warn!(
-                    "[MYSQL] delete duplicate records: {}/{}",
-                    ret.len(),
-                    ret.len()
-                );
-                // create index again
-                sqlx::query(unique_index_sql).execute(&pool).await?;
-                log::warn!("[MYSQL] create table index(file_list_stream_file_idx) succeed");
-            } else {
-                return Err(e.into());
+        log::warn!("[MYSQL] total: {} duplicate records", ret.len());
+        for (i, r) in ret.iter().enumerate() {
+            let stream = r.get::<String, &str>("stream");
+            let date = r.get::<String, &str>("date");
+            let file = r.get::<String, &str>("file");
+            let id = r.get::<i64, &str>("id");
+            sqlx::query(
+                r#"DELETE FROM file_list WHERE id != ? AND stream = ? AND date = ? AND file = ?;"#,
+            )
+            .bind(id)
+            .bind(stream)
+            .bind(date)
+            .bind(file)
+            .execute(&pool)
+            .await?;
+            if i % 1000 == 0 {
+                log::warn!("[MYSQL] delete duplicate records: {}/{}", i, ret.len());
             }
         }
+        log::warn!(
+            "[MYSQL] delete duplicate records: {}/{}",
+            ret.len(),
+            ret.len()
+        );
+        // create index again
+        create_index(
+            &pool,
+            "file_list_stream_file_idx",
+            "file_list",
+            true,
+            &["stream", "date", "file"],
+        )
+        .await?;
+        log::warn!("[MYSQL] create table index(file_list_stream_file_idx) succeed");
     }
 
     Ok(())

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -25,7 +25,10 @@ use hashbrown::HashMap;
 use sqlx::{Executor, Postgres, QueryBuilder, Row};
 
 use crate::{
-    db::{cache_indices_pg, postgres::CLIENT, DBIndex, INDICES},
+    db::{
+        postgres::{cache_indices, CLIENT},
+        DBIndex, INDICES,
+    },
     errors::{Error, Result},
 };
 
@@ -1169,7 +1172,7 @@ CREATE TABLE IF NOT EXISTS stream_stats
 
 pub async fn create_table_index() -> Result<()> {
     let pool = CLIENT.clone();
-    let indices = INDICES.get_or_init(|| cache_indices_pg(&pool)).await;
+    let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
     let sqls = vec![
         (
             "file_list_org_idx",

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1201,7 +1201,7 @@ pub async fn create_table_index() -> Result<()> {
         ("stream_stats_org_idx", "stream_stats", &["org"]),
     ];
     for (idx, table, fields) in indices {
-        create_index(&pool, idx, table, false, fields).await?;
+        create_index(idx, table, false, fields).await?;
     }
 
     let unique_indices: Vec<(&str, &str, &[&str])> = vec![
@@ -1218,12 +1218,11 @@ pub async fn create_table_index() -> Result<()> {
         ("stream_stats_stream_idx", "stream_stats", &["stream"]),
     ];
     for (idx, table, fields) in unique_indices {
-        create_index(&pool, idx, table, true, fields).await?;
+        create_index(idx, table, true, fields).await?;
     }
 
     // This is a case where we want to MAKE the index unique if it isn't
     let res = create_index(
-        &pool,
         "file_list_stream_file_idx",
         "file_list",
         true,
@@ -1267,7 +1266,6 @@ pub async fn create_table_index() -> Result<()> {
         );
         // create index again
         create_index(
-            &pool,
             "file_list_stream_file_idx",
             "file_list",
             true,

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -25,10 +25,7 @@ use hashbrown::HashMap;
 use sqlx::{Executor, Postgres, QueryBuilder, Row};
 
 use crate::{
-    db::{
-        postgres::{cache_indices, CLIENT},
-        DBIndex, INDICES,
-    },
+    db::postgres::{create_index, CLIENT},
     errors::{Error, Result},
 };
 
@@ -1172,101 +1169,85 @@ CREATE TABLE IF NOT EXISTS stream_stats
 
 pub async fn create_table_index() -> Result<()> {
     let pool = CLIENT.clone();
-    let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
-    let sqls = vec![
-        (
-            "file_list_org_idx",
-            "file_list",
-            "CREATE INDEX IF NOT EXISTS file_list_org_idx on file_list (org);",
-        ),
+
+    let indices: Vec<(&str, &str, &[&str])> = vec![
+        ("file_list_org_idx", "file_list", &["org"]),
         (
             "file_list_stream_ts_idx",
             "file_list",
-            "CREATE INDEX IF NOT EXISTS file_list_stream_ts_idx on file_list (stream, max_ts, min_ts);",
+            &["stream", "max_ts", "min_ts"],
         ),
-        (
-            "file_list_history_org_idx",
-            "file_list_history",
-            "CREATE INDEX IF NOT EXISTS file_list_history_org_idx on file_list_history (org);",
-        ),
+        ("file_list_history_org_idx", "file_list_history", &["org"]),
         (
             "file_list_history_stream_ts_idx",
             "file_list_history",
-            "CREATE INDEX IF NOT EXISTS file_list_history_stream_ts_idx on file_list_history (stream, max_ts, min_ts);",
-        ),
-        (
-            "file_list_history_stream_file_idx",
-            "file_list_history",
-            "CREATE UNIQUE INDEX IF NOT EXISTS file_list_history_stream_file_idx on file_list_history (stream, date, file);",
+            &["stream", "max_ts", "min_ts"],
         ),
         (
             "file_list_deleted_created_at_idx",
             "file_list_deleted",
-            "CREATE INDEX IF NOT EXISTS file_list_deleted_created_at_idx on file_list_deleted (org, created_at);",
+            &["org", "created_at"],
         ),
         (
             "file_list_deleted_stream_date_file_idx",
             "file_list_deleted",
-            "CREATE INDEX IF NOT EXISTS file_list_deleted_stream_date_file_idx on file_list_deleted (stream, date, file);",
-        ),
-        (
-            "file_list_jobs_stream_offsets_idx",
-            "file_list_jobs",
-            "CREATE UNIQUE INDEX IF NOT EXISTS file_list_jobs_stream_offsets_idx on file_list_jobs (stream, offsets);",
+            &["stream", "date", "file"],
         ),
         (
             "file_list_jobs_stream_status_idx",
             "file_list_jobs",
-            "CREATE INDEX IF NOT EXISTS file_list_jobs_stream_status_idx on file_list_jobs (status, stream);",
+            &["status", "stream"],
         ),
-        (
-            "stream_stats_org_idx",
-            "stream_stats",
-            "CREATE INDEX IF NOT EXISTS stream_stats_org_idx on stream_stats (org);",
-        ),
-        (
-            "stream_stats_stream_idx",
-            "stream_stats",
-            "CREATE UNIQUE INDEX IF NOT EXISTS stream_stats_stream_idx on stream_stats (stream);",
-        ),
+        ("stream_stats_org_idx", "stream_stats", &["org"]),
     ];
-    for (idx, table, sql) in sqls {
-        if indices.contains(&DBIndex {
-            name: idx.into(),
-            table: table.into(),
-        }) {
-            continue;
-        }
-        if let Err(e) = sqlx::query(sql).execute(&pool).await {
-            log::error!("[POSTGRES] create table {} index error: {}", table, e);
-            return Err(e.into());
-        }
+    for (idx, table, fields) in indices {
+        create_index(&pool, idx, table, false, fields).await?;
     }
 
-    // create UNIQUE index for file_list
-    if !indices.contains(&DBIndex {
-        name: "file_list_stream_file_idx".into(),
-        table: "file_list".into(),
-    }) {
-        let unique_index_sql = r#"CREATE UNIQUE INDEX IF NOT EXISTS file_list_stream_file_idx on file_list (stream, date, file);"#;
-        if let Err(e) = sqlx::query(unique_index_sql).execute(&pool).await {
-            if !e.to_string().contains("could not create unique index") {
-                return Err(e.into());
-            }
-            // delete duplicate records
-            log::warn!("[POSTGRES] starting delete duplicate records");
-            let ret = sqlx
+    let unique_indices: Vec<(&str, &str, &[&str])> = vec![
+        (
+            "file_list_history_stream_file_idx",
+            "file_list_history",
+            &["stream", "date", "file"],
+        ),
+        (
+            "file_list_jobs_stream_offsets_idx",
+            "file_list_jobs",
+            &["stream", "offsets"],
+        ),
+        ("stream_stats_stream_idx", "stream_stats", &["stream"]),
+    ];
+    for (idx, table, fields) in unique_indices {
+        create_index(&pool, idx, table, true, fields).await?;
+    }
+
+    // This is a case where we want to MAKE the index unique if it isn't
+    let res = create_index(
+        &pool,
+        "file_list_stream_file_idx",
+        "file_list",
+        true,
+        &["stream", "date", "file"],
+    )
+    .await;
+    if let Err(e) = res {
+        if !e.to_string().contains("could not create unique index") {
+            return Err(e);
+        }
+        // delete duplicate records
+        log::warn!("[POSTGRES] starting delete duplicate records");
+        let ret = sqlx
             ::query(
                 r#"SELECT stream, date, file, min(id) as id FROM file_list GROUP BY stream, date, file HAVING COUNT(*) > 1;"#
             )
             .fetch_all(&pool).await?;
-            log::warn!("[POSTGRES] total: {} duplicate records", ret.len());
-            for (i, r) in ret.iter().enumerate() {
-                let stream = r.get::<String, &str>("stream");
-                let date = r.get::<String, &str>("date");
-                let file = r.get::<String, &str>("file");
-                let id = r.get::<i64, &str>("id");
-                sqlx
+        log::warn!("[POSTGRES] total: {} duplicate records", ret.len());
+        for (i, r) in ret.iter().enumerate() {
+            let stream = r.get::<String, &str>("stream");
+            let date = r.get::<String, &str>("date");
+            let file = r.get::<String, &str>("file");
+            let id = r.get::<i64, &str>("id");
+            sqlx
                 ::query(
                     r#"DELETE FROM file_list WHERE id != $1 AND stream = $2 AND date = $3 AND file = $4;"#
                 )
@@ -1275,19 +1256,25 @@ pub async fn create_table_index() -> Result<()> {
                 .bind(date)
                 .bind(file)
                 .execute(&pool).await?;
-                if i / 1000 == 0 {
-                    log::warn!("[POSTGRES] delete duplicate records: {}/{}", i, ret.len());
-                }
+            if i % 1000 == 0 {
+                log::warn!("[POSTGRES] delete duplicate records: {}/{}", i, ret.len());
             }
-            log::warn!(
-                "[POSTGRES] delete duplicate records: {}/{}",
-                ret.len(),
-                ret.len()
-            );
-            // create index again
-            sqlx::query(unique_index_sql).execute(&pool).await?;
-            log::warn!("[POSTGRES] create table index(file_list_stream_file_idx) succeed");
         }
+        log::warn!(
+            "[POSTGRES] delete duplicate records: {}/{}",
+            ret.len(),
+            ret.len()
+        );
+        // create index again
+        create_index(
+            &pool,
+            "file_list_stream_file_idx",
+            "file_list",
+            true,
+            &["stream", "date", "file"],
+        )
+        .await?;
+        log::warn!("[POSTGRES] create table index(file_list_stream_file_idx) succeed");
     }
 
     Ok(())

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -1190,7 +1190,7 @@ pub async fn create_table_index() -> Result<()> {
         ("stream_stats_org_idx", "stream_stats", &["org"]),
     ];
     for (idx, table, fields) in indices {
-        create_index(&client, idx, table, false, fields).await?;
+        create_index(idx, table, false, fields).await?;
     }
 
     let unique_indices: Vec<(&str, &str, &[&str])> = vec![
@@ -1207,13 +1207,12 @@ pub async fn create_table_index() -> Result<()> {
         ("stream_stats_stream_idx", "stream_stats", &["stream"]),
     ];
     for (idx, table, fields) in unique_indices {
-        create_index(&client, idx, table, true, fields).await?;
+        create_index(idx, table, true, fields).await?;
     }
 
     // This is a case where we want to MAKE the index unique
 
     let res = create_index(
-        &client,
         "file_list_stream_file_idx",
         "file_list",
         true,
@@ -1249,7 +1248,6 @@ pub async fn create_table_index() -> Result<()> {
         );
         // create index again
         create_index(
-            &client,
             "file_list_stream_file_idx",
             "file_list",
             true,

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -25,10 +25,7 @@ use hashbrown::HashMap;
 use sqlx::{Executor, Pool, QueryBuilder, Row, Sqlite};
 
 use crate::{
-    db::{
-        sqlite::{cache_indices, CLIENT_RO, CLIENT_RW},
-        DBIndex, INDICES,
-    },
+    db::sqlite::{create_index, CLIENT_RO, CLIENT_RW},
     errors::{Error, Result},
 };
 
@@ -1159,117 +1156,107 @@ CREATE TABLE IF NOT EXISTS stream_stats
 }
 
 pub async fn create_table_index() -> Result<()> {
-    let sqls = vec![
-        (
-            "file_list_org_idx",
-            "file_list",
-            "CREATE INDEX IF NOT EXISTS file_list_org_idx on file_list (org);",
-        ),
+    let client = CLIENT_RW.clone();
+    let client = client.lock().await;
+
+    let indices: Vec<(&str, &str, &[&str])> = vec![
+        ("file_list_org_idx", "file_list", &["org"]),
         (
             "file_list_stream_ts_idx",
             "file_list",
-            "CREATE INDEX IF NOT EXISTS file_list_stream_ts_idx on file_list (stream, max_ts, min_ts);",
+            &["stream", "max_ts", "min_ts"],
         ),
-        (
-            "file_list_history_org_idx",
-            "file_list_history",
-            "CREATE INDEX IF NOT EXISTS file_list_history_org_idx on file_list_history (org);",
-        ),
+        ("file_list_history_org_idx", "file_list_history", &["org"]),
         (
             "file_list_history_stream_ts_idx",
             "file_list_history",
-            "CREATE INDEX IF NOT EXISTS file_list_history_stream_ts_idx on file_list_history (stream, max_ts, min_ts);",
-        ),
-        (
-            "file_list_history_stream_file_idx",
-            "file_list_history",
-            "CREATE UNIQUE INDEX IF NOT EXISTS file_list_history_stream_file_idx on file_list_history (stream, date, file);",
+            &["stream", "max_ts", "min_ts"],
         ),
         (
             "file_list_deleted_created_at_idx",
             "file_list_deleted",
-            "CREATE INDEX IF NOT EXISTS file_list_deleted_created_at_idx on file_list_deleted (org, created_at);",
+            &["org", "created_at"],
         ),
         (
             "file_list_deleted_stream_date_file_idx",
             "file_list_deleted",
-            "CREATE INDEX IF NOT EXISTS file_list_deleted_stream_date_file_idx on file_list_deleted (stream, date, file);",
-        ),
-        (
-            "file_list_jobs_stream_offsets_idx",
-            "file_list_jobs",
-            "CREATE UNIQUE INDEX IF NOT EXISTS file_list_jobs_stream_offsets_idx on file_list_jobs (stream, offsets);",
+            &["stream", "date", "file"],
         ),
         (
             "file_list_jobs_stream_status_idx",
             "file_list_jobs",
-            "CREATE INDEX IF NOT EXISTS file_list_jobs_stream_status_idx on file_list_jobs (status, stream);",
+            &["status", "stream"],
         ),
-        (
-            "stream_stats_org_idx",
-            "stream_stats",
-            "CREATE INDEX IF NOT EXISTS stream_stats_org_idx on stream_stats (org);",
-        ),
-        (
-            "stream_stats_stream_idx",
-            "stream_stats",
-            "CREATE UNIQUE INDEX IF NOT EXISTS stream_stats_stream_idx on stream_stats (stream);",
-        ),
+        ("stream_stats_org_idx", "stream_stats", &["org"]),
     ];
-
-    let client = CLIENT_RW.clone();
-    let client = client.lock().await;
-    let indices = INDICES.get_or_init(|| cache_indices(&client)).await;
-    for (idx, table, sql) in sqls {
-        if indices.contains(&DBIndex {
-            name: idx.into(),
-            table: table.into(),
-        }) {
-            continue;
-        }
-        if let Err(e) = sqlx::query(sql).execute(&*client).await {
-            log::error!("[SQLITE] create table {} index error: {}", table, e);
-            return Err(e.into());
-        }
+    for (idx, table, fields) in indices {
+        create_index(&client, idx, table, false, fields).await?;
     }
 
-    // create UNIQUE index for file_list
-    if !indices.contains(&DBIndex {
-        name: "file_list_stream_file_idx".into(),
-        table: "file_list".into(),
-    }) {
-        let unique_index_sql = r#"CREATE UNIQUE INDEX IF NOT EXISTS file_list_stream_file_idx on file_list (stream, date, file);"#;
-        if let Err(e) = sqlx::query(unique_index_sql).execute(&*client).await {
-            if !e.to_string().contains("UNIQUE constraint failed") {
-                return Err(e.into());
-            }
-            // delete duplicate records
-            log::warn!("[SQLITE] starting delete duplicate records");
-            let ret = sqlx::query(
+    let unique_indices: Vec<(&str, &str, &[&str])> = vec![
+        (
+            "file_list_history_stream_file_idx",
+            "file_list_history",
+            &["stream", "date", "file"],
+        ),
+        (
+            "file_list_jobs_stream_offsets_idx",
+            "file_list_jobs",
+            &["stream", "offsets"],
+        ),
+        ("stream_stats_stream_idx", "stream_stats", &["stream"]),
+    ];
+    for (idx, table, fields) in unique_indices {
+        create_index(&client, idx, table, true, fields).await?;
+    }
+
+    // This is a case where we want to MAKE the index unique
+
+    let res = create_index(
+        &client,
+        "file_list_stream_file_idx",
+        "file_list",
+        true,
+        &["stream", "date", "file"],
+    )
+    .await;
+    if let Err(e) = res {
+        if !e.to_string().contains("UNIQUE constraint failed") {
+            return Err(e);
+        }
+        // delete duplicate records
+        log::warn!("[SQLITE] starting delete duplicate records");
+        let ret = sqlx::query(
                 r#"SELECT stream, date, file, min(id) as id FROM file_list GROUP BY stream, date, file HAVING COUNT(*) > 1;"#,
             ).fetch_all(&*client).await?;
-            log::warn!("[SQLITE] total: {} duplicate records", ret.len());
-            for (i, r) in ret.iter().enumerate() {
-                let stream = r.get::<String, &str>("stream");
-                let date = r.get::<String, &str>("date");
-                let file = r.get::<String, &str>("file");
-                let id = r.get::<i64, &str>("id");
-                sqlx::query(
+        log::warn!("[SQLITE] total: {} duplicate records", ret.len());
+        for (i, r) in ret.iter().enumerate() {
+            let stream = r.get::<String, &str>("stream");
+            let date = r.get::<String, &str>("date");
+            let file = r.get::<String, &str>("file");
+            let id = r.get::<i64, &str>("id");
+            sqlx::query(
                     r#"DELETE FROM file_list WHERE id != $1 AND stream = $2 AND date = $3 AND file = $4;"#,
                 ).bind(id).bind(stream).bind(date).bind(file).execute(&*client).await?;
-                if i / 1000 == 0 {
-                    log::warn!("[SQLITE] delete duplicate records: {}/{}", i, ret.len());
-                }
+            if i % 1000 == 0 {
+                log::warn!("[SQLITE] delete duplicate records: {}/{}", i, ret.len());
             }
-            log::warn!(
-                "[SQLITE] delete duplicate records: {}/{}",
-                ret.len(),
-                ret.len()
-            );
-            // create index again
-            sqlx::query(unique_index_sql).execute(&*client).await?;
-            log::warn!("[SQLITE] create table index(file_list_stream_file_idx) succeed");
         }
+        log::warn!(
+            "[SQLITE] delete duplicate records: {}/{}",
+            ret.len(),
+            ret.len()
+        );
+        // create index again
+        create_index(
+            &client,
+            "file_list_stream_file_idx",
+            "file_list",
+            true,
+            &["stream", "date", "file"],
+        )
+        .await?;
+        log::warn!("[SQLITE] create table index(file_list_stream_file_idx) succeed");
     }
 
     // delete trigger for old version

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -25,7 +25,11 @@ use hashbrown::HashMap;
 use sqlx::{Executor, Pool, QueryBuilder, Row, Sqlite};
 
 use crate::{
-    db::sqlite::{CLIENT_RO, CLIENT_RW},
+    db::{
+        cache_indices_sqlite,
+        sqlite::{CLIENT_RO, CLIENT_RW},
+        DBIndex, INDICES,
+    },
     errors::{Error, Result},
 };
 
@@ -1158,46 +1162,57 @@ CREATE TABLE IF NOT EXISTS stream_stats
 pub async fn create_table_index() -> Result<()> {
     let sqls = vec![
         (
+            "file_list_org_idx",
             "file_list",
             "CREATE INDEX IF NOT EXISTS file_list_org_idx on file_list (org);",
         ),
         (
+            "file_list_stream_ts_idx",
             "file_list",
             "CREATE INDEX IF NOT EXISTS file_list_stream_ts_idx on file_list (stream, max_ts, min_ts);",
         ),
         (
+            "file_list_history_org_idx",
             "file_list_history",
             "CREATE INDEX IF NOT EXISTS file_list_history_org_idx on file_list_history (org);",
         ),
         (
+            "file_list_history_stream_ts_idx",
             "file_list_history",
             "CREATE INDEX IF NOT EXISTS file_list_history_stream_ts_idx on file_list_history (stream, max_ts, min_ts);",
         ),
         (
+            "file_list_history_stream_file_idx",
             "file_list_history",
             "CREATE UNIQUE INDEX IF NOT EXISTS file_list_history_stream_file_idx on file_list_history (stream, date, file);",
         ),
         (
+            "file_list_deleted_created_at_idx",
             "file_list_deleted",
             "CREATE INDEX IF NOT EXISTS file_list_deleted_created_at_idx on file_list_deleted (org, created_at);",
         ),
         (
+            "file_list_deleted_stream_date_file_idx",
             "file_list_deleted",
             "CREATE INDEX IF NOT EXISTS file_list_deleted_stream_date_file_idx on file_list_deleted (stream, date, file);",
         ),
         (
+            "file_list_jobs_stream_offsets_idx",
             "file_list_jobs",
             "CREATE UNIQUE INDEX IF NOT EXISTS file_list_jobs_stream_offsets_idx on file_list_jobs (stream, offsets);",
         ),
         (
+            "file_list_jobs_stream_status_idx",
             "file_list_jobs",
             "CREATE INDEX IF NOT EXISTS file_list_jobs_stream_status_idx on file_list_jobs (status, stream);",
         ),
         (
+            "stream_stats_org_idx",
             "stream_stats",
             "CREATE INDEX IF NOT EXISTS stream_stats_org_idx on stream_stats (org);",
         ),
         (
+            "stream_stats_stream_idx",
             "stream_stats",
             "CREATE UNIQUE INDEX IF NOT EXISTS stream_stats_stream_idx on stream_stats (stream);",
         ),
@@ -1205,7 +1220,14 @@ pub async fn create_table_index() -> Result<()> {
 
     let client = CLIENT_RW.clone();
     let client = client.lock().await;
-    for (table, sql) in sqls {
+    let indices = INDICES.get_or_init(|| cache_indices_sqlite(&*client)).await;
+    for (idx, table, sql) in sqls {
+        if indices.contains(&DBIndex {
+            name: idx.into(),
+            table: table.into(),
+        }) {
+            continue;
+        }
         if let Err(e) = sqlx::query(sql).execute(&*client).await {
             log::error!("[SQLITE] create table {} index error: {}", table, e);
             return Err(e.into());
@@ -1213,37 +1235,42 @@ pub async fn create_table_index() -> Result<()> {
     }
 
     // create UNIQUE index for file_list
-    let unique_index_sql = r#"CREATE UNIQUE INDEX IF NOT EXISTS file_list_stream_file_idx on file_list (stream, date, file);"#;
-    if let Err(e) = sqlx::query(unique_index_sql).execute(&*client).await {
-        if !e.to_string().contains("UNIQUE constraint failed") {
-            return Err(e.into());
-        }
-        // delete duplicate records
-        log::warn!("[SQLITE] starting delete duplicate records");
-        let ret = sqlx::query(
+    if !indices.contains(&DBIndex {
+        name: "file_list_stream_file_idx".into(),
+        table: "file_list".into(),
+    }) {
+        let unique_index_sql = r#"CREATE UNIQUE INDEX IF NOT EXISTS file_list_stream_file_idx on file_list (stream, date, file);"#;
+        if let Err(e) = sqlx::query(unique_index_sql).execute(&*client).await {
+            if !e.to_string().contains("UNIQUE constraint failed") {
+                return Err(e.into());
+            }
+            // delete duplicate records
+            log::warn!("[SQLITE] starting delete duplicate records");
+            let ret = sqlx::query(
                 r#"SELECT stream, date, file, min(id) as id FROM file_list GROUP BY stream, date, file HAVING COUNT(*) > 1;"#,
             ).fetch_all(&*client).await?;
-        log::warn!("[SQLITE] total: {} duplicate records", ret.len());
-        for (i, r) in ret.iter().enumerate() {
-            let stream = r.get::<String, &str>("stream");
-            let date = r.get::<String, &str>("date");
-            let file = r.get::<String, &str>("file");
-            let id = r.get::<i64, &str>("id");
-            sqlx::query(
+            log::warn!("[SQLITE] total: {} duplicate records", ret.len());
+            for (i, r) in ret.iter().enumerate() {
+                let stream = r.get::<String, &str>("stream");
+                let date = r.get::<String, &str>("date");
+                let file = r.get::<String, &str>("file");
+                let id = r.get::<i64, &str>("id");
+                sqlx::query(
                     r#"DELETE FROM file_list WHERE id != $1 AND stream = $2 AND date = $3 AND file = $4;"#,
                 ).bind(id).bind(stream).bind(date).bind(file).execute(&*client).await?;
-            if i / 1000 == 0 {
-                log::warn!("[SQLITE] delete duplicate records: {}/{}", i, ret.len());
+                if i / 1000 == 0 {
+                    log::warn!("[SQLITE] delete duplicate records: {}/{}", i, ret.len());
+                }
             }
+            log::warn!(
+                "[SQLITE] delete duplicate records: {}/{}",
+                ret.len(),
+                ret.len()
+            );
+            // create index again
+            sqlx::query(unique_index_sql).execute(&*client).await?;
+            log::warn!("[SQLITE] create table index(file_list_stream_file_idx) succeed");
         }
-        log::warn!(
-            "[SQLITE] delete duplicate records: {}/{}",
-            ret.len(),
-            ret.len()
-        );
-        // create index again
-        sqlx::query(unique_index_sql).execute(&*client).await?;
-        log::warn!("[SQLITE] create table index(file_list_stream_file_idx) succeed");
     }
 
     // delete trigger for old version

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -1220,7 +1220,7 @@ pub async fn create_table_index() -> Result<()> {
 
     let client = CLIENT_RW.clone();
     let client = client.lock().await;
-    let indices = INDICES.get_or_init(|| cache_indices_sqlite(&*client)).await;
+    let indices = INDICES.get_or_init(|| cache_indices_sqlite(&client)).await;
     for (idx, table, sql) in sqls {
         if indices.contains(&DBIndex {
             name: idx.into(),

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -26,8 +26,7 @@ use sqlx::{Executor, Pool, QueryBuilder, Row, Sqlite};
 
 use crate::{
     db::{
-        cache_indices_sqlite,
-        sqlite::{CLIENT_RO, CLIENT_RW},
+        sqlite::{cache_indices, CLIENT_RO, CLIENT_RW},
         DBIndex, INDICES,
     },
     errors::{Error, Result},
@@ -1220,7 +1219,7 @@ pub async fn create_table_index() -> Result<()> {
 
     let client = CLIENT_RW.clone();
     let client = client.lock().await;
-    let indices = INDICES.get_or_init(|| cache_indices_sqlite(&client)).await;
+    let indices = INDICES.get_or_init(|| cache_indices(&client)).await;
     for (idx, table, sql) in sqls {
         if indices.contains(&DBIndex {
             name: idx.into(),

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -20,7 +20,11 @@ use sqlx::Row;
 
 use super::{Trigger, TriggerId, TriggerModule, TriggerStatus, TRIGGERS_KEY};
 use crate::{
-    db::{self, cache_indices_mysql, mysql::CLIENT, DBIndex, INDICES},
+    db::{
+        self,
+        mysql::{cache_indices, CLIENT},
+        DBIndex, INDICES,
+    },
     errors::{DbError, Error, Result},
 };
 
@@ -78,7 +82,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
 
     async fn create_table_index(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        let indices = INDICES.get_or_init(|| cache_indices_mysql(&pool)).await;
+        let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
 
         let queries = vec![
             (

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -80,10 +80,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     }
 
     async fn create_table_index(&self) -> Result<()> {
-        let pool = CLIENT.clone();
-
         create_index(
-            &pool,
             "scheduled_jobs_key_idx",
             "scheduled_jobs",
             false,
@@ -91,7 +88,6 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         )
         .await?;
         create_index(
-            &pool,
             "scheduled_jobs_org_key_idx",
             "scheduled_jobs",
             false,
@@ -99,7 +95,6 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         )
         .await?;
         create_index(
-            &pool,
             "scheduled_jobs_org_module_key_idx",
             "scheduled_jobs",
             true,

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -22,8 +22,7 @@ use super::{Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
 use crate::{
     db::{
         self,
-        postgres::{cache_indices, CLIENT},
-        DBIndex, INDICES,
+        postgres::{create_index, CLIENT},
     },
     errors::{DbError, Error, Result},
 };
@@ -82,35 +81,32 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
 
     async fn create_table_index(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
 
-        let queries = vec![
-            (
-                "scheduled_jobs_key_idx",
-                "CREATE INDEX IF NOT EXISTS scheduled_jobs_key_idx on scheduled_jobs (module_key);",
-            ),
-            (
-                "scheduled_jobs_org_key_idx",
-                "CREATE INDEX IF NOT EXISTS scheduled_jobs_org_key_idx on scheduled_jobs (org, module_key);",
-            ),
-            (
-                "scheduled_jobs_org_module_key_idx",
-                "CREATE UNIQUE INDEX IF NOT EXISTS scheduled_jobs_org_module_key_idx on scheduled_jobs (org, module, module_key);",
-            ),
-        ];
+        create_index(
+            &pool,
+            "scheduled_jobs_key_idx",
+            "scheduled_jobs",
+            false,
+            &["module_key"],
+        )
+        .await?;
+        create_index(
+            &pool,
+            "scheduled_jobs_org_key_idx",
+            "scheduled_jobs",
+            false,
+            &["org", "module_key"],
+        )
+        .await?;
+        create_index(
+            &pool,
+            "scheduled_jobs_org_module_key_idx",
+            "scheduled_jobs",
+            true,
+            &["org", "module", "module_key"],
+        )
+        .await?;
 
-        for (idx, query) in queries {
-            if indices.contains(&DBIndex {
-                name: idx.into(),
-                table: "scheduled_jobs".into(),
-            }) {
-                continue;
-            }
-            if let Err(e) = sqlx::query(query).execute(&pool).await {
-                log::error!("[POSTGRES] create table scheduled_jobs index error: {}", e);
-                return Err(e.into());
-            }
-        }
         Ok(())
     }
 

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -20,7 +20,11 @@ use sqlx::Row;
 
 use super::{Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
 use crate::{
-    db::{self, cache_indices_pg, postgres::CLIENT, DBIndex, INDICES},
+    db::{
+        self,
+        postgres::{cache_indices, CLIENT},
+        DBIndex, INDICES,
+    },
     errors::{DbError, Error, Result},
 };
 
@@ -78,7 +82,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
 
     async fn create_table_index(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        let indices = INDICES.get_or_init(|| cache_indices_pg(&pool)).await;
+        let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
 
         let queries = vec![
             (

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -80,10 +80,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     }
 
     async fn create_table_index(&self) -> Result<()> {
-        let pool = CLIENT.clone();
-
         create_index(
-            &pool,
             "scheduled_jobs_key_idx",
             "scheduled_jobs",
             false,
@@ -91,7 +88,6 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         )
         .await?;
         create_index(
-            &pool,
             "scheduled_jobs_org_key_idx",
             "scheduled_jobs",
             false,
@@ -99,7 +95,6 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         )
         .await?;
         create_index(
-            &pool,
             "scheduled_jobs_org_module_key_idx",
             "scheduled_jobs",
             true,

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -20,7 +20,7 @@ use sqlx::Row;
 
 use super::{Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
 use crate::{
-    db::{self, postgres::CLIENT},
+    db::{self, cache_indices_pg, postgres::CLIENT, DBIndex, INDICES},
     errors::{DbError, Error, Result},
 };
 
@@ -78,14 +78,30 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
 
     async fn create_table_index(&self) -> Result<()> {
         let pool = CLIENT.clone();
+        let indices = INDICES.get_or_init(|| cache_indices_pg(&pool)).await;
 
         let queries = vec![
-            "CREATE INDEX IF NOT EXISTS scheduled_jobs_key_idx on scheduled_jobs (module_key);",
-            "CREATE INDEX IF NOT EXISTS scheduled_jobs_org_key_idx on scheduled_jobs (org, module_key);",
-            "CREATE UNIQUE INDEX IF NOT EXISTS scheduled_jobs_org_module_key_idx on scheduled_jobs (org, module, module_key);",
+            (
+                "scheduled_jobs_key_idx",
+                "CREATE INDEX IF NOT EXISTS scheduled_jobs_key_idx on scheduled_jobs (module_key);",
+            ),
+            (
+                "scheduled_jobs_org_key_idx",
+                "CREATE INDEX IF NOT EXISTS scheduled_jobs_org_key_idx on scheduled_jobs (org, module_key);",
+            ),
+            (
+                "scheduled_jobs_org_module_key_idx",
+                "CREATE UNIQUE INDEX IF NOT EXISTS scheduled_jobs_org_module_key_idx on scheduled_jobs (org, module, module_key);",
+            ),
         ];
 
-        for query in queries {
+        for (idx, query) in queries {
+            if indices.contains(&DBIndex {
+                name: idx.into(),
+                table: "scheduled_jobs".into(),
+            }) {
+                continue;
+            }
             if let Err(e) = sqlx::query(query).execute(&pool).await {
                 log::error!("[POSTGRES] create table scheduled_jobs index error: {}", e);
                 return Err(e.into());

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -22,8 +22,7 @@ use super::{Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
 use crate::{
     db::{
         self,
-        sqlite::{cache_indices, CLIENT_RO, CLIENT_RW},
-        DBIndex, INDICES,
+        sqlite::{create_index, CLIENT_RO, CLIENT_RW},
     },
     errors::{DbError, Error, Result},
 };
@@ -79,31 +78,32 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     async fn create_table_index(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
-        let indices = INDICES.get_or_init(|| cache_indices(&client)).await;
-        let queries = vec![
-            (
-                "scheduled_jobs_key_idx",
-                "CREATE INDEX IF NOT EXISTS scheduled_jobs_key_idx on scheduled_jobs (module_key);",
-            ),
-            (
-                "scheduled_jobs_org_key_idx",
-                "CREATE INDEX IF NOT EXISTS scheduled_jobs_org_key_idx on scheduled_jobs (org, module_key);",
-            ),
-            (
-                "scheduled_jobs_org_module_key_idx",
-                "CREATE UNIQUE INDEX IF NOT EXISTS scheduled_jobs_org_module_key_idx on scheduled_jobs (org, module, module_key);",
-            ),
-        ];
 
-        for (idx, query) in queries {
-            if indices.contains(&DBIndex {
-                name: idx.into(),
-                table: "scheduled_jobs".into(),
-            }) {
-                continue;
-            }
-            sqlx::query(query).execute(&*client).await?;
-        }
+        create_index(
+            &client,
+            "scheduled_jobs_key_idx",
+            "scheduled_jobs",
+            false,
+            &["module_key"],
+        )
+        .await?;
+        create_index(
+            &client,
+            "scheduled_jobs_org_key_idx",
+            "scheduled_jobs",
+            false,
+            &["org", "module_key"],
+        )
+        .await?;
+        create_index(
+            &client,
+            "scheduled_jobs_org_module_key_idx",
+            "scheduled_jobs",
+            true,
+            &["org", "module", "module_key"],
+        )
+        .await?;
+
         Ok(())
     }
 

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -76,11 +76,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     }
 
     async fn create_table_index(&self) -> Result<()> {
-        let client = CLIENT_RW.clone();
-        let client = client.lock().await;
-
         create_index(
-            &client,
             "scheduled_jobs_key_idx",
             "scheduled_jobs",
             false,
@@ -88,7 +84,6 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         )
         .await?;
         create_index(
-            &client,
             "scheduled_jobs_org_key_idx",
             "scheduled_jobs",
             false,
@@ -96,7 +91,6 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         )
         .await?;
         create_index(
-            &client,
             "scheduled_jobs_org_module_key_idx",
             "scheduled_jobs",
             true,

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -77,7 +77,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     async fn create_table_index(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
-        let indices = INDICES.get_or_init(|| cache_indices_sqlite(&*client)).await;
+        let indices = INDICES.get_or_init(|| cache_indices_sqlite(&client)).await;
         let queries = vec![
             (
                 "scheduled_jobs_key_idx",

--- a/src/infra/src/schema/history/mysql.rs
+++ b/src/infra/src/schema/history/mysql.rs
@@ -105,17 +105,8 @@ CREATE TABLE IF NOT EXISTS schema_history
 }
 
 pub async fn create_table_index() -> Result<()> {
-    let pool = CLIENT.clone();
+    create_index("schema_history_org_idx", "schema_history", false, &["org"]).await?;
     create_index(
-        &pool,
-        "schema_history_org_idx",
-        "schema_history",
-        false,
-        &["org"],
-    )
-    .await?;
-    create_index(
-        &pool,
         "schema_history_stream_idx",
         "schema_history",
         false,
@@ -123,7 +114,6 @@ pub async fn create_table_index() -> Result<()> {
     )
     .await?;
     create_index(
-        &pool,
         "schema_history_stream_version_idx",
         "schema_history",
         true,

--- a/src/infra/src/schema/history/mysql.rs
+++ b/src/infra/src/schema/history/mysql.rs
@@ -18,10 +18,7 @@ use config::{meta::stream::StreamType, utils::json};
 use datafusion::arrow::datatypes::Schema;
 
 use crate::{
-    db::{
-        mysql::{cache_indices, CLIENT},
-        DBIndex, INDICES,
-    },
+    db::mysql::{create_index, CLIENT},
     errors::{Error, Result},
 };
 
@@ -109,37 +106,30 @@ CREATE TABLE IF NOT EXISTS schema_history
 
 pub async fn create_table_index() -> Result<()> {
     let pool = CLIENT.clone();
-    let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
-    let sqls = vec![
-        (
-            "schema_history_org_idx",
-            "CREATE INDEX schema_history_org_idx on schema_history (org);",
-        ),
-        (
-            "schema_history_stream_idx",
-            "CREATE INDEX schema_history_stream_idx on schema_history (org, stream_type, stream_name);",
-        ),
-        (
-            "schema_history_stream_version_idx",
-            "CREATE UNIQUE INDEX schema_history_stream_version_idx on schema_history (org, stream_type, stream_name, start_dt);",
-        ),
-    ];
-    for (idx, sql) in sqls {
-        if indices.contains(&DBIndex {
-            name: idx.into(),
-            table: "schema_history".into(),
-        }) {
-            continue;
-        }
-        if let Err(e) = sqlx::query(sql).execute(&pool).await {
-            if e.to_string().contains("Duplicate key") {
-                // index already exists
-                continue;
-            }
-            log::error!("[MYSQL] create table schema_history index error: {}", e);
-            return Err(e.into());
-        }
-    }
+    create_index(
+        &pool,
+        "schema_history_org_idx",
+        "schema_history",
+        false,
+        &["org"],
+    )
+    .await?;
+    create_index(
+        &pool,
+        "schema_history_stream_idx",
+        "schema_history",
+        false,
+        &["org", "stream_type", "stream_name"],
+    )
+    .await?;
+    create_index(
+        &pool,
+        "schema_history_stream_version_idx",
+        "schema_history",
+        true,
+        &["org", "stream_type", "stream_name", "start_dt"],
+    )
+    .await?;
 
     Ok(())
 }

--- a/src/infra/src/schema/history/mysql.rs
+++ b/src/infra/src/schema/history/mysql.rs
@@ -18,7 +18,10 @@ use config::{meta::stream::StreamType, utils::json};
 use datafusion::arrow::datatypes::Schema;
 
 use crate::{
-    db::{cache_indices_mysql, mysql::CLIENT, DBIndex, INDICES},
+    db::{
+        mysql::{cache_indices, CLIENT},
+        DBIndex, INDICES,
+    },
     errors::{Error, Result},
 };
 
@@ -106,7 +109,7 @@ CREATE TABLE IF NOT EXISTS schema_history
 
 pub async fn create_table_index() -> Result<()> {
     let pool = CLIENT.clone();
-    let indices = INDICES.get_or_init(|| cache_indices_mysql(&pool)).await;
+    let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
     let sqls = vec![
         (
             "schema_history_org_idx",

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -106,18 +106,8 @@ CREATE TABLE IF NOT EXISTS schema_history
 }
 
 pub async fn create_table_index() -> Result<()> {
-    let pool = CLIENT.clone();
-
+    create_index("schema_history_org_idx", "schema_history", false, &["org"]).await?;
     create_index(
-        &pool,
-        "schema_history_org_idx",
-        "schema_history",
-        false,
-        &["org"],
-    )
-    .await?;
-    create_index(
-        &pool,
         "schema_history_stream_idx",
         "schema_history",
         false,
@@ -125,7 +115,6 @@ pub async fn create_table_index() -> Result<()> {
     )
     .await?;
     create_index(
-        &pool,
         "schema_history_stream_version_idx",
         "schema_history",
         true,

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -18,7 +18,10 @@ use config::{meta::stream::StreamType, utils::json};
 use datafusion::arrow::datatypes::Schema;
 
 use crate::{
-    db::{cache_indices_pg, postgres::CLIENT, DBIndex, INDICES},
+    db::{
+        postgres::{cache_indices, CLIENT},
+        DBIndex, INDICES,
+    },
     errors::{Error, Result},
 };
 
@@ -107,7 +110,7 @@ CREATE TABLE IF NOT EXISTS schema_history
 
 pub async fn create_table_index() -> Result<()> {
     let pool = CLIENT.clone();
-    let indices = INDICES.get_or_init(|| cache_indices_pg(&pool)).await;
+    let indices = INDICES.get_or_init(|| cache_indices(&pool)).await;
     let sqls = vec![
         (
             "schema_history_org_idx",

--- a/src/infra/src/schema/history/sqlite.rs
+++ b/src/infra/src/schema/history/sqlite.rs
@@ -107,18 +107,8 @@ CREATE TABLE IF NOT EXISTS schema_history
 }
 
 pub async fn create_table_index() -> Result<()> {
-    let client = CLIENT_RW.clone();
-    let client = client.lock().await;
+    create_index("schema_history_org_idx", "schema_history", false, &["org"]).await?;
     create_index(
-        &client,
-        "schema_history_org_idx",
-        "schema_history",
-        false,
-        &["org"],
-    )
-    .await?;
-    create_index(
-        &client,
         "schema_history_stream_idx",
         "schema_history",
         false,
@@ -126,7 +116,6 @@ pub async fn create_table_index() -> Result<()> {
     )
     .await?;
     create_index(
-        &client,
         "schema_history_stream_version_idx",
         "schema_history",
         true,

--- a/src/infra/src/schema/history/sqlite.rs
+++ b/src/infra/src/schema/history/sqlite.rs
@@ -18,7 +18,10 @@ use config::{meta::stream::StreamType, utils::json};
 use datafusion::arrow::datatypes::Schema;
 
 use crate::{
-    db::{cache_indices_sqlite, sqlite::CLIENT_RW, DBIndex, INDICES},
+    db::{
+        sqlite::{cache_indices, CLIENT_RW},
+        DBIndex, INDICES,
+    },
     errors::{Error, Result},
 };
 
@@ -124,7 +127,7 @@ pub async fn create_table_index() -> Result<()> {
 
     let client = CLIENT_RW.clone();
     let client = client.lock().await;
-    let indices = INDICES.get_or_init(|| cache_indices_sqlite(&client)).await;
+    let indices = INDICES.get_or_init(|| cache_indices(&client)).await;
     for (idx, sql) in sqls {
         if indices.contains(&DBIndex {
             name: idx.into(),

--- a/src/infra/src/schema/history/sqlite.rs
+++ b/src/infra/src/schema/history/sqlite.rs
@@ -124,7 +124,7 @@ pub async fn create_table_index() -> Result<()> {
 
     let client = CLIENT_RW.clone();
     let client = client.lock().await;
-    let indices = INDICES.get_or_init(|| cache_indices_sqlite(&*client)).await;
+    let indices = INDICES.get_or_init(|| cache_indices_sqlite(&client)).await;
     for (idx, sql) in sqls {
         if indices.contains(&DBIndex {
             name: idx.into(),

--- a/src/infra/src/schema/history/sqlite.rs
+++ b/src/infra/src/schema/history/sqlite.rs
@@ -18,10 +18,7 @@ use config::{meta::stream::StreamType, utils::json};
 use datafusion::arrow::datatypes::Schema;
 
 use crate::{
-    db::{
-        sqlite::{cache_indices, CLIENT_RW},
-        DBIndex, INDICES,
-    },
+    db::sqlite::{create_index, CLIENT_RW},
     errors::{Error, Result},
 };
 
@@ -110,36 +107,32 @@ CREATE TABLE IF NOT EXISTS schema_history
 }
 
 pub async fn create_table_index() -> Result<()> {
-    let sqls = vec![
-        (
-            "schema_history_org_idx",
-            "CREATE INDEX IF NOT EXISTS schema_history_org_idx on schema_history (org);",
-        ),
-        (
-            "schema_history_stream_idx",
-            "CREATE INDEX IF NOT EXISTS schema_history_stream_idx on schema_history (org, stream_type, stream_name);",
-        ),
-        (
-            "schema_history_stream_version_idx",
-            "CREATE UNIQUE INDEX IF NOT EXISTS schema_history_stream_version_idx on schema_history (org, stream_type, stream_name, start_dt);",
-        ),
-    ];
-
     let client = CLIENT_RW.clone();
     let client = client.lock().await;
-    let indices = INDICES.get_or_init(|| cache_indices(&client)).await;
-    for (idx, sql) in sqls {
-        if indices.contains(&DBIndex {
-            name: idx.into(),
-            table: "schema_history".into(),
-        }) {
-            continue;
-        }
-        if let Err(e) = sqlx::query(sql).execute(&*client).await {
-            log::error!("[SQLITE] create table schema_history index error: {}", e);
-            return Err(e.into());
-        }
-    }
+    create_index(
+        &client,
+        "schema_history_org_idx",
+        "schema_history",
+        false,
+        &["org"],
+    )
+    .await?;
+    create_index(
+        &client,
+        "schema_history_stream_idx",
+        "schema_history",
+        false,
+        &["org", "stream_type", "stream_name"],
+    )
+    .await?;
+    create_index(
+        &client,
+        "schema_history_stream_version_idx",
+        "schema_history",
+        true,
+        &["org", "stream_type", "stream_name", "start_dt"],
+    )
+    .await?;
 
     Ok(())
 }


### PR DESCRIPTION
fixes : #4601

This runs a query to get and cache existing indices before running queries to create indices. This way we only run the `create index...` command if the index does not exist.

Note that as we create indices at the start/init of the application, this does not add the newly created indices in the cache, because once that index is create at init, there is not other case which will re-try creating the same index. The issue is only at the pod start, i.e. the first application init, so this only cache pre-existing indices , i.e. ones that exist before the pod start.

As this cache is in-memory, it will be per-pod / per-node, hence when starting on a clean DB, this can still cause lock-ups if all nodes try to create the indices in the blank table simultaneously. Have not handled that as index creation on blannk table is not that time consuming anyways, and to implement that we will need to use etcd or something similar to coordinate the cache.

PS: Maybe we can also get the solution if we add `IF NOT EXIST` in all places, currently only some queries use this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a mechanism to check for existing database indices before creating or dropping them across MySQL, PostgreSQL, and SQLite implementations.
	- Added new SQL index creation logic for various tables, ensuring that indices are only created if they do not already exist.

- **Bug Fixes**
	- Enhanced error handling during index creation and deletion to prevent redundant operations and improve reliability.

- **Documentation**
	- Updated logging statements for clarity regarding index creation and error contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->