### PR TITLE
fix: generate partition key with null if the field is not exists

### DIFF
--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -843,7 +843,7 @@ pub(crate) async fn generate_index_on_ingester(
             .as_i64()
             .unwrap();
 
-        let hour_key = crate::service::ingestion::get_wal_time_key(
+        let hour_key = crate::service::ingestion::get_write_partition_key(
             timestamp,
             &Vec::new(),
             PartitionTimeLevel::Hourly,

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -157,7 +157,7 @@ pub async fn save_enrichment_data(
         if records.is_empty() {
             let schema = stream_schema_map.get(stream_name).unwrap();
             let schema_key = schema.hash_key();
-            hour_key = super::ingestion::get_wal_time_key(
+            hour_key = super::ingestion::get_write_partition_key(
                 timestamp,
                 &vec![],
                 PartitionTimeLevel::Unset,

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -48,7 +48,7 @@ use crate::{
         stream::{SchemaRecords, StreamParams},
     },
     service::{
-        db, ingestion::get_wal_time_key, schema::check_for_schema,
+        db, ingestion::get_write_partition_key, schema::check_for_schema,
         usage::report_request_usage_stats,
     },
 };
@@ -404,7 +404,7 @@ async fn write_logs(
         }
 
         // get hour key
-        let hour_key = get_wal_time_key(
+        let hour_key = get_write_partition_key(
             timestamp,
             &partition_keys,
             partition_time_level,

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -241,7 +241,7 @@ impl Metadata for DistinctValues {
                     get_config().common.column_timestamp.clone(),
                     json::Value::Number(timestamp.into()),
                 );
-                let hour_key = ingestion::get_wal_time_key(
+                let hour_key = ingestion::get_write_partition_key(
                     timestamp,
                     &vec![],
                     unwrap_partition_time_level(None, StreamType::Metadata),

--- a/src/service/metadata/trace_list_index.rs
+++ b/src/service/metadata/trace_list_index.rs
@@ -98,7 +98,7 @@ impl Metadata for TraceListIndex {
 
             let mut data = json::to_value(item).unwrap();
             let data = data.as_object_mut().unwrap();
-            let hour_key = ingestion::get_wal_time_key(
+            let hour_key = ingestion::get_write_partition_key(
                 timestamp,
                 PARTITION_KEYS.to_vec().as_ref(),
                 unwrap_partition_time_level(None, StreamType::Metadata),
@@ -263,7 +263,7 @@ mod tests {
             config::get_config().common.column_timestamp.clone(),
             json::Value::Number(timestamp.into()),
         );
-        let hour_key = ingestion::get_wal_time_key(
+        let hour_key = ingestion::get_write_partition_key(
             timestamp,
             &vec![],
             unwrap_partition_time_level(None, StreamType::Metadata),

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -40,7 +40,7 @@ use crate::{
     },
     service::{
         db, format_stream_name,
-        ingestion::{get_wal_time_key, write_file},
+        ingestion::{get_write_partition_key, write_file},
         schema::check_for_schema,
         usage::report_request_usage_stats,
     },
@@ -258,7 +258,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
             .clone()
             .with_metadata(HashMap::new());
         let schema_key = schema.hash_key();
-        let hour_key = get_wal_time_key(
+        let hour_key = get_write_partition_key(
             timestamp,
             &partition_keys,
             partition_time_level,

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -343,7 +343,7 @@ pub async fn handle_grpc_request(
                         .with_metadata(HashMap::new());
                     let schema_key = schema.hash_key();
                     // get hour key
-                    let hour_key = crate::service::ingestion::get_wal_time_key(
+                    let hour_key = crate::service::ingestion::get_write_partition_key(
                         timestamp,
                         &partition_keys,
                         partition_time_level,

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -426,7 +426,7 @@ pub async fn metrics_json_handler(
                             .entry(local_metric_name.to_owned())
                             .or_default();
                         // get hour key
-                        let hour_key = crate::service::ingestion::get_wal_time_key(
+                        let hour_key = crate::service::ingestion::get_write_partition_key(
                             timestamp,
                             &partition_keys,
                             partition_time_level,

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -375,7 +375,7 @@ pub async fn remote_write(
             let schema_key = schema.hash_key();
 
             // get hour key
-            let hour_key = crate::service::ingestion::get_wal_time_key(
+            let hour_key = crate::service::ingestion::get_write_partition_key(
                 timestamp,
                 &partition_keys,
                 partition_time_level,

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -630,7 +630,7 @@ async fn write_traces(
         // End check for alert trigger
 
         // get hour key
-        let hour_key = super::ingestion::get_wal_time_key(
+        let hour_key = super::ingestion::get_write_partition_key(
             timestamp,
             &partition_keys,
             partition_time_level,


### PR DESCRIPTION
## Issue

Earlier if a partition key doesn't contains in one row, we will skip generate partition key for this record. then we need always scan it because these data have no partition key.

For example:

- 70 % event with tenant_id 1
- 10 % event with tenant_id 2
- 20 % event no tenant_id

if you search for `tenant_id=2` we already need to scan the `20%` data which there is no `tenant_id` field.

## Solution

We can always generate partition key if there is no the partition field, we can set the value to `null`.