### PR TITLE
fix: add file list id cache

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -986,7 +986,7 @@ pub struct Compact {
     pub step_secs: i64,
     #[env_config(name = "ZO_COMPACT_SYNC_TO_DB_INTERVAL", default = 600)] // seconds
     pub sync_to_db_interval: u64,
-    #[env_config(name = "ZO_COMPACT_MAX_FILE_SIZE", default = 256)] // MB
+    #[env_config(name = "ZO_COMPACT_MAX_FILE_SIZE", default = 512)] // MB
     pub max_file_size: usize,
     #[env_config(name = "ZO_COMPACT_DATA_RETENTION_DAYS", default = 3650)] // days
     pub data_retention_days: i64,
@@ -1424,7 +1424,8 @@ fn check_common_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
     cfg.common.meta_store = cfg.common.meta_store.to_lowercase();
     if cfg.common.local_mode
-        || (cfg.common.meta_store != "sqlite" && cfg.common.meta_store != "etcd")
+        || cfg.common.meta_store.starts_with("mysql")
+        || cfg.common.meta_store.starts_with("postgres")
     {
         cfg.common.meta_store_external = true;
     }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -946,6 +946,12 @@ pub struct Limit {
         help = "timeout of transaction lock"
     )] // seconds
     pub meta_transaction_lock_timeout: usize,
+    #[env_config(
+        name = "ZO_META_ID_BATCH_SIZE",
+        default = 5000,
+        help = "batch size of id processing"
+    )]
+    pub meta_id_batch_size: usize,
     #[env_config(name = "ZO_DISTINCT_VALUES_INTERVAL", default = 10)] // seconds
     pub distinct_values_interval: u64,
     #[env_config(name = "ZO_DISTINCT_VALUES_HOURLY", default = false)]
@@ -1326,6 +1332,10 @@ pub fn init() -> Config {
 
     if cfg.limit.sql_db_connections_max == 0 {
         cfg.limit.sql_db_connections_max = cfg.limit.sql_db_connections_min * 2
+    }
+
+    if cfg.limit.meta_id_batch_size == 0 {
+        cfg.limit.meta_id_batch_size = 5000;
     }
 
     if cfg.limit.consistent_hash_vnodes == 0 {

--- a/src/infra/src/db/mod.rs
+++ b/src/infra/src/db/mod.rs
@@ -33,11 +33,16 @@ pub static NEED_WATCH: bool = true;
 pub static NO_NEED_WATCH: bool = false;
 
 static DEFAULT: OnceCell<Box<dyn Db>> = OnceCell::const_new();
+static LOCAL_CACHE: OnceCell<Box<dyn Db>> = OnceCell::const_new();
 static CLUSTER_COORDINATOR: OnceCell<Box<dyn Db>> = OnceCell::const_new();
 static SUPER_CLUSTER: OnceCell<Box<dyn Db>> = OnceCell::const_new();
 
 pub async fn get_db() -> &'static Box<dyn Db> {
     DEFAULT.get_or_init(default).await
+}
+
+pub async fn get_local_cache() -> &'static Box<dyn Db> {
+    LOCAL_CACHE.get_or_init(init_local_cache).await
 }
 
 pub async fn get_coordinator() -> &'static Box<dyn Db> {
@@ -71,6 +76,10 @@ async fn default() -> Box<dyn Db> {
         MetaStore::MySQL => Box::<mysql::MysqlDb>::default(),
         MetaStore::PostgreSQL => Box::<postgres::PostgresDb>::default(),
     }
+}
+
+async fn init_local_cache() -> Box<dyn Db> {
+    Box::<sqlite::SqliteDb>::default()
 }
 
 async fn init_cluster_coordinator() -> Box<dyn Db> {

--- a/src/infra/src/dist_lock.rs
+++ b/src/infra/src/dist_lock.rs
@@ -55,6 +55,9 @@ pub async fn lock_with_trace_id(
 
 #[inline(always)]
 pub async fn unlock_with_trace_id(trace_id: &str, locker: &Option<Locker>) -> Result<()> {
+    if locker.is_none() {
+        return Ok(());
+    }
     let unlock = unlock(locker).await;
     match unlock {
         Ok(_) => {

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -28,8 +28,6 @@ pub mod mysql;
 pub mod postgres;
 pub mod sqlite;
 
-const ID_BATCH_SIZE: usize = 10000;
-
 static CLIENT: Lazy<Box<dyn FileList>> = Lazy::new(connect_default);
 pub static LOCAL_CACHE: Lazy<Box<dyn FileList>> = Lazy::new(connect_local_cache);
 

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -28,7 +28,7 @@ pub mod mysql;
 pub mod postgres;
 pub mod sqlite;
 
-const ID_BATCH_SIZE: usize = 2000;
+const ID_BATCH_SIZE: usize = 10000;
 
 static CLIENT: Lazy<Box<dyn FileList>> = Lazy::new(connect_default);
 pub static LOCAL_CACHE: Lazy<Box<dyn FileList>> = Lazy::new(connect_local_cache);

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -354,7 +354,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let mut ret = Vec::new();
         let pool = CLIENT.clone();
 
-        for chunk in ids.chunks(super::ID_BATCH_SIZE) {
+        for chunk in ids.chunks(get_config().limit.meta_id_batch_size) {
             if chunk.is_empty() {
                 continue;
             }

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -79,7 +79,7 @@ impl super::FileList for MysqlFileList {
     }
 
     async fn batch_add_with_id(&self, _files: &[(i64, &FileKey)]) -> Result<()> {
-        todo!()
+        unimplemented!("Unsupported")
     }
 
     async fn batch_add_history(&self, files: &[FileKey]) -> Result<()> {
@@ -494,7 +494,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
     }
 
     async fn clean_by_min_pk_value(&self, _val: i64) -> Result<()> {
-        todo!()
+        Ok(()) // do nothing
     }
 
     async fn stats(

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -485,6 +485,18 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         Ok(ret.unwrap_or_default())
     }
 
+    async fn get_min_pk_value(&self) -> Result<i64> {
+        let pool = CLIENT.clone();
+        let ret: Option<i64> = sqlx::query_scalar(r#"SELECT MIN(id) AS id FROM file_list;"#)
+            .fetch_one(&pool)
+            .await?;
+        Ok(ret.unwrap_or_default())
+    }
+
+    async fn clean_by_min_pk_value(&self, _val: i64) -> Result<()> {
+        todo!()
+    }
+
     async fn stats(
         &self,
         org_id: &str,

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -366,7 +366,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let mut ret = Vec::new();
         let pool = CLIENT.clone();
 
-        for chunk in ids.chunks(super::ID_BATCH_SIZE) {
+        for chunk in ids.chunks(get_config().limit.meta_id_batch_size) {
             if chunk.is_empty() {
                 continue;
             }

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -79,7 +79,7 @@ impl super::FileList for PostgresFileList {
     }
 
     async fn batch_add_with_id(&self, _files: &[(i64, &FileKey)]) -> Result<()> {
-        todo!()
+        unimplemented!("Unsupported")
     }
 
     async fn batch_add_history(&self, files: &[FileKey]) -> Result<()> {
@@ -508,7 +508,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
     }
 
     async fn clean_by_min_pk_value(&self, _val: i64) -> Result<()> {
-        todo!()
+        Ok(()) // do nothing
     }
 
     async fn stats(

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -498,6 +498,19 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         Ok(ret.unwrap_or_default())
     }
 
+    async fn get_min_pk_value(&self) -> Result<i64> {
+        let pool = CLIENT.clone();
+        let ret: Option<i64> =
+            sqlx::query_scalar(r#"SELECT MIN(id)::BIGINT AS id FROM file_list;"#)
+                .fetch_one(&pool)
+                .await?;
+        Ok(ret.unwrap_or_default())
+    }
+
+    async fn clean_by_min_pk_value(&self, _val: i64) -> Result<()> {
+        todo!()
+    }
+
     async fn stats(
         &self,
         org_id: &str,

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -371,7 +371,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let mut ret = Vec::new();
         let pool = CLIENT_RO.clone();
 
-        for chunk in ids.chunks(super::ID_BATCH_SIZE) {
+        for chunk in ids.chunks(get_config().limit.meta_id_batch_size) {
             if chunk.is_empty() {
                 continue;
             }

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -69,6 +69,14 @@ impl super::FileList for SqliteFileList {
         self.inner_batch_add("file_list", files).await
     }
 
+    async fn batch_add_with_id(&self, files: &[(i64, &FileKey)]) -> Result<()> {
+        let files = files
+            .iter()
+            .map(|(id, f)| (Some(*id), *f))
+            .collect::<Vec<_>>();
+        self.inner_batch_add_with_id("file_list", &files).await
+    }
+
     async fn batch_add_history(&self, files: &[FileKey]) -> Result<()> {
         self.inner_batch_add("file_list_history", files).await
     }
@@ -355,7 +363,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
             .collect())
     }
 
-    async fn query_by_ids(&self, ids: &[i64]) -> Result<Vec<(String, FileMeta)>> {
+    async fn query_by_ids(&self, ids: &[i64]) -> Result<Vec<(i64, String, FileMeta)>> {
         if ids.is_empty() {
             return Ok(Vec::default());
         }
@@ -373,7 +381,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
                 .collect::<Vec<String>>()
                 .join(",");
             let query_str = format!(
-                "SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, flattened FROM file_list WHERE id IN ({ids})"
+                "SELECT id, stream, date, file, min_ts, max_ts, records, original_size, compressed_size FROM file_list WHERE id IN ({ids})"
             );
             let res = sqlx::query_as::<_, super::FileRecord>(&query_str)
                 .fetch_all(&pool)
@@ -385,6 +393,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
             .iter()
             .map(|r| {
                 (
+                    r.id,
                     format!("files/{}/{}/{}", r.stream, r.date, r.file),
                     r.into(),
                 )
@@ -935,6 +944,16 @@ SELECT stream, max(id) as id, COUNT(*) AS num
 
 impl SqliteFileList {
     async fn inner_add(&self, table: &str, file: &str, meta: &FileMeta) -> Result<()> {
+        self.inner_add_with_id(table, None, file, meta).await
+    }
+
+    async fn inner_add_with_id(
+        &self,
+        table: &str,
+        id: Option<i64>,
+        file: &str,
+        meta: &FileMeta,
+    ) -> Result<()> {
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
@@ -942,10 +961,11 @@ impl SqliteFileList {
         let client = client.lock().await;
         match  sqlx::query(
             format!(r#"
-INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, flattened)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);
+INSERT INTO {table} (id, org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, flattened)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);
         "#).as_str(),
     )
+        .bind(id)
         .bind(org_id)
         .bind(stream_key)
         .bind(date_key)
@@ -970,6 +990,15 @@ INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, 
     }
 
     async fn inner_batch_add(&self, table: &str, files: &[FileKey]) -> Result<()> {
+        let files: Vec<(Option<i64>, _)> = files.iter().map(|f| (None, f)).collect::<Vec<_>>();
+        self.inner_batch_add_with_id(table, &files).await
+    }
+
+    async fn inner_batch_add_with_id(
+        &self,
+        table: &str,
+        files: &[(Option<i64>, &FileKey)],
+    ) -> Result<()> {
         if files.is_empty() {
             return Ok(());
         }
@@ -979,13 +1008,14 @@ INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, 
             let client = client.lock().await;
             let mut tx = client.begin().await?;
             let mut query_builder: QueryBuilder<Sqlite> = QueryBuilder::new(
-                format!("INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, flattened)").as_str(),
+                format!("INSERT INTO {table} (id, org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, flattened)").as_str(),
             );
-            query_builder.push_values(files, |mut b, item| {
+            query_builder.push_values(files, |mut b, (id, item)| {
                 let (stream_key, date_key, file_name) =
                     parse_file_key_columns(&item.key).expect("parse file key failed");
                 let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
-                b.push_bind(org_id)
+                b.push_bind(id)
+                    .push_bind(org_id)
                     .push_bind(stream_key)
                     .push_bind(date_key)
                     .push_bind(file_name)
@@ -1024,8 +1054,11 @@ INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, 
                 // release lock
                 drop(client);
                 // add file one by one
-                for item in files {
-                    if let Err(e) = self.inner_add(table, &item.key, &item.meta).await {
+                for (id, item) in files {
+                    if let Err(e) = self
+                        .inner_add_with_id(table, *id, &item.key, &item.meta)
+                        .await
+                    {
                         log::error!("[SQLITE] single insert {table} add error: {}", e);
                         return Err(e);
                     }

--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -27,6 +27,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     db::init().await?;
     cache::init().await?;
     file_list::create_table().await?;
+    file_list::LOCAL_CACHE.create_table().await?;
     queue::init().await?;
     scheduler::init().await?;
     schema::init().await?;

--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -28,6 +28,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     cache::init().await?;
     file_list::create_table().await?;
     file_list::LOCAL_CACHE.create_table().await?;
+    file_list::local_cache_gc().await?;
     queue::init().await?;
     scheduler::init().await?;
     schema::init().await?;

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -179,6 +179,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
             infra_file_list::create_table_index()
                 .await
                 .expect("file list create table index failed");
+            infra_file_list::LOCAL_CACHE
+                .create_table_index()
+                .await
+                .expect("file list create table index failed");
             update_stats_from_file_list()
                 .await
                 .expect("file list remote calculate stats failed");
@@ -186,6 +190,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     }
 
     infra_file_list::create_table_index().await?;
+    infra_file_list::LOCAL_CACHE.create_table_index().await?;
     tokio::task::spawn(async move { db::file_list::remote::cache_stats().await });
 
     #[cfg(feature = "enterprise")]

--- a/src/service/db/file_list/remote.rs
+++ b/src/service/db/file_list/remote.rs
@@ -103,6 +103,7 @@ pub async fn cache(prefix: &str, force: bool) -> Result<(), anyhow::Error> {
 
     // create table index
     infra_file_list::create_table_index().await?;
+    infra_file_list::LOCAL_CACHE.create_table_index().await?;
     log::info!("Load file_list create table index done");
 
     // delete files

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -23,7 +23,11 @@ use config::{
     },
     utils::{file::get_file_meta as util_get_file_meta, json},
 };
-use infra::{file_list, storage};
+use hashbrown::HashSet;
+use infra::{
+    errors::{Error, Result},
+    file_list, storage,
+};
 
 use crate::service::db;
 
@@ -39,7 +43,7 @@ pub async fn query(
     time_level: PartitionTimeLevel,
     time_min: i64,
     time_max: i64,
-) -> Result<Vec<FileKey>, anyhow::Error> {
+) -> Result<Vec<FileKey>> {
     let files = file_list::query(
         org_id,
         stream_type,
@@ -61,18 +65,67 @@ pub async fn query(
     Ok(file_keys)
 }
 
-pub async fn query_by_ids(ids: &[i64]) -> Result<Vec<FileKey>, anyhow::Error> {
-    let files = file_list::query_by_ids(ids).await?;
-    let mut file_keys = Vec::with_capacity(files.len());
-    for (key, meta) in files {
-        file_keys.push(FileKey {
+pub async fn query_by_ids(trace_id: &str, ids: &[i64]) -> Result<Vec<FileKey>> {
+    let cfg = get_config();
+    // 1. first query from local cache
+    let (mut files, ids) = if !cfg.common.local_mode {
+        let ids_set: HashSet<_> = ids.iter().cloned().collect();
+        let cached_files = file_list::LOCAL_CACHE
+            .query_by_ids(ids)
+            .await
+            .unwrap_or_default();
+        let cached_ids = cached_files
+            .iter()
+            .map(|(id, ..)| *id)
+            .collect::<HashSet<_>>();
+        log::info!(
+            "[trace_id {trace_id}] file_list cached_ids: {:?}",
+            cached_ids.len()
+        );
+
+        let mut file_keys = Vec::with_capacity(ids.len());
+        for (_, key, meta) in cached_files {
+            file_keys.push(FileKey {
+                key,
+                meta,
+                deleted: false,
+                segment_ids: None,
+            });
+        }
+        (
+            file_keys,
+            ids_set.difference(&cached_ids).cloned().collect::<Vec<_>>(),
+        )
+    } else {
+        (Vec::with_capacity(ids.len()), ids.to_vec())
+    };
+
+    // 2. query from remote db
+    let cached_file_num = files.len();
+    let db_files = file_list::query_by_ids(&ids).await?;
+    let mut db_ids = Vec::with_capacity(db_files.len());
+    for (id, key, meta) in db_files {
+        db_ids.push(id);
+        files.push(FileKey {
             key,
             meta,
             deleted: false,
             segment_ids: None,
         });
     }
-    Ok(file_keys)
+
+    // 3. set the local cache
+    if !cfg.common.local_mode {
+        let mut db_files = Vec::with_capacity(files.len() - cached_file_num);
+        for (i, id) in db_ids.into_iter().enumerate() {
+            db_files.push((id, &files[i + cached_file_num]));
+        }
+        if let Err(e) = file_list::LOCAL_CACHE.batch_add_with_id(&db_files).await {
+            log::error!("[trace_id {trace_id}] file_list set cache failed: {:?}", e);
+        }
+    }
+
+    Ok(files)
 }
 
 #[tracing::instrument(
@@ -87,19 +140,19 @@ pub async fn query_ids(
     time_level: PartitionTimeLevel,
     time_min: i64,
     time_max: i64,
-) -> Result<Vec<file_list::FileId>, anyhow::Error> {
-    Ok(file_list::query_ids(
+) -> Result<Vec<file_list::FileId>> {
+    file_list::query_ids(
         org_id,
         stream_type,
         stream_name,
         time_level,
         Some((time_min, time_max)),
     )
-    .await?)
+    .await
 }
 
 #[inline]
-pub async fn calculate_files_size(files: &[FileKey]) -> Result<ScanStats, anyhow::Error> {
+pub async fn calculate_files_size(files: &[FileKey]) -> Result<ScanStats> {
     let mut stats = ScanStats::new();
     stats.files = files.len() as i64;
     for file in files {
@@ -111,7 +164,7 @@ pub async fn calculate_files_size(files: &[FileKey]) -> Result<ScanStats, anyhow
 }
 
 #[inline]
-pub fn calculate_local_files_size(files: &[String]) -> Result<u64, anyhow::Error> {
+pub fn calculate_local_files_size(files: &[String]) -> Result<u64> {
     let mut size = 0;
     for file in files {
         let file_size = match util_get_file_meta(file) {
@@ -124,7 +177,7 @@ pub fn calculate_local_files_size(files: &[String]) -> Result<u64, anyhow::Error
 }
 
 // Delete one parquet file and update the file list
-pub async fn delete_parquet_file(key: &str, file_list_only: bool) -> Result<(), anyhow::Error> {
+pub async fn delete_parquet_file(key: &str, file_list_only: bool) -> Result<()> {
     if get_config().common.meta_store_external {
         delete_parquet_file_db_only(key, file_list_only).await
     } else {
@@ -132,7 +185,7 @@ pub async fn delete_parquet_file(key: &str, file_list_only: bool) -> Result<(), 
     }
 }
 
-async fn delete_parquet_file_db_only(key: &str, file_list_only: bool) -> Result<(), anyhow::Error> {
+async fn delete_parquet_file_db_only(key: &str, file_list_only: bool) -> Result<()> {
     // delete from file list in metastore
     file_list::batch_remove(&[key.to_string()]).await?;
 
@@ -143,7 +196,7 @@ async fn delete_parquet_file_db_only(key: &str, file_list_only: bool) -> Result<
     Ok(())
 }
 
-async fn delete_parquet_file_s3(key: &str, file_list_only: bool) -> Result<(), anyhow::Error> {
+async fn delete_parquet_file_s3(key: &str, file_list_only: bool) -> Result<()> {
     let columns = key.split('/').collect::<Vec<&str>>();
     if columns[0] != "files" || columns.len() < 9 {
         return Ok(());
@@ -172,9 +225,15 @@ async fn delete_parquet_file_s3(key: &str, file_list_only: bool) -> Result<(), a
     write_buf.push(b'\n');
     buf.write_all(&write_buf)?;
     let compressed_bytes = buf.finish().unwrap();
-    storage::put(&new_file_list_key, compressed_bytes.into()).await?;
-    db::file_list::progress(key, Some(&meta), deleted).await?;
-    db::file_list::broadcast::send(&[file_data], None).await?;
+    storage::put(&new_file_list_key, compressed_bytes.into())
+        .await
+        .map_err(|e| Error::Message(e.to_string()))?;
+    db::file_list::progress(key, Some(&meta), deleted)
+        .await
+        .map_err(|e| Error::Message(e.to_string()))?;
+    db::file_list::broadcast::send(&[file_data], None)
+        .await
+        .map_err(|e| Error::Message(e.to_string()))?;
 
     // delete the parquet whaterever the file is exists or not
     if !file_list_only {

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -68,7 +68,7 @@ pub async fn query(
 pub async fn query_by_ids(trace_id: &str, ids: &[i64]) -> Result<Vec<FileKey>> {
     let cfg = get_config();
     // 1. first query from local cache
-    let (mut files, ids) = if !cfg.common.local_mode {
+    let (mut files, ids) = if !cfg.common.local_mode && cfg.common.meta_store_external {
         let ids_set: HashSet<_> = ids.iter().cloned().collect();
         let cached_files = file_list::LOCAL_CACHE
             .query_by_ids(ids)
@@ -115,7 +115,7 @@ pub async fn query_by_ids(trace_id: &str, ids: &[i64]) -> Result<Vec<FileKey>> {
     }
 
     // 3. set the local cache
-    if !cfg.common.local_mode {
+    if !cfg.common.local_mode && cfg.common.meta_store_external {
         let mut db_files = Vec::with_capacity(files.len() - cached_file_num);
         for (i, id) in db_ids.into_iter().enumerate() {
             db_files.push((id, &files[i + cached_file_num]));

--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -118,9 +118,10 @@ pub async fn search(
     };
 
     // 2. get inverted index file list
-    let (_use_inverted_index, idx_file_list, idx_scan_size, idx_took) =
+    let (use_fst_inverted_index, idx_file_list, idx_scan_size, idx_took) =
         get_inverted_index_file_lists(trace_id, &req, &sql, &query).await?;
     scan_stats.idx_scan_size = idx_scan_size as i64;
+    req.set_use_inverted_index(use_fst_inverted_index);
 
     // 3. get nodes
     let node_group = req
@@ -786,15 +787,17 @@ async fn get_inverted_index_file_lists(
         req.inverted_index_type.as_ref().unwrap().to_string()
     };
     let (use_inverted_index, index_terms) = super::super::is_use_inverted_index(sql);
-    let use_inverted_index =
+    let use_parquet_inverted_index =
         use_inverted_index && (inverted_index_type == "parquet" || inverted_index_type == "both");
+    let use_fst_inverted_index =
+        use_inverted_index && (inverted_index_type == "fst" || inverted_index_type == "both");
     log::info!(
         "[trace_id {trace_id}] flight->search: use_inverted_index with parquet format {}",
-        use_inverted_index
+        use_parquet_inverted_index
     );
 
-    if !use_inverted_index {
-        return Ok((false, vec![], 0, 0));
+    if !use_parquet_inverted_index {
+        return Ok((use_fst_inverted_index, vec![], 0, 0));
     }
 
     let stream_name = sql.stream_names.first().unwrap();
@@ -816,7 +819,12 @@ async fn get_inverted_index_file_lists(
         idx_took,
     );
 
-    Ok((true, idx_file_list, idx_scan_size, idx_took))
+    Ok((
+        use_fst_inverted_index,
+        idx_file_list,
+        idx_scan_size,
+        idx_took,
+    ))
 }
 
 pub async fn get_inverted_index_file_list(

--- a/src/service/search/grpc/flight.rs
+++ b/src/service/search/grpc/flight.rs
@@ -152,6 +152,7 @@ pub async fn search(
             .await
             .unwrap_or_default();
         let (file_list, file_list_took) = get_file_list_by_ids(
+            &trace_id,
             &org_id,
             stream_type,
             stream_name,
@@ -161,7 +162,7 @@ pub async fn search(
             &req.file_id_list,
             &req.idx_file_list,
         )
-        .await;
+        .await?;
         log::info!(
             "[trace_id {trace_id}] flight->search in: part_id: {}, get file_list by ids, num: {}, took: {} ms",
             req.partition,
@@ -269,6 +270,7 @@ pub async fn search(
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, fields(org_id = org_id, stream_name = stream_name))]
 async fn get_file_list_by_ids(
+    trace_id: &str,
     org_id: &str,
     stream_type: StreamType,
     stream_name: &str,
@@ -277,11 +279,9 @@ async fn get_file_list_by_ids(
     equal_items: &Option<Vec<(String, String)>>,
     ids: &[i64],
     idx_file_list: &[cluster_rpc::IdxFileName],
-) -> (Vec<FileKey>, usize) {
+) -> Result<(Vec<FileKey>, usize), Error> {
     let start = std::time::Instant::now();
-    let file_list = crate::service::file_list::query_by_ids(ids)
-        .await
-        .unwrap_or_default();
+    let file_list = crate::service::file_list::query_by_ids(trace_id, ids).await?;
     // if there are any files in idx_files_list, use them to filter the files we got from ids,
     // otherwise use all the files we got from ids
     let file_list = if idx_file_list.is_empty() {
@@ -323,5 +323,5 @@ async fn get_file_list_by_ids(
     }
     files.sort_by(|a, b| a.key.cmp(&b.key));
     files.dedup_by(|a, b| a.key == b.key);
-    (files, start.elapsed().as_millis() as usize)
+    Ok((files, start.elapsed().as_millis() as usize))
 }

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -552,11 +552,11 @@ async fn filter_file_list_by_inverted_index(
                         .unwrap();
                     file.segment_ids = Some(res.clone().into_vec());
                     log::info!(
-                        "[trace_id {}] search->storage: Final bitmap for fts_terms {:?} and index_terms: {:?} is {:?}",
+                        "[trace_id {}] search->storage: Final bitmap for fts_terms {:?} and index_terms: {:?} length {}",
                         query.trace_id,
                         *full_text_terms,
                         index_terms,
-                        res.iter_ones().collect_vec()
+                        res.len(),
                     );
                 } else {
                     // if the bitmap is empty then we remove the file from the list


### PR DESCRIPTION
We only retrieve the `id` from the `file_list` on the leader. Then, we use this `id` to get the `file name` from the same list. By adding a local SQLite cache for each node, we can significantly reduce calls to the remote database.

- [x] Implement cache for querier nodes
- [x] Develop a garbage collection strategy
- [x] Fix search with FST

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Increased default maximum file size for compacting from 256 MB to 512 MB.
	- Added new asynchronous methods for local cache management and file list operations, including `get_local_cache`, `get_min_pk_value`, and `clean_by_min_pk_value`.
	- Enhanced file querying with IDs included in results and added batch addition of files with IDs across various implementations.

- **Bug Fixes**
	- Improved control flow in various functions to handle cases where parameters may be `None`.

- **Documentation**
	- Updated logging for better traceability and clarity in cache and file operations.

- **Refactor**
	- Simplified return types in several functions for improved clarity and error management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->