### PR TITLE
perf: remove unnecessary setting for parquet writer

### DIFF
--- a/src/ingester/src/partition.rs
+++ b/src/ingester/src/partition.rs
@@ -150,16 +150,12 @@ impl Partition {
                 batch_num: data.data.len(),
             };
             // write into parquet buf
-            let (bloom_filter_fields, full_text_search_fields) =
+            let bloom_filter_fields =
                 if self.schema.fields().len() >= cfg.limit.file_move_fields_limit {
                     let settings = infra::schema::unwrap_stream_settings(self.schema.as_ref());
-                    let bloom_filter_fields =
-                        infra::schema::get_stream_setting_bloom_filter_fields(&settings);
-                    let full_text_search_fields =
-                        infra::schema::get_stream_setting_fts_fields(&settings);
-                    (bloom_filter_fields, full_text_search_fields)
+                    infra::schema::get_stream_setting_bloom_filter_fields(&settings)
                 } else {
-                    (vec![], vec![])
+                    vec![]
                 };
 
             let batches = data
@@ -175,13 +171,8 @@ impl Partition {
                     .context(MergeRecordBatchSnafu)?;
 
             let mut buf_parquet = Vec::new();
-            let mut writer = new_parquet_writer(
-                &mut buf_parquet,
-                &schema,
-                &bloom_filter_fields,
-                &full_text_search_fields,
-                &file_meta,
-            );
+            let mut writer =
+                new_parquet_writer(&mut buf_parquet, &schema, &bloom_filter_fields, &file_meta);
 
             writer
                 .write(&batches)

--- a/src/job/files/idx.rs
+++ b/src/job/files/idx.rs
@@ -75,7 +75,7 @@ pub(crate) async fn write_parquet_index_to_disk(
 
     // write parquet file
     let mut buf_parquet = Vec::new();
-    let mut writer = new_parquet_writer(&mut buf_parquet, &schema, &[], &[], &file_meta);
+    let mut writer = new_parquet_writer(&mut buf_parquet, &schema, &[], &file_meta);
     for batch in batches {
         writer.write(&batch).await?;
     }

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -657,7 +657,6 @@ async fn merge_files(
             new_schema.clone(),
             &new_batches,
             &bloom_filter_fields,
-            &full_text_search_fields,
             &new_file_meta,
         )
         .await?;

--- a/src/service/compact/flatten.rs
+++ b/src/service/compact/flatten.rs
@@ -187,22 +187,16 @@ pub async fn generate_file(file: &FileKey) -> Result<(), anyhow::Error> {
         .await
         .unwrap_or_default();
     let bloom_filter_fields = stream_setting.bloom_filter_fields;
-    let full_text_search_fields = stream_setting.full_text_search_keys;
     let new_file = format!(
         "files{}/{}",
         get_config().common.column_all,
         file.key.strip_prefix("files/").unwrap()
     );
     let new_schema = new_batches.first().unwrap().schema();
-    let new_data = write_recordbatch_to_parquet(
-        new_schema,
-        &new_batches,
-        &bloom_filter_fields,
-        &full_text_search_fields,
-        &file.meta,
-    )
-    .await
-    .map_err(|e| anyhow::anyhow!("write_recordbatch_to_parquet error: {}", e))?;
+    let new_data =
+        write_recordbatch_to_parquet(new_schema, &new_batches, &bloom_filter_fields, &file.meta)
+            .await
+            .map_err(|e| anyhow::anyhow!("write_recordbatch_to_parquet error: {}", e))?;
     // upload filee
     storage::put(&new_file, new_data.into()).await?;
     // delete from queue

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -727,7 +727,6 @@ pub async fn merge_files(
                 &mut buf,
                 Arc::new(schema),
                 &bloom_filter_fields,
-                &full_text_search_fields,
                 diff_fields,
                 FileType::PARQUET,
             )
@@ -769,7 +768,6 @@ pub async fn merge_files(
         new_schema.clone(),
         &new_batches,
         &bloom_filter_fields,
-        &full_text_search_fields,
         &new_file_meta,
     )
     .await?;

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -69,7 +69,6 @@ pub async fn convert_parquet_file(
     buf: &mut Vec<u8>,
     schema: Arc<Schema>,
     bloom_filter_fields: &[String],
-    full_text_search_fields: &[String],
     rules: HashMap<String, DataType>,
     file_type: FileType,
 ) -> Result<()> {
@@ -137,13 +136,7 @@ pub async fn convert_parquet_file(
     let schema = Arc::new(schema);
     let batches = df.collect().await?;
     let file_meta = FileMeta::default();
-    let mut writer = new_parquet_writer(
-        buf,
-        &schema,
-        bloom_filter_fields,
-        full_text_search_fields,
-        &file_meta,
-    );
+    let mut writer = new_parquet_writer(buf, &schema, bloom_filter_fields, &file_meta);
     for batch in batches {
         writer.write(&batch).await?;
     }


### PR DESCRIPTION
The [parquet document](https://parquet.apache.org/docs/file-format/data-pages/encodings/#dictionary-encoding-plain_dictionary--2-and-rle_dictionary--8) mentioned:
```
If the dictionary grows too big, whether in size or number of distinct values, the encoding will fall back to the plain encoding. 
```

So we don't need manually set it to `false`. that is not necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified handling of bloom filter fields in data processing.
  
- **Bug Fixes**
	- Removed redundant parameters from various function calls, streamlining interactions.

- **Refactor**
	- Eliminated full-text search fields from multiple functions, enhancing code clarity and reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->