### PR TITLE
fix: fixed unlimited calls when going back and forth

### DIFF
--- a/web/src/plugins/logs/SearchHistory.vue
+++ b/web/src/plugins/logs/SearchHistory.vue
@@ -383,7 +383,7 @@
 
 
       watch(() => props.isClicked, (value) => {
-        if(value == true){
+        if(value == true && !isLoading.value){
           fetchSearchHistory();
         }
       });

--- a/web/src/plugins/logs/SearchHistory.vue
+++ b/web/src/plugins/logs/SearchHistory.vue
@@ -31,6 +31,7 @@
                 label="Get History"
                 @click="fetchSearchHistory"
                 class="q-ml-md"
+                :disable="isLoading"
               />
             </div>
   


### PR DESCRIPTION
This PR fixes the unlimited calling when going back and forth from the search_history now only one call will be made until it get succeeded search_history wont make new calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced search history functionality with improved data fetching and display logic.
	- Added error handling and loading state management for better user experience.
	- Improved navigation to the logs page with clearer parameter construction.

- **Bug Fixes**
	- Resolved issues with multiple fetch calls during loading states.
	- Optimized row expansion to allow only one row to be expanded at a time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->