### PR TITLE
feat: add db metrics

### DIFF
--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -673,6 +673,16 @@ pub static DB_QUERY_NUMS: Lazy<IntCounterVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+pub static DB_QUERY_TIME: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new("db_query_time", "db query time. ".to_owned())
+            .namespace(NAMESPACE)
+            .const_labels(create_const_labels()),
+        &["kind", "table"],
+    )
+    .expect("Metric created")
+});
+
 pub static FILE_LIST_ID_SELECT_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
@@ -874,6 +884,9 @@ fn register_metrics(registry: &Registry) {
     // db stats
     registry
         .register(Box::new(DB_QUERY_NUMS.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(DB_QUERY_TIME.clone()))
         .expect("Metric registered");
 
     // file list specific metrics

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -668,7 +668,7 @@ pub static DB_QUERY_NUMS: Lazy<IntCounterVec> = Lazy::new(|| {
         Opts::new("db_query_nums", "db query number")
             .namespace(NAMESPACE)
             .const_labels(create_const_labels()),
-        &["type", "table"],
+        &["operation", "table"],
     )
     .expect("Metric created")
 });
@@ -678,7 +678,7 @@ pub static DB_QUERY_TIME: Lazy<HistogramVec> = Lazy::new(|| {
         HistogramOpts::new("db_query_time", "db query time. ".to_owned())
             .namespace(NAMESPACE)
             .const_labels(create_const_labels()),
-        &["kind", "table"],
+        &["operation", "table"],
     )
     .expect("Metric created")
 });

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -662,6 +662,17 @@ pub static QUERY_CANCELED_NUMS: Lazy<IntCounterVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+// This corresponds to mysql or pgsql queries, not sqlite as that is local and can be ignored
+pub static DB_QUERY_NUMS: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new("db_query_nums", "db query number")
+            .namespace(NAMESPACE)
+            .const_labels(create_const_labels()),
+        &["type","table"],
+    )
+    .expect("Metric created")
+});
+
 fn register_metrics(registry: &Registry) {
     // http latency
     registry
@@ -832,6 +843,11 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(QUERY_DISK_RESULT_CACHE_FILES.clone()))
+        .expect("Metric registered");
+
+    // db stats
+    registry
+        .register(Box::new(DB_QUERY_NUMS.clone()))
         .expect("Metric registered");
 }
 

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -668,7 +668,33 @@ pub static DB_QUERY_NUMS: Lazy<IntCounterVec> = Lazy::new(|| {
         Opts::new("db_query_nums", "db query number")
             .namespace(NAMESPACE)
             .const_labels(create_const_labels()),
-        &["type","table"],
+        &["type", "table"],
+    )
+    .expect("Metric created")
+});
+
+pub static FILE_LIST_ID_SELECT_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "file_list_id_select_count",
+            "total number of ids returned by file list query",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
+pub static FILE_LIST_CACHE_HIT_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "file_list_cache_hit_count",
+            "number of ids returned from file list cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
     )
     .expect("Metric created")
 });
@@ -848,6 +874,14 @@ fn register_metrics(registry: &Registry) {
     // db stats
     registry
         .register(Box::new(DB_QUERY_NUMS.clone()))
+        .expect("Metric registered");
+
+    // file list specific metrics
+    registry
+        .register(Box::new(FILE_LIST_ID_SELECT_COUNT.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(FILE_LIST_CACHE_HIT_COUNT.clone()))
         .expect("Metric registered");
 }
 

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -683,32 +683,6 @@ pub static DB_QUERY_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
-pub static FILE_LIST_ID_SELECT_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
-    IntGaugeVec::new(
-        Opts::new(
-            "file_list_id_select_count",
-            "total number of ids returned by file list query",
-        )
-        .namespace(NAMESPACE)
-        .const_labels(create_const_labels()),
-        &[],
-    )
-    .expect("Metric created")
-});
-
-pub static FILE_LIST_CACHE_HIT_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
-    IntGaugeVec::new(
-        Opts::new(
-            "file_list_cache_hit_count",
-            "number of ids returned from file list cache",
-        )
-        .namespace(NAMESPACE)
-        .const_labels(create_const_labels()),
-        &[],
-    )
-    .expect("Metric created")
-});
-
 fn register_metrics(registry: &Registry) {
     // http latency
     registry
@@ -887,14 +861,6 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(DB_QUERY_TIME.clone()))
-        .expect("Metric registered");
-
-    // file list specific metrics
-    registry
-        .register(Box::new(FILE_LIST_ID_SELECT_COUNT.clone()))
-        .expect("Metric registered");
-    registry
-        .register(Box::new(FILE_LIST_CACHE_HIT_COUNT.clone()))
         .expect("Metric registered");
 }
 

--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -75,7 +75,7 @@ impl super::Db for MysqlDb {
 
     async fn stats(&self) -> Result<super::Stats> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let keys_count: i64 =
             sqlx::query_scalar(r#"SELECT CAST(COUNT(*) AS SIGNED) AS num FROM meta;"#)
                 .fetch_one(&pool)
@@ -90,7 +90,7 @@ impl super::Db for MysqlDb {
     async fn get(&self, key: &str) -> Result<Bytes> {
         let (module, key1, key2) = super::parse_key(key);
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let query = r#"SELECT value FROM meta WHERE module = ? AND key1 = ? AND key2 = ? ORDER BY start_dt DESC;"#;
         let value: String = match sqlx::query_scalar(query)
             .bind(module)
@@ -125,7 +125,7 @@ impl super::Db for MysqlDb {
         let pool = CLIENT.clone();
         let local_start_dt = start_dt.unwrap_or_default();
         let mut tx = pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["INSERT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
         let start = std::time::Instant::now();
         if let Err(e) = sqlx::query(
             r#"INSERT IGNORE INTO meta (module, key1, key2, start_dt, value) VALUES (?, ?, ?, ?, '');"#
@@ -142,7 +142,7 @@ impl super::Db for MysqlDb {
             }
             return Err(e.into());
         }
-        DB_QUERY_NUMS.with_label_values(&["UPDATE", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "meta"]).inc();
         if let Err(e) = sqlx::query(
               r#"UPDATE meta SET value = ? WHERE module = ? AND key1 = ? AND key2 = ? AND start_dt = ?;"#
             )
@@ -197,7 +197,7 @@ impl super::Db for MysqlDb {
         );
         let unlock_sql = format!("SELECT RELEASE_LOCK('{}')", lock_id);
         let mut lock_tx = lock_pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["GET_LOCK", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         match sqlx::query_scalar::<_, i64>(&lock_sql)
             .fetch_one(&mut *lock_tx)
             .await
@@ -225,7 +225,7 @@ impl super::Db for MysqlDb {
         let mut tx = pool.begin().await?;
         let mut need_watch_dt = 0;
         let row = if let Some(start_dt) = start_dt {
-            DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+            DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
             match sqlx::query_as::<_,super::MetaRecord>(
                 r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = ? AND key1 = ? AND key2 = ? AND start_dt = ?;"#
             )
@@ -244,7 +244,7 @@ impl super::Db for MysqlDb {
                         if let Err(e) = tx.rollback().await {
                             log::error!("[MYSQL] rollback get_for_update error: {}", e);
                         }
-                        DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+                        DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                         if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                             log::error!("[MYSQL] unlock get_for_update error: {}", e);
                         }
@@ -256,7 +256,7 @@ impl super::Db for MysqlDb {
                 }
             }
         } else {
-            DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+            DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
             match sqlx::query_as::<_,super::MetaRecord>(
                 r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = ? AND key1 = ? AND key2 = ? ORDER BY id DESC;"#
             )
@@ -274,7 +274,7 @@ impl super::Db for MysqlDb {
                         if let Err(e) = tx.rollback().await {
                             log::error!("[MYSQL] rollback get_for_update error: {}", e);
                         }
-                        DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+                        DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                         if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                             log::error!("[MYSQL] unlock get_for_update error: {}", e);
                         }
@@ -294,7 +294,7 @@ impl super::Db for MysqlDb {
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback get_for_update error: {}", e);
                 }
-                DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_for_update error: {}", e);
                 }
@@ -307,7 +307,7 @@ impl super::Db for MysqlDb {
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback get_for_update error: {}", e);
                 }
-                DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_for_update error: {}", e);
                 }
@@ -322,14 +322,14 @@ impl super::Db for MysqlDb {
         // update value
         if let Some(value) = value {
             let ret = if exist {
-                DB_QUERY_NUMS.with_label_values(&["UPDATE", "meta"]).inc();
+                DB_QUERY_NUMS.with_label_values(&["update", "meta"]).inc();
                 sqlx::query(r#"UPDATE meta SET value = ? WHERE id = ?;"#)
                     .bind(String::from_utf8(value.to_vec()).unwrap_or_default())
                     .bind(row_id.unwrap())
                     .execute(&mut *tx)
                     .await
             } else {
-                DB_QUERY_NUMS.with_label_values(&["INSERT", "meta"]).inc();
+                DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
                 sqlx::query(
                     r#"INSERT INTO meta (module, key1, key2, start_dt, value) VALUES (?, ?, ?, ?, ?);"#,
                 )
@@ -345,7 +345,7 @@ impl super::Db for MysqlDb {
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback get_for_update error: {}", e);
                 }
-                DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_for_update error: {}", e);
                 }
@@ -360,7 +360,7 @@ impl super::Db for MysqlDb {
         if let Some((new_key, new_value, new_start_dt)) = new_value {
             need_watch_dt = new_start_dt.unwrap_or_default();
             let (module, key1, key2) = super::parse_key(&new_key);
-            DB_QUERY_NUMS.with_label_values(&["INSERT", "meta"]).inc();
+            DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
             if let Err(e) = sqlx::query(
                 r#"INSERT INTO meta (module, key1, key2, start_dt, value) VALUES (?, ?, ?, ?, ?);"#,
             )
@@ -375,7 +375,7 @@ impl super::Db for MysqlDb {
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback get_for_update error: {}", e);
                 }
-                DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_for_update error: {}", e);
                 }
@@ -390,7 +390,7 @@ impl super::Db for MysqlDb {
             log::error!("[MYSQL] commit get_for_update error: {}", e);
             return Err(e.into());
         }
-        DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
         if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
             log::error!("[MYSQL] unlock get_for_update error: {}", e);
         }
@@ -473,7 +473,7 @@ impl super::Db for MysqlDb {
         };
 
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["DELETE", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["delete", "meta"]).inc();
         sqlx::query(&sql).execute(&pool).await?;
 
         Ok(())
@@ -494,7 +494,7 @@ impl super::Db for MysqlDb {
         sql = format!("{} ORDER BY start_dt ASC", sql);
 
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -524,7 +524,7 @@ impl super::Db for MysqlDb {
 
         sql = format!("{} ORDER BY start_dt ASC", sql);
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -573,7 +573,7 @@ impl super::Db for MysqlDb {
         );
         sql = format!("{} ORDER BY start_dt ASC", sql);
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -596,7 +596,7 @@ impl super::Db for MysqlDb {
             sql = format!("{} AND (key2 = '{}' OR key2 LIKE '{}/%')", sql, key2, key2);
         }
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let count: i64 = sqlx::query_scalar(&sql).fetch_one(&pool).await?;
         Ok(count)
     }
@@ -618,7 +618,7 @@ impl super::Db for MysqlDb {
 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
-    DB_QUERY_NUMS.with_label_values(&["CREATE", "meta"]).inc();
+    DB_QUERY_NUMS.with_label_values(&["create", "meta"]).inc();
     // create table
     _ = sqlx::query(
         r#"
@@ -636,7 +636,7 @@ CREATE TABLE IF NOT EXISTS meta
     .execute(&pool)
     .await?;
     DB_QUERY_NUMS
-        .with_label_values(&["SELECT", "information_schema.columns"])
+        .with_label_values(&["select", "information_schema.columns"])
         .inc();
     // create start_dt column for old version <= 0.9.2
     let has_start_dt = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='meta' AND column_name='start_dt';")
@@ -674,7 +674,7 @@ async fn add_start_dt_column() -> Result<()> {
     let pool = CLIENT.clone();
     let mut tx = pool.begin().await?;
 
-    DB_QUERY_NUMS.with_label_values(&["ALTER", "meta"]).inc();
+    DB_QUERY_NUMS.with_label_values(&["alter", "meta"]).inc();
     if let Err(e) =
         sqlx::query(r#"ALTER TABLE meta ADD COLUMN start_dt BIGINT NOT NULL DEFAULT 0;"#)
             .execute(&mut *tx)
@@ -738,7 +738,7 @@ async fn create_meta_backup() -> Result<()> {
     let pool = CLIENT.clone();
     let mut tx = pool.begin().await?;
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "meta_backup_20240330"])
+        .with_label_values(&["create", "meta_backup_20240330"])
         .inc();
     // Create the meta_backup table like meta
     if let Err(e) = sqlx::query(r#"CREATE TABLE IF NOT EXISTS meta_backup_20240330 like meta;"#)
@@ -755,7 +755,7 @@ async fn create_meta_backup() -> Result<()> {
     }
 
     DB_QUERY_NUMS
-        .with_label_values(&["SELECT", "meta_backup_20240330"])
+        .with_label_values(&["select", "meta_backup_20240330"])
         .inc();
     // Check if meta_backup is empty before attempting to insert data
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM meta_backup_20240330")
@@ -764,7 +764,7 @@ async fn create_meta_backup() -> Result<()> {
 
     if count == 0 {
         DB_QUERY_NUMS
-            .with_label_values(&["INSERT", "meta_backup_20240330"])
+            .with_label_values(&["insert", "meta_backup_20240330"])
             .inc();
         // Attempt to insert data into meta_backup from meta since it's empty
         if let Err(e) = sqlx::query(r#"INSERT INTO meta_backup_20240330 SELECT * FROM meta;"#)

--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -653,7 +653,9 @@ CREATE TABLE IF NOT EXISTS meta
         "CREATE UNIQUE INDEX meta_module_start_dt_idx on meta (module, key1, key2, start_dt);",
     )
     .await?;
-
+    DB_QUERY_NUMS
+        .with_label_values(&["create", "meta"])
+        .inc_by(3);
     Ok(())
 }
 
@@ -695,6 +697,7 @@ async fn add_start_dt_column() -> Result<()> {
     };
 
     // create new index meta_module_start_dt_idx
+    DB_QUERY_NUMS.with_label_values(&["create", "meta"]).inc();
     if let Err(e) = create_index_item(
         "CREATE UNIQUE INDEX meta_module_start_dt_idx ON meta (module, key1, key2, start_dt);",
     )
@@ -709,6 +712,7 @@ async fn add_start_dt_column() -> Result<()> {
 
     // delete old index meta_module_key2_idx
     let mut tx = pool.begin().await?;
+    DB_QUERY_NUMS.with_label_values(&["drop", "meta"]).inc();
     if let Err(e) = sqlx::query(r#"DROP INDEX meta_module_key2_idx ON meta;"#)
         .execute(&mut *tx)
         .await

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -587,6 +587,9 @@ CREATE TABLE IF NOT EXISTS meta
         "CREATE UNIQUE INDEX IF NOT EXISTS meta_module_start_dt_idx on meta (module, key1, key2, start_dt);",
     )
     .await?;
+    DB_QUERY_NUMS
+        .with_label_values(&["create", "meta"])
+        .inc_by(3);
 
     Ok(())
 }
@@ -618,6 +621,7 @@ async fn add_start_dt_column() -> Result<()> {
     }
 
     // Proceed to drop the index if it exists and create a new one if it does not exist
+    DB_QUERY_NUMS.with_label_values(&["create", "meta"]).inc();
     if let Err(e) = sqlx::query(
         r#"CREATE UNIQUE INDEX IF NOT EXISTS meta_module_start_dt_idx ON meta (module, key1, key2, start_dt);"#
     )
@@ -629,6 +633,7 @@ async fn add_start_dt_column() -> Result<()> {
         }
         return Err(e.into());
     }
+    DB_QUERY_NUMS.with_label_values(&["drop", "meta"]).inc();
     if let Err(e) = sqlx::query(r#"DROP INDEX IF EXISTS meta_module_key2_idx;"#)
         .execute(&mut *tx)
         .await

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -75,7 +75,7 @@ impl super::Db for PostgresDb {
 
     async fn stats(&self) -> Result<super::Stats> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let keys_count: i64 = sqlx::query_scalar(r#"SELECT COUNT(*)::BIGINT AS num FROM meta;"#)
             .fetch_one(&pool)
             .await
@@ -89,7 +89,7 @@ impl super::Db for PostgresDb {
     async fn get(&self, key: &str) -> Result<Bytes> {
         let (module, key1, key2) = super::parse_key(key);
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let query = r#"SELECT value FROM meta WHERE module = $1 AND key1 = $2 AND key2 = $3 ORDER BY start_dt DESC;"#;
         let value: String = match sqlx::query_scalar(query)
             .bind(module)
@@ -124,7 +124,7 @@ impl super::Db for PostgresDb {
         let pool = CLIENT.clone();
         let local_start_dt = start_dt.unwrap_or_default();
         let mut tx = pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["INSERT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
         let start = std::time::Instant::now();
         if let Err(e) = sqlx::query(
             r#"INSERT INTO meta (module, key1, key2, start_dt, value) VALUES ($1, $2, $3, $4, '') ON CONFLICT DO NOTHING;"#
@@ -142,7 +142,7 @@ impl super::Db for PostgresDb {
             return Err(e.into());
         }
 
-        DB_QUERY_NUMS.with_label_values(&["UPDATE", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "meta"]).inc();
         if let Err(e) = sqlx::query(
                 r#"UPDATE meta SET value = $1 WHERE module = $2 AND key1 = $3 AND key2 = $4 AND start_dt = $5;"#
             )
@@ -197,7 +197,7 @@ impl super::Db for PostgresDb {
             lock_id as i64
         };
         let lock_sql = format!("SELECT pg_advisory_xact_lock({lock_id})");
-        DB_QUERY_NUMS.with_label_values(&["GET_LOCK", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         if let Err(e) = sqlx::query(&lock_sql).execute(&mut *tx).await {
             if let Err(e) = tx.rollback().await {
                 log::error!("[POSTGRES] rollback get_for_update error: {}", e);
@@ -206,7 +206,7 @@ impl super::Db for PostgresDb {
         };
         let mut need_watch_dt = 0;
         let row = if let Some(start_dt) = start_dt {
-            DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+            DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
             match sqlx::query_as::<_,super::MetaRecord>(
                 r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = $1 AND key1 = $2 AND key2 = $3 AND start_dt = $4;"#
             )
@@ -230,7 +230,7 @@ impl super::Db for PostgresDb {
                 }
             }
         } else {
-            DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+            DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
             match sqlx::query_as::<_,super::MetaRecord>(
                 r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = $1 AND key1 = $2 AND key2 = $3 ORDER BY id DESC;"#
             )
@@ -275,14 +275,14 @@ impl super::Db for PostgresDb {
         // update value
         if let Some(value) = value {
             let ret = if exist {
-                DB_QUERY_NUMS.with_label_values(&["UPDATE", "meta"]).inc();
+                DB_QUERY_NUMS.with_label_values(&["update", "meta"]).inc();
                 sqlx::query(r#"UPDATE meta SET value = $1 WHERE id = $2;"#)
                     .bind(String::from_utf8(value.to_vec()).unwrap_or_default())
                     .bind(row_id.unwrap())
                     .execute(&mut *tx)
                     .await
             } else {
-                DB_QUERY_NUMS.with_label_values(&["INSERT", "meta"]).inc();
+                DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
                 sqlx::query(
                 r#"INSERT INTO meta (module, key1, key2, start_dt, value) VALUES ($1, $2, $3, $4, $5);"#
             )
@@ -306,7 +306,7 @@ impl super::Db for PostgresDb {
         if let Some((new_key, new_value, new_start_dt)) = new_value {
             need_watch_dt = new_start_dt.unwrap_or_default();
             let (module, key1, key2) = super::parse_key(&new_key);
-            DB_QUERY_NUMS.with_label_values(&["INSERT", "meta"]).inc();
+            DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
             if let Err(e) = sqlx::query(
                 r#"INSERT INTO meta (module, key1, key2, start_dt, value) VALUES ($1, $2, $3, $4, $5);"#
             )
@@ -405,7 +405,7 @@ impl super::Db for PostgresDb {
         };
 
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["DELETE", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["delete", "meta"]).inc();
         sqlx::query(&sql).execute(&pool).await?;
 
         Ok(())
@@ -426,7 +426,7 @@ impl super::Db for PostgresDb {
         sql = format!("{} ORDER BY start_dt ASC", sql);
 
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -455,7 +455,7 @@ impl super::Db for PostgresDb {
         }
         sql = format!("{} ORDER BY start_dt ASC", sql);
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -504,7 +504,7 @@ impl super::Db for PostgresDb {
         sql = format!("{} ORDER BY start_dt ASC", sql);
 
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -527,7 +527,7 @@ impl super::Db for PostgresDb {
             sql = format!("{} AND (key2 = '{}' OR key2 LIKE '{}/%')", sql, key2, key2);
         }
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "meta"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let count: i64 = sqlx::query_scalar(&sql).fetch_one(&pool).await?;
         Ok(count)
     }
@@ -550,7 +550,7 @@ impl super::Db for PostgresDb {
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
 
-    DB_QUERY_NUMS.with_label_values(&["CREATE", "meta"]).inc();
+    DB_QUERY_NUMS.with_label_values(&["create", "meta"]).inc();
     // create table
     _ = sqlx::query(
         r#"
@@ -570,7 +570,7 @@ CREATE TABLE IF NOT EXISTS meta
 
     // create start_dt column for old version <= 0.9.2
     DB_QUERY_NUMS
-        .with_label_values(&["SELECT", "information_schema.columns"])
+        .with_label_values(&["select", "information_schema.columns"])
         .inc();
     let has_start_dt = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='meta' AND column_name='start_dt';")
             .fetch_one(&pool)
@@ -603,7 +603,7 @@ async fn create_index_item(sql: &str) -> Result<()> {
 async fn add_start_dt_column() -> Result<()> {
     let pool = CLIENT.clone();
     let mut tx = pool.begin().await?;
-    DB_QUERY_NUMS.with_label_values(&["ALTER", "meta"]).inc();
+    DB_QUERY_NUMS.with_label_values(&["alter", "meta"]).inc();
     if let Err(e) = sqlx::query(
         r#"ALTER TABLE meta ADD COLUMN IF NOT EXISTS start_dt BIGINT NOT NULL DEFAULT 0;"#,
     )
@@ -654,7 +654,7 @@ async fn create_meta_backup() -> Result<()> {
     let pool = CLIENT.clone();
     let mut tx = pool.begin().await?;
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "meta_backup_20240330"])
+        .with_label_values(&["create", "meta_backup_20240330"])
         .inc();
     if let Err(e) =
         sqlx::query(r#"CREATE TABLE IF NOT EXISTS meta_backup_20240330 AS SELECT * FROM meta;"#)

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -71,7 +71,7 @@ impl super::FileList for MysqlFileList {
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["DELETE", "file_list"])
+            .with_label_values(&["delete", "file_list"])
             .inc();
         sqlx::query(r#"DELETE FROM file_list WHERE stream = ? AND date = ? AND file = ?;"#)
             .bind(stream_key)
@@ -103,7 +103,7 @@ impl super::FileList for MysqlFileList {
                 let (stream_key, date_key, file_name) =
                     parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
                 DB_QUERY_NUMS
-                    .with_label_values(&["SELECT", "file_list"])
+                    .with_label_values(&["select", "file_list"])
                     .inc();
                 let start = std::time::Instant::now();
                 let query_res = sqlx::query_scalar(
@@ -136,7 +136,7 @@ impl super::FileList for MysqlFileList {
             if !ids.is_empty() {
                 let sql = format!("DELETE FROM file_list WHERE id IN({});", ids.join(","));
                 DB_QUERY_NUMS
-                    .with_label_values(&["DELETE", "file_list"])
+                    .with_label_values(&["delete", "file_list"])
                     .inc();
                 let start = std::time::Instant::now();
                 _ = pool.execute(sql.as_str()).await?;
@@ -177,7 +177,7 @@ impl super::FileList for MysqlFileList {
                     .push_bind(created_at);
             });
             DB_QUERY_NUMS
-                .with_label_values(&["INSERT", "file_list_deleted"])
+                .with_label_values(&["insert", "file_list_deleted"])
                 .inc();
             if let Err(e) = query_builder.build().execute(&mut *tx).await {
                 if let Err(e) = tx.rollback().await {
@@ -206,7 +206,7 @@ impl super::FileList for MysqlFileList {
                 let (stream_key, date_key, file_name) =
                     parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
                 DB_QUERY_NUMS
-                    .with_label_values(&["SELECT", "file_list_deleted"])
+                    .with_label_values(&["select", "file_list_deleted"])
                     .inc();
                 let ret: Option<i64> = match sqlx::query_scalar(
                     r#"SELECT id FROM file_list_deleted WHERE stream = ? AND date = ? AND file = ?"#,
@@ -238,7 +238,7 @@ impl super::FileList for MysqlFileList {
                     ids.join(",")
                 );
                 DB_QUERY_NUMS
-                    .with_label_values(&["DELETE", "file_list_deleted"])
+                    .with_label_values(&["delete", "file_list_deleted"])
                     .inc();
                 _ = pool.execute(sql.as_str()).await?;
             }
@@ -251,7 +251,7 @@ impl super::FileList for MysqlFileList {
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = sqlx::query_as::<_, super::FileRecord>(
@@ -277,7 +277,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret =
@@ -302,7 +302,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list"])
+            .with_label_values(&["update", "file_list"])
             .inc();
         sqlx::query(
             r#"UPDATE file_list SET flattened = ? WHERE stream = ? AND date = ? AND file = ?;"#,
@@ -339,7 +339,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
 
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = if flattened.is_some() {
@@ -447,7 +447,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
                 let pool = CLIENT.clone();
                 let cfg = get_config();
                 DB_QUERY_NUMS
-                    .with_label_values(&["SELECT", "file_list"])
+                    .with_label_values(&["select", "file_list"])
                     .inc();
                 if cfg.limit.use_upper_bound_for_max_ts {
                     // TODO: if partition is daily, we need to remove this logic
@@ -539,7 +539,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         }
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list_deleted"])
+            .with_label_values(&["select", "file_list_deleted"])
             .inc();
         let ret = sqlx::query_as::<_, super::FileDeletedRecord>(
             r#"SELECT stream, date, file, flattened FROM file_list_deleted WHERE org = ? AND created_at < ? LIMIT ?;"#,
@@ -570,7 +570,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         let min_ts = config::utils::time::BASE_TIME.timestamp_micros();
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret: Option<i64> =
             sqlx::query_scalar(r#"SELECT MIN(min_ts) AS id FROM file_list FORCE INDEX (file_list_stream_ts_idx) WHERE stream = ? AND min_ts > ?;"#)
@@ -584,7 +584,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
     async fn get_max_pk_value(&self) -> Result<i64> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret: Option<i64> = sqlx::query_scalar(r#"SELECT MAX(id) AS id FROM file_list;"#)
             .fetch_one(&pool)
@@ -629,7 +629,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         };
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
             .fetch_all(&pool)
@@ -658,7 +658,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         };
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "stream_stats"])
+            .with_label_values(&["select", "stream_stats"])
             .inc();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
             .fetch_all(&pool)
@@ -681,7 +681,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         );
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "stream_stats"])
+            .with_label_values(&["select", "stream_stats"])
             .inc();
         sqlx::query(&sql).execute(&pool).await?;
         Ok(())
@@ -713,7 +713,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         for stream_key in new_streams {
             let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
             DB_QUERY_NUMS
-                .with_label_values(&["INSERT", "stream_stats"])
+                .with_label_values(&["insert", "stream_stats"])
                 .inc();
             if let Err(e) = sqlx::query(
                 r#"
@@ -741,7 +741,7 @@ INSERT INTO stream_stats
         let mut tx = pool.begin().await?;
         for (stream_key, stats) in update_streams {
             DB_QUERY_NUMS
-                .with_label_values(&["UPDATE", "stream_stats"])
+                .with_label_values(&["update", "stream_stats"])
                 .inc();
             if let Err(e) = sqlx::query(
                 r#"
@@ -777,7 +777,7 @@ UPDATE stream_stats
     async fn reset_stream_stats(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "stream_stats"])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx::query(r#"UPDATE stream_stats SET file_num = 0, min_ts = 0, max_ts = 0, records = 0, original_size = 0, compressed_size = 0;"#)
              .execute(&pool)
@@ -793,7 +793,7 @@ UPDATE stream_stats
     ) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "stream_stats"])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx::query(r#"UPDATE stream_stats SET min_ts = ? WHERE stream = ?;"#)
             .bind(min_ts)
@@ -801,7 +801,7 @@ UPDATE stream_stats
             .execute(&pool)
             .await?;
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "stream_stats"])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx::query(
             r#"UPDATE stream_stats SET max_ts = min_ts WHERE stream = ? AND max_ts < min_ts;"#,
@@ -815,7 +815,7 @@ UPDATE stream_stats
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret = match sqlx::query(r#"SELECT CAST(COUNT(*) AS SIGNED) AS num FROM file_list;"#)
             .fetch_one(&pool)
@@ -851,7 +851,7 @@ UPDATE stream_stats
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["INSERT", "file_list_jobs"])
+            .with_label_values(&["insert", "file_list_jobs"])
             .inc();
         match sqlx::query(
             "INSERT IGNORE INTO file_list_jobs (org, stream, offsets, status, node, started_at, updated_at) VALUES (?, ?, ?, ?, '', 0, 0);",
@@ -884,7 +884,7 @@ UPDATE stream_stats
         );
         let unlock_sql = format!("SELECT RELEASE_LOCK('{}')", lock_id);
         let mut lock_tx = lock_pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["GET_LOCK", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         match sqlx::query_scalar::<_, i64>(&lock_sql)
             .fetch_one(&mut *lock_tx)
             .await
@@ -912,7 +912,7 @@ UPDATE stream_stats
         let mut tx = pool.begin().await?;
         // get pending jobs group by stream and order by num desc
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list_jobs"])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(
             r#"
@@ -935,7 +935,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
                         "[MYSQL] rollback select file_list_jobs pending jobs for update error: {e}"
                     );
                 }
-                DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_pending_jobs error: {}", e);
                 }
@@ -951,7 +951,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
             if let Err(e) = tx.rollback().await {
                 log::error!("[MYSQL] rollback select file_list_jobs pending jobs error: {e}");
             }
-            DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+            DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
             if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                 log::error!("[MYSQL] unlock get_pending_jobs error: {}", e);
             }
@@ -966,7 +966,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         );
         let now = config::utils::time::now_micros();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         if let Err(e) = sqlx::query(&sql)
             .bind(super::FileListJobStatus::Running)
@@ -979,7 +979,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
             if let Err(e) = tx.rollback().await {
                 log::error!("[MYSQL] rollback update file_list_jobs status error: {e}");
             }
-            DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+            DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
             if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                 log::error!("[MYSQL] unlock get_pending_jobs error: {}", e);
             }
@@ -994,7 +994,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
             ids.join(",")
         );
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list_jobs"])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret = match sqlx::query_as::<_, super::MergeJobRecord>(&sql)
             .fetch_all(&mut *tx)
@@ -1005,7 +1005,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback select file_list_jobs by ids error: {e}");
                 }
-                DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_pending_jobs error: {}", e);
                 }
@@ -1019,7 +1019,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
             log::error!("[MYSQL] commit select file_list_jobs pending jobs error: {e}");
             return Err(e.into());
         }
-        DB_QUERY_NUMS.with_label_values(&["RELEASE_LOCK", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
         if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
             log::error!("[MYSQL] unlock get_pending_jobs error: {}", e);
         }
@@ -1032,7 +1032,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
     async fn set_job_pending(&self, ids: &[i64]) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         let sql = format!(
             "UPDATE file_list_jobs SET status = ? WHERE id IN ({});",
@@ -1051,7 +1051,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
     async fn set_job_done(&self, id: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         sqlx::query(r#"UPDATE file_list_jobs SET status = ?, updated_at = ? WHERE id = ?;"#)
             .bind(super::FileListJobStatus::Done)
@@ -1065,7 +1065,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
     async fn update_running_jobs(&self, id: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         sqlx::query(r#"UPDATE file_list_jobs SET updated_at = ? WHERE id = ?;"#)
             .bind(config::utils::time::now_micros())
@@ -1078,7 +1078,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
     async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         let ret = sqlx::query(
             r#"UPDATE file_list_jobs SET status = ? WHERE status = ? AND updated_at < ?;"#,
@@ -1097,7 +1097,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
     async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["DELETE", "file_list_jobs"])
+            .with_label_values(&["delete", "file_list_jobs"])
             .inc();
         let ret = sqlx::query(r#"DELETE FROM file_list_jobs WHERE status = ? AND updated_at < ?;"#)
             .bind(super::FileListJobStatus::Done)
@@ -1114,7 +1114,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         let pool = CLIENT.clone();
 
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list_jobs"])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret =
             sqlx::query(r#"SELECT stream, status, count(*) as counts FROM file_list_jobs GROUP BY stream, status ORDER BY status desc;"#)
@@ -1153,7 +1153,7 @@ impl MysqlFileList {
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
-        DB_QUERY_NUMS.with_label_values(&["INSERT", table]).inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", table]).inc();
         match  sqlx::query(
             format!(r#"
 INSERT IGNORE INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, flattened)
@@ -1210,7 +1210,7 @@ INSERT IGNORE INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, re
                     .push_bind(item.meta.compressed_size)
                     .push_bind(item.meta.flattened);
             });
-            DB_QUERY_NUMS.with_label_values(&["INSERT", table]).inc();
+            DB_QUERY_NUMS.with_label_values(&["insert", table]).inc();
             let need_single_insert = match query_builder.build().execute(&mut *tx).await {
                 Ok(_) => false,
                 Err(sqlx::Error::Database(e)) => {
@@ -1253,7 +1253,7 @@ INSERT IGNORE INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, re
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "file_list"])
+        .with_label_values(&["create", "file_list"])
         .inc();
     sqlx::query(
         r#"
@@ -1278,7 +1278,7 @@ CREATE TABLE IF NOT EXISTS file_list
     .await?;
 
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "file_list_history"])
+        .with_label_values(&["create", "file_list_history"])
         .inc();
     sqlx::query(
         r#"
@@ -1303,7 +1303,7 @@ CREATE TABLE IF NOT EXISTS file_list_history
     .await?;
 
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "file_list_deleted"])
+        .with_label_values(&["create", "file_list_deleted"])
         .inc();
     sqlx::query(
         r#"
@@ -1323,7 +1323,7 @@ CREATE TABLE IF NOT EXISTS file_list_deleted
     .await?;
 
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "file_list_jobs"])
+        .with_label_values(&["create", "file_list_jobs"])
         .inc();
     sqlx::query(
         r#"
@@ -1344,7 +1344,7 @@ CREATE TABLE IF NOT EXISTS file_list_jobs
     .await?;
 
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "stream_stats"])
+        .with_label_values(&["create", "stream_stats"])
         .inc();
     sqlx::query(
         r#"
@@ -1449,7 +1449,7 @@ pub async fn create_table_index() -> Result<()> {
             log::warn!("[MYSQL] starting delete duplicate records");
             // delete duplicate records
             DB_QUERY_NUMS
-                .with_label_values(&["SELECT", "file_list"])
+                .with_label_values(&["select", "file_list"])
                 .inc();
             let ret = sqlx::query(
                 r#"SELECT stream, date, file, min(id) as id FROM file_list GROUP BY stream, date, file HAVING COUNT(*) > 1;"#,
@@ -1461,7 +1461,7 @@ pub async fn create_table_index() -> Result<()> {
                 let file = r.get::<String, &str>("file");
                 let id = r.get::<i64, &str>("id");
                 DB_QUERY_NUMS
-                    .with_label_values(&["DELETE", "file_list"])
+                    .with_label_values(&["delete", "file_list"])
                     .inc();
                 sqlx::query(
                     r#"DELETE FROM file_list WHERE id != ? AND stream = ? AND date = ? AND file = ?;"#,
@@ -1489,7 +1489,7 @@ pub async fn create_table_index() -> Result<()> {
 async fn add_column(table: &str, column: &str, data_type: &str) -> Result<()> {
     let pool = CLIENT.clone();
     DB_QUERY_NUMS
-        .with_label_values(&["SELECT", "information_schema.columns"])
+        .with_label_values(&["select", "information_schema.columns"])
         .inc();
     let check_sql = format!(
         "SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table}' AND column_name='{column}';"
@@ -1503,7 +1503,7 @@ async fn add_column(table: &str, column: &str, data_type: &str) -> Result<()> {
 
     let alert_sql = format!("ALTER TABLE {table} ADD COLUMN {column} {data_type};");
     let mut tx = pool.begin().await?;
-    DB_QUERY_NUMS.with_label_values(&["ALTER", table]).inc();
+    DB_QUERY_NUMS.with_label_values(&["alter", table]).inc();
     if let Err(e) = sqlx::query(&alert_sql).execute(&mut *tx).await {
         if !e.to_string().contains("Duplicate column name") {
             // Check for the specific MySQL error code for duplicate column

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -1429,6 +1429,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
     ];
     for (table, sql) in sqls {
+        DB_QUERY_NUMS.with_label_values(&["create", table]).inc();
         if let Err(e) = sqlx::query(sql).execute(&pool).await {
             if e.to_string().contains("Duplicate key") {
                 // index already exists
@@ -1440,6 +1441,9 @@ pub async fn create_table_index() -> Result<()> {
     }
 
     // create UNIQUE index for file_list
+    DB_QUERY_NUMS
+        .with_label_values(&["create", "file_list"])
+        .inc();
     let unique_index_sql =
         r#"CREATE UNIQUE INDEX file_list_stream_file_idx on file_list (stream, date, file);"#;
     if let Err(e) = sqlx::query(unique_index_sql).execute(&pool).await {
@@ -1476,6 +1480,9 @@ pub async fn create_table_index() -> Result<()> {
                 ret.len()
             );
             // create index again
+            DB_QUERY_NUMS
+                .with_label_values(&["create", "file_list"])
+                .inc();
             sqlx::query(unique_index_sql).execute(&pool).await?;
             log::warn!("[MYSQL] create table index(file_list_stream_file_idx) succeed");
         } else {

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -681,7 +681,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         );
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "stream_stats"])
+            .with_label_values(&["delete", "stream_stats"])
             .inc();
         sqlx::query(&sql).execute(&pool).await?;
         Ok(())

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -249,7 +249,7 @@ impl super::FileList for PostgresFileList {
             // delete files by ids
             if !ids.is_empty() {
                 DB_QUERY_NUMS
-                    .with_label_values(&["delete", "file_list"])
+                    .with_label_values(&["delete", "file_list_deleted"])
                     .inc();
                 let sql = format!(
                     "DELETE FROM file_list_deleted WHERE id IN({});",

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -73,7 +73,7 @@ impl super::FileList for PostgresFileList {
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
 
         DB_QUERY_NUMS
-            .with_label_values(&["DELETE", "file_list"])
+            .with_label_values(&["delete", "file_list"])
             .inc();
         sqlx::query(r#"DELETE FROM file_list WHERE stream = $1 AND date = $2 AND file = $3;"#)
             .bind(stream_key)
@@ -105,7 +105,7 @@ impl super::FileList for PostgresFileList {
                 let (stream_key, date_key, file_name) =
                     parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
                 DB_QUERY_NUMS
-                    .with_label_values(&["SELECT", "file_list"])
+                    .with_label_values(&["select", "file_list"])
                     .inc();
                 let start = std::time::Instant::now();
                 let query_res = sqlx::query_scalar(
@@ -142,7 +142,7 @@ impl super::FileList for PostgresFileList {
             // delete files by ids
             if !ids.is_empty() {
                 DB_QUERY_NUMS
-                    .with_label_values(&["DELETE", "file_list"])
+                    .with_label_values(&["delete", "file_list"])
                     .inc();
                 let sql = format!("DELETE FROM file_list WHERE id IN({});", ids.join(","));
                 let start = std::time::Instant::now();
@@ -184,7 +184,7 @@ impl super::FileList for PostgresFileList {
                     .push_bind(created_at);
             });
             DB_QUERY_NUMS
-                .with_label_values(&["INSERT", "file_list_deleted"])
+                .with_label_values(&["insert", "file_list_deleted"])
                 .inc();
             if let Err(e) = query_builder.build().execute(&mut *tx).await {
                 if let Err(e) = tx.rollback().await {
@@ -216,7 +216,7 @@ impl super::FileList for PostgresFileList {
                 let (stream_key, date_key, file_name) =
                     parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
                 DB_QUERY_NUMS
-                    .with_label_values(&["SELECT", "file_list_deleted"])
+                    .with_label_values(&["select", "file_list_deleted"])
                     .inc();
                 let ret: Option<i64> = match
                     sqlx
@@ -249,7 +249,7 @@ impl super::FileList for PostgresFileList {
             // delete files by ids
             if !ids.is_empty() {
                 DB_QUERY_NUMS
-                    .with_label_values(&["DELETE", "file_list"])
+                    .with_label_values(&["delete", "file_list"])
                     .inc();
                 let sql = format!(
                     "DELETE FROM file_list_deleted WHERE id IN({});",
@@ -266,7 +266,7 @@ impl super::FileList for PostgresFileList {
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = sqlx::query_as::<_, super::FileRecord>(
@@ -291,7 +291,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = sqlx::query(
@@ -317,7 +317,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list"])
+            .with_label_values(&["update", "file_list"])
             .inc();
         sqlx::query(
             r#"UPDATE file_list SET flattened = $1 WHERE stream = $2 AND date = $3 AND file = $4;"#,
@@ -354,7 +354,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
 
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = if flattened.is_some() {
@@ -459,7 +459,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
                 let pool = CLIENT.clone();
                 let cfg = get_config();
                 DB_QUERY_NUMS
-                .with_label_values(&["SELECT", "file_list"])
+                .with_label_values(&["select", "file_list"])
                 .inc();
                 if cfg.limit.use_upper_bound_for_max_ts {
                     // TODO: if partition is daily, we need to remove this logic
@@ -552,7 +552,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         }
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list_deleted"])
+            .with_label_values(&["select", "file_list_deleted"])
             .inc();
         let ret = sqlx
             ::query_as::<_, super::FileDeletedRecord>(
@@ -583,7 +583,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         let min_ts = config::utils::time::BASE_TIME.timestamp_micros();
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret: Option<i64> = sqlx::query_scalar(
             r#"SELECT MIN(min_ts)::BIGINT AS id FROM file_list WHERE stream = $1 AND min_ts > $2;"#,
@@ -598,7 +598,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
     async fn get_max_pk_value(&self) -> Result<i64> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret: Option<i64> =
             sqlx::query_scalar(r#"SELECT MAX(id)::BIGINT AS id FROM file_list;"#)
@@ -644,7 +644,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
         };
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
             .fetch_all(&pool)
@@ -673,7 +673,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
         };
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "stream_stats"])
+            .with_label_values(&["select", "stream_stats"])
             .inc();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
             .fetch_all(&pool)
@@ -696,7 +696,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
         );
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["DELETE", "stream_stats"])
+            .with_label_values(&["delete", "stream_stats"])
             .inc();
         sqlx::query(&sql).execute(&pool).await?;
         Ok(())
@@ -728,7 +728,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
         for stream_key in new_streams {
             let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
             DB_QUERY_NUMS
-                .with_label_values(&["INSERT", "stream_stats"])
+                .with_label_values(&["insert", "stream_stats"])
                 .inc();
             if let Err(e) = sqlx::query(
                 r#"
@@ -756,7 +756,7 @@ INSERT INTO stream_stats
         let mut tx = pool.begin().await?;
         for (stream_key, stats) in update_streams {
             DB_QUERY_NUMS
-                .with_label_values(&["UPDATE", "stream_stats"])
+                .with_label_values(&["update", "stream_stats"])
                 .inc();
             if
                 let Err(e) = sqlx
@@ -793,7 +793,7 @@ UPDATE stream_stats
     async fn reset_stream_stats(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "stream_stats"])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx
             ::query(
@@ -811,7 +811,7 @@ UPDATE stream_stats
     ) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "stream_stats"])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx::query(r#"UPDATE stream_stats SET min_ts = $1 WHERE stream = $2;"#)
             .bind(min_ts)
@@ -819,7 +819,7 @@ UPDATE stream_stats
             .execute(&pool)
             .await?;
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "stream_stats"])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx::query(
             r#"UPDATE stream_stats SET max_ts = min_ts WHERE stream = $1 AND max_ts < min_ts;"#,
@@ -833,7 +833,7 @@ UPDATE stream_stats
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret = match sqlx::query(r#"SELECT COUNT(*)::BIGINT AS num FROM file_list;"#)
             .fetch_one(&pool)
@@ -869,7 +869,7 @@ UPDATE stream_stats
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["INSERT", "file_list_jobs"])
+            .with_label_values(&["insert", "file_list_jobs"])
             .inc();
         match
             sqlx
@@ -903,7 +903,7 @@ UPDATE stream_stats
             lock_id as i64
         };
         let lock_sql = format!("SELECT pg_advisory_xact_lock({lock_id})");
-        DB_QUERY_NUMS.with_label_values(&["GET_LOCK", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         if let Err(e) = sqlx::query(&lock_sql).execute(&mut *tx).await {
             if let Err(e) = tx.rollback().await {
                 log::error!("[POSTGRES] rollback get_pending_jobs error: {}", e);
@@ -912,7 +912,7 @@ UPDATE stream_stats
         }
         // get pending jobs group by stream and order by num desc
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list_jobs"])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(
             r#"
@@ -952,7 +952,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         );
         let now = config::utils::time::now_micros();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         if let Err(e) = sqlx::query(&sql)
             .bind(super::FileListJobStatus::Running)
@@ -969,7 +969,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         }
         // get jobs by ids
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list_jobs"])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let sql = format!(
             "SELECT * FROM file_list_jobs WHERE id IN ({});",
@@ -1004,7 +1004,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
                 .join(",")
         );
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         sqlx::query(&sql)
             .bind(super::FileListJobStatus::Pending)
@@ -1016,7 +1016,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
     async fn set_job_done(&self, id: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         sqlx::query(r#"UPDATE file_list_jobs SET status = $1, updated_at = $2 WHERE id = $3;"#)
             .bind(super::FileListJobStatus::Done)
@@ -1030,7 +1030,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
     async fn update_running_jobs(&self, id: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         sqlx::query(r#"UPDATE file_list_jobs SET updated_at = $1 WHERE id = $2;"#)
             .bind(config::utils::time::now_micros())
@@ -1043,7 +1043,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
     async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         let ret = sqlx::query(
             r#"UPDATE file_list_jobs SET status = $1 WHERE status = $2 AND updated_at < $3;"#,
@@ -1062,7 +1062,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
     async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["DELETE", "file_list_jobs"])
+            .with_label_values(&["delete", "file_list_jobs"])
             .inc();
         let ret =
             sqlx::query(r#"DELETE FROM file_list_jobs WHERE status = $1 AND updated_at < $2;"#)
@@ -1080,7 +1080,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         let pool = CLIENT.clone();
 
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list_jobs"])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret = sqlx
             ::query(
@@ -1122,7 +1122,7 @@ impl PostgresFileList {
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
-        DB_QUERY_NUMS.with_label_values(&["INSERT", table]).inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", table]).inc();
         match
             sqlx
                 ::query(
@@ -1186,7 +1186,7 @@ INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, 
                     .push_bind(item.meta.compressed_size)
                     .push_bind(item.meta.flattened);
             });
-            DB_QUERY_NUMS.with_label_values(&["INSERT", table]).inc();
+            DB_QUERY_NUMS.with_label_values(&["insert", table]).inc();
             let need_single_insert = match query_builder.build().execute(&mut *tx).await {
                 Ok(_) => false,
                 Err(sqlx::Error::Database(e)) => {
@@ -1229,7 +1229,7 @@ INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "file_list"])
+        .with_label_values(&["create", "file_list"])
         .inc();
     sqlx::query(
         r#"
@@ -1254,7 +1254,7 @@ CREATE TABLE IF NOT EXISTS file_list
     .await?;
 
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "file_list_history"])
+        .with_label_values(&["create", "file_list_history"])
         .inc();
     sqlx::query(
         r#"
@@ -1279,7 +1279,7 @@ CREATE TABLE IF NOT EXISTS file_list_history
     .await?;
 
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "file_list_deleted"])
+        .with_label_values(&["create", "file_list_deleted"])
         .inc();
     sqlx::query(
         r#"
@@ -1299,7 +1299,7 @@ CREATE TABLE IF NOT EXISTS file_list_deleted
     .await?;
 
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "file_list_jobs"])
+        .with_label_values(&["create", "file_list_jobs"])
         .inc();
     sqlx::query(
         r#"
@@ -1320,7 +1320,7 @@ CREATE TABLE IF NOT EXISTS file_list_jobs
     .await?;
 
     DB_QUERY_NUMS
-        .with_label_values(&["CREATE", "stream_stats"])
+        .with_label_values(&["create", "stream_stats"])
         .inc();
     sqlx::query(
         r#"
@@ -1420,7 +1420,7 @@ pub async fn create_table_index() -> Result<()> {
         // delete duplicate records
         log::warn!("[POSTGRES] starting delete duplicate records");
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "file_list"])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret = sqlx
             ::query(
@@ -1434,7 +1434,7 @@ pub async fn create_table_index() -> Result<()> {
             let file = r.get::<String, &str>("file");
             let id = r.get::<i64, &str>("id");
             DB_QUERY_NUMS
-                .with_label_values(&["DELETE", "file_list"])
+                .with_label_values(&["delete", "file_list"])
                 .inc();
             sqlx
                 ::query(
@@ -1465,7 +1465,7 @@ pub async fn create_table_index() -> Result<()> {
 async fn add_column(table: &str, column: &str, data_type: &str) -> Result<()> {
     let pool = CLIENT.clone();
     DB_QUERY_NUMS
-        .with_label_values(&["SELECT", "information_schema.columns"])
+        .with_label_values(&["select", "information_schema.columns"])
         .inc();
     let check_sql = format!(
         "SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table}' AND column_name='{column}';"
@@ -1477,7 +1477,7 @@ async fn add_column(table: &str, column: &str, data_type: &str) -> Result<()> {
         return Ok(());
     }
 
-    DB_QUERY_NUMS.with_label_values(&["ALTER", table]).inc();
+    DB_QUERY_NUMS.with_label_values(&["alter", table]).inc();
     let alert_sql = format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {column} {data_type};");
     let mut tx = pool.begin().await?;
     if let Err(e) = sqlx::query(&alert_sql).execute(&mut *tx).await {

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use config::{
     get_config,
     meta::stream::{FileKey, FileMeta, PartitionTimeLevel, StreamStats, StreamType},
+    metrics::DB_QUERY_NUMS,
     utils::{
         hash::Sum64,
         parquet::parse_file_key_columns,
@@ -69,6 +70,10 @@ impl super::FileList for PostgresFileList {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
+
+        DB_QUERY_NUMS
+            .with_label_values(&["DELETE", "file_list"])
+            .inc();
         sqlx::query(r#"DELETE FROM file_list WHERE stream = $1 AND date = $2 AND file = $3;"#)
             .bind(stream_key)
             .bind(date_key)
@@ -98,6 +103,9 @@ impl super::FileList for PostgresFileList {
             for file in files {
                 let (stream_key, date_key, file_name) =
                     parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
+                DB_QUERY_NUMS
+                    .with_label_values(&["SELECT", "file_list"])
+                    .inc();
                 let ret: Option<i64> = match sqlx::query_scalar(
                     r#"SELECT id FROM file_list WHERE stream = $1 AND date = $2 AND file = $3;"#,
                 )
@@ -127,6 +135,9 @@ impl super::FileList for PostgresFileList {
             }
             // delete files by ids
             if !ids.is_empty() {
+                DB_QUERY_NUMS
+                    .with_label_values(&["DELETE", "file_list"])
+                    .inc();
                 let sql = format!("DELETE FROM file_list WHERE id IN({});", ids.join(","));
                 _ = pool.execute(sql.as_str()).await?;
             }
@@ -161,6 +172,9 @@ impl super::FileList for PostgresFileList {
                     .push_bind(flattened)
                     .push_bind(created_at);
             });
+            DB_QUERY_NUMS
+                .with_label_values(&["INSERT", "file_list_deleted"])
+                .inc();
             if let Err(e) = query_builder.build().execute(&mut *tx).await {
                 if let Err(e) = tx.rollback().await {
                     log::error!(
@@ -190,6 +204,9 @@ impl super::FileList for PostgresFileList {
             for file in files {
                 let (stream_key, date_key, file_name) =
                     parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
+                DB_QUERY_NUMS
+                    .with_label_values(&["SELECT", "file_list_deleted"])
+                    .inc();
                 let ret: Option<i64> = match
                     sqlx
                         ::query_scalar(
@@ -220,6 +237,9 @@ impl super::FileList for PostgresFileList {
             }
             // delete files by ids
             if !ids.is_empty() {
+                DB_QUERY_NUMS
+                    .with_label_values(&["DELETE", "file_list"])
+                    .inc();
                 let sql = format!(
                     "DELETE FROM file_list_deleted WHERE id IN({});",
                     ids.join(",")
@@ -234,6 +254,9 @@ impl super::FileList for PostgresFileList {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
+        DB_QUERY_NUMS
+        .with_label_values(&["SELECT", "file_list"])
+        .inc();
         let ret = sqlx
             ::query_as::<_, super::FileRecord>(
                 r#"
@@ -252,6 +275,9 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list"])
+            .inc();
         let ret = sqlx::query(
             r#"SELECT * FROM file_list WHERE stream = $1 AND date = $2 AND file = $3;"#,
         )
@@ -270,6 +296,9 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
+        DB_QUERY_NUMS
+            .with_label_values(&["UPDATE", "file_list"])
+            .inc();
         sqlx::query(
             r#"UPDATE file_list SET flattened = $1 WHERE stream = $2 AND date = $3 AND file = $4;"#,
         )
@@ -304,6 +333,9 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
 
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list"])
+            .inc();
         let ret = if flattened.is_some() {
             sqlx
                 ::query_as::<_, super::FileRecord>(
@@ -401,6 +433,9 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
             tasks.push(tokio::task::spawn(async move {
                 let pool = CLIENT.clone();
                 let cfg = get_config();
+                DB_QUERY_NUMS
+                .with_label_values(&["SELECT", "file_list"])
+                .inc();
                 if cfg.limit.use_upper_bound_for_max_ts {
                     // TODO: if partition is daily, we need to remove this logic
                     let max_ts_upper_bound =
@@ -491,6 +526,9 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
             return Ok(Vec::new());
         }
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list_deleted"])
+            .inc();
         let ret = sqlx
             ::query_as::<_, super::FileDeletedRecord>(
                 r#"SELECT stream, date, file, flattened FROM file_list_deleted WHERE org = $1 AND created_at < $2 LIMIT $3;"#
@@ -519,6 +557,9 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
         let min_ts = config::utils::time::BASE_TIME.timestamp_micros();
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list"])
+            .inc();
         let ret: Option<i64> = sqlx::query_scalar(
             r#"SELECT MIN(min_ts)::BIGINT AS id FROM file_list WHERE stream = $1 AND min_ts > $2;"#,
         )
@@ -531,6 +572,9 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
 
     async fn get_max_pk_value(&self) -> Result<i64> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list"])
+            .inc();
         let ret: Option<i64> =
             sqlx::query_scalar(r#"SELECT MAX(id)::BIGINT AS id FROM file_list;"#)
                 .fetch_one(&pool)
@@ -574,6 +618,9 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
             }
         };
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list"])
+            .inc();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -600,6 +647,9 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
             format!("SELECT * FROM stream_stats WHERE org = '{}';", org_id)
         };
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "stream_stats"])
+            .inc();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -620,6 +670,9 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
             org_id, stream_type, stream_name
         );
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["DELETE", "stream_stats"])
+            .inc();
         sqlx::query(&sql).execute(&pool).await?;
         Ok(())
     }
@@ -649,6 +702,9 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
         let mut tx = pool.begin().await?;
         for stream_key in new_streams {
             let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
+            DB_QUERY_NUMS
+                .with_label_values(&["INSERT", "stream_stats"])
+                .inc();
             if let Err(e) = sqlx::query(
                 r#"
 INSERT INTO stream_stats 
@@ -674,6 +730,9 @@ INSERT INTO stream_stats
 
         let mut tx = pool.begin().await?;
         for (stream_key, stats) in update_streams {
+            DB_QUERY_NUMS
+                .with_label_values(&["UPDATE", "stream_stats"])
+                .inc();
             if
                 let Err(e) = sqlx
                     ::query(
@@ -708,6 +767,9 @@ UPDATE stream_stats
 
     async fn reset_stream_stats(&self) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["UPDATE", "stream_stats"])
+            .inc();
         sqlx
             ::query(
                 r#"UPDATE stream_stats SET file_num = 0, min_ts = 0, max_ts = 0, records = 0, original_size = 0, compressed_size = 0;"#
@@ -723,11 +785,17 @@ UPDATE stream_stats
         min_ts: i64,
     ) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["UPDATE", "stream_stats"])
+            .inc();
         sqlx::query(r#"UPDATE stream_stats SET min_ts = $1 WHERE stream = $2;"#)
             .bind(min_ts)
             .bind(stream)
             .execute(&pool)
             .await?;
+        DB_QUERY_NUMS
+            .with_label_values(&["UPDATE", "stream_stats"])
+            .inc();
         sqlx::query(
             r#"UPDATE stream_stats SET max_ts = min_ts WHERE stream = $1 AND max_ts < min_ts;"#,
         )
@@ -739,6 +807,9 @@ UPDATE stream_stats
 
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list"])
+            .inc();
         let ret = match sqlx::query(r#"SELECT COUNT(*)::BIGINT AS num FROM file_list;"#)
             .fetch_one(&pool)
             .await
@@ -772,6 +843,9 @@ UPDATE stream_stats
     ) -> Result<()> {
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["INSERT", "file_list_jobs"])
+            .inc();
         match
             sqlx
                 ::query(
@@ -804,6 +878,7 @@ UPDATE stream_stats
             lock_id as i64
         };
         let lock_sql = format!("SELECT pg_advisory_xact_lock({lock_id})");
+        DB_QUERY_NUMS.with_label_values(&["GET_LOCK", ""]).inc();
         if let Err(e) = sqlx::query(&lock_sql).execute(&mut *tx).await {
             if let Err(e) = tx.rollback().await {
                 log::error!("[POSTGRES] rollback get_pending_jobs error: {}", e);
@@ -811,6 +886,9 @@ UPDATE stream_stats
             return Err(e.into());
         }
         // get pending jobs group by stream and order by num desc
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list_jobs"])
+            .inc();
         let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(
             r#"
 SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
@@ -848,6 +926,9 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
             ids.join(",")
         );
         let now = config::utils::time::now_micros();
+        DB_QUERY_NUMS
+            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .inc();
         if let Err(e) = sqlx::query(&sql)
             .bind(super::FileListJobStatus::Running)
             .bind(node)
@@ -862,6 +943,9 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
             return Err(e.into());
         }
         // get jobs by ids
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list_jobs"])
+            .inc();
         let sql = format!(
             "SELECT * FROM file_list_jobs WHERE id IN ({});",
             ids.join(",")
@@ -894,6 +978,9 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
                 .collect::<Vec<_>>()
                 .join(",")
         );
+        DB_QUERY_NUMS
+            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .inc();
         sqlx::query(&sql)
             .bind(super::FileListJobStatus::Pending)
             .execute(&pool)
@@ -903,6 +990,9 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
 
     async fn set_job_done(&self, id: i64) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .inc();
         sqlx::query(r#"UPDATE file_list_jobs SET status = $1, updated_at = $2 WHERE id = $3;"#)
             .bind(super::FileListJobStatus::Done)
             .bind(config::utils::time::now_micros())
@@ -914,6 +1004,9 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
 
     async fn update_running_jobs(&self, id: i64) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .inc();
         sqlx::query(r#"UPDATE file_list_jobs SET updated_at = $1 WHERE id = $2;"#)
             .bind(config::utils::time::now_micros())
             .bind(id)
@@ -924,6 +1017,9 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
 
     async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["UPDATE", "file_list_jobs"])
+            .inc();
         let ret = sqlx::query(
             r#"UPDATE file_list_jobs SET status = $1 WHERE status = $2 AND updated_at < $3;"#,
         )
@@ -940,6 +1036,9 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
 
     async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["DELETE", "file_list_jobs"])
+            .inc();
         let ret =
             sqlx::query(r#"DELETE FROM file_list_jobs WHERE status = $1 AND updated_at < $2;"#)
                 .bind(super::FileListJobStatus::Done)
@@ -955,6 +1054,9 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
     async fn get_pending_jobs_count(&self) -> Result<stdHashMap<String, stdHashMap<String, i64>>> {
         let pool = CLIENT.clone();
 
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list_jobs"])
+            .inc();
         let ret = sqlx
             ::query(
                 r#"SELECT stream, status, count(*) as counts FROM file_list_jobs GROUP BY stream, status ORDER BY status desc;"#
@@ -995,6 +1097,7 @@ impl PostgresFileList {
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
+        DB_QUERY_NUMS.with_label_values(&["INSERT", table]).inc();
         match
             sqlx
                 ::query(
@@ -1058,6 +1161,7 @@ INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, 
                     .push_bind(item.meta.compressed_size)
                     .push_bind(item.meta.flattened);
             });
+            DB_QUERY_NUMS.with_label_values(&["INSERT", table]).inc();
             let need_single_insert = match query_builder.build().execute(&mut *tx).await {
                 Ok(_) => false,
                 Err(sqlx::Error::Database(e)) => {
@@ -1099,6 +1203,9 @@ INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, 
 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
+    DB_QUERY_NUMS
+        .with_label_values(&["CREATE", "file_list"])
+        .inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS file_list
@@ -1121,6 +1228,9 @@ CREATE TABLE IF NOT EXISTS file_list
     .execute(&pool)
     .await?;
 
+    DB_QUERY_NUMS
+        .with_label_values(&["CREATE", "file_list_history"])
+        .inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS file_list_history
@@ -1143,6 +1253,9 @@ CREATE TABLE IF NOT EXISTS file_list_history
     .execute(&pool)
     .await?;
 
+    DB_QUERY_NUMS
+        .with_label_values(&["CREATE", "file_list_deleted"])
+        .inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS file_list_deleted
@@ -1160,6 +1273,9 @@ CREATE TABLE IF NOT EXISTS file_list_deleted
     .execute(&pool)
     .await?;
 
+    DB_QUERY_NUMS
+        .with_label_values(&["CREATE", "file_list_jobs"])
+        .inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS file_list_jobs
@@ -1178,6 +1294,9 @@ CREATE TABLE IF NOT EXISTS file_list_jobs
     .execute(&pool)
     .await?;
 
+    DB_QUERY_NUMS
+        .with_label_values(&["CREATE", "stream_stats"])
+        .inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS stream_stats
@@ -1275,6 +1394,9 @@ pub async fn create_table_index() -> Result<()> {
         }
         // delete duplicate records
         log::warn!("[POSTGRES] starting delete duplicate records");
+        DB_QUERY_NUMS
+            .with_label_values(&["SELECT", "file_list"])
+            .inc();
         let ret = sqlx
             ::query(
                 r#"SELECT stream, date, file, min(id) as id FROM file_list GROUP BY stream, date, file HAVING COUNT(*) > 1;"#
@@ -1286,6 +1408,9 @@ pub async fn create_table_index() -> Result<()> {
             let date = r.get::<String, &str>("date");
             let file = r.get::<String, &str>("file");
             let id = r.get::<i64, &str>("id");
+            DB_QUERY_NUMS
+                .with_label_values(&["DELETE", "file_list"])
+                .inc();
             sqlx
                 ::query(
                     r#"DELETE FROM file_list WHERE id != $1 AND stream = $2 AND date = $3 AND file = $4;"#
@@ -1314,6 +1439,9 @@ pub async fn create_table_index() -> Result<()> {
 
 async fn add_column(table: &str, column: &str, data_type: &str) -> Result<()> {
     let pool = CLIENT.clone();
+    DB_QUERY_NUMS
+        .with_label_values(&["SELECT", "information_schema.columns"])
+        .inc();
     let check_sql = format!(
         "SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table}' AND column_name='{column}';"
     );
@@ -1324,6 +1452,7 @@ async fn add_column(table: &str, column: &str, data_type: &str) -> Result<()> {
         return Ok(());
     }
 
+    DB_QUERY_NUMS.with_label_values(&["ALTER", table]).inc();
     let alert_sql = format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {column} {data_type};");
     let mut tx = pool.begin().await?;
     if let Err(e) = sqlx::query(&alert_sql).execute(&mut *tx).await {

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -16,6 +16,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::Duration;
+use config::metrics::DB_QUERY_NUMS;
 use sqlx::Row;
 
 use super::{Trigger, TriggerId, TriggerModule, TriggerStatus, TRIGGERS_KEY};
@@ -43,6 +44,7 @@ impl super::Scheduler for MySqlScheduler {
     /// Creates the Scheduled Jobs table
     async fn create_table(&self) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["CREATE", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"
 CREATE TABLE IF NOT EXISTS scheduled_jobs
@@ -67,6 +69,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         .await?;
 
         // create data column for old version <= 0.10.9
+        DB_QUERY_NUMS.with_label_values(&["SELECT", "information_schema.columns"]).inc();
         let has_data_column = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='scheduled_jobs' AND column_name='data';")
             .fetch_one(&pool)
             .await?;
@@ -101,6 +104,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     /// The count of jobs for the given module (Report/Alert etc.)
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
         let ret = match sqlx::query(
             r#"
 SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
@@ -126,6 +130,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
 
+        DB_QUERY_NUMS.with_label_values(&["INSERT", "scheduled_jobs"]).inc();
         if let Err(e) = sqlx::query(
             r#"
 INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time, data)
@@ -174,6 +179,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     /// Deletes the Trigger job matching the given parameters
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["DELETE", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"DELETE FROM scheduled_jobs WHERE org = ? AND module = ? AND module_key = ?;"#,
         )
@@ -205,6 +211,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         retries: i32,
     ) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs SET status = ?, retries = ? WHERE org = ? AND module_key = ? AND module = ?;"#
         )
@@ -223,6 +230,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
 
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs
 SET status = ?, retries = ?, next_run_at = ?, is_realtime = ?, is_silenced = ?, data = ?
@@ -283,6 +291,7 @@ WHERE org = ? AND module_key = ? AND module = ?;"#,
                 .num_microseconds()
                 .unwrap();
         let mut tx = pool.begin().await?;
+        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
         let job_ids: Vec<TriggerId> = match sqlx::query_as::<_, TriggerId>(
             r#"SELECT id
 FROM scheduled_jobs
@@ -323,6 +332,7 @@ FOR UPDATE;
         }
 
         let job_ids: Vec<String> = job_ids.into_iter().map(|id| id.id.to_string()).collect();
+        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
         let query = format!(
             "UPDATE scheduled_jobs
 SET status = ?, start_time = ?,
@@ -359,6 +369,7 @@ WHERE id IN ({});",
             job_ids.join(",")
         );
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
         let jobs: Vec<Trigger> = sqlx::query_as::<_, Trigger>(query.as_str())
             .fetch_all(&pool)
             .await?;
@@ -368,6 +379,7 @@ WHERE id IN ({});",
 
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
         let query =
             r#"SELECT * FROM scheduled_jobs WHERE org = ? AND module = ? AND module_key = ?;"#;
         let job = match sqlx::query_as::<_, Trigger>(query)
@@ -390,6 +402,7 @@ WHERE id IN ({});",
 
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
         let jobs: Vec<Trigger> = if let Some(module) = module {
             let query = r#"SELECT * FROM scheduled_jobs WHERE module = ? ORDER BY id;"#;
             sqlx::query_as::<_, Trigger>(query)
@@ -407,6 +420,7 @@ WHERE id IN ({});",
     /// retries >= threshold set through environment
     async fn clean_complete(&self) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["DELETE", "scheduled_jobs"]).inc();
         sqlx::query(r#"DELETE FROM scheduled_jobs WHERE status = ? OR retries >= ?;"#)
             .bind(TriggerStatus::Completed)
             .bind(config::get_config().limit.scheduler_max_retries)
@@ -424,6 +438,7 @@ WHERE id IN ({});",
     async fn watch_timeout(&self) -> Result<()> {
         let pool = CLIENT.clone();
         let now = chrono::Utc::now().timestamp_micros();
+        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs
 SET status = ?, retries = retries + 1
@@ -440,6 +455,7 @@ WHERE status = ? AND end_time <= ?
 
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
         let ret = match sqlx::query(
             r#"
 SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
@@ -465,6 +481,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
 
     async fn clear(&self) -> Result<()> {
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["DELETE", "scheduled_jobs"]).inc();
         match sqlx::query(r#"DELETE FROM scheduled_jobs;"#)
             .execute(&pool)
             .await
@@ -480,6 +497,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
 async fn add_data_column() -> Result<()> {
     log::info!("[MYSQL] Adding data column to scheduled_jobs table");
     let pool = CLIENT.clone();
+    DB_QUERY_NUMS.with_label_values(&["ALTER", "scheduled_jobs"]).inc();
     if let Err(e) = sqlx::query(r#"ALTER TABLE scheduled_jobs ADD COLUMN data LONGTEXT NOT NULL;"#)
         .execute(&pool)
         .await

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -44,7 +44,9 @@ impl super::Scheduler for MySqlScheduler {
     /// Creates the Scheduled Jobs table
     async fn create_table(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["create", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["create", "scheduled_jobs"])
+            .inc();
         sqlx::query(
             r#"
 CREATE TABLE IF NOT EXISTS scheduled_jobs
@@ -69,7 +71,9 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         .await?;
 
         // create data column for old version <= 0.10.9
-        DB_QUERY_NUMS.with_label_values(&["select", "information_schema.columns"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "information_schema.columns"])
+            .inc();
         let has_data_column = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='scheduled_jobs' AND column_name='data';")
             .fetch_one(&pool)
             .await?;
@@ -89,6 +93,9 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         ];
 
         for query in queries {
+            DB_QUERY_NUMS
+                .with_label_values(&["create", "scheduled_jobs"])
+                .inc();
             if let Err(e) = sqlx::query(query).execute(&pool).await {
                 if e.to_string().contains("Duplicate key") {
                     // index already exists
@@ -104,7 +111,9 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     /// The count of jobs for the given module (Report/Alert etc.)
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "scheduled_jobs"])
+            .inc();
         let ret = match sqlx::query(
             r#"
 SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
@@ -130,7 +139,9 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
 
-        DB_QUERY_NUMS.with_label_values(&["insert", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["insert", "scheduled_jobs"])
+            .inc();
         if let Err(e) = sqlx::query(
             r#"
 INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time, data)
@@ -179,7 +190,9 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     /// Deletes the Trigger job matching the given parameters
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["delete", "scheduled_jobs"])
+            .inc();
         sqlx::query(
             r#"DELETE FROM scheduled_jobs WHERE org = ? AND module = ? AND module_key = ?;"#,
         )
@@ -211,7 +224,9 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         retries: i32,
     ) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["update", "scheduled_jobs"])
+            .inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs SET status = ?, retries = ? WHERE org = ? AND module_key = ? AND module = ?;"#
         )
@@ -230,7 +245,9 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
 
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["update", "scheduled_jobs"])
+            .inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs
 SET status = ?, retries = ?, next_run_at = ?, is_realtime = ?, is_silenced = ?, data = ?
@@ -291,7 +308,9 @@ WHERE org = ? AND module_key = ? AND module = ?;"#,
                 .num_microseconds()
                 .unwrap();
         let mut tx = pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "scheduled_jobs"])
+            .inc();
         let job_ids: Vec<TriggerId> = match sqlx::query_as::<_, TriggerId>(
             r#"SELECT id
 FROM scheduled_jobs
@@ -332,7 +351,9 @@ FOR UPDATE;
         }
 
         let job_ids: Vec<String> = job_ids.into_iter().map(|id| id.id.to_string()).collect();
-        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["update", "scheduled_jobs"])
+            .inc();
         let query = format!(
             "UPDATE scheduled_jobs
 SET status = ?, start_time = ?,
@@ -369,7 +390,9 @@ WHERE id IN ({});",
             job_ids.join(",")
         );
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "scheduled_jobs"])
+            .inc();
         let jobs: Vec<Trigger> = sqlx::query_as::<_, Trigger>(query.as_str())
             .fetch_all(&pool)
             .await?;
@@ -379,7 +402,9 @@ WHERE id IN ({});",
 
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "scheduled_jobs"])
+            .inc();
         let query =
             r#"SELECT * FROM scheduled_jobs WHERE org = ? AND module = ? AND module_key = ?;"#;
         let job = match sqlx::query_as::<_, Trigger>(query)
@@ -402,7 +427,9 @@ WHERE id IN ({});",
 
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "scheduled_jobs"])
+            .inc();
         let jobs: Vec<Trigger> = if let Some(module) = module {
             let query = r#"SELECT * FROM scheduled_jobs WHERE module = ? ORDER BY id;"#;
             sqlx::query_as::<_, Trigger>(query)
@@ -420,7 +447,9 @@ WHERE id IN ({});",
     /// retries >= threshold set through environment
     async fn clean_complete(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["delete", "scheduled_jobs"])
+            .inc();
         sqlx::query(r#"DELETE FROM scheduled_jobs WHERE status = ? OR retries >= ?;"#)
             .bind(TriggerStatus::Completed)
             .bind(config::get_config().limit.scheduler_max_retries)
@@ -438,7 +467,9 @@ WHERE id IN ({});",
     async fn watch_timeout(&self) -> Result<()> {
         let pool = CLIENT.clone();
         let now = chrono::Utc::now().timestamp_micros();
-        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["update", "scheduled_jobs"])
+            .inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs
 SET status = ?, retries = retries + 1
@@ -455,7 +486,9 @@ WHERE status = ? AND end_time <= ?
 
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "scheduled_jobs"])
+            .inc();
         let ret = match sqlx::query(
             r#"
 SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
@@ -481,7 +514,9 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
 
     async fn clear(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["delete", "scheduled_jobs"])
+            .inc();
         match sqlx::query(r#"DELETE FROM scheduled_jobs;"#)
             .execute(&pool)
             .await
@@ -497,7 +532,9 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
 async fn add_data_column() -> Result<()> {
     log::info!("[MYSQL] Adding data column to scheduled_jobs table");
     let pool = CLIENT.clone();
-    DB_QUERY_NUMS.with_label_values(&["alter", "scheduled_jobs"]).inc();
+    DB_QUERY_NUMS
+        .with_label_values(&["alter", "scheduled_jobs"])
+        .inc();
     if let Err(e) = sqlx::query(r#"ALTER TABLE scheduled_jobs ADD COLUMN data LONGTEXT NOT NULL;"#)
         .execute(&pool)
         .await

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -44,7 +44,7 @@ impl super::Scheduler for MySqlScheduler {
     /// Creates the Scheduled Jobs table
     async fn create_table(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["CREATE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["create", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"
 CREATE TABLE IF NOT EXISTS scheduled_jobs
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         .await?;
 
         // create data column for old version <= 0.10.9
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "information_schema.columns"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "information_schema.columns"]).inc();
         let has_data_column = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='scheduled_jobs' AND column_name='data';")
             .fetch_one(&pool)
             .await?;
@@ -104,7 +104,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     /// The count of jobs for the given module (Report/Alert etc.)
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
         let ret = match sqlx::query(
             r#"
 SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
@@ -130,7 +130,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
 
-        DB_QUERY_NUMS.with_label_values(&["INSERT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", "scheduled_jobs"]).inc();
         if let Err(e) = sqlx::query(
             r#"
 INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time, data)
@@ -179,7 +179,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     /// Deletes the Trigger job matching the given parameters
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["DELETE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"DELETE FROM scheduled_jobs WHERE org = ? AND module = ? AND module_key = ?;"#,
         )
@@ -211,7 +211,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         retries: i32,
     ) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs SET status = ?, retries = ? WHERE org = ? AND module_key = ? AND module = ?;"#
         )
@@ -230,7 +230,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
 
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs
 SET status = ?, retries = ?, next_run_at = ?, is_realtime = ?, is_silenced = ?, data = ?
@@ -291,7 +291,7 @@ WHERE org = ? AND module_key = ? AND module = ?;"#,
                 .num_microseconds()
                 .unwrap();
         let mut tx = pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
         let job_ids: Vec<TriggerId> = match sqlx::query_as::<_, TriggerId>(
             r#"SELECT id
 FROM scheduled_jobs
@@ -332,7 +332,7 @@ FOR UPDATE;
         }
 
         let job_ids: Vec<String> = job_ids.into_iter().map(|id| id.id.to_string()).collect();
-        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
         let query = format!(
             "UPDATE scheduled_jobs
 SET status = ?, start_time = ?,
@@ -369,7 +369,7 @@ WHERE id IN ({});",
             job_ids.join(",")
         );
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
         let jobs: Vec<Trigger> = sqlx::query_as::<_, Trigger>(query.as_str())
             .fetch_all(&pool)
             .await?;
@@ -379,7 +379,7 @@ WHERE id IN ({});",
 
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
         let query =
             r#"SELECT * FROM scheduled_jobs WHERE org = ? AND module = ? AND module_key = ?;"#;
         let job = match sqlx::query_as::<_, Trigger>(query)
@@ -402,7 +402,7 @@ WHERE id IN ({});",
 
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
         let jobs: Vec<Trigger> = if let Some(module) = module {
             let query = r#"SELECT * FROM scheduled_jobs WHERE module = ? ORDER BY id;"#;
             sqlx::query_as::<_, Trigger>(query)
@@ -420,7 +420,7 @@ WHERE id IN ({});",
     /// retries >= threshold set through environment
     async fn clean_complete(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["DELETE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
         sqlx::query(r#"DELETE FROM scheduled_jobs WHERE status = ? OR retries >= ?;"#)
             .bind(TriggerStatus::Completed)
             .bind(config::get_config().limit.scheduler_max_retries)
@@ -438,7 +438,7 @@ WHERE id IN ({});",
     async fn watch_timeout(&self) -> Result<()> {
         let pool = CLIENT.clone();
         let now = chrono::Utc::now().timestamp_micros();
-        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs
 SET status = ?, retries = retries + 1
@@ -455,7 +455,7 @@ WHERE status = ? AND end_time <= ?
 
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
         let ret = match sqlx::query(
             r#"
 SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
@@ -481,7 +481,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
 
     async fn clear(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["DELETE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
         match sqlx::query(r#"DELETE FROM scheduled_jobs;"#)
             .execute(&pool)
             .await
@@ -497,7 +497,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
 async fn add_data_column() -> Result<()> {
     log::info!("[MYSQL] Adding data column to scheduled_jobs table");
     let pool = CLIENT.clone();
-    DB_QUERY_NUMS.with_label_values(&["ALTER", "scheduled_jobs"]).inc();
+    DB_QUERY_NUMS.with_label_values(&["alter", "scheduled_jobs"]).inc();
     if let Err(e) = sqlx::query(r#"ALTER TABLE scheduled_jobs ADD COLUMN data LONGTEXT NOT NULL;"#)
         .execute(&pool)
         .await

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -93,6 +93,9 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
         ];
 
         for query in queries {
+            DB_QUERY_NUMS
+                .with_label_values(&["create", "scheduled_jobs"])
+                .inc();
             if let Err(e) = sqlx::query(query).execute(&pool).await {
                 log::error!("[POSTGRES] create table scheduled_jobs index error: {}", e);
                 return Err(e.into());
@@ -104,7 +107,9 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     /// The count of jobs for the given module (Report/Alert etc.)
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "scheduled_jobs"])
+            .inc();
         let ret = match sqlx::query(
             r#"
 SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs WHERE module = $1;"#,
@@ -130,7 +135,9 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs WHERE module = $1;"#,
         // let db = db::get_db().await;
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["insert", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["insert", "scheduled_jobs"])
+            .inc();
         if let Err(e) = sqlx::query(
             r#"
 INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time, data)
@@ -180,7 +187,9 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     /// Deletes the Trigger job matching the given parameters
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["delete", "scheduled_jobs"])
+            .inc();
         sqlx::query(
             r#"DELETE FROM scheduled_jobs WHERE org = $1 AND module_key = $2 AND module = $3;"#,
         )
@@ -212,7 +221,9 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         retries: i32,
     ) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["update", "scheduled_jobs"])
+            .inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs SET status = $1, retries = $2 WHERE org = $3 AND module_key = $4 AND module = $5;"#
         )
@@ -231,7 +242,9 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
 
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["update", "scheduled_jobs"])
+            .inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs
 SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5, data = $6
@@ -290,7 +303,9 @@ WHERE org = $7 AND module_key = $8 AND module = $9;"#,
                 .unwrap()
                 .num_microseconds()
                 .unwrap();
-            DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["update", "scheduled_jobs"])
+            .inc();
         let query = r#"UPDATE scheduled_jobs
 SET status = $1, start_time = $2,
     end_time = CASE
@@ -341,7 +356,9 @@ RETURNING *;"#;
 
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "scheduled_jobs"])
+            .inc();
         let query = r#"
 SELECT * FROM scheduled_jobs
 WHERE org = $1 AND module = $2 AND module_key = $3;"#;
@@ -365,7 +382,9 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
 
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "scheduled_jobs"])
+            .inc();
         let jobs: Vec<Trigger> = if let Some(module) = module {
             let query = r#"SELECT * FROM scheduled_jobs WHERE module = $1 ORDER BY id;"#;
             sqlx::query_as::<_, Trigger>(query)
@@ -383,7 +402,9 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
     /// retries >= threshold set through environment
     async fn clean_complete(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["delete", "scheduled_jobs"])
+            .inc();
         sqlx::query(r#"DELETE FROM scheduled_jobs WHERE status = $1 OR retries >= $2;"#)
             .bind(TriggerStatus::Completed)
             .bind(config::get_config().limit.scheduler_max_retries)
@@ -400,7 +421,9 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
     /// - Update their status back to "Waiting" and increase their "retries" by 1
     async fn watch_timeout(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["update", "scheduled_jobs"])
+            .inc();
         let now = chrono::Utc::now().timestamp_micros();
         sqlx::query(
             r#"UPDATE scheduled_jobs
@@ -418,7 +441,9 @@ WHERE status = $2 AND end_time <= $3;
 
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "scheduled_jobs"])
+            .inc();
         let ret = match sqlx::query(
             r#"
 SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs;"#,
@@ -444,7 +469,9 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs;"#,
 
     async fn clear(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["delete", "scheduled_jobs"])
+            .inc();
         match sqlx::query(r#"DELETE FROM scheduled_jobs;"#)
             .execute(&pool)
             .await
@@ -460,7 +487,9 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs;"#,
 async fn add_data_column() -> Result<()> {
     log::info!("[POSTGRES] Adding data column to scheduled_jobs table");
     let pool = CLIENT.clone();
-    DB_QUERY_NUMS.with_label_values(&["alter", "scheduled_jobs"]).inc();
+    DB_QUERY_NUMS
+        .with_label_values(&["alter", "scheduled_jobs"])
+        .inc();
     if let Err(e) = sqlx::query(
         r#"ALTER TABLE scheduled_jobs ADD COLUMN IF NOT EXISTS data TEXT NOT NULL DEFAULT '';"#,
     )

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -45,7 +45,7 @@ impl super::Scheduler for PostgresScheduler {
     async fn create_table(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["CREATE", "scheduled_jobs"])
+            .with_label_values(&["create", "scheduled_jobs"])
             .inc();
         sqlx::query(
             r#"
@@ -72,7 +72,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
 
         // create start_dt column for old version <= 0.9.2
         DB_QUERY_NUMS
-            .with_label_values(&["SELECT", "information_schema.columns"])
+            .with_label_values(&["select", "information_schema.columns"])
             .inc();
         let has_data_column = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='scheduled_jobs' AND column_name='data';")
             .fetch_one(&pool)
@@ -104,7 +104,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     /// The count of jobs for the given module (Report/Alert etc.)
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
         let ret = match sqlx::query(
             r#"
 SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs WHERE module = $1;"#,
@@ -130,7 +130,7 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs WHERE module = $1;"#,
         // let db = db::get_db().await;
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["INSERT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", "scheduled_jobs"]).inc();
         if let Err(e) = sqlx::query(
             r#"
 INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, status, retries, next_run_at, start_time, end_time, data)
@@ -180,7 +180,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     /// Deletes the Trigger job matching the given parameters
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["DELETE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"DELETE FROM scheduled_jobs WHERE org = $1 AND module_key = $2 AND module = $3;"#,
         )
@@ -212,7 +212,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         retries: i32,
     ) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs SET status = $1, retries = $2 WHERE org = $3 AND module_key = $4 AND module = $5;"#
         )
@@ -231,7 +231,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
 
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
         sqlx::query(
             r#"UPDATE scheduled_jobs
 SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5, data = $6
@@ -290,7 +290,7 @@ WHERE org = $7 AND module_key = $8 AND module = $9;"#,
                 .unwrap()
                 .num_microseconds()
                 .unwrap();
-            DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
+            DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
         let query = r#"UPDATE scheduled_jobs
 SET status = $1, start_time = $2,
     end_time = CASE
@@ -341,7 +341,7 @@ RETURNING *;"#;
 
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
         let query = r#"
 SELECT * FROM scheduled_jobs
 WHERE org = $1 AND module = $2 AND module_key = $3;"#;
@@ -365,7 +365,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
 
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
         let jobs: Vec<Trigger> = if let Some(module) = module {
             let query = r#"SELECT * FROM scheduled_jobs WHERE module = $1 ORDER BY id;"#;
             sqlx::query_as::<_, Trigger>(query)
@@ -383,7 +383,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
     /// retries >= threshold set through environment
     async fn clean_complete(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["DELETE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
         sqlx::query(r#"DELETE FROM scheduled_jobs WHERE status = $1 OR retries >= $2;"#)
             .bind(TriggerStatus::Completed)
             .bind(config::get_config().limit.scheduler_max_retries)
@@ -400,7 +400,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
     /// - Update their status back to "Waiting" and increase their "retries" by 1
     async fn watch_timeout(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["UPDATE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "scheduled_jobs"]).inc();
         let now = chrono::Utc::now().timestamp_micros();
         sqlx::query(
             r#"UPDATE scheduled_jobs
@@ -418,7 +418,7 @@ WHERE status = $2 AND end_time <= $3;
 
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["SELECT", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "scheduled_jobs"]).inc();
         let ret = match sqlx::query(
             r#"
 SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs;"#,
@@ -444,7 +444,7 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs;"#,
 
     async fn clear(&self) -> Result<()> {
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["DELETE", "scheduled_jobs"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["delete", "scheduled_jobs"]).inc();
         match sqlx::query(r#"DELETE FROM scheduled_jobs;"#)
             .execute(&pool)
             .await
@@ -460,7 +460,7 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs;"#,
 async fn add_data_column() -> Result<()> {
     log::info!("[POSTGRES] Adding data column to scheduled_jobs table");
     let pool = CLIENT.clone();
-    DB_QUERY_NUMS.with_label_values(&["ALTER", "scheduled_jobs"]).inc();
+    DB_QUERY_NUMS.with_label_values(&["alter", "scheduled_jobs"]).inc();
     if let Err(e) = sqlx::query(
         r#"ALTER TABLE scheduled_jobs ADD COLUMN IF NOT EXISTS data TEXT NOT NULL DEFAULT '';"#,
     )

--- a/src/infra/src/schema/history/mysql.rs
+++ b/src/infra/src/schema/history/mysql.rs
@@ -56,7 +56,9 @@ impl super::SchemaHistory for MysqlSchemaHistory {
     ) -> Result<()> {
         let value = json::to_string(&schema)?;
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["insert", "schema_history"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["insert", "schema_history"])
+            .inc();
         match sqlx::query(
             r#"
 INSERT IGNORE INTO schema_history (org, stream_type, stream_name, start_dt, value)
@@ -86,7 +88,9 @@ INSERT IGNORE INTO schema_history (org, stream_type, stream_name, start_dt, valu
 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
-    DB_QUERY_NUMS.with_label_values(&["create", "schema_history"]).inc();
+    DB_QUERY_NUMS
+        .with_label_values(&["create", "schema_history"])
+        .inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS schema_history
@@ -123,6 +127,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
     ];
     for (table, sql) in sqls {
+        DB_QUERY_NUMS.with_label_values(&["create", table]).inc();
         if let Err(e) = sqlx::query(sql).execute(&pool).await {
             if e.to_string().contains("Duplicate key") {
                 // index already exists

--- a/src/infra/src/schema/history/mysql.rs
+++ b/src/infra/src/schema/history/mysql.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
-use config::{meta::stream::StreamType, utils::json};
+use config::{meta::stream::StreamType, metrics::DB_QUERY_NUMS, utils::json};
 use datafusion::arrow::datatypes::Schema;
 
 use crate::{
@@ -56,6 +56,7 @@ impl super::SchemaHistory for MysqlSchemaHistory {
     ) -> Result<()> {
         let value = json::to_string(&schema)?;
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["INSERT", "schema_history"]).inc();
         match sqlx::query(
             r#"
 INSERT IGNORE INTO schema_history (org, stream_type, stream_name, start_dt, value)
@@ -85,6 +86,7 @@ INSERT IGNORE INTO schema_history (org, stream_type, stream_name, start_dt, valu
 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
+    DB_QUERY_NUMS.with_label_values(&["CREATE", "schema_history"]).inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS schema_history

--- a/src/infra/src/schema/history/mysql.rs
+++ b/src/infra/src/schema/history/mysql.rs
@@ -56,7 +56,7 @@ impl super::SchemaHistory for MysqlSchemaHistory {
     ) -> Result<()> {
         let value = json::to_string(&schema)?;
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["INSERT", "schema_history"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", "schema_history"]).inc();
         match sqlx::query(
             r#"
 INSERT IGNORE INTO schema_history (org, stream_type, stream_name, start_dt, value)
@@ -86,7 +86,7 @@ INSERT IGNORE INTO schema_history (org, stream_type, stream_name, start_dt, valu
 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
-    DB_QUERY_NUMS.with_label_values(&["CREATE", "schema_history"]).inc();
+    DB_QUERY_NUMS.with_label_values(&["create", "schema_history"]).inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS schema_history

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -56,7 +56,7 @@ impl super::SchemaHistory for PostgresSchemaHistory {
     ) -> Result<()> {
         let value = json::to_string(&schema)?;
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["INSERT", "schema_history"]).inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", "schema_history"]).inc();
         match sqlx::query(
             r#"
 INSERT INTO schema_history (org, stream_type, stream_name, start_dt, value)
@@ -87,7 +87,7 @@ INSERT INTO schema_history (org, stream_type, stream_name, start_dt, value)
 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
-    DB_QUERY_NUMS.with_label_values(&["CREATE", "schema_history"]).inc();
+    DB_QUERY_NUMS.with_label_values(&["create", "schema_history"]).inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS schema_history

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
-use config::{meta::stream::StreamType, utils::json};
+use config::{meta::stream::StreamType, metrics::DB_QUERY_NUMS, utils::json};
 use datafusion::arrow::datatypes::Schema;
 
 use crate::{
@@ -56,6 +56,7 @@ impl super::SchemaHistory for PostgresSchemaHistory {
     ) -> Result<()> {
         let value = json::to_string(&schema)?;
         let pool = CLIENT.clone();
+        DB_QUERY_NUMS.with_label_values(&["INSERT", "schema_history"]).inc();
         match sqlx::query(
             r#"
 INSERT INTO schema_history (org, stream_type, stream_name, start_dt, value)
@@ -86,6 +87,7 @@ INSERT INTO schema_history (org, stream_type, stream_name, start_dt, value)
 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
+    DB_QUERY_NUMS.with_label_values(&["CREATE", "schema_history"]).inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS schema_history

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -56,7 +56,9 @@ impl super::SchemaHistory for PostgresSchemaHistory {
     ) -> Result<()> {
         let value = json::to_string(&schema)?;
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS.with_label_values(&["insert", "schema_history"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["insert", "schema_history"])
+            .inc();
         match sqlx::query(
             r#"
 INSERT INTO schema_history (org, stream_type, stream_name, start_dt, value)
@@ -87,7 +89,9 @@ INSERT INTO schema_history (org, stream_type, stream_name, start_dt, value)
 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT.clone();
-    DB_QUERY_NUMS.with_label_values(&["create", "schema_history"]).inc();
+    DB_QUERY_NUMS
+        .with_label_values(&["create", "schema_history"])
+        .inc();
     sqlx::query(
         r#"
 CREATE TABLE IF NOT EXISTS schema_history
@@ -124,6 +128,7 @@ pub async fn create_table_index() -> Result<()> {
         ),
     ];
     for (table, sql) in sqls {
+        DB_QUERY_NUMS.with_label_values(&["create", table]).inc();
         if let Err(e) = sqlx::query(sql).execute(&pool).await {
             log::error!("[POSTGRES] create table {} index error: {}", table, e);
             return Err(e.into());

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -23,6 +23,7 @@ use config::{
         search::ScanStats,
         stream::{FileKey, FileMeta, PartitionTimeLevel, StreamType},
     },
+    metrics::{FILE_LIST_CACHE_HIT_COUNT, FILE_LIST_ID_SELECT_COUNT},
     utils::{file::get_file_meta as util_get_file_meta, json},
 };
 use futures::future::try_join_all;

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -23,7 +23,6 @@ use config::{
         search::ScanStats,
         stream::{FileKey, FileMeta, PartitionTimeLevel, StreamType},
     },
-    metrics::{FILE_LIST_CACHE_HIT_COUNT, FILE_LIST_ID_SELECT_COUNT},
     utils::{file::get_file_meta as util_get_file_meta, json},
 };
 use futures::future::try_join_all;


### PR DESCRIPTION
This cherry-picks commits from https://github.com/openobserve/openobserve/pull/4676 , and adds two metrics

- db_query_nums : total number of db queries done, labeled by query type and table
- db_query_time: time taken for db query. 
