### PR TITLE
feat: use one trace_id for all query in query cache

### DIFF
--- a/src/cli/data/export.rs
+++ b/src/cli/data/export.rs
@@ -71,7 +71,7 @@ impl Context for Export {
             index_type: "".to_string(),
         };
 
-        match SearchService::search("", &c.org, stream_type, None, &req).await {
+        match SearchService::search("", &c.org, stream_type, None, &req, false).await {
             Ok(res) => {
                 if c.file_type != "json" {
                     eprintln!("No other file types are implemented");

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -885,7 +885,6 @@ async fn values_v1(
         .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
 
     // search
-    let use_cache = cfg.common.result_cache_enabled && get_use_cache_from_request(query);
     let req = config::meta::search::Request {
         query: config::meta::search::Query {
             sql: query_sql,
@@ -941,7 +940,8 @@ async fn values_v1(
         let mut req = req.clone();
         req.query.sql = sql;
 
-        let search_res = SearchService::cache::search(
+        let use_cache = cfg.common.result_cache_enabled && get_use_cache_from_request(query);
+        let search_res = SearchService::search(
             &trace_id,
             org_id,
             stream_type,

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -274,26 +274,10 @@ pub async fn search_multi(
             }
         }
 
-        metrics::QUERY_PENDING_NUMS
-            .with_label_values(&[&org_id])
-            .inc();
-        // get a local search queue lock
-        #[cfg(not(feature = "enterprise"))]
-        let locker = SearchService::QUEUE_LOCKER.clone();
-        #[cfg(not(feature = "enterprise"))]
-        let locker = locker.lock().await;
-        #[cfg(not(feature = "enterprise"))]
-        if !cfg.common.feature_query_queue_enabled {
-            drop(locker);
-        }
         #[cfg(not(feature = "enterprise"))]
         let took_wait = start.elapsed().as_millis() as usize;
         #[cfg(feature = "enterprise")]
         let took_wait = 0;
-        log::info!("http search multi API wait in queue took: {}", took_wait);
-        metrics::QUERY_PENDING_NUMS
-            .with_label_values(&[&org_id])
-            .dec();
 
         let trace_id = trace_id.clone();
         // do search
@@ -879,30 +863,6 @@ pub async fn around_multi(
         .map(|v| v.to_string());
 
     for around_sql in around_sqls.iter() {
-        metrics::QUERY_PENDING_NUMS
-            .with_label_values(&[&org_id])
-            .inc();
-        // get a local search queue lock
-        #[cfg(not(feature = "enterprise"))]
-        let locker = SearchService::QUEUE_LOCKER.clone();
-        #[cfg(not(feature = "enterprise"))]
-        let locker = locker.lock().await;
-        #[cfg(not(feature = "enterprise"))]
-        if !cfg.common.feature_query_queue_enabled {
-            drop(locker);
-        }
-        #[cfg(not(feature = "enterprise"))]
-        let took_wait = start.elapsed().as_millis() as usize;
-        #[cfg(feature = "enterprise")]
-        let took_wait = 0;
-        log::info!(
-            "http search around multi API wait in queue took: {}",
-            took_wait
-        );
-        metrics::QUERY_PENDING_NUMS
-            .with_label_values(&[&org_id])
-            .dec();
-
         // search forward
         let req = config::meta::search::Request {
             query: config::meta::search::Query {

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -303,6 +303,7 @@ pub async fn search_multi(
             stream_type,
             Some(user_id.to_string()),
             &req,
+            false,
         )
         .instrument(http_span.clone())
         .await;
@@ -925,10 +926,16 @@ pub async fn around_multi(
             search_type: Some(search::SearchEventType::UI),
             index_type: "".to_string(),
         };
-        let search_res =
-            SearchService::search(&trace_id, &org_id, stream_type, user_id.clone(), &req)
-                .instrument(http_span.clone())
-                .await;
+        let search_res = SearchService::search(
+            &trace_id,
+            &org_id,
+            stream_type,
+            user_id.clone(),
+            &req,
+            false,
+        )
+        .instrument(http_span.clone())
+        .await;
 
         let resp_forward = match search_res {
             Ok(res) => res,
@@ -998,10 +1005,16 @@ pub async fn around_multi(
             search_type: Some(search::SearchEventType::UI),
             index_type: "".to_string(),
         };
-        let search_res =
-            SearchService::search(&trace_id, &org_id, stream_type, user_id.clone(), &req)
-                .instrument(http_span.clone())
-                .await;
+        let search_res = SearchService::search(
+            &trace_id,
+            &org_id,
+            stream_type,
+            user_id.clone(),
+            &req,
+            false,
+        )
+        .instrument(http_span.clone())
+        .await;
 
         let resp_backward = match search_res {
             Ok(res) => res,

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -282,9 +282,16 @@ pub async fn get_latest_traces(
         .ok()
         .map(|v| v.to_string());
 
-    let search_res = SearchService::search(&trace_id, &org_id, stream_type, user_id.clone(), &req)
-        .instrument(http_span.clone())
-        .await;
+    let search_res = SearchService::search(
+        &trace_id,
+        &org_id,
+        stream_type,
+        user_id.clone(),
+        &req,
+        false,
+    )
+    .instrument(http_span.clone())
+    .await;
 
     let resp_search = match search_res {
         Ok(res) => res,
@@ -372,10 +379,16 @@ pub async fn get_latest_traces(
     let mut traces_service_name: HashMap<String, HashMap<String, u16>> = HashMap::new();
 
     loop {
-        let search_res =
-            SearchService::search(&trace_id, &org_id, stream_type, user_id.clone(), &req)
-                .instrument(http_span.clone())
-                .await;
+        let search_res = SearchService::search(
+            &trace_id,
+            &org_id,
+            stream_type,
+            user_id.clone(),
+            &req,
+            false,
+        )
+        .instrument(http_span.clone())
+        .await;
 
         let resp_search = match search_res {
             Ok(res) => res,

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -217,30 +217,6 @@ pub async fn get_latest_traces(
         .get("timeout")
         .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
 
-    metrics::QUERY_PENDING_NUMS
-        .with_label_values(&[&org_id])
-        .inc();
-    // get a local search queue lock
-    #[cfg(not(feature = "enterprise"))]
-    let locker = SearchService::QUEUE_LOCKER.clone();
-    #[cfg(not(feature = "enterprise"))]
-    let locker = locker.lock().await;
-    #[cfg(not(feature = "enterprise"))]
-    if !cfg.common.feature_query_queue_enabled {
-        drop(locker);
-    }
-    #[cfg(not(feature = "enterprise"))]
-    let took_wait = start.elapsed().as_millis() as usize;
-    #[cfg(feature = "enterprise")]
-    let took_wait = 0;
-    log::info!(
-        "http traces latest API wait in queue took: {} ms",
-        took_wait
-    );
-    metrics::QUERY_PENDING_NUMS
-        .with_label_values(&[&org_id])
-        .dec();
-
     // search
     let query_sql = format!(
         "SELECT trace_id, min({}) as zo_sql_timestamp, min(start_time) as trace_start_time, max(end_time) as trace_end_time FROM {stream_name}",

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1412,7 +1412,9 @@ pub async fn create_table_index() -> Result<()> {
     }
 
     // create UNIQUE index for file_list
-    DB_QUERY_NUMS.with_label_values(&["create", "file_list"]).inc();
+    DB_QUERY_NUMS
+        .with_label_values(&["create", "file_list"])
+        .inc();
     let unique_index_sql = r#"CREATE UNIQUE INDEX IF NOT EXISTS file_list_stream_file_idx on file_list (stream, date, file);"#;
     if let Err(e) = sqlx::query(unique_index_sql).execute(&pool).await {
         if !e.to_string().contains("could not create unique index") {
@@ -1456,7 +1458,9 @@ pub async fn create_table_index() -> Result<()> {
             ret.len()
         );
         // create index again
-        DB_QUERY_NUMS.with_label_values(&["create", "file_list"]).inc();
+        DB_QUERY_NUMS
+            .with_label_values(&["create", "file_list"])
+            .inc();
         sqlx::query(unique_index_sql).execute(&pool).await?;
         log::warn!("[POSTGRES] create table index(file_list_stream_file_idx) succeed");
     }

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -324,6 +324,7 @@ impl QueryCondition {
                 stream_param.stream_type,
                 None,
                 &req,
+                false,
             )
             .await
         };

--- a/src/service/db/enrichment_table.rs
+++ b/src/service/db/enrichment_table.rs
@@ -54,7 +54,7 @@ pub async fn get(org_id: &str, name: &str) -> Result<Vec<vrl::value::Value>, any
         index_type: "".to_string(),
     };
     // do search
-    match SearchService::search("", org_id, StreamType::EnrichmentTables, None, &req).await {
+    match SearchService::search("", org_id, StreamType::EnrichmentTables, None, &req, false).await {
         Ok(res) => {
             if !res.hits.is_empty() {
                 Ok(res.hits.iter().map(convert_to_vrl).collect())

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -648,22 +648,23 @@ pub(crate) async fn get_series(
         search_type: None,
         index_type: "".to_string(),
     };
-    let series = match search_service::search("", org_id, StreamType::Metrics, None, &req).await {
-        Err(err) => {
-            log::error!("search series error: {err}");
-            return Err(err);
-        }
-        Ok(resp) => resp
-            .hits
-            .into_iter()
-            .map(|mut val| {
-                if let Some(map) = val.as_object_mut() {
-                    map.remove(HASH_LABEL);
-                }
-                val
-            })
-            .collect(),
-    };
+    let series =
+        match search_service::search("", org_id, StreamType::Metrics, None, &req, false).await {
+            Err(err) => {
+                log::error!("search series error: {err}");
+                return Err(err);
+            }
+            Ok(resp) => resp
+                .hits
+                .into_iter()
+                .map(|mut val| {
+                    if let Some(map) = val.as_object_mut() {
+                        map.remove(HASH_LABEL);
+                    }
+                    val
+                })
+                .collect(),
+        };
     Ok(series)
 }
 
@@ -793,18 +794,19 @@ pub(crate) async fn get_label_values(
         search_type: None,
         index_type: "".to_string(),
     };
-    let mut label_values = match search_service::search("", org_id, stream_type, None, &req).await {
-        Ok(resp) => resp
-            .hits
-            .iter()
-            .filter_map(|v| v.as_object().unwrap().get(&label_name))
-            .map(|v| v.as_str().unwrap().to_string())
-            .collect::<Vec<_>>(),
-        Err(err) => {
-            log::error!("search values error: {:?}", err);
-            return Err(err);
-        }
-    };
+    let mut label_values =
+        match search_service::search("", org_id, stream_type, None, &req, false).await {
+            Ok(resp) => resp
+                .hits
+                .iter()
+                .filter_map(|v| v.as_object().unwrap().get(&label_name))
+                .map(|v| v.as_str().unwrap().to_string())
+                .collect::<Vec<_>>(),
+            Err(err) => {
+                log::error!("search values error: {:?}", err);
+                return Err(err);
+            }
+        };
     label_values.sort();
     label_values.dedup();
     Ok(label_values)

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -181,7 +181,6 @@ pub(super) async fn search(
         metrics::QUERY_PENDING_NUMS
             .with_label_values(&[org_id])
             .inc();
-
         // get a local search queue lock
         #[cfg(not(feature = "enterprise"))]
         let locker = SearchService::QUEUE_LOCKER.clone();
@@ -200,7 +199,6 @@ pub(super) async fn search(
             "[trace_id {trace_id}] http search API wait in queue took: {} ms",
             took_wait
         );
-
         metrics::QUERY_PENDING_NUMS
             .with_label_values(&[org_id])
             .dec();

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -52,7 +52,7 @@ pub mod multi;
 pub mod result_utils;
 
 #[tracing::instrument(name = "service:search:cacher:search", skip_all)]
-pub async fn search(
+pub(super) async fn search(
     trace_id: &str,
     org_id: &str,
     stream_type: StreamType,
@@ -245,14 +245,12 @@ pub async fn search(
                 }
 
                 let cfg = get_config();
-                if cfg.common.result_cache_enabled
-                    && cfg.common.print_key_sql
-                    && c_resp.has_cached_data
-                {
+                if cfg.common.result_cache_enabled && cfg.common.print_key_sql {
                     log::info!(
-                        "[trace_id {trace_id}] query index: {i}, new start time: {}, end time : {}",
+                        "[trace_id {trace_id}] query index: {i}, new start time: {}, end time : {}, has_cached_data: {}",
                         req.query.as_ref().unwrap().start_time,
-                        req.query.as_ref().unwrap().end_time
+                        req.query.as_ref().unwrap().end_time,
+                        c_resp.has_cached_data
                     );
                 }
 

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -31,6 +31,10 @@ use infra::{
 use proto::cluster_rpc;
 use result_utils::get_ts_value;
 use tracing::Instrument;
+#[cfg(feature = "enterprise")]
+use {
+    crate::service::search::cluster, o2_enterprise::enterprise::common::infra::config::O2_CONFIG,
+};
 
 use crate::{
     common::{

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -47,9 +47,9 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 #[cfg(feature = "enterprise")]
 use {
     crate::service::grpc::get_cached_channel,
-    o2_enterprise::enterprise::{common::infra::config::O2_CONFIG, search::TaskStatus},
+    o2_enterprise::enterprise::search::TaskStatus,
     tonic::{codec::CompressionEncoding, metadata::MetadataValue, Request},
-    tracing::{info_span, Instrument},
+    tracing::info_span,
 };
 
 use super::usage::report_request_usage_stats;

--- a/src/service/usage/stats.rs
+++ b/src/service/usage/stats.rs
@@ -96,7 +96,16 @@ pub async fn publish_stats() -> Result<(), anyhow::Error> {
             index_type: "".to_string(),
         };
         // do search
-        match SearchService::search("", &cfg.common.usage_org, StreamType::Logs, None, &req).await {
+        match SearchService::search(
+            "",
+            &cfg.common.usage_org,
+            StreamType::Logs,
+            None,
+            &req,
+            false,
+        )
+        .await
+        {
             Ok(res) => {
                 if !res.hits.is_empty() {
                     match report_stats(res.hits, &org_id, last_query_ts, current_ts).await {
@@ -159,6 +168,7 @@ async fn get_last_stats(
         StreamType::Logs,
         None,
         &req,
+        false,
     )
     .await
     {


### PR DESCRIPTION
use only on trace_id for all query in query cache