### PR TITLE
fix: short_url auth, redirect to `/web` if auth fails (#4750)

### DIFF
--- a/src/common/utils/mod.rs
+++ b/src/common/utils/mod.rs
@@ -17,5 +17,6 @@ pub mod auth;
 pub mod functions;
 pub mod http;
 pub mod jwt;
+pub mod redirect_response;
 pub mod stream;
 pub mod zo_logger;

--- a/src/common/utils/redirect_response.rs
+++ b/src/common/utils/redirect_response.rs
@@ -1,0 +1,67 @@
+// Copyright 2024 Zinc Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::fmt;
+
+use actix_web::{HttpResponse, ResponseError};
+
+const DEFAULT_REDIRECT_RELATIVE_URI: &str = "/web";
+
+#[derive(Debug)]
+pub struct RedirectResponse {
+    pub redirect_relative_uri: String,
+}
+
+impl RedirectResponse {
+    /// Create a new `RedirectResponse` with the given redirection URL.
+    ///
+    /// If no URL is provided, a default URL (`/web`) will be used.
+    pub fn new(redirect_relative_uri: &str) -> Self {
+        RedirectResponse {
+            redirect_relative_uri: redirect_relative_uri.to_string(),
+        }
+    }
+
+    pub fn redirect(&self) -> HttpResponse {
+        self.build_redirect_response()
+    }
+
+    fn build_redirect_response(&self) -> HttpResponse {
+        HttpResponse::Found()
+            .append_header(("Location", self.redirect_relative_uri.clone()))
+            .finish()
+    }
+}
+
+impl fmt::Display for RedirectResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Redirecting to {}", self.redirect_relative_uri)
+    }
+}
+
+impl ResponseError for RedirectResponse {
+    /// Generate an HTTP response that performs a redirection to the stored URL.
+    fn error_response(&self) -> HttpResponse {
+        self.build_redirect_response()
+    }
+}
+
+impl Default for RedirectResponse {
+    fn default() -> Self {
+        RedirectResponse {
+            redirect_relative_uri: DEFAULT_REDIRECT_RELATIVE_URI.to_string(),
+        }
+    }
+}

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -228,6 +228,9 @@ pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
 
     cfg.service(
         web::scope("/short")
+            .wrap(HttpAuthentication::with_fn(
+                super::auth::validator::validate_short_or_redirect,
+            ))
             .wrap(cors.clone())
             .service(short_url::retrieve),
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `RedirectResponse` struct for improved HTTP redirection handling.
	- Enhanced authentication validation with a new redirect mechanism for `/short/` requests.
	- Updated the `retrieve` function to improve logging and response handling.

- **Bug Fixes**
	- Improved error management for authentication failures.

- **Refactor**
	- Restructured route configurations to integrate new authentication middleware and enhance service management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->