### PR TITLE
fix: optimize nats watcher

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1212,6 +1212,8 @@ pub struct Nats {
     pub command_timeout: u64,
     #[env_config(name = "ZO_NATS_LOCK_WAIT_TIMEOUT", default = 3600)]
     pub lock_wait_timeout: u64,
+    #[env_config(name = "ZO_NATS_SUB_CAPACITY", default = 65535)]
+    pub subscription_capacity: usize,
     #[env_config(name = "ZO_NATS_QUEUE_MAX_AGE", default = 60)] // days
     pub queue_max_age: u64,
 }

--- a/src/infra/src/db/etcd.rs
+++ b/src/infra/src/db/etcd.rs
@@ -480,8 +480,7 @@ impl super::Db for Etcd {
                                 })),
                             };
                             if let Err(e) = ret {
-                                log::error!("[ETCD:watch] prefix: {}, send error: {}", prefix, e);
-                                break;
+                                log::warn!("[ETCD:watch] prefix: {}, send error: {}", prefix, e);
                             }
                         }
                     }

--- a/src/infra/src/db/etcd.rs
+++ b/src/infra/src/db/etcd.rs
@@ -480,7 +480,12 @@ impl super::Db for Etcd {
                                 })),
                             };
                             if let Err(e) = ret {
-                                log::warn!("[ETCD:watch] prefix: {}, send error: {}", prefix, e);
+                                log::warn!(
+                                    "[ETCD:watch] prefix: {}, key: {}, send error: {}",
+                                    prefix,
+                                    item_key,
+                                    e
+                                );
                             }
                         }
                     }

--- a/src/infra/src/db/etcd.rs
+++ b/src/infra/src/db/etcd.rs
@@ -433,7 +433,8 @@ impl super::Db for Etcd {
     }
 
     async fn watch(&self, prefix: &str) -> Result<Arc<mpsc::Receiver<Event>>> {
-        let (tx, rx) = mpsc::channel(1024);
+        let (tx, rx) = mpsc::channel(65535);
+        let prefix = prefix.to_string();
         let key = format!("{}{}", &self.prefix, prefix);
         let self_prefix = self.prefix.to_string();
         let _task: JoinHandle<Result<()>> = tokio::task::spawn(async move {
@@ -443,6 +444,7 @@ impl super::Db for Etcd {
                 }
                 let mut client = get_etcd_client().await.clone();
                 let opt = etcd_client::WatchOptions::new().with_prefix();
+                log::debug!("[ETCD:watch] prefix: {}", prefix);
                 let (mut _watcher, mut stream) =
                     match client.watch(key.clone(), Some(opt.clone())).await {
                         Ok((watcher, stream)) => (watcher, stream),
@@ -465,23 +467,21 @@ impl super::Db for Etcd {
                             let kv = ev.kv().unwrap();
                             let item_key = kv.key_str().unwrap();
                             let item_key = item_key.strip_prefix(&self_prefix).unwrap();
-                            match ev.event_type() {
-                                EventType::Put => tx
-                                    .send(Event::Put(EventData {
-                                        key: item_key.to_string(),
-                                        value: Some(Bytes::from(kv.value().to_vec())),
-                                        start_dt: None,
-                                    }))
-                                    .await
-                                    .unwrap(),
-                                EventType::Delete => tx
-                                    .send(Event::Delete(EventData {
-                                        key: item_key.to_string(),
-                                        value: None,
-                                        start_dt: None,
-                                    }))
-                                    .await
-                                    .unwrap(),
+                            let ret = match ev.event_type() {
+                                EventType::Put => tx.try_send(Event::Put(EventData {
+                                    key: item_key.to_string(),
+                                    value: Some(Bytes::from(kv.value().to_vec())),
+                                    start_dt: None,
+                                })),
+                                EventType::Delete => tx.try_send(Event::Delete(EventData {
+                                    key: item_key.to_string(),
+                                    value: None,
+                                    start_dt: None,
+                                })),
+                            };
+                            if let Err(e) = ret {
+                                log::error!("[ETCD:watch] prefix: {}, send error: {}", prefix, e);
+                                break;
                             }
                         }
                     }

--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -633,8 +633,7 @@ impl super::Db for NatsDb {
                                 }
                             };
                             if let Err(e) = ret {
-                                log::error!("[NATS:watch] prefix: {}, send error: {}", prefix, e);
-                                break;
+                                log::warn!("[NATS:watch] prefix: {}, send error: {}", prefix, e);
                             }
                         }
                     }

--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -551,7 +551,7 @@ impl super::Db for NatsDb {
     }
 
     async fn watch(&self, prefix: &str) -> Result<Arc<mpsc::Receiver<Event>>> {
-        let (tx, rx) = mpsc::channel(1024);
+        let (tx, rx) = mpsc::channel(65535);
         let prefix = prefix.to_string();
         let self_prefix = self.prefix.to_string();
         let _task: JoinHandle<Result<()>> = tokio::task::spawn(async move {
@@ -580,6 +580,7 @@ impl super::Db for NatsDb {
                     }
                 };
                 let bucket_prefix = "/".to_string() + bucket_name.trim_start_matches(&self_prefix);
+                log::debug!("[NATS:watch] bucket: {}, prefix: {}", bucket_name, prefix);
                 let mut entries = match bucket.watch_all().await {
                     Ok(v) => v,
                     Err(e) => {
@@ -595,7 +596,7 @@ impl super::Db for NatsDb {
                 loop {
                     match entries.next().await {
                         None => {
-                            log::error!("watching prefix: {}, get message error", new_key);
+                            log::error!("watching prefix: {}, get message error", prefix);
                             break;
                         }
                         Some(entry) => {
@@ -604,7 +605,7 @@ impl super::Db for NatsDb {
                                 Err(e) => {
                                     log::error!(
                                         "watching prefix: {}, get message error: {}",
-                                        new_key,
+                                        prefix,
                                         e
                                     );
                                     break;
@@ -614,24 +615,26 @@ impl super::Db for NatsDb {
                             if !item_key.starts_with(new_key) {
                                 continue;
                             }
-                            match entry.operation {
-                                jetstream::kv::Operation::Put => tx
-                                    .send(Event::Put(EventData {
+                            let ret = match entry.operation {
+                                jetstream::kv::Operation::Put => {
+                                    tx.try_send(Event::Put(EventData {
                                         key: bucket_prefix.to_string() + &item_key,
                                         value: Some(entry.value),
                                         start_dt: None,
                                     }))
-                                    .await
-                                    .unwrap(),
+                                }
                                 jetstream::kv::Operation::Delete
-                                | jetstream::kv::Operation::Purge => tx
-                                    .send(Event::Delete(EventData {
+                                | jetstream::kv::Operation::Purge => {
+                                    tx.try_send(Event::Delete(EventData {
                                         key: bucket_prefix.to_string() + &item_key,
                                         value: None,
                                         start_dt: None,
                                     }))
-                                    .await
-                                    .unwrap(),
+                                }
+                            };
+                            if let Err(e) = ret {
+                                log::error!("[NATS:watch] prefix: {}, send error: {}", prefix, e);
+                                break;
                             }
                         }
                     }
@@ -662,6 +665,9 @@ pub async fn connect() -> async_nats::Client {
 
     let mut opts = async_nats::ConnectOptions::new()
         .connection_timeout(Duration::from_secs(cfg.nats.connect_timeout));
+    if cfg.nats.subscription_capacity > 0 {
+        opts = opts.subscription_capacity(cfg.nats.subscription_capacity);
+    }
     if !cfg.nats.user.is_empty() {
         opts = opts.user_and_password(cfg.nats.user.to_string(), cfg.nats.password.to_string());
     }

--- a/src/service/compact/retention.rs
+++ b/src/service/compact/retention.rs
@@ -215,6 +215,10 @@ pub async fn delete_by_date(
 
     let mut date_start =
         DateTime::parse_from_rfc3339(&format!("{}T00:00:00Z", date_range.0))?.with_timezone(&Utc);
+    // Hack for 1970-01-01
+    if date_range.0 == "1970-01-01" {
+        date_start += Duration::try_milliseconds(1).unwrap();
+    }
     let date_end =
         DateTime::parse_from_rfc3339(&format!("{}T00:00:00Z", date_range.1))?.with_timezone(&Utc);
     let time_range = { (date_start.timestamp_micros(), date_end.timestamp_micros()) };

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -120,9 +120,30 @@ pub async fn remote_write(
             METADATA_LABEL.to_string(),
             json::to_string(&metadata).unwrap(),
         );
-        update_setting(org_id, &metric_name, StreamType::Metrics, extra_metadata)
+        let stream_schema = infra::schema::get(org_id, &metric_name, StreamType::Metrics)
             .await
-            .unwrap();
+            .unwrap_or(Schema::empty());
+        let schema_metadata = stream_schema.metadata();
+        // check if need to update metadata
+        let mut need_update = false;
+        for (k, v) in extra_metadata.iter() {
+            if schema_metadata.contains_key(k) && schema_metadata.get(k).unwrap() == v {
+                continue;
+            }
+            need_update = true;
+            break;
+        }
+        if need_update {
+            if let Err(e) =
+                update_setting(org_id, &metric_name, StreamType::Metrics, extra_metadata).await
+            {
+                log::error!(
+                    "Error updating metadata for stream: {}, err: {}",
+                    metric_name,
+                    e
+                );
+            }
+        }
     }
 
     // maybe empty, we can return immediately


### PR DESCRIPTION
Try to improve the case:
```
openobserve 2024-10-14T13:47:21.508478Z  INFO async_nats: event: slow consumers for subscription 30
openobserve 2024-10-14T13:47:21.508478Z  INFO async_nats: event: slow consumers for subscription 30
openobserve 2024-10-14T13:47:21.508478Z  INFO async_nats: event: slow consumers for subscription 30
openobserve 2024-10-14T13:47:21.508478Z  INFO async_nats: event: slow consumers for subscription 30
openobserve 2024-10-14T13:47:21.508478Z  INFO async_nats: event: slow consumers for subscription 30
```

- [x] Added some debug logs for it, at the end found the reason is too many events
- [x] Added some debug logs for events, found the reason is too many schema events for metrics
- [x] Fixed Prometheus RemoteWrite API schema setting issues, it always update schema setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `subscription_capacity` setting for NATS configuration, allowing users to define maximum subscriptions via environment variables.
	- Enhanced event handling in the `watch` method for improved message queuing and non-blocking sending.

- **Bug Fixes**
	- Adjusted date handling in the `delete_by_date` function to avoid issues with the epoch date.

- **Improvements**
	- Improved logging and error handling in the metrics update functions for better traceability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->