### PR TITLE
fix: increase file field size in file_list* tables

### DIFF
--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -61,15 +61,22 @@ async fn cache_indices() -> HashSet<DBIndex> {
         .inc();
     let var_name = r#"SELECT INDEX_NAME,TABLE_NAME FROM information_schema.statistics;"#;
     let sql = var_name;
-    let res = sqlx::query_as::<_, (String, String)>(sql)
+    // for some reason, mysql reports table_name as varbinary, hence we have to use Vec<u8>
+    let res = sqlx::query_as::<_, (String, Vec<u8>)>(sql)
         .fetch_all(&client)
         .await;
     match res {
         Ok(r) => r
             .into_iter()
-            .map(|(name, table)| DBIndex { name, table })
+            .map(|(name, table)| DBIndex {
+                name,
+                table: String::from_utf8_lossy(&table).into_owned(),
+            })
             .collect(),
-        Err(_) => HashSet::new(),
+        Err(e) => {
+            log::debug!("error in caching indices : {}", e);
+            HashSet::new()
+        }
     }
 }
 

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -1299,7 +1299,7 @@ CREATE TABLE IF NOT EXISTS file_list
     org       VARCHAR(100) not null,
     stream    VARCHAR(256) not null,
     date      VARCHAR(16)  not null,
-    file      VARCHAR(256) not null,
+    file      VARCHAR(496) not null,
     deleted   BOOLEAN default false not null,
     flattened BOOLEAN default false not null,
     min_ts    BIGINT not null,
@@ -1324,7 +1324,7 @@ CREATE TABLE IF NOT EXISTS file_list_history
     org       VARCHAR(100) not null,
     stream    VARCHAR(256) not null,
     date      VARCHAR(16)  not null,
-    file      VARCHAR(256) not null,
+    file      VARCHAR(496) not null,
     deleted   BOOLEAN default false not null,
     flattened BOOLEAN default false not null,
     min_ts    BIGINT not null,
@@ -1349,7 +1349,7 @@ CREATE TABLE IF NOT EXISTS file_list_deleted
     org        VARCHAR(100) not null,
     stream     VARCHAR(256) not null,
     date       VARCHAR(16)  not null,
-    file       VARCHAR(256) not null,
+    file       VARCHAR(496) not null,
     flattened  BOOLEAN default false not null,
     created_at BIGINT not null
 );

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1264,7 +1264,7 @@ CREATE TABLE IF NOT EXISTS file_list
     org       VARCHAR(100) not null,
     stream    VARCHAR(256) not null,
     date      VARCHAR(16)  not null,
-    file      VARCHAR(256) not null,
+    file      VARCHAR(1024) not null,
     deleted   BOOLEAN default false not null,
     flattened BOOLEAN default false not null,
     min_ts    BIGINT not null,
@@ -1289,7 +1289,7 @@ CREATE TABLE IF NOT EXISTS file_list_history
     org       VARCHAR(100) not null,
     stream    VARCHAR(256) not null,
     date      VARCHAR(16)  not null,
-    file      VARCHAR(256) not null,
+    file      VARCHAR(1024) not null,
     deleted   BOOLEAN default false not null,
     flattened BOOLEAN default false not null,
     min_ts    BIGINT not null,
@@ -1314,7 +1314,7 @@ CREATE TABLE IF NOT EXISTS file_list_deleted
     org        VARCHAR(100) not null,
     stream     VARCHAR(256) not null,
     date       VARCHAR(16)  not null,
-    file       VARCHAR(256) not null,
+    file       VARCHAR(1024) not null,
     flattened  BOOLEAN default false not null,
     created_at BIGINT not null
 );


### PR DESCRIPTION
closes #4765 
This increases the file column length to 1024 and 496 in file_list* tables in pg and mysql respectively.

The reason we can only set the size to 496 is in `file_list_deleted_stream_date_file_idx` index on `file_list_deleted` table already uses `(256+16)*4` bytes without `file` . As mysql places limit of 3072 bytes on index key, we can use atmost `3072-1088=1984` bytes for `file` field, which comes to 496 characters. We can increase this if we enforce charset=latin, but that might cause issues in cases prefix is non-latin chars.

As psql does not have any such issues, its size is increased to 1024.

Tested -
- new tables created with this branch use the new size for file field
- when run with existing tables, this does not error at initialization time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded file name storage capacity in MySQL and Postgres tables, allowing for longer file names (up to 496 characters for MySQL and 1024 characters for Postgres).
	- Enhanced database indexing for improved query performance.

- **Bug Fixes**
	- Improved error handling for caching indices, now logging detailed error messages for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->