### PR TITLE
feat: add new ENV for control logo

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -701,7 +701,7 @@ pub struct Common {
     #[env_config(
         name = "ZO_INVERTED_INDEX_STORE_FORMAT",
         default = "parquet",
-        help = "InvertedIndex store format, parquet(default), fst, or both."
+        help = "InvertedIndex store format, parquet(default), or both."
     )]
     pub inverted_index_store_format: String,
     #[env_config(
@@ -1529,9 +1529,9 @@ fn check_common_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     if cfg.common.inverted_index_store_format.is_empty() {
         cfg.common.inverted_index_search_format = "parquet".to_string();
     }
-    if !["both", "parquet", "fst"].contains(&cfg.common.inverted_index_store_format.as_str()) {
+    if !["both", "parquet"].contains(&cfg.common.inverted_index_store_format.as_str()) {
         return Err(anyhow::anyhow!(
-            "ZO_INVERTED_INDEX_SEARCH_FORMAT must be one of both, parquet, fst."
+            "ZO_INVERTED_INDEX_SEARCH_FORMAT must be one of both, parquet."
         ));
     }
     if cfg.common.inverted_index_store_format != "both" {

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -106,6 +106,7 @@ struct ConfigResponse<'a> {
     rum: Rum,
     custom_logo_img: Option<String>,
     custom_hide_menus: String,
+    custom_hide_self_logo: bool,
     meta_org: String,
     quick_mode_enabled: bool,
     user_defined_schemas_enabled: bool,
@@ -220,6 +221,11 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
     let custom_hide_menus = "";
 
     #[cfg(feature = "enterprise")]
+    let custom_hide_self_logo = O2_CONFIG.common.custom_hide_self_logo;
+    #[cfg(not(feature = "enterprise"))]
+    let custom_hide_self_logo = false;
+
+    #[cfg(feature = "enterprise")]
     let build_type = "enterprise";
     #[cfg(not(feature = "enterprise"))]
     let build_type = "opensource";
@@ -253,6 +259,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         custom_docs_url: custom_docs_url.to_string(),
         custom_logo_img: logo,
         custom_hide_menus: custom_hide_menus.to_string(),
+        custom_hide_self_logo,
         rum: Rum {
             enabled: cfg.rum.enabled,
             client_token: cfg.rum.client_token.to_string(),

--- a/src/job/compactor.rs
+++ b/src/job/compactor.rs
@@ -72,7 +72,13 @@ pub async fn run() -> Result<(), anyhow::Error> {
                                 }
                             }
                             Err(e) => {
-                                log::error!("[COMPACTOR:JOB] Error merging files: {}", e);
+                                log::error!(
+                                    "[COMPACTOR:JOB] Error merging files: stream: {}/{}/{}, err: {}",
+                                    msg.org_id,
+                                    msg.stream_type,
+                                    msg.stream_name,
+                                    e
+                                );
                                 if let Err(e) = tx.send(Err(e)).await {
                                     log::error!(
                                         "[COMPACTOR:JOB] Error sending error to merge_job: {}",

--- a/src/service/compact/file_list_deleted.rs
+++ b/src/service/compact/file_list_deleted.rs
@@ -17,7 +17,6 @@ use std::io::{BufRead, BufReader};
 
 use bytes::Buf;
 use chrono::{DateTime, Duration, TimeZone, Utc};
-use config::utils::inverted_index::convert_parquet_idx_file_name;
 use futures::future::try_join_all;
 use hashbrown::HashMap;
 use infra::{file_list as infra_file_list, storage};
@@ -51,29 +50,30 @@ pub async fn delete(
         }
     }
 
+    // TODO: disable it for now, we haven't enable inverted index puffin files
     // delete related inverted index puffin files
-    let inverted_index_files = files
-        .values()
-        .flatten()
-        .filter_map(|file| convert_parquet_idx_file_name(&file.0))
-        .collect::<Vec<_>>();
-    if !inverted_index_files.is_empty() {
-        if let Err(e) = storage::del(
-            &inverted_index_files
-                .iter()
-                .map(|file| file.as_str())
-                .collect::<Vec<_>>(),
-        )
-        .await
-        {
-            // maybe the file already deleted or there's not related index files,
-            // so we just skip the `not found` error
-            if !e.to_string().to_lowercase().contains("not found") {
-                log::error!("[COMPACT] delete files from storage failed: {}", e);
-                return Err(e);
-            }
-        }
-    }
+    // let inverted_index_files = files
+    //     .values()
+    //     .flatten()
+    //     .filter_map(|file| convert_parquet_idx_file_name(&file.0))
+    //     .collect::<Vec<_>>();
+    // if !inverted_index_files.is_empty() {
+    //     if let Err(e) = storage::del(
+    //         &inverted_index_files
+    //             .iter()
+    //             .map(|file| file.as_str())
+    //             .collect::<Vec<_>>(),
+    //     )
+    //     .await
+    //     {
+    //         // maybe the file already deleted or there's not related index files,
+    //         // so we just skip the `not found` error
+    //         if !e.to_string().to_lowercase().contains("not found") {
+    //             log::error!("[COMPACT] delete files from storage failed: {}", e);
+    //             return Err(e);
+    //         }
+    //     }
+    // }
 
     // delete flattened files from storage
     let flattened_files = files

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -424,6 +424,9 @@ fn merge_response(
         if res.hits.is_empty() {
             continue;
         }
+        // TODO: here we can't plus cluster_total, it is query in parallel
+        // TODO: and, use this value also is wrong, the cluster_total should be the total time of
+        // TODO: the query, here only calculate the time of the delta query
         if let Some(mut took_details) = res.took_detail {
             res_took.cluster_total += took_details.cluster_total;
             res_took.cluster_wait_queue += took_details.cluster_wait_queue;

--- a/web/src/components/login/Login.vue
+++ b/web/src/components/login/Login.vue
@@ -35,7 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         class="text-h6 text-bold q-pa-none cursor-pointer q-mr-sm full-width"
         >{{ store.state.zoConfig.custom_logo_text }}</span
       >
-      <span class="full-width">
+      <span class="full-width flex justify-center">
         <img
           v-if="
             store.state.zoConfig.hasOwnProperty('custom_logo_img') &&

--- a/web/src/components/login/Login.vue
+++ b/web/src/components/login/Login.vue
@@ -46,6 +46,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         />
       </span>
       <img
+        v-if="store.state.zoConfig.custom_hide_self_logo == false"
         class="appLogo"
         style="height: auto"
         :style="

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -57,6 +57,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             style="max-width: 150px; max-height: 31px"
           />
           <img
+            v-if="store.state.zoConfig.custom_hide_self_logo == false"
             class="appLogo"
             loading="lazy"
             :src="


### PR DESCRIPTION
Added a new ENV to control show our logo or not.
```
O2_CUSTOM_HIDE_SELF_LOGO=false
```
Also it will return in the config API:
```
custom_hide_self_logo: false
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated configuration options for the inverted index store format, now allowing only "parquet" or "both."
	- Introduced a new feature to conditionally hide the self logo in enterprise mode, configurable via the `custom_hide_self_logo` field.
	- Enhanced logo display logic in the login and main layout components based on the `custom_hide_self_logo` setting.
	- Improved caching mechanism for search functionality, optimizing performance and refining metrics.

- **Bug Fixes**
	- Improved validation to ensure outdated configuration options are flagged as invalid.
	- Enhanced error logging for better traceability during file merging operations. 

- **Chores**
	- Temporarily disabled the deletion of inverted index puffin files in the delete function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->