### PR TITLE
fix: improve delay deletion

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1034,7 +1034,7 @@ pub struct Compact {
     pub data_retention_history: bool,
     #[env_config(
         name = "ZO_COMPACT_BATCH_SIZE",
-        default = 100,
+        default = 500,
         help = "Batch size for compact get pending jobs"
     )]
     pub batch_size: i64,


### PR DESCRIPTION
Reduce `disk_lock` for delay deletion job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the default batch size for processing jobs from 100 to 500, enhancing the efficiency of compacting operations.
  
- **Bug Fixes**
	- Simplified the compaction process by removing unnecessary locking mechanisms, improving performance and reliability. 

- **Refactor**
	- Streamlined data retention and compaction functions for better clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->