### PR TITLE
fix: Ensure Vector Performs External Health Check for OpenObserve

### DIFF
--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -18,7 +18,7 @@ use std::{io::Error, sync::Arc};
 use actix_web::{
     cookie,
     cookie::{Cookie, SameSite},
-    get,
+    get, head,
     http::header,
     put, web, HttpRequest, HttpResponse,
 };
@@ -142,6 +142,13 @@ pub async fn healthz() -> Result<HttpResponse, Error> {
     Ok(HttpResponse::Ok().json(HealthzResponse {
         status: "ok".to_string(),
     }))
+}
+
+/// Healthz HEAD
+/// Vector pipeline healthcheck support
+#[head("/healthz")]
+pub async fn healthz_head() -> Result<HttpResponse, Error> {
+    Ok(HttpResponse::Ok().finish())
 }
 
 /// Healthz of the node for scheduled status

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -206,7 +206,9 @@ async fn proxy(
 
 pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
     let cors = get_cors();
-    cfg.service(status::healthz).service(status::schedulez);
+    cfg.service(status::healthz)
+        .service(status::healthz_head)
+        .service(status::schedulez);
     cfg.service(
         web::scope("/auth")
             .wrap(cors.clone())


### PR DESCRIPTION
## Problem Statement
When configuring Vector to send logs to OpenObserve, you can enable a health check to ensure that the OpenObserve service is up and running before sending logs. However, the behavior of the health check depends on how the configuration is set:

- ***if healthcheck.enabled = true is set without specifying a healthcheck.uri, Vector performs an internal health check, which only verifies if Vector itself is running fine. This can lead to a false sense of security, as it doesn't actually check the health of the OpenObserve service***.

- ***if you want to ensure that Vector checks the health of the OpenObserve service specifically, you must set both healthcheck.enabled = true and provide a healthcheck.uri that points to the OpenObserve health check endpoint (e.g., /healthz).***


### Sample Vector config

```toml
# Source to ingest logs from a file
[sources.my_source]
type = "file"
include = ["./k8slog_json.json"]
data_dir = "/Users/lin/o2/vector_pipeline/"
ignore_checkpoints = true
read_from = "beginning"

# Sink to send logs to OpenObserve
[sinks.openobserve]
type = "http"
inputs = ["my_source"]
uri = "http://localhost:5080/api/default/default/_json"
method = "post"
auth.strategy = "basic"
auth.user = "root@example.com"
auth.password = "passowrd"
compression = "gzip"
encoding.codec = "json"
encoding.timestamp_format = "rfc3339"

# Enable health checks for OpenObserve
healthcheck.enabled = true  # Enable health checks on the OpenObserve sink
healthcheck.uri = "http://localhost:5080/healthz"  # Health check endpoint for OpenObserve
```

## Fix
- fixes: #4513
- Implemented a `HEAD` http method for `/healthz` since vector uses it.

## TODO:
- [ ] Update openobserve documentation for vector (docs)[https://openobserve.ai/docs/ingestion/logs/vector/] to include the `healthcheck.uri`
```toml
# Enable health checks for OpenObserve
healthcheck.enabled = true
healthcheck.uri = "http://localhost:5080/healthz"
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new HTTP endpoint for health checks at `/healthz` that responds to `HEAD` requests.
	- Enhanced health check capabilities with the addition of the `healthz_head` service route.
- **Bug Fixes**
	- Improved middleware functionalities for auditing requests based on feature flags.
- **Chores**
	- Updated routing configurations and CORS settings for new routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->