### PR TITLE
feat: unix timestamp support short urls

### DIFF
--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -113,10 +113,11 @@ async fn cache_indices() -> RwLock<HashSet<DBIndex>> {
         .fetch_all(&client)
         .await;
     match res {
-        Ok(r) => RwLock::new(r
-            .into_iter()
-            .map(|(name, table)| DBIndex { name, table })
-            .collect()),
+        Ok(r) => RwLock::new(
+            r.into_iter()
+                .map(|(name, table)| DBIndex { name, table })
+                .collect(),
+        ),
         Err(_) => RwLock::new(HashSet::new()),
     }
 }

--- a/src/infra/src/short_url/mysql.rs
+++ b/src/infra/src/short_url/mysql.rs
@@ -375,7 +375,10 @@ async fn add_created_ts_column_if_not_exists(pool: &sqlx::Pool<sqlx::MySql>) -> 
         );
 
         if let Err(e) = sqlx::query(&update_query).execute(pool).await {
-            log::error!("[MYSQL] Error updating existing rows with created_ts: {}", e);
+            log::error!(
+                "[MYSQL] Error updating existing rows with created_ts: {}",
+                e
+            );
             return Err(e.into());
         }
 

--- a/src/infra/src/short_url/postgres.rs
+++ b/src/infra/src/short_url/postgres.rs
@@ -42,17 +42,17 @@ impl ShortUrl for PostgresShortUrl {
     /// Create table short_urls
     async fn create_table(&self) -> Result<()> {
         let pool = CLIENT.clone();
+        // `created_ts` is a Unix timestamp in microseconds
         let query = r#"
             CREATE TABLE IF NOT EXISTS short_urls (
                 id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                 short_id VARCHAR(32) NOT NULL,
                 original_url VARCHAR(2048) NOT NULL,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                created_ts BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000000)::BIGINT
+                created_ts BIGINT NOT NULL
             );
             "#;
         sqlx::query(query).execute(&pool).await?;
-        add_created_ts_column().await?;
+        manage_short_urls_schema().await?;
         Ok(())
     }
 
@@ -60,10 +60,10 @@ impl ShortUrl for PostgresShortUrl {
     async fn create_table_index(&self) -> Result<()> {
         create_index("short_urls_short_id_idx", "short_urls", true, &["short_id"]).await?;
         create_index(
-            "short_urls_created_at_idx",
+            "short_urls_created_ts_idx",
             "short_urls",
             false,
-            &["created_at"],
+            &["created_ts"],
         )
         .await?;
         Ok(())
@@ -72,10 +72,13 @@ impl ShortUrl for PostgresShortUrl {
     /// Add a new entry to the short_urls table
     async fn add(&self, short_id: &str, original_url: &str) -> Result<()> {
         let pool = CLIENT.clone();
-        let query = r#"INSERT INTO short_urls (short_id, original_url) VALUES ($1, $2);"#;
+        let created_ts = Utc::now().timestamp_micros();
+
+        let query = r#"INSERT INTO short_urls (short_id, original_url, created_ts) VALUES ($1, $2, $3);"#;
         let result = sqlx::query(query)
             .bind(short_id)
             .bind(original_url)
+            .bind(created_ts)
             .execute(&pool)
             .await;
 
@@ -111,7 +114,7 @@ impl ShortUrl for PostgresShortUrl {
     async fn list(&self, limit: Option<i64>) -> Result<Vec<ShortUrlRecord>> {
         let pool = CLIENT.clone();
         let mut query =
-            r#"SELECT short_id, original_url FROM short_urls ORDER BY id DESC"#.to_string();
+            r#"SELECT short_id, original_url FROM short_urls ORDER BY created_ts DESC"#.to_string();
 
         if limit.is_some() {
             query.push_str(" LIMIT $1");
@@ -178,10 +181,11 @@ impl ShortUrl for PostgresShortUrl {
         limit: Option<i64>,
     ) -> Result<Vec<String>> {
         let pool = CLIENT.clone();
+        let expired_before_ts = expired_before.timestamp_micros();
 
         let mut query = r#"
             SELECT short_id FROM short_urls
-            WHERE created_at < $1
+            WHERE created_ts < $1
             "#
         .to_string();
 
@@ -189,7 +193,7 @@ impl ShortUrl for PostgresShortUrl {
             query.push_str(" LIMIT $2");
         }
 
-        let mut query = sqlx::query_as(&query).bind(expired_before);
+        let mut query = sqlx::query_as(&query).bind(expired_before_ts);
 
         if let Some(limit_value) = limit {
             query = query.bind(limit_value);
@@ -219,37 +223,172 @@ impl ShortUrl for PostgresShortUrl {
     }
 }
 
-async fn add_created_ts_column() -> Result<()> {
+// Main function to manage the schema changes for `short_urls` table.
+//
+// This function performs the following steps:
+// 1. Drops the `created_at` column if it exists.
+// 2. Drops the index on `created_at` if it exists.
+// 3. Adds the `created_ts` column if it doesn't exist.
+async fn manage_short_urls_schema() -> Result<()> {
     let pool = CLIENT.clone();
 
-    // Check if the created_ts column exists
-    let check_query = r#"
-            SELECT EXISTS (
-                SELECT 1
-                FROM information_schema.columns
-                WHERE table_name='short_urls'
-                AND column_name='created_ts'
-            );
-        "#;
+    drop_column_if_exists(&pool, "created_at").await?;
+    drop_index_if_exists(&pool, "short_urls_created_at_idx").await?;
+    add_created_ts_column_if_not_exists(&pool).await?;
 
-    let exists: (bool,) = sqlx::query_as(check_query).fetch_one(&pool).await?;
+    Ok(())
+}
 
-    if !exists.0 {
-        log::info!("[POSTGRES] Adding created_ts column to short_urls table");
+// Checks if a column exists in the `short_urls` table.
+async fn column_exists(pool: &sqlx::Pool<sqlx::Postgres>, column_name: &str) -> Result<bool> {
+    let query = format!(
+        r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_name = 'short_urls'
+            AND column_name = '{}'
+        );
+        "#,
+        column_name
+    );
 
-        // Column does not exist, so we can add it
-        let alter_query = r#"
-                ALTER TABLE short_urls
-                ADD COLUMN created_ts BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000000)::BIGINT;
-            "#;
+    let exists: (bool,) = sqlx::query_as(&query).fetch_one(pool).await?;
+    Ok(exists.0)
+}
 
-        if let Err(e) = sqlx::query(alter_query).execute(&pool).await {
+// Drops a column from the `short_urls` table if it exists.
+async fn drop_column_if_exists(pool: &sqlx::Pool<sqlx::Postgres>, column_name: &str) -> Result<()> {
+    if column_exists(pool, column_name).await? {
+        log::info!(
+            "[POSTGRES] Dropping {} column from short_urls table",
+            column_name
+        );
+
+        let query = format!(
+            r#"
+            ALTER TABLE short_urls
+            DROP COLUMN {};
+            "#,
+            column_name
+        );
+
+        if let Err(e) = sqlx::query(&query).execute(pool).await {
             log::error!(
-                "[POSTGRES] Unexpected error in adding created_ts column: {}",
+                "[POSTGRES] Unexpected error in dropping {} column: {}",
+                column_name,
                 e
             );
             return Err(e.into());
         }
+
+        log::info!("[POSTGRES] Successfully dropped {} column", column_name);
+    } else {
+        log::info!(
+            "[POSTGRES] {} column does not exist in short_urls table",
+            column_name
+        );
+    }
+
+    Ok(())
+}
+
+// Checks if an index exists on the `short_urls` table.
+async fn index_exists(pool: &sqlx::Pool<sqlx::Postgres>, index_name: &str) -> Result<bool> {
+    let query = format!(
+        r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM pg_indexes
+            WHERE tablename = 'short_urls'
+            AND indexname = '{}'
+        );
+        "#,
+        index_name
+    );
+
+    let exists: (bool,) = sqlx::query_as(&query).fetch_one(pool).await?;
+    Ok(exists.0)
+}
+
+// Drops an index from the `short_urls` table if it exists.
+async fn drop_index_if_exists(pool: &sqlx::Pool<sqlx::Postgres>, index_name: &str) -> Result<()> {
+    if index_exists(pool, index_name).await? {
+        log::info!("[POSTGRES] Dropping index {} on short_urls table", index_name);
+
+        let query = format!(
+            r#"
+            DROP INDEX IF EXISTS {};
+            "#,
+            index_name
+        );
+
+        if let Err(e) = sqlx::query(&query).execute(pool).await {
+            log::error!(
+                "[POSTGRES] Unexpected error in dropping index {}: {}",
+                index_name,
+                e
+            );
+            return Err(e.into());
+        }
+
+        log::info!("[POSTGRES] Successfully dropped index {}", index_name);
+    } else {
+        log::info!(
+            "[POSTGRES] No index named {} found on short_urls table",
+            index_name
+        );
+    }
+
+    Ok(())
+}
+
+// Adds the `created_ts` column to the `short_urls` table if it doesn't already exist.
+async fn add_created_ts_column_if_not_exists(pool: &sqlx::Pool<sqlx::Postgres>) -> Result<()> {
+    if !column_exists(pool, "created_ts").await? {
+        log::info!("[POSTGRES] Adding created_ts column to short_urls table");
+
+        // Step 1: Add the column as nullable
+        let query = r#"
+            ALTER TABLE short_urls
+            ADD COLUMN created_ts BIGINT;
+        "#;
+
+        if let Err(e) = sqlx::query(query).execute(pool).await {
+            log::error!("[POSTGRES] Error adding nullable created_ts column: {}", e);
+            return Err(e.into());
+        }
+
+        // Step 2: Update existing rows with a default timestamp
+        let fallback_timestamp = Utc::now().timestamp_micros();
+        let update_query = format!(
+            r#"
+            UPDATE short_urls
+            SET created_ts = {}
+            WHERE created_ts IS NULL;
+            "#,
+            fallback_timestamp
+        );
+
+        if let Err(e) = sqlx::query(&update_query).execute(pool).await {
+            log::error!("[POSTGRES] Error updating existing rows with created_ts: {}", e);
+            return Err(e.into());
+        }
+
+        log::info!("[POSTGRES] Successfully updated existing rows with created_ts");
+
+        // Step 3: Alter the column to be NOT NULL after populating existing rows
+        let alter_query = r#"
+            ALTER TABLE short_urls
+            ALTER COLUMN created_ts SET NOT NULL;
+        "#;
+
+        if let Err(e) = sqlx::query(alter_query).execute(pool).await {
+            log::error!("[POSTGRES] Error setting created_ts column to NOT NULL: {}", e);
+            return Err(e.into());
+        }
+
+        log::info!("[POSTGRES] Successfully added and updated created_ts column");
     } else {
         log::info!("[POSTGRES] created_ts column already exists in short_urls table");
     }

--- a/src/infra/src/short_url/postgres.rs
+++ b/src/infra/src/short_url/postgres.rs
@@ -74,7 +74,8 @@ impl ShortUrl for PostgresShortUrl {
         let pool = CLIENT.clone();
         let created_ts = Utc::now().timestamp_micros();
 
-        let query = r#"INSERT INTO short_urls (short_id, original_url, created_ts) VALUES ($1, $2, $3);"#;
+        let query =
+            r#"INSERT INTO short_urls (short_id, original_url, created_ts) VALUES ($1, $2, $3);"#;
         let result = sqlx::query(query)
             .bind(short_id)
             .bind(original_url)
@@ -314,7 +315,10 @@ async fn index_exists(pool: &sqlx::Pool<sqlx::Postgres>, index_name: &str) -> Re
 // Drops an index from the `short_urls` table if it exists.
 async fn drop_index_if_exists(pool: &sqlx::Pool<sqlx::Postgres>, index_name: &str) -> Result<()> {
     if index_exists(pool, index_name).await? {
-        log::info!("[POSTGRES] Dropping index {} on short_urls table", index_name);
+        log::info!(
+            "[POSTGRES] Dropping index {} on short_urls table",
+            index_name
+        );
 
         let query = format!(
             r#"
@@ -371,7 +375,10 @@ async fn add_created_ts_column_if_not_exists(pool: &sqlx::Pool<sqlx::Postgres>) 
         );
 
         if let Err(e) = sqlx::query(&update_query).execute(pool).await {
-            log::error!("[POSTGRES] Error updating existing rows with created_ts: {}", e);
+            log::error!(
+                "[POSTGRES] Error updating existing rows with created_ts: {}",
+                e
+            );
             return Err(e.into());
         }
 
@@ -384,7 +391,10 @@ async fn add_created_ts_column_if_not_exists(pool: &sqlx::Pool<sqlx::Postgres>) 
         "#;
 
         if let Err(e) = sqlx::query(alter_query).execute(pool).await {
-            log::error!("[POSTGRES] Error setting created_ts column to NOT NULL: {}", e);
+            log::error!(
+                "[POSTGRES] Error setting created_ts column to NOT NULL: {}",
+                e
+            );
             return Err(e.into());
         }
 

--- a/src/infra/src/short_url/postgres.rs
+++ b/src/infra/src/short_url/postgres.rs
@@ -47,10 +47,12 @@ impl ShortUrl for PostgresShortUrl {
                 id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                 short_id VARCHAR(32) NOT NULL,
                 original_url VARCHAR(2048) NOT NULL,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                created_ts BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000000)::BIGINT
             );
             "#;
         sqlx::query(query).execute(&pool).await?;
+        add_created_ts_column().await?;
         Ok(())
     }
 
@@ -215,4 +217,42 @@ impl ShortUrl for PostgresShortUrl {
         sqlx::query(query).bind(&short_ids).execute(&pool).await?;
         Ok(())
     }
+}
+
+async fn add_created_ts_column() -> Result<()> {
+    let pool = CLIENT.clone();
+
+    // Check if the created_ts column exists
+    let check_query = r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name='short_urls'
+                AND column_name='created_ts'
+            );
+        "#;
+
+    let exists: (bool,) = sqlx::query_as(check_query).fetch_one(&pool).await?;
+
+    if !exists.0 {
+        log::info!("[POSTGRES] Adding created_ts column to short_urls table");
+
+        // Column does not exist, so we can add it
+        let alter_query = r#"
+                ALTER TABLE short_urls
+                ADD COLUMN created_ts BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000000)::BIGINT;
+            "#;
+
+        if let Err(e) = sqlx::query(alter_query).execute(&pool).await {
+            log::error!(
+                "[POSTGRES] Unexpected error in adding created_ts column: {}",
+                e
+            );
+            return Err(e.into());
+        }
+    } else {
+        log::info!("[POSTGRES] created_ts column already exists in short_urls table");
+    }
+
+    Ok(())
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `created_ts` timestamp format for managing short URLs across SQLite, MySQL, and PostgreSQL databases.
	- Added schema management functions to handle the transition from `created_at` to `created_ts`.

- **Bug Fixes**
	- Improved concurrency model for SQLite database interactions.

- **Documentation**
	- Updated documentation to reflect changes in database schema and functions related to short URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->