### PR TITLE
fix: skip alert if the delay is big

### DIFF
--- a/src/common/meta/alerts/mod.rs
+++ b/src/common/meta/alerts/mod.rs
@@ -39,6 +39,8 @@ pub struct TriggerCondition {
     pub silence: i64, // silence for 10 minutes after fire an alert
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
+    #[serde(default)]
+    pub tolerance_in_secs: Option<i64>,
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, ToSchema, PartialEq)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -942,6 +942,12 @@ pub struct Limit {
     pub scheduler_max_retries: i32,
     #[env_config(name = "ZO_SCHEDULER_PAUSE_ALERT_AFTER_RETRIES", default = false)]
     pub pause_alerts_on_retries: bool,
+    #[env_config(
+        name = "ZO_ALERT_CONSIDERABLE_DELAY",
+        default = 20,
+        help = "Integer value representing the delay in percentage of the alert frequency that will be included in alert evaluation timerange. Default is 20. This can be changed in runtime."
+    )]
+    pub alert_considerable_delay: i32,
     #[env_config(name = "ZO_SCHEDULER_CLEAN_INTERVAL", default = 30)] // seconds
     pub scheduler_clean_interval: u64,
     #[env_config(name = "ZO_SCHEDULER_WATCH_INTERVAL", default = 30)] // seconds

--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -65,7 +65,7 @@ pub struct TriggerData {
     pub error: Option<String>,
     pub success_response: Option<String>,
     pub is_partial: Option<bool>,
-    pub delay_in_seconds: Option<i64>,
+    pub delay_in_secs: Option<i64>,
     pub evaluation_took_in_secs: Option<f64>,
 }
 

--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -33,6 +33,8 @@ pub enum TriggerDataStatus {
     Failed,
     #[serde(rename = "condition_not_satisfied")]
     ConditionNotSatisfied,
+    #[serde(rename = "skipped")]
+    Skipped,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -63,6 +65,8 @@ pub struct TriggerData {
     pub error: Option<String>,
     pub success_response: Option<String>,
     pub is_partial: Option<bool>,
+    pub delay_in_seconds: Option<i64>,
+    pub evaluation_took_in_secs: Option<f64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/config/src/utils/rand.rs
+++ b/src/config/src/utils/rand.rs
@@ -24,3 +24,10 @@ pub fn get_rand_element<T>(arr: &[T]) -> &T {
 pub fn generate_random_string(len: usize) -> String {
     Alphanumeric.sample_string(&mut rand::thread_rng(), len)
 }
+
+/// Generate random number within the given range
+pub fn get_rand_num_within(min: u64, max: u64) -> u64 {
+    let mut buf = [0u8; 1];
+    getrandom::getrandom(&mut buf).unwrap();
+    min + buf[0] as u64 % (max - min)
+}

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -30,6 +30,7 @@ use proto::cluster_rpc;
 
 use crate::{
     common::meta::{alerts::FrequencyType, dashboards::reports::ReportFrequencyType},
+    handler::http::request::kv::get,
     service::{
         alerts::alert::{get_alert_start_end_time, get_row_column_map},
         db::{self, scheduler::DerivedTriggerData},
@@ -90,7 +91,9 @@ fn get_max_considerable_delay(frequency: i64) -> i64 {
         .num_microseconds()
         .unwrap();
     let max_delay = Duration::try_hours(1).unwrap().num_microseconds().unwrap();
-    let max_considerable_delay = (frequency as f64 * 0.2) as i64;
+    // limit.alert_considerable_delay is in percentage, convert into float
+    let considerable_delay = get_config().limit.alert_considerable_delay as f64 * 0.01;
+    let max_considerable_delay = (frequency as f64 * considerable_delay) as i64;
     std::cmp::min(max_delay, max_considerable_delay)
 }
 

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -759,11 +759,9 @@ async fn handle_derived_stream_triggers(
     };
     let trigger_data: Option<ScheduledTriggerData> = json::from_str(&trigger.data).ok();
     let start_time = if let Some(trigger_data) = trigger_data {
-        if let Some(period_end_time) = trigger_data.period_end_time {
-            Some(period_end_time + 1)
-        } else {
-            None
-        }
+        trigger_data
+            .period_end_time
+            .map(|period_end_time| period_end_time + 1)
     } else {
         None
     };

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -595,6 +595,8 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
     }
 
     let triggered_at = trigger.start_time.unwrap_or_default();
+    let processing_delay = triggered_at - trigger.next_run_at;
+
     let mut trigger_data_stream = TriggerData {
         _timestamp: triggered_at,
         org: trigger.org.clone(),
@@ -614,7 +616,7 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         error: None,
         success_response: None,
         is_partial: None,
-        delay_in_secs: None,
+        delay_in_secs: Some(Duration::microseconds(processing_delay).num_seconds()),
         evaluation_took_in_secs: None,
     };
 

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -187,7 +187,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                         .unwrap(),
                 end_time: trigger.next_run_at,
                 retries: trigger.retries,
-                delay_in_seconds: Some(Duration::microseconds(delay).num_seconds()),
+                delay_in_secs: Some(Duration::microseconds(delay).num_seconds()),
                 error: None,
                 success_response: None,
                 is_partial: None,
@@ -242,7 +242,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         error: None,
         success_response: None,
         is_partial: None,
-        delay_in_seconds: Some(Duration::microseconds(processing_delay).num_seconds()),
+        delay_in_secs: Some(Duration::microseconds(processing_delay).num_seconds()),
         evaluation_took_in_secs: None,
     };
 
@@ -614,7 +614,7 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         error: None,
         success_response: None,
         is_partial: None,
-        delay_in_seconds: None,
+        delay_in_secs: None,
         evaluation_took_in_secs: None,
     };
 
@@ -826,7 +826,7 @@ async fn handle_derived_stream_triggers(
         error: None,
         success_response: None,
         is_partial: None,
-        delay_in_seconds: None,
+        delay_in_secs: None,
         evaluation_took_in_secs: None,
     };
 

--- a/src/service/db/scheduler.rs
+++ b/src/service/db/scheduler.rs
@@ -27,8 +27,11 @@ use {
 };
 
 #[derive(Default, Serialize, Deserialize, Debug)]
-pub struct DerivedTriggerData {
-    pub period_end_time: i64,
+pub struct ScheduledTriggerData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub period_end_time: Option<i64>,
+    #[serde(default)]
+    pub tolerance: i64,
 }
 
 #[inline]

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -254,7 +254,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
             error: None,
             success_response: None,
             is_partial: None,
-            delay_in_seconds: None,
+            delay_in_secs: None,
             evaluation_took_in_secs: None,
         };
         match alert.send_notification(val, now, None).await {

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -254,6 +254,8 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
             error: None,
             success_response: None,
             is_partial: None,
+            delay_in_seconds: None,
+            evaluation_took_in_secs: None,
         };
         match alert.send_notification(val, now, None).await {
             Err(e) => {


### PR DESCRIPTION
Addresses #3750

When alert manager processes alerts, there can be some delay in processing of alert. This PR adds a check to decide whether to include the delay in the data timerange (to be used for alert evaluation) along with the period. If the delay is `<= 20%` of the frequency, the delay is added to the timerange (i.e. period + delay) and maximum considerable delay is 1 hour. Hence, the considerable delay is `min(20% of frequency, 1 hour)`.

In case the delay is more, that actual timerange will be skipped and new timerange (i.e. `now - alert period`) will be used to evaluate the alert.

Say for some reason, an alert(period - 5min, frequency - 5min) that was supposed to run at 10:00am, it is delayed to 10:04am. The delay is 4 mins which is `> 1min (20% of 5min)`. Hence, when running this alert the timerange of `9:55am to 10:00am` will be skipped and instead `9:59am to 10:04am` timerange will be used to evaluate the alert.

The `skipped` event will be logged into the `triggers` stream along with the `delay_in_secs` field.

- [x] Skip alerts when delay is big
- [x] Add tolerance in alert payload. When calculating `next_run_at` it adds a random delay within the given tolerance bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new status option "Skipped" for trigger data.
	- Introduced new fields for tracking delays and evaluation times in trigger and usage data.
	- Enhanced alert scheduling logic to better handle processing delays.
	- Added a new public function to generate random numbers within a specified range.
	- Expanded configuration options with new fields for alert management and tolerance settings.

- **Bug Fixes**
	- Improved accuracy in alert processing by refining delay handling and evaluation metrics.

- **Documentation**
	- Updated logging statements for clearer context during trigger evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->