### PR TITLE
fix: cases where _original/_o2_id missing when user defined schema

### DIFF
--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -621,14 +621,20 @@ async fn merge_files(
     let bloom_filter_fields = get_stream_setting_bloom_filter_fields(&stream_setting);
     let full_text_search_fields = get_stream_setting_fts_fields(&stream_setting);
     let index_fields = get_stream_setting_index_fields(&stream_setting);
-    let defined_schema_fields = stream_setting
-        .unwrap_or_default()
-        .defined_schema_fields
-        .unwrap_or_default();
+    let (defined_schema_fields, need_original) = match stream_setting {
+        Some(s) => (
+            s.defined_schema_fields.unwrap_or_default(),
+            s.store_original_data,
+        ),
+        None => (Vec::new(), false),
+    };
     let schema = if !defined_schema_fields.is_empty() {
-        let latest_schema = SchemaCache::new_from_arc(latest_schema.clone());
-        let latest_schema =
-            generate_schema_for_defined_schema_fields(&latest_schema, &defined_schema_fields);
+        let latest_schema = SchemaCache::new(latest_schema.as_ref().clone());
+        let latest_schema = generate_schema_for_defined_schema_fields(
+            &latest_schema,
+            &defined_schema_fields,
+            need_original,
+        );
         latest_schema.schema().clone()
     } else {
         latest_schema.clone()

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -322,6 +322,10 @@ fn generate_schema_fields(
             fields.push(field.clone());
         }
     }
+    // check _o2_id
+    if !fields.contains(&ID_COL_NAME.to_string()) && schema.field_with_name(ID_COL_NAME).is_ok() {
+        fields.push(ID_COL_NAME.to_string());
+    }
     fields
 }
 

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -183,10 +183,14 @@ impl Sql {
         statement.visit(&mut histogram_interval_visitor);
 
         // NOTE: only this place can modify the sql
-        // 9. add _timestamp is need
+        // 9. add _timestamp and _o2_id if need
         if !is_complex_query(&mut statement) {
             let mut add_timestamp_visitor = AddTimestampVisitor::new();
             statement.visit(&mut add_timestamp_visitor);
+            if o2_id_is_needed(&used_schemas) {
+                let mut add_o2_id_visitor = AddO2IdVisitor::new();
+                statement.visit(&mut add_o2_id_visitor);
+            }
         }
 
         Ok(Sql {
@@ -824,6 +828,57 @@ impl VisitorMut for AddTimestampVisitor {
     }
 }
 
+// add _o2_id to the query like `SELECT name FROM t` -> `SELECT _o2_id, name FROM t`
+struct AddO2IdVisitor {}
+
+impl AddO2IdVisitor {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl VisitorMut for AddO2IdVisitor {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &mut Query) -> ControlFlow<Self::Break> {
+        if let SetExpr::Select(select) = query.body.as_mut() {
+            let mut has_o2_id = false;
+            for item in select.projection.iter_mut() {
+                match item {
+                    SelectItem::UnnamedExpr(expr) => {
+                        let mut visitor = FieldNameVisitor::new();
+                        expr.visit(&mut visitor);
+                        if visitor.field_names.contains(ID_COL_NAME) {
+                            has_o2_id = true;
+                            break;
+                        }
+                    }
+                    SelectItem::ExprWithAlias { expr, alias: _ } => {
+                        let mut visitor = FieldNameVisitor::new();
+                        expr.visit(&mut visitor);
+                        if visitor.field_names.contains(ID_COL_NAME) {
+                            has_o2_id = true;
+                            break;
+                        }
+                    }
+                    SelectItem::Wildcard(_) => {
+                        has_o2_id = true;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            if !has_o2_id {
+                select.projection.insert(
+                    0,
+                    SelectItem::UnnamedExpr(Expr::Identifier(Ident::new(ID_COL_NAME.to_string()))),
+                );
+            }
+        }
+        ControlFlow::Continue(())
+    }
+}
+
 fn is_complex_query(statement: &mut Statement) -> bool {
     let mut visitor = ComplexQueryVisitor::new();
     statement.visit(&mut visitor);
@@ -1142,4 +1197,11 @@ pub fn pickup_where(sql: &str, meta: Option<MetaSql>) -> Result<Option<String>, 
         where_str = where_str[0..where_str.to_lowercase().rfind(" offset ").unwrap()].to_string();
     }
     Ok(Some(where_str))
+}
+
+fn o2_id_is_needed(schemas: &HashMap<String, Arc<SchemaCache>>) -> bool {
+    schemas.values().any(|schema| {
+        let stream_setting = unwrap_stream_settings(schema.schema());
+        stream_setting.map_or(false, |setting| setting.store_original_data)
+    })
 }


### PR DESCRIPTION
fix #4821  task 1 & 2

cherry-picked over

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced schema management with improved handling of schema fields.
	- Introduced a new parameter, `need_original`, for more flexible schema generation.
	- Added functionality to conditionally include an `_o2_id` field in SQL queries.
	- Improved logic for generating inverted indexes based on updated schema and file metadata.

- **Bug Fixes**
	- Improved error handling and logging for better insights during merging and schema processing.

- **Refactor**
	- Restructured logic for processing schema fields and merging Parquet files for improved clarity and maintainability.
	- Streamlined SQL query construction process for enhanced flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->