### PR TITLE
feat: bring per_thread_lock back

### DIFF
--- a/src/cli/data/import.rs
+++ b/src/cli/data/import.rs
@@ -43,6 +43,7 @@ async fn read_files_in_directory(c: Cli, dir_path: &str) -> Result<bool, anyhow:
         if path.is_file() {
             let content = fs::read(&path)?;
             if let Err(e) = logs::ingest::ingest(
+                0,
                 &c.org,
                 &c.stream_name,
                 IngestionRequest::JSON(&Bytes::from(content)),

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -562,6 +562,8 @@ pub struct Common {
     pub widening_schema_evolution: bool,
     #[env_config(name = "ZO_SKIP_SCHEMA_VALIDATION", default = false)]
     pub skip_schema_validation: bool,
+    #[env_config(name = "ZO_FEATURE_PER_THREAD_LOCK", default = false)]
+    pub feature_per_thread_lock: bool,
     #[env_config(name = "ZO_FEATURE_FULLTEXT_EXTRA_FIELDS", default = "")]
     pub feature_fulltext_extra_fields: String,
     #[env_config(name = "ZO_FEATURE_DISTINCT_EXTRA_FIELDS", default = "")]

--- a/src/handler/grpc/request/ingest.rs
+++ b/src/handler/grpc/request/ingest.rs
@@ -42,6 +42,7 @@ impl Ingest for Ingester {
                 match create_log_ingestion_req(log_ingestion_type, &data) {
                     Err(e) => Err(e),
                     Ok(ingestion_req) => crate::service::logs::ingest::ingest(
+                        0,
                         &org_id,
                         &stream_name,
                         ingestion_req,

--- a/src/handler/grpc/request/logs.rs
+++ b/src/handler/grpc/request/logs.rs
@@ -55,6 +55,7 @@ impl LogsService for LogsServer {
         };
 
         match crate::service::logs::otlp_grpc::handle_grpc_request(
+            0,
             org_id.unwrap().to_str().unwrap(),
             in_req,
             true,

--- a/src/handler/grpc/request/usage.rs
+++ b/src/handler/grpc/request/usage.rs
@@ -33,6 +33,7 @@ impl Usage for UsageServerImpl {
         let report_to_org_id = metadata.get(&config::get_config().grpc.org_header_key);
         let in_data = req.data.unwrap_or_default();
         let resp = crate::service::logs::ingest::ingest(
+            0,
             report_to_org_id.unwrap().to_str().unwrap(),
             &report_to_stream,
             IngestionRequest::Usage(&in_data.data.into()),

--- a/src/handler/http/request/logs/ingest.rs
+++ b/src/handler/http/request/logs/ingest.rs
@@ -50,22 +50,25 @@ use crate::{
 )]
 #[post("/{org_id}/_bulk")]
 pub async fn bulk(
+    thread_id: web::Data<usize>,
     org_id: web::Path<String>,
     body: web::Bytes,
     in_req: HttpRequest,
 ) -> Result<HttpResponse, Error> {
     let org_id = org_id.into_inner();
     let user_email = in_req.headers().get("user_id").unwrap().to_str().unwrap();
-    Ok(match logs::bulk::ingest(&org_id, body, user_email).await {
-        Ok(v) => MetaHttpResponse::json(v),
-        Err(e) => {
-            log::error!("Error processing request {org_id}/_bulk: {:?}", e);
-            HttpResponse::BadRequest().json(MetaHttpResponse::error(
-                http::StatusCode::BAD_REQUEST.into(),
-                e.to_string(),
-            ))
-        }
-    })
+    Ok(
+        match logs::bulk::ingest(**thread_id, &org_id, body, user_email).await {
+            Ok(v) => MetaHttpResponse::json(v),
+            Err(e) => {
+                log::error!("Error processing request {org_id}/_bulk: {:?}", e);
+                HttpResponse::BadRequest().json(MetaHttpResponse::error(
+                    http::StatusCode::BAD_REQUEST.into(),
+                    e.to_string(),
+                ))
+            }
+        },
+    )
 }
 
 /// _multi ingestion API
@@ -88,6 +91,7 @@ pub async fn bulk(
 )]
 #[post("/{org_id}/{stream_name}/_multi")]
 pub async fn multi(
+    thread_id: web::Data<usize>,
     path: web::Path<(String, String)>,
     body: web::Bytes,
     in_req: HttpRequest,
@@ -96,6 +100,7 @@ pub async fn multi(
     let user_email = in_req.headers().get("user_id").unwrap().to_str().unwrap();
     Ok(
         match logs::ingest::ingest(
+            **thread_id,
             &org_id,
             &stream_name,
             IngestionRequest::Multi(&body),
@@ -139,6 +144,7 @@ pub async fn multi(
 )]
 #[post("/{org_id}/{stream_name}/_json")]
 pub async fn json(
+    thread_id: web::Data<usize>,
     path: web::Path<(String, String)>,
     body: web::Bytes,
     in_req: HttpRequest,
@@ -147,6 +153,7 @@ pub async fn json(
     let user_email = in_req.headers().get("user_id").unwrap().to_str().unwrap();
     Ok(
         match logs::ingest::ingest(
+            **thread_id,
             &org_id,
             &stream_name,
             IngestionRequest::JSON(&body),
@@ -190,6 +197,7 @@ pub async fn json(
 )]
 #[post("/{org_id}/{stream_name}/_kinesis_firehose")]
 pub async fn handle_kinesis_request(
+    thread_id: web::Data<usize>,
     path: web::Path<(String, String)>,
     post_data: web::Json<KinesisFHRequest>,
     in_req: HttpRequest,
@@ -202,6 +210,7 @@ pub async fn handle_kinesis_request(
         .unwrap_or(chrono::Utc::now().timestamp_millis());
     Ok(
         match logs::ingest::ingest(
+            **thread_id,
             &org_id,
             &stream_name,
             IngestionRequest::KinesisFH(&post_data.into_inner()),
@@ -229,6 +238,7 @@ pub async fn handle_kinesis_request(
 
 #[post("/{org_id}/{stream_name}/_sub")]
 pub async fn handle_gcp_request(
+    thread_id: web::Data<usize>,
     path: web::Path<(String, String)>,
     post_data: web::Json<GCPIngestionRequest>,
     in_req: HttpRequest,
@@ -237,6 +247,7 @@ pub async fn handle_gcp_request(
     let user_email = in_req.headers().get("user_id").unwrap().to_str().unwrap();
     Ok(
         match logs::ingest::ingest(
+            **thread_id,
             &org_id,
             &stream_name,
             IngestionRequest::GCP(&post_data.into_inner()),
@@ -270,6 +281,7 @@ pub async fn handle_gcp_request(
 )]
 #[post("/{org_id}/v1/logs")]
 pub async fn otlp_logs_write(
+    thread_id: web::Data<usize>,
     org_id: web::Path<String>,
     req: HttpRequest,
     body: web::Bytes,
@@ -283,7 +295,7 @@ pub async fn otlp_logs_write(
         .map(|header| header.to_str().unwrap());
     if content_type.eq(CONTENT_TYPE_PROTO) {
         // log::info!("otlp::logs_proto_handler");
-        match logs_proto_handler(&org_id, body, in_stream_name, user_email).await {
+        match logs_proto_handler(**thread_id, &org_id, body, in_stream_name, user_email).await {
             Ok(v) => Ok(v),
             Err(e) => {
                 log::error!(
@@ -299,7 +311,7 @@ pub async fn otlp_logs_write(
         }
     } else if content_type.starts_with(CONTENT_TYPE_JSON) {
         // log::info!("otlp::logs_json_handler");
-        match logs_json_handler(&org_id, body, in_stream_name, user_email).await {
+        match logs_json_handler(**thread_id, &org_id, body, in_stream_name, user_email).await {
             Ok(v) => Ok(v),
             Err(e) => {
                 log::error!(

--- a/src/handler/http/request/rum/ingest.rs
+++ b/src/handler/http/request/rum/ingest.rs
@@ -115,6 +115,7 @@ pub async fn data(
     let extend_json = &rum_query_data.data;
     Ok(
         match logs::ingest::ingest(
+            0,
             &org_id,
             RUM_DATA_STREAM,
             IngestionRequest::RUM(&body),
@@ -156,6 +157,7 @@ pub async fn log(
     let extend_json = &rum_query_data.data;
     Ok(
         match logs::ingest::ingest(
+            0,
             &org_id,
             RUM_LOG_STREAM,
             IngestionRequest::RUM(&body),
@@ -214,6 +216,7 @@ pub async fn sessionreplay(
     let extend_json = &rum_query_data.data;
     Ok(
         match logs::ingest::ingest(
+            0,
             &org_id,
             RUM_SESSION_REPLAY_STREAM,
             IngestionRequest::RUM(&body.into()),

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -74,11 +74,17 @@ pub fn check_memtable_size() -> Result<()> {
 }
 
 /// Get a writer for a given org_id and stream_type
-pub async fn get_writer(org_id: &str, stream_type: &str, stream_name: &str) -> Arc<Writer> {
+pub async fn get_writer(
+    thread_id: usize,
+    org_id: &str,
+    stream_type: &str,
+    stream_name: &str,
+) -> Arc<Writer> {
     let idx = if let Some(idx) = MEM_TABLE_INDIVIDUAL_STREAMS.get(stream_name) {
         *idx
     } else {
-        let hash_id = gxhash::new().sum64(stream_name);
+        let key = format!("{}_{}", thread_id, stream_name);
+        let hash_id = gxhash::new().sum64(&key);
         hash_id as usize % (WRITERS.len() - MEM_TABLE_INDIVIDUAL_STREAMS.len())
     };
     let key = WriterKey::new(org_id, stream_type);

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -888,8 +888,13 @@ pub(crate) async fn generate_index_on_ingester(
         hour_buf.records.push(Arc::new(record_val));
         hour_buf.records_size += record_size;
     }
-    let writer =
-        ingester::get_writer(org_id, &StreamType::Index.to_string(), &index_stream_name).await;
+    let writer = ingester::get_writer(
+        0,
+        org_id,
+        &StreamType::Index.to_string(),
+        &index_stream_name,
+    )
+    .await;
     let _ = crate::service::ingestion::write_file(&writer, &index_stream_name, data_buf).await;
     if let Err(e) = writer.sync().await {
         log::error!("ingestion error while syncing writer: {}", e);

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -198,6 +198,7 @@ pub async fn save_enrichment_data(
 
     // write data to wal
     let writer = ingester::get_writer(
+        0,
         org_id,
         &StreamType::EnrichmentTables.to_string(),
         stream_name,

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -48,6 +48,7 @@ pub const TS_PARSE_FAILED: &str = "timestamp_parsing_failed";
 pub const SCHEMA_CONFORMANCE_FAILED: &str = "schema_conformance_failed";
 
 pub async fn ingest(
+    thread_id: usize,
     org_id: &str,
     body: web::Bytes,
     user_email: &str,
@@ -368,6 +369,7 @@ pub async fn ingest(
     let (metric_rpt_status_code, response_body) = {
         let mut status = IngestionStatus::Bulk(bulk_res);
         let write_result = super::write_logs_by_stream(
+            thread_id,
             org_id,
             user_email,
             (started_at, &start),

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -58,6 +58,7 @@ use crate::{
 };
 
 pub async fn ingest(
+    thread_id: usize,
     org_id: &str,
     in_stream_name: &str,
     in_req: IngestionRequest<'_>,
@@ -343,6 +344,7 @@ pub async fn ingest(
     let (metric_rpt_status_code, response_body) = {
         let mut status = IngestionStatus::Record(stream_status.status);
         let write_result = super::write_logs_by_stream(
+            thread_id,
             org_id,
             user_email,
             (started_at, &start),

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -188,6 +188,7 @@ fn set_parsing_error(parse_error: &mut String, field: &Field) {
 }
 
 async fn write_logs_by_stream(
+    thread_id: usize,
     org_id: &str,
     user_email: &str,
     time_stats: (i64, &Instant), // started_at
@@ -204,7 +205,7 @@ async fn write_logs_by_stream(
         }
 
         // write json data by stream
-        let mut req_stats = write_logs(org_id, &stream_name, status, json_data).await?;
+        let mut req_stats = write_logs(thread_id, org_id, &stream_name, status, json_data).await?;
 
         let time_took = time_stats.1.elapsed().as_secs_f64();
         req_stats.response_time = time_took;
@@ -231,6 +232,7 @@ async fn write_logs_by_stream(
 }
 
 async fn write_logs(
+    thread_id: usize,
     org_id: &str,
     stream_name: &str,
     status: &mut IngestionStatus,
@@ -446,7 +448,13 @@ async fn write_logs(
     }
 
     // write data to wal
-    let writer = ingester::get_writer(org_id, &StreamType::Logs.to_string(), stream_name).await;
+    let writer = ingester::get_writer(
+        thread_id,
+        org_id,
+        &StreamType::Logs.to_string(),
+        stream_name,
+    )
+    .await;
     let req_stats = write_file(&writer, stream_name, write_buf).await;
     if let Err(e) = writer.sync().await {
         log::error!("ingestion error while syncing writer: {}", e);

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -53,6 +53,7 @@ use crate::{
 };
 
 pub async fn handle_grpc_request(
+    thread_id: usize,
     org_id: &str,
     request: ExportLogsServiceRequest,
     is_grpc: bool,
@@ -343,6 +344,7 @@ pub async fn handle_grpc_request(
 
     let mut status = IngestionStatus::Record(stream_status.status);
     let (metric_rpt_status_code, response_body) = match super::write_logs_by_stream(
+        thread_id,
         org_id,
         user_email,
         (started_at, &start),
@@ -477,7 +479,7 @@ mod tests {
         };
 
         let result =
-            handle_grpc_request(org_id, request, true, Some("test_stream"), "a@a.com").await;
+            handle_grpc_request(0, org_id, request, true, Some("test_stream"), "a@a.com").await;
         assert!(result.is_ok());
     }
 }

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -54,14 +54,22 @@ const SERVICE_NAME: &str = "service.name";
 const SERVICE: &str = "service";
 
 pub async fn logs_proto_handler(
+    thread_id: usize,
     org_id: &str,
     body: web::Bytes,
     in_stream_name: Option<&str>,
     user_email: &str,
 ) -> Result<HttpResponse> {
     let request = ExportLogsServiceRequest::decode(body).expect("Invalid protobuf");
-    match super::otlp_grpc::handle_grpc_request(org_id, request, false, in_stream_name, user_email)
-        .await
+    match super::otlp_grpc::handle_grpc_request(
+        thread_id,
+        org_id,
+        request,
+        false,
+        in_stream_name,
+        user_email,
+    )
+    .await
     {
         Ok(res) => Ok(res),
         Err(e) => {
@@ -79,6 +87,7 @@ pub async fn logs_proto_handler(
 // example at: https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/#examples
 // otel collector handling json request for logs https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/plog/json.go
 pub async fn logs_json_handler(
+    thread_id: usize,
     org_id: &str,
     body: web::Bytes,
     in_stream_name: Option<&str>,
@@ -460,6 +469,7 @@ pub async fn logs_json_handler(
 
     let mut status = IngestionStatus::Record(stream_status.status);
     let (metric_rpt_status_code, response_body) = match super::write_logs_by_stream(
+        thread_id,
         org_id,
         user_email,
         (started_at, &start),

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -260,6 +260,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
     let (metric_rpt_status_code, response_body) = {
         let mut status = IngestionStatus::Record(stream_status.status);
         let write_result = super::write_logs(
+            0,
             org_id,
             &routed_stream_name,
             &mut status,

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -262,7 +262,8 @@ impl Metadata for DistinctValues {
             }
 
             let writer =
-                ingester::get_writer(&org_id, &StreamType::Metadata.to_string(), STREAM_NAME).await;
+                ingester::get_writer(0, &org_id, &StreamType::Metadata.to_string(), STREAM_NAME)
+                    .await;
             _ = ingestion::write_file(&writer, STREAM_NAME, buf).await;
             if let Err(e) = writer.sync().await {
                 log::error!("[DISTINCT_VALUES] error while syncing writer: {}", e);

--- a/src/service/metadata/trace_list_index.rs
+++ b/src/service/metadata/trace_list_index.rs
@@ -120,7 +120,7 @@ impl Metadata for TraceListIndex {
         }
 
         let writer =
-            ingester::get_writer(org_id, &StreamType::Metadata.to_string(), STREAM_NAME).await;
+            ingester::get_writer(0, org_id, &StreamType::Metadata.to_string(), STREAM_NAME).await;
         _ = ingestion::write_file(&writer, STREAM_NAME, buf).await;
         if let Err(e) = writer.sync().await {
             log::error!("[TraceListIndex] error while syncing writer: {}", e);
@@ -283,6 +283,7 @@ mod tests {
         hour_buf.records_size += data_size;
 
         let writer = ingester::get_writer(
+            0,
             "openobserve",
             &StreamType::Metadata.to_string(),
             STREAM_NAME,

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -299,7 +299,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
         }
 
         let writer =
-            ingester::get_writer(org_id, &StreamType::Metrics.to_string(), &stream_name).await;
+            ingester::get_writer(0, org_id, &StreamType::Metrics.to_string(), &stream_name).await;
         let mut req_stats = write_file(&writer, &stream_name, stream_data).await;
         // if let Err(e) = writer.sync().await {
         //     log::error!("ingestion error while syncing writer: {}", e);

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -410,7 +410,7 @@ pub async fn handle_grpc_request(
 
         // write to file
         let writer =
-            ingester::get_writer(org_id, &StreamType::Metrics.to_string(), &stream_name).await;
+            ingester::get_writer(0, org_id, &StreamType::Metrics.to_string(), &stream_name).await;
         let mut req_stats = write_file(&writer, &stream_name, stream_data).await;
         // if let Err(e) = writer.sync().await {
         //     log::error!("ingestion error while syncing writer: {}", e);

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -495,7 +495,7 @@ pub async fn metrics_json_handler(
 
         // write to file
         let writer =
-            ingester::get_writer(org_id, &StreamType::Metrics.to_string(), &stream_name).await;
+            ingester::get_writer(0, org_id, &StreamType::Metrics.to_string(), &stream_name).await;
         let mut req_stats = write_file(&writer, &stream_name, stream_data).await;
         // if let Err(e) = writer.sync().await {
         //     log::error!("ingestion error while syncing writer: {}", e);

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -459,7 +459,7 @@ pub async fn remote_write(
 
         // write to file
         let writer =
-            ingester::get_writer(org_id, &StreamType::Metrics.to_string(), &stream_name).await;
+            ingester::get_writer(0, org_id, &StreamType::Metrics.to_string(), &stream_name).await;
         let mut req_stats = write_file(&writer, &stream_name, stream_data).await;
         // if let Err(e) = writer.sync().await {
         //     log::error!("ingestion error while syncing writer: {}", e);

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -651,7 +651,8 @@ async fn write_traces(
     }
 
     // write data to wal
-    let writer = ingester::get_writer(org_id, &StreamType::Traces.to_string(), stream_name).await;
+    let writer =
+        ingester::get_writer(0, org_id, &StreamType::Traces.to_string(), stream_name).await;
     let req_stats = write_file(&writer, stream_name, data_buf).await;
     if let Err(e) = writer.sync().await {
         log::error!("ingestion error while syncing writer: {}", e);


### PR DESCRIPTION
Add a new ENV:
```
ZO_FEATURE_PER_THREAD_LOCK=false
```

Now we can use `ZO_FEATURE_PER_THREAD_LOCK` to enable lock for per thread, that will improve write performance for that case when only have one stream.

And you also need to set the `ZO_MEM_TABLE_BUCKET_NUM=1` to greater than 0. for example:

```
ZO_FEATURE_PER_THREAD_LOCK = true
ZO_MEM_TABLE_BUCKET_NUM = 5
```

Then, even you only have one stream, it will use `5` memtable to write data in concurrency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration field, `feature_per_thread_lock`, for enhanced control.
	- Enhanced log ingestion processes with new parameters for better tracking.

- **Bug Fixes**
	- Improved error handling in various ingestion methods to ensure robust data processing.

- **Documentation**
	- Updated method signatures to reflect changes in parameters and functionality.

- **Refactor**
	- Modified several functions to incorporate a new `thread_id` parameter for better concurrency management.

- **Chores**
	- Enhanced logging during HTTP server initialization for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->