### PR TITLE
fix: add _timestamp to sql when we can

### DIFF
--- a/src/service/search/datafusion/optimizer/add_sort_and_limit.rs
+++ b/src/service/search/datafusion/optimizer/add_sort_and_limit.rs
@@ -137,6 +137,7 @@ fn is_complex_query(plan: &LogicalPlan) -> bool {
             | LogicalPlan::RecursiveQuery(_)
             | LogicalPlan::SubqueryAlias(_)
             | LogicalPlan::Subquery(_)
+            | LogicalPlan::Window(_)
     )
 }
 


### PR DESCRIPTION
related to #4845 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SQL processing to consistently include the `_timestamp` field in query results.
	- Introduced a mechanism to identify complex SQL queries based on specific criteria.

- **Improvements**
	- Optimizer now handles more complex queries, particularly those involving window functions, ensuring appropriate application of sort and limit optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->