### PR TITLE
fix: Add new ENV to decide whether to pause alert after retrying for `ZO_SCHEDULER_MAX_RETRIES`

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -940,6 +940,8 @@ pub struct Limit {
     pub derived_stream_schedule_interval: i64,
     #[env_config(name = "ZO_SCHEDULER_MAX_RETRIES", default = 3)]
     pub scheduler_max_retries: i32,
+    #[env_config(name = "ZO_SCHEDULER_PAUSE_ALERT_AFTER_RETRIES", default = false)]
+    pub pause_alerts_on_retries: bool,
     #[env_config(name = "ZO_SCHEDULER_CLEAN_INTERVAL", default = 30)] // seconds
     pub scheduler_clean_interval: u64,
     #[env_config(name = "ZO_SCHEDULER_WATCH_INTERVAL", default = 30)] // seconds

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -211,7 +211,9 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
             trigger.retries + 1,
         )
         .await?;
-        if trigger.retries + 1 >= get_config().limit.scheduler_max_retries {
+        if trigger.retries + 1 >= get_config().limit.scheduler_max_retries
+            && get_config().limit.pause_alerts_on_retries
+        {
             // It has been tried the maximum time, just disable the alert
             // and show the error.
             if let Some(mut alert) =


### PR DESCRIPTION
**New ENV**: `ZO_SCHEDULER_PAUSE_ALERT_AFTER_RETRIES` (boolean variable). Default is `false`. By default, the alert will not be paused after the maximum retries (in case of alert evaluation errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to pause alerts during retries, enhancing alert management capabilities.
  
- **Bug Fixes**
	- Improved error handling for alert notifications, ensuring clearer logging and data management after maximum retries are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->