### PR TITLE
fix: when updating organization settings only consider the updated value

### DIFF
--- a/src/common/meta/organization.rs
+++ b/src/common/meta/organization.rs
@@ -110,6 +110,18 @@ fn default_span_id_field_name() -> String {
 }
 
 #[derive(Serialize, ToSchema, Deserialize, Debug, Clone)]
+pub struct OrganizationSettingPayload {
+    /// Ideally this should be the same as prometheus-scrape-interval (in
+    /// seconds).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scrape_interval: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id_field_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_id_field_name: Option<String>,
+}
+
+#[derive(Serialize, ToSchema, Deserialize, Debug, Clone)]
 pub struct OrganizationSetting {
     /// Ideally this should be the same as prometheus-scrape-interval (in
     /// seconds).

--- a/src/handler/http/request/organization/settings.rs
+++ b/src/handler/http/request/organization/settings.rs
@@ -66,8 +66,7 @@ async fn create(
         }
         Err(err) => {
             if let Error::DbError(DbError::KeyNotExists(_e)) = &err {
-                let data = OrganizationSetting::default();
-                data
+                OrganizationSetting::default();
             } else {
                 return Ok(MetaHttpResponse::bad_request(&err));
             }

--- a/src/handler/http/request/organization/settings.rs
+++ b/src/handler/http/request/organization/settings.rs
@@ -66,7 +66,7 @@ async fn create(
         }
         Err(err) => {
             if let Error::DbError(DbError::KeyNotExists(_e)) = &err {
-                OrganizationSetting::default();
+                OrganizationSetting::default()
             } else {
                 return Ok(MetaHttpResponse::bad_request(&err));
             }

--- a/src/handler/http/request/organization/settings.rs
+++ b/src/handler/http/request/organization/settings.rs
@@ -28,7 +28,9 @@ use {
 use crate::{
     common::meta::{
         http::HttpResponse as MetaHttpResponse,
-        organization::{OrganizationSetting, OrganizationSettingResponse},
+        organization::{
+            OrganizationSetting, OrganizationSettingPayload, OrganizationSettingResponse,
+        },
     },
     service::db::organization::{get_org_setting, set_org_setting},
 };
@@ -44,7 +46,7 @@ use crate::{
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = OrganizationSetting, description = "Organization settings", content_type = "application/json"),
+    request_body(content = OrganizationSettingPayload, description = "Organization settings", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = HttpResponse),
         (status = 400, description = "Failure", content_type = "application/json", body = HttpResponse),
@@ -53,16 +55,49 @@ use crate::{
 #[post("/{org_id}/settings")]
 async fn create(
     path: web::Path<String>,
-    settings: web::Json<OrganizationSetting>,
+    settings: web::Json<OrganizationSettingPayload>,
 ) -> Result<HttpResponse, StdErr> {
-    if settings.scrape_interval == 0 {
-        return Ok(MetaHttpResponse::bad_request(
-            "scrape_interval should be a positive value",
-        ));
+    let org_id = path.into_inner();
+    let settings = settings.into_inner();
+    let mut data = match get_org_setting(&org_id).await {
+        Ok(s) => {
+            let data: OrganizationSetting = json::from_slice(&s).unwrap();
+            data
+        }
+        Err(err) => {
+            if let Error::DbError(DbError::KeyNotExists(_e)) = &err {
+                let data = OrganizationSetting::default();
+                data
+            } else {
+                return Ok(MetaHttpResponse::bad_request(&err));
+            }
+        }
+    };
+
+    let mut field_found = false;
+    if let Some(scrape_interval) = settings.scrape_interval {
+        if scrape_interval == 0 {
+            return Ok(MetaHttpResponse::bad_request(
+                "scrape_interval should be a positive value",
+            ));
+        }
+        field_found = true;
+        data.scrape_interval = scrape_interval;
+    }
+    if let Some(trace_id_field_name) = settings.trace_id_field_name {
+        field_found = true;
+        data.trace_id_field_name = trace_id_field_name;
+    }
+    if let Some(span_id_field_name) = settings.span_id_field_name {
+        field_found = true;
+        data.span_id_field_name = span_id_field_name;
     }
 
-    let org_id = path.into_inner();
-    match set_org_setting(&org_id, &settings).await {
+    if !field_found {
+        return Ok(MetaHttpResponse::bad_request("No valid field found"));
+    }
+
+    match set_org_setting(&org_id, &data).await {
         Ok(()) => Ok(HttpResponse::Ok().json(serde_json::json!({"successful": "true"}))),
         Err(e) => Ok(MetaHttpResponse::bad_request(e.to_string().as_str())),
     }


### PR DESCRIPTION
Addresses #4854

Currently, when updating organization settings, if relevant fields (like `scrape_interval`, `trace_id_field_name` etc.) are not found, their default values are used and hence all the fields that are not in the request payload, are set to default.

This PR only updates the fields that are present in the request payload, if none of the relevant fields are present, it returns 400 bad request error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `OrganizationSettingPayload` structure for optional organization settings, enhancing flexibility in configuration.
	- Updated the settings creation process to handle optional fields and improve validation.

- **Bug Fixes**
	- Enhanced error handling for organization settings, ensuring proper responses for invalid or missing data.

- **Documentation**
	- Updated method signatures to reflect changes in the expected input structure for organization settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->