### PR TITLE
fix: After maximum alert retries, skip to the next run of the alert

### DIFF
--- a/src/common/meta/alerts/mod.rs
+++ b/src/common/meta/alerts/mod.rs
@@ -39,6 +39,8 @@ pub struct TriggerCondition {
     pub silence: i64, // silence for 10 minutes after fire an alert
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
+    #[serde(default)]
+    pub tolerance_in_secs: Option<i64>,
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, ToSchema, PartialEq)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -918,6 +918,12 @@ pub struct Limit {
     pub scheduler_max_retries: i32,
     #[env_config(name = "ZO_SCHEDULER_PAUSE_ALERT_AFTER_RETRIES", default = false)]
     pub pause_alerts_on_retries: bool,
+    #[env_config(
+        name = "ZO_ALERT_CONSIDERABLE_DELAY",
+        default = 20,
+        help = "Integer value representing the delay in percentage of the alert frequency that will be included in alert evaluation timerange. Default is 20. This can be changed in runtime."
+    )]
+    pub alert_considerable_delay: i32,
     #[env_config(name = "ZO_SCHEDULER_CLEAN_INTERVAL", default = 30)] // seconds
     pub scheduler_clean_interval: u64,
     #[env_config(name = "ZO_SCHEDULER_WATCH_INTERVAL", default = 30)] // seconds

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -925,9 +925,9 @@ pub struct Limit {
     )]
     pub alert_considerable_delay: i32,
     #[env_config(name = "ZO_SCHEDULER_CLEAN_INTERVAL", default = 30)] // seconds
-    pub scheduler_clean_interval: u64,
+    pub scheduler_clean_interval: i64,
     #[env_config(name = "ZO_SCHEDULER_WATCH_INTERVAL", default = 30)] // seconds
-    pub scheduler_watch_interval: u64,
+    pub scheduler_watch_interval: i64,
     #[env_config(name = "ZO_STARTING_EXPECT_QUERIER_NUM", default = 0)]
     pub starting_expect_querier_num: usize,
     #[env_config(name = "ZO_QUERY_OPTIMIZATION_NUM_FIELDS", default = 1000)]

--- a/src/config/src/meta/usage.rs
+++ b/src/config/src/meta/usage.rs
@@ -33,6 +33,8 @@ pub enum TriggerDataStatus {
     Failed,
     #[serde(rename = "condition_not_satisfied")]
     ConditionNotSatisfied,
+    #[serde(rename = "skipped")]
+    Skipped,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -63,6 +65,8 @@ pub struct TriggerData {
     pub error: Option<String>,
     pub success_response: Option<String>,
     pub is_partial: Option<bool>,
+    pub delay_in_secs: Option<i64>,
+    pub evaluation_took_in_secs: Option<f64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/config/src/utils/rand.rs
+++ b/src/config/src/utils/rand.rs
@@ -24,3 +24,10 @@ pub fn get_rand_element<T>(arr: &[T]) -> &T {
 pub fn generate_random_string(len: usize) -> String {
     Alphanumeric.sample_string(&mut rand::thread_rng(), len)
 }
+
+/// Generate random number within the given range
+pub fn get_rand_num_within(min: u64, max: u64) -> u64 {
+    let mut buf = [0u8; 1];
+    getrandom::getrandom(&mut buf).unwrap();
+    min + buf[0] as u64 % (max - min)
+}

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -232,3 +232,10 @@ pub async fn is_empty() -> bool {
 pub async fn clear() -> Result<()> {
     CLIENT.clear().await
 }
+
+/// Returns the scheduler_max_retries set through environment config
+/// The bool element in the tuple indicates if the retries are enabled
+pub fn get_scheduler_max_retries() -> (bool, i32) {
+    let max_retries = config::get_config().limit.scheduler_max_retries;
+    (max_retries > 0, max_retries.unsigned_abs() as i32)
+}

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -19,7 +19,9 @@ use chrono::Duration;
 use config::metrics::DB_QUERY_NUMS;
 use sqlx::Row;
 
-use super::{Trigger, TriggerId, TriggerModule, TriggerStatus, TRIGGERS_KEY};
+use super::{
+    get_scheduler_max_retries, Trigger, TriggerId, TriggerModule, TriggerStatus, TRIGGERS_KEY,
+};
 use crate::{
     db::{self, mysql::CLIENT},
     errors::{DbError, Error, Result},
@@ -294,6 +296,10 @@ WHERE org = ? AND module_key = ? AND module = ?;"#,
         report_timeout: i64,
     ) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
+        let (include_max, mut max_retries) = get_scheduler_max_retries();
+        if include_max {
+            max_retries += 1;
+        }
 
         log::debug!("Start pulling scheduled_job");
         let now = chrono::Utc::now().timestamp_micros();
@@ -322,7 +328,7 @@ FOR UPDATE;
         )
         .bind(TriggerStatus::Waiting)
         .bind(now)
-        .bind(config::get_config().limit.scheduler_max_retries)
+        .bind(max_retries)
         .bind(true)
         .bind(false)
         .bind(concurrency)
@@ -446,13 +452,17 @@ WHERE id IN ({});",
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
     async fn clean_complete(&self) -> Result<()> {
+        let (include_max, mut max_retries) = get_scheduler_max_retries();
+        if include_max {
+            max_retries += 1;
+        }
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
             .with_label_values(&["delete", "scheduled_jobs"])
             .inc();
         sqlx::query(r#"DELETE FROM scheduled_jobs WHERE status = ? OR retries >= ?;"#)
             .bind(TriggerStatus::Completed)
-            .bind(config::get_config().limit.scheduler_max_retries)
+            .bind(max_retries)
             .execute(&pool)
             .await?;
         Ok(())

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -78,9 +78,11 @@ async fn run_schedule_jobs() -> Result<(), anyhow::Error> {
 }
 
 async fn clean_complete_jobs() -> Result<(), anyhow::Error> {
-    let mut interval = time::interval(time::Duration::from_secs(
-        get_config().limit.scheduler_clean_interval,
-    ));
+    let scheduler_clean_interval = get_config().limit.scheduler_clean_interval;
+    if scheduler_clean_interval < 0 {
+        return Ok(());
+    }
+    let mut interval = time::interval(time::Duration::from_secs(scheduler_clean_interval as u64));
     interval.tick().await; // trigger the first run
     loop {
         interval.tick().await;
@@ -91,9 +93,11 @@ async fn clean_complete_jobs() -> Result<(), anyhow::Error> {
 }
 
 async fn watch_timeout_jobs() -> Result<(), anyhow::Error> {
-    let mut interval = time::interval(time::Duration::from_secs(
-        get_config().limit.scheduler_watch_interval,
-    ));
+    let scheduler_watch_interval = get_config().limit.scheduler_watch_interval;
+    if scheduler_watch_interval < 0 {
+        return Ok(());
+    }
+    let mut interval = time::interval(time::Duration::from_secs(scheduler_watch_interval as u64));
     interval.tick().await; // trigger the first run
     loop {
         interval.tick().await;

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -26,6 +26,7 @@ use config::{
 };
 use cron::Schedule;
 use futures::future::try_join_all;
+use infra::scheduler::get_scheduler_max_retries;
 use proto::cluster_rpc;
 
 use crate::{
@@ -97,6 +98,7 @@ fn get_max_considerable_delay(frequency: i64) -> i64 {
 }
 
 async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), anyhow::Error> {
+    let (_, max_retries) = get_scheduler_max_retries();
     log::debug!(
         "Inside handle_alert_triggers: processing trigger: {}",
         &trigger.module_key
@@ -156,6 +158,34 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         // update trigger, check on next week
         new_trigger.next_run_at += Duration::try_days(7).unwrap().num_microseconds().unwrap();
         new_trigger.is_silenced = true;
+        db::scheduler::update_trigger(new_trigger).await?;
+        return Ok(());
+    }
+
+    if trigger.retries >= max_retries {
+        // It has been tried the maximum time, just update the
+        // next_run_at to the next expected trigger time
+        log::info!(
+            "This alert trigger: {}/{} has passed maximum retries, skipping to next run",
+            &new_trigger.org,
+            &new_trigger.module_key
+        );
+        if alert.trigger_condition.frequency_type == FrequencyType::Cron {
+            let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;
+            // tz_offset is in minutes
+            let tz_offset = FixedOffset::east_opt(alert.tz_offset * 60).unwrap();
+            new_trigger.next_run_at = schedule
+                .upcoming(tz_offset)
+                .next()
+                .unwrap()
+                .timestamp_micros();
+        } else {
+            new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
+                .unwrap()
+                .num_microseconds()
+                .unwrap();
+        }
+        new_trigger.data = "".to_string();
         db::scheduler::update_trigger(new_trigger).await?;
         return Ok(());
     }
@@ -268,7 +298,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         }
         trigger_data_stream.error = Some(err_string);
         // update its status and retries
-        if trigger.retries + 1 >= get_config().limit.scheduler_max_retries {
+        if trigger.retries + 1 >= max_retries {
             if get_config().limit.pause_alerts_on_retries {
                 // It has been tried the maximum time, just disable the alert
                 // and show the error.
@@ -289,11 +319,23 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                 }
             }
             // This didn't work, update the next_run_at to the next expected trigger time
-            new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
-                .unwrap()
-                .num_microseconds()
-                .unwrap();
+            if alert.trigger_condition.frequency_type == FrequencyType::Cron {
+                let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;
+                // tz_offset is in minutes
+                let tz_offset = FixedOffset::east_opt(alert.tz_offset * 60).unwrap();
+                new_trigger.next_run_at = schedule
+                    .upcoming(tz_offset)
+                    .next()
+                    .unwrap()
+                    .timestamp_micros();
+            } else {
+                new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
+                    .unwrap()
+                    .num_microseconds()
+                    .unwrap();
+            }
             new_trigger.data = "".to_string();
+            trigger_data_stream.next_run_at = new_trigger.next_run_at;
             db::scheduler::update_trigger(new_trigger).await?;
         } else {
             // update its status and retries
@@ -444,7 +486,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                     &new_trigger.org,
                     &new_trigger.module_key
                 );
-                if trigger.retries + 1 >= get_config().limit.scheduler_max_retries {
+                if trigger.retries + 1 >= max_retries {
                     // It has been tried the maximum time, just update the
                     // next_run_at to the next expected trigger time
                     log::debug!(
@@ -463,6 +505,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                     // will be used to evaluate the alert.
                     trigger_data.period_end_time = None;
                     new_trigger.data = json::to_string(&trigger_data).unwrap();
+                    trigger_data_stream.next_run_at = new_trigger.next_run_at;
                     db::scheduler::update_trigger(new_trigger).await?;
                 } else {
                     // Otherwise update its status only
@@ -545,6 +588,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
 }
 
 async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), anyhow::Error> {
+    let (_, max_retires) = get_scheduler_max_retries();
     log::debug!(
         "Inside handle_report_trigger,org: {}, module_key: {}",
         &trigger.org,
@@ -650,6 +694,17 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         evaluation_took_in_secs: None,
     };
 
+    if trigger.retries >= max_retires {
+        // It has been tried the maximum time, just update the
+        // next_run_at to the next expected trigger time
+        log::info!(
+            "This report trigger: {org_id}/{report_name} has passed maximum retries, skipping to next run",
+            org_id = &new_trigger.org,
+            report_name = report_name
+        );
+        db::scheduler::update_trigger(new_trigger).await?;
+        return Ok(());
+    }
     match report.send_subscribers().await {
         Ok(_) => {
             log::info!("Report {} sent to destination", report_name);
@@ -663,12 +718,13 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         }
         Err(e) => {
             log::error!("Error sending report to subscribers: {e}");
-            if trigger.retries + 1 >= get_config().limit.scheduler_max_retries && !run_once {
+            if trigger.retries + 1 >= max_retires && !run_once {
                 // It has been tried the maximum time, just update the
                 // next_run_at to the next expected trigger time
                 log::debug!(
                     "This report trigger: {org_id}/{report_name} has reached maximum possible retries"
                 );
+                trigger_data_stream.next_run_at = new_trigger.next_run_at;
                 db::scheduler::update_trigger(new_trigger).await?;
             } else {
                 if run_once {
@@ -715,6 +771,7 @@ async fn handle_derived_stream_triggers(
         "Inside handle_derived_stream_triggers processing trigger: {}",
         trigger.module_key
     );
+    let (_, max_retries) = get_scheduler_max_retries();
 
     // module_key format: stream_type/stream_name/pipeline_name/derived_stream_name
     let columns = trigger.module_key.split('/').collect::<Vec<_>>();
@@ -781,6 +838,35 @@ async fn handle_derived_stream_triggers(
         retries: 0,
         ..trigger.clone()
     };
+
+    if trigger.retries >= max_retries {
+        // It has been tried the maximum time, just update the
+        // next_run_at to the next expected trigger time
+        log::info!(
+            "This DerivedStream trigger: {}/{} has passed maximum retries, skipping to next run",
+            &new_trigger.org,
+            &new_trigger.module_key
+        );
+        if derived_stream.trigger_condition.frequency_type == FrequencyType::Cron {
+            let schedule = Schedule::from_str(&derived_stream.trigger_condition.cron)?;
+            // tz_offset is in minutes
+            let tz_offset = FixedOffset::east_opt(derived_stream.tz_offset * 60).unwrap();
+            new_trigger.next_run_at = schedule
+                .upcoming(tz_offset)
+                .next()
+                .unwrap()
+                .timestamp_micros();
+        } else {
+            new_trigger.next_run_at +=
+                Duration::try_minutes(derived_stream.trigger_condition.frequency)
+                    .unwrap()
+                    .num_microseconds()
+                    .unwrap();
+        }
+        new_trigger.data = "".to_string();
+        db::scheduler::update_trigger(new_trigger).await?;
+        return Ok(());
+    }
 
     // evaluate trigger and configure trigger next run time
     let (ret, end_time) = derived_stream.evaluate(None, start_time).await?;
@@ -906,7 +992,7 @@ async fn handle_derived_stream_triggers(
                         new_trigger.org,
                         new_trigger.module_key
                     );
-                    if trigger.retries + 1 >= get_config().limit.scheduler_max_retries {
+                    if trigger.retries + 1 >= max_retries {
                         // It has been tried the maximum time, just update the
                         // next_run_at to the next expected trigger time
                         log::debug!(
@@ -914,6 +1000,7 @@ async fn handle_derived_stream_triggers(
                             &new_trigger.org,
                             &new_trigger.module_key
                         );
+                        trigger_data_stream.next_run_at = new_trigger.next_run_at;
                         db::scheduler::update_trigger(new_trigger).await?;
                     } else {
                         // Otherwise update its status only

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::str::FromStr;
+use std::{str::FromStr, time::Instant};
 
 use chrono::{Duration, FixedOffset, Utc};
 use config::{
@@ -22,7 +22,7 @@ use config::{
         stream::StreamType,
         usage::{TriggerData, TriggerDataStatus, TriggerDataType},
     },
-    utils::json,
+    utils::{json, rand::get_rand_num_within},
 };
 use cron::Schedule;
 use futures::future::try_join_all;
@@ -32,7 +32,7 @@ use crate::{
     common::meta::{alerts::FrequencyType, dashboards::reports::ReportFrequencyType},
     service::{
         alerts::alert::{get_alert_start_end_time, get_row_column_map},
-        db::{self, scheduler::DerivedTriggerData},
+        db::{self, scheduler::ScheduledTriggerData},
         ingestion::ingestion_service,
         usage::publish_triggers_usage,
     },
@@ -77,6 +77,23 @@ pub async fn handle_triggers(trigger: db::scheduler::Trigger) -> Result<(), anyh
             handle_derived_stream_triggers(trigger).await
         }
     }
+}
+
+/// Returns maximum considerable delay in microseconds - minimum of 1 hour or 20% of the frequency.
+fn get_max_considerable_delay(frequency: i64) -> i64 {
+    // Calculate the maximum delay that can be considered for the alert evaluation.
+    // If the delay is more than this, the alert will be skipped.
+    // The maximum delay is the lowest of 1 hour or 20% of the frequency.
+    // E.g. if the frequency is 5 mins, the maximum delay is 1 min.
+    let frequency = Duration::try_seconds(frequency)
+        .unwrap()
+        .num_microseconds()
+        .unwrap();
+    let max_delay = Duration::try_hours(1).unwrap().num_microseconds().unwrap();
+    // limit.alert_considerable_delay is in percentage, convert into float
+    let considerable_delay = get_config().limit.alert_considerable_delay as f64 * 0.01;
+    let max_considerable_delay = (frequency as f64 * considerable_delay) as i64;
+    std::cmp::min(max_delay, max_considerable_delay)
 }
 
 async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), anyhow::Error> {
@@ -125,32 +142,6 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         }
     };
     let now = Utc::now().timestamp_micros();
-    // The delay in processing the trigger from the time it was supposed to run
-    let processing_delay = if trigger.next_run_at == 0 {
-        0
-    } else {
-        now - trigger.next_run_at
-    };
-    // This is the end time of the last trigger timerange  + 1.
-    // This will be used in alert evaluation as the start time.
-    // If this is None, alert will use the period to evaluate alert
-    let start_time = if trigger.data.is_empty() {
-        // approximate the start time involving the alert manager delay
-        Some(
-            now - Duration::try_minutes(alert.trigger_condition.period)
-                .unwrap()
-                .num_microseconds()
-                .unwrap()
-                - processing_delay,
-        )
-    } else {
-        let last_data: Result<DerivedTriggerData, json::Error> = json::from_str(&trigger.data);
-        if let Ok(last_data) = last_data {
-            Some(last_data.period_end_time + 1)
-        } else {
-            None
-        }
-    };
 
     let mut new_trigger = db::scheduler::Trigger {
         next_run_at: now,
@@ -168,6 +159,75 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         db::scheduler::update_trigger(new_trigger).await?;
         return Ok(());
     }
+
+    // The delay in processing the trigger from the time it was supposed to run
+    let (processing_delay, use_period) = if trigger.next_run_at == 0 {
+        (0, true)
+    } else {
+        let delay = now - trigger.next_run_at;
+
+        // Skip Alerts: Say for some reason, this alert trigger (period: 10mins, frequency 5mins)
+        // which was supposed to run at 10am is now processed after a delay of 5 mins (may be alert
+        // manager was stuck or something). In that case, only use the period strictly to evaluate
+        // the alert. If the delay is within the max considerable delay, consider the delay with
+        // period, otherwise strictly use the period only. Also, since we are skipping this alert
+        // (9:50am to 10am timerange), we need to report this event to the `triggers` usage stream.
+        if delay > get_max_considerable_delay(alert.trigger_condition.frequency) {
+            publish_triggers_usage(TriggerData {
+                _timestamp: triggered_at - 1,
+                org: org_id.clone(),
+                module: TriggerDataType::Alert,
+                key: trigger.module_key.clone(),
+                next_run_at: triggered_at,
+                is_realtime: trigger.is_realtime,
+                is_silenced: trigger.is_silenced,
+                status: TriggerDataStatus::Skipped,
+                start_time: trigger.next_run_at
+                    - Duration::try_minutes(alert.trigger_condition.period)
+                        .unwrap()
+                        .num_microseconds()
+                        .unwrap(),
+                end_time: trigger.next_run_at,
+                retries: trigger.retries,
+                delay_in_secs: Some(Duration::microseconds(delay).num_seconds()),
+                error: None,
+                success_response: None,
+                is_partial: None,
+                evaluation_took_in_secs: None,
+            })
+            .await;
+            (0, true)
+        } else {
+            (delay, false)
+        }
+    };
+
+    let trigger_data: Result<ScheduledTriggerData, json::Error> = json::from_str(&trigger.data);
+    let mut trigger_data = if let Ok(trigger_data) = trigger_data {
+        trigger_data
+    } else {
+        ScheduledTriggerData {
+            period_end_time: None,
+            tolerance: 0,
+        }
+    };
+
+    // This is the end time of the last trigger timerange  + 1.
+    // This will be used in alert evaluation as the start time.
+    // If this is None, alert will use the period to evaluate alert
+    let start_time = if trigger_data.period_end_time.is_none() || use_period {
+        // approximate the start time involving the alert manager delay
+        Some(
+            now - Duration::try_minutes(alert.trigger_condition.period)
+                .unwrap()
+                .num_microseconds()
+                .unwrap()
+                - trigger_data.tolerance
+                - processing_delay,
+        )
+    } else {
+        Some(trigger_data.period_end_time.unwrap() + 1)
+    };
 
     let mut should_store_last_end_time =
         alert.trigger_condition.frequency == (alert.trigger_condition.period * 60);
@@ -190,10 +250,15 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         error: None,
         success_response: None,
         is_partial: None,
+        delay_in_secs: Some(Duration::microseconds(processing_delay).num_seconds()),
+        evaluation_took_in_secs: None,
     };
 
+    let evalutaion_took = Instant::now();
     // evaluate alert
     let result = alert.evaluate(None, start_time).await;
+    let evaluation_took = evalutaion_took.elapsed().as_secs_f64();
+    trigger_data_stream.evaluation_took_in_secs = Some(evaluation_took);
     if result.is_err() {
         let err = result.err().unwrap();
         trigger_data_stream.status = TriggerDataStatus::Failed;
@@ -203,34 +268,51 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         }
         trigger_data_stream.error = Some(err_string);
         // update its status and retries
-        db::scheduler::update_status(
-            &new_trigger.org,
-            new_trigger.module,
-            &new_trigger.module_key,
-            db::scheduler::TriggerStatus::Waiting,
-            trigger.retries + 1,
-        )
-        .await?;
-        if trigger.retries + 1 >= get_config().limit.scheduler_max_retries
-            && get_config().limit.pause_alerts_on_retries
-        {
-            // It has been tried the maximum time, just disable the alert
-            // and show the error.
-            if let Some(mut alert) =
-                super::alert::get(&org_id, stream_type, stream_name, alert_name).await?
-            {
-                alert.enabled = false;
-                if let Err(e) = db::alerts::alert::set_without_updating_trigger(
-                    &org_id,
-                    stream_type,
-                    stream_name,
-                    &alert,
-                )
-                .await
+        if trigger.retries + 1 >= get_config().limit.scheduler_max_retries {
+            if !get_config().limit.pause_alerts_on_retries {
+                new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
+                    .unwrap()
+                    .num_microseconds()
+                    .unwrap();
+                db::scheduler::update_trigger(new_trigger).await?;
+            } else {
+                // It has been tried the maximum time, just disable the alert
+                // and show the error.
+                if let Some(mut alert) =
+                    super::alert::get(&org_id, stream_type, stream_name, alert_name).await?
                 {
-                    log::error!("Failed to update alert: {alert_name} after trigger: {e}",);
+                    alert.enabled = false;
+                    if let Err(e) = db::alerts::alert::set_without_updating_trigger(
+                        &org_id,
+                        stream_type,
+                        stream_name,
+                        &alert,
+                    )
+                    .await
+                    {
+                        log::error!("Failed to update alert: {alert_name} after trigger: {e}",);
+                    }
                 }
+                // update its status and retries
+                db::scheduler::update_status(
+                    &new_trigger.org,
+                    new_trigger.module,
+                    &new_trigger.module_key,
+                    db::scheduler::TriggerStatus::Waiting,
+                    trigger.retries + 1,
+                )
+                .await?;
             }
+        } else {
+            // update its status and retries
+            db::scheduler::update_status(
+                &new_trigger.org,
+                new_trigger.module,
+                &new_trigger.module_key,
+                db::scheduler::TriggerStatus::Waiting,
+                trigger.retries + 1,
+            )
+            .await?;
         }
         publish_triggers_usage(trigger_data_stream).await;
         return Err(err);
@@ -244,6 +326,18 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
             &new_trigger.module_key
         );
     }
+    let tolerance = match alert.trigger_condition.tolerance_in_secs {
+        Some(tolerance) if tolerance > 0 => {
+            let tolerance = Duration::seconds(get_rand_num_within(0, tolerance as u64) as i64)
+                .num_microseconds()
+                .unwrap();
+            if tolerance > 0 {
+                trigger_data.tolerance = tolerance;
+            }
+            tolerance
+        }
+        _ => 0,
+    };
     if ret.is_some() && alert.trigger_condition.silence > 0 {
         if alert.trigger_condition.frequency_type == FrequencyType::Cron {
             let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;
@@ -255,7 +349,8 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                     .unwrap(),
             );
             // Check for the cron timestamp after the silence period
-            new_trigger.next_run_at = schedule.after(&silence).next().unwrap().timestamp_micros();
+            new_trigger.next_run_at =
+                schedule.after(&silence).next().unwrap().timestamp_micros() + tolerance;
         } else {
             // When the silence period is less than the frequency, the alert runs after the silence
             // period completely ignoring the frequency. So, if frequency is 60 mins and
@@ -270,7 +365,8 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
             new_trigger.next_run_at += Duration::try_seconds(next_run_in_seconds)
                 .unwrap()
                 .num_microseconds()
-                .unwrap();
+                .unwrap()
+                + tolerance;
         }
         new_trigger.is_silenced = true;
         // For silence period, no need to store last end time
@@ -283,12 +379,14 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
             .upcoming(tz_offset)
             .next()
             .unwrap()
-            .timestamp_micros();
+            .timestamp_micros()
+            + tolerance;
     } else {
         new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
             .unwrap()
             .num_microseconds()
-            .unwrap();
+            .unwrap()
+            + tolerance;
     }
     trigger_data_stream.next_run_at = new_trigger.next_run_at;
 
@@ -338,14 +436,12 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                 }
                 trigger_data_stream.success_response = Some(success_msg);
                 // Notification was sent successfully, store the last used end_time in the triggers
-                new_trigger.data = if should_store_last_end_time {
-                    json::to_string(&DerivedTriggerData {
-                        period_end_time: alert_end_time,
-                    })
-                    .unwrap()
+                trigger_data.period_end_time = if should_store_last_end_time {
+                    Some(alert_end_time)
                 } else {
-                    "".to_string()
+                    None
                 };
+                new_trigger.data = json::to_string(&trigger_data).unwrap();
                 // Notification is already sent to some destinations,
                 // hence in case of partial errors, no need to retry
                 db::scheduler::update_trigger(new_trigger).await?;
@@ -373,7 +469,8 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                     // still not changed) to 11:31am. This may create issues if the data is huge.
                     // To avoid that, we need to empty the data. So, in the next run, the period
                     // will be used to evaluate the alert.
-                    new_trigger.data = "".to_string();
+                    trigger_data.period_end_time = None;
+                    new_trigger.data = json::to_string(&trigger_data).unwrap();
                     db::scheduler::update_trigger(new_trigger).await?;
                 } else {
                     // Otherwise update its status only
@@ -400,14 +497,12 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         );
         // Condition did not match, store the last used end_time in the triggers
         // In the next run, the alert will be checked from the last end_time
-        new_trigger.data = if should_store_last_end_time {
-            json::to_string(&DerivedTriggerData {
-                period_end_time: end_time,
-            })
-            .unwrap()
+        trigger_data.period_end_time = if should_store_last_end_time {
+            Some(end_time)
         } else {
-            "".to_string()
+            None
         };
+        new_trigger.data = json::to_string(&trigger_data).unwrap();
         db::scheduler::update_trigger(new_trigger).await?;
         trigger_data_stream.start_time = match start_time {
             Some(start_time) => start_time,
@@ -538,6 +633,8 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
     }
 
     let triggered_at = trigger.start_time.unwrap_or_default();
+    let processing_delay = triggered_at - trigger.next_run_at;
+
     let mut trigger_data_stream = TriggerData {
         _timestamp: triggered_at,
         org: trigger.org.clone(),
@@ -557,6 +654,8 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         error: None,
         success_response: None,
         is_partial: None,
+        delay_in_secs: Some(Duration::microseconds(processing_delay).num_seconds()),
+        evaluation_took_in_secs: None,
     };
 
     match report.send_subscribers().await {
@@ -675,15 +774,13 @@ async fn handle_derived_stream_triggers(
             name,
         ));
     };
-    let start_time = if trigger.data.is_empty() {
-        None
+    let trigger_data: Option<ScheduledTriggerData> = json::from_str(&trigger.data).ok();
+    let start_time = if let Some(trigger_data) = trigger_data {
+        trigger_data
+            .period_end_time
+            .map(|period_end_time| period_end_time + 1)
     } else {
-        let last_data: Result<DerivedTriggerData, json::Error> = json::from_str(&trigger.data);
-        if let Ok(last_data) = last_data {
-            Some(last_data.period_end_time + 1)
-        } else {
-            None
-        }
+        None
     };
     let mut new_trigger = db::scheduler::Trigger {
         next_run_at: Utc::now().timestamp_micros(),
@@ -703,8 +800,9 @@ async fn handle_derived_stream_triggers(
         );
     }
     // Store the last used derived stream period end time
-    new_trigger.data = json::to_string(&DerivedTriggerData {
-        period_end_time: end_time,
+    new_trigger.data = json::to_string(&ScheduledTriggerData {
+        period_end_time: Some(end_time),
+        tolerance: 0,
     })
     .unwrap();
     if ret.is_some() && derived_stream.trigger_condition.silence > 0 {
@@ -767,6 +865,8 @@ async fn handle_derived_stream_triggers(
         error: None,
         success_response: None,
         is_partial: None,
+        delay_in_secs: None,
+        evaluation_took_in_secs: None,
     };
 
     // ingest evaluation result into destination

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -471,7 +471,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                 trigger_data_stream.success_response = Some(success_msg);
                 // Notification was sent successfully, store the last used end_time in the triggers
                 trigger_data.period_end_time = if should_store_last_end_time {
-                    Some(alert_end_time)
+                    Some(end_time)
                 } else {
                     None
                 };

--- a/src/service/db/scheduler.rs
+++ b/src/service/db/scheduler.rs
@@ -27,8 +27,11 @@ use {
 };
 
 #[derive(Default, Serialize, Deserialize, Debug)]
-pub struct DerivedTriggerData {
-    pub period_end_time: i64,
+pub struct ScheduledTriggerData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub period_end_time: Option<i64>,
+    #[serde(default)]
+    pub tolerance: i64,
 }
 
 #[inline]

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -251,6 +251,8 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
             error: None,
             success_response: None,
             is_partial: None,
+            delay_in_secs: None,
+            evaluation_took_in_secs: None,
         };
         match alert.send_notification(val, now, None).await {
             Err(e) => {


### PR DESCRIPTION
Whenever alert, report and derived stream retries reaches the maximum retries (`ZO_SCHEDULER_MAX_RETRIES`, default `3`), with this pr, the alert manager will skip to the next run timestamp.

Also, some flexibility added to the ENVs. For example, if the values of `ZO_SCHEDULER_CLEAN_INTERVAL` and `ZO_SCHEDULER_WATCH_INTERVAL` are negative, the background jobs for cleaning up and watching timeout for `scheduled_jobs` table will not run.

`ZO_SCHEDULER_MAX_RETRIES` now accepts both negative and positive values -
- For negative value, the max retries is the absolute value. But when pulling jobs, it will pull jobs matching condition `< max_retries`. If a job reaches max retries, it will never be pulled by the alert manager.
- For positive value (default case), It will pull jobs matching conditions `< max_retries + 1`. So, even if a job reaches the maximum retries, it will still be pulled by alert manager and will be skipped to the next run timestamp of the alert/report/derived stream.