### PR TITLE
fix: after alert is retried max time, skip to next trigger time

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -949,9 +949,9 @@ pub struct Limit {
     )]
     pub alert_considerable_delay: i32,
     #[env_config(name = "ZO_SCHEDULER_CLEAN_INTERVAL", default = 30)] // seconds
-    pub scheduler_clean_interval: u64,
+    pub scheduler_clean_interval: i64,
     #[env_config(name = "ZO_SCHEDULER_WATCH_INTERVAL", default = 30)] // seconds
-    pub scheduler_watch_interval: u64,
+    pub scheduler_watch_interval: i64,
     #[env_config(name = "ZO_STARTING_EXPECT_QUERIER_NUM", default = 0)]
     pub starting_expect_querier_num: usize,
     #[env_config(name = "ZO_QUERY_OPTIMIZATION_NUM_FIELDS", default = 1000)]

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -232,3 +232,10 @@ pub async fn is_empty() -> bool {
 pub async fn clear() -> Result<()> {
     CLIENT.clear().await
 }
+
+/// Returns the scheduler_max_retries set through environment config
+/// The bool element in the tuple indicates if the retries are enabled
+pub fn get_scheduler_max_retries() -> (bool, i32) {
+    let max_retries = config::get_config().limit.scheduler_max_retries;
+    (max_retries > 0, max_retries.unsigned_abs() as i32)
+}

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -234,7 +234,7 @@ pub async fn clear() -> Result<()> {
 }
 
 /// Returns the scheduler_max_retries set through environment config
-/// The bool element in the tuple indicates if the retries are enabled
+/// The bool element in the tuple indicates if the max retries value is included
 pub fn get_scheduler_max_retries() -> (bool, i32) {
     let max_retries = config::get_config().limit.scheduler_max_retries;
     (max_retries > 0, max_retries.unsigned_abs() as i32)

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -19,7 +19,9 @@ use chrono::Duration;
 use config::metrics::DB_QUERY_NUMS;
 use sqlx::Row;
 
-use super::{Trigger, TriggerId, TriggerModule, TriggerStatus, TRIGGERS_KEY};
+use super::{
+    get_scheduler_max_retries, Trigger, TriggerId, TriggerModule, TriggerStatus, TRIGGERS_KEY,
+};
 use crate::{
     db::{
         self,
@@ -299,6 +301,10 @@ WHERE org = ? AND module_key = ? AND module = ?;"#,
         report_timeout: i64,
     ) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
+        let (include_max, mut max_retries) = get_scheduler_max_retries();
+        if include_max {
+            max_retries += 1;
+        }
 
         log::debug!("Start pulling scheduled_job");
         let now = chrono::Utc::now().timestamp_micros();
@@ -327,7 +333,7 @@ FOR UPDATE;
         )
         .bind(TriggerStatus::Waiting)
         .bind(now)
-        .bind(config::get_config().limit.scheduler_max_retries)
+        .bind(max_retries)
         .bind(true)
         .bind(false)
         .bind(concurrency)
@@ -451,13 +457,17 @@ WHERE id IN ({});",
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
     async fn clean_complete(&self) -> Result<()> {
+        let (include_max, mut max_retries) = get_scheduler_max_retries();
+        if include_max {
+            max_retries += 1;
+        }
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
             .with_label_values(&["delete", "scheduled_jobs"])
             .inc();
         sqlx::query(r#"DELETE FROM scheduled_jobs WHERE status = ? OR retries >= ?;"#)
             .bind(TriggerStatus::Completed)
-            .bind(config::get_config().limit.scheduler_max_retries)
+            .bind(max_retries)
             .execute(&pool)
             .await?;
         Ok(())

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -19,7 +19,7 @@ use chrono::Duration;
 use config::metrics::DB_QUERY_NUMS;
 use sqlx::Row;
 
-use super::{Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
+use super::{get_scheduler_max_retries, Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
 use crate::{
     db::{
         self,
@@ -300,6 +300,10 @@ WHERE org = $7 AND module_key = $8 AND module = $9;"#,
         report_timeout: i64,
     ) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
+        let (include_max, mut max_retries) = get_scheduler_max_retries();
+        if include_max {
+            max_retries += 1;
+        }
 
         let now = chrono::Utc::now().timestamp_micros();
         let report_max_time = now
@@ -340,7 +344,7 @@ RETURNING *;"#;
             .bind(report_max_time)
             .bind(TriggerStatus::Waiting)
             .bind(now)
-            .bind(config::get_config().limit.scheduler_max_retries)
+            .bind(max_retries)
             .bind(true)
             .bind(false)
             .bind(concurrency)
@@ -411,12 +415,16 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
     /// retries >= threshold set through environment
     async fn clean_complete(&self) -> Result<()> {
         let pool = CLIENT.clone();
+        let (include_max, mut max_retries) = get_scheduler_max_retries();
+        if include_max {
+            max_retries += 1;
+        }
         DB_QUERY_NUMS
             .with_label_values(&["delete", "scheduled_jobs"])
             .inc();
         sqlx::query(r#"DELETE FROM scheduled_jobs WHERE status = $1 OR retries >= $2;"#)
             .bind(TriggerStatus::Completed)
-            .bind(config::get_config().limit.scheduler_max_retries)
+            .bind(max_retries)
             .execute(&pool)
             .await?;
         Ok(())

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -18,7 +18,7 @@ use chrono::Duration;
 use config::utils::json;
 use sqlx::{Pool, Row, Sqlite};
 
-use super::{Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
+use super::{get_scheduler_max_retries, Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
 use crate::{
     db::{
         self,
@@ -295,6 +295,10 @@ WHERE org = $7 AND module_key = $8 AND module = $9;"#,
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
 
+        let (include_max, mut max_retries) = get_scheduler_max_retries();
+        if include_max {
+            max_retries += 1;
+        }
         let now = chrono::Utc::now().timestamp_micros();
         let report_max_time = now
             + Duration::try_seconds(report_timeout)
@@ -329,7 +333,7 @@ RETURNING *;"#;
             .bind(report_max_time)
             .bind(TriggerStatus::Waiting)
             .bind(now)
-            .bind(config::get_config().limit.scheduler_max_retries)
+            .bind(max_retries)
             .bind(true)
             .bind(false)
             .bind(concurrency)
@@ -383,9 +387,13 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
     async fn clean_complete(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
+        let (include_max, mut max_retries) = get_scheduler_max_retries();
+        if include_max {
+            max_retries += 1;
+        }
         sqlx::query(r#"DELETE FROM scheduled_jobs WHERE status = $1 OR retries >= $2;"#)
             .bind(TriggerStatus::Completed)
-            .bind(config::get_config().limit.scheduler_max_retries)
+            .bind(max_retries)
             .execute(&*client)
             .await?;
         Ok(())

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -78,9 +78,11 @@ async fn run_schedule_jobs() -> Result<(), anyhow::Error> {
 }
 
 async fn clean_complete_jobs() -> Result<(), anyhow::Error> {
-    let mut interval = time::interval(time::Duration::from_secs(
-        get_config().limit.scheduler_clean_interval,
-    ));
+    let scheduler_clean_interval = get_config().limit.scheduler_clean_interval;
+    if scheduler_clean_interval < 0 {
+        return Ok(());
+    }
+    let mut interval = time::interval(time::Duration::from_secs(scheduler_clean_interval as u64));
     interval.tick().await; // trigger the first run
     loop {
         interval.tick().await;
@@ -91,9 +93,11 @@ async fn clean_complete_jobs() -> Result<(), anyhow::Error> {
 }
 
 async fn watch_timeout_jobs() -> Result<(), anyhow::Error> {
-    let mut interval = time::interval(time::Duration::from_secs(
-        get_config().limit.scheduler_watch_interval,
-    ));
+    let scheduler_watch_interval = get_config().limit.scheduler_watch_interval;
+    if scheduler_watch_interval < 0 {
+        return Ok(());
+    }
+    let mut interval = time::interval(time::Duration::from_secs(scheduler_watch_interval as u64));
     interval.tick().await; // trigger the first run
     loop {
         interval.tick().await;

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -26,6 +26,7 @@ use config::{
 };
 use cron::Schedule;
 use futures::future::try_join_all;
+use infra::scheduler::get_scheduler_max_retries;
 use proto::cluster_rpc;
 
 use crate::{
@@ -97,6 +98,7 @@ fn get_max_considerable_delay(frequency: i64) -> i64 {
 }
 
 async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), anyhow::Error> {
+    let (_, max_retries) = get_scheduler_max_retries();
     log::debug!(
         "Inside handle_alert_triggers: processing trigger: {}",
         &trigger.module_key
@@ -156,6 +158,34 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         // update trigger, check on next week
         new_trigger.next_run_at += Duration::try_days(7).unwrap().num_microseconds().unwrap();
         new_trigger.is_silenced = true;
+        db::scheduler::update_trigger(new_trigger).await?;
+        return Ok(());
+    }
+
+    if trigger.retries >= max_retries {
+        // It has been tried the maximum time, just update the
+        // next_run_at to the next expected trigger time
+        log::info!(
+            "This alert trigger: {}/{} has passed maximum retries, skipping to next run",
+            &new_trigger.org,
+            &new_trigger.module_key
+        );
+        if alert.trigger_condition.frequency_type == FrequencyType::Cron {
+            let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;
+            // tz_offset is in minutes
+            let tz_offset = FixedOffset::east_opt(alert.tz_offset * 60).unwrap();
+            new_trigger.next_run_at = schedule
+                .upcoming(tz_offset)
+                .next()
+                .unwrap()
+                .timestamp_micros();
+        } else {
+            new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
+                .unwrap()
+                .num_microseconds()
+                .unwrap();
+        }
+        new_trigger.data = "".to_string();
         db::scheduler::update_trigger(new_trigger).await?;
         return Ok(());
     }
@@ -268,14 +298,8 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         }
         trigger_data_stream.error = Some(err_string);
         // update its status and retries
-        if trigger.retries + 1 >= get_config().limit.scheduler_max_retries {
-            if !get_config().limit.pause_alerts_on_retries {
-                new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
-                    .unwrap()
-                    .num_microseconds()
-                    .unwrap();
-                db::scheduler::update_trigger(new_trigger).await?;
-            } else {
+        if trigger.retries + 1 >= max_retries {
+            if get_config().limit.pause_alerts_on_retries {
                 // It has been tried the maximum time, just disable the alert
                 // and show the error.
                 if let Some(mut alert) =
@@ -293,16 +317,26 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                         log::error!("Failed to update alert: {alert_name} after trigger: {e}",);
                     }
                 }
-                // update its status and retries
-                db::scheduler::update_status(
-                    &new_trigger.org,
-                    new_trigger.module,
-                    &new_trigger.module_key,
-                    db::scheduler::TriggerStatus::Waiting,
-                    trigger.retries + 1,
-                )
-                .await?;
             }
+            // This didn't work, update the next_run_at to the next expected trigger time
+            if alert.trigger_condition.frequency_type == FrequencyType::Cron {
+                let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;
+                // tz_offset is in minutes
+                let tz_offset = FixedOffset::east_opt(alert.tz_offset * 60).unwrap();
+                new_trigger.next_run_at = schedule
+                    .upcoming(tz_offset)
+                    .next()
+                    .unwrap()
+                    .timestamp_micros();
+            } else {
+                new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
+                    .unwrap()
+                    .num_microseconds()
+                    .unwrap();
+            }
+            new_trigger.data = "".to_string();
+            trigger_data_stream.next_run_at = new_trigger.next_run_at;
+            db::scheduler::update_trigger(new_trigger).await?;
         } else {
             // update its status and retries
             db::scheduler::update_status(
@@ -437,7 +471,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                 trigger_data_stream.success_response = Some(success_msg);
                 // Notification was sent successfully, store the last used end_time in the triggers
                 trigger_data.period_end_time = if should_store_last_end_time {
-                    Some(alert_end_time)
+                    Some(end_time)
                 } else {
                     None
                 };
@@ -452,7 +486,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                     &new_trigger.org,
                     &new_trigger.module_key
                 );
-                if trigger.retries + 1 >= get_config().limit.scheduler_max_retries {
+                if trigger.retries + 1 >= max_retries {
                     // It has been tried the maximum time, just update the
                     // next_run_at to the next expected trigger time
                     log::debug!(
@@ -471,6 +505,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
                     // will be used to evaluate the alert.
                     trigger_data.period_end_time = None;
                     new_trigger.data = json::to_string(&trigger_data).unwrap();
+                    trigger_data_stream.next_run_at = new_trigger.next_run_at;
                     db::scheduler::update_trigger(new_trigger).await?;
                 } else {
                     // Otherwise update its status only
@@ -553,6 +588,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
 }
 
 async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), anyhow::Error> {
+    let (_, max_retires) = get_scheduler_max_retries();
     log::debug!(
         "Inside handle_report_trigger,org: {}, module_key: {}",
         &trigger.org,
@@ -658,6 +694,17 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         evaluation_took_in_secs: None,
     };
 
+    if trigger.retries >= max_retires {
+        // It has been tried the maximum time, just update the
+        // next_run_at to the next expected trigger time
+        log::info!(
+            "This report trigger: {org_id}/{report_name} has passed maximum retries, skipping to next run",
+            org_id = &new_trigger.org,
+            report_name = report_name
+        );
+        db::scheduler::update_trigger(new_trigger).await?;
+        return Ok(());
+    }
     match report.send_subscribers().await {
         Ok(_) => {
             log::info!("Report {} sent to destination", report_name);
@@ -671,12 +718,13 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         }
         Err(e) => {
             log::error!("Error sending report to subscribers: {e}");
-            if trigger.retries + 1 >= get_config().limit.scheduler_max_retries && !run_once {
+            if trigger.retries + 1 >= max_retires && !run_once {
                 // It has been tried the maximum time, just update the
                 // next_run_at to the next expected trigger time
                 log::debug!(
                     "This report trigger: {org_id}/{report_name} has reached maximum possible retries"
                 );
+                trigger_data_stream.next_run_at = new_trigger.next_run_at;
                 db::scheduler::update_trigger(new_trigger).await?;
             } else {
                 if run_once {
@@ -723,6 +771,7 @@ async fn handle_derived_stream_triggers(
         "Inside handle_derived_stream_triggers processing trigger: {}",
         trigger.module_key
     );
+    let (_, max_retries) = get_scheduler_max_retries();
 
     // module_key format: stream_type/stream_name/pipeline_name/derived_stream_name
     let columns = trigger.module_key.split('/').collect::<Vec<_>>();
@@ -789,6 +838,35 @@ async fn handle_derived_stream_triggers(
         retries: 0,
         ..trigger.clone()
     };
+
+    if trigger.retries >= max_retries {
+        // It has been tried the maximum time, just update the
+        // next_run_at to the next expected trigger time
+        log::info!(
+            "This DerivedStream trigger: {}/{} has passed maximum retries, skipping to next run",
+            &new_trigger.org,
+            &new_trigger.module_key
+        );
+        if derived_stream.trigger_condition.frequency_type == FrequencyType::Cron {
+            let schedule = Schedule::from_str(&derived_stream.trigger_condition.cron)?;
+            // tz_offset is in minutes
+            let tz_offset = FixedOffset::east_opt(derived_stream.tz_offset * 60).unwrap();
+            new_trigger.next_run_at = schedule
+                .upcoming(tz_offset)
+                .next()
+                .unwrap()
+                .timestamp_micros();
+        } else {
+            new_trigger.next_run_at +=
+                Duration::try_minutes(derived_stream.trigger_condition.frequency)
+                    .unwrap()
+                    .num_microseconds()
+                    .unwrap();
+        }
+        new_trigger.data = "".to_string();
+        db::scheduler::update_trigger(new_trigger).await?;
+        return Ok(());
+    }
 
     // evaluate trigger and configure trigger next run time
     let (ret, end_time) = derived_stream.evaluate(None, start_time).await?;
@@ -914,7 +992,7 @@ async fn handle_derived_stream_triggers(
                         new_trigger.org,
                         new_trigger.module_key
                     );
-                    if trigger.retries + 1 >= get_config().limit.scheduler_max_retries {
+                    if trigger.retries + 1 >= max_retries {
                         // It has been tried the maximum time, just update the
                         // next_run_at to the next expected trigger time
                         log::debug!(
@@ -922,6 +1000,7 @@ async fn handle_derived_stream_triggers(
                             &new_trigger.org,
                             &new_trigger.module_key
                         );
+                        trigger_data_stream.next_run_at = new_trigger.next_run_at;
                         db::scheduler::update_trigger(new_trigger).await?;
                     } else {
                         // Otherwise update its status only

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -284,10 +284,10 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         evaluation_took_in_secs: None,
     };
 
-    let evalutaion_took = Instant::now();
+    let evaluation_took = Instant::now();
     // evaluate alert
     let result = alert.evaluate(None, start_time).await;
-    let evaluation_took = evalutaion_took.elapsed().as_secs_f64();
+    let evaluation_took = evaluation_took.elapsed().as_secs_f64();
     trigger_data_stream.evaluation_took_in_secs = Some(evaluation_took);
     if result.is_err() {
         let err = result.err().unwrap();
@@ -588,7 +588,7 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
 }
 
 async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), anyhow::Error> {
-    let (_, max_retires) = get_scheduler_max_retries();
+    let (_, max_retries) = get_scheduler_max_retries();
     log::debug!(
         "Inside handle_report_trigger,org: {}, module_key: {}",
         &trigger.org,
@@ -694,7 +694,7 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         evaluation_took_in_secs: None,
     };
 
-    if trigger.retries >= max_retires {
+    if trigger.retries >= max_retries {
         // It has been tried the maximum time, just update the
         // next_run_at to the next expected trigger time
         log::info!(
@@ -718,7 +718,7 @@ async fn handle_report_triggers(trigger: db::scheduler::Trigger) -> Result<(), a
         }
         Err(e) => {
             log::error!("Error sending report to subscribers: {e}");
-            if trigger.retries + 1 >= max_retires && !run_once {
+            if trigger.retries + 1 >= max_retries && !run_once {
                 // It has been tried the maximum time, just update the
                 // next_run_at to the next expected trigger time
                 log::debug!(


### PR DESCRIPTION
Whenever alert, report and derived stream retries reaches the maximum retries (`ZO_SCHEDULER_MAX_RETRIES`, default `3`), with this pr, the alert manager will skip to the next run timestamp.

Also, some flexibility added to the ENVs. For example, if the values of `ZO_SCHEDULER_CLEAN_INTERVAL` and `ZO_SCHEDULER_WATCH_INTERVAL` are negative, the background jobs for cleaning up and watching timeout for `scheduled_jobs` table will not run.

`ZO_SCHEDULER_MAX_RETRIES` now accepts both negative and positive values -
- For negative value, the max retries is the absolute value. But when pulling jobs, it will pull jobs matching condition `< max_retries`. If a job reaches max retries, it will never be pulled by the alert manager.
- For positive value (default case), It will pull jobs matching conditions `< max_retries + 1`. So, even if a job reaches the maximum retries, it will still be pulled by alert manager and will be skipped to the next run timestamp of the alert/report/derived stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new function to retrieve the maximum number of retries for scheduled jobs, enhancing dynamic configuration management.
	- Updated alert processing logic to handle retries consistently across different trigger types.

- **Bug Fixes**
	- Added error handling for negative interval values in job scheduling functions, improving robustness.

- **Refactor**
	- Improved code readability and maintainability by refactoring interval initialization in scheduling functions.

These changes enhance the overall functionality and reliability of the scheduling system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->