### PR TITLE
fix: add db operation related traces

### DIFF
--- a/src/infra/src/db/etcd.rs
+++ b/src/infra/src/db/etcd.rs
@@ -136,8 +136,7 @@ impl super::Db for Etcd {
         Ok(Bytes::from(ret.kvs()[0].value().to_vec()))
     }
 
-
-    #[tracing::instrument(name = "db::put", skip(self,value))]
+    #[tracing::instrument(name = "db::put", skip(self, value))]
     async fn put(
         &self,
         key: &str,
@@ -155,7 +154,7 @@ impl super::Db for Etcd {
         Ok(())
     }
 
-    #[tracing::instrument(name = "db::get_for_update", skip(self,update_fn))]
+    #[tracing::instrument(name = "db::get_for_update", skip(self, update_fn))]
     async fn get_for_update(
         &self,
         key: &str,

--- a/src/infra/src/db/etcd.rs
+++ b/src/infra/src/db/etcd.rs
@@ -67,6 +67,7 @@ impl Etcd {
         }
     }
 
+    #[tracing::instrument(name = "etcd::get_key_value", skip(self))]
     async fn get_key_value(&self, key: &str) -> Result<(String, Bytes)> {
         let key = format!("{}{}", self.prefix, key);
         let mut client = get_etcd_client().await.clone();
@@ -102,6 +103,7 @@ impl super::Db for Etcd {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::stats", skip(self))]
     async fn stats(&self) -> Result<super::Stats> {
         let mut client = get_etcd_client().await.clone();
         let stats = client.status().await?;
@@ -119,6 +121,7 @@ impl super::Db for Etcd {
         })
     }
 
+    #[tracing::instrument(name = "db::get", skip(self))]
     async fn get(&self, key: &str) -> Result<Bytes> {
         let key = format!("{}{}", self.prefix, key);
         let mut client = get_etcd_client().await.clone();
@@ -133,6 +136,8 @@ impl super::Db for Etcd {
         Ok(Bytes::from(ret.kvs()[0].value().to_vec()))
     }
 
+
+    #[tracing::instrument(name = "db::put", skip(self,value))]
     async fn put(
         &self,
         key: &str,
@@ -150,6 +155,7 @@ impl super::Db for Etcd {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::get_for_update", skip(self,update_fn))]
     async fn get_for_update(
         &self,
         key: &str,
@@ -211,6 +217,7 @@ impl super::Db for Etcd {
         ret
     }
 
+    #[tracing::instrument(name = "db::delete", skip(self))]
     async fn delete(
         &self,
         key: &str,
@@ -228,6 +235,7 @@ impl super::Db for Etcd {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::list", skip(self))]
     async fn list(&self, prefix: &str) -> Result<HashMap<String, Bytes>> {
         let cfg = get_config();
         let mut result = HashMap::default();
@@ -273,6 +281,7 @@ impl super::Db for Etcd {
         Ok(result)
     }
 
+    #[tracing::instrument(name = "db::list_keys", skip(self))]
     async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
         let cfg = get_config();
         let mut result = Vec::new();
@@ -318,6 +327,7 @@ impl super::Db for Etcd {
         Ok(result)
     }
 
+    #[tracing::instrument(name = "db::list_values", skip(self))]
     async fn list_values(&self, prefix: &str) -> Result<Vec<Bytes>> {
         let cfg = get_config();
         let mut result = Vec::new();
@@ -362,6 +372,7 @@ impl super::Db for Etcd {
         Ok(result)
     }
 
+    #[tracing::instrument(name = "db::list_values_by_start_dt", skip(self))]
     async fn list_values_by_start_dt(
         &self,
         prefix: &str,
@@ -424,6 +435,7 @@ impl super::Db for Etcd {
         Ok(result)
     }
 
+    #[tracing::instrument(name = "db::count", skip(self))]
     async fn count(&self, prefix: &str) -> Result<i64> {
         let key = format!("{}{}", self.prefix, prefix);
         let mut client = get_etcd_client().await.clone();
@@ -432,6 +444,7 @@ impl super::Db for Etcd {
         Ok(resp.count())
     }
 
+    #[tracing::instrument(name = "db::watch", skip(self))]
     async fn watch(&self, prefix: &str) -> Result<Arc<mpsc::Receiver<Event>>> {
         let (tx, rx) = mpsc::channel(1024);
         let key = format!("{}{}", &self.prefix, prefix);
@@ -629,6 +642,7 @@ impl Locker {
     }
 
     /// lock with timeout, 0 means use default timeout, unit: second
+    #[tracing::instrument(name = "etcd::locker::lock", skip(self))]
     pub(crate) async fn lock(&mut self, timeout: u64) -> Result<()> {
         let cfg = get_config();
         let mut client = get_etcd_client().await.clone();
@@ -667,6 +681,7 @@ impl Locker {
         Ok(())
     }
 
+    #[tracing::instrument(name = "etcd::locker::unlock", skip(self))]
     pub(crate) async fn unlock(&self) -> Result<()> {
         if self.state.load(Ordering::SeqCst) != 1 {
             return Ok(());

--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -93,6 +93,7 @@ impl super::Db for MysqlDb {
         create_table().await
     }
 
+    #[tracing::instrument(name = "db::stats", skip(self))]
     async fn stats(&self) -> Result<super::Stats> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
@@ -107,6 +108,7 @@ impl super::Db for MysqlDb {
         })
     }
 
+    #[tracing::instrument(name = "db::get", skip(self))]
     async fn get(&self, key: &str) -> Result<Bytes> {
         let (module, key1, key2) = super::parse_key(key);
         let pool = CLIENT.clone();
@@ -131,6 +133,7 @@ impl super::Db for MysqlDb {
         Ok(Bytes::from(value))
     }
 
+    #[tracing::instrument(name = "db::put", skip(self, value))]
     async fn put(
         &self,
         key: &str,
@@ -196,6 +199,7 @@ impl super::Db for MysqlDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::get_for_update", skip(self, update_fn))]
     async fn get_for_update(
         &self,
         key: &str,
@@ -431,6 +435,7 @@ impl super::Db for MysqlDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::delete", skip(self))]
     async fn delete(
         &self,
         key: &str,
@@ -496,6 +501,7 @@ impl super::Db for MysqlDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::list", skip(self))]
     async fn list(&self, prefix: &str) -> Result<HashMap<String, Bytes>> {
         let (module, key1, key2) = super::parse_key(prefix);
         let mut sql = "SELECT id, module, key1, key2, start_dt, value FROM meta".to_string();
@@ -526,6 +532,7 @@ impl super::Db for MysqlDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::list_keys", skip(self))]
     async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
         let (module, key1, key2) = super::parse_key(prefix);
         let mut sql = "SELECT id, module, key1, key2, start_dt, '' AS value FROM meta".to_string();
@@ -551,6 +558,7 @@ impl super::Db for MysqlDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::list_values", skip(self))]
     async fn list_values(&self, prefix: &str) -> Result<Vec<Bytes>> {
         let mut items = self.list(prefix).await?;
         let mut keys = items.keys().map(|k| k.to_string()).collect::<Vec<_>>();
@@ -561,6 +569,7 @@ impl super::Db for MysqlDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::list_values_by_start_dt", skip(self))]
     async fn list_values_by_start_dt(
         &self,
         prefix: &str,
@@ -600,6 +609,7 @@ impl super::Db for MysqlDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::count", skip(self))]
     async fn count(&self, prefix: &str) -> Result<i64> {
         let (module, key1, key2) = super::parse_key(prefix);
         let mut sql = "SELECT COUNT(*) AS num FROM meta".to_string();

--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -48,6 +48,7 @@ pub async fn get_nats_client() -> &'static Client {
     NATS_CLIENT.get_or_init(connect).await
 }
 
+#[tracing::instrument(name = "nats::get_bucket_by_key")]
 async fn get_bucket_by_key<'a>(
     prefix: &'a str,
     key: &'a str,
@@ -95,6 +96,7 @@ impl NatsDb {
         Self::new(SUPER_CLUSTER_PREFIX)
     }
 
+    #[tracing::instrument(name = "nats::get_key_value", skip(self))]
     async fn get_key_value(&self, key: &str) -> Result<(String, Bytes)> {
         let (bucket, new_key) = get_bucket_by_key(&self.prefix, key).await?;
         let bucket_name = bucket
@@ -164,6 +166,7 @@ impl super::Db for NatsDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::stats", skip(self))]
     async fn stats(&self) -> Result<super::Stats> {
         let client = get_nats_client().await.clone();
         let jetstream = async_nats::jetstream::new(client);
@@ -180,6 +183,7 @@ impl super::Db for NatsDb {
         })
     }
 
+    #[tracing::instrument(name = "db::get", skip(self))]
     async fn get(&self, key: &str) -> Result<Bytes> {
         let (bucket, new_key) = get_bucket_by_key(&self.prefix, key).await?;
         let key = key_encode(new_key);
@@ -224,6 +228,7 @@ impl super::Db for NatsDb {
         }
     }
 
+    #[tracing::instrument(name = "db::put", skip(self, value))]
     async fn put(
         &self,
         key: &str,
@@ -245,6 +250,7 @@ impl super::Db for NatsDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::get_for_update", skip(self, update_fn))]
     async fn get_for_update(
         &self,
         key: &str,
@@ -306,6 +312,7 @@ impl super::Db for NatsDb {
         ret
     }
 
+    #[tracing::instrument(name = "db::delete", skip(self))]
     async fn delete(
         &self,
         key: &str,
@@ -353,6 +360,7 @@ impl super::Db for NatsDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::list", skip(self))]
     async fn list(&self, prefix: &str) -> Result<HashMap<String, Bytes>> {
         let (bucket, new_key) = get_bucket_by_key(&self.prefix, prefix).await?;
         let bucket = &bucket;
@@ -403,6 +411,7 @@ impl super::Db for NatsDb {
         Ok(result)
     }
 
+    #[tracing::instrument(name = "db::list_keys", skip(self))]
     async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
         let (bucket, new_key) = get_bucket_by_key(&self.prefix, prefix).await?;
         let bucket = &bucket;
@@ -433,6 +442,7 @@ impl super::Db for NatsDb {
         Ok(keys)
     }
 
+    #[tracing::instrument(name = "db::list_values", skip(self))]
     async fn list_values(&self, prefix: &str) -> Result<Vec<Bytes>> {
         let (bucket, new_key) = get_bucket_by_key(&self.prefix, prefix).await?;
         let bucket = &bucket;
@@ -474,6 +484,7 @@ impl super::Db for NatsDb {
         Ok(result)
     }
 
+    #[tracing::instrument(name = "db::list_values_by_start_dt", skip(self))]
     async fn list_values_by_start_dt(
         &self,
         prefix: &str,
@@ -545,11 +556,13 @@ impl super::Db for NatsDb {
         Ok(result)
     }
 
+    #[tracing::instrument(name = "db::count", skip(self))]
     async fn count(&self, prefix: &str) -> Result<i64> {
         let keys = self.list_keys(prefix).await?;
         Ok(keys.len() as i64)
     }
 
+    #[tracing::instrument(name = "db::watch", skip(self))]
     async fn watch(&self, prefix: &str) -> Result<Arc<mpsc::Receiver<Event>>> {
         let (tx, rx) = mpsc::channel(1024);
         let prefix = prefix.to_string();
@@ -704,6 +717,7 @@ impl Locker {
     }
 
     /// lock with timeout, 0 means use default timeout, unit: second
+    #[tracing::instrument(name = "nats::locker::lock", skip(self))]
     pub(crate) async fn lock(
         &mut self,
         timeout: u64,
@@ -788,6 +802,7 @@ impl Locker {
         }
     }
 
+    #[tracing::instrument(name = "nats::locker::unlock", skip(self))]
     pub(crate) async fn unlock(&self) -> Result<()> {
         if self.state.load(Ordering::SeqCst) != 1 {
             return Ok(());

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -92,6 +92,7 @@ impl super::Db for PostgresDb {
         create_table().await
     }
 
+    #[tracing::instrument(name = "db::stats", skip(self))]
     async fn stats(&self) -> Result<super::Stats> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
@@ -105,6 +106,7 @@ impl super::Db for PostgresDb {
         })
     }
 
+    #[tracing::instrument(name = "db::get", skip(self))]
     async fn get(&self, key: &str) -> Result<Bytes> {
         let (module, key1, key2) = super::parse_key(key);
         let pool = CLIENT.clone();
@@ -129,6 +131,7 @@ impl super::Db for PostgresDb {
         Ok(Bytes::from(value))
     }
 
+    #[tracing::instrument(name = "db::put", skip(self, value))]
     async fn put(
         &self,
         key: &str,
@@ -195,6 +198,7 @@ impl super::Db for PostgresDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::get_for_update", skip(self, update_fn))]
     async fn get_for_update(
         &self,
         key: &str,
@@ -362,6 +366,7 @@ impl super::Db for PostgresDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::delete", skip(self))]
     async fn delete(
         &self,
         key: &str,
@@ -427,6 +432,7 @@ impl super::Db for PostgresDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::list", skip(self))]
     async fn list(&self, prefix: &str) -> Result<HashMap<String, Bytes>> {
         let (module, key1, key2) = super::parse_key(prefix);
         let mut sql = "SELECT id, module, key1, key2, start_dt, value FROM meta".to_string();
@@ -457,6 +463,7 @@ impl super::Db for PostgresDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::list_keys", skip(self))]
     async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
         let (module, key1, key2) = super::parse_key(prefix);
         let mut sql = "SELECT id, module, key1, key2, start_dt, '' AS value FROM meta ".to_string();
@@ -481,6 +488,7 @@ impl super::Db for PostgresDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::list_values", skip(self))]
     async fn list_values(&self, prefix: &str) -> Result<Vec<Bytes>> {
         let mut items = self.list(prefix).await?;
         let mut keys = items.keys().map(|k| k.to_string()).collect::<Vec<_>>();
@@ -491,6 +499,7 @@ impl super::Db for PostgresDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::list_values_by_start_dt", skip(self))]
     async fn list_values_by_start_dt(
         &self,
         prefix: &str,
@@ -530,6 +539,7 @@ impl super::Db for PostgresDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::count", skip(self))]
     async fn count(&self, prefix: &str) -> Result<i64> {
         let (module, key1, key2) = super::parse_key(prefix);
         let mut sql = "SELECT COUNT(*) AS num FROM meta".to_string();

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -206,6 +206,7 @@ impl super::Db for SqliteDb {
         create_table().await
     }
 
+    #[tracing::instrument(name = "db::stats", skip(self))]
     async fn stats(&self) -> Result<super::Stats> {
         let pool = CLIENT_RO.clone();
         let keys_count: i64 = sqlx::query_scalar(r#"SELECT COUNT(*) as num FROM meta;"#)
@@ -221,6 +222,7 @@ impl super::Db for SqliteDb {
         })
     }
 
+    #[tracing::instrument(name = "db::get", skip(self))]
     async fn get(&self, key: &str) -> Result<Bytes> {
         let (module, key1, key2) = super::parse_key(key);
         let pool = CLIENT_RO.clone();
@@ -244,6 +246,7 @@ impl super::Db for SqliteDb {
         Ok(Bytes::from(value))
     }
 
+    #[tracing::instrument(name = "db::put", skip(self, value))]
     async fn put(
         &self,
         key: &str,
@@ -314,6 +317,7 @@ impl super::Db for SqliteDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::get_for_update", skip(self, update_fn))]
     async fn get_for_update(
         &self,
         key: &str,
@@ -482,6 +486,7 @@ impl super::Db for SqliteDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::delete", skip(self))]
     async fn delete(
         &self,
         key: &str,
@@ -561,6 +566,7 @@ impl super::Db for SqliteDb {
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::list", skip(self))]
     async fn list(&self, prefix: &str) -> Result<HashMap<String, Bytes>> {
         let (module, key1, key2) = super::parse_key(prefix);
         let mut sql = "SELECT id, module, key1, key2, start_dt, value FROM meta".to_string();
@@ -590,6 +596,7 @@ impl super::Db for SqliteDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::list_keys", skip(self))]
     async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
         let (module, key1, key2) = super::parse_key(prefix);
         let mut sql = "SELECT id, module, key1, key2, start_dt, '' AS value FROM meta".to_string();
@@ -614,6 +621,7 @@ impl super::Db for SqliteDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::list_values", skip(self))]
     async fn list_values(&self, prefix: &str) -> Result<Vec<Bytes>> {
         let mut items = self.list(prefix).await?;
         let mut keys = items.keys().map(|k| k.to_string()).collect::<Vec<_>>();
@@ -624,6 +632,7 @@ impl super::Db for SqliteDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::list_values_by_start_dt", skip(self))]
     async fn list_values_by_start_dt(
         &self,
         prefix: &str,
@@ -662,6 +671,7 @@ impl super::Db for SqliteDb {
             .collect())
     }
 
+    #[tracing::instrument(name = "db::count", skip(self))]
     async fn count(&self, prefix: &str) -> Result<i64> {
         let (module, key1, key2) = super::parse_key(prefix);
         let mut sql = "SELECT COUNT(*) AS num FROM meta".to_string();
@@ -680,6 +690,7 @@ impl super::Db for SqliteDb {
         Ok(count)
     }
 
+    #[tracing::instrument(name = "db::watch", skip(self))]
     async fn watch(&self, prefix: &str) -> Result<Arc<mpsc::Receiver<Event>>> {
         let (tx, rx) = mpsc::channel(1024);
         WATCHERS

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -66,6 +66,7 @@ impl super::FileList for MysqlFileList {
         self.inner_add("file_list_history", file, meta).await
     }
 
+    #[tracing::instrument(name = "file_list::db::remove", skip(self))]
     async fn remove(&self, file: &str) -> Result<()> {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
@@ -90,6 +91,7 @@ impl super::FileList for MysqlFileList {
         self.inner_batch_add("file_list_history", files).await
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_remove", skip_all,field(file_count=files.len()))]
     async fn batch_remove(&self, files: &[String]) -> Result<()> {
         if files.is_empty() {
             return Ok(());
@@ -149,6 +151,7 @@ impl super::FileList for MysqlFileList {
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_add_deleted", skip(self,files),field(file_count=files.len()))]
     async fn batch_add_deleted(
         &self,
         org_id: &str,
@@ -193,6 +196,7 @@ impl super::FileList for MysqlFileList {
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_remove_deleted", skip_all,field(file_count=file.len()))]
     async fn batch_remove_deleted(&self, files: &[String]) -> Result<()> {
         if files.is_empty() {
             return Ok(());
@@ -246,6 +250,7 @@ impl super::FileList for MysqlFileList {
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::get", skip(self))]
     async fn get(&self, file: &str) -> Result<FileMeta> {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
@@ -297,6 +302,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         Ok(!ret.unwrap().is_empty())
     }
 
+    #[tracing::instrument(name = "file_list::db::update_flattened", skip(self))]
     async fn update_flattened(&self, file: &str, flattened: bool) -> Result<()> {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
@@ -320,6 +326,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         return Ok(vec![]); // disallow list all data
     }
 
+    #[tracing::instrument(name = "file_list::db::query", skip(self, _time_level))]
     async fn query(
         &self,
         org_id: &str,
@@ -406,6 +413,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::query_parallel", skip(self))]
     async fn query_parallel(
         &self,
         org_id: &str,
@@ -528,6 +536,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         Ok(files)
     }
 
+    #[tracing::instrument(name = "file_list::db::query_deleted", skip(self))]
     async fn query_deleted(
         &self,
         org_id: &str,
@@ -560,6 +569,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_min_ts", skip(self))]
     async fn get_min_ts(
         &self,
         org_id: &str,
@@ -581,6 +591,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         Ok(ret.unwrap_or_default())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_max_pk_value", skip(self))]
     async fn get_max_pk_value(&self) -> Result<i64> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -592,6 +603,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         Ok(ret.unwrap_or_default())
     }
 
+    #[tracing::instrument(name = "file_list::db::stats", skip(self))]
     async fn stats(
         &self,
         org_id: &str,
@@ -640,6 +652,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_stream_stats", skip(self))]
     async fn get_stream_stats(
         &self,
         org_id: &str,
@@ -669,6 +682,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::del_stream_stats", skip(self))]
     async fn del_stream_stats(
         &self,
         org_id: &str,
@@ -687,6 +701,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::set_stream_stats", skip(self,streams),field(stream_count=streams.len()))]
     async fn set_stream_stats(
         &self,
         org_id: &str,
@@ -774,6 +789,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::reset_stream_stats", skip(self))]
     async fn reset_stream_stats(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -785,6 +801,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::reset_stream_stats_min_ts", skip(self, _org_id))]
     async fn reset_stream_stats_min_ts(
         &self,
         _org_id: &str,
@@ -812,6 +829,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::len", skip(self))]
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -841,6 +859,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::add_job", skip(self))]
     async fn add_job(
         &self,
         org_id: &str,
@@ -873,6 +892,7 @@ UPDATE stream_stats
         }
     }
 
+    #[tracing::instrument(name = "file_list::db::get_pending_jobs", skip(self))]
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {
         let lock_pool = CLIENT.clone();
         let lock_key = "file_list_jobs:get_pending_jobs";
@@ -1029,6 +1049,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         Ok(ret)
     }
 
+    #[tracing::instrument(name = "file_list::db::set_job_pending", skip_all, field(id_count=ids.len()))]
     async fn set_job_pending(&self, ids: &[i64]) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -1048,6 +1069,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::set_job_done", skip(self))]
     async fn set_job_done(&self, id: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -1062,6 +1084,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::update_job_running", skip(self))]
     async fn update_running_jobs(&self, id: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -1075,6 +1098,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::check_running_jobs", skip(self))]
     async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -1094,6 +1118,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::clean_done_jobs", skip(self))]
     async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -1110,6 +1135,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_pending_jobs_count", skip(self))]
     async fn get_pending_jobs_count(&self) -> Result<stdHashMap<String, stdHashMap<String, i64>>> {
         let pool = CLIENT.clone();
 
@@ -1148,6 +1174,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
 }
 
 impl MysqlFileList {
+    #[tracing::instrument(name = "file_list::db::add", skip(self))]
     async fn inner_add(&self, table: &str, file: &str, meta: &FileMeta) -> Result<()> {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
@@ -1183,6 +1210,7 @@ INSERT IGNORE INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, re
         }
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_add", skip(self, files))]
     async fn inner_batch_add(&self, table: &str, files: &[FileKey]) -> Result<()> {
         if files.is_empty() {
             return Ok(());

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -28,6 +28,7 @@ use config::{
 };
 use hashbrown::HashMap;
 use sqlx::{Executor, Postgres, QueryBuilder, Row};
+use tracing::{info_span, Instrument};
 
 use crate::{
     db::postgres::CLIENT,
@@ -529,7 +530,8 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
                             .collect::<Vec<_>>()
                     })
                 }
-            }));
+            }).instrument(info_span!("search_partition",start_time=time_start,end_time=time_end))
+        );
         }
 
         let mut files = Vec::new();

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -463,75 +463,81 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let mut tasks = Vec::with_capacity(day_partitions.len());
         for (time_start, time_end) in day_partitions {
             let stream_key = stream_key.clone();
-            tasks.push(tokio::task::spawn(async move {
-                let pool = CLIENT.clone();
-                let cfg = get_config();
-                DB_QUERY_NUMS
-                    .with_label_values(&["select", "file_list"])
-                    .inc();
-                if cfg.limit.use_upper_bound_for_max_ts {
-                    // TODO: if partition is daily, we need to remove this logic
-                    let max_ts_upper_bound =
-                        time_end + cfg.limit.upper_bound_for_max_ts * 60 * 1_000_000;
-                    sqlx::query_as::<_, super::FileRecord>(
-                        r#"
+            tasks.push(
+                tokio::task::spawn(async move {
+                    let pool = CLIENT.clone();
+                    let cfg = get_config();
+                    DB_QUERY_NUMS
+                        .with_label_values(&["select", "file_list"])
+                        .inc();
+                    if cfg.limit.use_upper_bound_for_max_ts {
+                        // TODO: if partition is daily, we need to remove this logic
+                        let max_ts_upper_bound =
+                            time_end + cfg.limit.upper_bound_for_max_ts * 60 * 1_000_000;
+                        sqlx::query_as::<_, super::FileRecord>(
+                            r#"
 SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
     FROM file_list 
     WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4;
                         "#,
-                    )
-                    .bind(stream_key.clone())
-                    .bind(time_start)
-                    .bind(max_ts_upper_bound)
-                    .bind(time_end)
-                    .fetch_all(&pool)
-                    .await
-                    .map(|r| {
-                        r.into_iter()
-                            .map(|r| {
-                                (
-                                    "files/".to_string()
-                                        + &stream_key
-                                        + "/"
-                                        + &r.date
-                                        + "/"
-                                        + &r.file,
-                                    FileMeta::from(&r),
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                } else {
-                    sqlx::query_as::<_, super::FileRecord>(
-                        r#"
+                        )
+                        .bind(stream_key.clone())
+                        .bind(time_start)
+                        .bind(max_ts_upper_bound)
+                        .bind(time_end)
+                        .fetch_all(&pool)
+                        .await
+                        .map(|r| {
+                            r.into_iter()
+                                .map(|r| {
+                                    (
+                                        "files/".to_string()
+                                            + &stream_key
+                                            + "/"
+                                            + &r.date
+                                            + "/"
+                                            + &r.file,
+                                        FileMeta::from(&r),
+                                    )
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                    } else {
+                        sqlx::query_as::<_, super::FileRecord>(
+                            r#"
 SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
     FROM file_list 
     WHERE stream = $1 AND max_ts >= $2 AND min_ts <= $3;
                         "#,
-                    )
-                    .bind(stream_key.clone())
-                    .bind(time_start)
-                    .bind(time_end)
-                    .fetch_all(&pool)
-                    .await
-                    .map(|r| {
-                        r.into_iter()
-                            .map(|r| {
-                                (
-                                    "files/".to_string()
-                                        + &stream_key
-                                        + "/"
-                                        + &r.date
-                                        + "/"
-                                        + &r.file,
-                                    FileMeta::from(&r),
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                }
-            }).instrument(info_span!("search_partition",start_time=time_start,end_time=time_end))
-        );
+                        )
+                        .bind(stream_key.clone())
+                        .bind(time_start)
+                        .bind(time_end)
+                        .fetch_all(&pool)
+                        .await
+                        .map(|r| {
+                            r.into_iter()
+                                .map(|r| {
+                                    (
+                                        "files/".to_string()
+                                            + &stream_key
+                                            + "/"
+                                            + &r.date
+                                            + "/"
+                                            + &r.file,
+                                        FileMeta::from(&r),
+                                    )
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                    }
+                })
+                .instrument(info_span!(
+                    "search_partition",
+                    start_time = time_start,
+                    end_time = time_end
+                )),
+            );
         }
 
         let mut files = Vec::new();

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -66,6 +66,7 @@ impl super::FileList for PostgresFileList {
         self.inner_add("file_list_history", file, meta).await
     }
 
+    #[tracing::instrument(name = "file_list::db::remove", skip(self))]
     async fn remove(&self, file: &str) -> Result<()> {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
@@ -91,6 +92,7 @@ impl super::FileList for PostgresFileList {
         self.inner_batch_add("file_list_history", files).await
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_remove", skip_all,field(file_count=files.len()))]
     async fn batch_remove(&self, files: &[String]) -> Result<()> {
         if files.is_empty() {
             return Ok(());
@@ -155,6 +157,7 @@ impl super::FileList for PostgresFileList {
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_add_delete", skip(self,files),field(file_count=files.len()))]
     async fn batch_add_deleted(
         &self,
         org_id: &str,
@@ -202,6 +205,7 @@ impl super::FileList for PostgresFileList {
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_remove_deleted", skip_all,field(file_count=files.len()))]
     async fn batch_remove_deleted(&self, files: &[String]) -> Result<()> {
         if files.is_empty() {
             return Ok(());
@@ -260,6 +264,7 @@ impl super::FileList for PostgresFileList {
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::get", skip(self))]
     async fn get(&self, file: &str) -> Result<FileMeta> {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
@@ -311,6 +316,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         Ok(!ret.unwrap().is_empty())
     }
 
+    #[tracing::instrument(name = "file_list::db::update_flattened", skip(self))]
     async fn update_flattened(&self, file: &str, flattened: bool) -> Result<()> {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
@@ -334,6 +340,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         return Ok(vec![]); // disallow list all data
     }
 
+    #[tracing::instrument(name = "file_list::db::query", skip(self, _time_level))]
     async fn query(
         &self,
         org_id: &str,
@@ -417,6 +424,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::query_parallel", skip(self))]
     async fn query_parallel(
         &self,
         org_id: &str,
@@ -540,6 +548,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         Ok(files)
     }
 
+    #[tracing::instrument(name = "file_list::db::query_deleted", skip(self))]
     async fn query_deleted(
         &self,
         org_id: &str,
@@ -572,6 +581,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_min_ts", skip(self))]
     async fn get_min_ts(
         &self,
         org_id: &str,
@@ -594,6 +604,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         Ok(ret.unwrap_or_default())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_max_pk_value", skip(self))]
     async fn get_max_pk_value(&self) -> Result<i64> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -606,6 +617,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         Ok(ret.unwrap_or_default())
     }
 
+    #[tracing::instrument(name = "file_list::db::stats", skip(self))]
     async fn stats(
         &self,
         org_id: &str,
@@ -654,6 +666,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_stream_stats", skip(self))]
     async fn get_stream_stats(
         &self,
         org_id: &str,
@@ -683,6 +696,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::del_stream_stats", skip(self))]
     async fn del_stream_stats(
         &self,
         org_id: &str,
@@ -701,6 +715,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::set_stream_stats", skip(self,streams),field(stream_count=streams.len()))]
     async fn set_stream_stats(
         &self,
         org_id: &str,
@@ -789,6 +804,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::reset_stream_stats", skip(self))]
     async fn reset_stream_stats(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -802,6 +818,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::reset_stream_stats_min_ts", skip(self))]
     async fn reset_stream_stats_min_ts(
         &self,
         _org_id: &str,
@@ -829,6 +846,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::len", skip(self))]
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -858,6 +876,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::add_job", skip(self))]
     async fn add_job(
         &self,
         org_id: &str,
@@ -891,6 +910,7 @@ UPDATE stream_stats
         }
     }
 
+    #[tracing::instrument(name = "file_list::db::get_pending_jobs", skip(self))]
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
@@ -993,6 +1013,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         Ok(ret)
     }
 
+    #[tracing::instrument(name = "file_list::db::set_job_pending", skip_all,field(id_count=ids.len()))]
     async fn set_job_pending(&self, ids: &[i64]) -> Result<()> {
         let pool = CLIENT.clone();
         let sql = format!(
@@ -1012,6 +1033,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::set_job_done", skip(self))]
     async fn set_job_done(&self, id: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -1026,6 +1048,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::update_running_jobs", skip(self))]
     async fn update_running_jobs(&self, id: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -1039,6 +1062,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::check_running_jobs", skip(self))]
     async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -1058,6 +1082,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::clean_done_jobs", skip(self))]
     async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -1075,6 +1100,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_pending_jobs_count", skip(self))]
     async fn get_pending_jobs_count(&self) -> Result<stdHashMap<String, stdHashMap<String, i64>>> {
         let pool = CLIENT.clone();
 
@@ -1116,6 +1142,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
 }
 
 impl PostgresFileList {
+    #[tracing::instrument(name = "file_list::db::add", skip(self))]
     async fn inner_add(&self, table: &str, file: &str, meta: &FileMeta) -> Result<()> {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
@@ -1156,6 +1183,7 @@ INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, 
         }
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_add", skip(self, files))]
     async fn inner_batch_add(&self, table: &str, files: &[FileKey]) -> Result<()> {
         if files.is_empty() {
             return Ok(());

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -26,6 +26,7 @@ use config::{
 };
 use hashbrown::HashMap;
 use sqlx::{Executor, Pool, QueryBuilder, Row, Sqlite};
+use tracing::{info_span, Instrument};
 
 use crate::{
     db::sqlite::{CLIENT_RO, CLIENT_RW},
@@ -404,71 +405,78 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let mut tasks = Vec::with_capacity(day_partitions.len());
         for (time_start, time_end) in day_partitions {
             let stream_key = stream_key.clone();
-            tasks.push(tokio::task::spawn(async move {
-                let pool = CLIENT_RO.clone();
-                let cfg = get_config();
-                if cfg.limit.use_upper_bound_for_max_ts {
-                    // TODO: if partition is daily, we need to remove this logic
-                    let max_ts_upper_bound =
-                        time_end + cfg.limit.upper_bound_for_max_ts * 60 * 1_000_000;
-                    sqlx::query_as::<_, super::FileRecord>(
-                        r#"
+            tasks.push(
+                tokio::task::spawn(async move {
+                    let pool = CLIENT_RO.clone();
+                    let cfg = get_config();
+                    if cfg.limit.use_upper_bound_for_max_ts {
+                        // TODO: if partition is daily, we need to remove this logic
+                        let max_ts_upper_bound =
+                            time_end + cfg.limit.upper_bound_for_max_ts * 60 * 1_000_000;
+                        sqlx::query_as::<_, super::FileRecord>(
+                            r#"
 SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
     FROM file_list 
     WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4;
                         "#,
-                    )
-                    .bind(stream_key.clone())
-                    .bind(time_start)
-                    .bind(max_ts_upper_bound)
-                    .bind(time_end)
-                    .fetch_all(&pool)
-                    .await
-                    .map(|r| {
-                        r.into_iter()
-                            .map(|r| {
-                                (
-                                    "files/".to_string()
-                                        + &stream_key
-                                        + "/"
-                                        + &r.date
-                                        + "/"
-                                        + &r.file,
-                                    FileMeta::from(&r),
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                } else {
-                    sqlx::query_as::<_, super::FileRecord>(
-                        r#"
+                        )
+                        .bind(stream_key.clone())
+                        .bind(time_start)
+                        .bind(max_ts_upper_bound)
+                        .bind(time_end)
+                        .fetch_all(&pool)
+                        .await
+                        .map(|r| {
+                            r.into_iter()
+                                .map(|r| {
+                                    (
+                                        "files/".to_string()
+                                            + &stream_key
+                                            + "/"
+                                            + &r.date
+                                            + "/"
+                                            + &r.file,
+                                        FileMeta::from(&r),
+                                    )
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                    } else {
+                        sqlx::query_as::<_, super::FileRecord>(
+                            r#"
 SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
     FROM file_list 
     WHERE stream = $1 AND max_ts >= $2 AND min_ts <= $3;
                         "#,
-                    )
-                    .bind(stream_key.clone())
-                    .bind(time_start)
-                    .bind(time_end)
-                    .fetch_all(&pool)
-                    .await
-                    .map(|r| {
-                        r.into_iter()
-                            .map(|r| {
-                                (
-                                    "files/".to_string()
-                                        + &stream_key
-                                        + "/"
-                                        + &r.date
-                                        + "/"
-                                        + &r.file,
-                                    FileMeta::from(&r),
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                }
-            }));
+                        )
+                        .bind(stream_key.clone())
+                        .bind(time_start)
+                        .bind(time_end)
+                        .fetch_all(&pool)
+                        .await
+                        .map(|r| {
+                            r.into_iter()
+                                .map(|r| {
+                                    (
+                                        "files/".to_string()
+                                            + &stream_key
+                                            + "/"
+                                            + &r.date
+                                            + "/"
+                                            + &r.file,
+                                        FileMeta::from(&r),
+                                    )
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                    }
+                })
+                .instrument(info_span!(
+                    "search_partition",
+                    start_time = time_start,
+                    end_time = time_end
+                )),
+            );
         }
 
         let mut files = Vec::new();

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -76,6 +76,7 @@ impl super::FileList for SqliteFileList {
         self.inner_batch_add("file_list_history", files).await
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_remove", skip_all,field(file_count=files.len()))]
     async fn batch_remove(&self, files: &[String]) -> Result<()> {
         if files.is_empty() {
             return Ok(());
@@ -121,6 +122,7 @@ impl super::FileList for SqliteFileList {
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_add_deleted", skip(self,files),field(file_count=files.len()))]
     async fn batch_add_deleted(
         &self,
         org_id: &str,
@@ -163,6 +165,7 @@ impl super::FileList for SqliteFileList {
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_remove_deleted", skip_all,field(file_count=files.len()))]
     async fn batch_remove_deleted(&self, files: &[String]) -> Result<()> {
         if files.is_empty() {
             return Ok(());
@@ -212,6 +215,7 @@ impl super::FileList for SqliteFileList {
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::get", skip(self))]
     async fn get(&self, file: &str) -> Result<FileMeta> {
         let pool = CLIENT_RO.clone();
         let (stream_key, date_key, file_name) =
@@ -230,6 +234,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         Ok(FileMeta::from(&ret))
     }
 
+    #[tracing::instrument(name = "file_list::db::contains", skip(self))]
     async fn contains(&self, file: &str) -> Result<bool> {
         let pool = CLIENT_RO.clone();
         let (stream_key, date_key, file_name) =
@@ -248,6 +253,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         Ok(!ret.unwrap().is_empty())
     }
 
+    #[tracing::instrument(name = "file_list::db::update_flattened", skip(self))]
     async fn update_flattened(&self, file: &str, flattened: bool) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -265,6 +271,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::list", skip(self))]
     async fn list(&self) -> Result<Vec<(String, FileMeta)>> {
         let pool = CLIENT_RO.clone();
         let ret = sqlx::query_as::<_, super::FileRecord>(
@@ -283,6 +290,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::query", skip(self, _time_level))]
     async fn query(
         &self,
         org_id: &str,
@@ -358,6 +366,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::query_parallel", skip(self))]
     async fn query_parallel(
         &self,
         org_id: &str,
@@ -477,6 +486,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         Ok(files)
     }
 
+    #[tracing::instrument(name = "file_list::db::query_deleted", skip(self))]
     async fn query_deleted(
         &self,
         org_id: &str,
@@ -506,6 +516,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_min_ts", skip(self))]
     async fn get_min_ts(
         &self,
         org_id: &str,
@@ -525,6 +536,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         Ok(ret.unwrap_or_default())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_max_pk_value", skip(self))]
     async fn get_max_pk_value(&self) -> Result<i64> {
         let pool = CLIENT_RO.clone();
         let ret: Option<i64> = sqlx::query_scalar(r#"SELECT MAX(id) AS id FROM file_list;"#)
@@ -533,6 +545,7 @@ SELECT date, file, min_ts, max_ts, records, original_size, compressed_size
         Ok(ret.unwrap_or_default())
     }
 
+    #[tracing::instrument(name = "file_list::db::stats", skip(self))]
     async fn stats(
         &self,
         org_id: &str,
@@ -577,6 +590,7 @@ SELECT stream, MIN(min_ts) as min_ts, MAX(max_ts) as max_ts, COUNT(*) as file_nu
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_stream_stats", skip(self))]
     async fn get_stream_stats(
         &self,
         org_id: &str,
@@ -603,6 +617,7 @@ SELECT stream, MIN(min_ts) as min_ts, MAX(max_ts) as max_ts, COUNT(*) as file_nu
             .collect())
     }
 
+    #[tracing::instrument(name = "file_list::db::del_stream_stats", skip(self))]
     async fn del_stream_stats(
         &self,
         org_id: &str,
@@ -619,6 +634,7 @@ SELECT stream, MIN(min_ts) as min_ts, MAX(max_ts) as max_ts, COUNT(*) as file_nu
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::set_stream_stats", skip(self,streams),field(stream_count=streams.len()))]
     async fn set_stream_stats(
         &self,
         org_id: &str,
@@ -701,6 +717,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::reset_stream_stats_min_ts", skip(self, _org_id))]
     async fn reset_stream_stats_min_ts(
         &self,
         _org_id: &str,
@@ -723,6 +740,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::reset_stream_stats", skip_all)]
     async fn reset_stream_stats(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -732,6 +750,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::len", skip_all)]
     async fn len(&self) -> usize {
         let pool = CLIENT_RO.clone();
         let ret = match sqlx::query(r#"SELECT COUNT(*) as num FROM file_list;"#)
@@ -758,6 +777,7 @@ UPDATE stream_stats
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::add_job", skip(self))]
     async fn add_job(
         &self,
         org_id: &str,
@@ -788,6 +808,7 @@ UPDATE stream_stats
         }
     }
 
+    #[tracing::instrument(name = "file_list::db::get_pending_jobs", skip(self))]
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -867,6 +888,7 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         Ok(ret)
     }
 
+    #[tracing::instrument(name = "file_list::db::set_job_pending", skip_all,field(id_count=ids.len()))]
     async fn set_job_pending(&self, ids: &[i64]) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -884,6 +906,7 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::set_job_done", skip(self))]
     async fn set_job_done(&self, id: i64) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -896,6 +919,7 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::update_running_jobs", skip(self))]
     async fn update_running_jobs(&self, id: i64) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -907,6 +931,7 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::check_running_jobs", skip(self))]
     async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -924,6 +949,7 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::clean_done_jobs", skip(self))]
     async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -939,6 +965,7 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         Ok(())
     }
 
+    #[tracing::instrument(name = "file_list::db::get_pending_jobs_count", skip(self))]
     async fn get_pending_jobs_count(&self) -> Result<stdHashMap<String, stdHashMap<String, i64>>> {
         let pool = CLIENT_RO.clone();
 
@@ -1009,6 +1036,7 @@ INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, 
         }
     }
 
+    #[tracing::instrument(name = "file_list::db::batch_add", skip(self, files))]
     async fn inner_batch_add(&self, table: &str, files: &[FileKey]) -> Result<()> {
         if files.is_empty() {
             return Ok(());

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -111,6 +111,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     }
 
     /// The count of jobs for the given module (Report/Alert etc.)
+    #[tracing::instrument(name = "db::scheduler::len_module", skip(self))] 
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -137,6 +138,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
     }
 
     /// Pushes a Trigger job into the queue
+    #[tracing::instrument(name = "db::scheduler::push", skip(self))] 
     async fn push(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
@@ -190,6 +192,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     }
 
     /// Deletes the Trigger job matching the given parameters
+    #[tracing::instrument(name = "db::scheduler::delete", skip(self))] 
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -217,6 +220,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     }
 
     /// Updates the status of the Trigger job
+    #[tracing::instrument(name = "db::scheduler::update_status", skip(self))] 
     async fn update_status(
         &self,
         org: &str,
@@ -245,6 +249,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::scheduler::update_trigger", skip(self))] 
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -289,6 +294,7 @@ WHERE org = ? AND module_key = ? AND module = ?;"#,
     /// - Changes their statuses from "Waiting" to "Processing"
     /// - Commits as a single transaction
     /// - Returns the Trigger jobs
+    #[tracing::instrument(name = "db::scheduler::pull", skip(self))] 
     async fn pull(
         &self,
         concurrency: i64,
@@ -406,6 +412,7 @@ WHERE id IN ({});",
         Ok(jobs)
     }
 
+    #[tracing::instrument(name = "db::scheduler::get", skip(self))] 
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -431,6 +438,7 @@ WHERE id IN ({});",
         Ok(job)
     }
 
+    #[tracing::instrument(name = "db::scheduler::list", skip(self))] 
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -451,6 +459,7 @@ WHERE id IN ({});",
 
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
+    #[tracing::instrument(name = "db::scheduler::clean_complete", skip(self))] 
     async fn clean_complete(&self) -> Result<()> {
         let (include_max, mut max_retries) = get_scheduler_max_retries();
         if include_max {
@@ -474,6 +483,7 @@ WHERE id IN ({});",
     /// - calculate the current timestamp and difference from `start_time` of each record
     /// - Get the record ids with difference more than the given timeout
     /// - Update their status back to "Waiting" and increase their "retries" by 1
+    #[tracing::instrument(name = "db::scheduler::watch_timeout", skip(self))] 
     async fn watch_timeout(&self) -> Result<()> {
         let pool = CLIENT.clone();
         let now = chrono::Utc::now().timestamp_micros();
@@ -494,6 +504,7 @@ WHERE status = ? AND end_time <= ?
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::scheduler::len", skip(self))] 
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -522,6 +533,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
         self.len().await == 0
     }
 
+    #[tracing::instrument(name = "db::scheduler::clear", skip(self))] 
     async fn clear(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -111,7 +111,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     }
 
     /// The count of jobs for the given module (Report/Alert etc.)
-    #[tracing::instrument(name = "db::scheduler::len_module", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::len_module", skip(self))]
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -138,7 +138,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
     }
 
     /// Pushes a Trigger job into the queue
-    #[tracing::instrument(name = "db::scheduler::push", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::push", skip(self))]
     async fn push(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
@@ -192,7 +192,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     }
 
     /// Deletes the Trigger job matching the given parameters
-    #[tracing::instrument(name = "db::scheduler::delete", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::delete", skip(self))]
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -220,7 +220,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     }
 
     /// Updates the status of the Trigger job
-    #[tracing::instrument(name = "db::scheduler::update_status", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::update_status", skip(self))]
     async fn update_status(
         &self,
         org: &str,
@@ -249,7 +249,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         Ok(())
     }
 
-    #[tracing::instrument(name = "db::scheduler::update_trigger", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::update_trigger", skip(self))]
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -294,7 +294,7 @@ WHERE org = ? AND module_key = ? AND module = ?;"#,
     /// - Changes their statuses from "Waiting" to "Processing"
     /// - Commits as a single transaction
     /// - Returns the Trigger jobs
-    #[tracing::instrument(name = "db::scheduler::pull", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::pull", skip(self))]
     async fn pull(
         &self,
         concurrency: i64,
@@ -412,7 +412,7 @@ WHERE id IN ({});",
         Ok(jobs)
     }
 
-    #[tracing::instrument(name = "db::scheduler::get", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::get", skip(self))]
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -438,7 +438,7 @@ WHERE id IN ({});",
         Ok(job)
     }
 
-    #[tracing::instrument(name = "db::scheduler::list", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::list", skip(self))]
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -459,7 +459,7 @@ WHERE id IN ({});",
 
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
-    #[tracing::instrument(name = "db::scheduler::clean_complete", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::clean_complete", skip(self))]
     async fn clean_complete(&self) -> Result<()> {
         let (include_max, mut max_retries) = get_scheduler_max_retries();
         if include_max {
@@ -483,7 +483,7 @@ WHERE id IN ({});",
     /// - calculate the current timestamp and difference from `start_time` of each record
     /// - Get the record ids with difference more than the given timeout
     /// - Update their status back to "Waiting" and increase their "retries" by 1
-    #[tracing::instrument(name = "db::scheduler::watch_timeout", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::watch_timeout", skip(self))]
     async fn watch_timeout(&self) -> Result<()> {
         let pool = CLIENT.clone();
         let now = chrono::Utc::now().timestamp_micros();
@@ -504,7 +504,7 @@ WHERE status = ? AND end_time <= ?
         Ok(())
     }
 
-    #[tracing::instrument(name = "db::scheduler::len", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::len", skip(self))]
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -533,7 +533,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
         self.len().await == 0
     }
 
-    #[tracing::instrument(name = "db::scheduler::clear", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::clear", skip(self))]
     async fn clear(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -105,7 +105,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     }
 
     /// The count of jobs for the given module (Report/Alert etc.)
-    #[tracing::instrument(name = "db::scheduler::len_module", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::len_module", skip(self))]
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -132,7 +132,7 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs WHERE module = $1;"#,
     }
 
     /// Pushes a Trigger job into the queue
-    #[tracing::instrument(name = "db::scheduler::push", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::push", skip(self))]
     async fn push(&self, trigger: Trigger) -> Result<()> {
         // let db = db::get_db().await;
         let pool = CLIENT.clone();
@@ -187,7 +187,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     }
 
     /// Deletes the Trigger job matching the given parameters
-    #[tracing::instrument(name = "db::scheduler::delete", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::delete", skip(self))]
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -215,7 +215,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     }
 
     /// Updates the status of the Trigger job
-    #[tracing::instrument(name = "db::scheduler::update_status", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::update_status", skip(self))]
     async fn update_status(
         &self,
         org: &str,
@@ -244,7 +244,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         Ok(())
     }
 
-    #[tracing::instrument(name = "db::scheduler::update_trigger", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::update_trigger", skip(self))]
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -289,7 +289,7 @@ WHERE org = $7 AND module_key = $8 AND module = $9;"#,
     /// - Changes their statuses from "Waiting" to "Processing"
     /// - Commits as a single transaction
     /// - Returns the Trigger jobs
-    #[tracing::instrument(name = "db::scheduler::pull", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::pull", skip(self))]
     async fn pull(
         &self,
         concurrency: i64,
@@ -364,7 +364,7 @@ RETURNING *;"#;
         Ok(jobs)
     }
 
-    #[tracing::instrument(name = "db::scheduler::get", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::get", skip(self))]
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -391,7 +391,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
         Ok(job)
     }
 
-    #[tracing::instrument(name = "db::scheduler::list", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::list", skip(self))]
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -412,7 +412,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
 
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
-    #[tracing::instrument(name = "db::scheduler::clean_complete", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::clean_complete", skip(self))]
     async fn clean_complete(&self) -> Result<()> {
         let pool = CLIENT.clone();
         let (include_max, mut max_retries) = get_scheduler_max_retries();
@@ -436,7 +436,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
     /// - calculate the current timestamp and difference from `start_time` of each record
     /// - Get the record ids with difference more than the given timeout
     /// - Update their status back to "Waiting" and increase their "retries" by 1
-    #[tracing::instrument(name = "db::scheduler::watch_timeout", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::watch_timeout", skip(self))]
     async fn watch_timeout(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -457,7 +457,7 @@ WHERE status = $2 AND end_time <= $3;
         Ok(())
     }
 
-    #[tracing::instrument(name = "db::scheduler::len", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::len", skip(self))]
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -486,7 +486,7 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs;"#,
         self.len().await == 0
     }
 
-    #[tracing::instrument(name = "db::scheduler::clear", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::clear", skip(self))]
     async fn clear(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -105,6 +105,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     }
 
     /// The count of jobs for the given module (Report/Alert etc.)
+    #[tracing::instrument(name = "db::scheduler::len_module", skip(self))] 
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -131,6 +132,7 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs WHERE module = $1;"#,
     }
 
     /// Pushes a Trigger job into the queue
+    #[tracing::instrument(name = "db::scheduler::push", skip(self))] 
     async fn push(&self, trigger: Trigger) -> Result<()> {
         // let db = db::get_db().await;
         let pool = CLIENT.clone();
@@ -185,6 +187,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     }
 
     /// Deletes the Trigger job matching the given parameters
+    #[tracing::instrument(name = "db::scheduler::delete", skip(self))] 
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -212,6 +215,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     }
 
     /// Updates the status of the Trigger job
+    #[tracing::instrument(name = "db::scheduler::update_status", skip(self))] 
     async fn update_status(
         &self,
         org: &str,
@@ -240,6 +244,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::scheduler::update_trigger", skip(self))] 
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -284,6 +289,7 @@ WHERE org = $7 AND module_key = $8 AND module = $9;"#,
     /// - Changes their statuses from "Waiting" to "Processing"
     /// - Commits as a single transaction
     /// - Returns the Trigger jobs
+    #[tracing::instrument(name = "db::scheduler::pull", skip(self))] 
     async fn pull(
         &self,
         concurrency: i64,
@@ -358,6 +364,7 @@ RETURNING *;"#;
         Ok(jobs)
     }
 
+    #[tracing::instrument(name = "db::scheduler::get", skip(self))] 
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -384,6 +391,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
         Ok(job)
     }
 
+    #[tracing::instrument(name = "db::scheduler::list", skip(self))] 
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -404,6 +412,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
 
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
+    #[tracing::instrument(name = "db::scheduler::clean_complete", skip(self))] 
     async fn clean_complete(&self) -> Result<()> {
         let pool = CLIENT.clone();
         let (include_max, mut max_retries) = get_scheduler_max_retries();
@@ -427,6 +436,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
     /// - calculate the current timestamp and difference from `start_time` of each record
     /// - Get the record ids with difference more than the given timeout
     /// - Update their status back to "Waiting" and increase their "retries" by 1
+    #[tracing::instrument(name = "db::scheduler::watch_timeout", skip(self))] 
     async fn watch_timeout(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -447,6 +457,7 @@ WHERE status = $2 AND end_time <= $3;
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::scheduler::len", skip(self))] 
     async fn len(&self) -> usize {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -475,6 +486,7 @@ SELECT COUNT(*)::BIGINT AS num FROM scheduled_jobs;"#,
         self.len().await == 0
     }
 
+    #[tracing::instrument(name = "db::scheduler::clear", skip(self))] 
     async fn clear(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -91,6 +91,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     }
 
     /// The count of jobs for the given module (Report/Alert etc.)
+    #[tracing::instrument(name = "db::scheduler::len_module", skip(self))] 
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT_RO.clone();
         let ret = match sqlx::query(
@@ -114,6 +115,7 @@ SELECT COUNT(*) as num FROM scheduled_jobs WHERE module = $1;"#,
     }
 
     /// Pushes a Trigger job into the queue
+    #[tracing::instrument(name = "db::scheduler::push", skip(self))] 
     async fn push(&self, trigger: Trigger) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -174,6 +176,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     }
 
     /// Deletes the Trigger job matching the given parameters
+    #[tracing::instrument(name = "db::scheduler::delete", skip(self))] 
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -201,6 +204,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     }
 
     /// Updates the status of the Trigger job
+    #[tracing::instrument(name = "db::scheduler::update_status", skip(self))] 
     async fn update_status(
         &self,
         org: &str,
@@ -229,6 +233,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::scheduler::update_trigger", skip(self))] 
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -274,6 +279,7 @@ WHERE org = $7 AND module_key = $8 AND module = $9;"#,
     /// - Changes their statuses from "Waiting" to "Processing"
     /// - Commits as a single transaction
     /// - Returns the Trigger jobs
+    #[tracing::instrument(name = "db::scheduler::pull", skip(self))] 
     async fn pull(
         &self,
         concurrency: i64,
@@ -330,6 +336,7 @@ RETURNING *;"#;
         Ok(jobs)
     }
 
+    #[tracing::instrument(name = "db::scheduler::get", skip(self))] 
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT_RO.clone();
         let query = r#"
@@ -353,6 +360,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
         Ok(job)
     }
 
+    #[tracing::instrument(name = "db::scheduler::list", skip(self))] 
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let client = CLIENT_RO.clone();
         let jobs: Vec<Trigger> = if let Some(module) = module {
@@ -372,6 +380,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
 
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
+    #[tracing::instrument(name = "db::scheduler::clean_complete", skip(self))] 
     async fn clean_complete(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -393,6 +402,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
     /// - calculate the current timestamp and difference from `start_time` of each record
     /// - Get the record ids with difference more than the given timeout
     /// - Update their status back to "Waiting" and increase their "retries" by 1
+    #[tracing::instrument(name = "db::scheduler::watch_timeout", skip(self))] 
     async fn watch_timeout(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -411,6 +421,7 @@ WHERE status = $2 AND end_time <= $3;
         Ok(())
     }
 
+    #[tracing::instrument(name = "db::scheduler::len", skip(self))] 
     async fn len(&self) -> usize {
         let pool = CLIENT_RO.clone();
         let ret = match sqlx::query(
@@ -436,6 +447,7 @@ SELECT COUNT(*) as num FROM scheduled_jobs;"#,
         self.len().await == 0
     }
 
+    #[tracing::instrument(name = "db::scheduler::clear", skip(self))] 
     async fn clear(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -91,7 +91,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     }
 
     /// The count of jobs for the given module (Report/Alert etc.)
-    #[tracing::instrument(name = "db::scheduler::len_module", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::len_module", skip(self))]
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT_RO.clone();
         let ret = match sqlx::query(
@@ -115,7 +115,7 @@ SELECT COUNT(*) as num FROM scheduled_jobs WHERE module = $1;"#,
     }
 
     /// Pushes a Trigger job into the queue
-    #[tracing::instrument(name = "db::scheduler::push", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::push", skip(self))]
     async fn push(&self, trigger: Trigger) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -176,7 +176,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     }
 
     /// Deletes the Trigger job matching the given parameters
-    #[tracing::instrument(name = "db::scheduler::delete", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::delete", skip(self))]
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -204,7 +204,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
     }
 
     /// Updates the status of the Trigger job
-    #[tracing::instrument(name = "db::scheduler::update_status", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::update_status", skip(self))]
     async fn update_status(
         &self,
         org: &str,
@@ -233,7 +233,7 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         Ok(())
     }
 
-    #[tracing::instrument(name = "db::scheduler::update_trigger", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::update_trigger", skip(self))]
     async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -279,7 +279,7 @@ WHERE org = $7 AND module_key = $8 AND module = $9;"#,
     /// - Changes their statuses from "Waiting" to "Processing"
     /// - Commits as a single transaction
     /// - Returns the Trigger jobs
-    #[tracing::instrument(name = "db::scheduler::pull", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::pull", skip(self))]
     async fn pull(
         &self,
         concurrency: i64,
@@ -336,7 +336,7 @@ RETURNING *;"#;
         Ok(jobs)
     }
 
-    #[tracing::instrument(name = "db::scheduler::get", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::get", skip(self))]
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT_RO.clone();
         let query = r#"
@@ -360,7 +360,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
         Ok(job)
     }
 
-    #[tracing::instrument(name = "db::scheduler::list", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::list", skip(self))]
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let client = CLIENT_RO.clone();
         let jobs: Vec<Trigger> = if let Some(module) = module {
@@ -380,7 +380,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
 
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
-    #[tracing::instrument(name = "db::scheduler::clean_complete", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::clean_complete", skip(self))]
     async fn clean_complete(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -402,7 +402,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
     /// - calculate the current timestamp and difference from `start_time` of each record
     /// - Get the record ids with difference more than the given timeout
     /// - Update their status back to "Waiting" and increase their "retries" by 1
-    #[tracing::instrument(name = "db::scheduler::watch_timeout", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::watch_timeout", skip(self))]
     async fn watch_timeout(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -421,7 +421,7 @@ WHERE status = $2 AND end_time <= $3;
         Ok(())
     }
 
-    #[tracing::instrument(name = "db::scheduler::len", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::len", skip(self))]
     async fn len(&self) -> usize {
         let pool = CLIENT_RO.clone();
         let ret = match sqlx::query(
@@ -447,7 +447,7 @@ SELECT COUNT(*) as num FROM scheduled_jobs;"#,
         self.len().await == 0
     }
 
-    #[tracing::instrument(name = "db::scheduler::clear", skip(self))] 
+    #[tracing::instrument(name = "db::scheduler::clear", skip(self))]
     async fn clear(&self) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;

--- a/src/infra/src/schema/history/mysql.rs
+++ b/src/infra/src/schema/history/mysql.rs
@@ -46,6 +46,7 @@ impl super::SchemaHistory for MysqlSchemaHistory {
         create_table_index().await
     }
 
+    #[tracing::instrument(name = "db::schema_history::create", skip(self))] 
     async fn create(
         &self,
         org_id: &str,

--- a/src/infra/src/schema/history/mysql.rs
+++ b/src/infra/src/schema/history/mysql.rs
@@ -46,7 +46,7 @@ impl super::SchemaHistory for MysqlSchemaHistory {
         create_table_index().await
     }
 
-    #[tracing::instrument(name = "db::schema_history::create", skip(self))] 
+    #[tracing::instrument(name = "db::schema_history::create", skip(self))]
     async fn create(
         &self,
         org_id: &str,

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -46,6 +46,7 @@ impl super::SchemaHistory for PostgresSchemaHistory {
         create_table_index().await
     }
 
+    #[tracing::instrument(name = "db::schema_history::create", skip(self))] 
     async fn create(
         &self,
         org_id: &str,

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -46,7 +46,7 @@ impl super::SchemaHistory for PostgresSchemaHistory {
         create_table_index().await
     }
 
-    #[tracing::instrument(name = "db::schema_history::create", skip(self))] 
+    #[tracing::instrument(name = "db::schema_history::create", skip(self))]
     async fn create(
         &self,
         org_id: &str,

--- a/src/infra/src/schema/history/sqlite.rs
+++ b/src/infra/src/schema/history/sqlite.rs
@@ -46,7 +46,7 @@ impl super::SchemaHistory for SqliteSchemaHistory {
         create_table_index().await
     }
 
-    #[tracing::instrument(name = "db::schema_history::create", skip(self))] 
+    #[tracing::instrument(name = "db::schema_history::create", skip(self))]
     async fn create(
         &self,
         org_id: &str,

--- a/src/infra/src/schema/history/sqlite.rs
+++ b/src/infra/src/schema/history/sqlite.rs
@@ -46,6 +46,7 @@ impl super::SchemaHistory for SqliteSchemaHistory {
         create_table_index().await
     }
 
+    #[tracing::instrument(name = "db::schema_history::create", skip(self))] 
     async fn create(
         &self,
         org_id: &str,

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -1007,6 +1007,7 @@ pub async fn cancel_query(
 }
 
 /// match a source is a valid file or not
+#[tracing::instrument(name = "service::search::match_source", skip(stream, filters))]
 pub async fn match_source(
     stream: StreamParams,
     time_range: Option<(i64, i64)>,

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -579,6 +579,10 @@ impl Sql {
     }
 
     /// match a source is a valid file or not
+    #[tracing::instrument(
+        name = "service::search::sql::match_source",
+        skip(self, source, partition_keys)
+    )]
     pub async fn match_source(
         &self,
         source: &FileKey,


### PR DESCRIPTION
This adds traces to db related operations, so we can get a better idea when debugging via traces of how much time db operations are taking. There are no code logic changes, only tracing instrument macros are added. A couple of major diff are just space changes after running `cargo fmt`.