### PR TITLE
fix: unit test for join order

### DIFF
--- a/src/common/meta/dashboards/v5/mod.rs
+++ b/src/common/meta/dashboards/v5/mod.rs
@@ -308,7 +308,7 @@ pub struct Field {
 #[serde(rename_all = "camelCase")]
 pub struct Config {
     #[serde(rename = "type")]
-    typee: String, 
+    typee: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<Value>,
 }
@@ -473,7 +473,7 @@ pub struct LegendWidth {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct LabelOption {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub position:  Option<LabelPosition>,
+    pub position: Option<LabelPosition>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rotate: Option<f64>,
 }
@@ -497,5 +497,5 @@ pub enum LabelPosition {
     Top,
     Inside,
     InsideTop,
-    InsideBottom
+    InsideBottom,
 }

--- a/src/service/search/datafusion/optimizer/join_reorder.rs
+++ b/src/service/search/datafusion/optimizer/join_reorder.rs
@@ -140,7 +140,7 @@ mod tests {
         .unwrap();
 
         let state = SessionStateBuilder::new()
-            .with_config(SessionConfig::new())
+            .with_config(SessionConfig::new().with_target_partitions(12))
             .with_runtime_env(Arc::new(RuntimeEnv::new(RuntimeConfig::default()).unwrap()))
             .with_default_features()
             .with_physical_optimizer_rule(Arc::new(JoinReorderRule::new()))


### PR DESCRIPTION
fix unit test and some change from cargo fmt && cargo clippy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved syntax correctness in struct and enum definitions for better code stability.
  
- **New Features**
	- Enhanced optimization logic for the execution plan in the join reordering process.
	- Updated session configuration to target 12 partitions for improved performance during tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->