### PR TITLE
fix: remove trace from match_source

### DIFF
--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -252,7 +252,7 @@ impl super::Db for PostgresDb {
         } else {
             DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
             match sqlx::query_as::<_,super::MetaRecord>(
-                r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = $1 AND key1 = $2 AND key2 = $3 start_dt DESC, id DESC;"#
+                r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = $1 AND key1 = $2 AND key2 = $3 ORDER BY start_dt DESC, id DESC;"#
             )
             .bind(&module)
             .bind(&key1)

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -352,7 +352,7 @@ impl super::Db for SqliteDb {
             }
         } else {
             match sqlx::query_as::<_,super::MetaRecord>(
-                r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = $1 AND key1 = $2 AND key2 = $3 start_dt DESC, id DESC;"#
+                r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = $1 AND key1 = $2 AND key2 = $3 ORDER BY start_dt DESC, id DESC;"#
             )
             .bind(&module)
             .bind(&key1)

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -1007,7 +1007,6 @@ pub async fn cancel_query(
 }
 
 /// match a source is a valid file or not
-#[tracing::instrument(name = "service::search::match_source", skip(stream, filters))]
 pub async fn match_source(
     stream: StreamParams,
     time_range: Option<(i64, i64)>,

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -579,10 +579,6 @@ impl Sql {
     }
 
     /// match a source is a valid file or not
-    #[tracing::instrument(
-        name = "service::search::sql::match_source",
-        skip(self, source, partition_keys)
-    )]
     pub async fn match_source(
         &self,
         source: &FileKey,


### PR DESCRIPTION
This removes traces from `match_source` functions, as they create a lot of noise without any useful info.