### PR TITLE
feat: Expand logs query editor with a button

### DIFF
--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -543,8 +543,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
       </div>
     </div>
-    <div class="row query-editor-container" v-show="searchObj.meta.showQuery">
-      <div class="col" style="border-top: 1px solid #dbdbdb; height: 100%">
+
+    <div class="row query-editor-container" v-show="searchObj.meta.showQuery"  >
+
+      <div class="col" style="border-top: 1px solid #dbdbdb; height: 100%;" :class="{ 'expand-on-focus': isFocused }" :style="backgroundColorStyle"
+      >
         <q-splitter
           class="logs-search-splitter"
           no-scroll
@@ -553,6 +556,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           style="width: 100%; height: 100%"
         >
           <template #before>
+
             <query-editor
               data-test="logs-search-bar-query-editor"
               editor-id="logsQueryEditor"
@@ -1121,6 +1125,8 @@ export default defineComponent({
     const savedFunctionSelectedName: string = ref("");
     const saveFunctionLoader = ref(false);
 
+    const isFocused = ref(false);
+
     // confirm dialog for logs visualization toggle
     const confirmLogsVisualizeModeChangeDialog = ref(false);
 
@@ -1176,6 +1182,20 @@ export default defineComponent({
       { immediate: true, deep: true }
     );
 
+    watch(
+     [ () => searchObj.meta.functionEditorPlaceholderFlag, () => searchObj.meta.queryEditorPlaceholderFlag],
+      (values) => {
+        if(values[0] == true && values[1] == true){
+          //this is for non focus mode
+          isFocused.value = false;
+          console.log(values)
+        }
+        else{
+          //this for focus mode
+          isFocused.value = true;
+        }
+      }
+    );
     watch(
       () => searchObj.data.stream.functions,
       (funs) => {
@@ -2566,6 +2586,11 @@ export default defineComponent({
 
       return searchIds.flat() as string[];
     });
+    const backgroundColorStyle = computed(() => {
+      return {
+        backgroundColor: (searchObj.meta.toggleFunction == true && isFocused.value == true) ? '#575A5A' : '' // Yellow if true, white if false
+      };
+    });
     const { traceIdRef, cancelQuery: cancelVisualizeQuery } = useCancelQuery();
 
     const cancelVisualizeQueries = () => {
@@ -2665,6 +2690,8 @@ export default defineComponent({
       visualizeSearchRequestTraceIds,
       disable,
       cancelVisualizeQueries,
+      isFocused,
+      backgroundColorStyle,
     };
   },
   computed: {
@@ -3205,5 +3232,14 @@ export default defineComponent({
     background-color: var(--q-primary) !important;
     color: white;
   }
+}
+
+
+</style>
+<style scoped>
+.expand-on-focus{
+  height: 700px !important;
+  z-index: 20 !important;
+  border-bottom: 2px solid #575A5A;
 }
 </style>

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -605,6 +605,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </template>
         </q-splitter>
       </div>
+      <q-btn
+        data-test="logs-search-field-list-collapse-btn"
+        :icon="isFocused ? 'fullscreen_exit' : 'fullscreen'"
+        :title="isFocused ? 'Collapse' : 'Expand'"
+        dense
+        size="10px"
+        round
+        class="field-list-collapse-btn"
+        color="primary"
+        @click="isFocused = !isFocused"
+        style="position: absolute; top: 42px; right: 10px; z-index: 20;"
+      ></q-btn>
     </div>
 
     <q-dialog ref="confirmDialog" v-model="confirmDialogVisible">
@@ -1188,11 +1200,6 @@ export default defineComponent({
         if(values[0] == true && values[1] == true){
           //this is for non focus mode
           isFocused.value = false;
-          console.log(values)
-        }
-        else{
-          //this for focus mode
-          isFocused.value = true;
         }
       }
     );
@@ -1362,6 +1369,11 @@ export default defineComponent({
         console.log(e, "Logs: Error while updating query value");
       }
     };
+    const  handleEscKey = (event: KeyboardEvent) =>{
+      if (event.key === 'Escape') {
+        isFocused.value = false;       
+      }
+    }
 
     const updateDateTime = async (value: object) => {
       if (
@@ -1502,12 +1514,15 @@ export default defineComponent({
         fnEditorRef?.value?.resetEditorLayout();
         searchObj.config.fnSplitterModel = 60;
       }
+      window.addEventListener('keydown', handleEscKey);
+
     });
 
     onUnmounted(() => {
       window.removeEventListener("click", () => {
         fnEditorRef?.value?.resetEditorLayout();
       });
+      window.removeEventListener('keydown', handleEscKey);
     });
 
     onActivated(() => {

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -607,7 +607,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </q-splitter>
       </div>
       <q-btn
-        data-test="logs-search-field-list-collapse-btn"
+        data-test="logs-query-editor-full_screen-btn"
         :icon="isFocused ? 'fullscreen_exit' : 'fullscreen'"
         :title="isFocused ? 'Collapse' : 'Expand'"
         dense

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -613,7 +613,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         dense
         size="10px"
         round
-        class="field-list-collapse-btn"
         color="primary"
         @click="isFocused = !isFocused"
         style="position: absolute; top: 42px; right: 10px; z-index: 20;"

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -1193,16 +1193,6 @@ export default defineComponent({
       },
       { immediate: true, deep: true }
     );
-
-    watch(
-     [ () => searchObj.meta.functionEditorPlaceholderFlag, () => searchObj.meta.queryEditorPlaceholderFlag],
-      (values) => {
-        if(values[0] == true && values[1] == true){
-          //this is for non focus mode
-          isFocused.value = false;
-        }
-      }
-    );
     watch(
       () => searchObj.data.stream.functions,
       (funs) => {

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -562,7 +562,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               editor-id="logsQueryEditor"
               ref="queryEditorRef"
               class="monaco-editor"
-
+              :style="editorWidthToggleFunction"
               v-model:query="searchObj.data.query"
               :keywords="autoCompleteKeywords"
               :suggestions="autoCompleteSuggestions"
@@ -948,7 +948,7 @@ import {
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { useStore } from "vuex";
-import { useQuasar, copyToClipboard } from "quasar";
+import { useQuasar, copyToClipboard, is } from "quasar";
 
 import DateTime from "@/components/DateTime.vue";
 import useLogs from "@/composables/useLogs";
@@ -2593,9 +2593,30 @@ export default defineComponent({
       return searchIds.flat() as string[];
     });
     const backgroundColorStyle = computed(() => {
+      const isDarkMode = store.state.theme === 'dark';
       return {
-        backgroundColor: (searchObj.meta.toggleFunction == true && isFocused.value == true) ? '#575A5A' : '' // Yellow if true, white if false
+        backgroundColor: (searchObj.meta.toggleFunction && isFocused.value)
+          ? (isDarkMode ? '#575A5A' : '#E0E0E0')  // Dark mode: grey, Light mode: yellow (or any color)
+          : '',
+          borderBottom: (searchObj.meta.toggleFunction && isFocused.value) ?
+          (isDarkMode ? '2px solid #575A5A ' : '2px solid #E0E0E0') : 'none',
       };
+    });
+    const editorWidthToggleFunction = computed(() => {
+      const isDarkMode = store.state.theme === 'dark';
+
+      if(!searchObj.meta.toggleFunction && isFocused.value){
+        return {
+          width: `calc(100 - ${searchObj.config.fnSplitterModel})%`,
+          borderBottom: (isDarkMode ? '2px solid #575A5A' : '2px solid #E0E0E0'),
+        };
+      }
+      else{
+        return {
+          width: '100%',
+          borderBottom: 'none'
+        }
+      }
     });
     const { traceIdRef, cancelQuery: cancelVisualizeQuery } = useCancelQuery();
 
@@ -2698,6 +2719,7 @@ export default defineComponent({
       cancelVisualizeQueries,
       isFocused,
       backgroundColorStyle,
+      editorWidthToggleFunction,
     };
   },
   computed: {

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -562,6 +562,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               editor-id="logsQueryEditor"
               ref="queryEditorRef"
               class="monaco-editor"
+
               v-model:query="searchObj.data.query"
               :keywords="autoCompleteKeywords"
               :suggestions="autoCompleteSuggestions"
@@ -3242,9 +3243,8 @@ export default defineComponent({
 
 </style>
 <style scoped>
-.expand-on-focus{
-  height: 700px !important;
+.expand-on-focus {
+  height: calc(100vh - 200px) !important;
   z-index: 20 !important;
-  border-bottom: 2px solid #575A5A;
 }
 </style>


### PR DESCRIPTION
1.This feat includes an expand button along with if user looses focus or press ESC button the query editor will be shrinked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a toggle button for expanding and collapsing the query editor in the logs search interface.
	- Dynamic icon and title updates for the toggle button based on editor state.
	- Added keyboard shortcut (Escape key) to quickly collapse the editor.

- **Improvements**
	- Enhanced user experience with conditional background color for the focused editor.
	- Refined layout and styling for a consistent user interface.
	- Adjusted editor width based on toggle state and focus status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->