### PR TITLE
feat: configurable thread number for usage reporting job

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -890,6 +890,8 @@ pub struct Limit {
     pub file_merge_thread_num: usize,
     #[env_config(name = "ZO_MEM_DUMP_THREAD_NUM", default = 0)]
     pub mem_dump_thread_num: usize,
+    #[env_config(name = "ZO_USAGE_REPORTING_THREAD_NUM", default = 0)]
+    pub usage_reporting_thread_num: usize,
     #[env_config(name = "ZO_QUERY_THREAD_NUM", default = 0)]
     pub query_thread_num: usize,
     #[env_config(name = "ZO_QUERY_TIMEOUT", default = 600)]
@@ -1404,6 +1406,14 @@ pub fn init() -> Config {
     // HACK for mem_dump_thread_num equal to CPU core
     if cfg.limit.mem_dump_thread_num == 0 {
         cfg.limit.mem_dump_thread_num = cpu_num;
+    }
+    // HACK for usage_reporting_thread_num equal to half of CPU core
+    if cfg.limit.usage_reporting_thread_num == 0 {
+        if cfg.common.local_mode {
+            cfg.limit.usage_reporting_thread_num = std::cmp::max(1, cpu_num / 2);
+        } else {
+            cfg.limit.usage_reporting_thread_num = cpu_num;
+        }
     }
     if cfg.limit.file_push_interval == 0 {
         cfg.limit.file_push_interval = 10;

--- a/src/service/usage/mod.rs
+++ b/src/service/usage/mod.rs
@@ -49,7 +49,9 @@ fn initialize_usage_queuer() -> UsageQueuer {
     let timeout = time::Duration::from_secs(cfg.common.usage_publish_interval.try_into().unwrap());
     let batch_size = cfg.common.usage_batch_size;
 
-    let (msg_sender, msg_receiver) = mpsc::channel::<UsageMessage>(batch_size * 2);
+    let (msg_sender, msg_receiver) = mpsc::channel::<UsageMessage>(
+        batch_size * std::cmp::max(2, cfg.limit.usage_reporting_thread_num),
+    );
     let msg_receiver = Arc::new(Mutex::new(msg_receiver));
 
     // configurable number of threads for usage_reporting

--- a/src/service/usage/mod.rs
+++ b/src/service/usage/mod.rs
@@ -36,7 +36,7 @@ use once_cell::sync::Lazy;
 use proto::cluster_rpc;
 use reqwest::Client;
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::{mpsc, oneshot, Mutex},
     time,
 };
 
@@ -50,8 +50,15 @@ fn initialize_usage_queuer() -> UsageQueuer {
     let batch_size = cfg.common.usage_batch_size;
 
     let (msg_sender, msg_receiver) = mpsc::channel::<UsageMessage>(batch_size * 2);
+    let msg_receiver = Arc::new(Mutex::new(msg_receiver));
 
-    tokio::task::spawn(async move { ingest_usage_job(msg_receiver, batch_size, timeout).await });
+    // configurable number of threads for usage_reporting
+    for thread_id in 0..cfg.limit.usage_reporting_thread_num {
+        let msg_receiver = msg_receiver.clone();
+        tokio::task::spawn(async move {
+            ingest_usage_job(thread_id, msg_receiver, batch_size, timeout).await
+        });
+    }
 
     UsageQueuer::new(msg_sender)
 }
@@ -69,16 +76,16 @@ pub async fn run() {
         .send(UsageMessage::Ping(ping_sender))
         .await
     {
-        log::error!("Failed to initialize usage queuer: {e}");
+        log::error!("[USAGE] Failed to initialize usage queuer: {e}");
         return;
     }
 
     if let Err(e) = ping_receiver.await {
-        log::error!("Usage queuer initialization failed: {e}");
+        log::error!("[USAGE] Usage queuer initialization failed: {e}");
         return;
     }
 
-    log::debug!("Usage queuer initialized successfully");
+    log::debug!("[USAGE] Usage queuer initialized successfully");
 }
 
 pub async fn report_request_usage_stats(
@@ -194,7 +201,7 @@ async fn publish_usage(usage: Vec<UsageData>) {
         return;
     }
 
-    match USAGE_QUEUER
+    if let Err(e) = USAGE_QUEUER
         .enqueue(
             usage
                 .into_iter()
@@ -203,13 +210,8 @@ async fn publish_usage(usage: Vec<UsageData>) {
         )
         .await
     {
-        Err(e) => {
-            log::error!("Failed to send usage data to background ingesting job: {e}")
-        }
-        Ok(()) => {
-            log::debug!("Successfully queued usage data to be ingested")
-        }
-    }
+        log::error!("[USAGE] Failed to send usage data to background ingesting job: {e}")
+    };
 }
 
 pub async fn publish_triggers_usage(trigger: TriggerData) {
@@ -223,10 +225,12 @@ pub async fn publish_triggers_usage(trigger: TriggerData) {
         .await
     {
         Err(e) => {
-            log::error!("Failed to send trigger usage data to background ingesting job: {e}")
+            log::error!(
+                "[USAGE] Failed to send trigger usage data to background ingesting job: {e}"
+            )
         }
         Ok(()) => {
-            log::debug!("Successfully queued trigger usage data to be ingested")
+            log::debug!("[USAGE] Successfully queued trigger usage data to be ingested")
         }
     }
 }
@@ -237,17 +241,19 @@ pub async fn flush() {
     flush_audit().await;
 
     // shutdown usage_queuer
-    let (res_sender, res_receiver) = oneshot::channel();
-    if let Err(e) = USAGE_QUEUER.shutdown(res_sender).await {
-        log::error!("Error shutting down USAGE_QUEUER: {e}");
+    for _ in 0..get_config().limit.usage_reporting_thread_num {
+        let (res_sender, res_receiver) = oneshot::channel();
+        if let Err(e) = USAGE_QUEUER.shutdown(res_sender).await {
+            log::error!("[USAGE] Error shutting down USAGE_QUEUER: {e}");
+        }
+        // wait for flush ingestion job
+        res_receiver.await.ok();
     }
-    // wait for flush ingestion job
-    res_receiver.await.ok();
 }
 
 async fn ingest_usages(curr_usages: Vec<UsageData>) {
     if curr_usages.is_empty() {
-        log::info!(" Returning as no usages reported ");
+        log::info!("Returning as no usages reported ");
         return;
     }
     let mut groups: HashMap<GroupKey, AggregatedData> = HashMap::new();
@@ -503,36 +509,40 @@ impl UsageReportRunner {
 /// Ingestion happens when either the batch_size or the timeout is exceeded, whichever satisfies the
 /// first.
 async fn ingest_usage_job(
-    mut msg_receiver: mpsc::Receiver<UsageMessage>,
+    thread_id: usize,
+    msg_receiver: Arc<Mutex<mpsc::Receiver<UsageMessage>>>,
     batch_size: usize,
     timeout: time::Duration,
 ) {
+    log::debug!("[USAGE:JOB] thread_{thread_id} starts waiting for reporting jobs");
     let mut usage_report_runner = UsageReportRunner::new(batch_size, timeout);
     let mut interval = time::interval(timeout);
 
     loop {
+        let mut msg_receiver = msg_receiver.lock().await;
         tokio::select! {
             msg = msg_receiver.recv() => {
                 match msg {
                     Some(UsageMessage::Data(usage_buf)) => {
+                        log::debug!("[USAGE:JOB] thread_{thread_id} received and queued {} messages.", usage_buf.len());
                         usage_report_runner.push(usage_buf);
                         if usage_report_runner.should_process() {
                             let buffered = usage_report_runner.take_batch();
-                            ingest_buffered_usage(buffered).await;
+                            ingest_buffered_usage(thread_id, buffered).await;
                         }
                     }
                     Some(UsageMessage::Shutdown(res_sender)) => {
-                        log::debug!("Received shutdown signal");
+                        log::debug!("[USAGE:JOB] thread_{thread_id} received shutdown signal");
                         // process any remaining data before shutting down
                         if !usage_report_runner.pending.is_empty() {
                             let buffered = usage_report_runner.take_batch();
-                            ingest_buffered_usage(buffered).await;
+                            ingest_buffered_usage(thread_id, buffered).await;
                         }
                         res_sender.send(()).ok();
                         break;
                     }
                     Some(UsageMessage::Ping(ping_sender)) => {
-                        log::debug!("Received initialization ping");
+                        log::debug!("[USAGE:JOB] thread_{thread_id} received initialization ping");
                         ping_sender.send(()).ok();
                     }
                     None => break, // channel closed
@@ -541,15 +551,18 @@ async fn ingest_usage_job(
             _ = interval.tick() => {
                 if usage_report_runner.should_process() {
                     let buffered = usage_report_runner.take_batch();
-                    ingest_buffered_usage(buffered).await;
+                    ingest_buffered_usage(thread_id, buffered).await;
                 }
             }
         }
     }
 }
 
-async fn ingest_buffered_usage(usage_buffer: Vec<UsageBuffer>) {
-    log::debug!("Ingest {} buffered usage data", usage_buffer.len());
+async fn ingest_buffered_usage(thread_id: usize, usage_buffer: Vec<UsageBuffer>) {
+    log::debug!(
+        "[USAGE:JOB] thread_{thread_id} ingests {} buffered usage data",
+        usage_buffer.len()
+    );
     let (mut usage_data, mut trigger_data) = (Vec::new(), Vec::new());
     for item in usage_buffer {
         match item {


### PR DESCRIPTION
impl #4974 

envs to configure usage reporting jobs:
1. `ZO_USAGE_REPORTING_THREAD_NUM`: number of threads handling the background usage reporting job.
     default: 0
       -> local_mode: `cpu_num / 2`
       -> distributed: `cpu_num`
2. `ZO_USAGE_BATCH_SIZE`: num of usage data to be buffered in memory before all buffered is ingested into usage org
     default: 2,000
     applied to each thread
3. `ZO_USAGE_PUBLISH_INTERVAL`: max num of seconds between each ingestion, regardless if `ZO_USAGE_BATCH_SIZE` is met or not. 
     default: 60s
     applied to each thread

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable field for dynamic thread allocation in usage reporting based on environment settings.
	- Enhanced concurrency in the usage reporting system, allowing multiple threads to process usage messages simultaneously.

- **Bug Fixes**
	- Improved error handling in logging for usage-related functions.

- **Documentation**
	- Updated logging statements for better clarity and context regarding thread processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->