### PR TITLE
fix: delete related pipelines when deleting functions and streams

### DIFF
--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -314,6 +314,7 @@ impl FromRequest for AuthExtractor {
                 || method.eq("DELETE")
                 || path_columns[1].starts_with("reports")
                 || path_columns[1].starts_with("savedviews")
+                || path_columns[1].starts_with("functions")
             {
                 format!(
                     "{}:{}",

--- a/src/config/src/meta/pipeline/mod.rs
+++ b/src/config/src/meta/pipeline/mod.rs
@@ -298,6 +298,17 @@ pub struct PipelineList {
     pub list: Vec<Pipeline>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+pub struct PipelineDependencyItem {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+pub struct PipelineDependencyResponse {
+    pub list: Vec<PipelineDependencyItem>,
+}
+
 /// DFS traversal to check:
 /// 1. all leaf nodes are of StreamNode
 /// 2. No `After Flattened` unchecked FunctionNode follows `After Flatten` checked FunctionNode in

--- a/src/config/src/meta/pipeline/mod.rs
+++ b/src/config/src/meta/pipeline/mod.rs
@@ -218,6 +218,19 @@ impl Pipeline {
             .filter(|node| node.is_function_node())
             .count()
     }
+
+    /// Checks if any of the FunctionNode uses the given function identified by name.
+    ///
+    /// Used for function deletion api
+    pub fn contains_function(&self, func_name: &str) -> bool {
+        self.nodes.iter().any(|node| {
+            if let NodeData::Function(func) = &node.data {
+                func.name == func_name
+            } else {
+                false
+            }
+        })
+    }
 }
 
 impl<'r, R: Row> FromRow<'r, R> for Pipeline

--- a/src/handler/http/request/functions/mod.rs
+++ b/src/handler/http/request/functions/mod.rs
@@ -158,3 +158,27 @@ pub async fn update_function(
     transform.function = transform.function.trim().to_string();
     crate::service::functions::update_function(&org_id, name, transform).await
 }
+
+/// FunctionPipelineDependency
+#[utoipa::path(
+    context_path = "/api",
+    tag = "Functions",
+    operation_id = "functionPipelineDependency",
+    security(
+        ("Authorization"= [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("name" = String, Path, description = "Function name"),
+    ),
+    responses(
+        (status = 200, description = "Success", content_type = "application/json", body = FunctionList),
+    )
+)]
+#[get("/{org_id}/functions/{name}")]
+pub async fn list_pipeline_dependencies(
+    path: web::Path<(String, String)>,
+) -> Result<HttpResponse, Error> {
+    let (org_id, fn_name) = path.into_inner();
+    crate::service::functions::get_pipeline_dependencies(&org_id, &fn_name).await
+}

--- a/src/handler/http/request/functions/mod.rs
+++ b/src/handler/http/request/functions/mod.rs
@@ -114,18 +114,9 @@ async fn list_functions(
     )
 )]
 #[delete("/{org_id}/functions/{name}")]
-async fn delete_function(
-    path: web::Path<(String, String)>,
-    req: HttpRequest,
-) -> Result<HttpResponse, Error> {
+async fn delete_function(path: web::Path<(String, String)>) -> Result<HttpResponse, Error> {
     let (org_id, name) = path.into_inner();
-    let query =
-        web::Query::<ahash::HashMap<String, String>>::from_query(req.query_string()).unwrap();
-    let force_del = match query.get("force") {
-        Some(v) => v.parse::<bool>().unwrap_or_default(),
-        None => false,
-    };
-    crate::service::functions::delete_function(org_id, name, force_del).await
+    crate::service::functions::delete_function(org_id, name).await
 }
 
 /// UpdateFunction
@@ -173,6 +164,8 @@ pub async fn update_function(
     ),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = FunctionList),
+        (status = 404, description = "Function not found", content_type = "application/json", body = HttpResponse),
+        (status = 500, description = "Internal server error", content_type = "application/json", body = HttpResponse),
     )
 )]
 #[get("/{org_id}/functions/{name}")]

--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -47,6 +47,7 @@ use crate::{
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("stream_name" = String, Path, description = "Stream name"),
+        ("type" = String, Query, description = "Stream type"),
     ),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Stream),
@@ -86,6 +87,7 @@ async fn schema(
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("stream_name" = String, Path, description = "Stream name"),
+        ("type" = String, Query, description = "Stream type"),
     ),
     request_body(content = StreamSettings, description = "Stream settings", content_type = "application/json"),
     responses(
@@ -145,6 +147,7 @@ async fn settings(
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("stream_name" = String, Path, description = "Stream name"),
+        ("type" = String, Query, description = "Stream type"),
     ),
     request_body(content = UpdateStreamSettings, description = "Stream settings", content_type = "application/json"),
     responses(
@@ -252,6 +255,7 @@ async fn update_settings(
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("stream_name" = String, Path, description = "Stream name"),
+        ("type" = String, Query, description = "Stream type"),
     ),
     request_body(content = StreamDeleteFields, description = "Stream delete fields", content_type = "application/json"),
     responses(
@@ -308,6 +312,7 @@ async fn delete_fields(
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("stream_name" = String, Path, description = "Stream name"),
+        ("type" = String, Query, description = "Stream type"),
     ),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = HttpResponse),
@@ -346,6 +351,7 @@ async fn delete(
     ),
     params(
         ("org_id" = String, Path, description = "Organization name"),
+        ("type" = String, Query, description = "Stream type"),
     ),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = ListStream),
@@ -423,6 +429,23 @@ async fn list(org_id: web::Path<String>, req: HttpRequest) -> impl Responder {
     Ok(HttpResponse::Ok().json(ListStream { list: indices }))
 }
 
+#[utoipa::path(
+    context_path = "/api",
+    tag = "Streams",
+    operation_id = "StreamDeleteCache",
+    security(
+        ("Authorization"= [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("stream_name" = String, Path, description = "Stream name"),
+        ("type" = String, Query, description = "Stream type"),
+    ),
+    responses(
+        (status = 200, description = "Success", content_type = "application/json", body = HttpResponse),
+        (status = 400, description = "Failure", content_type = "application/json", body = HttpResponse),
+    )
+)]
 #[delete("/{org_id}/streams/{stream_name}/cache/results")]
 async fn delete_stream_cache(
     path: web::Path<(String, String)>,

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -403,6 +403,7 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
             .service(functions::list_functions)
             .service(functions::delete_function)
             .service(functions::update_function)
+            .service(functions::list_pipeline_dependencies)
             .service(dashboards::create_dashboard)
             .service(dashboards::update_dashboard)
             .service(dashboards::list_dashboards)

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -74,6 +74,7 @@ use crate::{common::meta, handler::http::request};
         request::functions::update_function,
         request::functions::save_function,
         request::functions::delete_function,
+        request::functions::list_pipeline_dependencies,
         request::dashboards::create_dashboard,
         request::dashboards::update_dashboard,
         request::dashboards::list_dashboards,

--- a/src/service/db/pipeline.rs
+++ b/src/service/db/pipeline.rs
@@ -86,8 +86,7 @@ pub async fn get_executable_pipeline(stream_params: &StreamParams) -> Option<Exe
     if let Some(exec_pl) = STREAM_EXECUTABLE_PIPELINES.read().await.get(stream_params) {
         return Some(exec_pl.clone());
     }
-    let pipeline = get_by_stream(stream_params).await.ok();
-    match pipeline {
+    match get_by_stream(stream_params).await {
         Some(pl) if pl.enabled => match ExecutablePipeline::new(&pl).await {
             Ok(exec_pl) => {
                 let mut stream_exec_pl_cache = STREAM_EXECUTABLE_PIPELINES.write().await;
@@ -110,21 +109,8 @@ pub async fn get_executable_pipeline(stream_params: &StreamParams) -> Option<Exe
 /// Returns the pipeline by id.
 ///
 /// Used to get the pipeline associated with the ID when scheduled job is ran.
-pub async fn get_by_stream(stream_params: &StreamParams) -> Result<Pipeline> {
-    infra_pipeline::get_by_stream(stream_params)
-        .await
-        .map_err(|e| {
-            log::error!(
-                "Error getting pipeline associated with {}: {}",
-                stream_params,
-                e
-            );
-            anyhow::anyhow!(
-                "Error getting pipeline associated with {}: {}",
-                stream_params,
-                e
-            )
-        })
+pub async fn get_by_stream(stream_params: &StreamParams) -> Option<Pipeline> {
+    infra_pipeline::get_by_stream(stream_params).await.ok()
 }
 
 /// Returns the pipeline by id.

--- a/src/service/db/pipeline.rs
+++ b/src/service/db/pipeline.rs
@@ -86,7 +86,7 @@ pub async fn get_executable_pipeline(stream_params: &StreamParams) -> Option<Exe
     if let Some(exec_pl) = STREAM_EXECUTABLE_PIPELINES.read().await.get(stream_params) {
         return Some(exec_pl.clone());
     }
-    let pipeline = infra_pipeline::get_by_stream(stream_params).await.ok();
+    let pipeline = get_by_stream(stream_params).await.ok();
     match pipeline {
         Some(pl) if pl.enabled => match ExecutablePipeline::new(&pl).await {
             Ok(exec_pl) => {
@@ -105,6 +105,26 @@ pub async fn get_executable_pipeline(stream_params: &StreamParams) -> Option<Exe
         },
         _ => None,
     }
+}
+
+/// Returns the pipeline by id.
+///
+/// Used to get the pipeline associated with the ID when scheduled job is ran.
+pub async fn get_by_stream(stream_params: &StreamParams) -> Result<Pipeline> {
+    infra_pipeline::get_by_stream(stream_params)
+        .await
+        .map_err(|e| {
+            log::error!(
+                "Error getting pipeline associated with {}: {}",
+                stream_params,
+                e
+            );
+            anyhow::anyhow!(
+                "Error getting pipeline associated with {}: {}",
+                stream_params,
+                e
+            )
+        })
 }
 
 /// Returns the pipeline by id.

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -108,6 +108,15 @@ pub async fn update_function(
     }
     extract_num_args(&mut func);
 
+    if let Err(error) = db::functions::set(org_id, &func.name, &func).await {
+        return Ok(
+            HttpResponse::InternalServerError().json(MetaHttpResponse::message(
+                http::StatusCode::INTERNAL_SERVER_ERROR.into(),
+                error.to_string(),
+            )),
+        );
+    }
+
     // update associated pipelines
     if let Ok(associated_pipelines) = db::pipeline::list_by_org(org_id).await {
         for pipeline in associated_pipelines {
@@ -127,14 +136,6 @@ pub async fn update_function(
         }
     }
 
-    if let Err(error) = db::functions::set(org_id, &func.name, &func).await {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::message(
-                http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                error.to_string(),
-            )),
-        );
-    }
     Ok(HttpResponse::Ok().json(MetaHttpResponse::message(
         http::StatusCode::OK.into(),
         FN_SUCCESS.to_string(),

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -206,11 +206,12 @@ pub async fn delete_function(
                 return Ok(HttpResponse::Conflict().json(MetaHttpResponse::error(
                     http::StatusCode::CONFLICT.into(),
                     format!(
-                        "Caution: Function '{}' has {} pipeline dependencies. \
-                        This deletion operation will cascade to all dependent pipelines. \
-                        Confirm to proceed.",
+                        "Warning: Function '{}' has {} pipeline dependencies, \
+                        including: {:?} \
+                        Please remove these pipelines first.",
                         fn_name,
-                        pipelines.len()
+                        pipelines.len(),
+                        pipelines.iter().map(|pl| &pl.name).collect::<Vec<_>>()
                     ),
                 )));
             }

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -202,19 +202,31 @@ pub async fn delete_function(
                         _ => {}
                     }
                 }
-            } else {
+            } 
+            else {
+                let pipeline_info: Vec<_> = pipelines
+                    .iter()
+                    .map(|pl| {
+                        serde_json::json!({
+                            "id": pl.id,
+                            "name": pl.name
+                        })
+                    })
+                    .collect();
+            
+                let pipeline_data = serde_json::to_string(&pipeline_info).unwrap_or_else(|_| "[]".to_string());
+            
                 return Ok(HttpResponse::Conflict().json(MetaHttpResponse::error(
                     http::StatusCode::CONFLICT.into(),
                     format!(
-                        "Warning: Function '{}' has {} pipeline dependencies, \
-                        including: {:?} \
-                        Please remove these pipelines first.",
+                        "Warning: Function '{}' has {} pipeline dependencies. Please remove these pipelines first: {}",
                         fn_name,
                         pipelines.len(),
-                        pipelines.iter().map(|pl| &pl.name).collect::<Vec<_>>()
+                        pipeline_data
                     ),
                 )));
             }
+            
         }
     }
     let result = db::functions::delete(&org_id, &fn_name).await;

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -18,7 +18,7 @@ use std::io::Error;
 use actix_web::{http, http::StatusCode, HttpResponse};
 use config::{
     is_local_disk_storage,
-    meta::stream::{StreamSettings, StreamStats, StreamType, UpdateStreamSettings},
+    meta::stream::{StreamParams, StreamSettings, StreamStats, StreamType, UpdateStreamSettings},
     utils::json,
     SIZE_IN_MB, SQL_FULL_TEXT_SEARCH_FIELDS,
 };
@@ -462,6 +462,23 @@ pub async fn delete_stream(
             )),
         );
     };
+
+    // delete associated pipelines
+    if let Ok(pipeline) =
+        db::pipeline::get_by_stream(&StreamParams::new(org_id, stream_name, stream_type)).await
+    {
+        if let Err(e) = db::pipeline::delete(&pipeline.id).await {
+            return Ok(
+                HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+                    StatusCode::INTERNAL_SERVER_ERROR.into(),
+                    format!(
+                        "Stream deletion fail: failed to delete the associated pipeline {}: {e}",
+                        pipeline.name
+                    ),
+                )),
+            );
+        }
+    }
 
     crate::common::utils::auth::remove_ownership(
         org_id,

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -464,7 +464,7 @@ pub async fn delete_stream(
     };
 
     // delete associated pipelines
-    if let Ok(pipeline) =
+    if let Some(pipeline) =
         db::pipeline::get_by_stream(&StreamParams::new(org_id, stream_name, stream_type)).await
     {
         if let Err(e) = db::pipeline::delete(&pipeline.id).await {

--- a/web/src/components/functions/FunctionList.vue
+++ b/web/src/components/functions/FunctionList.vue
@@ -67,8 +67,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :title="'Associated Pipelines'"
               @click="getAssociatedPipelines(props)"
             ></q-btn>
-            <q-btn icon="fa fa-sitemap" label="Sitemap" />
-
           </q-td>
         </template>
 

--- a/web/src/components/functions/FunctionList.vue
+++ b/web/src/components/functions/FunctionList.vue
@@ -56,6 +56,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :title="t('function.delete')"
               @click="showDeleteDialogFn(props)"
             ></q-btn>
+            <q-btn
+              :icon="outlinedAccountTree"
+              class="q-ml-xs"
+              padding="sm"
+              unelevated
+              size="sm"
+              round
+              flat
+              :title="'Associated Pipelines'"
+              @click="getAssociatedPipelines(props)"
+            ></q-btn>
+            <q-btn icon="fa fa-sitemap" label="Sitemap" />
+
           </q-td>
         </template>
 
@@ -178,7 +191,7 @@ import NoData from "../shared/grid/NoData.vue";
 import ConfirmDialog from "../ConfirmDialog.vue";
 import segment from "../../services/segment_analytics";
 import { getImageURL, verifyOrganizationStatus } from "../../utils/zincutils";
-import { outlinedDelete } from "@quasar/extras/material-icons-outlined";
+import { outlinedDelete ,outlinedAccountTree} from "@quasar/extras/material-icons-outlined";
 import useLogs from "@/composables/useLogs";
 
 export default defineComponent({
@@ -524,6 +537,19 @@ export default defineComponent({
       confirmDelete.value = true;
     };
 
+    const getAssociatedPipelines = (props: any) => {
+      selectedDelete.value = props.row
+      jsTransformService.getAssociatedPipelines(
+        store.state.selectedOrganization.identifier,
+        props.row.name
+      ).then((res: any) => {
+        pipelineList.value = res.data.list;
+        confirmForceDelete.value = true;
+      }).catch((err) => {
+        console.log(err);
+      });
+    }
+
     const forceRemoveFunction = (message : any) =>{
       const match = message.match(/\[([^\]]+)\]/);
       if (match) {
@@ -570,6 +596,7 @@ export default defineComponent({
       showAddJSTransformDialog,
       changeMaxRecordToReturn,
       outlinedDelete,
+      outlinedAccountTree,
       forceDeleteFn,
       confirmForceDelete,
       pipelineList,
@@ -577,6 +604,7 @@ export default defineComponent({
       closeDialog,
       onPipelineSelect,
       transformedPipelineList,
+      getAssociatedPipelines,
       filterQuery: ref(""),
       filterData(rows: any, terms: any) {
         var filtered = [];

--- a/web/src/components/functions/FunctionList.vue
+++ b/web/src/components/functions/FunctionList.vue
@@ -137,20 +137,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <q-card style="width: 40vw; max-height: 90vh; overflow-y: auto;">
     <q-card-section class="text-h6 dialog-heading tw-flex tw-justify-between tw-items-center" >
       <div>Pipelines Associated with  <strong> {{ selectedDelete.name}}</strong> </div>
-          <div
-          data-test="close-dialog-associated-pipelines-btn"
-          class="flex justify-center items-center q-mr-md cursor-pointer"
-          style="
-            border: 1.5px solid;
-            border-radius: 50%;
-            width: 22px;
-            height: 22px;
-          "
-          title="Go Back"
-          @click="closeDialog"
-        >
-          <q-icon name="close" size="14px" />
-        </div>
+          <q-icon  name="close" size="18px" @click="closeDialog" style="cursor: pointer" />
     </q-card-section>
     <q-card-section>
   <div class="pipeline-list-container">

--- a/web/src/components/functions/FunctionList.vue
+++ b/web/src/components/functions/FunctionList.vue
@@ -398,7 +398,7 @@ export default defineComponent({
     };
 
     const transformedPipelineList = computed(() => {
-      return pipelineList.value.map(pipeline => ({
+      return pipelineList.value.map((pipeline:any) => ({
         label: pipeline.name,
         value: pipeline.id
       }));

--- a/web/src/components/pipeline/PipelineEditor.vue
+++ b/web/src/components/pipeline/PipelineEditor.vue
@@ -636,7 +636,15 @@ const openCancelDialog = () => {
   confirmDialogMeta.value.show = true;
   confirmDialogMeta.value.title = t("common.cancelChanges");
   confirmDialogMeta.value.message = "Are you sure you want to cancel changes?";
-  confirmDialogMeta.value.onConfirm = () => router.back();
+  confirmDialogMeta.value.onConfirm = () => {
+    resetPipelineData();
+    router.push({
+      name: "pipelines",
+      query: {
+        org_identifier: store.state.selectedOrganization.identifier,
+      },
+    });
+  };
 };
 
 const resetConfirmDialog = () => {

--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -507,9 +507,6 @@ const editPipeline = (pipeline: any) => {
     query: {
       id: pipeline.pipeline_id,
       name: pipeline.name,
-      stream: pipeline.stream_name,
-      stream_type: pipeline.stream_type,
-      org_identifier: store.state.selectedOrganization.identifier,
     },
   });
 };

--- a/web/src/services/jstransform.ts
+++ b/web/src/services/jstransform.ts
@@ -31,6 +31,9 @@ const jstransform = {
   create: (org_identifier: string, data: any) => {
     return http().post(`/api/${org_identifier}/functions`, data);
   },
+  getAssociatedPipelines: (org_identifier: string, name: string) => {
+    return http().get(`/api/${org_identifier}/functions/${name}`);
+  },
   update: (org_identifier: string, data: any) => {
     return http().put(`/api/${org_identifier}/functions/${data.name}`, data);
   },

--- a/web/src/services/jstransform.ts
+++ b/web/src/services/jstransform.ts
@@ -34,8 +34,10 @@ const jstransform = {
   update: (org_identifier: string, data: any) => {
     return http().put(`/api/${org_identifier}/functions/${data.name}`, data);
   },
-  delete: (org_identifier: string, transform_name: string) => {
-    return http().delete(`/api/${org_identifier}/functions/${transform_name}`);
+  delete: (org_identifier: string, transform_name: string, force?: boolean) => {
+    const url = `/api/${org_identifier}/functions/${transform_name}`;
+    const config = force ? { params: { force: true } } : {};
+    return http().delete(url, config);
   },
   create_with_index: (
     org_identifier: string,


### PR DESCRIPTION
Adds a new endpoint for `/functions` to find a list of associate pipelines. 
This list is also used to warn user to remove associated pipelines before deleting a function. 

endpoint: `name` is the function name
```bash
GET /{org_id}/functions/{name}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new method to check for function dependencies within pipelines.
	- Added a new endpoint to list pipeline dependencies.
	- Enhanced HTTP request handling for functions and streams with new query parameters.
	- Added functionality to manage associated pipelines in the user interface.
	- Introduced a new method to retrieve associated pipelines via API.

- **Bug Fixes**
	- Improved error handling for function deletions and pipeline updates.
	- Enhanced notifications for user actions regarding pipelines.

- **UI Enhancements**
	- New dialog for displaying and managing associated pipelines.
	- Improved layout and responsiveness of the pipeline list.

- **Documentation**
	- Updated OpenAPI documentation to include new endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->