### PR TITLE
fix: Do not prefix email subjects

### DIFF
--- a/benchmarks/pyroscope/README.md
+++ b/benchmarks/pyroscope/README.md
@@ -1,6 +1,6 @@
 ## Pyroscope for profiling
 
-Pyroscope can be used for basic profiling of `Openobserve`.
+Pyroscope can be used for basic profiling of `OpenObserve`.
 The following steps can be followed:
 - Setup a local `pyroscope` server from `benchmarks/pyroscope` directory:
   - `docker-compose up docker-compose.yml`

--- a/src/report_server/src/report.rs
+++ b/src/report_server/src/report.rs
@@ -388,7 +388,7 @@ pub async fn send_email(
 
     let mut email = Message::builder()
         .from(config.from_email.parse()?)
-        .subject(format!("Openobserve Report - {}", &email_details.title));
+        .subject(format!("{}", &email_details.title));
 
     for recipient in recipients {
         email = email.to(recipient.parse()?);

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -556,7 +556,7 @@ pub async fn send_email_notification(
 
     let mut email = Message::builder()
         .from(cfg.smtp.smtp_from_email.parse()?)
-        .subject(format!("Openobserve Alert - {}", email_subject));
+        .subject(format!("{}", email_subject));
 
     for recipient in recipients {
         email = email.to(recipient.parse()?);

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -379,7 +379,7 @@ impl Report {
 
         let mut email = Message::builder()
             .from(cfg.smtp.smtp_from_email.parse()?)
-            .subject(format!("Openobserve Report - {}", &self.title));
+            .subject(format!("{}", &self.title));
 
         for recipient in recipients {
             email = email.to(recipient.parse()?);


### PR DESCRIPTION
Email subjects come with a hard-coded prefix. These should be free-form to whatever subject the user set on the `template`.

Related to #4996 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the spelling of "Openobserve" to "OpenObserve" in the documentation.

- **New Features**
	- Simplified email subject lines for reports and alerts by removing the prefix, enhancing clarity for recipients. 

- **Documentation**
	- Updated README to reflect the correct spelling of "OpenObserve."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->