### PR TITLE
fix: set ownership for metadata streams only in the first time

### DIFF
--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -180,21 +180,6 @@ impl Metadata for DistinctValues {
                 .await
                 .map_err(|v| Error::Message(v.to_string()))?;
         }
-        #[cfg(feature = "enterprise")]
-        {
-            use o2_enterprise::enterprise::{
-                common::infra::config::get_config as get_o2_config,
-                openfga::authorizer::authz::set_ownership_if_not_exists,
-            };
-
-            if get_o2_config().openfga.enabled {
-                set_ownership_if_not_exists(
-                    org_id,
-                    &format!("{}:{}", StreamType::Metadata, STREAM_NAME),
-                )
-                .await;
-            }
-        }
         Ok(())
     }
 
@@ -217,7 +202,9 @@ impl Metadata for DistinctValues {
             let db_schema = infra::schema::get(&org_id, STREAM_NAME, StreamType::Metadata)
                 .await
                 .unwrap();
+            let mut is_new = false;
             if db_schema.fields().is_empty() {
+                is_new = true;
                 let schema = schema.as_ref().clone();
                 if let Err(e) = service::db::schema::merge(
                     &org_id,
@@ -267,6 +254,22 @@ impl Metadata for DistinctValues {
             _ = ingestion::write_file(&writer, STREAM_NAME, buf).await;
             if let Err(e) = writer.sync().await {
                 log::error!("[DISTINCT_VALUES] error while syncing writer: {}", e);
+            }
+            #[cfg(feature = "enterprise")]
+            {
+                use o2_enterprise::enterprise::{
+                    common::infra::config::get_config as get_o2_config,
+                    openfga::authorizer::authz::set_ownership_if_not_exists,
+                };
+
+                // set ownership only in the first time
+                if is_new && get_o2_config().openfga.enabled {
+                    set_ownership_if_not_exists(
+                        &org_id,
+                        &format!("{}:{}", StreamType::Metadata, STREAM_NAME),
+                    )
+                    .await;
+                }
             }
         }
         Ok(())

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -202,9 +202,9 @@ impl Metadata for DistinctValues {
             let db_schema = infra::schema::get(&org_id, STREAM_NAME, StreamType::Metadata)
                 .await
                 .unwrap();
-            let mut is_new = false;
+            let mut _is_new = false;
             if db_schema.fields().is_empty() {
-                is_new = true;
+                _is_new = true;
                 let schema = schema.as_ref().clone();
                 if let Err(e) = service::db::schema::merge(
                     &org_id,
@@ -263,7 +263,7 @@ impl Metadata for DistinctValues {
                 };
 
                 // set ownership only in the first time
-                if is_new && get_o2_config().openfga.enabled {
+                if _is_new && get_o2_config().openfga.enabled {
                     set_ownership_if_not_exists(
                         &org_id,
                         &format!("{}:{}", StreamType::Metadata, STREAM_NAME),

--- a/src/service/metadata/trace_list_index.rs
+++ b/src/service/metadata/trace_list_index.rs
@@ -83,9 +83,9 @@ impl Metadata for TraceListIndex {
         let timestamp = chrono::Utc::now().timestamp_micros();
         let schema_key = self.schema.hash_key();
 
-        let mut is_new = false;
+        let mut _is_new = false;
         if !self.db_schema_init.load(Ordering::Relaxed) {
-            is_new = self.set_db_schema(org_id).await?
+            _is_new = self.set_db_schema(org_id).await?
         }
 
         let mut buf: HashMap<String, SchemaRecords> = HashMap::new();
@@ -135,7 +135,7 @@ impl Metadata for TraceListIndex {
             };
 
             // set ownership only in the first time
-            if is_new && get_o2_config().openfga.enabled {
+            if _is_new && get_o2_config().openfga.enabled {
                 set_ownership_if_not_exists(
                     org_id,
                     &format!("{}:{}", StreamType::Metadata, STREAM_NAME),


### PR DESCRIPTION
Fixes #4999 

- Ownership should be set only when writing to metadata streams for the first time.
- For distinct values, the ownership should set while flush and not write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for schema creation and ownership management in the database.
	- New boolean variable `_is_new` added to track first-time schema initialization.

- **Bug Fixes**
	- Corrected a typo in the shutdown event type from `Shutudown` to `Shutdown`.

- **Documentation**
	- Updated method signatures to reflect changes in functionality and return types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->