### PR TITLE
feat: allow dynamic stream name in pipeline destinations

### DIFF
--- a/src/service/db/pipeline.rs
+++ b/src/service/db/pipeline.rs
@@ -39,7 +39,7 @@ pub async fn set(pipeline: &Pipeline) -> Result<()> {
     // save to cache if realtime pipeline
     if let PipelineSource::Realtime(stream_params) = &pipeline.source {
         if pipeline.enabled {
-            update_cache(stream_params, pipeline, PipelineTableEvent::Add).await;
+            update_cache(stream_params, PipelineTableEvent::Add(pipeline)).await;
         }
     }
 
@@ -49,20 +49,24 @@ pub async fn set(pipeline: &Pipeline) -> Result<()> {
 /// Updates a pipeline entry with the sane values.
 ///
 /// Pipeline validation should be handled by the caller.
-pub async fn update(pipeline: &Pipeline) -> Result<()> {
+pub async fn update(pipeline: &Pipeline, prev_source_stream: Option<StreamParams>) -> Result<()> {
     if let Err(e) = infra_pipeline::update(pipeline).await {
         log::error!("Error updating pipeline: {}", e);
         return Err(anyhow::anyhow!("Error updating pipeline: {}", e));
     }
 
+    if let Some(prev_stream_params) = prev_source_stream {
+        update_cache(&prev_stream_params, PipelineTableEvent::Remove).await;
+    }
+
     // save to cache if realtime pipeline
     if let PipelineSource::Realtime(stream_params) = &pipeline.source {
         let db_event = if pipeline.enabled {
-            PipelineTableEvent::Add
+            PipelineTableEvent::Add(pipeline)
         } else {
             PipelineTableEvent::Remove
         };
-        update_cache(stream_params, pipeline, db_event).await;
+        update_cache(stream_params, db_event).await;
     }
 
     Ok(())
@@ -161,7 +165,7 @@ pub async fn delete(pipeline_id: &str) -> Result<()> {
         Ok(pipeline) => {
             // remove from cache if realtime pipeline
             if let PipelineSource::Realtime(stream_params) = &pipeline.source {
-                update_cache(stream_params, &pipeline, PipelineTableEvent::Remove).await;
+                update_cache(stream_params, PipelineTableEvent::Remove).await;
             }
         }
     }
@@ -197,20 +201,21 @@ pub async fn cache() -> Result<(), anyhow::Error> {
 }
 
 /// Update STREAM_PIPELINES cache for realtime pipelines
-async fn update_cache(
-    stream_params: &StreamParams,
-    pipeline: &Pipeline,
-    event: PipelineTableEvent,
-) {
+async fn update_cache<'a>(stream_params: &StreamParams, event: PipelineTableEvent<'a>) {
     match event {
         PipelineTableEvent::Remove => {
-            log::info!("[Pipeline]: pipeline {} removed from cache.", &pipeline.id);
-            STREAM_EXECUTABLE_PIPELINES
+            if let Some(removed) = STREAM_EXECUTABLE_PIPELINES
                 .write()
                 .await
-                .remove(stream_params);
+                .remove(stream_params)
+            {
+                log::info!(
+                    "[Pipeline]: pipeline {} removed from cache.",
+                    removed.get_pipeline_id()
+                );
+            }
         }
-        PipelineTableEvent::Add => {
+        PipelineTableEvent::Add(pipeline) => {
             let mut stream_pl_exec = STREAM_EXECUTABLE_PIPELINES.write().await;
             match ExecutablePipeline::new(pipeline).await {
                 Err(e) => {
@@ -231,7 +236,7 @@ async fn update_cache(
     }
 }
 
-enum PipelineTableEvent {
-    Add,
+enum PipelineTableEvent<'a> {
+    Add(&'a Pipeline),
     Remove,
 }

--- a/src/service/db/pipeline.rs
+++ b/src/service/db/pipeline.rs
@@ -216,7 +216,6 @@ async fn update_cache<'a>(stream_params: &StreamParams, event: PipelineTableEven
             }
         }
         PipelineTableEvent::Add(pipeline) => {
-            let mut stream_pl_exec = STREAM_EXECUTABLE_PIPELINES.write().await;
             match ExecutablePipeline::new(pipeline).await {
                 Err(e) => {
                     log::error!(
@@ -228,10 +227,11 @@ async fn update_cache<'a>(stream_params: &StreamParams, event: PipelineTableEven
                     );
                 }
                 Ok(exec_pl) => {
+                    let mut stream_pl_exec = STREAM_EXECUTABLE_PIPELINES.write().await;
                     stream_pl_exec.insert(stream_params.clone(), exec_pl);
+                    log::info!("[Pipeline]: pipeline {} added to cache.", &pipeline.id);
                 }
             };
-            log::info!("[Pipeline]: pipeline {} added to cache.", &pipeline.id);
         }
     }
 }

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -121,7 +121,7 @@ pub async fn update_function(
     if let Ok(associated_pipelines) = db::pipeline::list_by_org(org_id).await {
         for pipeline in associated_pipelines {
             if pipeline.contains_function(&func.name) {
-                if let Err(e) = db::pipeline::update(&pipeline).await {
+                if let Err(e) = db::pipeline::update(&pipeline, None).await {
                     return Ok(HttpResponse::InternalServerError().json(
                         MetaHttpResponse::message(
                             http::StatusCode::INTERNAL_SERVER_ERROR.into(),

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -325,6 +325,10 @@ impl ExecutablePipeline {
             .count()
     }
 
+    pub fn get_pipeline_id(&self) -> &str {
+        &self.id
+    }
+
     fn get_source_stream_params(&self) -> StreamParams {
         // source_node_id must exist in node_map
         match &self.node_map.get(&self.source_node_id).unwrap().node_data {

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -209,7 +209,7 @@ impl ExecutablePipeline {
             let mut count: usize = 0;
             let mut results = HashMap::new();
             while let Some((idx, mut stream_params, record)) = result_receiver.recv().await {
-                if stream_params.stream_name.contains("{{") {
+                if stream_params.stream_name.contains("{") {
                     match resolve_stream_name(&stream_params.stream_name, &record) {
                         Ok(stream_name) => {
                             stream_params.stream_name = stream_name.into();
@@ -713,9 +713,9 @@ async fn get_transforms(org_id: &str, fn_name: &str) -> Result<Transform> {
 }
 
 fn resolve_stream_name(haystack: &str, record: &Value) -> Result<String> {
-    // Fast path: if it's a complete pattern like "{{field}}", avoid regex
-    if haystack.starts_with("{{") && haystack.ends_with("}}") {
-        let field_name = &haystack[2..haystack.len() - 2];
+    // Fast path: if it's a complete pattern like "{field}", avoid regex
+    if haystack.starts_with("{") && haystack.ends_with("}") {
+        let field_name = &haystack[1..haystack.len() - 1];
         return match record.get(field_name) {
             Some(stream_name) => stream_name
                 .as_str()

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -40,7 +40,7 @@ use crate::{
 };
 
 static DYNAMIC_STREAM_NAME_PATTERN: Lazy<regex::Regex> =
-    Lazy::new(|| regex::Regex::new(r"\{\{([^}]+)\}\}").unwrap());
+    Lazy::new(|| regex::Regex::new(r"\{([^}]+)\}").unwrap());
 
 #[async_trait]
 pub trait PipelineExt: Sync + Send + 'static {
@@ -765,9 +765,9 @@ mod tests {
         });
         let ok_cases = vec![
             ("container_name", "container_name"),
-            ("{{container_name}}", "compactor"),
-            ("abc-{{container_name}}", "abc-compactor"),
-            ("abc-{{container_name}}-xyz", "abc-compactor-xyz"),
+            ("{container_name}", "compactor"),
+            ("abc-{container_name}", "abc-compactor"),
+            ("abc-{container_name}-xyz", "abc-compactor-xyz"),
         ];
         for (test, expected) in ok_cases {
             let result = resolve_stream_name(test, &record);

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -28,6 +28,7 @@ use config::{
     utils::{flatten, json::Value},
 };
 use futures::future::try_join_all;
+use once_cell::sync::Lazy;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use crate::{
@@ -202,7 +203,8 @@ impl ExecutablePipeline {
         // task to collect results
         let result_task = tokio::spawn(async move {
             log::debug!("[Pipeline]: starts result collecting job");
-            let dynamic_stream_name_regex = regex::Regex::new(r"\{\{([^}]+)\}\}").unwrap();
+            let dynamic_stream_name_regex =
+                Lazy::new(|| regex::Regex::new(r"\{\{([^}]+)\}\}").unwrap());
             let mut count: usize = 0;
             let mut results = HashMap::new();
             while let Some((idx, mut stream_params, record)) = result_receiver.recv().await {
@@ -220,7 +222,7 @@ impl ExecutablePipeline {
                         None => {
                             log::error!(
                                 "[Pipeline]: dynamic stream name detected in destination, \
-                                but failed to resolve to a concrete stream from the record. Record dropped"
+                                but failed to resolve to a concrete stream name from the record. Record dropped"
                             );
                             continue;
                         }

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -216,7 +216,7 @@ impl ExecutablePipeline {
                         }
                         Err(e) => {
                             log::error!(
-                                "[Pipeline]: dynamic stream name detected in destination, but failed to resolve due to {e}. Record dropped"
+                                "[Pipeline]: dynamic stream name detected in destination, but failed to resolve due to {e}. Record dropped."
                             );
                             continue;
                         }

--- a/src/service/pipeline/mod.rs
+++ b/src/service/pipeline/mod.rs
@@ -81,42 +81,27 @@ pub async fn save_pipeline(mut pipeline: Pipeline) -> Result<HttpResponse, Error
 
 #[tracing::instrument(skip(pipeline))]
 pub async fn update_pipeline(mut pipeline: Pipeline) -> Result<HttpResponse, Error> {
-    match db::pipeline::get_by_id(&pipeline.id).await {
-        Err(_err) => {
-            return Ok(HttpResponse::NotFound().json(MetaHttpResponse::error(
-                StatusCode::NOT_FOUND.into(),
-                format!("Existing Pipeline with ID {} not found", pipeline.id),
-            )));
-        }
-        Ok(existing_pipeline) => {
-            if existing_pipeline == pipeline {
-                return Ok(HttpResponse::Ok().json("No changes found".to_string()));
-            }
-            // check version
-            if existing_pipeline.version != pipeline.version {
-                return Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(
-                    http::StatusCode::BAD_REQUEST.into(),
-                    format!(
-                        "Pipeline with ID {} modified by someone else. Please refresh",
-                        pipeline.id
-                    ),
-                )));
-            }
-            // if the source is changed, check if the new source exists in another pipeline
-            if existing_pipeline.source != pipeline.source {
-                if let Ok(similar_pl) = db::pipeline::get_with_same_source_stream(&pipeline).await {
-                    return Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(
-                        http::StatusCode::BAD_REQUEST.into(),
-                        format!(
-                            "The new source already exists in another pipeline in org: {} with name: {}",
-                            similar_pl.org,
-                            similar_pl.name
-                        ),
-                    )));
-                }
-            }
-        }
+    let Ok(existing_pipeline) = db::pipeline::get_by_id(&pipeline.id).await else {
+        return Ok(HttpResponse::NotFound().json(MetaHttpResponse::error(
+            StatusCode::NOT_FOUND.into(),
+            format!("Existing Pipeline with ID {} not found", pipeline.id),
+        )));
     };
+
+    if existing_pipeline == pipeline {
+        return Ok(HttpResponse::Ok().json("No changes found".to_string()));
+    }
+
+    // check version
+    if existing_pipeline.version != pipeline.version {
+        return Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(
+            http::StatusCode::BAD_REQUEST.into(),
+            format!(
+                "Pipeline with ID {} modified by someone else. Please refresh",
+                pipeline.id
+            ),
+        )));
+    }
 
     // validate pipeline
     if let Err(e) = pipeline.validate() {
@@ -126,13 +111,54 @@ pub async fn update_pipeline(mut pipeline: Pipeline) -> Result<HttpResponse, Err
         )));
     }
 
+    // if the source is changed, check if the new source exists in another pipeline
+    let prev_source_stream = if existing_pipeline.source != pipeline.source {
+        if let Ok(similar_pl) = db::pipeline::get_with_same_source_stream(&pipeline).await {
+            return Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(
+                http::StatusCode::BAD_REQUEST.into(),
+                format!(
+                    "The update source already exists in another pipeline with name {}, under org {}",
+                    similar_pl.name, similar_pl.org
+                ),
+            )));
+        }
+        // Pipeline source changed:
+        match existing_pipeline.source {
+            // realtime: remove prev. src. stream_params from cache
+            PipelineSource::Realtime(stream_params) => Some(stream_params),
+            // scheduled: delete prev. trigger
+            PipelineSource::Scheduled(derived_stream) => {
+                if let Err(error) = super::alerts::derived_streams::delete(
+                    derived_stream,
+                    &existing_pipeline.name,
+                    &existing_pipeline.id,
+                )
+                .await
+                {
+                    let err_msg = format!(
+                        "Failed to update: error deleting DerivedStream associated with previous pipeline version: {}",
+                        error
+                    );
+                    return Ok(HttpResponse::InternalServerError().json(
+                        MetaHttpResponse::message(
+                            http::StatusCode::INTERNAL_SERVER_ERROR.into(),
+                            err_msg,
+                        ),
+                    ));
+                }
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // update the pipeline version
     pipeline.version += 1;
 
     // Save DerivedStream details if there's any
     if let PipelineSource::Scheduled(ref mut derived_stream) = &mut pipeline.source {
         derived_stream.query_condition.search_event_type = Some(SearchEventType::DerivedStream);
-        // save derived_stream to triggers table
         if let Err(e) = super::alerts::derived_streams::save(
             derived_stream.clone(),
             &pipeline.name,
@@ -147,7 +173,7 @@ pub async fn update_pipeline(mut pipeline: Pipeline) -> Result<HttpResponse, Err
         }
     }
 
-    match db::pipeline::update(&pipeline).await {
+    match db::pipeline::update(&pipeline, prev_source_stream).await {
         Err(error) => Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::message(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
@@ -216,7 +242,7 @@ pub async fn enable_pipeline(
     };
 
     pipeline.enabled = value;
-    match db::pipeline::update(&pipeline).await {
+    match db::pipeline::update(&pipeline, None).await {
         Err(error) => Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::message(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),

--- a/src/service/pipeline/mod.rs
+++ b/src/service/pipeline/mod.rs
@@ -111,18 +111,18 @@ pub async fn update_pipeline(mut pipeline: Pipeline) -> Result<HttpResponse, Err
         )));
     }
 
-    // if the source is changed, check if the new source exists in another pipeline
+    // additional checks when the source is changed
     let prev_source_stream = if existing_pipeline.source != pipeline.source {
+        // check if the new source exists in another pipeline
         if let Ok(similar_pl) = db::pipeline::get_with_same_source_stream(&pipeline).await {
             return Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(
                 http::StatusCode::BAD_REQUEST.into(),
                 format!(
-                    "The update source already exists in another pipeline with name {}, under org {}",
+                    "The updated source already exists in another pipeline with name {}, under org {}. Same source can have only one pipeline in an org",
                     similar_pl.name, similar_pl.org
                 ),
             )));
         }
-        // Pipeline source changed:
         match existing_pipeline.source {
             // realtime: remove prev. src. stream_params from cache
             PipelineSource::Realtime(stream_params) => Some(stream_params),

--- a/src/service/search/datafusion/udf/regexp_matches_udf.rs
+++ b/src/service/search/datafusion/udf/regexp_matches_udf.rs
@@ -34,12 +34,14 @@ pub(crate) static REGEX_MATCHES_UDF: Lazy<ScalarUDF> =
 
 /// # `re_matches` User-Defined Function (UDF)
 ///
-/// This UDF extracts all substrings from a string column that match a given regular expression pattern.
-/// It is designed to work with the DataFusion query engine and supports both scalar and array inputs.
+/// This UDF extracts all substrings from a string column that match a given regular expression
+/// pattern. It is designed to work with the DataFusion query engine and supports both scalar and
+/// array inputs.
 ///
 /// ## Purpose
 ///
-/// The `re_matches` UDF allows users to extract all matches of a regular expression from a string column.
+/// The `re_matches` UDF allows users to extract all matches of a regular expression from a string
+/// column.
 ///
 /// ## Function Signature
 ///
@@ -52,9 +54,9 @@ pub(crate) static REGEX_MATCHES_UDF: Lazy<ScalarUDF> =
 ///
 /// ## Return Type
 ///
-/// - The function returns a `List` of strings for each input row. If no matches are found, an empty list is returned.
+/// - The function returns a `List` of strings for each input row. If no matches are found, an empty
+///   list is returned.
 /// - If the input string or pattern is null, the function returns null for that row.
-///
 #[derive(Debug)]
 pub struct RegexpMatchesFunc {
     signature: Signature,
@@ -150,9 +152,8 @@ pub fn regexp_matches<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef>
     // Precompile the regex if it's scalar
     let scalar_regex = if is_scalar_pattern {
         Some(
-            Regex::new(regex.value(0)).map_err(|e| {
-                DataFusionError::Execution(format!("Invalid regex pattern: {}", e))
-            })?,
+            Regex::new(regex.value(0))
+                .map_err(|e| DataFusionError::Execution(format!("Invalid regex pattern: {}", e)))?,
         )
     } else {
         None
@@ -257,7 +258,7 @@ mod tests {
 
         // Define schema
         let schema = Arc::new(Schema::new(vec![
-            Field::new("log", DataType::Utf8, true),    // Allow NULLs in `log`
+            Field::new("log", DataType::Utf8, true), // Allow NULLs in `log`
             Field::new("regex", DataType::Utf8, true), // Allow NULLs in `regex`
         ]));
 
@@ -266,22 +267,22 @@ mod tests {
             schema.clone(),
             vec![
                 Arc::new(StringArray::from(vec![
-                    Some("abc123def456"), // Normal case: numbers in the string
+                    Some("abc123def456"),  // Normal case: numbers in the string
                     Some("no match here"), // No match case
-                    Some("789ghi123"), // Multiple matches
-                    None, // NULL log
-                    Some(""), // Empty string
+                    Some("789ghi123"),     // Multiple matches
+                    None,                  // NULL log
+                    Some(""),              // Empty string
                 ])),
                 Arc::new(StringArray::from(vec![
-                    Some("\\d+"), // Match any digits
+                    Some("\\d+"),     // Match any digits
                     Some("no match"), // Match literal "no match"
-                    Some("ghi"), // Match substring "ghi"
-                    Some("\\w+"), // Match any word (NULL log should return NULL)
-                    None, // NULL regex
+                    Some("ghi"),      // Match substring "ghi"
+                    Some("\\w+"),     // Match any word (NULL log should return NULL)
+                    None,             // NULL regex
                 ])),
             ],
         )
-            .unwrap();
+        .unwrap();
 
         // Create a session context
         let ctx = SessionContext::new();

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -136,11 +136,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             use-input
             hide-selected
             fill-input
-            :input-debounce="400"
             @filter="filterStreams"
             behavior="menu"
+            @input-debounce="100"
             :rules="[(val: any) => !!val || 'Field is required!']"
             :option-disable="(option : any)  => option.isDisable"
+            @input-value="handleDynamicStreamName"
+           
             />
           </div>
         </div>
@@ -240,6 +242,8 @@ const streamTypes = ["logs", "metrics", "traces"];
 //for testing purpose but remove metrics and traces as discuessedf
 const outputStreamTypes = ["logs", "metrics", "traces"];
 const stream_name = ref((pipelineObj.currentSelectedNodeData?.data as { stream_name?: string })?.stream_name || {label: "", value: "", isDisable: false});
+const dynamic_stream_name = ref((pipelineObj.currentSelectedNodeData?.data as { stream_name?: string })?.stream_name || {label: "", value: "", isDisable: false});
+
 const stream_type = ref((pipelineObj.currentSelectedNodeData?.data as { stream_type?: string })?.stream_type || "logs");
 const selectedNodeType = ref((pipelineObj.currentSelectedNodeData as { io_type?: string })?.io_type || "");
 onMounted(async () => {
@@ -331,11 +335,30 @@ const updateStreams = () => {
   
 };
 
+
+
+const handleDynamicStreamName = (val:any) =>{
+  val = val.replace(/-/g, '_');
+  dynamic_stream_name.value = {label: val, value: val, isDisable: false};
+}
+
+const saveDynamicStream = () =>{
+  if(typeof dynamic_stream_name.value == 'object' && dynamic_stream_name.value.hasOwnProperty('value') && dynamic_stream_name.value.hasOwnProperty('label')){
+    const{label,value} = dynamic_stream_name.value;
+    stream_name.value = {label: label, value:value, isDisable: false}; 
+  }
+  //this condition will never be true but we are keeping it for future reference
+  else{
+    stream_name.value = dynamic_stream_name.value;
+  }
+}
+
 const filteredStreamTypes = computed(() => {
       return selectedNodeType.value === 'output' ? outputStreamTypes : streamTypes;
     });
 
 const getLogStream = (data: any) =>{
+
   data.name = data.name.replace(/-/g, '_');
 
   stream_name.value = {label: data.name, value: data.name, isDisable: false};

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -17,7 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <template>
   <div
     data-test="add-stream-input-stream-routing-section"
-    class="full-width full-height"
+    class=" full-height"
+    style="width: 40vw;"
     :class="store.state.theme === 'dark' ? 'bg-dark' : 'bg-white'"
   >
     <div class="stream-routing-title q-pb-sm q-pl-md">
@@ -115,44 +116,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             />
           </div>
           <div
-            data-test="input-node-stream-select"
-            class="o2-input full-width"
+            data-test="input-node-stream-type-select"
+            class="alert-stream-type o2-input q-mr-sm full-width"
             style="padding-top: 0"
           >
-          <span>
-            <label class="q-mb-xs q-mt-none text-bold" style="color: #BABABA;">
-            {{ t('alerts.stream_name') + ' *' }}
-          </label>
-          
-          <q-icon
-            :name="outlinedInfo"
-            size="17px"
-            class="q-ml-xs cursor-pointer"
-            :class="
-              store.state.theme === 'dark' ? 'text-grey-5' : 'text-grey-7'
-            "
-          >
-            <q-tooltip
-              anchor="center right"
-              self="center left"
-              max-width="300px"
-              :label="'hello'"
-            >
-              <span style="font-size: 14px">To set Stream Name dynamically using the value of a field, please surround the field name with &#123;&#123;  &#125;&#125; <br> Eg: &#123;&#123;kubernetes_namespace_name&#125;&#125;</span>
-            </q-tooltip>
-          </q-icon>
-          </span>
           <q-select
             v-model="stream_name"
             :options="filteredStreams"
              option-label="label"
               option-value="value"
-            label=""
+            :label="t('alerts.stream_name') + ' *'"
             :loading="isFetchingStreams"
             :popup-content-style="{ textTransform: 'lowercase' }"
             color="input-border"
             bg-color="input-bg"
-            class="q-pb-sm showLabelOnTop no-case full-width"
+            class="q-py-sm showLabelOnTop no-case full-width"
             filled
             stack-label
             dense
@@ -165,13 +143,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :rules="[(val: any) => !!val || 'Field is required!']"
             :option-disable="(option : any)  => option.isDisable"
             @input-value="handleDynamicStreamName"
-            style="padding-top: 4px !important;"
            
             />
 
 
 
+
           </div>
+          <div style="font-size: 14px;" class="note-message" >
+          <span class="tw-flex tw-items-center"> <q-icon name="info" class="q-pr-xs"</q-icon> Use curly braces {} to include dynamic values. e.g. static_text_{fieldname}_postfix</span>
+            </div>
         </div>
 
         <div
@@ -309,9 +290,8 @@ watch(selected, (newValue:any) => {
 watch(() => dynamic_stream_name.value,
 ()=>{
   if(  dynamic_stream_name.value !== null && dynamic_stream_name.value !== ""){
-    const regex = /\{(?!\{)[^{}]+\}(?!\})/g;
-
-// Check if there is any value between {{ stream_name }}
+    const regex = /^[a-zA-Z0-9_]*\{[a-zA-Z0-9_]+\}[a-zA-Z0-9_]*$/;
+    // Check if there is any value between {{ stream_name }}
       if ( typeof dynamic_stream_name.value == 'object' &&  dynamic_stream_name.value.hasOwnProperty('value') && regex.test(dynamic_stream_name.value.value)) {
         saveDynamicStream();
       }
@@ -523,6 +503,16 @@ const filterColumns = (options: any[], val: String, update: Function) => {
   text-transform: none !important;
   font-size: 0.875rem; /* Keep the font size and weight as needed */
   font-weight: 600;
+}
+
+.note-message{
+  background-color: #F9F290 ;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid #F5A623;
+  color: #865300;
+  width: 100%;
+  margin-bottom: 20px;
 }
 
 

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -123,6 +123,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <label class="q-mb-xs q-mt-none text-bold" style="color: #BABABA;">
             {{ t('alerts.stream_name') + ' *' }}
           </label>
+          
           <q-icon
             :name="outlinedInfo"
             size="17px"
@@ -167,6 +168,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             style="padding-top: 4px !important;"
            
             />
+
+
 
           </div>
         </div>
@@ -306,12 +309,11 @@ watch(selected, (newValue:any) => {
 watch(() => dynamic_stream_name.value,
 ()=>{
   if(  dynamic_stream_name.value !== null && dynamic_stream_name.value !== ""){
-    const regex = /\{\{.+\}\}/;
+    const regex = /\{(?!\{)[^{}]+\}(?!\})/g;
 
 // Check if there is any value between {{ stream_name }}
       if ( typeof dynamic_stream_name.value == 'object' &&  dynamic_stream_name.value.hasOwnProperty('value') && regex.test(dynamic_stream_name.value.value)) {
         saveDynamicStream();
-        console.log(dynamic_stream_name.value, "val");
       }
    
   }

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -151,7 +151,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           </div>
           <div style="font-size: 14px;" class="note-message" >
-          <span class="tw-flex tw-items-center"> <q-icon name="info" class="q-pr-xs"</q-icon> Use curly braces {} to include dynamic values. e.g. static_text_{fieldname}_postfix</span>
+          <span class="tw-flex tw-items-center"> <q-icon name="info" class="q-pr-xs"</q-icon> Use curly braces '{}' to configure stream name dynamically. e.g. static_text_{fieldname}_postfix. Static text before/after {} is optional</span>
             </div>
         </div>
 

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -119,17 +119,39 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             class="o2-input full-width"
             style="padding-top: 0"
           >
+          <span>
+            <label class="q-mb-xs q-mt-none text-bold" style="color: #BABABA;">
+            {{ t('alerts.stream_name') + ' *' }}
+          </label>
+          <q-icon
+            :name="outlinedInfo"
+            size="17px"
+            class="q-ml-xs cursor-pointer"
+            :class="
+              store.state.theme === 'dark' ? 'text-grey-5' : 'text-grey-7'
+            "
+          >
+            <q-tooltip
+              anchor="center right"
+              self="center left"
+              max-width="300px"
+              :label="'hello'"
+            >
+              <span style="font-size: 14px">To pass Dynamic Stream Name you need to surround stream name with &#123;&#123;  &#125;&#125; <br> Eg: &#123;&#123; Stream Name  &#125;&#125;</span>
+            </q-tooltip>
+          </q-icon>
+          </span>
           <q-select
             v-model="stream_name"
             :options="filteredStreams"
              option-label="label"
               option-value="value"
-            :label="t('alerts.stream_name') + ' *'"
+            label=""
             :loading="isFetchingStreams"
             :popup-content-style="{ textTransform: 'lowercase' }"
             color="input-border"
             bg-color="input-bg"
-            class="q-py-sm showLabelOnTop no-case full-width"
+            class="q-pb-sm showLabelOnTop no-case full-width"
             filled
             stack-label
             dense
@@ -142,8 +164,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :rules="[(val: any) => !!val || 'Field is required!']"
             :option-disable="(option : any)  => option.isDisable"
             @input-value="handleDynamicStreamName"
+            style="padding-top: 4px !important;"
            
             />
+
           </div>
         </div>
 
@@ -213,6 +237,8 @@ import AddStream from "@/components/logstream/AddStream.vue";
 
 import { useQuasar } from "quasar";
 
+import { outlinedInfo } from "@quasar/extras/material-icons-outlined";
+
 const emit = defineEmits(["cancel:hideform"]);
 
 
@@ -276,17 +302,20 @@ onMounted(async () => {
 watch(selected, (newValue:any) => {
       pipelineObj.userSelectedNode = newValue; 
 });
-watch(stream_type, (newValue:any) => {
-  if(newValue){
-    // pipelineObj.currentSelectedNodeData.data.stream_type = newValue;
-    stream_name.value = {label: "", value: "", isDisable: false};
-    
 
-    // pipelineObj.currentSelectedNodeData.data.stream_name = "";
+watch(() => dynamic_stream_name.value,
+()=>{
+  if(  dynamic_stream_name.value !== null && dynamic_stream_name.value !== ""){
+    const regex = /\{\{.+\}\}/;
 
+// Check if there is any value between {{ stream_name }}
+      if ( typeof dynamic_stream_name.value == 'object' &&  dynamic_stream_name.value.hasOwnProperty('value') && regex.test(dynamic_stream_name.value.value)) {
+        saveDynamicStream();
+        console.log(dynamic_stream_name.value, "val");
+      }
+   
   }
-  getStreamList();
-});
+})
 async function getUsedStreamsList() {
     const org_identifier = store.state.selectedOrganization.identifier;
   try {

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -137,7 +137,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               max-width="300px"
               :label="'hello'"
             >
-              <span style="font-size: 14px">To pass Dynamic Stream Name you need to surround stream name with &#123;&#123;  &#125;&#125; <br> Eg: &#123;&#123; Stream Name  &#125;&#125;</span>
+              <span style="font-size: 14px">To set Stream Name dynamically using the value of a field, please surround the field name with &#123;&#123;  &#125;&#125; <br> Eg: &#123;&#123;kubernetes_namespace_name&#125;&#125;</span>
             </q-tooltip>
           </q-icon>
           </span>

--- a/web/src/plugins/pipelines/useDnD.ts
+++ b/web/src/plugins/pipelines/useDnD.ts
@@ -65,6 +65,7 @@ const defaultObject = {
   currentSelectedNodeData : <any> {
     stream_type: "logs",
     stream_name: "",
+    dynamic_stream_name:"",
     data: {},
     type:"",
   },


### PR DESCRIPTION
impl #4968 

## How to use
When using pipeline to configure/modify data ingestion, users can set the destination `Stream` dynamically based on the records that are being ingested now. 

When configuring the destination stream in pipeline editor, instead of selecting any existing streams from the dropdown or creating a new stream, one can use `{}` to wrap _**flattened**_ `field_name`, the value of such field will be the final destination stream. 

<img width="1192" alt="image" src="https://github.com/user-attachments/assets/3aa90099-3abf-43b2-bf32-b3780a1beff2">

For above example, record below will be ingested into stream _**container_mystifying_ptolemy_app1**_

```
{
    "app_name": "o2",
    "kubernetes": {
        "container_name": "mystifying_ptolemy"
    }
    "value": 123
}
```

--- 

This pr also fixes issues with the updating pipeline api, specifically when pipeline source is changed:
- remove prev trigger data for scheduled
- remove prev ExecutablePipeline from cache for realtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced stream creation interface with dynamic stream name handling.
  - Introduced dynamic stream name support in node data for improved functionality.

- **Improvements**
  - Streamlined pipeline caching and update processes for better performance.
  - Improved error handling and control flow in pipeline updates.
  - Added logic for resolving dynamic stream names in batch processing.

- **Bug Fixes**
  - Adjusted logic for resolving dynamic stream names to ensure accurate processing.

- **Documentation**
  - Updated comments for clarity in user-defined functions and related components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->