### PR TITLE
fix: panic when the inverted index file is empty

### DIFF
--- a/src/config/src/utils/parquet.rs
+++ b/src/config/src/utils/parquet.rs
@@ -124,7 +124,7 @@ pub async fn get_recordbatch_reader_from_bytes(
     let schema_reader = Cursor::new(data.clone());
     let arrow_reader = ParquetRecordBatchStreamBuilder::new(schema_reader).await?;
     let schema = arrow_reader.schema().clone();
-    let reader = arrow_reader.build()?;
+    let reader = arrow_reader.with_batch_size(PARQUET_BATCH_SIZE).build()?;
     Ok((schema, reader))
 }
 
@@ -134,7 +134,7 @@ pub async fn get_recordbatch_reader_from_file(
     let file = tokio::fs::File::open(path).await?;
     let arrow_reader = ParquetRecordBatchStreamBuilder::new(file).await?;
     let schema = arrow_reader.schema().clone();
-    let reader = arrow_reader.build()?;
+    let reader = arrow_reader.with_batch_size(PARQUET_BATCH_SIZE).build()?;
     Ok((schema, reader))
 }
 

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -149,7 +149,7 @@ pub trait FileList: Sync + Send + 'static {
         stream_type: StreamType,
         stream: &str,
         offset: i64,
-    ) -> Result<()>;
+    ) -> Result<i64>;
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<MergeJobRecord>>;
     async fn get_pending_jobs_count(&self) -> Result<stdHashMap<String, stdHashMap<String, i64>>>;
     async fn set_job_pending(&self, ids: &[i64]) -> Result<()>;
@@ -383,7 +383,7 @@ pub async fn add_job(
     stream_type: StreamType,
     stream: &str,
     offset: i64,
-) -> Result<()> {
+) -> Result<i64> {
     CLIENT.add_job(org_id, stream_type, stream, offset).await
 }
 

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -897,7 +897,7 @@ UPDATE stream_stats
         stream_type: StreamType,
         stream: &str,
         offset: i64,
-    ) -> Result<()> {
+    ) -> Result<i64> {
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -907,20 +907,31 @@ UPDATE stream_stats
             "INSERT IGNORE INTO file_list_jobs (org, stream, offsets, status, node, started_at, updated_at) VALUES (?, ?, ?, ?, '', 0, 0);",
         )
         .bind(org_id)
-        .bind(stream_key)
+        .bind(&stream_key)
         .bind(offset)
         .bind(super::FileListJobStatus::Pending)
         .execute(&pool)
         .await
         {
-            Err(sqlx::Error::Database(e)) => if e.is_unique_violation() {
-                Ok(())
-            } else {
-                Err(Error::Message(e.to_string()))
+            Err(sqlx::Error::Database(e)) => if !e.is_unique_violation() {
+                return Err(Error::Message(e.to_string()));
+            }
+            Err(e) => {
+                return Err(e.into());
             },
-            Err(e) => Err(e.into()),
-            Ok(_) => Ok(()),
-        }
+            Ok(_) => {}
+        };
+
+        // get job id
+        let ret = sqlx::query(
+            "SELECT id FROM file_list_jobs WHERE org = ? AND stream = ? AND offsets = ?;",
+        )
+        .bind(org_id)
+        .bind(&stream_key)
+        .bind(offset)
+        .fetch_one(&pool)
+        .await?;
+        Ok(ret.try_get::<i64, &str>("id").unwrap_or_default())
     }
 
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -915,7 +915,7 @@ UPDATE stream_stats
         stream_type: StreamType,
         stream: &str,
         offset: i64,
-    ) -> Result<()> {
+    ) -> Result<i64> {
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
@@ -927,19 +927,30 @@ UPDATE stream_stats
                     "INSERT INTO file_list_jobs (org, stream, offsets, status, node, started_at, updated_at) VALUES ($1, $2, $3, $4, '', 0, 0) ON CONFLICT DO NOTHING;"
                 )
                 .bind(org_id)
-                .bind(stream_key)
+                .bind(&stream_key)
                 .bind(offset)
                 .bind(super::FileListJobStatus::Pending)
                 .execute(&pool).await
         {
-            Err(sqlx::Error::Database(e)) => if e.is_unique_violation() {
-                Ok(())
-            } else {
-                Err(Error::Message(e.to_string()))
+            Err(sqlx::Error::Database(e)) => if !e.is_unique_violation() {
+                return Err(Error::Message(e.to_string()));
             }
-            Err(e) => Err(e.into()),
-            Ok(_) => Ok(()),
-        }
+            Err(e) => {
+                return Err(e.into());
+            },
+            Ok(_) => {}
+        };
+
+        // get job id
+        let ret = sqlx::query(
+            "SELECT id FROM file_list_jobs WHERE org = ? AND stream = ? AND offsets = ?;",
+        )
+        .bind(org_id)
+        .bind(&stream_key)
+        .bind(offset)
+        .fetch_one(&pool)
+        .await?;
+        Ok(ret.try_get::<i64, &str>("id").unwrap_or_default())
     }
 
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -943,7 +943,7 @@ UPDATE stream_stats
 
         // get job id
         let ret = sqlx::query(
-            "SELECT id FROM file_list_jobs WHERE org = ? AND stream = ? AND offsets = ?;",
+            "SELECT id FROM file_list_jobs WHERE org = $1 AND stream = $2 AND offsets = $3;",
         )
         .bind(org_id)
         .bind(&stream_key)

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -802,7 +802,7 @@ UPDATE stream_stats
         stream_type: StreamType,
         stream: &str,
         offset: i64,
-    ) -> Result<()> {
+    ) -> Result<i64> {
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
@@ -810,20 +810,31 @@ UPDATE stream_stats
             "INSERT INTO file_list_jobs (org, stream, offsets, status, node, started_at, updated_at) VALUES ($1, $2, $3, $4, '', 0, 0);",
         )
         .bind(org_id)
-        .bind(stream_key)
+        .bind(&stream_key)
         .bind(offset)
         .bind(super::FileListJobStatus::Pending)
         .execute(&*client)
         .await
         {
-            Err(sqlx::Error::Database(e)) => if e.is_unique_violation() {
-                Ok(())
-            } else {
-                Err(Error::Message(e.to_string()))
+            Err(sqlx::Error::Database(e)) => if !e.is_unique_violation() {
+                return Err(Error::Message(e.to_string()));
             },
-            Err(e) => Err(e.into()),
-            Ok(_) => Ok(()),
-        }
+            Err(e) => {
+                return Err(e.into());
+            },
+            Ok(_) => {}
+        };
+
+        // get job id
+        let ret = sqlx::query(
+            "SELECT id FROM file_list_jobs WHERE org = ? AND stream = ? AND offsets = ?;",
+        )
+        .bind(org_id)
+        .bind(&stream_key)
+        .bind(offset)
+        .fetch_one(&*client)
+        .await?;
+        Ok(ret.try_get::<i64, &str>("id").unwrap_or_default())
     }
 
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -827,7 +827,7 @@ UPDATE stream_stats
 
         // get job id
         let ret = sqlx::query(
-            "SELECT id FROM file_list_jobs WHERE org = ? AND stream = ? AND offsets = ?;",
+            "SELECT id FROM file_list_jobs WHERE org = $1 AND stream = $2 AND offsets = $3;",
         )
         .bind(org_id)
         .bind(&stream_key)

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -1008,12 +1008,6 @@ pub(crate) async fn generate_index_on_compactor(
         return Ok(vec![]);
     }
 
-    log::info!(
-        "[COMPACT:JOB] prepare_index_record_batches, data file: {}, took: {} ms",
-        new_file_key,
-        start.elapsed().as_millis(),
-    );
-
     let schema = record_batches.first().unwrap().schema();
     let prefix_to_remove = format!("files/{}/{}/{}/", org_id, stream_type, stream_name);
     let len_of_columns_to_invalidate = file_list_to_invalidate.len();
@@ -1101,7 +1095,6 @@ async fn prepare_index_record_batches(
     schema: Arc<Schema>,
     reader: &mut ParquetRecordBatchStream<std::io::Cursor<Bytes>>,
 ) -> Result<Vec<RecordBatch>, anyhow::Error> {
-    let start = std::time::Instant::now();
     let cfg = get_config();
     let schema_fields = schema
         .fields()
@@ -1250,13 +1243,6 @@ async fn prepare_index_record_batches(
         tokio::task::yield_now().await;
     }
 
-    tokio::task::yield_now().await;
-    log::info!(
-        "[INGESTER:JOB] prepare_index_record_batches, collect records, data file: {}, took: {} ms",
-        new_file_key,
-        start.elapsed().as_millis(),
-    );
-
     // build record batch
     let prefix_to_remove = format!("files/{}/{}/{}/", org_id, stream_type, stream_name);
     let file_name_without_prefix = new_file_key.trim_start_matches(&prefix_to_remove);
@@ -1328,12 +1314,6 @@ async fn prepare_index_record_batches(
                 tokio::task::yield_now().await;
             }
         }
-
-        log::info!(
-            "[INGESTER:JOB] prepare_index_record_batches, build record batch, data file: {}, took: {} ms",
-            new_file_key,
-            start.elapsed().as_millis(),
-        );
     }
 
     Ok(indexed_record_batches_to_merge)

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -131,7 +131,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         tokio::task::spawn(async move { db::enrichment_table::watch().await });
     }
 
-    tokio::task::yield_now().await; // yield let other tasks run
+    tokio::task::yield_now().await;
 
     // cache core metadata
     db::schema::cache().await.expect("stream cache failed");

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -830,7 +830,7 @@ pub async fn merge_files(
                 continue;
             }
             log::info!(
-                "Created parquet index file during compaction: {}",
+                "created parquet index file during compaction: {}",
                 file_name
             );
             // Notify that we wrote the index file to the db.

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -826,7 +826,13 @@ pub async fn merge_files(
             )
         })?;
         for (file_name, filemeta) in files {
-            log::info!("Created parquet index file during compaction {}", file_name);
+            if file_name.is_empty() {
+                continue;
+            }
+            log::info!(
+                "Created parquet index file during compaction: {}",
+                file_name
+            );
             // Notify that we wrote the index file to the db.
             if let Err(e) = write_file_list(
                 org_id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The `add_job` method now returns a job ID upon successful insertion, enhancing tracking and reference capabilities.

- **Bug Fixes**
	- Improved error handling in the `add_job` method across various database implementations to streamline responses to unique constraint violations.

- **Chores**
	- Enhanced logging behavior in the `merge_files` function to prevent empty log entries, improving log clarity.
	- Added timing information to logging statements for better observability during parquet file processing and indexing.
	- Set explicit batch size for record batch readers to optimize data processing.
	- Enhanced logging for successful index file uploads, including file size and duration of the operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->