### PR TITLE
feat: improve replay wal to avoid OOM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "chrono",
- "chrono-tz 0.10.0",
+ "chrono-tz",
  "half",
  "hashbrown 0.14.5",
  "num",
@@ -2176,35 +2176,13 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build 0.3.0",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6dd8046d00723a59a2f8c5f295c515b9bb9a331ee4f8f3d4dd49e428acd3b6"
 dependencies = [
  "chrono",
- "chrono-tz-build 0.4.0",
+ "chrono-tz-build",
  "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -3638,7 +3616,7 @@ dependencies = [
 [[package]]
 name = "enrichment"
 version = "0.1.0"
-source = "git+https://github.com/openobserve/vector?rev=70e61fc344b9db2f191cfba9ad58ee08e79d30b4#70e61fc344b9db2f191cfba9ad58ee08e79d30b4"
+source = "git+https://github.com/openobserve/vector?rev=3d16e345232bb3cb9b104ee6461e9dd0b4c361da#3d16e345232bb3cb9b104ee6461e9dd0b4c361da"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -3773,6 +3751,17 @@ checksum = "9e0be0a561335815e06dab7c62e50353134c796e7a6155402a64bcff66b6a5e0"
 dependencies = [
  "dissimilar",
  "once_cell",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4767,6 +4756,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "influxdb-line-protocol"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fa7ee6be451ea0b1912b962c91c8380835e97cf1584a77e18264e908448dcb"
+dependencies = [
+ "bytes",
+ "log",
+ "nom",
+ "smallvec",
+ "snafu 0.7.5",
+]
+
+[[package]]
 name = "infra"
 version = "0.1.0"
 dependencies = [
@@ -5041,7 +5043,7 @@ dependencies = [
  "bit-set",
  "ena",
  "itertools 0.11.0",
- "lalrpop-util",
+ "lalrpop-util 0.20.2",
  "petgraph",
  "regex",
  "regex-syntax 0.8.5",
@@ -5057,6 +5059,12 @@ name = "lalrpop-util"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+
+[[package]]
+name = "lalrpop-util"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108dc8f5dabad92c65a03523055577d847f5dcc00f3e7d3a68bc4d48e01d8fe1"
 dependencies = [
  "regex-automata 0.4.8",
 ]
@@ -6915,13 +6923,13 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5eec97d5d34bdd17ad2db2219aabf46b054c6c41bd5529767c9ce55be5898f"
+checksum = "4b7535b02f0e5efe3e1dbfcb428be152226ed0c66cad9541f2274c8ba8d4cd40"
 dependencies = [
  "once_cell",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost 0.13.3",
+ "prost-types 0.13.3",
 ]
 
 [[package]]
@@ -9729,9 +9737,9 @@ dependencies = [
 
 [[package]]
 name = "vrl"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84451e6a979d54175932cfe49f36f31ab7a483f3feb3cfa65ee584b91ef2f858"
+checksum = "5c22ec61cbd43e563df185521f9a2fb2f42f6ab96604a574c82f6564049fb431"
 dependencies = [
  "aes",
  "ansi_term",
@@ -9746,11 +9754,12 @@ dependencies = [
  "chacha20poly1305",
  "charset",
  "chrono",
- "chrono-tz 0.9.0",
+ "chrono-tz",
  "cidr-utils",
  "clap 4.5.20",
  "codespan-reporting",
  "community-id",
+ "convert_case 0.6.0",
  "crypto_secretbox",
  "csv",
  "ctr",
@@ -9760,6 +9769,7 @@ dependencies = [
  "domain",
  "dyn-clone",
  "exitcode",
+ "fancy-regex",
  "flate2",
  "grok",
  "hex",
@@ -9769,9 +9779,10 @@ dependencies = [
  "idna 0.5.0",
  "indexmap 2.2.6",
  "indoc",
+ "influxdb-line-protocol",
  "itertools 0.13.0",
  "lalrpop",
- "lalrpop-util",
+ "lalrpop-util 0.21.0",
  "md-5",
  "nom",
  "ofb",
@@ -9785,7 +9796,7 @@ dependencies = [
  "pest_derive",
  "prettydiff",
  "prettytable-rs",
- "prost 0.12.6",
+ "prost 0.13.3",
  "prost-reflect",
  "psl",
  "psl-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ url.workspace = true
 utoipa.workspace = true
 utoipa-swagger-ui.workspace = true
 version-compare = "0.2.0"
-vector-enrichment = { package = "enrichment", git = "https://github.com/openobserve/vector", rev = "70e61fc344b9db2f191cfba9ad58ee08e79d30b4" }
+vector-enrichment.workspace = true
 vrl.workspace = true
 zstd.workspace = true
 config.workspace = true
@@ -323,5 +323,6 @@ url = "2.2"
 urlencoding = "2.1"
 utoipa = { version = "4", features = ["actix_extras", "openapi_extensions"] }
 utoipa-swagger-ui = { version = "4", features = ["actix-web"] }
-vrl = { version = "0.17.0", features = ["value", "compiler", "test"] }
+vector-enrichment = { version = "0.1.0", package = "enrichment", git = "https://github.com/openobserve/vector", rev = "3d16e345232bb3cb9b104ee6461e9dd0b4c361da" }
+vrl = { version = "0.19.0", features = ["value", "compiler", "test"] }
 zstd = "0.13"

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -857,10 +857,10 @@ pub struct Limit {
     #[env_config(name = "ZO_MAX_FILE_RETENTION_TIME", default = 600)] // seconds
     pub max_file_retention_time: u64,
     // MB, per log file size limit on disk
-    #[env_config(name = "ZO_MAX_FILE_SIZE_ON_DISK", default = 256)]
+    #[env_config(name = "ZO_MAX_FILE_SIZE_ON_DISK", default = 128)]
     pub max_file_size_on_disk: usize,
     // MB, per data file size limit in memory
-    #[env_config(name = "ZO_MAX_FILE_SIZE_IN_MEMORY", default = 256)]
+    #[env_config(name = "ZO_MAX_FILE_SIZE_IN_MEMORY", default = 128)]
     pub max_file_size_in_memory: usize,
     #[env_config(name = "ZO_UDSCHEMA_MAX_FIELDS", default = 0)]
     pub udschema_max_fields: usize,
@@ -1493,13 +1493,13 @@ fn check_common_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
 
     // check max_file_size_on_disk to MB
     if cfg.limit.max_file_size_on_disk == 0 {
-        cfg.limit.max_file_size_on_disk = 256 * 1024 * 1024; // 256MB
+        cfg.limit.max_file_size_on_disk = 128 * 1024 * 1024; // 128MB
     } else {
         cfg.limit.max_file_size_on_disk *= 1024 * 1024;
     }
     // check max_file_size_in_memory to MB
     if cfg.limit.max_file_size_in_memory == 0 {
-        cfg.limit.max_file_size_in_memory = 256 * 1024 * 1024; // 256MB
+        cfg.limit.max_file_size_in_memory = 128 * 1024 * 1024; // 128MB
     } else {
         cfg.limit.max_file_size_in_memory *= 1024 * 1024;
     }

--- a/src/handler/http/request/logs/ingest.rs
+++ b/src/handler/http/request/logs/ingest.rs
@@ -114,7 +114,10 @@ pub async fn multi(
                 _ => MetaHttpResponse::json(v),
             },
             Err(e) => {
-                log::error!("Error processing request {org_id}/{stream_name}: {:?}", e);
+                log::error!(
+                    "Error processing request {org_id}/{stream_name}/_multi: {:?}",
+                    e
+                );
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
                     http::StatusCode::BAD_REQUEST.into(),
                     e.to_string(),
@@ -167,7 +170,10 @@ pub async fn json(
                 _ => MetaHttpResponse::json(v),
             },
             Err(e) => {
-                log::error!("Error processing request {org_id}/{stream_name}: {:?}", e);
+                log::error!(
+                    "Error processing request {org_id}/{stream_name}/_json: {:?}",
+                    e
+                );
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
                     http::StatusCode::BAD_REQUEST.into(),
                     e.to_string(),
@@ -258,7 +264,10 @@ pub async fn handle_gcp_request(
         {
             Ok(v) => MetaHttpResponse::json(v),
             Err(e) => {
-                log::error!("Error processing request {org_id}/{stream_name}: {:?}", e);
+                log::error!(
+                    "Error processing request {org_id}/{stream_name}/_gcp: {:?}",
+                    e
+                );
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
                     http::StatusCode::BAD_REQUEST.into(),
                     e.to_string(),

--- a/src/handler/http/request/metrics/ingest.rs
+++ b/src/handler/http/request/metrics/ingest.rs
@@ -49,7 +49,7 @@ pub async fn json(org_id: web::Path<String>, body: web::Bytes) -> Result<HttpRes
     Ok(match metrics::json::ingest(&org_id, body).await {
         Ok(v) => HttpResponse::Ok().json(v),
         Err(e) => {
-            log::error!("Error processing request {org_id}/metrics: {:?}", e);
+            log::error!("Error processing request {org_id}/metrics/_json: {:?}", e);
             HttpResponse::BadRequest().json(MetaHttpResponse::error(
                 http::StatusCode::BAD_REQUEST.into(),
                 e.to_string(),

--- a/src/ingester/src/immutable.rs
+++ b/src/ingester/src/immutable.rs
@@ -184,3 +184,7 @@ pub(crate) async fn persist_table(idx: usize, path: PathBuf) -> Result<()> {
 
     Ok(())
 }
+
+pub(crate) async fn len() -> usize {
+    IMMUTABLES.read().await.len()
+}

--- a/src/ingester/src/lib.rs
+++ b/src/ingester/src/lib.rs
@@ -46,7 +46,11 @@ pub async fn init() -> errors::Result<()> {
     wal::check_uncompleted_parquet_files().await?;
 
     // replay wal files to create immutable
-    wal::replay_wal_files().await?;
+    tokio::task::spawn(async move {
+        if let Err(e) = wal::replay_wal_files().await {
+            log::error!("replay wal files error: {}", e);
+        }
+    });
 
     // start a job to flush memtable to immutable
     tokio::task::spawn(async move {

--- a/src/ingester/src/wal.rs
+++ b/src/ingester/src/wal.rs
@@ -205,6 +205,11 @@ pub(crate) async fn replay_wal_files() -> Result<()> {
             wal_file.to_owned(),
             Arc::new(immutable::Immutable::new(idx, key, memtable)),
         );
+
+        // to avoid the memory OOM, sleep for a while after reply one wal file
+        if immutable::len().await > 2 {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
     }
 
     Ok(())

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -189,7 +189,7 @@ async fn scan_wal_files(
         }
     }
     if files_num > 0 {
-        log::info!(
+        log::debug!(
             "[INGESTER:JOB] scan files get total: {}, took: {} ms",
             files_num,
             start.elapsed().as_millis()
@@ -611,6 +611,7 @@ async fn merge_files(
         new_file_size += file.meta.original_size;
         new_compressed_file_size += file.meta.compressed_size;
         new_file_list.push(file.clone());
+        log::info!("[INGESTER:JOB:{thread_id}] merge small file: {}", &file.key);
     }
     // no files need to merge
     if new_file_list.is_empty() {

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -69,7 +69,7 @@ pub async fn metrics_proto_handler(
     match handle_grpc_request(org_id, request, false).await {
         Ok(res) => Ok(res),
         Err(e) => {
-            log::error!("error processing request: {}", e);
+            log::error!("error processing request/{org_id}/metrics/otlp: {}", e);
             Ok(
                 HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                     http::StatusCode::INTERNAL_SERVER_ERROR.into(),

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -136,7 +136,7 @@ pub async fn merge_parquet_files(
     ctx.deregister_table("tbl")?;
     drop(ctx);
 
-    log::info!(
+    log::debug!(
         "merge_parquet_files took {} ms",
         start.elapsed().as_millis()
     );


### PR DESCRIPTION
It will sleep 1 second if Immutable has more than 2 tables when replay next WAL file.

- [x] fixed #5022 
- [x] fixed #5023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new asynchronous function to count entries in the immutables collection.
- **Improvements**
	- Adjusted maximum file size limits for disk and memory to enhance configuration settings.
	- Enhanced error handling during the Write-Ahead Logging (WAL) replay process for better stability.
	- Implemented a delay mechanism to manage memory usage during WAL file replay, reducing the risk of out-of-memory issues.
	- Refined logging levels and session configuration handling for improved clarity and robustness.
	- Expanded functionality for merging parquet files with enhanced logging and error handling.
	- Improved handling of file processing and logging within parquet file jobs.
	- Enhanced error logging for HTTP request handling, providing clearer context for issues.
- **Bug Fixes**
	- Improved configuration validation to ensure new limits are consistently enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->