### PR TITLE
fix: Search history disable when usage report  disabled

### DIFF
--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -129,7 +129,8 @@
     "flattened": "Flattened",
     "unflattened": "Unflattened",
     "original": "Original",
-    "resetFilters": "Reset Filters"
+    "resetFilters": "Reset Filters",
+    "redirect_to_logs_page":"Go Back to Logs page"
   },
   "menu": {
     "home": "Home",

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -307,7 +307,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         color="secondary"
       
         unelevated
-        label="Go Back to Logs page"
+        :label="t('search.redirect_to_logs_page')"
         no-caps
         @click="redirectBackToLogs"
       />

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -297,7 +297,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
       <div class="text-h4" style="opacity: 0.8">Search history is not enabled. </div>
       <div  style="opacity: 0.8" class="q-mt-sm flex items-center justify-center">
-        <q-icon name="info" class="q-mr-xs " size="20px" />
+        <q-icon name="info" class="q-mr-xs " size="20px" style="opacity: 0.5;" />
         <span class="text-h6 text-center ">
           Please contact administrator to enable.</span>
       </div>

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -280,8 +280,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         @closeSearchHistory="closeSearchHistoryfn"
         :isClicked="showSearchHistory"
       />
-      <div v-else>
-        <Error404 />
+      <div v-else style="height: 200px;" >
+        <div style="height: 100vh"
+      class=" text-center q-pa-md flex flex-center"
+     >
+    <div>
+      <div class="text-h4" style="opacity: 0.8">Search history not enabled /activated. Please contact to administrator.</div>
+
+      <q-btn
+        class="q-mt-xl"
+      
+        text-color="blue"
+        unelevated
+        label="Go Back to Logs page"
+        no-caps
+        @click="redirectBackToLogs"
+      />
+    </div>
+  </div>
       </div>
     </div>
 
@@ -322,7 +338,6 @@ import { buildSqlQuery, getFieldsFromQuery } from "@/utils/query/sqlUtils";
 import useNotifications from "@/composables/useNotifications";
 import SearchBar from "@/plugins/logs/SearchBar.vue";
 import SearchHistory from "@/plugins/logs/SearchHistory.vue";
-import Error404 from "@/views/Error404.vue";
 
 export default defineComponent({
   name: "PageSearch",
@@ -340,7 +355,6 @@ export default defineComponent({
     SanitizedHtmlRenderer,
     VisualizeLogsQuery,
     SearchHistory,
-    Error404,
   },
   mixins: [MainLayoutCloudMixin],
   methods: {
@@ -884,6 +898,15 @@ export default defineComponent({
 
     };
 
+    const redirectBackToLogs = () =>{
+      router.push({
+        name: "logs",
+        query: {
+          org_identifier: store.state.selectedOrganization.identifier,
+        },
+      });
+    }
+
     function removeFieldByName(data, fieldName) {
       return data.filter((item: any) => {
         if (item.expr) {
@@ -1228,6 +1251,7 @@ export default defineComponent({
       onAutoIntervalTrigger,
       showSearchHistory,
       showSearchHistoryfn,
+      redirectBackToLogs,
       handleRunQuery,
       refreshTimezone,
       resetSearchObj,

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -299,7 +299,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div  style="opacity: 0.8" class="q-mt-sm flex items-center justify-center">
         <q-icon name="info" class="q-mr-xs " size="20px" style="opacity: 0.5;" />
         <span class="text-h6 text-center ">
-          Please contact administrator to enable.</span>
+          Set ZO_USAGE_REPORTING_ENABLED to true to enable usage reporting.</span>
       </div>
 
       <q-btn

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -273,13 +273,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </template>
       </q-splitter>
     </div>
-    <div v-show="showSearchHistory">
+    <div   v-show="showSearchHistory">
       <search-history
+        v-if="store.state.zoConfig.usage_enabled"
         ref="searchHistoryRef"
         @closeSearchHistory="closeSearchHistoryfn"
         :isClicked="showSearchHistory"
       />
+      <div v-else>
+        <Error404 />
+      </div>
     </div>
+
   </q-page>
 </template>
 
@@ -317,6 +322,7 @@ import { buildSqlQuery, getFieldsFromQuery } from "@/utils/query/sqlUtils";
 import useNotifications from "@/composables/useNotifications";
 import SearchBar from "@/plugins/logs/SearchBar.vue";
 import SearchHistory from "@/plugins/logs/SearchHistory.vue";
+import Error404 from "@/views/Error404.vue";
 
 export default defineComponent({
   name: "PageSearch",
@@ -334,6 +340,7 @@ export default defineComponent({
     SanitizedHtmlRenderer,
     VisualizeLogsQuery,
     SearchHistory,
+    Error404,
   },
   mixins: [MainLayoutCloudMixin],
   methods: {
@@ -865,7 +872,7 @@ export default defineComponent({
       }
     };
     const showSearchHistoryfn = () => {
-      router.push({
+        router.push({
         name: "logs",
         query: {
           action: "history",
@@ -874,6 +881,7 @@ export default defineComponent({
         },
       });
       showSearchHistory.value = true;
+
     };
 
     function removeFieldByName(data, fieldName) {

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -281,16 +281,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :isClicked="showSearchHistory"
       />
       <div v-else style="height: 200px;" >
-        <div style="height: 100vh"
+        <div style="height: 80vh"
       class=" text-center q-pa-md flex flex-center"
      >
     <div>
-      <div class="text-h4" style="opacity: 0.8">Search history not enabled /activated. Please contact to administrator.</div>
+      <div class="text-h4" style="opacity: 0.8">Search history not enabled. <br> <span class="text-h6">Please contact to administrator.</span></div>
 
       <q-btn
         class="q-mt-xl"
+        color="primary"
       
-        text-color="blue"
         unelevated
         label="Go Back to Logs page"
         no-caps

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -285,11 +285,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       class=" text-center q-pa-md flex flex-center"
      >
     <div>
-      <div class="text-h4" style="opacity: 0.8">Search history not enabled. <br> <span class="text-h6">Please contact to administrator.</span></div>
+      <div>
+        <q-icon
+          name="history"
+          size="100px"
+          color="gray"
+          class="q-mb-md"
+          style="opacity: 0.1;"
+  
+        />
+      </div>
+      <div class="text-h4" style="opacity: 0.8">Search history is not enabled. </div>
+      <div  style="opacity: 0.8" class="q-mt-sm flex items-center justify-center">
+        <q-icon name="info" class="q-mr-xs " size="20px" />
+        <span class="text-h6 text-center ">
+          Please contact administrator to enable.</span>
+      </div>
 
       <q-btn
         class="q-mt-xl"
-        color="primary"
+        color="secondary"
       
         unelevated
         label="Go Back to Logs page"

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -400,6 +400,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :loading="shareLink.isLoading.value"
         ></q-btn>
         <q-btn
+        v-if="store.state.zoConfig.usage_enabled"
           data-test="logs-search-bar-share-link-btn"
           class="q-mr-xs download-logs-btn q-px-sm"
           size="sm"

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -400,7 +400,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :loading="shareLink.isLoading.value"
         ></q-btn>
         <q-btn
-        v-if="store.state.zoConfig.usage_enabled"
           data-test="logs-search-bar-share-link-btn"
           class="q-mr-xs download-logs-btn q-px-sm"
           size="sm"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced conditional rendering for search history based on usage settings.
	- Added a user-friendly message and navigation button when search history is not enabled.

- **Bug Fixes**
	- Improved navigation by implementing a method to redirect users back to the logs page.

- **Localization**
	- Added a new message for navigating back to the logs page in the English language support. 

- **Style**
	- Minor formatting adjustments for better readability in the template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->