### PR TITLE
fix: DerivedStream query period

### DIFF
--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -352,7 +352,7 @@ pub trait AlertExt: Sync + Send + 'static {
     async fn evaluate(
         &self,
         row: Option<&Map<String, Value>>,
-        start_time: Option<i64>,
+        (start_time, end_time): (Option<i64>, i64),
     ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error>;
 
     /// Returns a tuple containing a boolean - if all the send notification jobs successfully
@@ -370,7 +370,7 @@ impl AlertExt for Alert {
     async fn evaluate(
         &self,
         row: Option<&Map<String, Value>>,
-        start_time: Option<i64>,
+        (start_time, end_time): (Option<i64>, i64),
     ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error> {
         if self.is_real_time {
             self.query_condition.evaluate_realtime(row).await
@@ -385,7 +385,7 @@ impl AlertExt for Alert {
                     Some(&self.stream_name),
                     self.stream_type,
                     &self.trigger_condition,
-                    start_time,
+                    (start_time, end_time),
                     Some(SearchEventType::Alerts),
                     Some(search_event_ctx),
                 )

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -405,6 +405,7 @@ async fn write_logs(
         // start check for alert trigger
         if let Some(alerts) = cur_stream_alerts {
             if triggers.len() < alerts.len() {
+                let end_time = chrono::Utc::now().timestamp_micros();
                 for alert in alerts {
                     let key = format!(
                         "{}/{}/{}/{}",
@@ -418,7 +419,9 @@ async fn write_logs(
                     if evaluated_alerts.contains(&key) {
                         continue;
                     }
-                    if let Ok((Some(v), _)) = alert.evaluate(Some(&record_val), None).await {
+                    if let Ok((Some(v), _)) =
+                        alert.evaluate(Some(&record_val), (None, end_time)).await
+                    {
                         triggers.push((alert.clone(), v));
                         evaluated_alerts.insert(key);
                     }

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -411,8 +411,11 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
                 let key = format!("{}/{}/{}", org_id, StreamType::Metrics, stream_name);
                 if let Some(alerts) = stream_alerts_map.get(&key) {
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
+                    let alert_end_time = chrono::Utc::now().timestamp_micros();
                     for alert in alerts {
-                        if let Ok((Some(v), _)) = alert.evaluate(Some(record), None).await {
+                        if let Ok((Some(v), _)) =
+                            alert.evaluate(Some(record), (None, alert_end_time)).await
+                        {
                             trigger_alerts.push((alert.clone(), v));
                         }
                     }

--- a/src/service/metrics/otlp_grpc.rs
+++ b/src/service/metrics/otlp_grpc.rs
@@ -472,8 +472,11 @@ pub async fn handle_grpc_request(
                 );
                 if let Some(alerts) = stream_alerts_map.get(&key) {
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
+                    let alert_end_time = chrono::Utc::now().timestamp_micros();
                     for alert in alerts {
-                        if let Ok((Some(v), _)) = alert.evaluate(Some(val_map), None).await {
+                        if let Ok((Some(v), _)) =
+                            alert.evaluate(Some(val_map), (None, alert_end_time)).await
+                        {
                             trigger_alerts.push((alert.clone(), v));
                         }
                     }

--- a/src/service/metrics/otlp_http.rs
+++ b/src/service/metrics/otlp_http.rs
@@ -554,8 +554,11 @@ pub async fn metrics_json_handler(
                 let key = format!("{}/{}/{}", &org_id, StreamType::Metrics, local_metric_name);
                 if let Some(alerts) = stream_alerts_map.get(&key) {
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
+                    let alert_end_time = chrono::Utc::now().timestamp_micros();
                     for alert in alerts {
-                        if let Ok((Some(v), _)) = alert.evaluate(Some(val_map), None).await {
+                        if let Ok((Some(v), _)) =
+                            alert.evaluate(Some(val_map), (None, alert_end_time)).await
+                        {
                             trigger_alerts.push((alert.clone(), v));
                         }
                     }

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -491,8 +491,11 @@ pub async fn remote_write(
                 );
                 if let Some(alerts) = stream_alerts_map.get(&key) {
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
+                    let alert_end_time = chrono::Utc::now().timestamp_micros();
                     for alert in alerts {
-                        if let Ok((Some(v), _)) = alert.evaluate(Some(val_map), None).await {
+                        if let Ok((Some(v), _)) =
+                            alert.evaluate(Some(val_map), (None, alert_end_time)).await
+                        {
                             trigger_alerts.push((alert.clone(), v));
                         }
                     }

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -748,6 +748,7 @@ async fn write_traces(
         // Start check for alert trigger
         if let Some(alerts) = cur_stream_alerts {
             if triggers.len() < alerts.len() {
+                let alert_end_time = chrono::Utc::now().timestamp_micros();
                 for alert in alerts {
                     let key = format!(
                         "{}/{}/{}/{}",
@@ -760,7 +761,10 @@ async fn write_traces(
                     if evaluated_alerts.contains(&key) {
                         continue;
                     }
-                    if let Ok((Some(v), _)) = alert.evaluate(Some(&record_val), None).await {
+                    if let Ok((Some(v), _)) = alert
+                        .evaluate(Some(&record_val), (None, alert_end_time))
+                        .await
+                    {
                         triggers.push((alert.clone(), v));
                         evaluated_alerts.insert(key);
                     }


### PR DESCRIPTION
DerivedStream is executed periodically in the background according to a schedule set by its trigger's Frequency and Period. In our system, triggers are pulled from the `scheduled_jobs` table periodically based on another schedule set by env `ZO_ALERT_SCHEDULE_INTERVAL`. 

If this interval is set too long, potentially the time difference between two consecutive executions can be greater than the DerivedStream's trigger's period. Previously, the DerivedStream would query the time range that covers the entire time difference, which overrides the purpose of Period.
This PR addresses this issue by breaking down the time difference by Period to execute consecutively until the entire time different is covered. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced alert evaluation logic to include an end time parameter, improving the accuracy of alert triggers based on timing.
	- Introduced a mechanism for managing time ranges in derived stream evaluations, allowing for iterative checks over specified periods.

- **Bug Fixes**
	- Improved error handling and logging during alert evaluations and data type casting operations.

- **Documentation**
	- Updated error messages for clarity during data type casting failures.

These changes aim to enhance the overall functionality and reliability of alert management within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->