### PR TITLE
fix: mark union queries as complex to avoid adding _timestamp

### DIFF
--- a/src/config/src/utils/sql.rs
+++ b/src/config/src/utils/sql.rs
@@ -43,6 +43,7 @@ pub fn is_aggregate_query(query: &str) -> Result<bool, sqlparser::parser::Parser
                 || has_having(query)
                 || has_join(query)
                 || has_subquery(statement)
+                || has_union(query)
             {
                 return Ok(true);
             }
@@ -138,6 +139,13 @@ fn has_join(query: &Query) -> bool {
     } else {
         false
     }
+}
+
+fn has_union(query: &Query) -> bool {
+    if let SetExpr::SetOperation { .. } = *query.body {
+        return true;
+    }
+    false
 }
 
 fn has_subquery(stat: &Statement) -> bool {

--- a/src/service/search/datafusion/optimizer/add_sort_and_limit.rs
+++ b/src/service/search/datafusion/optimizer/add_sort_and_limit.rs
@@ -139,6 +139,7 @@ fn is_complex_query(plan: &LogicalPlan) -> bool {
             | LogicalPlan::SubqueryAlias(_)
             | LogicalPlan::Subquery(_)
             | LogicalPlan::Window(_)
+            | LogicalPlan::Union(_)
     )
 }
 


### PR DESCRIPTION
fix #5097 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced query optimization by improving handling of complex queries, including those with UNION, EXCEPT, and INTERSECT operations.
	- Introduced a new function to check for UNION operations in SQL queries, expanding aggregate query identification.
	- Added logging for better debugging of table scan projections.

- **Bug Fixes**
	- Adjusted logic to accurately classify SQL queries as complex based on new criteria.

- **Refactor**
	- Improved structure and efficiency of the query evaluation methods for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->