### PR TITLE
fix: report pdf must have .pdf extension

### DIFF
--- a/src/report_server/src/report.rs
+++ b/src/report_server/src/report.rs
@@ -408,7 +408,7 @@ pub async fn send_email(
                 .singlepart(
                     // Only supports PDF for now, attach the PDF
                     lettre::message::Attachment::new(
-                        format!("{}.pdf", email_details.title), // Attachment filename
+                        format!("{}.pdf", sanitize_filename(&email_details.title)), // Attachment filename
                     )
                     .body(pdf_data.to_owned(), ContentType::parse("application/pdf")?),
                 ),
@@ -449,4 +449,17 @@ pub async fn wait_for_panel_data_load(page: &Page) -> Result<Duration, anyhow::E
 
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
+}
+
+fn sanitize_filename(filename: &str) -> String {
+    filename
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ' ' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }

--- a/src/report_server/src/report.rs
+++ b/src/report_server/src/report.rs
@@ -408,7 +408,7 @@ pub async fn send_email(
                 .singlepart(
                     // Only supports PDF for now, attach the PDF
                     lettre::message::Attachment::new(
-                        email_details.title, // Attachment filename
+                        format!("{}.pdf", email_details.title), // Attachment filename
                     )
                     .body(pdf_data.to_owned(), ContentType::parse("application/pdf")?),
                 ),

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -392,15 +392,16 @@ impl Report {
         let email = email
             .multipart(
                 MultiPart::mixed()
-                    .singlepart(SinglePart::html(self.message.clone()))
                     .singlepart(SinglePart::html(format!(
-                        "<p><a href='{dashb_url}' target='_blank'>Link to dashboard</a></p>"
+                        "{}\n\n<p><a href='{dashb_url}' target='_blank'>Link to dashboard</a></p>",
+                        self.message
                     )))
                     .singlepart(
                         // Only supports PDF for now, attach the PDF
-                        lettre::message::Attachment::new(
-                            format!("{}.pdf", self.title), // Attachment filename
-                        )
+                        lettre::message::Attachment::new(format!(
+                            "{}.pdf",
+                            sanitize_filename(&self.title)
+                        ))
                         .body(pdf_data.to_owned(), ContentType::parse("application/pdf")?),
                     ),
             )
@@ -651,4 +652,17 @@ async fn wait_for_panel_data_load(page: &Page) -> Result<(), anyhow::Error> {
 
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
+}
+
+fn sanitize_filename(filename: &str) -> String {
+    filename
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ' ' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -399,7 +399,7 @@ impl Report {
                     .singlepart(
                         // Only supports PDF for now, attach the PDF
                         lettre::message::Attachment::new(
-                            self.title.clone(), // Attachment filename
+                            format!("{}.pdf", self.title), // Attachment filename
                         )
                         .body(pdf_data.to_owned(), ContentType::parse("application/pdf")?),
                     ),


### PR DESCRIPTION
Ref: https://github.com/openobserve/o2_report_server/issues/10.

This PR adds ".pdf" extension to the report pdf attached to smtp email message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced email attachment functionality by ensuring PDF files are correctly named with a `.pdf` extension for better recognition by email clients.
	- Improved email body structure by adding the report message before the dashboard link.

- **Bug Fixes**
	- Improved error handling and logging for the email sending process, providing clearer messages and more context during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->