### PR TITLE
chore: set default value for uds fields limit

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -880,7 +880,7 @@ pub struct Limit {
     // MB, per data file size limit in memory
     #[env_config(name = "ZO_MAX_FILE_SIZE_IN_MEMORY", default = 128)]
     pub max_file_size_in_memory: usize,
-    #[env_config(name = "ZO_UDSCHEMA_MAX_FIELDS", default = 2000)]
+    #[env_config(name = "ZO_UDSCHEMA_MAX_FIELDS", default = 1000)]
     pub udschema_max_fields: usize,
     // MB, total data size in memory, default is 50% of system memory
     #[env_config(name = "ZO_MEM_TABLE_MAX_SIZE", default = 0)]


### PR DESCRIPTION
Setting the value for ZO_UDSCHEMA_MAX_FIELDS to 1000 so as to trigger User defined Schemas after stream exceeds the limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Decreased the default limit for user-defined schema fields from 2000 to 1000, adjusting the maximum number of fields allowed in schema definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->