### PR TITLE
fix: pipeline init error due to functions fail to compile

### DIFF
--- a/src/config/src/meta/self_reporting/error.rs
+++ b/src/config/src/meta/self_reporting/error.rs
@@ -46,6 +46,8 @@ pub enum ErrorSource {
 pub struct PipelineError {
     pub pipeline_id: String,
     pub pipeline_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(serialize_with = "serialize_values_only")]
     pub node_errors: HashMap<String, NodeErrors>,
@@ -56,6 +58,7 @@ impl PipelineError {
         Self {
             pipeline_id: pipeline_id.to_string(),
             pipeline_name: pipeline_name.to_string(),
+            error: None,
             node_errors: HashMap::new(),
         }
     }
@@ -122,6 +125,7 @@ mod tests {
             error_source: ErrorSource::Pipeline(PipelineError {
                 pipeline_id: "pipeline_id".to_string(),
                 pipeline_name: "pipeline_name".to_string(),
+                error: Some("pipeline init error".to_string()),
                 node_errors: HashMap::from([(
                     "node_1".to_string(),
                     NodeErrors {

--- a/src/job/mmdb_downloader.rs
+++ b/src/job/mmdb_downloader.rs
@@ -13,14 +13,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{cmp::min, path::Path};
+use std::{cmp::min, path::Path, sync::Arc};
 
 use config::{MMDB_ASN_FILE_NAME, MMDB_CITY_FILE_NAME};
 use futures::stream::StreamExt;
 use once_cell::sync::Lazy;
 use reqwest::Client;
 use sha256::try_digest;
-use tokio::{fs::File, io::AsyncWriteExt, time};
+use tokio::{fs::File, io::AsyncWriteExt, sync::Notify, time};
 
 use crate::{
     common::{
@@ -30,7 +30,8 @@ use crate::{
     service::enrichment_table::geoip::{Geoip, GeoipConfig},
 };
 
-pub static CLIENT_INITIALIZED: Lazy<bool> = Lazy::new(|| true);
+static CLIENT_INITIALIZED: Lazy<bool> = Lazy::new(|| true);
+pub static MMDB_INIT_NOTIFIER: Lazy<Arc<Notify>> = Lazy::new(|| Arc::new(Notify::new()));
 
 pub async fn run() -> Result<(), anyhow::Error> {
     let cfg = config::get_config();
@@ -44,7 +45,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
     }
 }
 
-pub async fn run_download_files() {
+async fn run_download_files() {
     let cfg = config::get_config();
 
     // send request and await response
@@ -88,6 +89,7 @@ pub async fn run_download_files() {
         update_global_maxmind_client(&asn_fname).await;
         update_global_maxmind_client(&city_fname).await;
         log::info!("Maxmind client initialized");
+        Lazy::force(&MMDB_INIT_NOTIFIER).notify_one();
     } else {
         if download_asn_files {
             log::info!("New asn file found, updating client");

--- a/src/job/mmdb_downloader.rs
+++ b/src/job/mmdb_downloader.rs
@@ -30,7 +30,7 @@ use crate::{
     service::enrichment_table::geoip::{Geoip, GeoipConfig},
 };
 
-static CLIENT_INITIALIZED: Lazy<bool> = Lazy::new(|| true);
+pub static CLIENT_INITIALIZED: Lazy<bool> = Lazy::new(|| true);
 
 pub async fn run() -> Result<(), anyhow::Error> {
     let cfg = config::get_config();
@@ -44,7 +44,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
     }
 }
 
-async fn run_download_files() {
+pub async fn run_download_files() {
     let cfg = config::get_config();
 
     // send request and await response

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -39,6 +39,8 @@ mod stats;
 pub(crate) mod syslog_server;
 mod telemetry;
 
+pub use mmdb_downloader::{run_download_files, CLIENT_INITIALIZED};
+
 pub async fn init() -> Result<(), anyhow::Error> {
     let email_regex = Regex::new(
         r"^([a-z0-9_+]([a-z0-9_+.-]*[a-z0-9_+])?)@([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})",

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -39,7 +39,7 @@ mod stats;
 pub(crate) mod syslog_server;
 mod telemetry;
 
-pub use mmdb_downloader::{run_download_files, CLIENT_INITIALIZED};
+pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 
 pub async fn init() -> Result<(), anyhow::Error> {
     let email_regex = Regex::new(

--- a/src/service/db/pipeline.rs
+++ b/src/service/db/pipeline.rs
@@ -224,9 +224,9 @@ async fn update_cache(
                 }
                 Ok(exec_pl) => {
                     stream_pl_exec.insert(stream_params.clone(), exec_pl);
+                    log::info!("[Pipeline]: pipeline {} added to cache.", &pipeline.id);
                 }
             };
-            log::info!("[Pipeline]: pipeline {} added to cache.", &pipeline.id);
         }
     }
 }

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -28,12 +28,10 @@ use config::{
     utils::{flatten, json::Value},
 };
 use futures::future::try_join_all;
-use once_cell::sync::Lazy;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use crate::{
     common::infra::config::QUERY_FUNCTIONS,
-    job,
     service::{
         ingestion::{apply_vrl_fn, compile_vrl_function},
         self_reporting::publish_error,
@@ -53,10 +51,6 @@ impl PipelineExt for Pipeline {
         let mut vrl_map = HashMap::new();
         for node in &self.nodes {
             if let NodeData::Function(func_params) = &node.data {
-                let client = Lazy::get(&job::CLIENT_INITIALIZED);
-                if client.is_none() {
-                    job::run_download_files().await;
-                }
                 let transform = get_transforms(&self.org, &func_params.name).await?;
                 let vrl_runtime_config = compile_vrl_function(&transform.function, &self.org)?;
                 let registry = vrl_runtime_config

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -28,10 +28,12 @@ use config::{
     utils::{flatten, json::Value},
 };
 use futures::future::try_join_all;
+use once_cell::sync::Lazy;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use crate::{
     common::infra::config::QUERY_FUNCTIONS,
+    job,
     service::{
         ingestion::{apply_vrl_fn, compile_vrl_function},
         self_reporting::publish_error,
@@ -51,6 +53,10 @@ impl PipelineExt for Pipeline {
         let mut vrl_map = HashMap::new();
         for node in &self.nodes {
             if let NodeData::Function(func_params) = &node.data {
+                let client = Lazy::get(&job::CLIENT_INITIALIZED);
+                if client.is_none() {
+                    job::run_download_files().await;
+                }
                 let transform = get_transforms(&self.org, &func_params.name).await?;
                 let vrl_runtime_config = compile_vrl_function(&transform.function, &self.org)?;
                 let registry = vrl_runtime_config

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -52,21 +52,19 @@ impl PipelineExt for Pipeline {
         for node in &self.nodes {
             if let NodeData::Function(func_params) = &node.data {
                 let transform = get_transforms(&self.org, &func_params.name).await?;
-                if let Ok(vrl_runtime_config) = compile_vrl_function(&transform.function, &self.org)
-                {
-                    let registry = vrl_runtime_config
-                        .config
-                        .get_custom::<vector_enrichment::TableRegistry>()
-                        .unwrap();
-                    registry.finish_load();
-                    vrl_map.insert(
-                        node.get_node_id(),
-                        VRLResultResolver {
-                            program: vrl_runtime_config.program,
-                            fields: vrl_runtime_config.fields,
-                        },
-                    );
-                }
+                let vrl_runtime_config = compile_vrl_function(&transform.function, &self.org)?;
+                let registry = vrl_runtime_config
+                    .config
+                    .get_custom::<vector_enrichment::TableRegistry>()
+                    .unwrap();
+                registry.finish_load();
+                vrl_map.insert(
+                    node.get_node_id(),
+                    VRLResultResolver {
+                        program: vrl_runtime_config.program,
+                        fields: vrl_runtime_config.fields,
+                    },
+                );
             }
         }
         Ok(vrl_map)
@@ -130,8 +128,44 @@ impl ExecutablePipeline {
             })
             .collect();
 
-        let vrl_map = pipeline.register_functions().await?;
-        let sorted_nodes = topological_sort(&node_map)?;
+        let vrl_map = match pipeline.register_functions().await {
+            Ok(vrl_map) => vrl_map,
+            Err(e) => {
+                let pipeline_error = PipelineError {
+                    pipeline_id: pipeline.id.to_string(),
+                    pipeline_name: pipeline.name.to_string(),
+                    error: Some(format!("Init error: failed to compile function: {e}")),
+                    node_errors: HashMap::new(),
+                };
+                publish_error(ErrorData {
+                    _timestamp: Utc::now().timestamp_micros(),
+                    stream_params: pipeline.get_source_stream_params(),
+                    error_source: ErrorSource::Pipeline(pipeline_error),
+                })
+                .await;
+                return Err(e);
+            }
+        };
+        let sorted_nodes = match topological_sort(&node_map) {
+            Ok(sorted) => sorted,
+            Err(e) => {
+                let pipeline_error = PipelineError {
+                    pipeline_id: pipeline.id.to_string(),
+                    pipeline_name: pipeline.name.to_string(),
+                    error: Some(
+                        "Init error: failed to sort pipeline nodes for execution".to_string(),
+                    ),
+                    node_errors: HashMap::new(),
+                };
+                publish_error(ErrorData {
+                    _timestamp: Utc::now().timestamp_micros(),
+                    stream_params: pipeline.get_source_stream_params(),
+                    error_source: ErrorSource::Pipeline(pipeline_error),
+                })
+                .await;
+                return Err(e);
+            }
+        };
         let source_node_id = sorted_nodes[0].to_owned();
 
         Ok(Self {

--- a/src/service/self_reporting/queues.rs
+++ b/src/service/self_reporting/queues.rs
@@ -182,7 +182,7 @@ async fn ingest_buffered_data(thread_id: usize, buffered: Vec<ReportingData>) {
                     .await
                 {
                     log::error!(
-                        "[SELF-REPORTING] Error in pushing back un-ingested Usage data to UsageQueuer: {e}"
+                        "[SELF-REPORTING] Error in pushing back un-ingested UsageData to UsageQueue: {e}"
                     );
                 }
             }
@@ -204,7 +204,7 @@ async fn ingest_buffered_data(thread_id: usize, buffered: Vec<ReportingData>) {
                     .await
                 {
                     log::error!(
-                        "[SELF-REPORTING] Error in pushing back un-ingested Usage data to UsageQueuer: {e}"
+                        "[SELF-REPORTING] Error in pushing back un-ingested ErrorData to ErrorQueue: {e}"
                     );
                 }
             }


### PR DESCRIPTION
When active realtime pipelines are cached into memory during application startup time, if there's any associated functions, they can fail to compile since mmdb data that is being downloaded in another async thread is not yet available. 

For this scenario, this pr adds a `NOTIFIER` to wait the background thread to finish downloading the mmdb data before attempting to compile the functions. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced error reporting in the pipeline with optional error messages.
	- Introduced a notification mechanism for better synchronization during Maxmind client initialization.

- **Bug Fixes**
	- Improved error handling during function registration and pipeline initialization.

- **Documentation**
	- Updated log messages for clarity in the data ingestion process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->