### PR TITLE
fix: distinct query is complex

### DIFF
--- a/src/proto/proto/cluster/plan.proto
+++ b/src/proto/proto/cluster/plan.proto
@@ -25,24 +25,25 @@ message FlightSearchRequest {
     // query identifier
     string                       trace_id = 1;
     uint32                      partition = 2;
-    string                         org_id = 3;
-    string                    stream_type = 4;
+    string                         job_id = 3;
+    string                         org_id = 4;
+    string                    stream_type = 5;
     // used for search
-    bytes                            plan = 6;
-    repeated int64           file_id_list = 7;
-    repeated IdxFileName    idx_file_list = 8;
-    repeated KvItem            equal_keys = 9;
-    repeated string       match_all_keys = 10;
-    int64                     start_time = 11;
-    int64                       end_time = 12;
-    int64                        timeout = 13;
+    bytes                            plan = 7;
+    repeated int64           file_id_list = 8;
+    repeated IdxFileName    idx_file_list = 9;
+    repeated KvItem           equal_keys = 10;
+    repeated string       match_all_keys = 11;
+    int64                     start_time = 12;
+    int64                       end_time = 13;
+    int64                        timeout = 14;
     // used for super cluster and enterprise
-    bool                is_super_cluster = 14;
-    bool              use_inverted_index = 15;
-    optional string           work_group = 16;
-    optional string              user_id = 18;
-    optional string    search_event_type = 19;
-    string               index_condition = 20;
+    bool                is_super_cluster = 18;
+    bool              use_inverted_index = 19;
+    optional string           work_group = 20;
+    optional string              user_id = 21;
+    optional string    search_event_type = 22;
+    string               index_condition = 23;
 }
 
 message KvItem {

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -2473,38 +2473,40 @@ pub struct FlightSearchRequest {
     #[prost(uint32, tag = "2")]
     pub partition: u32,
     #[prost(string, tag = "3")]
-    pub org_id: ::prost::alloc::string::String,
+    pub job_id: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
+    pub org_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "5")]
     pub stream_type: ::prost::alloc::string::String,
     /// used for search
-    #[prost(bytes = "vec", tag = "6")]
+    #[prost(bytes = "vec", tag = "7")]
     pub plan: ::prost::alloc::vec::Vec<u8>,
-    #[prost(int64, repeated, tag = "7")]
+    #[prost(int64, repeated, tag = "8")]
     pub file_id_list: ::prost::alloc::vec::Vec<i64>,
-    #[prost(message, repeated, tag = "8")]
-    pub idx_file_list: ::prost::alloc::vec::Vec<IdxFileName>,
     #[prost(message, repeated, tag = "9")]
+    pub idx_file_list: ::prost::alloc::vec::Vec<IdxFileName>,
+    #[prost(message, repeated, tag = "10")]
     pub equal_keys: ::prost::alloc::vec::Vec<KvItem>,
-    #[prost(string, repeated, tag = "10")]
+    #[prost(string, repeated, tag = "11")]
     pub match_all_keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(int64, tag = "11")]
-    pub start_time: i64,
     #[prost(int64, tag = "12")]
-    pub end_time: i64,
+    pub start_time: i64,
     #[prost(int64, tag = "13")]
+    pub end_time: i64,
+    #[prost(int64, tag = "14")]
     pub timeout: i64,
     /// used for super cluster and enterprise
-    #[prost(bool, tag = "14")]
+    #[prost(bool, tag = "18")]
     pub is_super_cluster: bool,
-    #[prost(bool, tag = "15")]
+    #[prost(bool, tag = "19")]
     pub use_inverted_index: bool,
-    #[prost(string, optional, tag = "16")]
+    #[prost(string, optional, tag = "20")]
     pub work_group: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "18")]
+    #[prost(string, optional, tag = "21")]
     pub user_id: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "19")]
+    #[prost(string, optional, tag = "22")]
     pub search_event_type: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, tag = "20")]
+    #[prost(string, tag = "23")]
     pub index_condition: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/src/service/search/datafusion/distributed_plan/remote_scan.rs
+++ b/src/service/search/datafusion/distributed_plan/remote_scan.rs
@@ -250,9 +250,11 @@ async fn get_remote_batch(
         None => "".to_string(),
     };
 
+    let job_id = config::ider::uuid();
     let request = FlightSearchRequest {
         trace_id: req.trace_id.clone(),
         partition: partition as u32,
+        job_id,
         org_id: req.org_id.clone(),
         stream_type: req.stream_type.to_string(),
         plan: physical_plan_bytes.to_vec(),

--- a/src/service/search/grpc/flight.rs
+++ b/src/service/search/grpc/flight.rs
@@ -154,7 +154,8 @@ pub async fn search(
 
     let query_params = Arc::new(super::QueryParams {
         trace_id: trace_id.to_string(),
-        org_id: org_id.to_string(),
+        org_id: org_id.clone(),
+        job_id: req.job_id.clone(),
         stream_type,
         stream_name: stream_name.to_string(),
         time_range: Some((req.start_time, req.end_time)),

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -31,6 +31,7 @@ pub type SearchTable = Result<(Vec<Arc<dyn TableProvider>>, ScanStats)>;
 pub struct QueryParams {
     pub trace_id: String,
     pub org_id: String,
+    pub job_id: String,
     pub stream_type: StreamType,
     pub stream_name: String,
     pub time_range: Option<(i64, i64)>,

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -279,7 +279,7 @@ pub async fn search(
         let schema = schema.with_metadata(std::collections::HashMap::new());
 
         let session = config::meta::search::Session {
-            id: format!("{}-{ver}", query.trace_id),
+            id: format!("{}-{}-{ver}", query.trace_id, query.job_id),
             storage_type: StorageType::Memory,
             work_group: query.work_group.clone(),
             target_partitions,

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -261,7 +261,7 @@ pub async fn search_parquet(
             .clone()
             .with_metadata(std::collections::HashMap::new());
         let session = config::meta::search::Session {
-            id: format!("{}-wal-{ver}", query.trace_id),
+            id: format!("{}-{}-wal-{ver}", query.trace_id, query.job_id),
             storage_type: StorageType::Wal,
             work_group: query.work_group.clone(),
             target_partitions: cfg.limit.cpu_num,

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -976,6 +976,7 @@ fn is_complex_query(statement: &mut Statement) -> bool {
 // 3. has group by
 // 4. has aggregate
 // 5. has SetOperation(UNION/EXCEPT/INTERSECT of two queries)
+// 6. has distinct
 struct ComplexQueryVisitor {
     pub is_complex: bool,
 }
@@ -999,6 +1000,9 @@ impl VisitorMut for ComplexQueryVisitor {
                 }
                 // check if has join
                 if select.from.len() > 1 || select.from.iter().any(|from| !from.joins.is_empty()) {
+                    self.is_complex = true;
+                }
+                if select.distinct.is_some() {
                     self.is_complex = true;
                 }
                 if self.is_complex {


### PR DESCRIPTION
Fix:
1. distinct query is complex
2. give each remote_scan an unique ID to prevent overwriting the file list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SQL query processing to better handle `DISTINCT` queries, improving complexity detection and aggregation behavior.
- **Documentation**
	- Added comments to clarify new checks and their implications for SQL processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->