### PR TITLE
fix: update chromiumoxide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.23.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e9efbe14612da0a19fb983059a0b621e9cf6225d7018ecab4f9988215540dc"
+checksum = "90e661b6cb0a6eb34d02c520b052daa3aa9ac0cc02495c9d066bbce13ead132b"
 dependencies = [
  "futures-io",
  "futures-util",
@@ -2099,11 +2099,11 @@ dependencies = [
 
 [[package]]
 name = "chromiumoxide"
-version = "0.5.7"
-source = "git+https://github.com/mattsse/chromiumoxide?rev=348967500868c2b5dfcb3930fe483b2ff17b35ff#348967500868c2b5dfcb3930fe483b2ff17b35ff"
+version = "0.7.0"
+source = "git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#6f2392f78ae851e2acf33df8e9764cc299d837db"
 dependencies = [
  "async-tungstenite",
- "base64 0.21.7",
+ "base64 0.22.1",
  "cfg-if 1.0.0",
  "chromiumoxide_cdp",
  "chromiumoxide_fetcher",
@@ -2113,7 +2113,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "pin-project-lite",
- "reqwest 0.11.27",
+ "reqwest 0.12.8",
  "serde",
  "serde_json",
  "thiserror",
@@ -2121,13 +2121,13 @@ dependencies = [
  "tracing",
  "url",
  "which",
- "winreg 0.51.0",
+ "winreg 0.52.0",
 ]
 
 [[package]]
 name = "chromiumoxide_cdp"
-version = "0.5.2"
-source = "git+https://github.com/mattsse/chromiumoxide?rev=348967500868c2b5dfcb3930fe483b2ff17b35ff#348967500868c2b5dfcb3930fe483b2ff17b35ff"
+version = "0.7.0"
+source = "git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#6f2392f78ae851e2acf33df8e9764cc299d837db"
 dependencies = [
  "chromiumoxide_pdl",
  "chromiumoxide_types",
@@ -2137,13 +2137,13 @@ dependencies = [
 
 [[package]]
 name = "chromiumoxide_fetcher"
-version = "0.5.3"
-source = "git+https://github.com/mattsse/chromiumoxide?rev=348967500868c2b5dfcb3930fe483b2ff17b35ff#348967500868c2b5dfcb3930fe483b2ff17b35ff"
+version = "0.7.0"
+source = "git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#6f2392f78ae851e2acf33df8e9764cc299d837db"
 dependencies = [
  "anyhow",
  "directories",
  "os_info",
- "reqwest 0.11.27",
+ "reqwest 0.12.8",
  "thiserror",
  "tokio",
  "zip",
@@ -2151,8 +2151,8 @@ dependencies = [
 
 [[package]]
 name = "chromiumoxide_pdl"
-version = "0.5.2"
-source = "git+https://github.com/mattsse/chromiumoxide?rev=348967500868c2b5dfcb3930fe483b2ff17b35ff#348967500868c2b5dfcb3930fe483b2ff17b35ff"
+version = "0.7.0"
+source = "git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#6f2392f78ae851e2acf33df8e9764cc299d837db"
 dependencies = [
  "chromiumoxide_types",
  "either",
@@ -2167,8 +2167,8 @@ dependencies = [
 
 [[package]]
 name = "chromiumoxide_types"
-version = "0.5.2"
-source = "git+https://github.com/mattsse/chromiumoxide?rev=348967500868c2b5dfcb3930fe483b2ff17b35ff#348967500868c2b5dfcb3930fe483b2ff17b35ff"
+version = "0.7.0"
+source = "git+https://github.com/mattsse/chromiumoxide?rev=6f2392f78ae851e2acf33df8e9764cc299d837db#6f2392f78ae851e2acf33df8e9764cc299d837db"
 dependencies = [
  "serde",
  "serde_json",
@@ -9797,20 +9797,19 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.12",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand",
  "sha1",
  "thiserror",
- "url",
  "utf-8",
 ]
 
@@ -10400,14 +10399,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
- "once_cell",
  "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -10750,13 +10749,19 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "937f3df7948156640f46aacef17a70db0de5917bda9c92b0f751f3a955b588fc"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "woothee"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,7 +229,7 @@ byteorder = "1.4.3"
 chromiumoxide = { git = "https://github.com/mattsse/chromiumoxide", features = [
     "tokio-runtime",
     "_fetcher-rusttls-tokio",
-], default-features = false, rev = "348967500868c2b5dfcb3930fe483b2ff17b35ff" }
+], default-features = false, rev = "6f2392f78ae851e2acf33df8e9764cc299d837db" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 cityhasher = { version = "0.1", default-features = false }
 collapse = "0.1.2"


### PR DESCRIPTION
Uses the latest chromiumoxide commit (https://github.com/mattsse/chromiumoxide/commit/6f2392f78ae851e2acf33df8e9764cc299d837db) to avoid the chromium websocket message parsing error for new chromium.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated multiple dependencies to enhance compatibility and functionality, including `chromiumoxide`, `arrow`, `parquet`, and `actix-web`.
  
- **Bug Fixes**
	- Improvements in dependency management to ensure smoother operation and integration of features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->