### PR TITLE
fix: Report all stream names for joins when usage reporting

### DIFF
--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -64,9 +64,9 @@ pub async fn search(
     let mut origin_sql = in_req.query.sql.clone();
     origin_sql = origin_sql.replace('\n', " ");
     let is_aggregate = is_aggregate_query(&origin_sql).unwrap_or_default();
-    let stream_name = match resolve_stream_names(&origin_sql) {
+    let (stream_name, all_streams) = match resolve_stream_names(&origin_sql) {
         // TODO: cache don't not support multiple stream names
-        Ok(v) => v[0].clone(),
+        Ok(v) => (v[0].clone(), v.join(",")),
         Err(e) => {
             return Err(Error::Message(e.to_string()));
         }
@@ -314,7 +314,7 @@ pub async fn search(
     report_request_usage_stats(
         req_stats,
         org_id,
-        &stream_name,
+        &all_streams,
         stream_type,
         UsageType::Search,
         num_fn,


### PR DESCRIPTION
A join query involves multiple stream names. But when report usage of join query, it only reports the first stream name mentioned in the query and not the others. This impacts the search history UI page which uses the stream names in the URI parameters to show the streams in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced stream name management with improved reporting capabilities.
	- The search function now returns both a single stream name and a concatenated string of all stream names.

- **Bug Fixes**
	- Maintained robust error handling for stream name resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->