### PR TITLE
fix: don't report dashboard search as logs stream type

### DIFF
--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -159,7 +159,7 @@ pub async fn search(
     let request = crate::service::search::request::Request::new(
         trace_id.clone(),
         org_id.to_string(),
-        stream_type,
+        stream_type.clone(),
         in_req.timeout,
         user_id.clone(),
         Some((query.start_time, query.end_time)),
@@ -207,6 +207,7 @@ pub async fn search(
                     if matches!(
                         search_type,
                         search::SearchEventType::UI
+                            | search::SearchEventType::Dashboards
                             | search::SearchEventType::Values
                             | search::SearchEventType::Other
                     ) {
@@ -255,6 +256,7 @@ pub async fn search(
                         None
                     },
                     work_group: _work_group,
+                    result_cache_ratio: Some(res.result_cache_ratio),
                     ..Default::default()
                 };
                 let num_fn = if req_query.query_fn.is_empty() { 0 } else { 1 };
@@ -262,7 +264,7 @@ pub async fn search(
                     req_stats,
                     org_id,
                     &stream_name,
-                    StreamType::Logs,
+                    stream_type,
                     UsageType::Search,
                     num_fn,
                     started_at,

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -159,7 +159,7 @@ pub async fn search(
     let request = crate::service::search::request::Request::new(
         trace_id.clone(),
         org_id.to_string(),
-        stream_type.clone(),
+        stream_type,
         in_req.timeout,
         user_id.clone(),
         Some((query.start_time, query.end_time)),


### PR DESCRIPTION
Fixes #5161.

Currently, for dashboard queries (`search_type = dashboard`), the same metrics query is reported twice in the usage stream - one as `logs`, other as `metrics`. Hence, the dashboard metrics search is shown in the search history page as well. This pr fixes this by reporting the search query only once for dashboards search type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced reporting of usage statistics with the addition of a cache ratio for results.
	- Improved formatting and error handling in the search functionality for better query management.

- **Bug Fixes**
	- Refined logic for accumulating results and managing errors in multi-query execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->