### PR TITLE
fix: order by with histogram logic

### DIFF
--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -508,14 +508,8 @@ impl VisitorMut for ColumnVisitor<'_> {
             for select_item in select.projection.iter_mut() {
                 match select_item {
                     SelectItem::ExprWithAlias { expr, alias } => {
-                        let mut name_visitor = FieldNameVisitor::new();
-                        expr.visit(&mut name_visitor);
-                        if name_visitor.field_names.len() == 1 {
-                            let expr_name =
-                                name_visitor.field_names.iter().next().unwrap().to_string();
-                            self.columns_alias
-                                .insert((expr_name, alias.value.to_string()));
-                        }
+                        self.columns_alias
+                            .insert((expr.to_string(), alias.value.to_string()));
                     }
                     SelectItem::Wildcard(_) => {
                         self.is_wildcard = true;


### PR DESCRIPTION
The result of this query is wrong:
```sql
SELECT histogram(_timestamp, '1 second') as x_axis_1, count(_timestamp) as y_axis_1 FROM "test8" GROUP BY x_axis_1 ORDER BY x_axis_1 ASC
```

Because we get order field from `alias` in cache module, but the original field of `x_axis_1` and `y_axis_1` both `_timestamp`, so it will get `x_axis_1` or `x_axis_1` as the final order field.

The solution is follow the old version, when we generate `alias` we use the full name like this:
```
    aliases: [
        (
            "count(_timestamp)",
            "y_axis_1",
        ),
        (
            "histogram(_timestamp, '1 second')",
            "x_axis_1",
        ),
    ],
```