### PR TITLE
fix: use search type to choose query group on router

### DIFF
--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashMap;
+
 use ::config::{
     get_config,
     meta::cluster::{Role, RoleGroup},
@@ -20,7 +22,7 @@ use ::config::{
 };
 use actix_web::{http::Error, route, web, HttpRequest, HttpResponse};
 
-use crate::common::infra::cluster;
+use crate::common::{infra::cluster, utils::http::get_search_type_from_request};
 
 const QUERIER_ROUTES: [&str; 18] = [
     "/config",
@@ -217,7 +219,15 @@ async fn get_url(path: &str) -> URLDetails {
 
     let nodes = if is_querier_path {
         node_type = Role::Querier;
-        let nodes = cluster::get_cached_online_querier_nodes(Some(RoleGroup::Interactive)).await;
+        let mut node_group = RoleGroup::Interactive;
+        let query_str = path[path.find("?").unwrap_or(path.len())..].to_string();
+        if let Ok(query_params) = web::Query::<HashMap<String, String>>::from_query(&query_str) {
+            let search_type = get_search_type_from_request(&query_params).unwrap_or(None);
+            node_group = search_type
+                .map(RoleGroup::from)
+                .unwrap_or(RoleGroup::Interactive);
+        }
+        let nodes = cluster::get_cached_online_querier_nodes(Some(node_group)).await;
         if is_fixed_querier_route(path) && nodes.is_some() && !nodes.as_ref().unwrap().is_empty() {
             nodes.map(|v| v.into_iter().take(1).collect())
         } else {

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -219,14 +219,15 @@ async fn get_url(path: &str) -> URLDetails {
 
     let nodes = if is_querier_path {
         node_type = Role::Querier;
-        let mut node_group = RoleGroup::Interactive;
         let query_str = path[path.find("?").unwrap_or(path.len())..].to_string();
-        if let Ok(query_params) = web::Query::<HashMap<String, String>>::from_query(&query_str) {
-            let search_type = get_search_type_from_request(&query_params).unwrap_or(None);
-            node_group = search_type
-                .map(RoleGroup::from)
-                .unwrap_or(RoleGroup::Interactive);
-        }
+        let node_group = web::Query::<HashMap<String, String>>::from_query(&query_str)
+            .map(|query_params| {
+                get_search_type_from_request(&query_params)
+                    .unwrap_or(None)
+                    .map(RoleGroup::from)
+                    .unwrap_or(RoleGroup::Interactive)
+            })
+            .unwrap_or(RoleGroup::Interactive);
         let nodes = cluster::get_cached_online_querier_nodes(Some(node_group)).await;
         if is_fixed_querier_route(path) && nodes.is_some() && !nodes.as_ref().unwrap().is_empty() {
             nodes.map(|v| v.into_iter().take(1).collect())


### PR DESCRIPTION
fixed #5160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for determining node group based on query parameters.
	- Improved error handling and dynamic node selection for requests without available nodes.
  
- **Bug Fixes**
	- Refined handling when no nodes are found, now returning a constructed URL for the ingester service if applicable.
  
- **Documentation**
	- Minor adjustments to comments for clarity.
  
- **Refactor**
	- Updated function signature for `get_url` to improve return type clarity with `URLDetails` struct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->