### PR TITLE
fix: pipeline condition node incorrect evaluation

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yaml
@@ -1,4 +1,4 @@
-name: 'Feature Request'
+name: "Feature Request"
 description: Suggest a feature for OpenObserve
 labels: ["✏️ Feature"]
 
@@ -18,7 +18,7 @@ body:
         - ingestion
         - alerts
         - localization
-        - routing
+        - pipeline
         - metrics
         - traces
         - other

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -822,13 +822,14 @@ impl RoutingCondition {
         let val = match row.get(&self.column) {
             Some(val) => val,
             None => {
+                // field not found -> dropped
                 return false;
             }
         };
         match val {
             Value::String(v) => {
                 let val = v.as_str();
-                let con_val = self.value.as_str().unwrap_or_default();
+                let con_val = self.value.as_str().unwrap_or_default().trim_matches('"'); // "" is interpreted as empty string
                 match self.operator {
                     Operator::EqualTo => val == con_val,
                     Operator::NotEqualTo => val != con_val,
@@ -879,7 +880,8 @@ impl RoutingCondition {
                 }
             }
             Value::Null => {
-                matches!(self.value, Value::Null) && matches!(self.operator, Operator::EqualTo)
+                matches!(self.operator, Operator::EqualTo)
+                    && matches!(&self.value, Value::String(v) if v == "null")
             }
             _ => false,
         }

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -878,6 +878,9 @@ impl RoutingCondition {
                     _ => false,
                 }
             }
+            Value::Null => {
+                matches!(self.value, Value::Null) && matches!(self.operator, Operator::EqualTo)
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
fix #5218 

Backend:
- [x] allow condition node to evaluate `null` and `""`, empty, for both `=` and `!=` conditions
- [x] stop ingestion when resolved dynamic stream name is empty

**How to Use(In ConditionNode):**
To evaluate field value is not empty:
`app_name != ""` 
To evaluate field value is not null:
`app_name != null` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the feature request template for improved clarity and options.
	- Enhanced error handling in the pipeline execution process for dynamic stream names.
  
- **Bug Fixes**
	- Improved robustness of condition evaluations to prevent errors from missing fields and ensure accurate string comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->