### PR TITLE
feat: add option for NATS deliver policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3bdd6ea595b2ea504500a3566071beb81125fc15d40a6f6bffa43575f64152"
+checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1023,6 +1023,7 @@ dependencies = [
  "nkeys",
  "nuid",
  "once_cell",
+ "pin-project",
  "portable-atomic",
  "rand",
  "regex",
@@ -1039,6 +1040,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-util",
+ "tokio-websockets",
  "tracing",
  "tryhard",
  "url",
@@ -9503,6 +9505,27 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "httparse",
+ "rand",
+ "ring",
+ "rustls-native-certs 0.8.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ log = "0.4"
 md5 = "0.7.0"
 memchr = "2.7"
 murmur3 = "0.5"
-async-nats = "0.37"
+async-nats = "0.38"
 once_cell = "1.17"
 ordered-float = { version = "4.5.0", features = ["serde"] }
 parking_lot = "0.12"

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1292,7 +1292,7 @@ pub struct Nats {
     pub history: i64,
     #[env_config(
         name = "ZO_NATS_DELIVER_POLICY",
-        default = "",
+        default = "all",
         help = "The point in the stream from which to receive messages, default is: all, valid option is: all, last, new."
     )]
     pub deliver_policy: String,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1290,6 +1290,12 @@ pub struct Nats {
         To update this, delete and recreate the bucket."
     )]
     pub history: i64,
+    #[env_config(
+        name = "ZO_NATS_DELIVER_POLICY",
+        default = "",
+        help = "The point in the stream from which to receive messages, default is: all, valid option is: all, last, new."
+    )]
+    pub deliver_policy: String,
     #[env_config(name = "ZO_NATS_CONNECT_TIMEOUT", default = 5)]
     pub connect_timeout: u64,
     #[env_config(name = "ZO_NATS_COMMAND_TIMEOUT", default = 10)]

--- a/src/infra/src/queue/nats.rs
+++ b/src/infra/src/queue/nats.rs
@@ -15,10 +15,10 @@
 
 use std::{cmp::max, sync::Arc, time::Duration};
 
-use async_nats::jetstream;
+use async_nats::jetstream::{self, consumer::DeliverPolicy};
 use async_trait::async_trait;
 use bytes::Bytes;
-use config::get_cluster_name;
+use config::{get_cluster_name, get_config};
 use futures::TryStreamExt;
 use tokio::{sync::mpsc, task::JoinHandle};
 
@@ -92,6 +92,7 @@ impl super::Queue for NatsQueue {
             let config = jetstream::consumer::pull::Config {
                 name: Some(consumer_name.to_string()),
                 durable_name: Some(consumer_name.to_string()),
+                deliver_policy: get_deliver_policy(),
                 ..Default::default()
             };
             let consumer = stream
@@ -112,5 +113,14 @@ impl super::Queue for NatsQueue {
 
     async fn purge(&self, _topic: &str, _sequence: usize) -> Result<()> {
         Ok(())
+    }
+}
+
+fn get_deliver_policy() -> DeliverPolicy {
+    match get_config().nats.deliver_policy.to_lowercase().as_str() {
+        "all" | "DeliverAll" => DeliverPolicy::All,
+        "last" | "DeliverLast" => DeliverPolicy::Last,
+        "new" | "DeliverNew" => DeliverPolicy::New,
+        _ => DeliverPolicy::All,
     }
 }

--- a/src/infra/src/queue/nats.rs
+++ b/src/infra/src/queue/nats.rs
@@ -118,9 +118,9 @@ impl super::Queue for NatsQueue {
 
 fn get_deliver_policy() -> DeliverPolicy {
     match get_config().nats.deliver_policy.to_lowercase().as_str() {
-        "all" | "DeliverAll" => DeliverPolicy::All,
-        "last" | "DeliverLast" => DeliverPolicy::Last,
-        "new" | "DeliverNew" => DeliverPolicy::New,
+        "all" | "deliverall" | "deliver_all" => DeliverPolicy::All,
+        "last" | "deliverlast" | "deliver_last" => DeliverPolicy::Last,
+        "new" | "delivernew" | "deliver_new" => DeliverPolicy::New,
         _ => DeliverPolicy::All,
     }
 }

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -332,9 +332,8 @@ pub fn get_stream_setting_index_setting_timestamp(
     };
     match settings {
         Some(settings) => {
-            let timestamp = settings.index_setting_timestamp;
-            if timestamp > 0 {
-                timestamp
+            if settings.index_setting_timestamp > 0 {
+                settings.index_setting_timestamp
             } else {
                 created_at
             }

--- a/src/service/search/tantivy/puffin_directory/footer_cache.rs
+++ b/src/service/search/tantivy/puffin_directory/footer_cache.rs
@@ -124,22 +124,13 @@ impl FooterCache {
         // parse footer data
         let mut data = HashMap::new();
         for (path, items) in metadata.files.iter() {
-            // TODO: remove it later, just for debug
-            let path = PathBuf::from(path);
-            let ext = path
-                .extension()
-                .and_then(|s| s.to_str())
-                .unwrap_or_default();
-            if EMPTY_FILE_EXT.contains(&ext) {
-                continue;
-            }
             let mut slice_data = HashMap::new();
             for item in items.iter() {
                 let range = item.start as usize..(item.start + item.len) as usize;
                 let data = bytes.slice(item.offset as usize..(item.offset + item.len) as usize);
                 slice_data.insert(range, data);
             }
-            data.insert(path, slice_data);
+            data.insert(PathBuf::from(path), slice_data);
         }
         Ok(Self {
             data: RwLock::new(data),


### PR DESCRIPTION
impl #5139 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configurable delivery policy for NATS messaging, allowing users to specify message receipt options (all, last, new).
- **Improvements**
	- Enhanced the NATS queue functionality to support flexible consumer behavior based on the new delivery policy.
	- Improved clarity in retrieving settings within the application.
- **Dependency Updates**
	- Updated multiple dependencies, including `async-nats`, `actix-web`, and `dashmap`, to ensure compatibility and improved functionality. New dependencies `async-walkdir` and `cityhasher` added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->