### PR TITLE
fix: don't add `\n` in email row templates, add trigger time variables in alert template

### DIFF
--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -466,10 +466,12 @@ pub async fn send_notification(
         alert,
         rows,
         &rows_tpl_val,
-        rows_end_time,
-        start_time,
-        evaluation_timestamp,
-        is_email,
+        ProcessTemplateOptions {
+            rows_end_time,
+            start_time,
+            evaluation_timestamp,
+            is_email,
+        },
     )
     .await;
 
@@ -479,10 +481,12 @@ pub async fn send_notification(
             alert,
             rows,
             &rows_tpl_val,
-            rows_end_time,
-            start_time,
-            evaluation_timestamp,
-            is_email,
+            ProcessTemplateOptions {
+                rows_end_time,
+                start_time,
+                evaluation_timestamp,
+                is_email,
+            },
         )
         .await
     } else {
@@ -731,17 +735,27 @@ fn process_row_template(tpl: &String, alert: &Alert, rows: &[Map<String, Value>]
     rows_tpl
 }
 
+struct ProcessTemplateOptions {
+    pub rows_end_time: i64,
+    pub start_time: Option<i64>,
+    pub evaluation_timestamp: i64,
+    pub is_email: bool,
+}
+
 async fn process_dest_template(
     tpl: &str,
     alert: &Alert,
     rows: &[Map<String, Value>],
     rows_tpl_val: &[String],
-    rows_end_time: i64,
-    start_time: Option<i64>,
-    evaluation_timestamp: i64,
-    is_email: bool,
+    options: ProcessTemplateOptions,
 ) -> String {
     let cfg = get_config();
+    let ProcessTemplateOptions {
+        rows_end_time,
+        start_time,
+        evaluation_timestamp,
+        is_email,
+    } = options;
     // format values
     let alert_count = rows.len();
     let mut vars = HashMap::with_capacity(rows.len());

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -339,8 +339,9 @@ pub async fn trigger(
             ));
         }
     };
+    let now = Utc::now().timestamp_micros();
     alert
-        .send_notification(&[], Utc::now().timestamp_micros(), None)
+        .send_notification(&[], now, None, now)
         .await
         .map_err(|e| (http::StatusCode::INTERNAL_SERVER_ERROR, e))
 }
@@ -362,6 +363,7 @@ pub trait AlertExt: Sync + Send + 'static {
         rows: &[Map<String, Value>],
         rows_end_time: i64,
         start_time: Option<i64>,
+        evaluation_timestamp: i64,
     ) -> Result<(String, String), anyhow::Error>;
 }
 
@@ -398,13 +400,23 @@ impl AlertExt for Alert {
         rows: &[Map<String, Value>],
         rows_end_time: i64,
         start_time: Option<i64>,
+        evaluation_timestamp: i64,
     ) -> Result<(String, String), anyhow::Error> {
         let mut err_message = "".to_string();
         let mut success_message = "".to_string();
         let mut no_of_error = 0;
         for dest in self.destinations.iter() {
             let dest = destinations::get_with_template(&self.org_id, dest).await?;
-            match send_notification(self, &dest, rows, rows_end_time, start_time).await {
+            match send_notification(
+                self,
+                &dest,
+                rows,
+                rows_end_time,
+                start_time,
+                evaluation_timestamp,
+            )
+            .await
+            {
                 Ok(resp) => {
                     success_message =
                         format!("{success_message} destination {} {resp};", dest.name);
@@ -441,12 +453,14 @@ pub async fn send_notification(
     rows: &[Map<String, Value>],
     rows_end_time: i64,
     start_time: Option<i64>,
+    evaluation_timestamp: i64,
 ) -> Result<String, anyhow::Error> {
     let rows_tpl_val = if alert.row_template.is_empty() {
         vec!["".to_string()]
     } else {
         process_row_template(&alert.row_template, alert, rows)
     };
+    let is_email = dest.destination_type == DestinationType::Email;
     let msg: String = process_dest_template(
         &dest.template.body,
         alert,
@@ -454,6 +468,8 @@ pub async fn send_notification(
         &rows_tpl_val,
         rows_end_time,
         start_time,
+        evaluation_timestamp,
+        is_email,
     )
     .await;
 
@@ -465,6 +481,8 @@ pub async fn send_notification(
             &rows_tpl_val,
             rows_end_time,
             start_time,
+            evaluation_timestamp,
+            is_email,
         )
         .await
     } else {
@@ -631,7 +649,7 @@ fn process_row_template(tpl: &String, alert: &Alert, rows: &[Map<String, Value>]
             } else {
                 value.to_string()
             };
-            process_variable_replace(&mut resp, key, &VarValue::Str(&value));
+            process_variable_replace(&mut resp, key, &VarValue::Str(&value), false);
 
             // calculate start and end time
             if key == &get_config().common.column_timestamp {
@@ -703,7 +721,7 @@ fn process_row_template(tpl: &String, alert: &Alert, rows: &[Map<String, Value>]
 
         if let Some(attrs) = &alert.context_attributes {
             for (key, value) in attrs.iter() {
-                process_variable_replace(&mut resp, key, &VarValue::Str(value));
+                process_variable_replace(&mut resp, key, &VarValue::Str(value), false);
             }
         }
 
@@ -720,6 +738,8 @@ async fn process_dest_template(
     rows_tpl_val: &[String],
     rows_end_time: i64,
     start_time: Option<i64>,
+    evaluation_timestamp: i64,
+    is_email: bool,
 ) -> String {
     let cfg = get_config();
     // format values
@@ -767,6 +787,14 @@ async fn process_dest_template(
     let alert_end_time_str = if alert_end_time > 0 {
         Local
             .timestamp_nanos(alert_end_time * 1000)
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string()
+    } else {
+        String::from("N/A")
+    };
+    let evaluation_timestamp_str = if evaluation_timestamp > 0 {
+        Local
+            .timestamp_nanos(evaluation_timestamp * 1000)
             .format("%Y-%m-%dT%H:%M:%S")
             .to_string()
     } else {
@@ -890,7 +918,9 @@ async fn process_dest_template(
         .replace("{alert_count}", &alert_count.to_string())
         .replace("{alert_start_time}", &alert_start_time_str)
         .replace("{alert_end_time}", &alert_end_time_str)
-        .replace("{alert_url}", &alert_url);
+        .replace("{alert_url}", &alert_url)
+        .replace("{alert_trigger_time}", &evaluation_timestamp.to_string())
+        .replace("{alert_trigger_time_str}", &evaluation_timestamp_str);
 
     if let Some(contidion) = &alert.query_condition.promql_condition {
         resp = resp
@@ -898,26 +928,26 @@ async fn process_dest_template(
             .replace("{alert_promql_value}", &contidion.value.to_string());
     }
 
-    process_variable_replace(&mut resp, "rows", &VarValue::Vector(rows_tpl_val));
+    process_variable_replace(&mut resp, "rows", &VarValue::Vector(rows_tpl_val), is_email);
     for (key, value) in vars.iter() {
         if resp.contains(&format!("{{{key}}}")) {
             let val = value.iter().cloned().collect::<Vec<_>>();
-            process_variable_replace(&mut resp, key, &VarValue::Str(&val.join(", ")));
+            process_variable_replace(&mut resp, key, &VarValue::Str(&val.join(", ")), is_email);
         }
     }
     if let Some(attrs) = &alert.context_attributes {
         for (key, value) in attrs.iter() {
-            process_variable_replace(&mut resp, key, &VarValue::Str(value));
+            process_variable_replace(&mut resp, key, &VarValue::Str(value), is_email);
         }
     }
 
     resp
 }
 
-fn process_variable_replace(tpl: &mut String, var_name: &str, var_val: &VarValue) {
+fn process_variable_replace(tpl: &mut String, var_name: &str, var_val: &VarValue, is_email: bool) {
     let pattern = "{".to_owned() + var_name + "}";
     if tpl.contains(&pattern) {
-        *tpl = tpl.replace(&pattern, &var_val.to_string_with_length(0));
+        *tpl = tpl.replace(&pattern, &var_val.to_string_with_length(0, is_email));
         return;
     }
     let pattern = "{".to_owned() + var_name + ":";
@@ -929,7 +959,7 @@ fn process_variable_replace(tpl: &mut String, var_name: &str, var_val: &VarValue
             if len > 0 {
                 *tpl = tpl.replace(
                     &tpl[start..p + end + 1],
-                    &var_val.to_string_with_length(len),
+                    &var_val.to_string_with_length(len, is_email),
                 );
             }
         }
@@ -1078,7 +1108,7 @@ impl VarValue<'_> {
         }
     }
 
-    fn to_string_with_length(&self, n: usize) -> String {
+    fn to_string_with_length(&self, n: usize, is_email: bool) -> String {
         let n = if n > 0 && n < self.len() {
             n
         } else {
@@ -1086,7 +1116,7 @@ impl VarValue<'_> {
         };
         match self {
             VarValue::Str(v) => format_variable_value(v.chars().take(n).collect()),
-            VarValue::Vector(v) => v[0..n].join("\\n"),
+            VarValue::Vector(v) => v[0..n].join(if is_email { "" } else { "\\n" }),
         }
     }
 }

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -455,7 +455,10 @@ async fn handle_alert_triggers(trigger: db::scheduler::Trigger) -> Result<(), an
         );
         trigger_data_stream.start_time = alert_start_time;
         trigger_data_stream.end_time = alert_end_time;
-        match alert.send_notification(&data, end_time, start_time).await {
+        match alert
+            .send_notification(&data, end_time, start_time, now)
+            .await
+        {
             Ok((success_msg, err_msg)) => {
                 let success_msg = success_msg.trim().to_owned();
                 let err_msg = err_msg.trim().to_owned();

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -245,7 +245,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
             delay_in_secs: None,
             evaluation_took_in_secs: None,
         };
-        match alert.send_notification(val, now, None).await {
+        match alert.send_notification(val, now, None, now).await {
             Err(e) => {
                 log::error!("Failed to send notification: {}", e);
                 trigger_data_stream.status = TriggerDataStatus::Failed;

--- a/web/src/components/alerts/AddTemplate.vue
+++ b/web/src/components/alerts/AddTemplate.vue
@@ -165,6 +165,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div>alert_period, alert_operator, alert_threshold</div>
             <div>alert_count, alert_agg_value</div>
             <div>alert_start_time, alert_end_time, alert_url</div>
+            <div>alert_trigger_time, alert_trigger_time_str</div>
             <div><b>rows</b> multiple lines of row template</div>
             <div><b>All of the stream fields are variables.</b></div>
             <div>{rows:N} {var:N} used to limit rows or string length.</div>


### PR DESCRIPTION
As mentioned in the comments of #4996 

- [x] When using row templates with emails, O2 automatically adds `\n` at the last of the row in email body. Since, email body is currently treated as html body, the below row template -
```
<p> This is an event {alert_start_time} </p>
```
generates this email body -
```
This is an event 2024-12-02T11:25:40
\n
This is an event 2024-12-02T11:26:40
\n
This is an event 2024-12-02T11:27:40
\n
...
```

- [x] Adds new variables to represent when the alert got evaluated - `alert_trigger_time` (unix timestamp in microseconds) and `alert_trigger_time_str` (formatted, e.g. - `2024-12-02T11:27:40`)
- [x] Update document add `alert_trigger_time` and `alert_trigger_time_str`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced alert notifications with improved timestamp handling.
	- Updated alert template documentation to include new variables for better clarity.

- **Bug Fixes**
	- Refined error handling in the notification sending process for better logging and context.

- **Documentation**
	- Added documentation for new variables in the alert template section to assist users in utilizing timestamps effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->