### PR TITLE
fix: support both text and html for alert email

### DIFF
--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -39,7 +39,7 @@ use config::{
     SMTP_CLIENT,
 };
 use cron::Schedule;
-use lettre::{message::SinglePart, AsyncTransport, Message};
+use lettre::{message::MultiPart, AsyncTransport, Message};
 
 use crate::{
     common::{
@@ -588,7 +588,9 @@ pub async fn send_email_notification(
         email = email.reply_to(cfg.smtp.smtp_reply_to.parse()?);
     }
 
-    let email = email.singlepart(SinglePart::html(msg)).unwrap();
+    let email = email
+        .multipart(MultiPart::alternative_plain_html(msg.clone(), msg))
+        .unwrap();
 
     // Send the email
     match SMTP_CLIENT.as_ref().unwrap().send(email).await {


### PR DESCRIPTION
Addresses the first point of #4996 

Alert emails currently sends the alert template body as a html content. This might create problems for email clients that does not prefer/support html content. This PR addresses this issue by offering both text and html version of the same message. Email clients can now use whatever version it prefers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced email notifications to support both plain text and HTML formats, improving compatibility with various email clients.

- **Bug Fixes**
	- Adjusted email message construction for better rendering in email clients without altering the overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->