### PR TITLE
fix: set text col length to satisfy mysql

### DIFF
--- a/src/infra/src/table/distinct_values.rs
+++ b/src/infra/src/table/distinct_values.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
-#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(15))")]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(16))")]
 pub enum OriginType {
     #[sea_orm(string_value = "stream")]
     Stream,
@@ -41,17 +41,17 @@ pub enum OriginType {
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "distinct_value_fields")]
 pub struct Model {
-    #[sea_orm(primary_key, column_type = "Text")]
+    #[sea_orm(primary_key, column_type = "String(StringLen::N(16))")]
     pub origin: OriginType,
-    #[sea_orm(primary_key, column_type = "Text")]
+    #[sea_orm(primary_key, column_type = "String(StringLen::N(32))")]
     pub origin_id: String,
-    #[sea_orm(primary_key, column_type = "Text")]
+    #[sea_orm(primary_key, column_type = "String(StringLen::N(128))")]
     pub org_name: String,
-    #[sea_orm(primary_key, column_type = "Text")]
+    #[sea_orm(primary_key, column_type = "String(StringLen::N(256))")]
     pub stream_name: String,
-    #[sea_orm(primary_key, column_type = "Text")]
+    #[sea_orm(primary_key, column_type = "String(StringLen::N(16))")]
     pub stream_type: String,
-    #[sea_orm(primary_key, column_type = "Text")]
+    #[sea_orm(primary_key, column_type = "String(StringLen::N(256))")]
     pub field_name: String,
 }
 


### PR DESCRIPTION
In my previous PR for distinct values, https://github.com/openobserve/openobserve/pull/5087 the schema defined for `distinct_values_fields` table did not work with mysql, and OO failed to start. In this PR I fix that by updating the schema. 

The core issue was that mysql does not allow unbounded (text) data type cols in its index/primary keys whereas sqlite and pgsql do. To fix the issue, I have updated the table schema to instead used bounded length columns. The following considerations has been done for size determination :
- origin, stream_type and origin_id are given size based on sensible estimates of what the length of possible values could be
- org and stream_name is matched with org in file_llist table
- field_name is given  remaining size around power of 2.
The limit is `sum of sizes *4 <=3072 `.

I have tested this on
- new sqlite, mysql, pgsql to make sure this scheme works with all three dbs
- existing sqlite and pgsql db, where code form current main was run, and the table was already created. This works with them too, so it is backward compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased maximum length for several database fields, enhancing data storage capabilities.
	- Updated field types in the data model for better structure and clarity. 

These changes improve the application's ability to handle larger data inputs while maintaining data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->