### PR TITLE
feat: Expose new fields for rendering dashboard search results

### DIFF
--- a/src/handler/http/models/dashboards.rs
+++ b/src/handler/http/models/dashboards.rs
@@ -1,4 +1,8 @@
-use config::meta::dashboards::{v1, v2, v3, v4, v5};
+use chrono::{DateTime, FixedOffset, Utc};
+use config::meta::{
+    dashboards::{v1, v2, v3, v4, v5, Dashboard as MetaDashboard},
+    folder::Folder as MetaFolder,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use utoipa::ToSchema;
@@ -50,6 +54,18 @@ pub struct ListDashboardsResponseBody {
 /// An item in the list returned by the `ListDashboards` endpoint.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ListDashboardsResponseBodyItem {
+    pub folder_id: String,
+    pub folder_name: String,
+    pub dashboard_id: String,
+    pub title: String,
+    pub description: String,
+    pub role: String,
+    pub owner: String,
+    #[schema(value_type = String, format = DateTime)]
+    pub created: DateTime<FixedOffset>,
+    pub hash: String,
+    pub version: i32,
+
     #[deprecated(note = "use GetDashboard endpoint to get dashboard details")]
     pub v1: Option<v1::Dashboard>,
     #[deprecated(note = "use GetDashboard endpoint to get dashboard details")]
@@ -84,7 +100,7 @@ pub struct DashboardDetails {
     pub hash: String,
 }
 
-impl TryFrom<CreateDashboardRequestBody> for config::meta::dashboards::Dashboard {
+impl TryFrom<CreateDashboardRequestBody> for MetaDashboard {
     type Error = serde_json::Error;
 
     fn try_from(value: CreateDashboardRequestBody) -> Result<Self, Self::Error> {
@@ -93,19 +109,19 @@ impl TryFrom<CreateDashboardRequestBody> for config::meta::dashboards::Dashboard
     }
 }
 
-impl From<config::meta::dashboards::Dashboard> for CreateDashboardResponseBody {
-    fn from(value: config::meta::dashboards::Dashboard) -> Self {
+impl From<MetaDashboard> for CreateDashboardResponseBody {
+    fn from(value: MetaDashboard) -> Self {
         Self(value.into())
     }
 }
 
-impl From<config::meta::dashboards::Dashboard> for GetDashboardResponseBody {
-    fn from(value: config::meta::dashboards::Dashboard) -> Self {
+impl From<MetaDashboard> for GetDashboardResponseBody {
+    fn from(value: MetaDashboard) -> Self {
         Self(value.into())
     }
 }
 
-impl TryFrom<UpdateDashboardRequestBody> for config::meta::dashboards::Dashboard {
+impl TryFrom<UpdateDashboardRequestBody> for MetaDashboard {
     type Error = serde_json::Error;
 
     fn try_from(value: UpdateDashboardRequestBody) -> Result<Self, Self::Error> {
@@ -114,8 +130,8 @@ impl TryFrom<UpdateDashboardRequestBody> for config::meta::dashboards::Dashboard
     }
 }
 
-impl From<config::meta::dashboards::Dashboard> for UpdateDashboardResponseBody {
-    fn from(value: config::meta::dashboards::Dashboard) -> Self {
+impl From<MetaDashboard> for UpdateDashboardResponseBody {
+    fn from(value: MetaDashboard) -> Self {
         Self(value.into())
     }
 }
@@ -152,31 +168,45 @@ impl ListDashboardsQuery {
     }
 }
 
-impl From<Vec<config::meta::dashboards::Dashboard>> for ListDashboardsResponseBody {
-    fn from(value: Vec<config::meta::dashboards::Dashboard>) -> Self {
-        let dashboards = value.into_iter().map(|d| d.into()).collect();
+impl From<Vec<(MetaFolder, MetaDashboard)>> for ListDashboardsResponseBody {
+    fn from(value: Vec<(MetaFolder, MetaDashboard)>) -> Self {
+        let dashboards = value.into_iter().map(|fd| fd.into()).collect();
         Self { dashboards }
     }
 }
 
-impl From<config::meta::dashboards::Dashboard> for ListDashboardsResponseBodyItem {
+impl From<(MetaFolder, MetaDashboard)> for ListDashboardsResponseBodyItem {
     #[allow(deprecated)]
-    fn from(value: config::meta::dashboards::Dashboard) -> Self {
+    fn from(value: (MetaFolder, MetaDashboard)) -> Self {
+        let folder = value.0;
+        let dashboard = value.1;
         Self {
-            hash: value.hash,
-            version: value.version,
+            folder_id: folder.folder_id,
+            folder_name: folder.name,
+            dashboard_id: dashboard.dashboard_id().unwrap_or_default().to_owned(),
+            title: dashboard.title().unwrap_or_default().to_owned(),
+            description: dashboard.description().unwrap_or_default().to_owned(),
+            role: dashboard.role().unwrap_or_default().to_owned(),
+            owner: dashboard.owner().unwrap_or_default().to_owned(),
+            created: dashboard.created_at_deprecated().unwrap_or_else(|| {
+                Utc::now().with_timezone(
+                    &FixedOffset::east_opt(0).expect("Out of bounds timezone difference"),
+                )
+            }),
+            hash: dashboard.hash,
+            version: dashboard.version,
             // Populate deprecated fields until they are removed from the API.
-            v1: value.v1,
-            v2: value.v2,
-            v3: value.v3,
-            v4: value.v4,
-            v5: value.v5,
+            v1: dashboard.v1,
+            v2: dashboard.v2,
+            v3: dashboard.v3,
+            v4: dashboard.v4,
+            v5: dashboard.v5,
         }
     }
 }
 
-impl From<config::meta::dashboards::Dashboard> for DashboardDetails {
-    fn from(value: config::meta::dashboards::Dashboard) -> Self {
+impl From<MetaDashboard> for DashboardDetails {
+    fn from(value: MetaDashboard) -> Self {
         Self {
             version: value.version,
             v1: value.v1,
@@ -190,9 +220,7 @@ impl From<config::meta::dashboards::Dashboard> for DashboardDetails {
 }
 
 /// Parses the JSON value from an HTTP request body into a dashboard.
-fn parse_dashboard_request(
-    value: JsonValue,
-) -> Result<config::meta::dashboards::Dashboard, serde_json::Error> {
+fn parse_dashboard_request(value: JsonValue) -> Result<MetaDashboard, serde_json::Error> {
     // Pull the version field out of the JSON. If it doesn't exist, assume the
     // default version is 1.
     let version = value

--- a/src/handler/http/models/dashboards.rs
+++ b/src/handler/http/models/dashboards.rs
@@ -54,18 +54,6 @@ pub struct ListDashboardsResponseBody {
 /// An item in the list returned by the `ListDashboards` endpoint.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ListDashboardsResponseBodyItem {
-    pub folder_id: String,
-    pub folder_name: String,
-    pub dashboard_id: String,
-    pub title: String,
-    pub description: String,
-    pub role: String,
-    pub owner: String,
-    #[schema(value_type = String, format = DateTime)]
-    pub created: DateTime<FixedOffset>,
-    pub hash: String,
-    pub version: i32,
-
     #[deprecated(note = "use GetDashboard endpoint to get dashboard details")]
     pub v1: Option<v1::Dashboard>,
     #[deprecated(note = "use GetDashboard endpoint to get dashboard details")]
@@ -76,8 +64,19 @@ pub struct ListDashboardsResponseBodyItem {
     pub v4: Option<v4::Dashboard>,
     #[deprecated(note = "use GetDashboard endpoint to get dashboard details")]
     pub v5: Option<v5::Dashboard>,
+
     pub version: i32,
     pub hash: String,
+
+    pub folder_id: String,
+    pub folder_name: String,
+    pub dashboard_id: String,
+    pub title: String,
+    pub description: String,
+    pub role: String,
+    pub owner: String,
+    #[schema(value_type = String, format = DateTime)]
+    pub created: DateTime<FixedOffset>,
 }
 
 /// HTTP request body for `MoveDashboard` endpoint.

--- a/src/infra/src/table/dashboards.rs
+++ b/src/infra/src/table/dashboards.rs
@@ -282,7 +282,8 @@ async fn list_models(
     db: &DatabaseConnection,
     params: ListDashboardsParams,
 ) -> Result<Vec<(folders::Model, dashboards::Model)>, sea_orm::DbErr> {
-    let query = folders::Entity::find()
+    let query = dashboards::Entity::find()
+        .find_also_related(folders::Entity)
         .filter(folders::Column::Org.eq(params.org_id))
         .filter(folders::Column::Type.eq::<i16>(FolderType::Dashboards.into()));
 
@@ -292,15 +293,6 @@ async fn list_models(
     } else {
         query
     };
-
-    // Apply ordering. Confusingly, it is necessary to apply the ordering BEFORE
-    // adding a join to the query builder. If we don't do this then Sea ORM will
-    // always sort on the join key (folder.id) before any other sorting
-    // conditions.
-    let query = query.order_by(dashboards::Column::Title, sea_orm::Order::Asc);
-
-    // Left join on dashboards table.
-    let query = query.find_with_related(dashboards::Entity);
 
     // Apply the optional title substring filter.
     let title_pat = params
@@ -313,13 +305,18 @@ async fn list_models(
         query
     };
 
-    let dashboards = query
+    // Apply ordering.
+    let query = query
+        .order_by_asc(dashboards::Column::Title)
+        .order_by_asc(folders::Column::Name);
+
+    let dashboards_and_folders = query
         .all(db)
         .await?
         .into_iter()
-        .flat_map(|(f, ds)| ds.into_iter().map(move |d| (f.clone(), d)))
+        .filter_map(|(d, maybe_f)| maybe_f.map(|f| (f, d)))
         .collect();
-    Ok(dashboards)
+    Ok(dashboards_and_folders)
 }
 
 /// Lists all dashboard ORM models that belong to the given org and folder.
@@ -419,7 +416,7 @@ mod tests {
             db.into_transaction_log(),
             vec![Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
-                r#"SELECT "folders"."id" AS "A_id", "folders"."org" AS "A_org", "folders"."folder_id" AS "A_folder_id", "folders"."name" AS "A_name", "folders"."description" AS "A_description", "folders"."type" AS "A_type", "dashboards"."id" AS "B_id", "dashboards"."dashboard_id" AS "B_dashboard_id", "dashboards"."folder_id" AS "B_folder_id", "dashboards"."owner" AS "B_owner", "dashboards"."role" AS "B_role", "dashboards"."title" AS "B_title", "dashboards"."description" AS "B_description", "dashboards"."data" AS "B_data", "dashboards"."version" AS "B_version", "dashboards"."created_at" AS "B_created_at" FROM "folders" LEFT JOIN "dashboards" ON "folders"."id" = "dashboards"."folder_id" WHERE "folders"."org" = $1 AND "folders"."type" = $2 AND "folders"."folder_id" = $3 AND LOWER("title") LIKE $4 ORDER BY "dashboards"."title" ASC, "folders"."id" ASC"#,
+                r#"SELECT "dashboards"."id" AS "A_id", "dashboards"."dashboard_id" AS "A_dashboard_id", "dashboards"."folder_id" AS "A_folder_id", "dashboards"."owner" AS "A_owner", "dashboards"."role" AS "A_role", "dashboards"."title" AS "A_title", "dashboards"."description" AS "A_description", "dashboards"."data" AS "A_data", "dashboards"."version" AS "A_version", "dashboards"."created_at" AS "A_created_at", "folders"."id" AS "B_id", "folders"."org" AS "B_org", "folders"."folder_id" AS "B_folder_id", "folders"."name" AS "B_name", "folders"."description" AS "B_description", "folders"."type" AS "B_type" FROM "dashboards" LEFT JOIN "folders" ON "dashboards"."folder_id" = "folders"."id" WHERE "folders"."org" = $1 AND "folders"."type" = $2 AND "folders"."folder_id" = $3 AND LOWER("title") LIKE $4 ORDER BY "dashboards"."title" ASC, "folders"."name" ASC"#,
                 [
                     "orgId".into(),
                     0i16.into(),
@@ -446,7 +443,7 @@ mod tests {
             db.into_transaction_log(),
             vec![Transaction::from_sql_and_values(
                 DatabaseBackend::MySql,
-                r#"SELECT `folders`.`id` AS `A_id`, `folders`.`org` AS `A_org`, `folders`.`folder_id` AS `A_folder_id`, `folders`.`name` AS `A_name`, `folders`.`description` AS `A_description`, `folders`.`type` AS `A_type`, `dashboards`.`id` AS `B_id`, `dashboards`.`dashboard_id` AS `B_dashboard_id`, `dashboards`.`folder_id` AS `B_folder_id`, `dashboards`.`owner` AS `B_owner`, `dashboards`.`role` AS `B_role`, `dashboards`.`title` AS `B_title`, `dashboards`.`description` AS `B_description`, `dashboards`.`data` AS `B_data`, `dashboards`.`version` AS `B_version`, `dashboards`.`created_at` AS `B_created_at` FROM `folders` LEFT JOIN `dashboards` ON `folders`.`id` = `dashboards`.`folder_id` WHERE `folders`.`org` = ? AND `folders`.`type` = ? AND `folders`.`folder_id` = ? AND LOWER(`title`) LIKE ? ORDER BY `dashboards`.`title` ASC, `folders`.`id` ASC"#,
+                r#"SELECT `dashboards`.`id` AS `A_id`, `dashboards`.`dashboard_id` AS `A_dashboard_id`, `dashboards`.`folder_id` AS `A_folder_id`, `dashboards`.`owner` AS `A_owner`, `dashboards`.`role` AS `A_role`, `dashboards`.`title` AS `A_title`, `dashboards`.`description` AS `A_description`, `dashboards`.`data` AS `A_data`, `dashboards`.`version` AS `A_version`, `dashboards`.`created_at` AS `A_created_at`, `folders`.`id` AS `B_id`, `folders`.`org` AS `B_org`, `folders`.`folder_id` AS `B_folder_id`, `folders`.`name` AS `B_name`, `folders`.`description` AS `B_description`, `folders`.`type` AS `B_type` FROM `dashboards` LEFT JOIN `folders` ON `dashboards`.`folder_id` = `folders`.`id` WHERE `folders`.`org` = ? AND `folders`.`type` = ? AND `folders`.`folder_id` = ? AND LOWER(`title`) LIKE ? ORDER BY `dashboards`.`title` ASC, `folders`.`name` ASC"#,
                 [
                     "orgId".into(),
                     0i16.into(),
@@ -473,7 +470,7 @@ mod tests {
             db.into_transaction_log(),
             vec![Transaction::from_sql_and_values(
                 DatabaseBackend::Sqlite,
-                r#"SELECT "folders"."id" AS "A_id", "folders"."org" AS "A_org", "folders"."folder_id" AS "A_folder_id", "folders"."name" AS "A_name", "folders"."description" AS "A_description", "folders"."type" AS "A_type", "dashboards"."id" AS "B_id", "dashboards"."dashboard_id" AS "B_dashboard_id", "dashboards"."folder_id" AS "B_folder_id", "dashboards"."owner" AS "B_owner", "dashboards"."role" AS "B_role", "dashboards"."title" AS "B_title", "dashboards"."description" AS "B_description", "dashboards"."data" AS "B_data", "dashboards"."version" AS "B_version", "dashboards"."created_at" AS "B_created_at" FROM "folders" LEFT JOIN "dashboards" ON "folders"."id" = "dashboards"."folder_id" WHERE "folders"."org" = ? AND "folders"."type" = ? AND "folders"."folder_id" = ? AND LOWER("title") LIKE ? ORDER BY "dashboards"."title" ASC, "folders"."id" ASC"#,
+                r#"SELECT "dashboards"."id" AS "A_id", "dashboards"."dashboard_id" AS "A_dashboard_id", "dashboards"."folder_id" AS "A_folder_id", "dashboards"."owner" AS "A_owner", "dashboards"."role" AS "A_role", "dashboards"."title" AS "A_title", "dashboards"."description" AS "A_description", "dashboards"."data" AS "A_data", "dashboards"."version" AS "A_version", "dashboards"."created_at" AS "A_created_at", "folders"."id" AS "B_id", "folders"."org" AS "B_org", "folders"."folder_id" AS "B_folder_id", "folders"."name" AS "B_name", "folders"."description" AS "B_description", "folders"."type" AS "B_type" FROM "dashboards" LEFT JOIN "folders" ON "dashboards"."folder_id" = "folders"."id" WHERE "folders"."org" = ? AND "folders"."type" = ? AND "folders"."folder_id" = ? AND LOWER("title") LIKE ? ORDER BY "dashboards"."title" ASC, "folders"."name" ASC"#,
                 [
                     "orgId".into(),
                     0i16.into(),

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -143,7 +143,7 @@ pub async fn update_dashboard(
 #[tracing::instrument]
 pub async fn list_dashboards(
     params: ListDashboardsParams,
-) -> Result<Vec<Dashboard>, DashboardError> {
+) -> Result<Vec<(Folder, Dashboard)>, DashboardError> {
     let dashboards = table::dashboards::list(params).await?;
     Ok(dashboards)
 }


### PR DESCRIPTION
Adds new fields to the items returned in the `ListDashboardsResponseBody`

- new fields about the dashboard's parent folder: #5198 
- common dashboard fields that will enable us to eventually remove the large `v1`,...,`v5` dashboard details objects: #5196 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced dashboard management with detailed metadata in responses, including folder associations.
	- Improved integration of folder and dashboard data for better contextual retrieval.

- **Bug Fixes**
	- Enhanced error handling for dashboard moving and updating operations.

- **Refactor**
	- Updated return types for several functions to include folder information alongside dashboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->