### PR TITLE
feat: Limit dashboard search results

### DIFF
--- a/src/config/src/meta/dashboards/mod.rs
+++ b/src/config/src/meta/dashboards/mod.rs
@@ -201,6 +201,9 @@ pub struct ListDashboardsParams {
     /// The optional case-insensitive title substring with which to filter
     /// dashboards.
     pub title_pat: Option<String>,
+
+    /// The optional page size and page index of results to retrieve.
+    pub page_size_and_idx: Option<(u64, u64)>,
 }
 
 impl ListDashboardsParams {
@@ -211,6 +214,7 @@ impl ListDashboardsParams {
             org_id: org_id.to_string(),
             folder_id: None,
             title_pat: None,
+            page_size_and_idx: None,
         }
     }
 
@@ -226,6 +230,12 @@ impl ListDashboardsParams {
     /// contains the case-insitive title pattern.
     pub fn where_title_contains(mut self, title_pat: &str) -> Self {
         self.title_pat = Some(title_pat.to_string());
+        self
+    }
+
+    /// Paginate the results by the given page size and page index.
+    pub fn paginate(mut self, page_size: u64, page_idx: u64) -> Self {
+        self.page_size_and_idx = Some((page_size, page_idx));
         self
     }
 }


### PR DESCRIPTION
This PR introduces the optional `page_size` query parameter to the `ListDashboards` endpoint. When set this will limit the size of the result set to the specified value. The client/frontend will be able to set this query parameter in calls to `ListDashboards` to limit the number of results returned - specifically in requests to search dashboards across folders.

This PR only implements limiting the result set size and does not actually expose pagination as functionality of the `ListDashboards` endpoint. My hope however is that this implementation will put us in a good place to easily expose pagination on this endpoint if that's something we want to do in the future - though it would by no means be necessary.

There are a couple of idiosyncrasies here.

1. The `ListDashboards` endpoint does not read or use any `page_idx` or `page_number` query parameter, as one might expect from a paginated endpoint. Therefore if the client sets the `page_size` parameter to some number N then the `ListDashboards` endpoint will always return the top N results. (Considered in a different way, the endpoint always acts as if the requested page index is `0`.)
    - In the future we might want to add an additional `page_idx` query parameter as well to enable "true" pagination (rather than simply limiting the result set to the first N results). However there are no immediate plans for this.
2. The `page_size` query parameter is only read/used by the endpoint when the `title` parameter is **also** set. This means that when the `title` parameter is **not** set the endpoint will ignore the `page_size` parameter and will always return all dashboards that match the other query parameter, `folder`. 
   - In the future we could choose to use this parameter any time it is provided, not just when `title` is also provided. To do that there would need to first be an update to the UI to address the issue described below.
   - For the time being this is necessary in order to not break the UI. This is because currently the UI always sends the query parameter `page_size=1000` to the endpoint, even though before now that query parameter was never recognized by the endpoint. Additionally, the UI assumes that the calls it makes to `ListDashboards` in order to show the dashboards in a selected folder always return **all** dashboards, and in such requests the frontend sets the `folder` query parameter but not the `title` query parameter. Therefore, if we actually to use the `page_size` parameter in **those** requests, then in its current implementation the UI would fail to show all dashboards when a folder with over 1000 dashboards is selected.