### PR TITLE
fix: use boolQuery replace termSet for tantivy

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -592,7 +592,7 @@ pub struct Common {
     pub feature_query_exclude_all: bool,
     #[env_config(name = "ZO_FEATURE_QUERY_WITHOUT_INDEX", default = false)]
     pub feature_query_without_index: bool,
-    #[env_config(name = "ZO_FEATURE_QUERY_REMOVE_FILTER_WITH_INDEX", default = false)]
+    #[env_config(name = "ZO_FEATURE_QUERY_REMOVE_FILTER_WITH_INDEX", default = true)]
     pub feature_query_remove_filter_with_index: bool,
     #[env_config(name = "ZO_UI_ENABLED", default = true)]
     pub ui_enabled: bool,


### PR DESCRIPTION
fixed #5287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced query construction for `In` and `MatchAll` conditions, allowing for more flexible and logical grouping of search queries.
	- Default feature for query filter removal is now enabled, improving initial configuration settings.

- **Bug Fixes**
	- Improved handling of term collections in `MatchAll` conditions to ensure accurate query results.

- **Refactor**
	- Simplified query optimization process by removing the `optimize_or_query_with_termset` function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->