### PR TITLE
feat: Remove `folder_id` query param from `GetDashboard` and `DeleteDashboard`

### DIFF
--- a/src/handler/http/request/dashboards/mod.rs
+++ b/src/handler/http/request/dashboards/mod.rs
@@ -184,10 +184,9 @@ async fn list_dashboards(org_id: web::Path<String>, req: HttpRequest) -> impl Re
     ),
 )]
 #[get("/{org_id}/dashboards/{dashboard_id}")]
-async fn get_dashboard(path: web::Path<(String, String)>, req: HttpRequest) -> impl Responder {
+async fn get_dashboard(path: web::Path<(String, String)>) -> impl Responder {
     let (org_id, dashboard_id) = path.into_inner();
-    let folder = get_folder(req);
-    let dashboard = match dashboards::get_dashboard(&org_id, &dashboard_id, &folder).await {
+    let dashboard = match dashboards::get_dashboard(&org_id, &dashboard_id).await {
         Ok(dashboard) => dashboard,
         Err(err) => return err.into(),
     };
@@ -214,10 +213,9 @@ async fn get_dashboard(path: web::Path<(String, String)>, req: HttpRequest) -> i
     ),
 )]
 #[delete("/{org_id}/dashboards/{dashboard_id}")]
-async fn delete_dashboard(path: web::Path<(String, String)>, req: HttpRequest) -> impl Responder {
+async fn delete_dashboard(path: web::Path<(String, String)>) -> impl Responder {
     let (org_id, dashboard_id) = path.into_inner();
-    let folder_id = get_folder(req);
-    match dashboards::delete_dashboard(&org_id, &dashboard_id, &folder_id).await {
+    match dashboards::delete_dashboard(&org_id, &dashboard_id).await {
         Ok(()) => HttpResponse::Ok().json(MetaHttpResponse::message(
             http::StatusCode::OK.into(),
             "Dashboard deleted".to_string(),

--- a/src/infra/src/table/folders.rs
+++ b/src/infra/src/table/folders.rs
@@ -15,8 +15,8 @@
 
 use config::meta::folder::Folder;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, DatabaseConnection, EntityTrait,
-    ModelTrait, QueryFilter, QueryOrder, Set, TryIntoModel,
+    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, ConnectionTrait, DatabaseConnection,
+    EntityTrait, ModelTrait, QueryFilter, QueryOrder, Set, TryIntoModel,
 };
 
 use super::entity::folders::{ActiveModel, Column, Entity, Model};
@@ -126,8 +126,8 @@ pub async fn delete(org_id: &str, folder_id: &str) -> Result<(), errors::Error> 
 }
 
 /// Gets a folder ORM entity by its `folder_id`.
-async fn get_model(
-    db: &DatabaseConnection,
+pub(crate) async fn get_model<C: ConnectionTrait>(
+    db: &C,
     org_id: &str,
     folder_id: &str,
 ) -> Result<Option<Model>, sea_orm::DbErr> {
@@ -139,8 +139,8 @@ async fn get_model(
 }
 
 /// Lists all folder ORM models with the specified type.
-async fn list_models(
-    db: &DatabaseConnection,
+async fn list_models<C: ConnectionTrait>(
+    db: &C,
     org_id: &str,
     folder_type: FolderType,
 ) -> Result<Vec<Model>, sea_orm::DbErr> {

--- a/src/infra/src/table/folders.rs
+++ b/src/infra/src/table/folders.rs
@@ -15,8 +15,8 @@
 
 use config::meta::folder::Folder;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, ConnectionTrait, DatabaseConnection,
-    EntityTrait, ModelTrait, QueryFilter, QueryOrder, Set, TryIntoModel,
+    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait,
+    QueryFilter, QueryOrder, Set, TryIntoModel,
 };
 
 use super::entity::folders::{ActiveModel, Column, Entity, Model};

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -200,7 +200,8 @@ pub async fn move_dashboard(
     };
 
     // add the dashboard to the destination folder
-    put(org_id, dashboard_id, to_folder, dashboard, None).await?;
+    let hash = dashboard.hash.clone();
+    put(org_id, dashboard_id, to_folder, dashboard, Some(&hash)).await?;
 
     // delete the dashboard from the source folder
     let _ = table::dashboards::delete(org_id, dashboard_id).await;

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -149,34 +149,26 @@ pub async fn list_dashboards(
 }
 
 #[tracing::instrument]
-pub async fn get_dashboard(
-    org_id: &str,
-    dashboard_id: &str,
-    folder_id: &str,
-) -> Result<Dashboard, DashboardError> {
-    table::dashboards::get(org_id, folder_id, dashboard_id)
+pub async fn get_dashboard(org_id: &str, dashboard_id: &str) -> Result<Dashboard, DashboardError> {
+    table::dashboards::get(org_id, dashboard_id)
         .await?
         .ok_or(DashboardError::DashboardNotFound)
+        .map(|(_f, d)| d)
 }
 
 #[tracing::instrument]
-pub async fn delete_dashboard(
-    org_id: &str,
-    dashboard_id: &str,
-    folder_id: &str,
-) -> Result<(), DashboardError> {
-    match table::dashboards::get(org_id, folder_id, dashboard_id).await? {
-        Some(_) => {} // Dashboard exists. Continue with deleting.
-        None => return Err(DashboardError::DashboardNotFound),
+pub async fn delete_dashboard(org_id: &str, dashboard_id: &str) -> Result<(), DashboardError> {
+    let Some((folder, _dash)) = table::dashboards::get(org_id, dashboard_id).await? else {
+        return Err(DashboardError::DashboardNotFound);
     };
-    table::dashboards::delete(org_id, folder_id, dashboard_id).await?;
+    table::dashboards::delete(org_id, dashboard_id).await?;
     remove_ownership(
         org_id,
         "dashboards",
         Authz {
             obj_id: dashboard_id.to_owned(),
             parent_type: "folders".to_owned(),
-            parent: folder_id.to_owned(),
+            parent: folder.folder_id.to_owned(),
         },
     )
     .await;
@@ -194,7 +186,11 @@ pub async fn move_dashboard(
         return Err(DashboardError::MoveMissingFolderParam);
     };
 
-    let Some(dashboard) = table::dashboards::get(org_id, from_folder, dashboard_id).await? else {
+    let Some((curr_folder, dashboard)) = table::dashboards::get(org_id, dashboard_id).await? else {
+        return Err(DashboardError::DashboardNotFound);
+    };
+
+    if curr_folder.folder_id != from_folder {
         return Err(DashboardError::DashboardNotFound);
     };
 
@@ -207,7 +203,7 @@ pub async fn move_dashboard(
     put(org_id, dashboard_id, to_folder, dashboard, None).await?;
 
     // delete the dashboard from the source folder
-    let _ = table::dashboards::delete(org_id, from_folder, dashboard_id).await;
+    let _ = table::dashboards::delete(org_id, dashboard_id).await;
 
     Ok(())
 }
@@ -220,7 +216,7 @@ async fn put(
     mut dashboard: Dashboard,
     hash: Option<&str>,
 ) -> Result<Dashboard, DashboardError> {
-    if let Some(existing_dash) = table::dashboards::get(org_id, folder_id, dashboard_id).await? {
+    if let Some((_, existing_dash)) = table::dashboards::get(org_id, dashboard_id).await? {
         let existing_dash_hash = existing_dash.hash;
 
         let Some(Ok(hash_val)) = hash.map(|hash_str| hash_str.parse::<u64>()) else {

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -134,7 +134,6 @@ pub async fn save(
     let mut tasks = Vec::with_capacity(report.dashboards.len());
     for dashboard in report.dashboards.iter() {
         let dash_id = &dashboard.dashboard;
-        let folder = &dashboard.folder;
         if dashboard.tabs.is_empty() {
             return Err(anyhow::anyhow!("Atleast one tab is required"));
         }
@@ -142,7 +141,9 @@ pub async fn save(
         // Supports only one tab for now
         let tab_id = &dashboard.tabs[0];
         tasks.push(async move {
-            let maybe_dashboard = table::dashboards::get(org_id, folder, dash_id).await?;
+            let maybe_dashboard = table::dashboards::get(org_id, dash_id)
+                .await?
+                .map(|(_f, d)| d);
             // Check if the tab_id exists
             if let Some(dashboard) = maybe_dashboard.and_then(|d| d.v3) {
                 let mut tab_found = false;


### PR DESCRIPTION
Previously the `GetDashboard` and `DeleteDashboard` endpoints required the client to pass in the `folder_id` query parameter. The query parameter was actually superfluous because the `org_id` and `dashboard_id` URL parameters provided to each endpoint already uniquely identified a dashboard. Therefore, this PR removes `folder_id` as a query parameter from those endpoints. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified dashboard management functions by removing unnecessary parameters and logic.
	- Enhanced error handling for dashboard retrieval and validation processes.

- **Bug Fixes**
	- Improved error handling for dashboard existence checks and tab validation.

- **Documentation**
	- Updated logging statements for better context during report modifications.

- **Refactor**
	- Streamlined function signatures and internal logic for dashboard operations.
	- Adapted database connection handling for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->