### PR TITLE
fix: create destination button in add alert

### DIFF
--- a/web/src/components/alerts/AddAlert.vue
+++ b/web/src/components/alerts/AddAlert.vue
@@ -298,7 +298,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </div>
             </div>
 
-            <div class="o2-input flex justify-start items-center">
+            <div class="o2-input flex justify-start items-start q-mt-sm">
               <div
                 data-test="add-alert-destination-title"
                 class="text-bold q-pb-sm"
@@ -311,7 +311,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   v-model="formData.destinations"
                   :options="getFormattedDestinations"
                   color="input-border"
-                  bg-color="input-bg q-mt-sm"
+                  bg-color="input-bg "
                   class="no-case"
                   stack-label
                   outlined
@@ -321,7 +321,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   use-input
                   fill-input
                   :rules="[(val: any) => !!val || 'Field is required!']"
-                  style="width: 250px"
+                  style="width: 200px"
                 >
                   <template v-slot:option="option">
                     <q-list dense>
@@ -346,6 +346,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     </q-list>
                   </template>
                 </q-select>
+              </div>
+              <div class="q-pl-sm">
+                <q-btn
+                data-test="create-destination-btn"
+                icon="refresh"
+                title="Refresh latest Destinations"
+                class="text-bold no-border"
+                no-caps
+                flat
+                dense
+                @click="$emit('refresh:destinations')"
+              />
+              </div>
+              <div class="q-pl-sm">
+                <q-btn
+                data-test="create-destination-btn"
+                label="Create Destination"
+                class="text-bold no-border"
+                color="secondary"
+                no-caps
+                @click="routeToCreateDestination"
+
+              />
               </div>
             </div>
 
@@ -543,7 +566,7 @@ export default defineComponent({
       default: () => [],
     },
   },
-  emits: ["update:list", "cancel:hideform"],
+  emits: ["update:list", "cancel:hideform", "refresh:destinations"],
   components: {
     ScheduledAlert: defineAsyncComponent(() => import("./ScheduledAlert.vue")),
     RealTimeAlert: defineAsyncComponent(() => import("./RealTimeAlert.vue")),
@@ -720,6 +743,15 @@ export default defineComponent({
 
       onInputUpdate("stream_name", stream_name);
     };
+    watch(
+      () => props.destinations.length, // Watch for length changes
+      (newLength, oldLength) => {
+        formData.value.destinations  = formData.value.destinations.filter(destination => {
+          return props.destinations.some(dest => {
+            return dest.name === destination});
+        });
+      }
+    );
 
     watch(
       triggerCols.value,
@@ -1194,6 +1226,17 @@ export default defineComponent({
       }
     };
 
+    const routeToCreateDestination = () => {
+      const url = router.resolve({
+          name: "alertDestinations",
+          query: {
+            action: "add",
+            org_identifier: store.state.selectedOrganization.identifier,
+          },
+        }).href;
+      window.open(url, "_blank");
+    };
+
     return {
       t,
       q,
@@ -1258,6 +1301,7 @@ export default defineComponent({
       getTimezonesByOffset,
       showTimezoneWarning,
       updateMultiTimeRange,
+      routeToCreateDestination,
     };
   },
 

--- a/web/src/components/alerts/AddAlert.vue
+++ b/web/src/components/alerts/AddAlert.vue
@@ -746,8 +746,8 @@ export default defineComponent({
     watch(
       () => props.destinations.length, // Watch for length changes
       (newLength, oldLength) => {
-        formData.value.destinations  = formData.value.destinations.filter(destination => {
-          return props.destinations.some(dest => {
+        formData.value.destinations  = formData.value.destinations.filter((destination : any) => {
+          return props.destinations.some((dest:any) => {
             return dest.name === destination});
         });
       }

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -223,6 +223,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :destinations="destinations"
         @update:list="refreshList"
         @cancel:hideform="hideForm"
+        @refresh:destinations="refreshDestination"
       />
     </template>
     <ConfirmDialog
@@ -559,7 +560,7 @@ export default defineComponent({
         if (!action) showAddAlertDialog.value = false;
       }
     );
-    const getDestinations = () => {
+    const getDestinations = async () => {
       destinationService
         .list({
           org_identifier: store.state.selectedOrganization.identifier,
@@ -917,6 +918,12 @@ export default defineComponent({
       });
     };
 
+    const refreshDestination = async () =>{
+
+      await getDestinations();
+
+    }
+
     return {
       t,
       qTable,
@@ -1003,6 +1010,7 @@ export default defineComponent({
       alertStateLoadingMap,
       templates,
       routeTo,
+      refreshDestination,
     };
   },
 });

--- a/web/src/components/alerts/DestinationList.vue
+++ b/web/src/components/alerts/DestinationList.vue
@@ -152,7 +152,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </q-page>
 </template>
 <script lang="ts">
-import { ref, onBeforeMount, onActivated, watch, defineComponent } from "vue";
+import { ref, onBeforeMount, onActivated, watch, defineComponent, onMounted } from "vue"; 
 import type { Ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useQuasar, type QTableProps } from "quasar";
@@ -259,6 +259,10 @@ export default defineComponent({
         if (!action) showDestinationEditor.value = false;
       }
     );
+
+    onMounted(()=>{
+      updateRoute();
+    })
 
     const getDestinations = () => {
       const dismiss = q.notify({


### PR DESCRIPTION
This PR fixes the #5323 issue that is related to adding create destination button in add alert page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added buttons for refreshing and creating destinations in the alert creation interface.
	- Introduced a new event for refreshing destinations and a method to navigate to the destination creation page.

- **Improvements**
	- Enhanced filtering logic for destinations and refined validation for the alert form.
	- Improved error handling for asynchronous operations in the alert management system.
	- Streamlined the filtering process in the destination list.
	- Implemented lifecycle hook to ensure route updates on component mount.

- **Bug Fixes**
	- Adjusted layout and styling for better usability and consistency across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->