### PR TITLE
fix: short_url duplicating to meta

### DIFF
--- a/src/infra/src/table/migration/m20241215_190333_delete_metas.rs
+++ b/src/infra/src/table/migration/m20241215_190333_delete_metas.rs
@@ -1,0 +1,68 @@
+// Copyright 2024 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Deletes dashboard records from the meta table.
+
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, TransactionTrait};
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let txn = manager.get_connection().begin().await?;
+        meta::Entity::delete_many()
+            .filter(meta::Column::Module.eq("short_urls"))
+            .exec(&txn)
+            .await?;
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        // The deletion of records from the meta table is not reversable.
+        Ok(())
+    }
+}
+
+// The schemas of tables might change after subsequent migrations. Therefore
+// this migration only references ORM models in private submodules that should
+// remain unchanged rather than ORM models in the `entity` module that will be
+// updated to reflect the latest changes to table schemas.
+
+/// Representation of the meta table at the time this migration executes.
+mod meta {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
+    #[sea_orm(table_name = "meta")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i64,
+        pub module: String,
+        pub key1: String,
+        pub key2: String,
+        pub start_dt: i64,
+        #[sea_orm(column_type = "Text")]
+        pub value: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}

--- a/src/infra/src/table/migration/mod.rs
+++ b/src/infra/src/table/migration/mod.rs
@@ -24,6 +24,7 @@ mod m20241119_000002_populate_dashboards_table;
 mod m20241119_000003_delete_metas;
 mod m20241204_143100_create_table_search_queue;
 mod m20241209_120000_create_alerts_table;
+mod m20241215_190333_delete_metas;
 
 pub struct Migrator;
 
@@ -39,7 +40,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20241119_000002_populate_dashboards_table::Migration),
             Box::new(m20241119_000003_delete_metas::Migration),
             Box::new(m20241204_143100_create_table_search_queue::Migration),
-            Box::new(m20241209_120000_create_alerts_table::Migration),
+            Box::new(m20241215_190333_delete_metas::Migration),
         ]
     }
 }


### PR DESCRIPTION
Currently short_url triggers db watch event by calling db::put directly, which duplicates the values into both `short_urls` table and `meta` table. 

This pr fixes by changing to trigger db watch via cluster coordinator.
Also deletes all duplicated `short_urls` from meta.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a migration to delete specific records from the `meta` table.
	- Updated migration sequence to focus on metadata deletion instead of creating an alerts table.

- **Bug Fixes**
	- Enhanced the access method for triggering watch events and deleting entries in the short URL service.

- **Chores**
	- Refactored the cluster coordination logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->