### PR TITLE
fix: cache partial responses only if its a range error

### DIFF
--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -293,31 +293,12 @@ pub async fn search(
         Some(user_id),
         &req,
         use_cache,
+        range_error,
     )
     .instrument(http_span)
     .await;
     match res {
-        Ok(mut res) => {
-            if res.is_partial {
-                let partial_err = "Please be aware that the response is based on partial data";
-                res.function_error = if res.function_error.is_empty() {
-                    partial_err.to_string()
-                } else {
-                    format!("{} \n {}", partial_err, res.function_error)
-                };
-            }
-            if !range_error.is_empty() {
-                res.is_partial = true;
-                res.function_error = if res.function_error.is_empty() {
-                    range_error
-                } else {
-                    format!("{} \n {}", range_error, res.function_error)
-                };
-                res.new_start_time = Some(req.query.start_time);
-                res.new_end_time = Some(req.query.end_time);
-            }
-            Ok(HttpResponse::Ok().json(res))
-        }
+        Ok(res) => Ok(HttpResponse::Ok().json(res)),
         Err(err) => {
             http_report_metrics(start, &org_id, stream_type, "", "500", "_search");
             log::error!("[trace_id {trace_id}] search error: {}", err);
@@ -984,6 +965,7 @@ async fn values_v1(
             Some(user_id.to_string()),
             &req,
             use_cache,
+            "".to_string(),
         )
         .instrument(http_span)
         .await;

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -347,16 +347,15 @@ pub async fn search(
     // 2. Super cluster error
     // 3. Range error (max_query_limit)
     // Cache partial results only if there is a range error
-    let cache_partial_response = res.is_partial
-        && !res.function_error.is_empty()
-        && res.new_start_time.is_some()
-        && res.new_end_time.is_some();
+    let skip_cache_results = (res.is_partial
+        && (res.new_start_time.is_none() || res.new_end_time.is_none()))
+        || (!res.function_error.is_empty() && res.function_error.contains("vrl"));
 
     // result cache save changes start
     if cfg.common.result_cache_enabled
         && should_exec_query
         && c_resp.cache_query_response
-        && cache_partial_response
+        && !skip_cache_results
         && (results.first().is_some_and(|res| !res.hits.is_empty())
             || results.last().is_some_and(|res| !res.hits.is_empty()))
     {

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -55,6 +55,7 @@ pub async fn search(
     user_id: Option<String>,
     in_req: &search::Request,
     use_cache: bool,
+    range_error: String,
 ) -> Result<search::Response, Error> {
     let start = std::time::Instant::now();
     let started_at = Utc::now().timestamp_micros();
@@ -322,10 +323,40 @@ pub async fn search(
     )
     .await;
 
+    if res.is_partial {
+        let partial_err = "Please be aware that the response is based on partial data";
+        res.function_error = if res.function_error.is_empty() {
+            partial_err.to_string()
+        } else {
+            format!("{} \n {}", partial_err, res.function_error)
+        };
+    }
+    if !range_error.is_empty() {
+        res.is_partial = true;
+        res.function_error = if res.function_error.is_empty() {
+            range_error
+        } else {
+            format!("{} \n {}", range_error, res.function_error)
+        };
+        res.new_start_time = Some(req.query.start_time);
+        res.new_end_time = Some(req.query.end_time);
+    }
+
+    // There are 3 types of partial responses:
+    // 1. VRL error
+    // 2. Super cluster error
+    // 3. Range error (max_query_limit)
+    // Cache partial results only if there is a range error
+    let cache_partial_response = res.is_partial
+        && !res.function_error.is_empty()
+        && res.new_start_time.is_some()
+        && res.new_end_time.is_some();
+
     // result cache save changes start
     if cfg.common.result_cache_enabled
         && should_exec_query
         && c_resp.cache_query_response
+        && cache_partial_response
         && (results.first().is_some_and(|res| !res.hits.is_empty())
             || results.last().is_some_and(|res| !res.hits.is_empty()))
     {


### PR DESCRIPTION
There are 3 types of partial responses:
1. VRL error
2. Super cluster error
3. Range error (max_query_limit)

Cache partial results only if there is a range error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced search functionality with improved error handling for query ranges.
	- Introduced caching logic for partial results based on specific error conditions.

- **Bug Fixes**
	- Streamlined response generation and error reporting in search-related functions, ensuring clarity and efficiency.

- **Documentation**
	- Updated method signatures to reflect the latest changes in functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->