### PR TITLE
feat: Use `folder_type` parameter in internal folder methods

### DIFF
--- a/src/handler/http/request/folders.rs
+++ b/src/handler/http/request/folders.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse, Responder};
+use infra::table::folders::FolderType;
 
 use crate::{
     common::meta::http::HttpResponse as MetaHttpResponse,
@@ -75,7 +76,8 @@ pub async fn create_folder(
 ) -> impl Responder {
     let org_id = path.into_inner();
     let folder = body.into_inner().into();
-    match folders::save_folder(&org_id, folder, false).await {
+    let folder_type = FolderType::Dashboards;
+    match folders::save_folder(&org_id, folder, folder_type, false).await {
         Ok(folder) => {
             let body: CreateFolderResponseBody = folder.into();
             HttpResponse::Ok().json(body)
@@ -116,7 +118,8 @@ pub async fn update_folder(
 ) -> impl Responder {
     let (org_id, folder_id) = path.into_inner();
     let folder = body.into_inner().into();
-    match folders::update_folder(&org_id, &folder_id, folder).await {
+    let folder_type = FolderType::Dashboards;
+    match folders::update_folder(&org_id, &folder_id, folder_type, folder).await {
         Ok(_) => HttpResponse::Ok().body("Folder updated"),
         Err(err) => err.into(),
     }
@@ -150,7 +153,8 @@ pub async fn list_folders(path: web::Path<String>, req: HttpRequest) -> impl Res
         return HttpResponse::Forbidden().finish();
     };
 
-    match folders::list_folders(&org_id, user_id).await {
+    let folder_type = FolderType::Dashboards;
+    match folders::list_folders(&org_id, user_id, folder_type).await {
         Ok(folders) => {
             let body: ListFoldersResponseBody = folders.into();
             HttpResponse::Ok().json(body)
@@ -179,7 +183,8 @@ pub async fn list_folders(path: web::Path<String>, req: HttpRequest) -> impl Res
 #[get("/{org_id}/folders/{folder_id}")]
 pub async fn get_folder(path: web::Path<(String, String)>) -> impl Responder {
     let (org_id, folder_id) = path.into_inner();
-    match folders::get_folder(&org_id, &folder_id).await {
+    let folder_type = FolderType::Dashboards;
+    match folders::get_folder(&org_id, &folder_id, folder_type).await {
         Ok(folder) => {
             let body: CreateFolderResponseBody = folder.into();
             HttpResponse::Ok().json(body)
@@ -209,7 +214,8 @@ pub async fn get_folder(path: web::Path<(String, String)>) -> impl Responder {
 #[delete("/{org_id}/folders/{folder_id}")]
 async fn delete_folder(path: web::Path<(String, String)>) -> impl Responder {
     let (org_id, folder_id) = path.into_inner();
-    match folders::delete_folder(&org_id, &folder_id).await {
+    let folder_type = FolderType::Dashboards;
+    match folders::delete_folder(&org_id, &folder_id, folder_type).await {
         Ok(()) => HttpResponse::Ok().body("Folder deleted"),
         Err(err) => err.into(),
     }

--- a/src/infra/src/table/folders.rs
+++ b/src/infra/src/table/folders.rs
@@ -27,7 +27,7 @@ use crate::{
 
 /// Indicates the type of data that the folder can contain.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum FolderType {
+pub enum FolderType {
     Dashboards,
 }
 
@@ -50,24 +50,35 @@ impl From<Model> for Folder {
 }
 
 /// Gets a folder by its ID.
-pub async fn get(org_id: &str, folder_id: &str) -> Result<Option<Folder>, errors::Error> {
+pub async fn get(
+    org_id: &str,
+    folder_id: &str,
+    folder_type: FolderType,
+) -> Result<Option<Folder>, errors::Error> {
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
-    let folder = get_model(client, org_id, folder_id)
+    let folder = get_model(client, org_id, folder_id, folder_type)
         .await
         .map(|f| f.map(Folder::from))?;
     Ok(folder)
 }
 
 /// Checks if the folder with the given ID exists.
-pub async fn exists(org_id: &str, folder_id: &str) -> Result<bool, errors::Error> {
-    let exists = get(org_id, folder_id).await?.is_some();
+pub async fn exists(
+    org_id: &str,
+    folder_id: &str,
+    folder_type: FolderType,
+) -> Result<bool, errors::Error> {
+    let exists = get(org_id, folder_id, folder_type).await?.is_some();
     Ok(exists)
 }
 
-/// Lists all dashboard folders.
-pub async fn list_dashboard_folders(org_id: &str) -> Result<Vec<Folder>, errors::Error> {
+/// Lists all dashboard folders of the specified type.
+pub async fn list_folders(
+    org_id: &str,
+    folder_type: FolderType,
+) -> Result<Vec<Folder>, errors::Error> {
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
-    let folders = list_models(client, org_id, FolderType::Dashboards)
+    let folders = list_models(client, org_id, folder_type)
         .await?
         .into_iter()
         .map(Folder::from)
@@ -77,31 +88,33 @@ pub async fn list_dashboard_folders(org_id: &str) -> Result<Vec<Folder>, errors:
 
 /// Creates a new folder or updates an existing folder in the database. Returns
 /// the new or updated folder.
-pub async fn put(org_id: &str, folder: Folder) -> Result<Folder, errors::Error> {
+pub async fn put(
+    org_id: &str,
+    folder: Folder,
+    folder_type: FolderType,
+) -> Result<Folder, errors::Error> {
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
-    let mut active: ActiveModel = match get_model(client, org_id, &folder.folder_id).await? {
-        // If a folder with the given folder_id already exists, get that folder
-        // model and use it as the active model so that Sea ORM will update the
-        // corresponding DB record when the active model is saved.
-        Some(model) => model.into(),
-        // In no folder with the given folder_id already exists, create a new
-        // active record so that Sea ORM will create a new DB record when the
-        // active model is saved.
-        None => ActiveModel {
-            id: NotSet,          // Set by DB.
-            name: NotSet,        // Can be updated so this is set below.
-            description: NotSet, // Can be updated so this is set below.
-            org: Set(org_id.to_owned()),
-            // We should probably generate folder_id here for new folders,
-            // rather than depending on caller code to generate it.
-            folder_id: Set(folder.folder_id),
-            // Currently we only create dashboard folders. If we want to support
-            // creating different types of folders then we can allow the caller
-            // to pass the folder type as a field on the Folder struct.
-            r#type: Set::<i16>(FolderType::Dashboards.into()),
-        },
-    };
+    let mut active: ActiveModel =
+        match get_model(client, org_id, &folder.folder_id, folder_type).await? {
+            // If a folder with the given folder_id already exists, get that folder
+            // model and use it as the active model so that Sea ORM will update the
+            // corresponding DB record when the active model is saved.
+            Some(model) => model.into(),
+            // In no folder with the given folder_id already exists, create a new
+            // active record so that Sea ORM will create a new DB record when the
+            // active model is saved.
+            None => ActiveModel {
+                id: NotSet,          // Set by DB.
+                name: NotSet,        // Can be updated so this is set below.
+                description: NotSet, // Can be updated so this is set below.
+                org: Set(org_id.to_owned()),
+                // We should probably generate folder_id here for new folders,
+                // rather than depending on caller code to generate it.
+                folder_id: Set(folder.folder_id),
+                r#type: Set::<i16>(folder_type.into()),
+            },
+        };
 
     active.name = Set(folder.name);
     active.description = Set(if folder.description.is_empty() {
@@ -114,9 +127,13 @@ pub async fn put(org_id: &str, folder: Folder) -> Result<Folder, errors::Error> 
 }
 
 /// Deletes a folder with the given `folder_id` surrogate key.
-pub async fn delete(org_id: &str, folder_id: &str) -> Result<(), errors::Error> {
+pub async fn delete(
+    org_id: &str,
+    folder_id: &str,
+    folder_type: FolderType,
+) -> Result<(), errors::Error> {
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
-    let model = get_model(client, org_id, folder_id).await?;
+    let model = get_model(client, org_id, folder_id, folder_type).await?;
 
     if let Some(model) = model {
         let _ = model.delete(client).await?;
@@ -130,10 +147,12 @@ async fn get_model(
     db: &DatabaseConnection,
     org_id: &str,
     folder_id: &str,
+    folder_type: FolderType,
 ) -> Result<Option<Model>, sea_orm::DbErr> {
     Entity::find()
         .filter(Column::Org.eq(org_id))
         .filter(Column::FolderId.eq(folder_id))
+        .filter(Column::Type.eq(i16::from(folder_type)))
         .one(db)
         .await
 }

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -25,6 +25,7 @@ use hashbrown::HashMap;
 use infra::table::{
     self,
     distinct_values::{self, DistinctFieldRecord, OriginType},
+    folders::FolderType,
 };
 
 use super::{folders, stream::save_stream_settings};
@@ -268,7 +269,7 @@ pub async fn create_dashboard(
     // NOTE: Overwrite whatever `dashboard_id` the client has sent us
     // If folder is default folder & doesn't exist then create it
 
-    if table::folders::exists(org_id, folder_id).await? {
+    if table::folders::exists(org_id, folder_id, FolderType::Dashboards).await? {
         let dashboard_id = ider::generate();
         let saved = put(org_id, &dashboard_id, folder_id, dashboard, None).await?;
         set_ownership(
@@ -288,7 +289,7 @@ pub async fn create_dashboard(
             name: DEFAULT_FOLDER.to_string(),
             description: DEFAULT_FOLDER.to_string(),
         };
-        folders::save_folder(org_id, folder, true)
+        folders::save_folder(org_id, folder, FolderType::Dashboards, true)
             .await
             .map_err(|_| DashboardError::CreateDefaultFolder)?;
         let dashboard_id = ider::generate();
@@ -375,7 +376,7 @@ pub async fn move_dashboard(
     };
 
     // make sure the destination folder exists
-    if !table::folders::exists(org_id, to_folder).await? {
+    if !table::folders::exists(org_id, to_folder, FolderType::Dashboards).await? {
         return Err(DashboardError::MoveDestinationFolderNotFound);
     };
 


### PR DESCRIPTION
In this [other PR ](https://github.com/openobserve/openobserve/pull/5390) I need to be able to add logic to create a default "alerts" folder.

In order to do that, we first need to enable callers to pass a `folder_type` parameter to different internal methods for getting/creating/updating/deleting/listing folders. Previously those methods assumed that the folder type was always `Dashboards` since thus far that was the only folder type that existed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced folder management functionality by introducing folder type distinctions for creating, updating, listing, retrieving, and deleting folders.
  - Default folder creation for dashboards now explicitly categorizes folders as `Dashboards`.

- **Bug Fixes**
  - Improved error handling for folder existence checks and dashboard creation processes.

- **Documentation**
  - Updated method signatures in documentation to reflect the inclusion of the `folder_type` parameter across various functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->