### PR TITLE
fix: check invalid stream_name during bulk ingestion

### DIFF
--- a/src/config/src/utils/schema.rs
+++ b/src/config/src/utils/schema.rs
@@ -266,14 +266,6 @@ pub fn format_stream_name(stream_name: &str) -> String {
         .to_lowercase()
 }
 
-// Check if stream name is valid
-// Stream name must be alphanumeric and can contain underscores
-// Stream name cannot be all underscores
-// Stream name cannot be empty
-pub fn is_valid_stream_name(stream_name: &str) -> bool {
-    !RE_CORRECT_STREAM_NAME.is_match(stream_name) && !stream_name.chars().all(|c| c == '_')
-}
-
 /// match a source is a needed file or not, return true if needed
 pub fn filter_source_by_partition_key(source: &str, filters: &[(String, Vec<String>)]) -> bool {
     !filters.iter().any(|(k, v)| {
@@ -394,15 +386,5 @@ mod tests {
         for (filter, expected) in filters {
             assert_eq!(filter_source_by_partition_key(path, &filter), expected);
         }
-    }
-
-    #[test]
-    fn test_invalid_stream_names() {
-        assert!(!is_valid_stream_name(""));
-        assert!(!is_valid_stream_name("_"));
-        assert!(!is_valid_stream_name("____"));
-        assert!(is_valid_stream_name("123stream"));
-        assert!(is_valid_stream_name("stream1"));
-        assert!(is_valid_stream_name("stream_name"));
     }
 }

--- a/src/config/src/utils/schema.rs
+++ b/src/config/src/utils/schema.rs
@@ -266,6 +266,14 @@ pub fn format_stream_name(stream_name: &str) -> String {
         .to_lowercase()
 }
 
+// Check if stream name is valid
+// Stream name must be alphanumeric and can contain underscores
+// Stream name cannot be all underscores
+// Stream name cannot be empty
+pub fn is_valid_stream_name(stream_name: &str) -> bool {
+    !RE_CORRECT_STREAM_NAME.is_match(stream_name) && !stream_name.chars().all(|c| c == '_')
+}
+
 /// match a source is a needed file or not, return true if needed
 pub fn filter_source_by_partition_key(source: &str, filters: &[(String, Vec<String>)]) -> bool {
     !filters.iter().any(|(k, v)| {
@@ -386,5 +394,15 @@ mod tests {
         for (filter, expected) in filters {
             assert_eq!(filter_source_by_partition_key(path, &filter), expected);
         }
+    }
+
+    #[test]
+    fn test_invalid_stream_names() {
+        assert!(!is_valid_stream_name(""));
+        assert!(!is_valid_stream_name("_"));
+        assert!(!is_valid_stream_name("____"));
+        assert!(is_valid_stream_name("123stream"));
+        assert!(is_valid_stream_name("stream1"));
+        assert!(is_valid_stream_name("stream_name"));
     }
 }

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -28,7 +28,7 @@ use config::{
         stream::{StreamParams, StreamType},
     },
     metrics,
-    utils::{flatten, json, schema::is_valid_stream_name, time::parse_timestamp_micro_from_value},
+    utils::{flatten, json, time::parse_timestamp_micro_from_value},
     BLOCKED_STREAMS, ID_COL_NAME, ORIGINAL_DATA_COL_NAME,
 };
 
@@ -104,7 +104,8 @@ pub async fn ingest(
             }
             (action, stream_name, doc_id) = ret.unwrap();
 
-            if !is_valid_stream_name(&stream_name) {
+            if stream_name.is_empty() || stream_name == "_" || stream_name == "/" {
+                log::warn!("Invalid stream name: '{}'", stream_name);
                 bulk_res.errors = true;
                 let err_msg = format!("Invalid stream name: {}", stream_name);
                 let err = BulkResponseError::new(

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -105,14 +105,14 @@ pub async fn ingest(
             (action, stream_name, doc_id) = ret.unwrap();
 
             if stream_name.is_empty() || stream_name == "_" || stream_name == "/" {
-                log::warn!("Invalid stream name: '{}'", stream_name);
+                let err_msg = format!("Invalid stream name: {}", line);
+                log::warn!("{}", err_msg);
                 bulk_res.errors = true;
-                let err_msg = format!("Invalid stream name: {}", stream_name);
                 let err = BulkResponseError::new(
                     err_msg.to_string(),
                     stream_name.clone(),
                     err_msg,
-                    "0".to_string(), // TODO check
+                    "0".to_string(),
                 );
                 let mut item = HashMap::new();
                 item.insert(
@@ -559,7 +559,7 @@ pub fn add_record_status(
                 failure_type,
                 stream_name.clone(),
                 failure_reason.unwrap(),
-                "0".to_owned(), // TODO check
+                "0".to_owned(),
             );
 
             item.insert(

--- a/tests/api-testing/tests/test_bulk.py
+++ b/tests/api-testing/tests/test_bulk.py
@@ -30,34 +30,6 @@ def test_e2e_bulk_ingest(create_session, base_url):
         f"Expected no errors in the valid bulk request response, but got {resp_valid_bulk.json()}"
     )
 
-    # **Negative Test Case 1: Invalid Bulk Payload (Missing Document Body)**
-    invalid_bulk_payload = (
-        '{ "index" : { "_index" : "pytest10222", "_id" : "1" } }\n'
-        '{ "field1" : "value1" }'  # Add a document body after the index action
-    )
-
-    resp_invalid_bulk_1 = session.post(url, data=invalid_bulk_payload, headers=headers)
-    
-    # Print the raw response and content for debugging
-    print("Negative Test Response (Raw Content):", resp_invalid_bulk_1.content)
-    
-    try:
-        response_json = resp_invalid_bulk_1.json()  # Attempt to parse the JSON response
-        print("Negative Test Response (JSON):", response_json)
-    except Exception as e:
-        print("Error parsing JSON response:", str(e))
-
-    # Assert negative case for the first invalid payload
-    # Expecting a 200 response even for invalid data, but check that there's no error field
-    assert resp_invalid_bulk_1.status_code == 200, (
-        f"Expected status code 200 for invalid bulk request, but got {resp_invalid_bulk_1.status_code}. "
-        f"Response: {resp_invalid_bulk_1.content}"
-    )
-    # Assert that errors is true
-    assert resp_invalid_bulk_1.json().get("errors"), (
-        f"Expected errors in the invalid bulk request response, but got {resp_invalid_bulk_1.json()}"
-    )
-
     # **Negative Test Case 2: Invalid Bulk Payload (Empty Index)**
     invalid_bulk_payload2 = [
         { "index" : { "_index" : "" } },  # Empty index
@@ -86,9 +58,9 @@ def test_e2e_bulk_ingest(create_session, base_url):
         f"Response: {resp_invalid_bulk_2.content}"
     )
 
-    # Assert no errors in the response, as expected from Postman behavior
+    # Assert errors is true in the response
     assert resp_invalid_bulk_2.json().get("errors"), (
-        f"Expected no errors in the invalid bulk request response, but got {resp_invalid_bulk_2.json()}"
+        f"Expected errors to be true in the invalid bulk request response, but got {resp_invalid_bulk_2.json()}"
     )
 
 

--- a/tests/api-testing/tests/test_bulk.py
+++ b/tests/api-testing/tests/test_bulk.py
@@ -80,7 +80,7 @@ def test_e2e_bulk_ingest(create_session, base_url):
         print("Error parsing JSON response:", str(e))
 
     # Assert that we get a 200 status code (as observed in Postman behavior)
-    assert resp_invalid_bulk_2.status_code == 200, (
+    assert resp_invalid_bulk_2.status_code == 422, (
         f"Expected status code 200 for invalid bulk request, but got {resp_invalid_bulk_2.status_code}. "
         f"Response: {resp_invalid_bulk_2.content}"
     )
@@ -103,7 +103,7 @@ def test_e2e_bulk_ingest(create_session, base_url):
     print("Negative Test Response:", resp_valid_bulk.content)
 
     # Assert positive case
-    assert resp_valid_bulk.status_code == 200, (
+    assert resp_valid_bulk.status_code == 422, (
         f"Expected status code 200 for valid bulk request, but got {resp_valid_bulk.status_code}. "
         f"Response: {resp_valid_bulk.content}"
     )

--- a/tests/api-testing/tests/test_bulk.py
+++ b/tests/api-testing/tests/test_bulk.py
@@ -53,8 +53,9 @@ def test_e2e_bulk_ingest(create_session, base_url):
         f"Expected status code 200 for invalid bulk request, but got {resp_invalid_bulk_1.status_code}. "
         f"Response: {resp_invalid_bulk_1.content}"
     )
-    assert not resp_invalid_bulk_1.json().get("errors"), (
-        f"Expected no errors in the invalid bulk request response, but got {resp_invalid_bulk_1.json()}"
+    # Assert that errors is true
+    assert resp_invalid_bulk_1.json().get("errors"), (
+        f"Expected errors in the invalid bulk request response, but got {resp_invalid_bulk_1.json()}"
     )
 
     # **Negative Test Case 2: Invalid Bulk Payload (Empty Index)**
@@ -80,13 +81,13 @@ def test_e2e_bulk_ingest(create_session, base_url):
         print("Error parsing JSON response:", str(e))
 
     # Assert that we get a 200 status code (as observed in Postman behavior)
-    assert resp_invalid_bulk_2.status_code == 422, (
+    assert resp_invalid_bulk_2.status_code == 200, (
         f"Expected status code 200 for invalid bulk request, but got {resp_invalid_bulk_2.status_code}. "
         f"Response: {resp_invalid_bulk_2.content}"
     )
 
     # Assert no errors in the response, as expected from Postman behavior
-    assert not resp_invalid_bulk_2.json().get("errors"), (
+    assert resp_invalid_bulk_2.json().get("errors"), (
         f"Expected no errors in the invalid bulk request response, but got {resp_invalid_bulk_2.json()}"
     )
 
@@ -103,7 +104,7 @@ def test_e2e_bulk_ingest(create_session, base_url):
     print("Negative Test Response:", resp_valid_bulk.content)
 
     # Assert positive case
-    assert resp_valid_bulk.status_code == 422, (
+    assert resp_valid_bulk.status_code == 200, (
         f"Expected status code 200 for valid bulk request, but got {resp_valid_bulk.status_code}. "
         f"Response: {resp_valid_bulk.content}"
     )


### PR DESCRIPTION
#5378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for invalid stream names during ingestion, ensuring appropriate logging and response for empty or invalid entries.
	- Updated assertions in tests to reflect the correct handling of invalid bulk payloads by the API, ensuring errors are present for invalid submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->