### PR TITLE
chore: compactor pending jobs metric improvements

### DIFF
--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -1191,7 +1191,8 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
             .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret =
-            sqlx::query(r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = 0 GROUP BY stream, status ORDER BY status desc;"#)
+            sqlx::query(r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = ? GROUP BY stream, status ORDER BY status desc;"#)
+                .bind(super::FileListJobStatus::Pending)
                 .fetch_all(&pool)
                 .await?;
 

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -1191,7 +1191,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
             .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret =
-            sqlx::query(r#"SELECT stream, status, count(*) as counts FROM file_list_jobs GROUP BY stream, status ORDER BY status desc;"#)
+            sqlx::query(r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = 0 GROUP BY stream, status ORDER BY status desc;"#)
                 .fetch_all(&pool)
                 .await?;
 

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1147,7 +1147,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
             .inc();
         let ret = sqlx
             ::query(
-                r#"SELECT stream, status, count(*) as counts FROM file_list_jobs GROUP BY stream, status ORDER BY status desc;"#
+                r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = 0 GROUP BY stream, status ORDER BY status desc;"#
             )
             .fetch_all(&pool).await?;
 

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1149,6 +1149,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
             ::query(
                 r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = 0 GROUP BY stream, status ORDER BY status desc;"#
             )
+            .bind(super::FileListJobStatus::Pending)
             .fetch_all(&pool).await?;
 
         let mut job_status: stdHashMap<String, stdHashMap<String, i64>> = stdHashMap::new();

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1147,7 +1147,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
             .inc();
         let ret = sqlx
             ::query(
-                r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = 0 GROUP BY stream, status ORDER BY status desc;"#
+                r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = $1 GROUP BY stream, status ORDER BY status desc;"#
             )
             .bind(super::FileListJobStatus::Pending)
             .fetch_all(&pool).await?;

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -994,7 +994,7 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         let pool = CLIENT_RO.clone();
 
         let ret =
-            sqlx::query(r#"SELECT stream, status, count(*) as counts FROM file_list_jobs GROUP BY stream, status ORDER BY status desc;"#)
+            sqlx::query(r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = 0 GROUP BY stream, status ORDER BY status desc;"#)
                 .fetch_all(&pool)
                 .await?;
 

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -994,7 +994,8 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         let pool = CLIENT_RO.clone();
 
         let ret =
-            sqlx::query(r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = 0 GROUP BY stream, status ORDER BY status desc;"#)
+            sqlx::query(r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = $1 GROUP BY stream, status ORDER BY status desc;"#)
+                .bind(super::FileListJobStatus::Pending)
                 .fetch_all(&pool)
                 .await?;
 


### PR DESCRIPTION
## Description

When fetching the status of pending jobs on compactors, limit results from database to only those jobs with `status = 0`.

```SQL
SELECT stream, status, count(*) as counts 
FROM file_list_jobs 
WHERE status = 0 
GROUP BY stream, status 
ORDER BY status desc;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced job counting functionality to focus solely on pending jobs across different database systems (MySQL, PostgreSQL, SQLite).
  
- **Bug Fixes**
	- Adjusted SQL queries to ensure accurate reporting of pending job counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->