### PR TITLE
fix: broken MySQL migration for dropping index

### DIFF
--- a/src/infra/src/table/migration/m20241114_000001_create_folders_table.rs
+++ b/src/infra/src/table/migration/m20241114_000001_create_folders_table.rs
@@ -36,10 +36,20 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_index(Index::drop().name(FOLDERS_ORG_FOLDER_ID_IDX).to_owned())
+            .drop_index(
+                Index::drop()
+                    .name(FOLDERS_ORG_FOLDER_ID_IDX)
+                    .table(Folders::Table)
+                    .to_owned(),
+            )
             .await?;
         manager
-            .drop_index(Index::drop().name(FOLDERS_ORG_IDX).to_owned())
+            .drop_index(
+                Index::drop()
+                    .name(FOLDERS_ORG_IDX)
+                    .table(Folders::Table)
+                    .to_owned(),
+            )
             .await?;
         manager
             .drop_table(Table::drop().table(Folders::Table).to_owned())

--- a/src/infra/src/table/migration/m20241119_000001_create_dashboards_table.rs
+++ b/src/infra/src/table/migration/m20241119_000001_create_dashboards_table.rs
@@ -38,6 +38,7 @@ impl MigrationTrait for Migration {
             .drop_index(
                 Index::drop()
                     .name(DASHBOARDS_FOLDER_ID_DASHBOARD_ID_IDX)
+                    .table(Dashboards::Table)
                     .to_owned(),
             )
             .await?;

--- a/src/infra/src/table/migration/m20241204_143100_create_table_search_queue.rs
+++ b/src/infra/src/table/migration/m20241204_143100_create_table_search_queue.rs
@@ -17,10 +17,20 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_index(Index::drop().name(SEARCH_QUEUE_WORK_GROUP_IDX).to_owned())
+            .drop_index(
+                Index::drop()
+                    .name(SEARCH_QUEUE_WORK_GROUP_IDX)
+                    .table(SearchQueue::Table)
+                    .to_owned(),
+            )
             .await?;
         manager
-            .drop_index(Index::drop().name(SEARCH_QUEUE_CREATED_AT_IDX).to_owned())
+            .drop_index(
+                Index::drop()
+                    .name(SEARCH_QUEUE_CREATED_AT_IDX)
+                    .table(SearchQueue::Table)
+                    .to_owned(),
+            )
             .await?;
         manager
             .drop_table(Table::drop().table(SearchQueue::Table).to_owned())

--- a/src/infra/src/table/migration/m20241209_120000_create_alerts_table.rs
+++ b/src/infra/src/table/migration/m20241209_120000_create_alerts_table.rs
@@ -40,12 +40,18 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_index(Index::drop().name(ALERTS_FOLDER_ID_IDX).to_owned())
+            .drop_index(
+                Index::drop()
+                    .name(ALERTS_FOLDER_ID_IDX)
+                    .table(Alerts::Table)
+                    .to_owned(),
+            )
             .await?;
         manager
             .drop_index(
                 Index::drop()
                     .name(ALERTS_ORG_STREAM_TYPE_STREAM_NAME_NAME_IDX)
+                    .table(Alerts::Table)
                     .to_owned(),
             )
             .await?;

--- a/src/infra/src/table/migration/m20241217_154900_alter_folders_table_idx.rs
+++ b/src/infra/src/table/migration/m20241217_154900_alter_folders_table_idx.rs
@@ -31,7 +31,12 @@ const NEW_FOLDERS_ORG_TYPE_FOLDER_ID_IDX: &str = "folders_org_type_folder_id_idx
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_index(Index::drop().name(OLD_FOLDERS_ORG_FOLDER_ID_IDX).to_owned())
+            .drop_index(
+                Index::drop()
+                    .name(OLD_FOLDERS_ORG_FOLDER_ID_IDX)
+                    .table(Folders::Table)
+                    .to_owned(),
+            )
             .await?;
         manager
             .create_index(create_new_folders_org_type_folder_id_idx_stmnt())
@@ -44,6 +49,7 @@ impl MigrationTrait for Migration {
             .drop_index(
                 Index::drop()
                     .name(NEW_FOLDERS_ORG_TYPE_FOLDER_ID_IDX)
+                    .table(Folders::Table)
                     .to_owned(),
             )
             .await?;

--- a/src/infra/src/table/mod.rs
+++ b/src/infra/src/table/mod.rs
@@ -41,6 +41,12 @@ pub async fn migrate() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+pub async fn down(steps: Option<u32>) -> Result<(), anyhow::Error> {
+    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+    Migrator::down(client, steps).await?;
+    Ok(())
+}
+
 /// Acquires a lock on the SQLite client if SQLite is configured as the meta store.
 ///
 /// # Returns


### PR DESCRIPTION
The migration to drop an index on the `folders` table fails for MySQL. The `DROP INDEX` statement in MySQL requires specifying the table name but including the table name is not allowed for PostgreSQL and Sqlite.

⚠️  **Migration change:** This PR modifies an existing migration, so we should be very careful not to alter the behavior of a migration that has already been applied to users' databases. In this case, this PR only changes the behavior of the `aler_folder_table_idx` migration when the database backend is MySQL. Prior to this PR that migration would panic when ran on a MySQL database, so no user with a MySQL database will have been able to successfully run this migration yet. Therefore there should be not risk of creating diverging migration behavior in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated migration logic for the `folders` table to enhance indexing clarity.
	- Improved index drop operations for the dashboards, alerts, and search queue tables by specifying the associated tables.
	- Introduced a new CLI command `seaorm-rollback` for rolling back migration steps, with options to rollback all or the last N migrations.
	- Added an asynchronous function to facilitate migration rollbacks with optional step specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->