### PR TITLE
fix: fix ListFolders v2

### DIFF
--- a/src/handler/http/request/folders.rs
+++ b/src/handler/http/request/folders.rs
@@ -159,7 +159,6 @@ pub async fn list_folders(
         return HttpResponse::Forbidden().finish();
     };
 
-    let folder_type = FolderType::Dashboards;
     match folders::list_folders(&org_id, user_id, folder_type.into()).await {
         Ok(folders) => {
             let body: ListFoldersResponseBody = folders.into();


### PR DESCRIPTION
The v2 ListFolders endpoint was reading the folder type from the URL but was then overwriting it with the dashboards folder type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced folder management functionality with dynamic folder type handling based on request parameters.
	- Updated deprecated folder endpoints to align with the new API path structure.

- **Bug Fixes**
	- Improved consistency in handling folder types across both new and deprecated endpoints.

- **Documentation**
	- Clarified API structure and error handling responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->