### PR TITLE
fix: wrong return type from list_alert route handle

### DIFF
--- a/src/handler/http/request/alerts/alert.rs
+++ b/src/handler/http/request/alerts/alert.rs
@@ -206,9 +206,7 @@ async fn list_alerts(path: web::Path<String>, req: HttpRequest) -> HttpResponse 
                 _alert_list_from_rbac = stream_list;
             }
             Err(e) => {
-                return Ok(crate::common::meta::http::HttpResponse::forbidden(
-                    e.to_string(),
-                ));
+                return MetaHttpResponse::forbidden(e.to_string());
             }
         }
         // Get List of allowed objects ends

--- a/src/service/db/alerts/alert/new.rs
+++ b/src/service/db/alerts/alert/new.rs
@@ -377,7 +377,7 @@ mod super_cluster {
 
     /// Sends event to the super cluster queue indicating that all alert have
     /// been deleted from the database.
-    pub async fn emit_delete_all_event() -> Result<(), infra::errors::Error> {
+    pub async fn _emit_delete_all_event() -> Result<(), infra::errors::Error> {
         if get_o2_config().super_cluster.enabled {
             o2_enterprise::enterprise::super_cluster::queue::delete("/alerts/", true, false, None)
                 .await


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for unauthorized access in the alert listing functionality.

- **Refactor**
	- Renamed the `emit_delete_all_event` method to `_emit_delete_all_event` to indicate internal usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->