### PR TITLE
feat: support cross stream type join

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -748,13 +748,13 @@ pub struct Common {
     pub inverted_index_old_format: bool,
     #[env_config(
         name = "ZO_INVERTED_INDEX_STORE_FORMAT",
-        default = "parquet",
+        default = "tantivy",
         help = "InvertedIndex store format, parquet(default), tantivy, both"
     )]
     pub inverted_index_store_format: String,
     #[env_config(
         name = "ZO_INVERTED_INDEX_SEARCH_FORMAT",
-        default = "",
+        default = "tantivy",
         help = "InvertedIndex search format, parquet(default), tantivy."
     )]
     pub inverted_index_search_format: String,

--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -73,16 +73,15 @@ pub fn resolve_stream_names_with_type(sql: &str) -> Result<Vec<TableReference>, 
 }
 
 pub trait TableReferenceExt {
-    fn stream_type(&self) -> StreamType;
+    fn stream_type(&self) -> String;
     fn stream_name(&self) -> String;
     fn has_stream_type(&self) -> bool;
     fn get_stream_type(&self, stream_type: StreamType) -> StreamType;
 }
 
 impl TableReferenceExt for TableReference {
-    fn stream_type(&self) -> StreamType {
-        let stream_type = self.schema().unwrap_or("");
-        StreamType::from(stream_type)
+    fn stream_type(&self) -> String {
+        self.schema().unwrap_or("").to_string()
     }
 
     fn stream_name(&self) -> String {
@@ -95,7 +94,7 @@ impl TableReferenceExt for TableReference {
 
     fn get_stream_type(&self, stream_type: StreamType) -> StreamType {
         if self.has_stream_type() {
-            self.stream_type()
+            StreamType::from(self.stream_type().as_str())
         } else {
             stream_type
         }

--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -14,7 +14,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use chrono::DateTime;
-use datafusion::{catalog_common::resolve_table_references, sql::parser::DFParser};
+use datafusion::{
+    catalog_common::resolve_table_references,
+    sql::{parser::DFParser, TableReference},
+};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sqlparser::{
@@ -28,6 +31,7 @@ use sqlparser::{
 };
 use utoipa::ToSchema;
 
+use super::stream::StreamType;
 use crate::get_config;
 
 pub const MAX_LIMIT: i64 = 100000;
@@ -53,6 +57,49 @@ pub fn resolve_stream_names(sql: &str) -> Result<Vec<String>, anyhow::Error> {
         tables.push(table.table().to_string());
     }
     Ok(tables)
+}
+
+pub fn resolve_stream_names_with_type(sql: &str) -> Result<Vec<TableReference>, anyhow::Error> {
+    let dialect = &PostgreSqlDialect {};
+    let statement = DFParser::parse_sql_with_dialect(sql, dialect)?
+        .pop_back()
+        .unwrap();
+    let (table_refs, _) = resolve_table_references(&statement, true)?;
+    let mut tables = Vec::new();
+    for table in table_refs {
+        tables.push(table);
+    }
+    Ok(tables)
+}
+
+pub trait TableReferenceExt {
+    fn stream_type(&self) -> StreamType;
+    fn stream_name(&self) -> String;
+    fn has_stream_type(&self) -> bool;
+    fn get_stream_type(&self, stream_type: StreamType) -> StreamType;
+}
+
+impl TableReferenceExt for TableReference {
+    fn stream_type(&self) -> StreamType {
+        let stream_type = self.schema().unwrap_or("");
+        StreamType::from(stream_type)
+    }
+
+    fn stream_name(&self) -> String {
+        self.table().to_string()
+    }
+
+    fn has_stream_type(&self) -> bool {
+        self.schema().is_some()
+    }
+
+    fn get_stream_type(&self, stream_type: StreamType) -> StreamType {
+        if self.has_stream_type() {
+            self.stream_type()
+        } else {
+            stream_type
+        }
+    }
 }
 
 /// parsed sql
@@ -1175,5 +1222,12 @@ mod tests {
             let actual = Sql::new(sql).unwrap().fields;
             assert_eq!(actual, fields);
         }
+    }
+
+    #[test]
+    fn test_resolve_stream_names_with_type() {
+        let sql = "select * from \"log\".default";
+        let names = resolve_stream_names_with_type(sql).unwrap();
+        println!("{:?}", names);
     }
 }

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -83,7 +83,7 @@ impl From<&str> for StreamType {
             "logs" => StreamType::Logs,
             "metrics" => StreamType::Metrics,
             "traces" => StreamType::Traces,
-            "enrichment_tables" => StreamType::EnrichmentTables,
+            "enrichment_tables" | "enrich" => StreamType::EnrichmentTables,
             "file_list" => StreamType::Filelist,
             "metadata" => StreamType::Metadata,
             "index" => StreamType::Index,

--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -23,14 +23,15 @@ use config::{
         bitvec::BitVec,
         cluster::{IntoArcVec, Node, Role, RoleGroup},
         search::{ScanStats, SearchEventType},
+        sql::TableReferenceExt,
         stream::{FileKey, QueryPartitionStrategy, StreamType},
     },
     metrics,
-    utils::inverted_index::split_token,
+    utils::{inverted_index::split_token, json},
     INDEX_FIELD_NAME_FOR_ALL, QUERY_WITH_NO_LIMIT,
 };
 use datafusion::{
-    common::tree_node::TreeNode,
+    common::{tree_node::TreeNode, TableReference},
     error::DataFusionError,
     physical_plan::{displayable, visit_execution_plan, ExecutionPlan},
     prelude::SessionContext,
@@ -41,6 +42,7 @@ use infra::{
     errors::{Error, ErrorCodes, Result},
     file_list::FileId,
 };
+use itertools::Itertools;
 use proto::cluster_rpc::{self, SearchQuery};
 use tracing::{info_span, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -244,10 +246,17 @@ pub async fn search(
         ));
     }
 
+    let trace_stream_name = json::to_string(
+        &sql.stream_names
+            .iter()
+            .map(|s| (s.get_stream_type(sql.stream_type), s.stream_name()))
+            .collect_vec(),
+    )
+    .unwrap();
     let datafusion_span = info_span!(
         "service:search:flight:datafusion",
         org_id = sql.org_id,
-        stream_name = sql.stream_names.first().unwrap(),
+        stream_name = trace_stream_name,
         stream_type = sql.stream_type.to_string(),
     );
 
@@ -328,7 +337,7 @@ pub async fn run_datafusion(
     req: Request,
     sql: Arc<Sql>,
     nodes: Vec<Node>,
-    partitioned_file_lists: HashMap<String, Vec<Vec<i64>>>,
+    partitioned_file_lists: HashMap<TableReference, Vec<Vec<i64>>>,
     idx_file_list: Vec<FileKey>,
 ) -> Result<(Vec<RecordBatch>, ScanStats, String)> {
     let cfg = get_config();
@@ -366,7 +375,7 @@ pub async fn run_datafusion(
     {
         for (stream, items) in sql.prefix_items.iter() {
             equal_keys
-                .entry(stream.to_string())
+                .entry(stream.clone())
                 .or_insert_with(Vec::new)
                 .extend(items.iter().map(|(k, v)| cluster_rpc::KvItem::new(k, v)));
         }
@@ -396,9 +405,7 @@ pub async fn run_datafusion(
         let table_name = sql.stream_names.first().unwrap();
         physical_plan = Arc::new(RemoteScanExec::new(
             physical_plan,
-            rewrite
-                .remote_scan_nodes
-                .get_remote_node(table_name.as_str()),
+            rewrite.remote_scan_nodes.get_remote_node(table_name),
         )?);
     }
 
@@ -577,10 +584,10 @@ pub async fn check_work_group(
 
 #[tracing::instrument(name = "service:search:cluster:flight:partition_file_lists", skip_all)]
 pub async fn partition_file_lists(
-    file_id_lists: HashMap<String, Vec<FileId>>,
+    file_id_lists: HashMap<TableReference, Vec<FileId>>,
     nodes: &[Node],
     group: Option<RoleGroup>,
-) -> Result<HashMap<String, Vec<Vec<i64>>>> {
+) -> Result<HashMap<TableReference, Vec<Vec<i64>>>> {
     let mut file_partitions = HashMap::with_capacity(file_id_lists.len());
     for (stream_name, file_id_list) in file_id_lists {
         let partitions = partition_filt_list(file_id_list, nodes, group).await?;
@@ -730,14 +737,14 @@ pub async fn generate_context(
 }
 
 pub async fn register_table(ctx: &SessionContext, sql: &Sql) -> Result<()> {
-    for (stream_name, schema) in &sql.schemas {
+    for (stream, schema) in &sql.schemas {
         let schema = schema.schema().as_ref().clone();
+        let stream_name = stream.to_quoted_string();
         let table = Arc::new(
-            NewEmptyTable::new(stream_name, Arc::new(schema))
+            NewEmptyTable::new(&stream_name, Arc::new(schema))
                 .with_partitions(ctx.state().config().target_partitions())
                 .with_sorted_by_time(sql.sorted_by_time),
         );
-        let stream_name = format!("\"{}\"", stream_name);
         ctx.register_table(stream_name, table)?;
     }
     Ok(())
@@ -747,15 +754,17 @@ pub async fn register_table(ctx: &SessionContext, sql: &Sql) -> Result<()> {
 pub async fn get_file_id_lists(
     org_id: &str,
     stream_type: StreamType,
-    stream_names: &[String],
+    stream_names: &[TableReference],
     time_range: Option<(i64, i64)>,
-) -> Result<HashMap<String, Vec<FileId>>> {
+) -> Result<HashMap<TableReference, Vec<FileId>>> {
     let mut file_lists = HashMap::with_capacity(stream_names.len());
-    for name in stream_names {
+    for stream in stream_names {
+        let name = stream.stream_name();
+        let stream_type = stream.get_stream_type(stream_type);
         // get file list
         let file_id_list =
-            crate::service::file_list::query_ids(org_id, stream_type, name, time_range).await?;
-        file_lists.insert(name.clone(), file_id_list);
+            crate::service::file_list::query_ids(org_id, stream_type, &name, time_range).await?;
+        file_lists.insert(stream.clone(), file_id_list);
     }
     Ok(file_lists)
 }
@@ -784,13 +793,13 @@ async fn get_inverted_index_file_lists(
         return Ok((use_ttv_inverted_index, vec![], 0, 0));
     }
 
-    let stream_name = sql.stream_names.first().unwrap();
+    let stream_name = sql.stream_names.first().unwrap().stream_name();
     let match_terms = sql.match_items.clone().unwrap_or_default();
     let index_terms = generate_filter_from_equal_items(&index_terms);
     let (idx_file_list, idx_scan_size, idx_took) = get_inverted_index_file_list(
         req.clone(),
         query.clone(),
-        stream_name,
+        &stream_name,
         &match_terms,
         &index_terms,
     )

--- a/src/service/search/datafusion/distributed_plan/node.rs
+++ b/src/service/search/datafusion/distributed_plan/node.rs
@@ -4,6 +4,7 @@ use config::{
     meta::{cluster::NodeInfo, inverted_index::InvertedIndexOptimizeMode, stream::FileKey},
     utils::json,
 };
+use datafusion::common::TableReference;
 use hashbrown::HashMap;
 use proto::cluster_rpc::{
     IdxFileName, IndexInfo, KvItem, QueryIdentifier, SearchInfo, SuperClusterInfo,
@@ -17,9 +18,9 @@ use crate::service::search::{
 pub struct RemoteScanNodes {
     pub req: Request,
     pub nodes: Vec<Arc<dyn NodeInfo>>,
-    pub file_id_lists: HashMap<String, Vec<Vec<i64>>>,
+    pub file_id_lists: HashMap<TableReference, Vec<Vec<i64>>>,
     pub idx_file_list: Vec<FileKey>,
-    pub equal_keys: HashMap<String, Vec<KvItem>>,
+    pub equal_keys: HashMap<TableReference, Vec<KvItem>>,
     pub match_all_keys: Vec<String>,
     pub index_condition: Option<IndexCondition>,
     pub index_optimize_mode: Option<InvertedIndexOptimizeMode>,
@@ -32,9 +33,9 @@ impl RemoteScanNodes {
     pub fn new(
         req: Request,
         nodes: Vec<Arc<dyn NodeInfo>>,
-        file_id_lists: HashMap<String, Vec<Vec<i64>>>,
+        file_id_lists: HashMap<TableReference, Vec<Vec<i64>>>,
         idx_file_list: Vec<FileKey>,
-        equal_keys: HashMap<String, Vec<KvItem>>,
+        equal_keys: HashMap<TableReference, Vec<KvItem>>,
         match_all_keys: Vec<String>,
         index_condition: Option<IndexCondition>,
         index_optimize_mode: Option<InvertedIndexOptimizeMode>,
@@ -55,7 +56,7 @@ impl RemoteScanNodes {
         }
     }
 
-    pub fn get_remote_node(&self, table_name: &str) -> RemoteScanNode {
+    pub fn get_remote_node(&self, table_name: &TableReference) -> RemoteScanNode {
         let query_identifier = QueryIdentifier {
             trace_id: self.req.trace_id.clone(),
             org_id: self.req.org_id.clone(),

--- a/src/service/search/datafusion/distributed_plan/rewrite.rs
+++ b/src/service/search/datafusion/distributed_plan/rewrite.rs
@@ -19,7 +19,7 @@ use config::meta::{cluster::NodeInfo, inverted_index::InvertedIndexOptimizeMode,
 use datafusion::{
     common::{
         tree_node::{Transformed, TreeNode, TreeNodeRecursion, TreeNodeRewriter, TreeNodeVisitor},
-        Result,
+        Result, TableReference,
     },
     physical_plan::{repartition::RepartitionExec, ExecutionPlan, Partitioning},
 };
@@ -43,9 +43,9 @@ impl RemoteScanRewriter {
     pub fn new(
         req: Request,
         nodes: Vec<Arc<dyn NodeInfo>>,
-        file_id_lists: HashMap<String, Vec<Vec<i64>>>,
+        file_id_lists: HashMap<TableReference, Vec<Vec<i64>>>,
         idx_file_list: Vec<FileKey>,
-        equal_keys: HashMap<String, Vec<KvItem>>,
+        equal_keys: HashMap<TableReference, Vec<KvItem>>,
         match_all_keys: Vec<String>,
         index_condition: Option<IndexCondition>,
         index_optimizer_mode: Option<InvertedIndexOptimizeMode>,
@@ -83,7 +83,7 @@ impl TreeNodeRewriter for RemoteScanRewriter {
                 let node_len = self.remote_scan_nodes.nodes.len();
                 let remote_scan = Arc::new(RemoteScanExec::new(
                     input.clone(),
-                    self.remote_scan_nodes.get_remote_node(table_name.as_str()),
+                    self.remote_scan_nodes.get_remote_node(&table_name),
                 )?);
                 let partitioning = Partitioning::RoundRobinBatch(node_len);
                 let repartition = Arc::new(RepartitionExec::try_new(remote_scan, partitioning)?);
@@ -102,7 +102,7 @@ impl TreeNodeRewriter for RemoteScanRewriter {
 
                 let remote_scan = Arc::new(RemoteScanExec::new(
                     new_input,
-                    self.remote_scan_nodes.get_remote_node(table_name.as_str()),
+                    self.remote_scan_nodes.get_remote_node(&table_name),
                 )?);
                 let new_node = node.with_new_children(vec![remote_scan])?;
                 self.is_changed = true;
@@ -120,7 +120,7 @@ impl TreeNodeRewriter for RemoteScanRewriter {
                     let table_name = visitor.table_name.clone().unwrap();
                     let remote_scan = Arc::new(RemoteScanExec::new(
                         child.clone(),
-                        self.remote_scan_nodes.get_remote_node(table_name.as_str()),
+                        self.remote_scan_nodes.get_remote_node(&table_name),
                     )?);
                     new_children.push(remote_scan);
                 }
@@ -136,7 +136,7 @@ impl TreeNodeRewriter for RemoteScanRewriter {
 // visit physical plan to get underlying table name and check is add a remote scan after current
 // physical plan
 struct TableNameVisitor {
-    table_name: Option<String>,
+    table_name: Option<TableReference>,
     is_remote_scan: bool, // is add remote scan after current physical plan
 }
 
@@ -159,7 +159,7 @@ impl<'n> TreeNodeVisitor<'n> for TableNameVisitor {
             Ok(TreeNodeRecursion::Stop)
         } else if name == "NewEmptyExec" {
             let table = node.as_any().downcast_ref::<NewEmptyExec>().unwrap();
-            self.table_name = Some(table.name().to_string());
+            self.table_name = Some(TableReference::from(table.name()));
             Ok(TreeNodeRecursion::Continue)
         } else {
             Ok(TreeNodeRecursion::Continue)

--- a/src/service/search/datafusion/table_provider/catalog.rs
+++ b/src/service/search/datafusion/table_provider/catalog.rs
@@ -1,0 +1,75 @@
+// Copyright 2024 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    any::Any,
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use async_trait::async_trait;
+use datafusion::{catalog::SchemaProvider, datasource::TableProvider, error::Result};
+
+#[derive(Debug)]
+pub struct StreamTypeProvider {
+    #[allow(dead_code)]
+    name: String,
+    tables: RwLock<HashMap<String, Arc<dyn TableProvider>>>,
+}
+
+impl StreamTypeProvider {
+    pub async fn create(name: &str) -> Result<Arc<Self>> {
+        Ok(Arc::new(Self {
+            name: name.to_string(),
+            tables: RwLock::new(HashMap::new()),
+        }))
+    }
+}
+
+#[async_trait]
+impl SchemaProvider for StreamTypeProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        let tables = self.tables.read().unwrap();
+        tables.keys().cloned().collect::<Vec<_>>()
+    }
+
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
+        let tables = self.tables.read().unwrap();
+        Ok(tables.get(name).cloned())
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        let tables = self.tables.read().unwrap();
+        tables.contains_key(name)
+    }
+
+    fn register_table(
+        &self,
+        name: String,
+        table: Arc<dyn TableProvider>,
+    ) -> Result<Option<Arc<dyn TableProvider>>> {
+        let mut tables = self.tables.write().unwrap();
+        tables.insert(name, table.clone());
+        Ok(Some(table))
+    }
+
+    fn deregister_table(&self, _name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
+        unreachable!("deregister_table is not implemented")
+    }
+}

--- a/src/service/search/datafusion/table_provider/mod.rs
+++ b/src/service/search/datafusion/table_provider/mod.rs
@@ -64,6 +64,7 @@ use tokio::sync::Semaphore;
 
 use crate::service::search::index::IndexCondition;
 
+pub mod catalog;
 pub mod empty_table;
 mod helpers;
 pub mod memtable;

--- a/src/service/search/grpc/flight.rs
+++ b/src/service/search/grpc/flight.rs
@@ -26,11 +26,12 @@ use config::{
         bitvec::BitVec,
         inverted_index::InvertedIndexOptimizeMode,
         search::ScanStats,
+        sql::TableReferenceExt,
         stream::{FileKey, StreamPartition, StreamType},
     },
     utils::json,
 };
-use datafusion::physical_plan::union::UnionExec;
+use datafusion::{common::TableReference, physical_plan::union::UnionExec};
 use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
 use hashbrown::HashMap;
 use infra::{
@@ -115,10 +116,12 @@ pub async fn search(
     }
 
     // get stream name
-    let stream_name = empty_exec.name();
+    let stream = TableReference::from(empty_exec.name());
+    let stream_name = stream.stream_name().to_string();
+    let stream_type = stream.get_stream_type(stream_type);
 
     // check if we are allowed to search
-    if db::compact::retention::is_deleting_stream(&org_id, stream_type, stream_name, None) {
+    if db::compact::retention::is_deleting_stream(&org_id, stream_type, &stream_name, None) {
         return Err(Error::ErrorCode(ErrorCodes::SearchStreamNotFound(format!(
             "stream [{}] is being deleted",
             &stream_name
@@ -193,14 +196,14 @@ pub async fn search(
     // search in object storage
     let mut tantivy_file_list = Vec::new();
     if !req.search_info.file_id_list.is_empty() {
-        let stream_settings = infra::schema::get_settings(&org_id, stream_name, stream_type)
+        let stream_settings = infra::schema::get_settings(&org_id, &stream_name, stream_type)
             .await
             .unwrap_or_default();
         let (mut file_list, file_list_took) = get_file_list_by_ids(
             &trace_id,
             &org_id,
             stream_type,
-            stream_name,
+            &stream_name,
             query_params.time_range,
             &stream_settings.partition_keys,
             &search_partition_keys,

--- a/src/service/search/index.rs
+++ b/src/service/search/index.rs
@@ -406,13 +406,18 @@ impl Condition {
                 Ok(Arc::new(InListExpr::new(left, values, false, None)))
             }
             Condition::MatchAll(value) => {
+                let value = value
+                    .trim_start_matches("re:") // regex
+                    .trim_start_matches('*') // contains
+                    .trim_end_matches('*') // prefix or contains
+                    .to_string();
                 let term = Arc::new(Literal::new(ScalarValue::Utf8(Some(format!("%{value}%")))));
                 let mut expr_list: Vec<Arc<dyn PhysicalExpr>> =
                     Vec::with_capacity(fst_fields.len());
                 for field in fst_fields.iter() {
                     let new_expr = Arc::new(LikeExpr::new(
                         false,
-                        false,
+                        true,
                         Arc::new(Column::new(field, schema.index_of(field).unwrap())),
                         term.clone(),
                     ));

--- a/src/service/search/super_cluster/leader.rs
+++ b/src/service/search/super_cluster/leader.rs
@@ -19,7 +19,8 @@ use arrow::array::RecordBatch;
 use async_recursion::async_recursion;
 use config::{
     get_config,
-    meta::{cluster::NodeInfo, search::ScanStats},
+    meta::{cluster::NodeInfo, search::ScanStats, sql::TableReferenceExt},
+    utils::json,
 };
 use datafusion::{
     common::{tree_node::TreeNode, DataFusionError},
@@ -27,6 +28,7 @@ use datafusion::{
 };
 use hashbrown::HashMap;
 use infra::errors::{Error, ErrorCodes, Result};
+use itertools::Itertools;
 use o2_enterprise::enterprise::super_cluster::search::get_cluster_nodes;
 use proto::cluster_rpc;
 use tracing::{info_span, Instrument};
@@ -99,11 +101,17 @@ pub async fn search(
         ));
     }
 
+    let trace_stream_name = json::to_string(
+        &sql.stream_names
+            .iter()
+            .map(|s| (s.get_stream_type(sql.stream_type), s.stream_name()))
+            .collect_vec(),
+    )
+    .unwrap();
     let datafusion_span = info_span!(
         "service:search:flight:super_cluster::datafusion",
         org_id = sql.org_id,
-        stream_name = sql.stream_names.first().unwrap(),
-        stream_type = sql.stream_type.to_string(),
+        stream_name = trace_stream_name,
     );
 
     let trace_id_move = trace_id.to_string();

--- a/tests/api-testing/tests/test_search.py
+++ b/tests/api-testing/tests/test_search.py
@@ -727,7 +727,7 @@ def test_e2e_matchallupperlowercase(create_session, base_url):
     
     json_data = {
         "query": {
-            "sql": "select * from \"stream_pytest_data\" WHERE match_all('E2E_test')",
+            "sql": "select * from \"stream_pytest_data\" WHERE match_all('E2E_test*')",
             "start_time": one_min_ago,
             "end_time": end_time,
             "from": 0,


### PR DESCRIPTION
close #5420 

- [x] set tantivy index as default index
- [x] support cross stream type join like below
```
select t1.ip, t2.name from logs.t1 as t1 join enrich.t2 as t1 on t1.ip = t2.ip
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `TableReferenceExt` module to enhance SQL-related functionalities.
	- Added a new `StreamTypeProvider` struct for managing table providers.
- **Improvements**
	- Updated configuration defaults for inverted index formats.
	- Enhanced handling of stream names and types throughout various functions for better type safety.
	- Improved logging with structured stream information.
	- Refined the processing of the `MatchAll` condition in SQL-like expressions.
- **Bug Fixes**
	- Expanded string matching for `StreamType` to accommodate additional input formats.
- **Documentation**
	- Retained help comments for context on configuration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->