### PR TITLE
fix: on edit panel, query reset issue

### DIFF
--- a/web/src/components/dashboards/addPanel/FieldList.vue
+++ b/web/src/components/dashboards/addPanel/FieldList.vue
@@ -671,7 +671,7 @@ export default defineComponent({
   name: "FieldList",
   props: ["editMode"],
   setup(props, { emit }) {
-    const dashboardPanelDataPageKey = inject(
+    const dashboardPanelDataPageKey: any = inject(
       "dashboardPanelDataPageKey",
       "dashboard",
     );
@@ -827,7 +827,10 @@ export default defineComponent({
             await extractFields();
 
             // if promql mode
-            if (promqlMode.value) {
+            // NOTE: For the metrics page, we added one watch that resets the query on stream change.
+            // Because of that, the default query overrides the original/saved query on the edit panel.
+            // To prevent this, we added the dashboardPanelDataPageKey condition.
+            if (promqlMode.value && dashboardPanelDataPageKey === "metrics") {
               // set the query
               dashboardPanelData.data.queries[
                 dashboardPanelData.layout.currentQueryIndex


### PR DESCRIPTION
- #5449 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety for the dashboard panel data handling.
	- Improved logic to prevent unintended query resets when switching to the metrics page.

- **Bug Fixes**
	- Adjusted control flow to ensure original queries are preserved in edit mode under specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->