### PR TITLE
feat: Alerts API v2 - part 4 - new `GetAlert` (by KSUID) endpoint

### DIFF
--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -435,6 +435,7 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
         .service(alerts::deprecated::delete_alert)
         .service(alerts::deprecated::enable_alert)
         .service(alerts::deprecated::trigger_alert)
+        .service(alerts::get_alert)
         .service(alerts::templates::save_template)
         .service(alerts::templates::update_template)
         .service(alerts::templates::get_template)

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -99,6 +99,7 @@ use crate::{common::meta, handler::http::request};
         request::alerts::deprecated::delete_alert,
         request::alerts::deprecated::enable_alert,
         request::alerts::deprecated::trigger_alert,
+        request::alerts::get_alert,
         request::alerts::templates::list_templates,
         request::alerts::templates::get_template,
         request::alerts::templates::save_template,

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -45,6 +45,8 @@ use infra::{
     table::{self, folders::FolderType},
 };
 use lettre::{message::MultiPart, AsyncTransport, Message};
+use sea_orm::ConnectionTrait;
+use svix_ksuid::Ksuid;
 
 use crate::{
     common::{
@@ -353,6 +355,17 @@ pub async fn save(
             Ok(())
         }
         Err(e) => Err(e.into()),
+    }
+}
+
+pub async fn get_by_id<C: ConnectionTrait>(
+    conn: &C,
+    org_id: &str,
+    alert_id: Ksuid,
+) -> Result<Alert, AlertError> {
+    match table::alerts::get_by_id(conn, org_id, alert_id).await? {
+        Some((_f, a)) => Ok(a),
+        None => Err(AlertError::AlertNotFound),
     }
 }
 

--- a/src/service/db/alerts/alert/mod.rs
+++ b/src/service/db/alerts/alert/mod.rs
@@ -28,6 +28,16 @@ mod new;
 mod old;
 
 use config::meta::{alerts::alert::Alert, stream::StreamType};
+use sea_orm::ConnectionTrait;
+use svix_ksuid::Ksuid;
+
+pub async fn get_by_id<C: ConnectionTrait>(
+    conn: &C,
+    org_id: &str,
+    alert_id: Ksuid,
+) -> Result<Option<Alert>, infra::errors::Error> {
+    new::get_by_id(conn, org_id, alert_id).await
+}
 
 pub async fn get_by_name(
     org_id: &str,

--- a/src/service/db/alerts/alert/new.rs
+++ b/src/service/db/alerts/alert/new.rs
@@ -27,8 +27,23 @@ use infra::{
     table::alerts as table,
 };
 use itertools::Itertools;
+use sea_orm::ConnectionTrait;
+use svix_ksuid::Ksuid;
 
 use crate::{common::infra::config::STREAM_ALERTS, service::db};
+
+pub async fn get_by_id<C: ConnectionTrait>(
+    conn: &C,
+    org_id: &str,
+    alert_id: Ksuid,
+) -> Result<Option<Alert>, infra::errors::Error> {
+    // We cannot check the cache because the cache stores alerts by stream type
+    // and stream name which are currently unknown.
+    let alert = table::get_by_id(conn, org_id, alert_id)
+        .await?
+        .map(|(_f, a)| a);
+    Ok(alert)
+}
 
 pub async fn get_by_name(
     org_id: &str,


### PR DESCRIPTION
#5253 

Part 4 in a series of PRs to add new Alerts endpoints that support parent folders and KSUIDs

This PR introduces the new Get endpoint for getting an alert by its KSUID ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint for retrieving alerts by ID.
	- Added functionality to fetch alerts by ID in the alert management system.
  
- **Bug Fixes**
	- Improved error handling for alert retrieval and management.

- **Documentation**
	- Updated OpenAPI documentation to include the new alert retrieval endpoint.

- **Refactor**
	- Renamed existing functions for clarity and consistency in alert management.

- **Chores**
	- Added necessary imports to support new functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->