### PR TITLE
feat: Alerts API v2 - part 5 - new `CreateAlert` (with folder) endpoint

### DIFF
--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -13,13 +13,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use actix_web::{get, web, HttpResponse};
+use actix_web::{get, post, web, HttpResponse};
+use config::meta::{alerts::alert::Alert as MetaAlert, folder::DEFAULT_FOLDER};
 use infra::db::{connect_to_orm, ORM_CLIENT};
 use svix_ksuid::Ksuid;
 
 use crate::{
-    common::meta::http::HttpResponse as MetaHttpResponse,
-    handler::http::models::alerts::responses::GetAlertResponseBody,
+    common::{meta::http::HttpResponse as MetaHttpResponse, utils::auth::UserEmail},
+    handler::http::models::alerts::{
+        requests::CreateAlertRequestBody, responses::GetAlertResponseBody,
+    },
     service::alerts::alert::{self, AlertError},
 };
 
@@ -38,6 +41,7 @@ impl From<AlertError> for HttpResponse {
             AlertError::AlertNameContainsForwardSlash => MetaHttpResponse::bad_request(value),
             AlertError::AlertDestinationMissing => MetaHttpResponse::bad_request(value),
             AlertError::CreateAlreadyExists => MetaHttpResponse::conflict(value),
+            AlertError::CreateFolderNotFound => MetaHttpResponse::not_found(value),
             AlertError::AlertNotFound => MetaHttpResponse::not_found(value),
             AlertError::AlertDestinationNotFound { .. } => MetaHttpResponse::not_found(value),
             AlertError::StreamNotFound { .. } => MetaHttpResponse::not_found(value),
@@ -54,6 +58,47 @@ impl From<AlertError> for HttpResponse {
             AlertError::PeriodExceedsMaxQueryRange { .. } => MetaHttpResponse::bad_request(value),
             AlertError::ResolveStreamNameError(_) => MetaHttpResponse::internal_error(value),
         }
+    }
+}
+
+/// CreateAlert
+#[utoipa::path(
+    context_path = "/api",
+    tag = "Alerts",
+    operation_id = "CreateAlert",
+    security(
+        ("Authorization"= [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+      ),
+    request_body(content = CreateAlertRequestBody, description = "Alert data", content_type = "application/json"),    
+    responses(
+        (status = 200, description = "Success", content_type = "application/json", body = HttpResponse),
+        (status = 400, description = "Error",   content_type = "application/json", body = HttpResponse),
+    )
+)]
+#[post("v2/{org_id}/alerts")]
+pub async fn create_alert(
+    path: web::Path<String>,
+    req_body: web::Json<CreateAlertRequestBody>,
+    user_email: UserEmail,
+) -> HttpResponse {
+    let org_id = path.into_inner();
+    let req_body = req_body.into_inner();
+
+    let folder_id = req_body
+        .folder_id
+        .clone()
+        .unwrap_or(DEFAULT_FOLDER.to_string());
+    let mut alert: MetaAlert = req_body.into();
+    alert.owner = Some(user_email.user_id.clone());
+    alert.last_edited_by = Some(user_email.user_id);
+
+    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+    match alert::create(client, &org_id, &folder_id, alert).await {
+        Ok(_) => MetaHttpResponse::ok("Alert saved"),
+        Err(e) => e.into(),
     }
 }
 

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -435,6 +435,7 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
         .service(alerts::deprecated::delete_alert)
         .service(alerts::deprecated::enable_alert)
         .service(alerts::deprecated::trigger_alert)
+        .service(alerts::create_alert)
         .service(alerts::get_alert)
         .service(alerts::templates::save_template)
         .service(alerts::templates::update_template)

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -99,6 +99,7 @@ use crate::{common::meta, handler::http::request};
         request::alerts::deprecated::delete_alert,
         request::alerts::deprecated::enable_alert,
         request::alerts::deprecated::trigger_alert,
+        request::alerts::create_alert,
         request::alerts::get_alert,
         request::alerts::templates::list_templates,
         request::alerts::templates::get_template,

--- a/src/service/db/alerts/alert/mod.rs
+++ b/src/service/db/alerts/alert/mod.rs
@@ -28,7 +28,7 @@ mod new;
 mod old;
 
 use config::meta::{alerts::alert::Alert, stream::StreamType};
-use sea_orm::ConnectionTrait;
+use sea_orm::{ConnectionTrait, TransactionTrait};
 use svix_ksuid::Ksuid;
 
 pub async fn get_by_id<C: ConnectionTrait>(
@@ -74,6 +74,15 @@ pub async fn set_without_updating_trigger(org_id: &str, alert: Alert) -> Result<
     } else {
         new::set_without_updating_trigger(org_id, alert).await
     }
+}
+
+pub async fn create<C: TransactionTrait>(
+    conn: &C,
+    org_id: &str,
+    folder_id: &str,
+    alert: Alert,
+) -> Result<Alert, infra::errors::Error> {
+    new::create(conn, org_id, folder_id, alert).await
 }
 
 pub async fn delete_by_name(


### PR DESCRIPTION
#5253 

Part 5 in a series of PRs to add new Alerts endpoints that support parent folders and KSUIDs

This PR introduces the new `CreateAlert` endpoint which takes a `folder_id` parameter to specify the parent folder of the new alert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new HTTP POST endpoint for creating alerts.
	- Added functionality for creating alerts in the database.
	- Enhanced API documentation to include the new alert creation endpoint.

- **Bug Fixes**
	- Improved error handling for alert creation, including a specific error for non-existent folders.

- **Chores**
	- Updated import statements to include necessary types for new functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->