### PR TITLE
feat: Alerts API v2 - part 6 - new `UpdateAlert` (by KSUID) endpoint

### DIFF
--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -437,6 +437,7 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
         .service(alerts::deprecated::trigger_alert)
         .service(alerts::create_alert)
         .service(alerts::get_alert)
+        .service(alerts::update_alert)
         .service(alerts::templates::save_template)
         .service(alerts::templates::update_template)
         .service(alerts::templates::get_template)

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -101,6 +101,7 @@ use crate::{common::meta, handler::http::request};
         request::alerts::deprecated::trigger_alert,
         request::alerts::create_alert,
         request::alerts::get_alert,
+        request::alerts::update_alert,
         request::alerts::templates::list_templates,
         request::alerts::templates::get_template,
         request::alerts::templates::save_template,

--- a/src/infra/src/table/alerts/mod.rs
+++ b/src/infra/src/table/alerts/mod.rs
@@ -36,7 +36,7 @@ use super::{
     entity::{alerts, folders},
     folders::FolderType,
 };
-use crate::errors::{self, FromStrError};
+use crate::errors::{self, FromStrError, PutAlertError};
 
 pub mod intermediate;
 

--- a/src/infra/src/table/alerts/mod.rs
+++ b/src/infra/src/table/alerts/mod.rs
@@ -36,7 +36,7 @@ use super::{
     entity::{alerts, folders},
     folders::FolderType,
 };
-use crate::errors::{self, FromStrError, PutAlertError};
+use crate::errors::{self, FromStrError};
 
 pub mod intermediate;
 

--- a/src/service/db/alerts/alert/mod.rs
+++ b/src/service/db/alerts/alert/mod.rs
@@ -85,6 +85,15 @@ pub async fn create<C: TransactionTrait>(
     new::create(conn, org_id, folder_id, alert).await
 }
 
+pub async fn update<C: ConnectionTrait + TransactionTrait>(
+    conn: &C,
+    org_id: &str,
+    folder_id: Option<&str>,
+    alert: Alert,
+) -> Result<Alert, infra::errors::Error> {
+    new::update(conn, org_id, folder_id, alert).await
+}
+
 pub async fn delete_by_name(
     org_id: &str,
     stream_type: StreamType,


### PR DESCRIPTION
#5253 

Part 6 in a series of PRs to add new Alerts endpoints that support parent folders and KSUIDs

This PR introduces the new `UpdateAlert` endpoint which identifies the alert to update by its KSUID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new HTTP endpoint for updating alerts.
	- Added functionality to update existing alerts in the database.
	- Enhanced OpenAPI documentation with the new alert update path.

- **Bug Fixes**
	- Improved error handling for folder-related operations during alert updates.

- **Refactor**
	- Renamed several alert management functions for clarity and consistency.
	- Updated existing functions to streamline alert creation and updating processes.

- **Documentation**
	- Updated API documentation to reflect new alert management capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->