### PR TITLE
fix: metric chart issue for promql query

### DIFF
--- a/web/src/plugins/metrics/Index.vue
+++ b/web/src/plugins/metrics/Index.vue
@@ -468,6 +468,8 @@ export default defineComponent({
       // need to remove the xy filters
       removeXYFilters();
 
+      // set default chart type as line
+      dashboardPanelData.data.type = "line";
       // set the default query type as promql for metrics
       dashboardPanelData.data.queryType = "promql";
       dashboardPanelData.data.queries[0].customQuery = true;

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -387,3 +387,60 @@ export const findFirstValidMappedValue = (
     return false;
   });
 };
+
+/**
+ * Calculates the width of a given text.
+ * Useful to calculate nameGap for the left axis
+ *
+ * @param {string} text - The text to calculate the width of.
+ * @param {string} fontSize - The font size of the text.
+ * @return {number} The width of the text in pixels.
+ */
+export const calculateWidthText = (
+  text: string,
+  fontSize: string = "12px",
+): number => {
+  if (!text) return 0;
+
+  const span = document.createElement("span");
+  document.body.appendChild(span);
+
+  span.style.font = "sans-serif";
+  span.style.fontSize = fontSize || "12px";
+  span.style.height = "auto";
+  span.style.width = "auto";
+  span.style.top = "0px";
+  span.style.position = "absolute";
+  span.style.whiteSpace = "no-wrap";
+  span.innerHTML = text;
+
+  const width = Math.ceil(span.clientWidth);
+  span.remove();
+  return width;
+};
+
+/**
+ * Calculates the optimal font size for a given text that fits the canvas width.
+ * @param text - The text to calculate the font size for.
+ * @param canvasWidth - canvas width in pixels
+ * @returns {number} - The optimal font size in pixels.
+ */
+export const calculateOptimalFontSize = (text: string, canvasWidth: number) => {
+  let minFontSize = 1; // Start with the smallest font size
+  let maxFontSize = 90; // Set a maximum possible font size
+  let optimalFontSize = minFontSize;
+
+  while (minFontSize <= maxFontSize) {
+    const midFontSize = Math.floor((minFontSize + maxFontSize) / 2);
+    const textWidth = calculateWidthText(text, `${midFontSize}px`);
+
+    if (textWidth > canvasWidth) {
+      maxFontSize = midFontSize - 1; // Text is too wide, reduce font size
+    } else {
+      optimalFontSize = midFontSize; // Text fits, but we try larger
+      minFontSize = midFontSize + 1;
+    }
+  }
+
+  return optimalFontSize; // Return the largest font size that fits
+};

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import {
+  calculateOptimalFontSize,
   formatDate,
   formatUnitValue,
   getUnitValue,
@@ -620,12 +621,14 @@ export const convertPromQLData = async (
 
         switch (it?.resultType) {
           case "matrix": {
-            const series = it?.result?.map((metric: any) => {
+            // take first result
+            const series = [it?.result[0]]?.map((metric: any) => {
               const values = metric.values.sort(
                 (a: any, b: any) => a[0] - b[0],
               );
+              // first value
               const unitValue = getUnitValue(
-                values[values.length - 1][1],
+                values?.[0]?.[1],
                 panelSchema.config?.unit,
                 panelSchema.config?.unit_custom,
                 panelSchema.config?.decimals,
@@ -637,7 +640,10 @@ export const convertPromQLData = async (
                     type: "text",
                     style: {
                       text: formatUnitValue(unitValue),
-                      fontSize: Math.min(params.coordSys.cx / 2, 90), //coordSys is relative. so that we can use it to calculate the dynamic size
+                      fontSize: calculateOptimalFontSize(
+                        formatUnitValue(unitValue),
+                        params.coordSys.cx * 2,
+                      ), //coordSys is relative. so that we can use it to calculate the dynamic size
                       fontWeight: 500,
                       align: "center",
                       verticalAlign: "middle",

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -25,6 +25,8 @@ import { toZonedTime } from "date-fns-tz";
 import { dateBin } from "@/utils/dashboard/datetimeStartPoint";
 import { format } from "date-fns";
 import {
+  calculateOptimalFontSize,
+  calculateWidthText,
   formatDate,
   formatUnitValue,
   getUnitValue,
@@ -2478,37 +2480,6 @@ const getLegendPosition = (legendPosition: string) => {
 };
 
 /**
- * Calculates the width of a given text.
- * Useful to calculate nameGap for the left axis
- *
- * @param {string} text - The text to calculate the width of.
- * @param {string} fontSize - The font size of the text.
- * @return {number} The width of the text in pixels.
- */
-const calculateWidthText = (
-  text: string,
-  fontSize: string = "12px",
-): number => {
-  if (!text) return 0;
-
-  const span = document.createElement("span");
-  document.body.appendChild(span);
-
-  span.style.font = "sans-serif";
-  span.style.fontSize = fontSize || "12px";
-  span.style.height = "auto";
-  span.style.width = "auto";
-  span.style.top = "0px";
-  span.style.position = "absolute";
-  span.style.whiteSpace = "no-wrap";
-  span.innerHTML = text;
-
-  const width = Math.ceil(span.clientWidth);
-  span.remove();
-  return width;
-};
-
-/**
  * Finds the largest label in the given data array.
  *
  * @param {any[]} data - An array of data.
@@ -2712,30 +2683,4 @@ const getPropsByChartTypeForSeries = (panelSchema: any) => {
         type: "bar",
       };
   }
-};
-
-/**
- * Calculates the optimal font size for a given text that fits the canvas width.
- * @param text - The text to calculate the font size for.
- * @param canvasWidth - canvas width in pixels
- * @returns {number} - The optimal font size in pixels.
- */
-const calculateOptimalFontSize = (text: string, canvasWidth: number) => {
-  let minFontSize = 1; // Start with the smallest font size
-  let maxFontSize = 90; // Set a maximum possible font size
-  let optimalFontSize = minFontSize;
-
-  while (minFontSize <= maxFontSize) {
-    const midFontSize = Math.floor((minFontSize + maxFontSize) / 2);
-    const textWidth = calculateWidthText(text, `${midFontSize}px`);
-
-    if (textWidth > canvasWidth) {
-      maxFontSize = midFontSize - 1; // Text is too wide, reduce font size
-    } else {
-      optimalFontSize = midFontSize; // Text fits, but we try larger
-      minFontSize = midFontSize + 1;
-    }
-  }
-
-  return optimalFontSize; // Return the largest font size that fits
 };


### PR DESCRIPTION
- #5482 
- for metrics page, default chart type as `line` chart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Default chart type for the metrics dashboard is now set to "line".
	- Enhanced font size calculations for chart labels and tooltips.
- **Bug Fixes**
	- Tooltip configuration updated to reflect the first value of the metric for improved accuracy.
- **Refactor**
	- Consolidation of font size calculation functions for better performance and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->