### PR TITLE
feat: Alerts API v2 - part 9 - cleanup

### DIFF
--- a/src/config/src/meta/alerts/alert.rs
+++ b/src/config/src/meta/alerts/alert.rs
@@ -112,13 +112,15 @@ pub struct AlertListFilter {
 #[derive(Debug, Clone)]
 pub struct ListAlertsParams {
     /// The optional org ID surrogate key with which to filter alerts.
-    pub org_id: Option<String>,
+    pub org_id: String,
 
     /// The optional folder ID surrogate key with which to filter alerts.
     pub folder_id: Option<String>,
 
-    /// The optional stream type and name with which to filter alerts.
-    pub stream_type_and_name: Option<(StreamType, String)>,
+    /// The optional stream type and stream name with which to filter alerts.
+    ///
+    /// The stream name can only be provided if the stream type is also provide.
+    pub stream_type_and_name: Option<(StreamType, Option<String>)>,
 
     /// The optional filter on the enabled field. `Some(true)` indicates that
     /// only enabled alerts should be returned, while `Some(false)` indicates
@@ -137,19 +139,7 @@ impl ListAlertsParams {
     /// key.
     pub fn new(org_id: &str) -> Self {
         Self {
-            org_id: Some(org_id.to_owned()),
-            folder_id: None,
-            stream_type_and_name: None,
-            enabled: None,
-            owner: None,
-            page_size_and_idx: None,
-        }
-    }
-
-    /// Returns new parameters to list all dashboards.
-    pub fn all() -> Self {
-        Self {
-            org_id: None,
+            org_id: org_id.to_owned(),
             folder_id: None,
             stream_type_and_name: None,
             enabled: None,
@@ -164,9 +154,9 @@ impl ListAlertsParams {
         self
     }
 
-    /// Filter alerts by the given stream type and name.
-    pub fn for_stream(mut self, stream_type: StreamType, stream_name: &str) -> Self {
-        self.stream_type_and_name = Some((stream_type, stream_name.to_string()));
+    /// Filter alerts by the given stream type and optional stream name.
+    pub fn for_stream(mut self, stream_type: StreamType, stream_name: Option<&str>) -> Self {
+        self.stream_type_and_name = Some((stream_type, stream_name.map(|n| n.to_string())));
         self
     }
 

--- a/src/handler/http/models/alerts/mod.rs
+++ b/src/handler/http/models/alerts/mod.rs
@@ -81,7 +81,6 @@ pub struct Alert {
 
     /// Time when alert was last updated. Unix timestamp.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = String, format = DateTime)]
     pub updated_at: Option<i64>,
 
     #[serde(default)]

--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -84,7 +84,7 @@ impl From<AlertError> for HttpResponse {
         (status = 400, description = "Error",   content_type = "application/json", body = HttpResponse),
     )
 )]
-#[post("v2/{org_id}/alerts")]
+#[post("/v2/{org_id}/alerts")]
 pub async fn create_alert(
     path: web::Path<String>,
     req_body: web::Json<CreateAlertRequestBody>,
@@ -125,7 +125,7 @@ pub async fn create_alert(
         (status = 404, description = "NotFound", content_type = "application/json", body = HttpResponse),
     )
 )]
-#[get("v2/{org_id}/alerts/{alert_id}")]
+#[get("/v2/{org_id}/alerts/{alert_id}")]
 async fn get_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
     let (org_id, alert_id) = path.into_inner();
 
@@ -194,7 +194,7 @@ pub async fn update_alert(
         (status = 500, description = "Failure",  content_type = "application/json", body = HttpResponse),
     )
 )]
-#[delete("v2/{org_id}/alerts/{alert_id}")]
+#[delete("/v2/{org_id}/alerts/{alert_id}")]
 async fn delete_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
     let (org_id, alert_id) = path.into_inner();
 
@@ -266,7 +266,7 @@ async fn list_alerts(path: web::Path<String>, req: HttpRequest) -> HttpResponse 
         (status = 500, description = "Failure",  content_type = "application/json", body = HttpResponse),
     )
 )]
-#[put("v2/{org_id}/alerts/{alert_id}/enable")]
+#[put("/v2/{org_id}/alerts/{alert_id}/enable")]
 async fn enable_alert(path: web::Path<(String, Ksuid)>, req: HttpRequest) -> HttpResponse {
     let (org_id, alert_id) = path.into_inner();
     let Ok(query) = web::Query::<EnableAlertQuery>::from_query(req.query_string()) else {

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -439,6 +439,7 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
         .service(alerts::get_alert)
         .service(alerts::update_alert)
         .service(alerts::delete_alert)
+        .service(alerts::list_alerts)
         .service(alerts::enable_alert)
         .service(alerts::trigger_alert)
         .service(alerts::templates::save_template)

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -103,6 +103,7 @@ use crate::{common::meta, handler::http::request};
         request::alerts::get_alert,
         request::alerts::update_alert,
         request::alerts::delete_alert,
+        request::alerts::list_alerts,
         request::alerts::enable_alert,
         request::alerts::trigger_alert,
         request::alerts::templates::list_templates,

--- a/src/infra/src/table/alerts/mod.rs
+++ b/src/infra/src/table/alerts/mod.rs
@@ -36,7 +36,7 @@ use super::{
     entity::{alerts, folders},
     folders::FolderType,
 };
-use crate::errors::{self, FromStrError};
+use crate::errors::{self, FromStrError, PutAlertError};
 
 pub mod intermediate;
 

--- a/src/infra/src/table/alerts/mod.rs
+++ b/src/infra/src/table/alerts/mod.rs
@@ -365,14 +365,11 @@ pub async fn delete_by_id<C: ConnectionTrait>(
     alert_id: Ksuid,
 ) -> Result<(), errors::Error> {
     let _lock = super::get_lock().await;
-    let model = get_model_by_id(conn, org_id, alert_id)
-        .await?
-        .map(|(_folder, alert)| alert);
-
-    if let Some(model) = model {
-        let _ = model.delete(conn).await?;
-    }
-
+    alerts::Entity::delete_many()
+        .filter(alerts::Column::Org.eq(org_id))
+        .filter(alerts::Column::Id.eq(alert_id.to_string()))
+        .exec(conn)
+        .await?;
     Ok(())
 }
 

--- a/src/infra/src/table/alerts/mod.rs
+++ b/src/infra/src/table/alerts/mod.rs
@@ -36,7 +36,7 @@ use super::{
     entity::{alerts, folders},
     folders::FolderType,
 };
-use crate::errors::{self, FromStrError, PutAlertError};
+use crate::errors::{self, FromStrError};
 
 pub mod intermediate;
 

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -1440,7 +1440,7 @@ async fn permitted_alerts(
         org_id, user_id, "GET", "alert",
     )
     .await
-    .map_err(|err| FolderError::PermittedAlertsValidator(err.to_string()))?;
+    .map_err(|err| AlertError::PermittedAlertsValidator(err.to_string()))?;
     Ok(stream_list)
 }
 

--- a/src/service/db/alerts/alert/mod.rs
+++ b/src/service/db/alerts/alert/mod.rs
@@ -27,7 +27,12 @@
 mod new;
 mod old;
 
-use config::meta::{alerts::alert::Alert, stream::StreamType};
+use config::meta::{
+    alerts::alert::{Alert, ListAlertsParams},
+    folder::Folder,
+    stream::StreamType,
+};
+use infra::db::{connect_to_orm, ORM_CLIENT};
 use sea_orm::{ConnectionTrait, TransactionTrait};
 use svix_ksuid::Ksuid;
 
@@ -123,8 +128,28 @@ pub async fn list(
     if should_use_meta_alerts() {
         old::list(org_id, stream_type, stream_name).await
     } else {
-        new::list(org_id, stream_type, stream_name).await
+        let params = ListAlertsParams::new(org_id).in_folder("default");
+        let params = if let Some(stream_name) = stream_name {
+            params.for_stream(stream_type.unwrap_or_default(), Some(stream_name))
+        } else {
+            params
+        };
+
+        let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+        let alerts = new::list(client, params)
+            .await?
+            .into_iter()
+            .map(|(_f, a)| a)
+            .collect();
+        Ok(alerts)
     }
+}
+
+pub async fn list_with_folders<C: ConnectionTrait>(
+    conn: &C,
+    params: ListAlertsParams,
+) -> Result<Vec<(Folder, Alert)>, infra::errors::Error> {
+    new::list(conn, params).await
 }
 
 pub async fn watch() -> Result<(), anyhow::Error> {

--- a/src/service/db/alerts/alert/new.rs
+++ b/src/service/db/alerts/alert/new.rs
@@ -27,7 +27,6 @@ use infra::{
     db::{connect_to_orm, ORM_CLIENT},
     table::alerts as table,
 };
-use itertools::Itertools;
 use sea_orm::{ConnectionTrait, TransactionTrait};
 use svix_ksuid::Ksuid;
 


### PR DESCRIPTION
#5253 

Miscellaneous cleanup tasks for the new alerts v2 endpoints:

- fixes some of the new route paths
- removes utoipa schema attribute from a Unix timestamp field on the HTTP model
- removes unnecessary call to DB in "delete" operation