### PR TITLE
feat: Alerts API v2 - part 9 - cleanup

### DIFF
--- a/src/handler/http/models/alerts/mod.rs
+++ b/src/handler/http/models/alerts/mod.rs
@@ -81,7 +81,6 @@ pub struct Alert {
 
     /// Time when alert was last updated. Unix timestamp.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = String, format = DateTime)]
     pub updated_at: Option<i64>,
 
     #[serde(default)]

--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -84,7 +84,7 @@ impl From<AlertError> for HttpResponse {
         (status = 400, description = "Error",   content_type = "application/json", body = HttpResponse),
     )
 )]
-#[post("v2/{org_id}/alerts")]
+#[post("/v2/{org_id}/alerts")]
 pub async fn create_alert(
     path: web::Path<String>,
     req_body: web::Json<CreateAlertRequestBody>,
@@ -125,7 +125,7 @@ pub async fn create_alert(
         (status = 404, description = "NotFound", content_type = "application/json", body = HttpResponse),
     )
 )]
-#[get("v2/{org_id}/alerts/{alert_id}")]
+#[get("/v2/{org_id}/alerts/{alert_id}")]
 async fn get_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
     let (org_id, alert_id) = path.into_inner();
 
@@ -194,7 +194,7 @@ pub async fn update_alert(
         (status = 500, description = "Failure",  content_type = "application/json", body = HttpResponse),
     )
 )]
-#[delete("v2/{org_id}/alerts/{alert_id}")]
+#[delete("/v2/{org_id}/alerts/{alert_id}")]
 async fn delete_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
     let (org_id, alert_id) = path.into_inner();
 
@@ -266,7 +266,7 @@ async fn list_alerts(path: web::Path<String>, req: HttpRequest) -> HttpResponse 
         (status = 500, description = "Failure",  content_type = "application/json", body = HttpResponse),
     )
 )]
-#[put("v2/{org_id}/alerts/{alert_id}/enable")]
+#[put("/v2/{org_id}/alerts/{alert_id}/enable")]
 async fn enable_alert(path: web::Path<(String, Ksuid)>, req: HttpRequest) -> HttpResponse {
     let (org_id, alert_id) = path.into_inner();
     let Ok(query) = web::Query::<EnableAlertQuery>::from_query(req.query_string()) else {

--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -190,7 +190,6 @@ pub async fn update_alert(
     ),
     responses(
         (status = 200, description = "Success",  content_type = "application/json", body = HttpResponse),
-        (status = 404, description = "NotFound", content_type = "application/json", body = HttpResponse),
         (status = 500, description = "Failure",  content_type = "application/json", body = HttpResponse),
     )
 )]

--- a/src/infra/src/table/alerts/mod.rs
+++ b/src/infra/src/table/alerts/mod.rs
@@ -365,14 +365,11 @@ pub async fn delete_by_id<C: ConnectionTrait>(
     alert_id: Ksuid,
 ) -> Result<(), errors::Error> {
     let _lock = super::get_lock().await;
-    let model = get_model_by_id(conn, org_id, alert_id)
-        .await?
-        .map(|(_folder, alert)| alert);
-
-    if let Some(model) = model {
-        let _ = model.delete(conn).await?;
-    }
-
+    alerts::Entity::delete_many()
+        .filter(alerts::Column::Org.eq(org_id))
+        .filter(alerts::Column::Id.eq(alert_id.to_string()))
+        .exec(conn)
+        .await?;
     Ok(())
 }
 


### PR DESCRIPTION
#5253 

Miscellaneous cleanup tasks for the new alerts v2 endpoints:

- fixes some of the new route paths
- removes utoipa schema attribute from a Unix timestamp field on the HTTP model
- removes unnecessary call to DB in "delete" operation