### PR TITLE
feat: add inverted index search for promql

### DIFF
--- a/src/service/promql/search/grpc/mod.rs
+++ b/src/service/promql/search/grpc/mod.rs
@@ -53,8 +53,15 @@ impl TableProvider for StorageProvider {
         let mut resp = Vec::new();
         // register storage table
         let trace_id = self.trace_id.to_owned() + "-storage-" + stream_name;
-        let ctx =
-            storage::create_context(&trace_id, org_id, stream_name, time_range, filters).await?;
+        let ctx = storage::create_context(
+            &trace_id,
+            org_id,
+            stream_name,
+            time_range,
+            matchers.clone(),
+            filters,
+        )
+        .await?;
         resp.push(ctx);
         // register Wal table
         if self.need_wal {

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -168,17 +168,17 @@ pub(crate) async fn create_context(
 
     // search tantivy index
     let index_condition = convert_matchers_to_index_condition(&matchers, &schema)?;
-    if !matchers.matchers.is_empty() && cfg.common.inverted_index_enabled {
+    if !index_condition.conditions.is_empty() && cfg.common.inverted_index_enabled {
         let (idx_took, ..) =
             filter_file_list_by_tantivy_index(query, &mut files, Some(index_condition), None)
                 .await
                 .map_err(|e| {
                     log::error!(
-                        "[trace_id {trace_id}] filter file list by tantivy index error: {e}"
+                        "[trace_id {trace_id}] promql->search->storage: filter file list by tantivy index error: {e}"
                     );
                     DataFusionError::Execution(e.to_string())
                 })?;
-        log::info!("[trace_id {trace_id}] filter file list by tantivy index took: {idx_took} ms",);
+        log::info!("[trace_id {trace_id}] promql->search->storage: filter file list by tantivy index took: {idx_took} ms",);
     }
 
     let session = SearchSession {

--- a/src/service/promql/utils.rs
+++ b/src/service/promql/utils.rs
@@ -26,6 +26,8 @@ use datafusion::{
 };
 use promql_parser::label::{MatchOp, Matchers};
 
+use crate::service::search::datafusion::udf::regexp_udf::{REGEX_MATCH_UDF, REGEX_NOT_MATCH_UDF};
+
 pub fn apply_matchers(df: DataFrame, schema: &Schema, matchers: &Matchers) -> Result<DataFrame> {
     let cfg = get_config();
     let mut df = df;
@@ -42,19 +44,15 @@ pub fn apply_matchers(df: DataFrame, schema: &Schema, matchers: &Matchers) -> Re
                 df = df.filter(col(mat.name.clone()).not_eq(lit(mat.value.clone())))?
             }
             MatchOp::Re(regex) => {
-                let regexp_match_udf =
-                    crate::service::search::datafusion::udf::regexp_udf::REGEX_MATCH_UDF.clone();
-                df = df.filter(
-                    regexp_match_udf.call(vec![col(mat.name.clone()), lit(regex.as_str())]),
-                )?
+                let regexp_match_udf = REGEX_MATCH_UDF.clone();
+                let regex = format!("^{}$", regex.as_str());
+                df = df.filter(regexp_match_udf.call(vec![col(mat.name.clone()), lit(regex)]))?
             }
             MatchOp::NotRe(regex) => {
-                let regexp_not_match_udf =
-                    crate::service::search::datafusion::udf::regexp_udf::REGEX_NOT_MATCH_UDF
-                        .clone();
-                df = df.filter(
-                    regexp_not_match_udf.call(vec![col(mat.name.clone()), lit(regex.as_str())]),
-                )?
+                let regexp_not_match_udf = REGEX_NOT_MATCH_UDF.clone();
+                let regex = format!("^{}$", regex.as_str());
+                df =
+                    df.filter(regexp_not_match_udf.call(vec![col(mat.name.clone()), lit(regex)]))?
             }
         }
     }


### PR DESCRIPTION
reuse the function `filter_file_list_by_tantivy_index` in log tantivy index to impl the inverted index for promql.

the inverted index for promql only support Equal and Regex, don't not support NotEqual and NotRegex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for regex-based conditions in the query system.
	- Enhanced context creation with advanced filtering capabilities using matchers.
	- Improved search functionality with more flexible matcher options.

- **Improvements**
	- Expanded query parameter handling for complex queries.
	- Introduced stricter regex matching criteria for filtering operations.
	- Added logging for filtering performance insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->