### PR TITLE
fix: add changes for super_cluster for distinct_values

### DIFF
--- a/src/infra/src/table/distinct_values.rs
+++ b/src/infra/src/table/distinct_values.rs
@@ -17,6 +17,7 @@ use sea_orm::{
     entity::prelude::*, ColumnTrait, ConnectionTrait, EntityTrait, FromQueryResult, QueryFilter,
     Schema, Set,
 };
+use serde::{Deserialize, Serialize};
 
 use super::get_lock;
 use crate::{
@@ -24,7 +25,7 @@ use crate::{
     errors::{self, DbError, Error},
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(rs_type = "String", db_type = "String(StringLen::N(16))")]
 pub enum OriginType {
     #[sea_orm(string_value = "stream")]
@@ -66,7 +67,7 @@ impl RelationTrait for Relation {
 
 impl ActiveModelBehavior for ActiveModel {}
 
-#[derive(FromQueryResult, Debug)]
+#[derive(FromQueryResult, Debug, Serialize, Deserialize)]
 pub struct DistinctFieldRecord {
     pub origin: OriginType,
     pub origin_id: String,
@@ -74,6 +75,12 @@ pub struct DistinctFieldRecord {
     pub stream_name: String,
     pub stream_type: String,
     pub field_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BatchDeleteMessage {
+    pub origin_type: OriginType,
+    pub id: String,
 }
 
 impl DistinctFieldRecord {

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -24,11 +24,11 @@ use config::{
 use hashbrown::HashMap;
 use infra::table::{
     self,
-    distinct_values::{self, DistinctFieldRecord, OriginType},
+    distinct_values::{DistinctFieldRecord, OriginType},
     folders::FolderType,
 };
 
-use super::{folders, stream::save_stream_settings};
+use super::{db::distinct_values, folders, stream::save_stream_settings};
 use crate::common::{
     meta::authz::Authz,
     utils::auth::{remove_ownership, set_ownership},

--- a/src/service/db/distinct_values.rs
+++ b/src/service/db/distinct_values.rs
@@ -1,0 +1,75 @@
+use config::utils::json;
+use infra::{
+    errors,
+    table::distinct_values::{BatchDeleteMessage, DistinctFieldRecord, OriginType},
+};
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::common::infra::config::get_config;
+
+pub async fn add(record: DistinctFieldRecord) -> Result<(), errors::Error> {
+    #[cfg(feature = "enterprise")]
+    emit_put_event(&record).await?;
+    infra::table::distinct_values::add(record).await
+}
+
+pub async fn remove(record: DistinctFieldRecord) -> Result<(), errors::Error> {
+    #[cfg(feature = "enterprise")]
+    emit_delete_event(&record).await?;
+    infra::table::distinct_values::remove(record).await
+}
+
+pub async fn batch_remove(origin: OriginType, origin_id: &str) -> Result<(), errors::Error> {
+    #[cfg(feature = "enterprise")]
+    emit_batch_delete_event(&origin, origin_id).await?;
+    infra::table::distinct_values::batch_remove(origin, origin_id).await
+}
+
+/// Sends event to super cluster queue for a new distinct values entry.
+#[cfg(feature = "enterprise")]
+pub async fn emit_put_event(record: &DistinctFieldRecord) -> Result<(), errors::Error> {
+    if get_config().super_cluster.enabled {
+        let value = json::to_vec(&record)?.into();
+        let key = format!("/distinct_values/{}", record.org_name);
+        o2_enterprise::enterprise::super_cluster::queue::distinct_values_put(&key, value, true)
+            .await
+            .map_err(|e| infra::errors::Error::Message(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Sends event to super cluster queue for a deleted distinct values entry.
+#[cfg(feature = "enterprise")]
+pub async fn emit_delete_event(record: &DistinctFieldRecord) -> Result<(), infra::errors::Error> {
+    if get_config().super_cluster.enabled {
+        let value = json::to_vec(&record)?.into();
+        let key = format!("/distinct_values/{}", record.org_name);
+        o2_enterprise::enterprise::super_cluster::queue::distinct_values_delete(
+            &key, value, false, true,
+        )
+        .await
+        .map_err(|e| infra::errors::Error::Message(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Sends event to super cluster queue for a deleted distinct values batch.
+#[cfg(feature = "enterprise")]
+pub async fn emit_batch_delete_event(
+    origin_type: &OriginType,
+    id: &str,
+) -> Result<(), infra::errors::Error> {
+    if get_config().super_cluster.enabled {
+        let value = json::to_vec(&BatchDeleteMessage {
+            origin_type: *origin_type,
+            id: id.to_owned(),
+        })?
+        .into();
+        let key = format!("/distinct_values/{}", id);
+        o2_enterprise::enterprise::super_cluster::queue::distinct_values_delete(
+            &key, value, true, true,
+        )
+        .await
+        .map_err(|e| infra::errors::Error::Message(e.to_string()))?;
+    }
+    Ok(())
+}

--- a/src/service/db/distinct_values.rs
+++ b/src/service/db/distinct_values.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "enterprise")]
 use config::utils::json;
+#[cfg(feature = "enterprise")]
+use infra::table::distinct_values::BatchDeleteMessage;
 use infra::{
     errors,
-    table::distinct_values::{BatchDeleteMessage, DistinctFieldRecord, OriginType},
+    table::distinct_values::{DistinctFieldRecord, OriginType},
 };
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::common::infra::config::get_config;

--- a/src/service/db/distinct_values.rs
+++ b/src/service/db/distinct_values.rs
@@ -1,3 +1,18 @@
+// Copyright 2024 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #[cfg(feature = "enterprise")]
 use config::utils::json;
 #[cfg(feature = "enterprise")]

--- a/src/service/db/mod.rs
+++ b/src/service/db/mod.rs
@@ -25,6 +25,7 @@ use {
 pub mod alerts;
 pub mod compact;
 pub mod dashboards;
+pub mod distinct_values;
 pub mod enrichment_table;
 pub mod file_list;
 pub mod functions;


### PR DESCRIPTION
This adds support for super_cluster queue notification for addition/removal of distinct value fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added serialization capabilities for `OriginType` and `DistinctFieldRecord`.
	- Introduced new asynchronous functions for managing distinct field records in the database.
	- Added enterprise-specific event emission for record operations.

- **Refactor**
	- Updated import statements across multiple service modules.
	- Reorganized distinct values handling in the database service.

- **Chores**
	- Added a new module for distinct values management.
	- Improved error handling for dashboard updates and stream operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->