### PR TITLE
fix: dashboard when changing org it throws error as dashboardID is not found

### DIFF
--- a/web/src/utils/commons.ts
+++ b/web/src/utils/commons.ts
@@ -522,6 +522,10 @@ export const getDashboard = async (
   if (store.state.organizationData.allDashboardData[dashboardId]) {
     return store.state.organizationData.allDashboardData[dashboardId];
   }
+  
+  if(!dashboardId){
+    return;
+  }
 
   const apiResponse = await dashboardService.get_Dashboard(
     store.state.selectedOrganization.identifier,


### PR DESCRIPTION
- #5531
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved dashboard retrieval logic to handle cases with missing or invalid dashboard identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->