### PR TITLE
feat: Move alert cluster coordinator event methods into `infra` crate

### DIFF
--- a/src/infra/src/cluster_coordinator/alerts.rs
+++ b/src/infra/src/cluster_coordinator/alerts.rs
@@ -1,0 +1,98 @@
+use std::{future::Future, sync::Arc};
+
+use bytes::Bytes;
+use config::meta::{alerts::alert::Alert, stream::StreamType};
+use itertools::Itertools;
+
+use crate::{db::Event, errors::Error};
+
+/// Sends event to the cluster coordinator indicating that an alert has been put
+/// into the database.
+pub async fn emit_put_event(org: &str, alert: &Alert) -> Result<(), Error> {
+    let key = alert_key(org, alert.stream_type, &alert.stream_name, &alert.name);
+    let cluster_coordinator = super::get_coordinator().await;
+    cluster_coordinator
+        .put(&key, bytes::Bytes::from(""), true, None)
+        .await?;
+    Ok(())
+}
+
+/// Sends event to the cluster coordinator indicating that an alert has been
+/// deleted from the database.
+pub async fn emit_delete_event(
+    org: &str,
+    stream_type: StreamType,
+    stream_name: &str,
+    alert_name: &str,
+) -> Result<(), Error> {
+    let key = alert_key(org, stream_type, stream_name, alert_name);
+    let cluster_coordinator = super::get_coordinator().await;
+    cluster_coordinator.delete(&key, false, true, None).await
+}
+
+/// Watch for alert events published to the cluster coordinator.
+pub async fn watch_events<OnPut, OnPutFut, OnDelete, OnDeleteFut>(
+    on_put: OnPut,
+    on_delete: OnDelete,
+) -> Result<(), anyhow::Error>
+where
+    OnPut: Fn(String, StreamType, String, String, Option<Bytes>) -> OnPutFut,
+    OnPutFut: Future<Output = Result<(), anyhow::Error>>,
+    OnDelete: Fn(String, StreamType, String, String) -> OnDeleteFut,
+    OnDeleteFut: Future<Output = Result<(), anyhow::Error>>,
+{
+    let cluster_coordinator = super::get_coordinator().await;
+    let mut events = cluster_coordinator.watch("/alerts/").await?;
+    let events = Arc::get_mut(&mut events).unwrap();
+    log::info!("Start watching alerts");
+    loop {
+        let ev = match events.recv().await {
+            Some(ev) => ev,
+            None => {
+                log::error!("watch_alerts: event channel closed");
+                break;
+            }
+        };
+        match ev {
+            Event::Put(ev) => {
+                let Some((org, stream_type, stream_name, alert_name)) = parse_alert_key(&ev.key)
+                else {
+                    log::error!("watch_alerts: failed to parse event key {}", &ev.key);
+                    continue;
+                };
+                let _ = (on_put)(org, stream_type, stream_name, alert_name, ev.value).await;
+            }
+            Event::Delete(ev) => {
+                let Some((org, stream_type, stream_name, alert_name)) = parse_alert_key(&ev.key)
+                else {
+                    log::error!("watch_alerts: failed to parse event key {}", &ev.key);
+                    continue;
+                };
+                let _ = (on_delete)(org, stream_type, stream_name, alert_name).await;
+            }
+            Event::Empty => {}
+        }
+    }
+    Ok(())
+}
+
+/// Returns the key used to identify an individual alert in events sent to
+/// cluster cache watchers.
+fn alert_key(org: &str, stream_type: StreamType, stream_name: &str, alert_name: &str) -> String {
+    format!("/alerts/{org}/{stream_type}/{stream_name}/{alert_name}")
+}
+
+/// Tries to parse the key used to identify an individual alert in avents
+/// sent to cluster cache watchers. Returns the organization, stream type,
+/// stream name, and alert name from the key.
+fn parse_alert_key(key: &str) -> Option<(String, StreamType, String, String)> {
+    let parts = key.trim_start_matches("/").split('/').collect_vec();
+    if parts.len() < 5 || parts[0] != "alerts" {
+        return None;
+    }
+    let org = parts[1].to_owned();
+    let stream_type: StreamType = parts[2].into();
+    let stream_name = parts[3].to_owned();
+    let alert_name = parts[4].to_owned();
+    Some((org, stream_type, stream_name, alert_name))
+}

--- a/src/infra/src/cluster_coordinator/mod.rs
+++ b/src/infra/src/cluster_coordinator/mod.rs
@@ -1,0 +1,7 @@
+pub mod alerts;
+
+use crate::db::Db;
+
+pub async fn get_coordinator() -> &'static Box<dyn Db> {
+    super::db::get_coordinator().await
+}

--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub mod cache;
+pub mod cluster_coordinator;
 pub mod db;
 pub mod dist_lock;
 pub mod errors;


### PR DESCRIPTION
This moves the methods for emitting and listening for alert-related cluster coordinator events to the infra crate.

We are doing this so that logic in the enterprise crate can call the methods to emit cluster coordinator events when responding to a super cluster queue event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced alert management functionality in the cluster coordinator
	- Added new methods for emitting and watching alert events
	- Introduced improved event handling mechanisms for alerts

- **Refactor**
	- Restructured alert event processing logic
	- Modularized cluster coordinator event management
	- Streamlined cache update mechanisms for alerts

- **Chores**
	- Updated infrastructure and service layer modules
	- Added new module for cluster coordinator functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->