### PR TITLE
feat: OpenFGA alert ID migration

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -117,6 +117,7 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                         .help("the parquet file name"),
                 ),
             clap::Command::new("migrate-schemas").about("migrate from single row to row per schema version"),
+            clap::Command::new("migrate-alerts-rbac").about("migrate RBAC identifier for alerts in OpenFGA"),
             clap::Command::new("seaorm-rollback").about("rollback SeaORM migration steps")
                 .subcommand(
                     clap::Command::new("all")
@@ -283,6 +284,11 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
             println!("Running schema migration to row per schema version");
             #[allow(deprecated)]
             migration::schema::run().await?
+        }
+        "migrate-alerts-rbac" =>
+        {
+            #[cfg(feature = "enterprise")]
+            migration::alerts_openfga_ids::run().await?
         }
         "seaorm-rollback" => match command.subcommand() {
             Some(("all", _)) => {

--- a/src/common/infra/ofga.rs
+++ b/src/common/infra/ofga.rs
@@ -91,6 +91,8 @@ pub async fn init() -> Result<(), anyhow::Error> {
     if let Some(existing_model) = &existing_meta {
         if meta.version == existing_model.version {
             log::info!("OFGA model already exists & no changes required");
+            o2_enterprise::enterprise::common::infra::config::OFGA_STORE_ID
+                .insert("store_id".to_owned(), existing_model.store_id.clone());
             if !init_tuples.is_empty() {
                 match update_tuples(init_tuples, vec![]).await {
                     Ok(_) => {

--- a/src/common/migration/alerts_openfga_ids.rs
+++ b/src/common/migration/alerts_openfga_ids.rs
@@ -1,0 +1,30 @@
+use infra::{
+    db::{connect_to_orm, ORM_CLIENT},
+    table::entity::alerts,
+};
+use o2_enterprise::enterprise::{
+    common::infra::config::get_config as get_o2_config,
+    openfga::{add_init_ofga_tuples, authorizer::authz::get_ownership_tuple},
+};
+use sea_orm::{EntityTrait, PaginatorTrait};
+
+/// Generates a neww ID in OpenFGA for each alert using the alert's KSUID.
+pub async fn run() -> Result<(), anyhow::Error> {
+    if !get_o2_config().openfga.enabled {
+        return Ok(());
+    }
+    let conn = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
+    let mut pages = alerts::Entity::find().paginate(conn, 100);
+    while let Some(alerts) = pages.fetch_and_next().await? {
+        let mut tuples = vec![];
+        for a in alerts {
+            get_ownership_tuple(&a.org, "alerts", &a.id, &mut tuples);
+        }
+        add_init_ofga_tuples(tuples).await;
+    }
+
+    o2_enterprise::enterprise::openfga::authorizer::authz::init_open_fga().await;
+    let _ = crate::common::infra::ofga::init().await;
+    Ok(())
+}

--- a/src/common/migration/alerts_openfga_ids.rs
+++ b/src/common/migration/alerts_openfga_ids.rs
@@ -2,29 +2,31 @@ use infra::{
     db::{connect_to_orm, ORM_CLIENT},
     table::entity::alerts,
 };
-use o2_enterprise::enterprise::{
-    common::infra::config::get_config as get_o2_config,
-    openfga::{add_init_ofga_tuples, authorizer::authz::get_ownership_tuple},
-};
+use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
 use sea_orm::{EntityTrait, PaginatorTrait};
+
+use crate::common::{
+    meta::authz::Authz,
+    utils::auth::{remove_ownership, set_ownership},
+};
 
 /// Generates a neww ID in OpenFGA for each alert using the alert's KSUID.
 pub async fn run() -> Result<(), anyhow::Error> {
     if !get_o2_config().openfga.enabled {
         return Ok(());
     }
+
+    o2_enterprise::enterprise::openfga::authorizer::authz::init_open_fga().await;
+    let _ = crate::common::infra::ofga::init().await;
     let conn = ORM_CLIENT.get_or_init(connect_to_orm).await;
 
     let mut pages = alerts::Entity::find().paginate(conn, 100);
     while let Some(alerts) = pages.fetch_and_next().await? {
-        let mut tuples = vec![];
         for a in alerts {
-            get_ownership_tuple(&a.org, "alerts", &a.id, &mut tuples);
+            remove_ownership(&a.org, "alerts", Authz::new(&a.name)).await;
+            set_ownership(&a.org, "alerts", Authz::new(&a.id)).await;
         }
-        add_init_ofga_tuples(tuples).await;
     }
 
-    o2_enterprise::enterprise::openfga::authorizer::authz::init_open_fga().await;
-    let _ = crate::common::infra::ofga::init().await;
     Ok(())
 }

--- a/src/common/migration/mod.rs
+++ b/src/common/migration/mod.rs
@@ -17,6 +17,8 @@ use config::cluster::LOCAL_NODE;
 use schema::migrate_resource_names;
 use version_compare::Version;
 
+#[cfg(feature = "enterprise")]
+pub mod alerts_openfga_ids;
 pub mod dashboards;
 pub mod file_list;
 pub mod meta;

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -547,6 +547,7 @@ pub async fn delete_by_id<C: ConnectionTrait>(
     if let Some(id) = alert.id.map(|id| id.to_string()) {
         remove_ownership(org_id, "alerts", Authz::new(&id)).await;
     }
+    remove_ownership(org_id, "alerts", Authz::new(&alert.name)).await;
     Ok(())
 }
 


### PR DESCRIPTION
Introduces a migration that can be ran through a CLI command to 
- remove the old `name` identifier in OpenFGA for each alert
- add the new `id` (KSUID) identifier in OpenFGA for each alert

This also updates the old alert endpoints so that they will add/remove both the old `name` and new `id` OpenFGA identifiers at the same time, so that RBAC logic continues functioning both before and after clients run the migration command through the CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new CLI subcommand `migrate-alerts-rbac` for migrating RBAC identifiers for alerts in OpenFGA
  - Enhanced alert ownership management during creation and deletion processes

- **Improvements**
  - Updated alert management functions to provide more detailed return values
  - Improved OpenFGA integration for alert ownership tracking

- **Enterprise Features**
  - Added new migration functionality for alert identifiers in OpenFGA
  - Introduced conditional feature flag for enterprise-specific operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->