### PR TITLE
fix: only 1 source node is allowed while creating / editing pipeline

### DIFF
--- a/web/src/components/pipeline/NodeSidebar.vue
+++ b/web/src/components/pipeline/NodeSidebar.vue
@@ -35,7 +35,7 @@ export default {
       v-for="node in node_types"
       :key="node.io_type"
       class="o2vf_node q-gutter-md q-pb-md"
-      :draggable="node.io_type == 'input' && pipelineObj.hasInputNode ? false : true"
+      :draggable="true"
       @dragstart="onDragStart($event, node)"
     >
       <q-btn

--- a/web/src/components/pipeline/PipelineEditor.vue
+++ b/web/src/components/pipeline/PipelineEditor.vue
@@ -410,7 +410,6 @@ onUnmounted(() => {
 let forceSkipBeforeUnloadListener = false;
 
 onBeforeRouteLeave((to, from, next) => {
-  console.log("beforeRouteLeave", pipelineObj.currentSelectedPipeline.nodes);
   // check if it is a force navigation, then allow
   if (forceSkipBeforeUnloadListener) {
     next();

--- a/web/src/plugins/pipelines/useDnD.ts
+++ b/web/src/plugins/pipelines/useDnD.ts
@@ -111,7 +111,6 @@ export default function useDragAndDrop() {
     pipelineObj.isDragging = true;
     pipelineObj.currentSelectedNodeData = null;
 
-
     document.addEventListener("drop", onDragEnd);
   }
 
@@ -148,6 +147,18 @@ export default function useDragAndDrop() {
    * @param {DragEvent} event
    */
   function onDrop(event:any ,offSet:any = {x:0,y:0}) {
+    if (
+      pipelineObj.hasInputNode &&
+      pipelineObj.draggedNode.io_type == "input"
+    ) {
+      $q.notify({
+        message: "Only 1 source node is allowed",
+        color: "negative",
+        position: "bottom",
+        timeout: 2000, 
+    });
+      return;
+    }
 
     const position = screenToFlowCoordinate({
       x: event.clientX + offSet.x,
@@ -515,7 +526,6 @@ export default function useDragAndDrop() {
 
       const ids1 = extractAndSortIds(items1);
       const ids2 = extractAndSortIds(items2);
-      console.log(ids1,ids2)
   
       return JSON.stringify(ids1) === JSON.stringify(ids2);
     };
@@ -553,7 +563,6 @@ export default function useDragAndDrop() {
       pipelineObj.dirtyFlag = true;
     }
     
-    console.log(pipelineObj.currentSelectedPipeline,"edges")
   }
 
   const resetPipelineData = () => {


### PR DESCRIPTION
This Pr solves the issue in #5587 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced drag-and-drop functionality for all pipeline nodes.
	- Added validation to restrict the addition of multiple source nodes in a pipeline.

- **Bug Fixes**
	- Improved node dragging behavior across pipeline components.

- **Chores**
	- Removed unnecessary console logging statements for cleaner code.

The changes focus on improving the user experience and workflow in the pipeline editor by refining node interaction and adding logical constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->