### PR TITLE
fix: return error if old dashboard delete fails in move dashboard

### DIFF
--- a/src/handler/http/request/dashboards/mod.rs
+++ b/src/handler/http/request/dashboards/mod.rs
@@ -41,7 +41,8 @@ impl From<DashboardError> for HttpResponse {
             DashboardError::MoveDestinationFolderNotFound => MetaHttpResponse::not_found("Folder not found"),
             DashboardError::CreateFolderNotFound => MetaHttpResponse::not_found("Folder not found"),
             DashboardError::CreateDefaultFolder => MetaHttpResponse::internal_error("Error saving default folder"),
-            DashboardError::DistinctValueError => MetaHttpResponse::internal_error("Error in updating distinct values")
+            DashboardError::DistinctValueError => MetaHttpResponse::internal_error("Error in updating distinct values"),
+            DashboardError::MoveDashboardDeleteOld(dashb_id, folder_id, e) => MetaHttpResponse::internal_error(format!("error deleting the dashboard {dashb_id} from old folder {folder_id} : {e}"))
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Enhanced error handling for dashboard movement operations
    - Improved error reporting when deleting dashboards from old folders during move operations

- **New Features**
    - Added more detailed error tracking for dashboard-related actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->