### PR TITLE
ci: add more debug tools

### DIFF
--- a/deploy/build/Dockerfile.pr.amd64
+++ b/deploy/build/Dockerfile.pr.amd64
@@ -2,7 +2,8 @@
 
 FROM public.ecr.aws/debian/debian:bookworm-20240513-slim AS runtime
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libatk1.0-0 libnss3 libglib2.0-0/stable ca-certificates curl htop iftop sysstat procps lsof net-tools sqlite3 && \
+    apt-get install -y --no-install-recommends libatk1.0-0 libnss3 libglib2.0-0/stable ca-certificates curl \
+    htop iftop nload iptraf ncdu tcpdump sysstat procps lsof net-tools sqlite3 && \
     update-ca-certificates
 COPY ./bin/openobserve /
 RUN ["/openobserve", "init-dir", "-p", "/data/"]

--- a/deploy/build/Dockerfile.tag-debug.aarch64
+++ b/deploy/build/Dockerfile.tag-debug.aarch64
@@ -30,7 +30,7 @@ RUN mv /openobserve/target/aarch64-unknown-linux-gnu/release-prod/openobserve /o
 
 FROM public.ecr.aws/debian/debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools sqlite3
+RUN apt-get install -y curl htop iftop nload iptraf ncdu tcpdump sysstat procps lsof net-tools sqlite3
 RUN update-ca-certificates
 COPY --from=builder /openobserve/target/release/openobserve /
 COPY --from=builder /lib/aarch64-linux-gnu/liblzma.so.5 /lib/aarch64-linux-gnu/liblzma.so.5

--- a/deploy/build/Dockerfile.tag-debug.amd64
+++ b/deploy/build/Dockerfile.tag-debug.amd64
@@ -27,7 +27,7 @@ RUN mv /openobserve/target/x86_64-unknown-linux-gnu/release-prod/openobserve /op
 
 FROM public.ecr.aws/debian/debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools sqlite3
+RUN apt-get install -y curl htop iftop nload iptraf ncdu tcpdump sysstat procps lsof net-tools sqlite3
 RUN update-ca-certificates
 COPY --from=builder /openobserve/target/release/openobserve /
 COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so.5 /lib/x86_64-linux-gnu/liblzma.so.5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added network monitoring tools (`nload`, `iptraf`, `tcpdump`) to Dockerfiles for AMD64 and AARCH64 architectures
	- Enhanced runtime environment with additional network analysis capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->