### PR TITLE
feat: support limit join's right side

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -610,6 +610,8 @@ pub struct Common {
     pub feature_query_remove_filter_with_index: bool,
     #[env_config(name = "ZO_FEATURE_QUERY_STREAMING_AGGS", default = false)]
     pub feature_query_streaming_aggs: bool,
+    #[env_config(name = "ZO_FEATURE_JOIN_RIGHT_SIDE_MAX_ROWS", default = 0)]
+    pub feature_join_right_side_max_rows: usize,
     #[env_config(name = "ZO_UI_ENABLED", default = true)]
     pub ui_enabled: bool,
     #[env_config(name = "ZO_UI_SQL_BASE64_ENABLED", default = false)]

--- a/src/service/search/datafusion/optimizer/add_sort_and_limit.rs
+++ b/src/service/search/datafusion/optimizer/add_sort_and_limit.rs
@@ -13,31 +13,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
-
-use config::get_config;
 use datafusion::{
     common::{
-        tree_node::{
-            Transformed, TransformedResult, TreeNode, TreeNodeRecursion, TreeNodeRewriter,
-        },
-        DFSchema, Result,
+        tree_node::{Transformed, TreeNode, TreeNodeRecursion},
+        Result,
     },
-    logical_expr::{col, Limit, LogicalPlan, Projection, Sort, SortExpr, TableScan},
+    logical_expr::LogicalPlan,
     optimizer::{optimizer::ApplyOrder, OptimizerConfig, OptimizerRule},
-    prelude::Expr,
-    scalar::ScalarValue,
 };
 
-/// Optimization rule that add sort and limit to table scan
-#[derive(Default, Debug)]
+use super::utils::AddSortAndLimit;
+
+#[derive(Debug)]
 pub struct AddSortAndLimitRule {
     limit: usize,
     offset: usize,
 }
 
 impl AddSortAndLimitRule {
-    #[allow(missing_docs)]
     pub fn new(limit: usize, offset: usize) -> Self {
         Self { limit, offset }
     }
@@ -61,201 +54,9 @@ impl OptimizerRule for AddSortAndLimitRule {
         plan: LogicalPlan,
         _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
-        if self.limit == 0 {
-            return Ok(Transformed::new(plan, false, TreeNodeRecursion::Stop));
-        }
-
-        let is_complex = plan.exists(|plan| Ok(is_complex_query(plan)))?;
-        let mut is_stop = true;
-        let (mut transformed, schema) = match plan {
-            LogicalPlan::Projection(_) => {
-                is_stop = false;
-                (Transformed::no(plan), None)
-            }
-            LogicalPlan::Limit(mut limit) => match limit.input.as_ref() {
-                LogicalPlan::Sort(_) => (Transformed::no(LogicalPlan::Limit(limit)), None),
-                _ => {
-                    if is_complex {
-                        (Transformed::no(LogicalPlan::Limit(limit)), None)
-                    } else {
-                        // the add sort plan should reflect the limit
-                        let fetch = get_int_from_expr(&limit.fetch);
-                        let skip = get_int_from_expr(&limit.skip);
-                        let (sort, schema) = generate_sort_plan(limit.input.clone(), fetch + skip);
-                        limit.input = Arc::new(sort);
-                        (Transformed::yes(LogicalPlan::Limit(limit)), schema)
-                    }
-                }
-            },
-            LogicalPlan::Sort(sort) => {
-                if sort.fetch.is_some() {
-                    (Transformed::no(LogicalPlan::Sort(sort)), None)
-                } else {
-                    let plan = generate_limit_plan(
-                        Arc::new(LogicalPlan::Sort(sort)),
-                        self.limit,
-                        self.offset,
-                    );
-                    (Transformed::yes(plan), None)
-                }
-            }
-            _ => {
-                if is_complex {
-                    (
-                        Transformed::yes(generate_limit_plan(
-                            Arc::new(plan),
-                            self.limit,
-                            self.offset,
-                        )),
-                        None,
-                    )
-                } else {
-                    let (plan, schema) =
-                        generate_limit_and_sort_plan(Arc::new(plan), self.limit, self.offset);
-                    (Transformed::yes(plan), schema)
-                }
-            }
-        };
-        if is_stop {
-            transformed.tnr = TreeNodeRecursion::Stop;
-        }
-        if let Some(schema) = schema {
-            let plan = transformed.data;
-            let proj = LogicalPlan::Projection(Projection::new_from_schema(Arc::new(plan), schema));
-            transformed.data = proj;
-        }
-        Ok(transformed)
-    }
-}
-
-// check if the plan is a complex query that we can't add sort _timestamp
-fn is_complex_query(plan: &LogicalPlan) -> bool {
-    matches!(
-        plan,
-        LogicalPlan::Aggregate(_)
-            | LogicalPlan::Join(_)
-            | LogicalPlan::Distinct(_)
-            | LogicalPlan::RecursiveQuery(_)
-            | LogicalPlan::SubqueryAlias(_)
-            | LogicalPlan::Subquery(_)
-            | LogicalPlan::Window(_)
-            | LogicalPlan::Union(_)
-    )
-}
-
-fn generate_limit_plan(input: Arc<LogicalPlan>, limit: usize, skip: usize) -> LogicalPlan {
-    LogicalPlan::Limit(Limit {
-        skip: Some(Box::new(Expr::Literal(ScalarValue::Int64(Some(
-            skip as i64,
-        ))))),
-        fetch: Some(Box::new(Expr::Literal(ScalarValue::Int64(Some(
-            limit as i64,
-        ))))),
-        input,
-    })
-}
-
-fn generate_sort_plan(
-    input: Arc<LogicalPlan>,
-    limit: usize,
-) -> (LogicalPlan, Option<Arc<DFSchema>>) {
-    let config = get_config();
-    let timestamp = SortExpr {
-        expr: col(config.common.column_timestamp.clone()),
-        asc: false,
-        nulls_first: false,
-    };
-    let schema = input.schema().clone();
-    if schema
-        .field_with_name(None, config.common.column_timestamp.as_str())
-        .is_err()
-    {
-        let mut input = input.as_ref().clone();
-        input = input
-            .rewrite(&mut ChangeTableScanSchema::new())
-            .data()
-            .unwrap();
-        return (
-            LogicalPlan::Sort(Sort {
-                expr: vec![timestamp],
-                input: Arc::new(input),
-                fetch: Some(limit),
-            }),
-            Some(schema),
-        );
-    }
-    (
-        LogicalPlan::Sort(Sort {
-            expr: vec![timestamp],
-            input,
-            fetch: Some(limit),
-        }),
-        None,
-    )
-}
-
-fn generate_limit_and_sort_plan(
-    input: Arc<LogicalPlan>,
-    limit: usize,
-    skip: usize,
-) -> (LogicalPlan, Option<Arc<DFSchema>>) {
-    let (sort, schema) = generate_sort_plan(input, limit + skip);
-    (
-        LogicalPlan::Limit(Limit {
-            skip: Some(Box::new(Expr::Literal(ScalarValue::Int64(Some(
-                skip as i64,
-            ))))),
-            fetch: Some(Box::new(Expr::Literal(ScalarValue::Int64(Some(
-                limit as i64,
-            ))))),
-            input: Arc::new(sort),
-        }),
-        schema,
-    )
-}
-
-fn get_int_from_expr(expr: &Option<Box<Expr>>) -> usize {
-    match expr {
-        Some(expr) => match expr.as_ref() {
-            Expr::Literal(ScalarValue::Int64(Some(value))) => *value as usize,
-            _ => 0,
-        },
-        _ => 0,
-    }
-}
-
-struct ChangeTableScanSchema {}
-
-impl ChangeTableScanSchema {
-    fn new() -> Self {
-        Self {}
-    }
-}
-
-impl TreeNodeRewriter for ChangeTableScanSchema {
-    type Node = LogicalPlan;
-
-    fn f_up(&mut self, node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
-        let mut transformed = match node {
-            LogicalPlan::TableScan(scan) => {
-                let schema = scan.source.schema();
-                let timestamp_idx =
-                    schema.index_of(get_config().common.column_timestamp.as_str())?;
-                let mut projection = scan.projection.clone().unwrap();
-                projection.push(timestamp_idx);
-                let table_scan = TableScan::try_new(
-                    scan.table_name,
-                    scan.source,
-                    Some(projection),
-                    scan.filters,
-                    scan.fetch,
-                )?;
-                Transformed::yes(LogicalPlan::TableScan(table_scan))
-            }
-            _ => Transformed::no(node),
-        };
-        transformed.tnr = TreeNodeRecursion::Stop;
-        Ok(transformed)
+        let mut plan = plan.rewrite(&mut AddSortAndLimit::new(self.limit, self.offset))?;
+        plan.tnr = TreeNodeRecursion::Stop;
+        Ok(plan)
     }
 }
 

--- a/src/service/search/datafusion/optimizer/limit_join_right_side.rs
+++ b/src/service/search/datafusion/optimizer/limit_join_right_side.rs
@@ -1,0 +1,311 @@
+// Copyright 2024 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use datafusion::{
+    common::{
+        tree_node::{Transformed, TreeNode},
+        Result,
+    },
+    logical_expr::LogicalPlan,
+    optimizer::{optimizer::ApplyOrder, OptimizerConfig, OptimizerRule},
+};
+
+use super::utils::AddSortAndLimit;
+
+#[derive(Default, Debug)]
+pub struct LimitJoinRightSide {
+    limit: usize,
+}
+
+impl LimitJoinRightSide {
+    pub fn new(limit: usize) -> Self {
+        Self { limit }
+    }
+}
+
+impl OptimizerRule for LimitJoinRightSide {
+    fn name(&self) -> &str {
+        "limit_join_right_side"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::TopDown)
+    }
+
+    fn supports_rewrite(&self) -> bool {
+        true
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>> {
+        match plan {
+            LogicalPlan::Join(mut join) => {
+                let plan = (*join.right)
+                    .clone()
+                    .rewrite(&mut AddSortAndLimit::new(self.limit, 0))?
+                    .data;
+                join.right = Arc::new(plan);
+                Ok(Transformed::yes(LogicalPlan::Join(join)))
+            }
+            _ => Ok(Transformed::no(plan)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{Int64Array, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::{
+        arrow::record_batch::RecordBatch,
+        common::Result,
+        datasource::MemTable,
+        execution::{
+            runtime_env::{RuntimeConfig, RuntimeEnv},
+            SessionStateBuilder,
+        },
+        physical_plan::get_plan_string,
+        prelude::{SessionConfig, SessionContext},
+    };
+
+    use super::LimitJoinRightSide;
+
+    #[tokio::test]
+    async fn test_subquery() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("_timestamp", DataType::Int64, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+            ],
+        )
+        .unwrap();
+
+        let state = SessionStateBuilder::new()
+            .with_config(SessionConfig::new().with_target_partitions(12))
+            .with_runtime_env(Arc::new(
+                RuntimeEnv::try_new(RuntimeConfig::default()).unwrap(),
+            ))
+            .with_default_features()
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+        ctx.add_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000)));
+        let provider1 = MemTable::try_new(schema.clone(), vec![vec![batch.clone()]]).unwrap();
+        ctx.register_table("t1", Arc::new(provider1)).unwrap();
+
+        let sql = "SELECT count(*) from t1 where name in (select distinct name from t1)";
+        let plan = ctx.state().create_logical_plan(sql).await?;
+        let plan = ctx.state().optimize(&plan)?;
+
+        // println!("{}", plan.to_string());
+
+        let physical_plan = ctx.state().create_physical_plan(&plan).await?;
+
+        // use datafusion::physical_plan::displayable;
+        // println!(
+        //     "{}",
+        //     displayable(physical_plan.as_ref())
+        //         .indent(false)
+        //         .to_string()
+        // );
+
+        let expected = vec![
+            "AggregateExec: mode=Final, gby=[], aggr=[count(*)]", 
+            "  CoalescePartitionsExec", 
+            "    AggregateExec: mode=Partial, gby=[], aggr=[count(*)]", 
+            "      ProjectionExec: expr=[]", 
+            "        CoalesceBatchesExec: target_batch_size=8192", 
+            "          HashJoinExec: mode=Partitioned, join_type=LeftSemi, on=[(name@0, name@0)]", 
+            "            CoalesceBatchesExec: target_batch_size=8192", 
+            "              RepartitionExec: partitioning=Hash([name@0], 12), input_partitions=1", 
+            "                MemoryExec: partitions=1, partition_sizes=[1]", 
+            "            CoalesceBatchesExec: target_batch_size=8192", 
+            "              RepartitionExec: partitioning=Hash([name@0], 12), input_partitions=12", 
+            "                RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1", 
+            "                  GlobalLimitExec: skip=0, fetch=50000", 
+            "                    CoalescePartitionsExec", 
+            "                      AggregateExec: mode=FinalPartitioned, gby=[name@0 as name], aggr=[], lim=[50000]", 
+            "                        CoalesceBatchesExec: target_batch_size=8192", 
+            "                          RepartitionExec: partitioning=Hash([name@0], 12), input_partitions=12", 
+            "                            RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1", 
+            "                              AggregateExec: mode=Partial, gby=[name@0 as name], aggr=[], lim=[50000]", 
+            "                                MemoryExec: partitions=1, partition_sizes=[1]"
+        ];
+
+        assert_eq!(expected, get_plan_string(&physical_plan));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_join_two_table() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("_timestamp", DataType::Int64, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+            ],
+        )
+        .unwrap();
+
+        let state = SessionStateBuilder::new()
+            .with_config(SessionConfig::new().with_target_partitions(12))
+            .with_runtime_env(Arc::new(
+                RuntimeEnv::try_new(RuntimeConfig::default()).unwrap(),
+            ))
+            .with_default_features()
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+        ctx.add_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000)));
+        let provider1 = MemTable::try_new(schema.clone(), vec![vec![batch.clone()]]).unwrap();
+        let provider2 = MemTable::try_new(schema, vec![vec![batch.clone()], vec![batch]]).unwrap();
+        ctx.register_table("t1", Arc::new(provider1)).unwrap();
+        ctx.register_table("t2", Arc::new(provider2)).unwrap();
+
+        let sql = "SELECT t1.id from t1 join t2 on t1.id = t2.id";
+        let plan = ctx.state().create_logical_plan(sql).await?;
+        let plan = ctx.state().optimize(&plan)?;
+
+        // println!("{}", plan.to_string());
+
+        let physical_plan = ctx.state().create_physical_plan(&plan).await?;
+
+        // use datafusion::physical_plan::displayable;
+        // println!(
+        //     "{}",
+        //     displayable(physical_plan.as_ref())
+        //         .indent(false)
+        //         .to_string()
+        // );
+
+        let expected = vec![
+            "CoalesceBatchesExec: target_batch_size=8192", 
+            "  HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, id@0)], projection=[id@1]", 
+            "    ProjectionExec: expr=[id@0 as id]", 
+            "      SortPreservingMergeExec: [_timestamp@1 DESC NULLS LAST], fetch=50000", 
+            "        SortExec: TopK(fetch=50000), expr=[_timestamp@1 DESC NULLS LAST], preserve_partitioning=[true]", 
+            "          MemoryExec: partitions=2, partition_sizes=[1, 1]", 
+            "    MemoryExec: partitions=1, partition_sizes=[1]"
+        ];
+
+        assert_eq!(expected, get_plan_string(&physical_plan));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_join_three_table() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("usr_id", DataType::Int64, false),
+            Field::new("prod_id", DataType::Int64, false),
+            Field::new("_timestamp", DataType::Int64, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(Int64Array::from(vec![4, 5, 6])),
+                Arc::new(Int64Array::from(vec![7, 8, 9])),
+            ],
+        )
+        .unwrap();
+
+        let state = SessionStateBuilder::new()
+            .with_config(SessionConfig::new().with_target_partitions(12))
+            .with_runtime_env(Arc::new(
+                RuntimeEnv::try_new(RuntimeConfig::default()).unwrap(),
+            ))
+            .with_default_features()
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+        ctx.add_optimizer_rule(Arc::new(LimitJoinRightSide::new(50_000)));
+        let provider1 = MemTable::try_new(schema.clone(), vec![vec![batch.clone()]]).unwrap();
+        let provider2 = MemTable::try_new(
+            schema.clone(),
+            vec![vec![batch.clone()], vec![batch.clone()]],
+        )
+        .unwrap();
+        let provider3 = MemTable::try_new(
+            schema,
+            vec![vec![batch.clone()], vec![batch.clone()], vec![batch]],
+        )
+        .unwrap();
+        ctx.register_table("t1", Arc::new(provider1)).unwrap();
+        ctx.register_table("t2", Arc::new(provider2)).unwrap();
+        ctx.register_table("t3", Arc::new(provider3)).unwrap();
+
+        let sql = "SELECT t1.usr_id, t2.prod_id from t1 join t2 on t1.usr_id = t2.usr_id join t3 on t2.prod_id = t3.prod_id";
+        let plan = ctx.state().create_logical_plan(sql).await?;
+        let plan = ctx.state().optimize(&plan)?;
+
+        // println!("{}", plan.to_string());
+
+        let physical_plan = ctx.state().create_physical_plan(&plan).await?;
+
+        // use datafusion::physical_plan::displayable;
+        // println!(
+        //     "{}",
+        //     displayable(physical_plan.as_ref())
+        //         .indent(false)
+        //         .to_string()
+        // );
+
+        let expected = vec![
+            "CoalesceBatchesExec: target_batch_size=8192", 
+            "  HashJoinExec: mode=Partitioned, join_type=Inner, on=[(prod_id@1, prod_id@0)], projection=[usr_id@0, prod_id@1]", 
+            "    CoalesceBatchesExec: target_batch_size=8192", 
+            "      RepartitionExec: partitioning=Hash([prod_id@1], 12), input_partitions=12", 
+            "        RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1", 
+            "          ProjectionExec: expr=[usr_id@1 as usr_id, prod_id@0 as prod_id]", 
+            "            CoalesceBatchesExec: target_batch_size=8192", 
+            "              HashJoinExec: mode=Partitioned, join_type=Inner, on=[(usr_id@0, usr_id@0)], projection=[prod_id@1, usr_id@2]", 
+            "                ProjectionExec: expr=[usr_id@0 as usr_id, prod_id@1 as prod_id]", 
+            "                  SortPreservingMergeExec: [_timestamp@2 DESC NULLS LAST], fetch=50000", 
+            "                    SortExec: TopK(fetch=50000), expr=[_timestamp@2 DESC NULLS LAST], preserve_partitioning=[true]", 
+            "                      MemoryExec: partitions=2, partition_sizes=[1, 1]", 
+            "                MemoryExec: partitions=1, partition_sizes=[1]", 
+            "    CoalesceBatchesExec: target_batch_size=8192", 
+            "      RepartitionExec: partitioning=Hash([prod_id@0], 12), input_partitions=1", 
+            "        ProjectionExec: expr=[prod_id@0 as prod_id]", 
+            "          SortPreservingMergeExec: [_timestamp@1 DESC NULLS LAST], fetch=50000", 
+            "            SortExec: TopK(fetch=50000), expr=[_timestamp@1 DESC NULLS LAST], preserve_partitioning=[true]", 
+            "              MemoryExec: partitions=3, partition_sizes=[1, 1, 1]"
+        ];
+
+        assert_eq!(expected, get_plan_string(&physical_plan));
+
+        Ok(())
+    }
+}

--- a/src/service/search/datafusion/optimizer/mod.rs
+++ b/src/service/search/datafusion/optimizer/mod.rs
@@ -33,6 +33,7 @@ use datafusion::optimizer::{
     unwrap_cast_in_comparison::UnwrapCastInComparison, OptimizerRule,
 };
 use infra::schema::get_stream_setting_fts_fields;
+use limit_join_right_side::LimitJoinRightSide;
 use rewrite_histogram::RewriteHistogram;
 use rewrite_match::RewriteMatch;
 
@@ -41,10 +42,13 @@ use crate::service::search::sql::Sql;
 pub mod add_sort_and_limit;
 pub mod add_timestamp;
 pub mod join_reorder;
+pub mod limit_join_right_side;
 pub mod rewrite_histogram;
 pub mod rewrite_match;
+pub mod utils;
 
 pub fn generate_optimizer_rules(sql: &Sql) -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
+    let cfg = config::get_config();
     let limit = if sql.limit as i32 > config::QUERY_WITH_NO_LIMIT {
         if sql.limit > 0 {
             Some(sql.limit as usize)
@@ -75,6 +79,12 @@ pub fn generate_optimizer_rules(sql: &Sql) -> Vec<Arc<dyn OptimizerRule + Send +
         // *********** custom rules ***********
         rules.push(Arc::new(RewriteMatch::new(fields)));
         // ************************************
+    }
+
+    if cfg.common.feature_join_right_side_max_rows > 0 {
+        rules.push(Arc::new(LimitJoinRightSide::new(
+            cfg.common.feature_join_right_side_max_rows,
+        )));
     }
 
     rules.push(Arc::new(EliminateNestedUnion::new()));

--- a/src/service/search/datafusion/optimizer/utils.rs
+++ b/src/service/search/datafusion/optimizer/utils.rs
@@ -39,7 +39,6 @@ pub fn is_complex_query(plan: &LogicalPlan) -> bool {
             | LogicalPlan::Join(_)
             | LogicalPlan::Distinct(_)
             | LogicalPlan::RecursiveQuery(_)
-            | LogicalPlan::SubqueryAlias(_)
             | LogicalPlan::Subquery(_)
             | LogicalPlan::Window(_)
             | LogicalPlan::Union(_)
@@ -68,7 +67,7 @@ impl TreeNodeRewriter for AddSortAndLimit {
         let is_complex = node.exists(|plan| Ok(is_complex_query(plan)))?;
         let mut is_stop = true;
         let (mut transformed, schema) = match node {
-            LogicalPlan::Projection(_) => {
+            LogicalPlan::Projection(_) | LogicalPlan::SubqueryAlias(_) => {
                 is_stop = false;
                 (Transformed::no(node), None)
             }

--- a/src/service/search/datafusion/optimizer/utils.rs
+++ b/src/service/search/datafusion/optimizer/utils.rs
@@ -282,13 +282,17 @@ fn generate_table_source_with_sorted_by_time(
         .as_any()
         .downcast_ref::<DefaultTableSource>()
         .unwrap();
-    let table_provider = source
+    if let Some(table_provider) = source
         .table_provider
         .as_any()
         .downcast_ref::<NewEmptyTable>()
-        .unwrap();
-    let mut new_table_provider = (*table_provider).clone();
-    new_table_provider.sorted_by_time = true;
-    let new_source = DefaultTableSource::new(Arc::new(new_table_provider));
-    Arc::new(new_source)
+    {
+        let mut new_table_provider = (*table_provider).clone();
+        new_table_provider.sorted_by_time = true;
+        let new_source = DefaultTableSource::new(Arc::new(new_table_provider));
+        Arc::new(new_source)
+    } else {
+        // for unit test
+        table_source
+    }
 }

--- a/src/service/search/datafusion/optimizer/utils.rs
+++ b/src/service/search/datafusion/optimizer/utils.rs
@@ -1,0 +1,242 @@
+// Copyright 2024 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use config::get_config;
+use datafusion::{
+    common::{
+        tree_node::{
+            Transformed, TransformedResult, TreeNode, TreeNodeRecursion, TreeNodeRewriter,
+        },
+        DFSchema, Result,
+    },
+    logical_expr::{col, Limit, LogicalPlan, Projection, Sort, SortExpr, TableScan},
+    prelude::Expr,
+    scalar::ScalarValue,
+};
+
+// check if the plan is a complex query that we can't add sort _timestamp
+pub fn is_complex_query(plan: &LogicalPlan) -> bool {
+    matches!(
+        plan,
+        LogicalPlan::Aggregate(_)
+            | LogicalPlan::Join(_)
+            | LogicalPlan::Distinct(_)
+            | LogicalPlan::RecursiveQuery(_)
+            | LogicalPlan::SubqueryAlias(_)
+            | LogicalPlan::Subquery(_)
+            | LogicalPlan::Window(_)
+            | LogicalPlan::Union(_)
+    )
+}
+
+pub struct AddSortAndLimit {
+    pub limit: usize,
+    pub offset: usize,
+}
+
+impl AddSortAndLimit {
+    pub fn new(limit: usize, offset: usize) -> Self {
+        Self { limit, offset }
+    }
+}
+
+impl TreeNodeRewriter for AddSortAndLimit {
+    type Node = LogicalPlan;
+
+    fn f_down(&mut self, node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+        if self.limit == 0 {
+            return Ok(Transformed::new(node, false, TreeNodeRecursion::Stop));
+        }
+
+        let is_complex = node.exists(|plan| Ok(is_complex_query(plan)))?;
+        let mut is_stop = true;
+        let (mut transformed, schema) = match node {
+            LogicalPlan::Projection(_) => {
+                is_stop = false;
+                (Transformed::no(node), None)
+            }
+            LogicalPlan::Limit(mut limit) => match limit.input.as_ref() {
+                LogicalPlan::Sort(_) => (Transformed::no(LogicalPlan::Limit(limit)), None),
+                _ => {
+                    if is_complex {
+                        (Transformed::no(LogicalPlan::Limit(limit)), None)
+                    } else {
+                        // the add sort plan should reflect the limit
+                        let fetch = get_int_from_expr(&limit.fetch);
+                        let skip = get_int_from_expr(&limit.skip);
+                        let (sort, schema) = generate_sort_plan(limit.input.clone(), fetch + skip);
+                        limit.input = Arc::new(sort);
+                        (Transformed::yes(LogicalPlan::Limit(limit)), schema)
+                    }
+                }
+            },
+            LogicalPlan::Sort(sort) => {
+                if sort.fetch.is_some() {
+                    (Transformed::no(LogicalPlan::Sort(sort)), None)
+                } else {
+                    let plan = generate_limit_plan(
+                        Arc::new(LogicalPlan::Sort(sort)),
+                        self.limit,
+                        self.offset,
+                    );
+                    (Transformed::yes(plan), None)
+                }
+            }
+            _ => {
+                if is_complex {
+                    (
+                        Transformed::yes(generate_limit_plan(
+                            Arc::new(node),
+                            self.limit,
+                            self.offset,
+                        )),
+                        None,
+                    )
+                } else {
+                    let (plan, schema) =
+                        generate_limit_and_sort_plan(Arc::new(node), self.limit, self.offset);
+                    (Transformed::yes(plan), schema)
+                }
+            }
+        };
+        if is_stop {
+            transformed.tnr = TreeNodeRecursion::Stop;
+        }
+        if let Some(schema) = schema {
+            let plan = transformed.data;
+            let proj = LogicalPlan::Projection(Projection::new_from_schema(Arc::new(plan), schema));
+            transformed.data = proj;
+        }
+        Ok(transformed)
+    }
+}
+
+fn generate_limit_plan(input: Arc<LogicalPlan>, limit: usize, skip: usize) -> LogicalPlan {
+    LogicalPlan::Limit(Limit {
+        skip: Some(Box::new(Expr::Literal(ScalarValue::Int64(Some(
+            skip as i64,
+        ))))),
+        fetch: Some(Box::new(Expr::Literal(ScalarValue::Int64(Some(
+            limit as i64,
+        ))))),
+        input,
+    })
+}
+
+fn generate_sort_plan(
+    input: Arc<LogicalPlan>,
+    limit: usize,
+) -> (LogicalPlan, Option<Arc<DFSchema>>) {
+    let config = get_config();
+    let timestamp = SortExpr {
+        expr: col(config.common.column_timestamp.clone()),
+        asc: false,
+        nulls_first: false,
+    };
+    let schema = input.schema().clone();
+    if schema
+        .field_with_name(None, config.common.column_timestamp.as_str())
+        .is_err()
+    {
+        let mut input = input.as_ref().clone();
+        input = input
+            .rewrite(&mut ChangeTableScanSchema::new())
+            .data()
+            .unwrap();
+        return (
+            LogicalPlan::Sort(Sort {
+                expr: vec![timestamp],
+                input: Arc::new(input),
+                fetch: Some(limit),
+            }),
+            Some(schema),
+        );
+    }
+    (
+        LogicalPlan::Sort(Sort {
+            expr: vec![timestamp],
+            input,
+            fetch: Some(limit),
+        }),
+        None,
+    )
+}
+
+fn generate_limit_and_sort_plan(
+    input: Arc<LogicalPlan>,
+    limit: usize,
+    skip: usize,
+) -> (LogicalPlan, Option<Arc<DFSchema>>) {
+    let (sort, schema) = generate_sort_plan(input, limit + skip);
+    (
+        LogicalPlan::Limit(Limit {
+            skip: Some(Box::new(Expr::Literal(ScalarValue::Int64(Some(
+                skip as i64,
+            ))))),
+            fetch: Some(Box::new(Expr::Literal(ScalarValue::Int64(Some(
+                limit as i64,
+            ))))),
+            input: Arc::new(sort),
+        }),
+        schema,
+    )
+}
+
+fn get_int_from_expr(expr: &Option<Box<Expr>>) -> usize {
+    match expr {
+        Some(expr) => match expr.as_ref() {
+            Expr::Literal(ScalarValue::Int64(Some(value))) => *value as usize,
+            _ => 0,
+        },
+        _ => 0,
+    }
+}
+
+struct ChangeTableScanSchema {}
+
+impl ChangeTableScanSchema {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl TreeNodeRewriter for ChangeTableScanSchema {
+    type Node = LogicalPlan;
+
+    fn f_up(&mut self, node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+        let mut transformed = match node {
+            LogicalPlan::TableScan(scan) => {
+                let schema = scan.source.schema();
+                let timestamp_idx =
+                    schema.index_of(get_config().common.column_timestamp.as_str())?;
+                let mut projection = scan.projection.clone().unwrap();
+                projection.push(timestamp_idx);
+                let table_scan = TableScan::try_new(
+                    scan.table_name,
+                    scan.source,
+                    Some(projection),
+                    scan.filters,
+                    scan.fetch,
+                )?;
+                Transformed::yes(LogicalPlan::TableScan(table_scan))
+            }
+            _ => Transformed::no(node),
+        };
+        transformed.tnr = TreeNodeRecursion::Stop;
+        Ok(transformed)
+    }
+}

--- a/src/service/search/datafusion/table_provider/empty_table.rs
+++ b/src/service/search/datafusion/table_provider/empty_table.rs
@@ -30,12 +30,12 @@ use crate::service::search::datafusion::distributed_plan::empty_exec::NewEmptyEx
 
 /// An empty plan that is useful for testing and generating plans
 /// without mapping them to actual data.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NewEmptyTable {
     name: String,
     schema: SchemaRef,
     partitions: usize,
-    sorted_by_time: bool,
+    pub sorted_by_time: bool,
 }
 
 impl NewEmptyTable {


### PR DESCRIPTION
related #5602

## New env
```
ZO_FEATURE_JOIN_RIGHT_SIDE_MAX_ROWS=0
```
default is 0, means disable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configuration option to limit rows on the right side of join operations
	- Introduced new optimization rules for query processing

- **Improvements**
	- Enhanced DataFusion query optimizer with more flexible sorting and limiting capabilities
	- Streamlined logical plan transformation logic

- **Configuration**
	- New environment variable `ZO_FEATURE_JOIN_RIGHT_SIDE_MAX_ROWS` added to control join row limits

- **Technical Enhancements**
	- Updated table provider and optimizer utilities
	- Improved query plan optimization strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->