### PR TITLE
feat: New `MoveAlert` endpoint

### DIFF
--- a/src/handler/http/models/alerts/requests.rs
+++ b/src/handler/http/models/alerts/requests.rs
@@ -15,6 +15,7 @@
 
 use config::meta::alerts::alert as meta_alerts;
 use serde::Deserialize;
+use svix_ksuid::Ksuid;
 use utoipa::ToSchema;
 
 use super::{Alert, StreamType};
@@ -33,6 +34,16 @@ pub struct CreateAlertRequestBody {
 /// HTTP request body for `UpdateAlert` endpoint.
 #[derive(Clone, Debug, Deserialize, ToSchema)]
 pub struct UpdateAlertRequestBody(pub Alert);
+
+/// HTTP request body for `MoveAlerts` endpoint.
+#[derive(Clone, Debug, Deserialize, ToSchema)]
+pub struct MoveAlertsRequestBody {
+    /// IDs of the alerts to move.
+    pub alert_ids: Vec<Ksuid>,
+
+    /// Indicates the folder to which alerts should be moved.
+    pub dst_folder_id: String,
+}
 
 /// HTTP URL query component that contains parameters for listing alerts.
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
@@ -81,7 +92,7 @@ pub struct EnableAlertQuery {
 #[into_params(style = Form, parameter_in = Query)]
 #[serde(rename_all = "snake_case")]
 pub struct MoveAlertQuery {
-    pub from: String,
+    pub id: Vec<Ksuid>,
     pub to: String,
 }
 

--- a/src/handler/http/models/alerts/requests.rs
+++ b/src/handler/http/models/alerts/requests.rs
@@ -87,15 +87,6 @@ pub struct EnableAlertQuery {
     pub value: bool,
 }
 
-/// HTTP URL query component that contains parameters for moving alerts.
-#[derive(Debug, Deserialize, utoipa::IntoParams)]
-#[into_params(style = Form, parameter_in = Query)]
-#[serde(rename_all = "snake_case")]
-pub struct MoveAlertQuery {
-    pub id: Vec<Ksuid>,
-    pub to: String,
-}
-
 impl From<CreateAlertRequestBody> for meta_alerts::Alert {
     fn from(value: CreateAlertRequestBody) -> Self {
         value.alert.into()

--- a/src/handler/http/models/alerts/requests.rs
+++ b/src/handler/http/models/alerts/requests.rs
@@ -76,6 +76,15 @@ pub struct EnableAlertQuery {
     pub value: bool,
 }
 
+/// HTTP URL query component that contains parameters for moving alerts.
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+#[into_params(style = Form, parameter_in = Query)]
+#[serde(rename_all = "snake_case")]
+pub struct MoveAlertQuery {
+    pub from: String,
+    pub to: String,
+}
+
 impl From<CreateAlertRequestBody> for meta_alerts::Alert {
     fn from(value: CreateAlertRequestBody) -> Self {
         value.alert.into()

--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -22,8 +22,8 @@ use crate::{
     common::{meta::http::HttpResponse as MetaHttpResponse, utils::auth::UserEmail},
     handler::http::models::alerts::{
         requests::{
-            CreateAlertRequestBody, EnableAlertQuery, ListAlertsQuery, MoveAlertQuery,
-            MoveAlertsRequestBody, UpdateAlertRequestBody,
+            CreateAlertRequestBody, EnableAlertQuery, ListAlertsQuery, MoveAlertsRequestBody,
+            UpdateAlertRequestBody,
         },
         responses::{EnableAlertResponseBody, GetAlertResponseBody, ListAlertsResponseBody},
     },
@@ -47,7 +47,6 @@ impl From<AlertError> for HttpResponse {
             AlertError::CreateAlreadyExists => MetaHttpResponse::conflict(value),
             AlertError::CreateFolderNotFound => MetaHttpResponse::not_found(value),
             AlertError::MoveDestinationFolderNotFound => MetaHttpResponse::not_found(value),
-            AlertError::MoveAlertNotInSourceFolder => MetaHttpResponse::conflict(value),
             AlertError::AlertNotFound => MetaHttpResponse::not_found(value),
             AlertError::AlertDestinationNotFound { .. } => MetaHttpResponse::not_found(value),
             AlertError::StreamNotFound { .. } => MetaHttpResponse::not_found(value),

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -428,7 +428,7 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(alerts::list_alerts)
         .service(alerts::enable_alert)
         .service(alerts::trigger_alert)
-        .service(alerts::move_alert)
+        .service(alerts::move_alerts)
         .service(alerts::deprecated::save_alert)
         .service(alerts::deprecated::update_alert)
         .service(alerts::deprecated::get_alert)

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -428,6 +428,7 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(alerts::list_alerts)
         .service(alerts::enable_alert)
         .service(alerts::trigger_alert)
+        .service(alerts::move_alert)
         .service(alerts::deprecated::save_alert)
         .service(alerts::deprecated::update_alert)
         .service(alerts::deprecated::get_alert)

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -107,6 +107,7 @@ use crate::{common::meta, handler::http::request};
         request::alerts::list_alerts,
         request::alerts::enable_alert,
         request::alerts::trigger_alert,
+        request::alerts::move_alert,
         request::alerts::templates::list_templates,
         request::alerts::templates::get_template,
         request::alerts::templates::save_template,

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -107,7 +107,7 @@ use crate::{common::meta, handler::http::request};
         request::alerts::list_alerts,
         request::alerts::enable_alert,
         request::alerts::trigger_alert,
-        request::alerts::move_alert,
+        request::alerts::move_alerts,
         request::alerts::templates::list_templates,
         request::alerts::templates::get_template,
         request::alerts::templates::save_template,

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -184,6 +184,7 @@ use crate::{common::meta, handler::http::request};
             // Alerts
             crate::handler::http::models::alerts::requests::CreateAlertRequestBody,
             crate::handler::http::models::alerts::requests::UpdateAlertRequestBody,
+            crate::handler::http::models::alerts::requests::MoveAlertsRequestBody,
             crate::handler::http::models::alerts::responses::GetAlertResponseBody,
             crate::handler::http::models::alerts::responses::ListAlertsResponseBody,
             crate::handler::http::models::alerts::responses::ListAlertsResponseBodyItem,

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -95,11 +95,6 @@ pub enum AlertError {
 
     /// Error that occurs when trying to move an alert to a destination folder
     /// that cannot be found.
-    #[error("Error moving alert because the alert is no longer in the original folder")]
-    MoveAlertNotInSourceFolder,
-
-    /// Error that occurs when trying to move an alert to a destination folder
-    /// that cannot be found.
     #[error("Error moving alert to folder that cannot be found")]
     MoveDestinationFolderNotFound,
 

--- a/src/service/db/alerts/alert/mod.rs
+++ b/src/service/db/alerts/alert/mod.rs
@@ -36,11 +36,12 @@ use infra::db::{connect_to_orm, ORM_CLIENT};
 use sea_orm::{ConnectionTrait, TransactionTrait};
 use svix_ksuid::Ksuid;
 
+/// Gets the alert and its parent folder.
 pub async fn get_by_id<C: ConnectionTrait>(
     conn: &C,
     org_id: &str,
     alert_id: Ksuid,
-) -> Result<Option<Alert>, infra::errors::Error> {
+) -> Result<Option<(Folder, Alert)>, infra::errors::Error> {
     new::get_by_id(conn, org_id, alert_id).await
 }
 

--- a/src/service/db/alerts/alert/new.rs
+++ b/src/service/db/alerts/alert/new.rs
@@ -32,17 +32,16 @@ use svix_ksuid::Ksuid;
 
 use crate::{common::infra::config::STREAM_ALERTS, service::db};
 
+/// Gets the alert and its parent folder.
 pub async fn get_by_id<C: ConnectionTrait>(
     conn: &C,
     org_id: &str,
     alert_id: Ksuid,
-) -> Result<Option<Alert>, infra::errors::Error> {
+) -> Result<Option<(Folder, Alert)>, infra::errors::Error> {
     // We cannot check the cache because the cache stores alerts by stream type
     // and stream name which are currently unknown.
-    let alert = table::get_by_id(conn, org_id, alert_id)
-        .await?
-        .map(|(_f, a)| a);
-    Ok(alert)
+    let folder_and_alert = table::get_by_id(conn, org_id, alert_id).await?;
+    Ok(folder_and_alert)
 }
 
 pub async fn get_by_name(


### PR DESCRIPTION
Adds a new endpoint for moving an alert between different folders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added ability to move alerts between folders.
	- Introduced new endpoint for moving alerts.
	- Enhanced alert management with improved validation and error handling.

- **Bug Fixes**
	- Improved alert retrieval to include folder context.

- **Documentation**
	- Updated OpenAPI documentation to include new alert movement endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->