### PR TITLE
fix: metrics ingestion with otlp json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,14 +372,14 @@ dependencies = [
 
 [[package]]
 name = "actix-web-opentelemetry"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e0327e7b731c61b77fb54b278477aa3ebd09752bde38d169863167636e2d48"
+checksum = "4c72677f49b2d25f10bb235d7db8e2f6688b6180e2ccde0f0be63894492b326d"
 dependencies = [
  "actix-http",
  "actix-web",
  "futures-util",
- "opentelemetry 0.22.0",
+ "opentelemetry 0.24.0",
  "opentelemetry-semantic-conventions",
  "serde",
 ]
@@ -6106,7 +6106,7 @@ dependencies = [
  "mimalloc",
  "object_store",
  "once_cell",
- "opentelemetry 0.25.0",
+ "opentelemetry 0.26.0",
  "opentelemetry-otlp",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -6167,9 +6167,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -6177,14 +6177,13 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "thiserror 1.0.69",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803801d3d3b71cd026851a53f974ea03df3d179cb758b260136a6c9e22e196af"
+checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -6196,27 +6195,27 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8c2b76e5f7848a289aa9666dbe56b16f8a22a4c5246ef37a14941818d2913"
+checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.2.0",
- "opentelemetry 0.25.0",
+ "opentelemetry 0.26.0",
  "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "596b1719b3cab83addb20bcbffdf21575279d9436d9ccccfe651a3bf0ab5ab06"
+checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
 dependencies = [
  "async-trait",
  "futures-core",
  "http 1.2.0",
- "opentelemetry 0.25.0",
+ "opentelemetry 0.26.0",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -6231,12 +6230,12 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c43620e8f93359eb7e627a3b16ee92d8585774986f24f2ab010817426c5ce61"
+checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
 dependencies = [
  "hex",
- "opentelemetry 0.25.0",
+ "opentelemetry 0.26.0",
  "opentelemetry_sdk",
  "prost 0.13.4",
  "serde",
@@ -6245,15 +6244,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0da0d6b47a3dbc6e9c9e36a0520e25cf943e046843818faaa3f87365a548c82"
+checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -6261,7 +6260,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.25.0",
+ "opentelemetry 0.26.0",
  "percent-encoding",
  "rand",
  "serde_json",
@@ -9707,13 +9706,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eabc56d23707ad55ba2a0750fc24767125d5a0f51993ba41ad2c441cc7b8dea"
+checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.25.0",
+ "opentelemetry 0.26.0",
  "opentelemetry_sdk",
  "smallvec",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ actix-multipart = { version = "0.7", features = ["derive"] }
 actix-web.workspace = true
 actix-web-httpauth = "0.8"
 actix-web-lab = "0.20"
-actix-web-opentelemetry = { version = "0.17", features = ["metrics"] }
+actix-web-opentelemetry = { version = "0.19", features = ["metrics"] }
 actix-web-prometheus.workspace = true
 actix-web-rust-embed-responder = { version = "2.2", default-features = false, features = [
     "support-rust-embed-for-web",
@@ -112,26 +112,10 @@ maxminddb = "0.23.0"
 memory-stats = "1.1.0"
 mimalloc = { version = "0.1", default-features = false, optional = true }
 once_cell.workspace = true
-opentelemetry = "0.25"
-opentelemetry_sdk = { version = "0.25", features = [
-    "rt-tokio",
-    "trace",
-    "metrics",
-] }
-opentelemetry-otlp = { version = "0.25", features = [
-    "http-proto",
-    "serialize",
-    "serde",
-    "trace",
-    "reqwest-client",
-] }
-opentelemetry-proto = { version = "0.25", features = [
-    "gen-tonic",
-    "with-serde",
-    "logs",
-    "metrics",
-    "trace",
-] }
+opentelemetry.workspace = true
+opentelemetry_sdk.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry-proto.workspace = true
 parking_lot.workspace = true
 prometheus.workspace = true
 promql-parser = "0.4"
@@ -223,7 +207,12 @@ report_server = { path = "src/report_server" }
 ahash = { version = "0.8", features = ["serde"] }
 actix-web = { version = "4.9", features = ["rustls-0_23"] }
 actix-web-prometheus = { version = "0.1", features = ["process"] }
-actix-tls = { version = "3.4", features = ["connect", "uri", "rustls-0_23-native-roots", "rustls-0_23-webpki-roots"] }
+actix-tls = { version = "3.4", features = [
+    "connect",
+    "uri",
+    "rustls-0_23-native-roots",
+    "rustls-0_23-webpki-roots",
+] }
 anyhow = "1.0"
 arc-swap = "1.7.1"
 argon2 = { version = "0.5", features = ["alloc", "password-hash"] }
@@ -298,7 +287,10 @@ reqwest = { version = "0.12", default-features = false, features = [
     "stream",
 ] }
 rustls-pemfile = "2"
-rustls = { version = "0.23.20", default-features = false, features = ["std", "tls12"]}
+rustls = { version = "0.23.20", default-features = false, features = [
+    "std",
+    "tls12",
+] }
 sea-orm = { version = "1.1.0", features = [
     "sqlx-all",
     "runtime-tokio-rustls",
@@ -337,11 +329,31 @@ tonic = { version = "0.12.3", features = ["gzip", "prost", "tls"] }
 tracing = "0.1.40"
 tracing-appender = "0.2.3"
 tracing-log = "0.2"
-tracing-opentelemetry = "0.26"
+tracing-opentelemetry = "0.27"
 tracing-subscriber = { version = "0.3.0", features = [
     "env-filter",
     "json",
     "registry",
+] }
+opentelemetry = "0.26"
+opentelemetry_sdk = { version = "0.26", features = [
+    "rt-tokio",
+    "trace",
+    "metrics",
+] }
+opentelemetry-otlp = { version = "0.26", features = [
+    "http-proto",
+    "serialize",
+    "serde",
+    "trace",
+    "reqwest-client",
+] }
+opentelemetry-proto = { version = "0.26", features = [
+    "gen-tonic",
+    "with-serde",
+    "logs",
+    "metrics",
+    "trace",
 ] }
 url = "2.2"
 urlencoding = "2.1"

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1033,6 +1033,8 @@ pub struct Limit {
     pub keep_alive: u64,
     #[env_config(name = "ZO_ACTIX_KEEP_ALIVE_DISABLED", default = false)]
     pub keep_alive_disabled: bool,
+    #[env_config(name = "ZO_ACTIX_SLOW_LOG_THRESHOLD", default = 5)] // seconds
+    pub http_slow_log_threshold: u64,
     #[env_config(name = "ZO_ACTIX_SHUTDOWN_TIMEOUT", default = 5)] // seconds
     pub http_shutdown_timeout: u64,
     #[env_config(name = "ZO_ALERT_SCHEDULE_INTERVAL", default = 10)] // seconds

--- a/src/handler/http/router/middlewares/check_keep_alive.rs
+++ b/src/handler/http/router/middlewares/check_keep_alive.rs
@@ -1,0 +1,35 @@
+// Copyright 2024 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use actix_web::{
+    body::MessageBody,
+    dev::{ServiceRequest, ServiceResponse},
+    http::{ConnectionType, StatusCode},
+};
+use actix_web_lab::middleware::Next;
+
+pub async fn check_keep_alive(
+    req: ServiceRequest,
+    next: Next<impl MessageBody>,
+) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
+    let req_conn_type = req.head().connection_type();
+    let mut resp = next.call(req).await?;
+    if resp.status() >= StatusCode::BAD_REQUEST || req_conn_type == ConnectionType::Close {
+        resp.response_mut()
+            .head_mut()
+            .set_connection_type(ConnectionType::Close);
+    }
+    Ok(resp)
+}

--- a/src/handler/http/router/middlewares/mod.rs
+++ b/src/handler/http/router/middlewares/mod.rs
@@ -1,0 +1,20 @@
+// Copyright 2024 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+mod check_keep_alive;
+mod slow_log;
+
+pub use check_keep_alive::check_keep_alive;
+pub use slow_log::SlowLog;

--- a/src/handler/http/router/middlewares/slow_log.rs
+++ b/src/handler/http/router/middlewares/slow_log.rs
@@ -1,0 +1,103 @@
+// Copyright 2024 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    future::{ready, Ready},
+    time::{Duration, Instant},
+};
+
+use actix_web::{
+    dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
+    Error,
+};
+use futures_util::future::LocalBoxFuture;
+
+pub struct SlowLog {
+    threshold_secs: u64,
+}
+
+impl SlowLog {
+    pub fn new(threshold_secs: u64) -> Self {
+        SlowLog { threshold_secs }
+    }
+}
+
+impl<S, B> Transform<S, ServiceRequest> for SlowLog
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = SlowLogMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(SlowLogMiddleware {
+            service,
+            threshold_secs: self.threshold_secs,
+        }))
+    }
+}
+
+pub struct SlowLogMiddleware<S> {
+    service: S,
+    threshold_secs: u64,
+}
+
+impl<S, B> Service<ServiceRequest> for SlowLogMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let start = Instant::now();
+        let path = req
+            .uri()
+            .path_and_query()
+            .map(|x| x.as_str())
+            .unwrap_or("")
+            .to_string();
+        let method = req.method().to_string();
+        let threshold = Duration::from_secs(self.threshold_secs);
+
+        let fut = self.service.call(req);
+
+        Box::pin(async move {
+            let res = fut.await?;
+            let duration = start.elapsed();
+
+            if duration > threshold {
+                log::warn!(
+                    "Slow request detected - method: {}, path: {}, took: {:.6}",
+                    method,
+                    path,
+                    duration.as_secs_f64()
+                );
+            }
+
+            Ok(res)
+        })
+    }
+}

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -19,7 +19,7 @@ use actix_cors::Cors;
 use actix_web::{
     body::MessageBody,
     dev::{Service, ServiceRequest, ServiceResponse},
-    http::{header, ConnectionType, StatusCode},
+    http::header,
     middleware, web, HttpRequest, HttpResponse,
 };
 use actix_web_httpauth::middleware::HttpAuthentication;
@@ -47,6 +47,7 @@ use super::{
 };
 use crate::common::meta::{middleware_data::RumExtraData, proxy::PathParamProxyURL};
 
+pub mod middlewares;
 pub mod openapi;
 pub mod ui;
 
@@ -145,28 +146,14 @@ async fn audit_middleware(
     next.call(req).await
 }
 
-async fn check_keep_alive(
-    req: ServiceRequest,
-    next: Next<impl MessageBody>,
-) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
-    let req_conn_type = req.head().connection_type();
-    let mut resp = next.call(req).await?;
-    if resp.status() >= StatusCode::BAD_REQUEST || req_conn_type == ConnectionType::Close {
-        resp.response_mut()
-            .head_mut()
-            .set_connection_type(ConnectionType::Close);
-    }
-    Ok(resp)
-}
-
 /// This is a very trivial proxy to overcome the cors errors while
 /// session-replay in rrweb.
-pub fn get_proxy_routes(cfg: &mut web::ServiceConfig) {
+pub fn get_proxy_routes(svc: &mut web::ServiceConfig) {
     let enable_authentication_on_route = true;
-    get_proxy_routes_inner(cfg, enable_authentication_on_route)
+    get_proxy_routes_inner(svc, enable_authentication_on_route)
 }
 
-pub fn get_proxy_routes_inner(cfg: &mut web::ServiceConfig, enable_validator: bool) {
+pub fn get_proxy_routes_inner(svc: &mut web::ServiceConfig, enable_validator: bool) {
     let cors = Cors::default()
         .allow_any_origin()
         .allow_any_method()
@@ -174,14 +161,14 @@ pub fn get_proxy_routes_inner(cfg: &mut web::ServiceConfig, enable_validator: bo
 
     if enable_validator {
         let auth = HttpAuthentication::with_fn(validator_proxy_url);
-        cfg.service(
+        svc.service(
             web::resource("/proxy/{org_id}/{target_url:.*}")
                 .wrap(auth)
                 .wrap(cors)
                 .route(web::get().to(proxy)),
         );
     } else {
-        cfg.service(
+        svc.service(
             web::resource("/proxy/{org_id}/{target_url:.*}")
                 .wrap(cors)
                 .route(web::get().to(proxy)),
@@ -210,12 +197,12 @@ async fn proxy(
     Ok(HttpResponse::build(actix_web::http::StatusCode::from_u16(status).unwrap()).body(body))
 }
 
-pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
+pub fn get_basic_routes(svc: &mut web::ServiceConfig) {
     let cors = get_cors();
-    cfg.service(status::healthz)
+    svc.service(status::healthz)
         .service(status::healthz_head)
         .service(status::schedulez);
-    cfg.service(
+    svc.service(
         web::scope("/auth")
             .wrap(cors.clone())
             .service(users::authentication)
@@ -223,7 +210,7 @@ pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
             .service(users::get_auth),
     );
 
-    cfg.service(
+    svc.service(
         web::scope("/node")
             .wrap(HttpAuthentication::with_fn(
                 super::auth::validator::oo_validator,
@@ -235,7 +222,7 @@ pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
     );
 
     if get_config().common.swagger_enabled {
-        cfg.service(
+        svc.service(
             SwaggerUi::new("/swagger/{_:.*}")
                 .url(
                     format!("{}/api-doc/openapi.json", get_config().common.base_uri),
@@ -243,14 +230,14 @@ pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
                 )
                 .url("/api-doc/openapi.json", openapi::ApiDoc::openapi()),
         );
-        cfg.service(web::redirect("/swagger", "/swagger/"));
-        cfg.service(web::redirect("/docs", "/swagger/"));
+        svc.service(web::redirect("/swagger", "/swagger/"));
+        svc.service(web::redirect("/docs", "/swagger/"));
     }
 
     if get_config().common.ui_enabled {
-        cfg.service(web::redirect("/", "./web/"));
-        cfg.service(web::redirect("/web", "./web/"));
-        cfg.service(
+        svc.service(web::redirect("/", "./web/"));
+        svc.service(web::redirect("/web", "./web/"));
+        svc.service(
             web::scope("/web")
                 .wrap_fn(|req, srv| {
                     let cfg = get_config();
@@ -289,9 +276,9 @@ pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
 }
 
 #[cfg(not(feature = "enterprise"))]
-pub fn get_config_routes(cfg: &mut web::ServiceConfig) {
+pub fn get_config_routes(svc: &mut web::ServiceConfig) {
     let cors = get_cors();
-    cfg.service(
+    svc.service(
         web::scope("/config")
             .wrap(cors.clone())
             .service(status::zo_config)
@@ -301,9 +288,9 @@ pub fn get_config_routes(cfg: &mut web::ServiceConfig) {
 }
 
 #[cfg(feature = "enterprise")]
-pub fn get_config_routes(cfg: &mut web::ServiceConfig) {
+pub fn get_config_routes(svc: &mut web::ServiceConfig) {
     let cors = get_cors();
-    cfg.service(
+    svc.service(
         web::scope("/config")
             .wrap(cors)
             .service(status::zo_config)
@@ -316,17 +303,18 @@ pub fn get_config_routes(cfg: &mut web::ServiceConfig) {
     );
 }
 
-pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
+pub fn get_service_routes(svc: &mut web::ServiceConfig) {
+    let cfg = get_config();
     let cors = get_cors();
     // set server header
     #[cfg(feature = "enterprise")]
     let server = format!(
         "{}-{}",
         get_o2_config().super_cluster.region,
-        get_config().common.instance_name_short
+        cfg.common.instance_name_short
     );
     #[cfg(not(feature = "enterprise"))]
-    let server = get_config().common.instance_name_short.to_string();
+    let server = cfg.common.instance_name_short.to_string();
 
     let service = web::scope("/api")
         .wrap(from_fn(audit_middleware))
@@ -334,7 +322,8 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
             super::auth::validator::oo_validator,
         ))
         .wrap(cors.clone())
-        .wrap(from_fn(check_keep_alive))
+        .wrap(middlewares::SlowLog::new(cfg.limit.http_slow_log_threshold))
+        .wrap(from_fn(middlewares::check_keep_alive))
         .wrap(middleware::DefaultHeaders::new().add(("X-Api-Node", server)))
         .service(users::list)
         .service(users::save)
@@ -525,13 +514,13 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
         .service(search::job::cancel_query)
         .service(search::job::query_status);
 
-    cfg.service(service);
+    svc.service(service);
 }
 
-pub fn get_other_service_routes(cfg: &mut web::ServiceConfig) {
+pub fn get_other_service_routes(svc: &mut web::ServiceConfig) {
     let cors = get_cors();
     let amz_auth = HttpAuthentication::with_fn(validator_aws);
-    cfg.service(
+    svc.service(
         web::scope("/aws")
             .wrap(cors.clone())
             .wrap(amz_auth)
@@ -539,7 +528,7 @@ pub fn get_other_service_routes(cfg: &mut web::ServiceConfig) {
     );
 
     let gcp_auth = HttpAuthentication::with_fn(validator_gcp);
-    cfg.service(
+    svc.service(
         web::scope("/gcp")
             .wrap(cors.clone())
             .wrap(gcp_auth)
@@ -550,7 +539,7 @@ pub fn get_other_service_routes(cfg: &mut web::ServiceConfig) {
     // `rum_auth`, we drop it in the RumExtraData data.
     // https://docs.rs/actix-web/latest/actix_web/middleware/index.html#ordering
     let rum_auth = HttpAuthentication::with_fn(validator_rum);
-    cfg.service(
+    svc.service(
         web::scope("/rum")
             .wrap(cors)
             .wrap(from_fn(RumExtraData::extractor))

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -199,6 +199,10 @@ impl Writer {
         }
     }
 
+    pub fn get_key_str(&self) -> String {
+        format!("{}/{}", self.key.org_id, self.key.stream_type)
+    }
+
     // check_ttl is used to check if the memtable has expired
     pub async fn write(&self, schema: Arc<Schema>, mut entry: Entry, fsync: bool) -> Result<()> {
         if entry.data.is_empty() {

--- a/src/job/metrics.rs
+++ b/src/job/metrics.rs
@@ -28,9 +28,8 @@ use once_cell::sync::Lazy;
 use opentelemetry::{global, metrics::Histogram, KeyValue};
 use opentelemetry_sdk::{
     metrics::{
-        new_view,
-        reader::{DefaultAggregationSelector, DefaultTemporalitySelector},
-        Aggregation, Instrument, PeriodicReader, SdkMeterProvider, Stream,
+        new_view, reader::DefaultTemporalitySelector, Aggregation, Instrument, PeriodicReader,
+        SdkMeterProvider, Stream,
     },
     runtime, Resource,
 };
@@ -291,7 +290,6 @@ pub async fn init_meter_provider() -> Result<SdkMeterProvider, anyhow::Error> {
     let exporter = O2MetricsExporter::new(
         O2MetricsClient::new(),
         Box::new(DefaultTemporalitySelector::new()),
-        Box::new(DefaultAggregationSelector::new()),
     );
     let reader = PeriodicReader::builder(exporter, runtime::Tokio)
         .with_interval(Duration::from_secs(

--- a/src/service/exporter/otlp_metrics_exporter.rs
+++ b/src/service/exporter/otlp_metrics_exporter.rs
@@ -23,8 +23,8 @@ use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequ
 use opentelemetry_sdk::metrics::{
     data::{ResourceMetrics, Temporality},
     exporter::PushMetricsExporter,
-    reader::{AggregationSelector, TemporalitySelector},
-    Aggregation, InstrumentKind,
+    reader::TemporalitySelector,
+    InstrumentKind,
 };
 
 use crate::service::metrics::otlp::handle_otlp_request;
@@ -40,7 +40,6 @@ pub trait MetricsClient: fmt::Debug + Send + Sync + 'static {
 pub struct O2MetricsExporter {
     client: Box<dyn MetricsClient>,
     temporality_selector: Box<dyn TemporalitySelector>,
-    aggregation_selector: Box<dyn AggregationSelector>,
 }
 
 impl Debug for O2MetricsExporter {
@@ -52,12 +51,6 @@ impl Debug for O2MetricsExporter {
 impl TemporalitySelector for O2MetricsExporter {
     fn temporality(&self, kind: InstrumentKind) -> Temporality {
         self.temporality_selector.temporality(kind)
-    }
-}
-
-impl AggregationSelector for O2MetricsExporter {
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        self.aggregation_selector.aggregation(kind)
     }
 }
 
@@ -82,12 +75,10 @@ impl O2MetricsExporter {
     pub fn new(
         client: impl MetricsClient,
         temporality_selector: Box<dyn TemporalitySelector>,
-        aggregation_selector: Box<dyn AggregationSelector>,
     ) -> O2MetricsExporter {
         O2MetricsExporter {
             client: Box::new(client),
             temporality_selector,
-            aggregation_selector,
         }
     }
 }

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -374,7 +374,12 @@ pub async fn write_file(
             (acc_records + records, acc_size + size)
         });
     if let Err(e) = writer.write_batch(entries, fsync).await {
-        log::error!("ingestion write file error: {}", e);
+        log::error!(
+            "ingestion write file for stream {}/{} error: {}",
+            writer.get_key_str(),
+            stream_name,
+            e
+        );
     }
 
     req_stats.size += entries_size as f64 / SIZE_IN_MB;

--- a/tests/api-testing/tests/test_traces.py
+++ b/tests/api-testing/tests/test_traces.py
@@ -161,7 +161,8 @@ def test_e2e_trace_invalid_ids(create_session, base_url):
     org_id = "default"
     
     start_time = int(time.time()*1000000)
-    end_time = start_time+100000000
+    start_time = start_time - 10000000
+    end_time = start_time + 100000000
     start_time_str = "{:d}".format(start_time)
     end_time_str = "{:d}".format(end_time)
     get_query_url = f"{url}api/{org_id}/default/traces/latest?filter=duration >= 0 AND duration <= 100000000&start_time={start_time_str}&end_time={end_time_str}&from=0&size=25"
@@ -182,8 +183,8 @@ def test_e2e_trace_invalid_ids(create_session, base_url):
     resp_post_trace = session.post(f"{url}api/{org_id}/v1/traces",json=trace)
 
     assert (
-        resp_post_trace.status_code == 200
-    ), f"Invalid trace span id expected 200, but got {resp_post_trace.status_code}"
+        resp_post_trace.status_code == 400
+    ), f"Invalid span id expected 400, but got {resp_post_trace.status_code}"
 
     trace = valid_trace()
     trace["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["links"] = [
@@ -198,10 +199,10 @@ def test_e2e_trace_invalid_ids(create_session, base_url):
     resp_post_trace = session.post(f"{url}api/{org_id}/v1/traces",json=trace)
 
     assert (
-        resp_post_trace.status_code == 200
-    ), f"Invalid trace span id expected 200, but got {resp_post_trace.status_code}"
+        resp_post_trace.status_code == 400
+    ), f"Invalid trace id expected 400, but got {resp_post_trace.status_code}"
 
     resp_get_trace = session.get(get_query_url)
     new_count = len(resp_get_trace.json()["hits"])
 
-    assert (original_count + 1 == new_count), "Expected count of traces to increase by 1."
+    assert (original_count == new_count), "Expected count of traces to increase by 1."


### PR DESCRIPTION
There is a lot of error in our cloud:
```
ERROR openobserve::service::metrics::otlp: [METRICS:OTLP] Invalid json: missing field `metadata` at line 1 column 1667
```

This PR used to fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added configuration for logging slow HTTP requests with a configurable threshold.
  - Introduced middleware for tracking and logging slow HTTP requests.

- **Dependency Updates**
  - Updated OpenTelemetry-related dependencies to newer versions.
  - Updated Actix web and tracing dependencies.

- **Improvements**
  - Enhanced error logging with more detailed context in ingestion write file errors.
  - Added ability to retrieve a key string representation for writers.
  - Adjusted trace ingestion and validation logic for better error handling.

- **Chores**
  - Restructured middleware and routing configurations.
  - Simplified metrics exporter implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->