### PR TITLE
feat: search job return total result

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -292,7 +292,7 @@ impl Response {
             .take(size as usize)
             .cloned()
             .collect();
-        self.total = self.hits.len();
+        // self.total = self.hits.len();
     }
 
     pub fn add_hit(&mut self, hit: &json::Value) {

--- a/src/handler/http/request/search/search_job.rs
+++ b/src/handler/http/request/search/search_job.rs
@@ -224,9 +224,7 @@ pub async fn get_job_result(
         .to_string();
 
     let from = req.from.unwrap_or(0);
-    let size = req
-        .size
-        .unwrap_or(config::get_config().limit.query_default_limit);
+    let size = req.size.unwrap_or(100);
 
     let org_id = path.0.clone();
     let job_id = path.1.clone();


### PR DESCRIPTION
- [x] for search job, in `total` field, will return the total records numbers.
- [x] if not set the from and size when get result, we set default from = 0 and size = 100