### PR TITLE
fix: move dashboard rbac ownership

### DIFF
--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -36,7 +36,10 @@ use crate::common::{
 pub mod reports;
 
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
+use o2_enterprise::enterprise::{
+    common::infra::config::get_config as get_o2_config,
+    openfga::authorizer::authz::{get_ofga_type, remove_parent_relation, set_parent_relation},
+};
 
 /// An error that occurs interacting with dashboards.
 #[derive(Debug, thiserror::Error)]
@@ -425,6 +428,17 @@ pub async fn move_dashboard(
 
     // add the dashboard to the destination folder
     put(org_id, dashboard_id, to_folder, dashboard, None).await?;
+    // OFGA ownership
+    #[cfg(feature = "enterprise")]
+    if get_o2_config().openfga.enabled {
+        set_parent_relation(
+            dashboard_id,
+            &get_ofga_type("dashboards"),
+            to_folder,
+            &get_ofga_type("folders"),
+        )
+        .await;
+    }
 
     // delete the dashboard from the source folder
     table::dashboards::delete_from_folder(org_id, from_folder, dashboard_id)
@@ -437,6 +451,16 @@ pub async fn move_dashboard(
             )
         })?;
 
+    #[cfg(feature = "enterprise")]
+    if get_o2_config().openfga.enabled {
+        remove_parent_relation(
+            dashboard_id,
+            &get_ofga_type("dashboards"),
+            from_folder,
+            &get_ofga_type("folders"),
+        )
+        .await;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
When we move a dashboard from one folder to another, currently the rbac relations are not updated, so the folder still points to the old folder as `parent` in the ofga `tuple` database.

This PR fixes this issue by updating the `parent` relationship between the dashboard and the old and new folders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dashboard management with improved access control integration
	- Added support for setting and removing parent relations for dashboards using OpenFGA system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->