### PR TITLE
fix: use multi search api for multi stream search when web socket is enabled

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1486,7 +1486,12 @@ const useLogs = () => {
       // else use organization settings
       const shouldUseWebSocket = isWebSocketEnabled();
 
-      searchObj.communicationMethod = shouldUseWebSocket ? "ws" : "http";
+      const isMultiStreamSearch =
+        searchObj.data.stream.selectedStream.length > 1 &&
+        !searchObj.meta.sqlMode;
+
+      searchObj.communicationMethod =
+        shouldUseWebSocket && !isMultiStreamSearch ? "ws" : "http";
 
       if (searchObj.communicationMethod === "ws") {
         getDataThroughWebSocket(isPagination);


### PR DESCRIPTION
#5687 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved search communication method selection logic
	- Enhanced handling of search requests across different stream configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->