### PR TITLE
feat: keep optimize metrics cache

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1033,6 +1033,8 @@ pub struct Limit {
     pub metrics_max_series_per_query: usize,
     #[env_config(name = "ZO_METRICS_MAX_POINTS_PER_SERIES", default = 30000)]
     pub metrics_max_points_per_series: usize,
+    #[env_config(name = "ZO_METRICS_CACHE_MAX_ENTRIES", default = 100000)]
+    pub metrics_cache_max_entries: usize,
     #[env_config(name = "ZO_COLS_PER_RECORD_LIMIT", default = 1000)]
     pub req_cols_per_record_limit: usize,
     #[env_config(name = "ZO_NODE_HEARTBEAT_TTL", default = 30)] // seconds
@@ -1710,10 +1712,13 @@ fn check_common_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         cfg.limit.metrics_max_search_interval_per_group *= 3_600_000_000;
     }
     if cfg.limit.metrics_max_series_per_query == 0 {
-        cfg.limit.metrics_max_series_per_query = 30000;
+        cfg.limit.metrics_max_series_per_query = 30_000;
     }
     if cfg.limit.metrics_max_points_per_series == 0 {
-        cfg.limit.metrics_max_points_per_series = 30000;
+        cfg.limit.metrics_max_points_per_series = 30_000;
+    }
+    if cfg.limit.metrics_cache_max_entries == 0 {
+        cfg.limit.metrics_cache_max_entries = 100_000;
     }
 
     // check search job retention

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -274,18 +274,6 @@ pub static QUERY_MEMORY_CACHE_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .expect("Metric created")
 });
-pub static QUERY_MEMORY_METRICS_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
-    IntGaugeVec::new(
-        Opts::new(
-            "query_memory_metrics_cache_used_bytes",
-            "Querier memory metrics result cache used bytes. ".to_owned() + HELP_SUFFIX,
-        )
-        .namespace(NAMESPACE)
-        .const_labels(create_const_labels()),
-        &[],
-    )
-    .expect("Metric created")
-});
 
 // querier disk cache stats
 pub static QUERY_DISK_CACHE_LIMIT_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
@@ -343,6 +331,32 @@ pub static QUERY_DISK_METRICS_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(||
         Opts::new(
             "query_disk_metrics_cache_used_bytes",
             "Querier disk metrics result cached bytes. ".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
+// query metrics cache stats
+pub static QUERY_METRICS_CACHE_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_metrics_cache_requests",
+            "Querier metrics cache requests. ".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_METRICS_CACHE_HITS: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_metrics_cache_hits",
+            "Querier metrics cache hits. ".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -777,9 +791,6 @@ fn register_metrics(registry: &Registry) {
         .register(Box::new(QUERY_MEMORY_CACHE_FILES.clone()))
         .expect("Metric registered");
     registry
-        .register(Box::new(QUERY_MEMORY_METRICS_CACHE_USED_BYTES.clone()))
-        .expect("Metric registered");
-    registry
         .register(Box::new(QUERY_DISK_CACHE_LIMIT_BYTES.clone()))
         .expect("Metric registered");
     registry
@@ -793,6 +804,12 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(QUERY_DISK_METRICS_CACHE_USED_BYTES.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_METRICS_CACHE_REQUESTS.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_METRICS_CACHE_HITS.clone()))
         .expect("Metric registered");
 
     // query manager

--- a/src/infra/src/cache/file_data/memory.rs
+++ b/src/infra/src/cache/file_data/memory.rs
@@ -125,10 +125,6 @@ impl FileData {
             metrics::QUERY_MEMORY_CACHE_USED_BYTES
                 .with_label_values(&[columns[1], columns[2]])
                 .add(data_size as i64);
-        } else if columns[0] == "metrics_results" {
-            metrics::QUERY_MEMORY_METRICS_CACHE_USED_BYTES
-                .with_label_values(&[])
-                .add(data_size as i64);
         }
         Ok(())
     }
@@ -163,10 +159,6 @@ impl FileData {
                     .dec();
                 metrics::QUERY_MEMORY_CACHE_USED_BYTES
                     .with_label_values(&[columns[1], columns[2]])
-                    .sub(data_size as i64);
-            } else if columns[0] == "metrics_results" {
-                metrics::QUERY_MEMORY_METRICS_CACHE_USED_BYTES
-                    .with_label_values(&[])
                     .sub(data_size as i64);
             }
             release_size += data_size;
@@ -210,10 +202,6 @@ impl FileData {
                 .dec();
             metrics::QUERY_MEMORY_CACHE_USED_BYTES
                 .with_label_values(&[columns[1], columns[2]])
-                .sub(data_size as i64);
-        } else if columns[0] == "metrics_results" {
-            metrics::QUERY_MEMORY_METRICS_CACHE_USED_BYTES
-                .with_label_values(&[])
                 .sub(data_size as i64);
         }
 

--- a/src/infra/src/cache/file_data/mod.rs
+++ b/src/infra/src/cache/file_data/mod.rs
@@ -148,16 +148,11 @@ pub async fn set(trace_id: &str, key: &str, data: bytes::Bytes) -> Result<(), an
     }
 }
 
-pub async fn get(
-    _trace_id: &str,
-    file: &str,
-    range: Option<Range<usize>>,
-) -> object_store::Result<bytes::Bytes> {
-    get_opts(_trace_id, file, range, true).await
+pub async fn get(file: &str, range: Option<Range<usize>>) -> object_store::Result<bytes::Bytes> {
+    get_opts(file, range, true).await
 }
 
 pub async fn get_opts(
-    _trace_id: &str,
     file: &str,
     range: Option<Range<usize>>,
     remote: bool,
@@ -189,15 +184,11 @@ pub async fn get_opts(
     })
 }
 
-pub async fn get_size(_trace_id: &str, file: &str) -> object_store::Result<usize> {
-    get_size_opts(_trace_id, file, true).await
+pub async fn get_size(file: &str) -> object_store::Result<usize> {
+    get_size_opts(file, true).await
 }
 
-pub async fn get_size_opts(
-    _trace_id: &str,
-    file: &str,
-    remote: bool,
-) -> object_store::Result<usize> {
+pub async fn get_size_opts(file: &str, remote: bool) -> object_store::Result<usize> {
     let cfg = config::get_config();
     // get from memory cache
     if cfg.memory_cache.enabled {

--- a/src/infra/src/cache/storage.rs
+++ b/src/infra/src/cache/storage.rs
@@ -49,7 +49,7 @@ impl CacheFS {
 impl ObjectStore for CacheFS {
     async fn get(&self, location: &Path) -> Result<GetResult> {
         let path = location.to_string();
-        if let Ok(data) = file_data::get_opts("", &path, None, false).await {
+        if let Ok(data) = file_data::get_opts(&path, None, false).await {
             let meta = ObjectMeta {
                 location: location.clone(),
                 last_modified: *BASE_TIME,
@@ -77,7 +77,7 @@ impl ObjectStore for CacheFS {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         log::warn!("OOPS: please check cache:storage:get_opts: {:?}", location);
         let path = location.to_string();
-        if let Ok(data) = file_data::get_opts("", &path, None, false).await {
+        if let Ok(data) = file_data::get_opts(&path, None, false).await {
             let meta = ObjectMeta {
                 location: location.clone(),
                 last_modified: *BASE_TIME,
@@ -112,13 +112,13 @@ impl ObjectStore for CacheFS {
             return Err(crate::storage::Error::BadRange(location.to_string()).into());
         }
         let path = location.to_string();
-        let data = file_data::get_opts("", &path, Some(range), true).await?;
+        let data = file_data::get_opts(&path, Some(range), true).await?;
         Ok(data)
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         let path = location.to_string();
-        if let Ok(size) = file_data::get_size_opts("", &path, false).await {
+        if let Ok(size) = file_data::get_size_opts(&path, false).await {
             return Ok(ObjectMeta {
                 location: location.clone(),
                 last_modified: *BASE_TIME,

--- a/src/proto/proto/cluster/metrics.proto
+++ b/src/proto/proto/cluster/metrics.proto
@@ -33,7 +33,7 @@ message MetricsQueryResponse {
     Job                 job = 1;
     int32              took = 2;
     string      result_type = 3; // vector, matrix, scalar, exemplars
-    repeated Series  result = 4;
+    repeated Series  series = 4;
     ScanStats    scan_stats = 5;
 }
 

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -428,7 +428,7 @@ pub struct MetricsQueryResponse {
     #[prost(string, tag = "3")]
     pub result_type: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "4")]
-    pub result: ::prost::alloc::vec::Vec<Series>,
+    pub series: ::prost::alloc::vec::Vec<Series>,
     #[prost(message, optional, tag = "5")]
     pub scan_stats: ::core::option::Option<ScanStats>,
 }

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -703,7 +703,7 @@ pub async fn merge_files(
     for file in new_file_list.iter() {
         fi += 1;
         log::info!("[COMPACT:{thread_id}:{fi}] merge small file: {}", &file.key);
-        let buf = file_data::get("", &file.key, None).await?;
+        let buf = file_data::get(&file.key, None).await?;
         let schema = read_schema_from_bytes(&buf).await?;
         let schema = schema.as_ref().clone().with_metadata(Default::default());
         let schema_key = schema.hash_key();

--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -56,15 +56,17 @@ pub struct Engine {
     /// Filters to include certain columns
     col_filters: Option<HashSet<String>>,
     result_type: Option<String>,
+    trace_id: String,
 }
 
 impl Engine {
-    pub fn new(ctx: Arc<PromqlContext>, time: i64) -> Self {
+    pub fn new(trace_id: &str, ctx: Arc<PromqlContext>, time: i64) -> Self {
         Self {
             ctx,
             time,
             col_filters: Some(HashSet::new()),
             result_type: None,
+            trace_id: trace_id.to_string(),
         }
     }
 
@@ -244,7 +246,8 @@ impl Engine {
                     (Value::None, Value::None) => Value::None,
                     _ => {
                         log::debug!(
-                            "[PromExpr::Binary] either lhs or rhs vector is found to be empty"
+                            "[trace_id: {}] [PromExpr::Binary] either lhs or rhs vector is found to be empty",
+                            self.trace_id
                         );
                         Value::Vector(vec![])
                     }
@@ -504,7 +507,7 @@ impl Engine {
         let metrics = match self.selector_load_data_inner(selector, range).await {
             Ok(v) => v,
             Err(e) => {
-                log::error!("[PromQL] Failed to load data for stream: {table_name}, error: {e:?}");
+                log::error!("[trace_id: {}] [PromQL] Failed to load data for stream: {table_name}, error: {e:?}", self.trace_id);
                 *data_loaded = true;
                 return Err(e);
             }
@@ -573,7 +576,8 @@ impl Engine {
         // 1. Group by metrics (sets of label name-value pairs)
         let table_name = selector.name.as_ref().unwrap();
         log::info!(
-            "[PromQL] Loading data for stream: {}, range: [{},{}), filter: {:?}",
+            "[trace_id: {}] [PromQL] Loading data for stream: {}, range: [{},{}), filter: {:?}",
+            self.trace_id,
             table_name,
             start,
             end,
@@ -647,6 +651,13 @@ impl Engine {
                 }
             }
         }
+
+        log::info!(
+            "[trace_id: {}] [PromQL] Load data done for stream: {}",
+            self.trace_id,
+            table_name
+        );
+
         Ok(metrics)
     }
 

--- a/src/service/promql/exec.rs
+++ b/src/service/promql/exec.rs
@@ -73,7 +73,11 @@ impl PromqlContext {
     }
 
     #[tracing::instrument(name = "promql:engine:exec", skip_all)]
-    pub async fn exec(&mut self, stmt: EvalStmt) -> Result<(Value, Option<String>, ScanStats)> {
+    pub async fn exec(
+        &mut self,
+        trace_id: &str,
+        stmt: EvalStmt,
+    ) -> Result<(Value, Option<String>, ScanStats)> {
         let cfg = config::get_config();
         self.start = micros_since_epoch(stmt.start);
         self.end = micros_since_epoch(stmt.end);
@@ -93,7 +97,7 @@ impl PromqlContext {
             result_type = Some("matrix".to_string());
         } else {
             // Instant query
-            let mut engine = Engine::new(ctx, self.start);
+            let mut engine = Engine::new(trace_id, ctx, self.start);
             let (mut value, result_type_exec) = engine.exec(&expr).await?;
             if let Value::Float(val) = value {
                 value = Value::Sample(Sample::new(self.end, val));
@@ -116,7 +120,7 @@ impl PromqlContext {
             let time = self.start + (self.interval * i);
             let expr = expr.clone();
             let permit = semaphore.clone().acquire_owned().await.unwrap();
-            let mut engine = Engine::new(ctx.clone(), time);
+            let mut engine = Engine::new(trace_id, ctx.clone(), time);
             let task: tokio::task::JoinHandle<Result<(Value, Option<String>)>> =
                 tokio::task::spawn(async move {
                     let ret = engine.exec(&expr).await;
@@ -203,6 +207,7 @@ impl PromqlContext {
     #[tracing::instrument(name = "promql:engine:query_exemplars", skip_all)]
     pub async fn query_exemplars(
         &mut self,
+        trace_id: &str,
         stmt: EvalStmt,
     ) -> Result<(Value, Option<String>, ScanStats)> {
         let cfg = config::get_config();
@@ -226,7 +231,7 @@ impl PromqlContext {
             let time = self.start;
             let expr = Arc::new(expr);
             let permit = semaphore.clone().acquire_owned().await.unwrap();
-            let mut engine = Engine::new(ctx.clone(), time);
+            let mut engine = Engine::new(trace_id, ctx.clone(), time);
             let task: tokio::task::JoinHandle<Result<(Value, Option<String>)>> =
                 tokio::task::spawn(async move {
                     let ret = engine.exec(&expr).await;

--- a/src/service/promql/search/cache/mod.rs
+++ b/src/service/promql/search/cache/mod.rs
@@ -184,10 +184,13 @@ pub async fn get(
         }
     }
 
-    // if new_start > start, it means we have data in cache, so we need to add step for next query
-    if new_start > start {
-        new_start += step;
+    // if new_start == start, it means we have no data in cache, so we need to return None
+    if new_start == start {
+        return Ok(None);
     }
+
+    // if new_start > start, it means we have data in cache, so we need to add step for next query
+    new_start += step;
     Ok(Some((new_start, range_values)))
 }
 

--- a/src/service/promql/search/grpc/mod.rs
+++ b/src/service/promql/search/grpc/mod.rs
@@ -233,14 +233,14 @@ pub(crate) fn add_value(resp: &mut cluster_rpc::MetricsQueryResponse, value: Val
     match value {
         value::Value::None => {}
         value::Value::Instant(v) => {
-            resp.result.push(cluster_rpc::Series {
+            resp.series.push(cluster_rpc::Series {
                 metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
                 sample: Some((&v.sample).into()),
                 ..Default::default()
             });
         }
         value::Value::Range(v) => {
-            resp.result.push(cluster_rpc::Series {
+            resp.series.push(cluster_rpc::Series {
                 metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
                 samples: v.samples.iter().map(|x| x.into()).collect(),
                 ..Default::default()
@@ -248,7 +248,7 @@ pub(crate) fn add_value(resp: &mut cluster_rpc::MetricsQueryResponse, value: Val
         }
         value::Value::Vector(v) => {
             v.iter().for_each(|v| {
-                resp.result.push(cluster_rpc::Series {
+                resp.series.push(cluster_rpc::Series {
                     metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
                     sample: Some((&v.sample).into()),
                     ..Default::default()
@@ -267,7 +267,7 @@ pub(crate) fn add_value(resp: &mut cluster_rpc::MetricsQueryResponse, value: Val
                     cluster_rpc::Exemplars { exemplars }
                 });
                 if !samples.is_empty() || exemplars.is_some() {
-                    resp.result.push(cluster_rpc::Series {
+                    resp.series.push(cluster_rpc::Series {
                         metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
                         samples,
                         exemplars,
@@ -277,19 +277,19 @@ pub(crate) fn add_value(resp: &mut cluster_rpc::MetricsQueryResponse, value: Val
             });
         }
         value::Value::Sample(v) => {
-            resp.result.push(cluster_rpc::Series {
+            resp.series.push(cluster_rpc::Series {
                 sample: Some((&v).into()),
                 ..Default::default()
             });
         }
         value::Value::Float(v) => {
-            resp.result.push(cluster_rpc::Series {
+            resp.series.push(cluster_rpc::Series {
                 scalar: Some(v),
                 ..Default::default()
             });
         }
         value::Value::String(v) => {
-            resp.result.push(cluster_rpc::Series {
+            resp.series.push(cluster_rpc::Series {
                 stringliteral: Some(v),
                 ..Default::default()
             });

--- a/src/service/promql/search/grpc/mod.rs
+++ b/src/service/promql/search/grpc/mod.rs
@@ -208,12 +208,12 @@ pub async fn search_inner(
 }
 
 /// generate search group
-/// if the group_interval is less than 10 steps, it will be set to 10 * step
+/// if the group_interval is less than 5 steps, it will be set to 5 * step
 /// if the last group is less than group_interval * 25%, it will be merged into the previous group
 fn generate_search_group(start: i64, end: i64, step: i64, group_interval: i64) -> Vec<(i64, i64)> {
     let mut group_interval = group_interval - group_interval % step;
-    if group_interval < step * 10 {
-        group_interval = step * 10;
+    if group_interval < step * 5 {
+        group_interval = step * 5;
     }
     let mut resp = Vec::new();
     let mut start = start;
@@ -338,10 +338,10 @@ mod tests {
         let group_interval = hour_micros(1);
         let resp = generate_search_group(start, end, step, group_interval);
         let mut expected = Vec::new();
-        for i in 0..24 {
+        for i in 0..43 {
             expected.push((
-                start + i * step * 10 + i * step,
-                start + (i + 1) * step * 10 + i * step,
+                start + i * step * 5 + i * step,
+                start + (i + 1) * step * 5 + i * step,
             ));
         }
         expected.last_mut().unwrap().1 = end;

--- a/src/service/promql/search/grpc/mod.rs
+++ b/src/service/promql/search/grpc/mod.rs
@@ -189,9 +189,9 @@ pub async fn search_inner(
     );
 
     let (value, result_type, mut scan_stats) = if query.query_exemplars {
-        ctx.query_exemplars(eval_stmt).await?
+        ctx.query_exemplars(&trace_id, eval_stmt).await?
     } else {
-        ctx.exec(eval_stmt).await?
+        ctx.exec(&trace_id, eval_stmt).await?
     };
     let result_type = match result_type {
         Some(v) => v,

--- a/src/service/search/datafusion/storage/file_statistics_cache.rs
+++ b/src/service/search/datafusion/storage/file_statistics_cache.rs
@@ -109,8 +109,9 @@ impl CacheAccessor<Path, Arc<Statistics>> for FileStatisticsCache {
         let k = self.format_key(k);
         let mut w = self.cacher.lock();
         if w.len() >= self.max_entries {
-            // release 5% of the cache
-            for _ in 0..(self.max_entries / 20) {
+            // release 10% of the cache
+            log::warn!("FileStatisticsCache is full, releasing 10% of the cache");
+            for _ in 0..(self.max_entries / 10) {
                 if let Some(k) = w.pop_front() {
                     self.statistics.remove(&k);
                 } else {


### PR DESCRIPTION
- [x] Optimize cache gc logic, use FIFO
- [x] New encoding of RangeValue for cache, use gRPC protobuf
- [x] Only use disk cache for second level cache
- [x] Add metrics for cache status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Metrics**
	- Removed memory metrics cache usage tracking.
	- Added new metrics for tracking cache requests and hits.

- **Performance**
	- Simplified function signatures by removing unused `trace_id` parameters across multiple service methods.
	- Updated cache retrieval logic in search and file data handling.
	- Adjusted cache eviction strategy to release 10% of the cache when full.
	- Enhanced tracking of files loaded from disk using an atomic counter.

- **Bug Fixes**
	- Adjusted group interval calculation in search group generation.
	- Streamlined cache metric tracking.
	- Enhanced logging with trace ID for improved traceability.

- **Documentation**
	- Updated field name in `MetricsQueryResponse` from `result` to `series`.
	- Added a new constant for metrics cache maximum entries in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->