### PR TITLE
fix: renamed save function to save

### DIFF
--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -470,7 +470,7 @@
     "search": "Search Function",
     "name": "Name",
     "function": "Function Detail",
-    "save": "Save Function",
+    "save": "Save",
     "jsfunction": "Function",
     "stream_name": "Stream Name",
     "order": "Order",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated English language localization for the "save" action, simplifying the text from "Save Function" to "Save"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->