### PR TITLE
fix: dashboard cache issue with websocket

### DIFF
--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -707,12 +707,12 @@ export const usePanelDataLoader = (
     // remove current traceId
     cleanupSearchRetries(payload?.traceId);
 
-    // save current state to cache
-    saveCurrentStateToCache();
-
     // set loading to false
     state.loading = false;
     state.isOperationCancelled = false;
+
+    // save current state to cache
+    saveCurrentStateToCache();
   };
 
   const handleSearchError = (

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -707,6 +707,9 @@ export const usePanelDataLoader = (
     // remove current traceId
     cleanupSearchRetries(payload?.traceId);
 
+    // save current state to cache
+    saveCurrentStateToCache();
+
     // set loading to false
     state.loading = false;
     state.isOperationCancelled = false;


### PR DESCRIPTION
- panel response not cached for dashboard panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced state caching mechanism when closing search operations
	- Improved data retrieval efficiency by preserving panel state in cache

<!-- end of auto-generated comment: release notes by coderabbit.ai -->