### PR TITLE
fix: update error message for folder duplicate name error

### DIFF
--- a/src/handler/http/request/folders.rs
+++ b/src/handler/http/request/folders.rs
@@ -43,6 +43,9 @@ impl From<FolderError> for HttpResponse {
             FolderError::NotFound => MetaHttpResponse::not_found("Folder not found"),
             FolderError::PermittedFoldersMissingUser => MetaHttpResponse::forbidden(""),
             FolderError::PermittedFoldersValidator(err) => MetaHttpResponse::forbidden(err),
+            FolderError::FolderNameAlreadyExists => MetaHttpResponse::bad_request(
+                "Folder with this name already exists in this organization",
+            ),
         }
     }
 }


### PR DESCRIPTION
Currently, the backend returns a raw database internal server error (500) when updating or creating a folder with a name that already exists in the same organization. This pr avoids exposing the raw database error to the api and instead returns a 400 bad request error.

Addresses #5723 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced folder management with prevention of duplicate folder names within an organization
- **Bug Fixes**
	- Added validation to prevent creating folders with names that already exist
- **Improvements**
	- Improved error handling for folder creation and update scenarios
	- More descriptive error messages for folder-related operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->