### PR TITLE
fix: use http domain for tls inner communication

### DIFF
--- a/src/common/utils/http.rs
+++ b/src/common/utils/http.rs
@@ -19,8 +19,10 @@ use std::{
     net::{AddrParseError, IpAddr, SocketAddr},
 };
 
-use actix_web::{http::header::HeaderName, web::Query};
-use awc::http::header::HeaderMap;
+use actix_web::{
+    http::header::{HeaderMap, HeaderName},
+    web::Query,
+};
 use config::meta::{
     search::{SearchEventContext, SearchEventType},
     stream::StreamType,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -544,9 +544,6 @@ pub struct Route {
     pub timeout: u64,
     #[env_config(name = "ZO_ROUTE_MAX_CONNECTIONS", default = 1024)]
     pub max_connections: usize,
-    // zo1-openobserve-ingester.ziox-dev.svc.cluster.local
-    #[env_config(name = "ZO_INGESTER_SERVICE_URL", default = "")]
-    pub ingester_srv_url: String,
 }
 
 #[derive(EnvConfig)]

--- a/src/router/http/ws.rs
+++ b/src/router/http/ws.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::str::FromStr;
+use std::{net::SocketAddr, str::FromStr};
 
 use actix_web::{web, Error, HttpRequest, HttpResponse};
 use actix_ws::Message;
@@ -27,7 +27,7 @@ use url::Url;
 pub async fn ws_proxy(
     req: HttpRequest,
     payload: web::Payload,
-    ws_base_url: String,
+    ws_base_url: &str,
 ) -> Result<HttpResponse, Error> {
     // log node role
     let cfg = get_config();
@@ -36,7 +36,7 @@ pub async fn ws_proxy(
     // Upgrade the client connection to a WebSocket
     let (response, mut session, mut client_msg_stream) = actix_ws::handle(&req, payload)?;
 
-    let ws_req = match convert_actix_to_tungstenite_request(&req, &ws_base_url) {
+    let ws_req = match convert_actix_to_tungstenite_request(&req, ws_base_url) {
         Ok(req) => req,
         Err(e) => {
             log::error!(
@@ -173,7 +173,7 @@ fn from_tungstenite_msg_to_actix_msg(msg: tungstenite::protocol::Message) -> Mes
 }
 
 /// Helper function to convert an HTTP/HTTPS URL to a WebSocket URL
-pub fn convert_to_websocket_url(url_str: &str) -> Result<String, String> {
+pub fn convert_to_websocket_url(url_str: &str, node: &str) -> Result<String, String> {
     let mut parsed_url = match Url::parse(url_str) {
         Ok(url) => url,
         Err(e) => {
@@ -197,6 +197,17 @@ pub fn convert_to_websocket_url(url_str: &str) -> Result<String, String> {
             return Err(format!("Unsupported URL scheme: {}", parsed_url.scheme()));
         }
     }
+
+    // set host and port
+    let parse_node = node
+        .parse::<SocketAddr>()
+        .map_err(|_| "Failed to parse node".to_string())?;
+    parsed_url
+        .set_host(Some(parse_node.ip().to_string().as_str()))
+        .map_err(|_| "Failed to set host".to_string())?;
+    parsed_url
+        .set_port(Some(parse_node.port()))
+        .map_err(|_| "Failed to set port".to_string())?;
 
     Ok(parsed_url.to_string())
 }

--- a/src/service/grpc.rs
+++ b/src/service/grpc.rs
@@ -41,19 +41,11 @@ pub(crate) async fn get_ingester_channel() -> Result<(String, Channel), tonic::S
 }
 
 async fn get_rand_ingester_addr() -> Result<String, tonic::Status> {
-    let cfg = get_config();
     let nodes = cluster::get_cached_online_ingester_nodes().await;
     if nodes.is_none() || nodes.as_ref().unwrap().is_empty() {
-        if !cfg.route.ingester_srv_url.is_empty() {
-            Ok(format!(
-                "http://{}:{}",
-                cfg.route.ingester_srv_url, cfg.grpc.port
-            ))
-        } else {
-            Err(tonic::Status::internal(
-                "No online ingester nodes".to_string(),
-            ))
-        }
+        Err(tonic::Status::internal(
+            "No online ingester nodes".to_string(),
+        ))
     } else {
         let nodes = nodes.unwrap();
         let node = get_rand_element(&nodes);

--- a/src/service/tls/mod.rs
+++ b/src/service/tls/mod.rs
@@ -57,7 +57,7 @@ pub fn http_tls_config() -> Result<ServerConfig, anyhow::Error> {
     Ok(tls_config)
 }
 
-pub fn awc_client_tls_config() -> Result<Arc<ClientConfig>, anyhow::Error> {
+pub fn client_tls_config() -> Result<Arc<ClientConfig>, anyhow::Error> {
     let cfg = config::get_config();
     let cert_store = if cfg.http.tls_root_certificates.as_str().to_lowercase() == "native" {
         native_roots_cert_store()?


### PR DESCRIPTION

- [x] support use the request domain for validation the internal communication. 
- [x] support only router enable TLS, others no.
- [ ] support ws tls proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Refactor**
  - Updated TLS configuration function naming.
  - Improved URL handling and error reporting in routing logic.
  - Simplified WebSocket connection address parsing.
  - Streamlined ingester service address retrieval.

- **Code Structure**
  - Removed deprecated configuration fields.
  - Consolidated and cleaned up import statements.
  - Enhanced error handling in various service components.

No user-facing features or functionality changes were introduced in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->