### PR TITLE
fix: tls with router

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -555,7 +555,8 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
         );
         let mut app = App::new().wrap(prometheus.clone());
         if config::cluster::LOCAL_NODE.is_router() {
-            let http_client = router::http::create_http_client();
+            let http_client =
+                router::http::create_http_client().expect("Failed to create http tls client");
             app = app
                 .service(
                     // if `cfg.common.base_uri` is empty, scope("") still works as expected.
@@ -654,7 +655,8 @@ async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
 
         let mut app = App::new().wrap(prometheus.clone());
         if config::cluster::LOCAL_NODE.is_router() {
-            let http_client = router::http::create_http_client();
+            let http_client =
+                router::http::create_http_client().expect("Failed to create http tls client");
             app = app
                 .service(
                     // if `cfg.common.base_uri` is empty, scope("") still works as expected.

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-use openobserve::service::tls::{client_tls_config, http_tls_config};
+use openobserve::service::tls::http_tls_config;
 use tracing_subscriber::{
     filter::LevelFilter as TracingLevelFilter, fmt::Layer, prelude::*, EnvFilter,
 };
@@ -555,7 +555,7 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
         );
         let mut app = App::new().wrap(prometheus.clone());
         if config::cluster::LOCAL_NODE.is_router() {
-            let http_client = create_http_client();
+            let http_client = router::http::create_http_client();
             app = app
                 .service(
                     // if `cfg.common.base_uri` is empty, scope("") still works as expected.
@@ -654,7 +654,7 @@ async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
 
         let mut app = App::new().wrap(prometheus.clone());
         if config::cluster::LOCAL_NODE.is_router() {
-            let http_client = create_http_client();
+            let http_client = router::http::create_http_client();
             app = app
                 .service(
                     // if `cfg.common.base_uri` is empty, scope("") still works as expected.
@@ -712,19 +712,6 @@ async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
     });
     server.await?;
     Ok(())
-}
-
-fn create_http_client() -> awc::Client {
-    let cfg = get_config();
-    let mut client_builder = awc::Client::builder()
-        .connector(awc::Connector::new().limit(cfg.route.max_connections))
-        .timeout(Duration::from_secs(cfg.route.timeout))
-        .disable_redirects();
-    if cfg.http.tls_enabled {
-        let config = client_tls_config().unwrap();
-        client_builder = client_builder.connector(awc::Connector::new().rustls_0_23(config));
-    }
-    client_builder.finish()
 }
 
 async fn graceful_shutdown(handle: ServerHandle) {

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -264,6 +264,7 @@ async fn default_proxy(
     // send query
     let req = if new_url.full_url.starts_with("https://") {
         create_http_client()
+            .unwrap()
             .request_from(req.full_url().to_string(), req.head())
             .address(new_url.node_addr.parse().unwrap())
     } else {
@@ -360,6 +361,7 @@ async fn proxy_querier_by_body(
     // send query
     let req = if new_url.full_url.starts_with("https://") {
         create_http_client()
+            .unwrap()
             .request_from(req.full_url().to_string(), req.head())
             .address(new_url.node_addr.parse().unwrap())
     } else {
@@ -455,17 +457,17 @@ async fn proxy_ws(
     }
 }
 
-pub fn create_http_client() -> awc::Client {
+pub fn create_http_client() -> Result<awc::Client, anyhow::Error> {
     let cfg = get_config();
     let mut client_builder = awc::Client::builder()
         .connector(awc::Connector::new().limit(cfg.route.max_connections))
         .timeout(std::time::Duration::from_secs(cfg.route.timeout))
         .disable_redirects();
     if cfg.http.tls_enabled {
-        let tls_config = crate::service::tls::client_tls_config().unwrap();
+        let tls_config = crate::service::tls::client_tls_config()?;
         client_builder = client_builder.connector(awc::Connector::new().rustls_0_23(tls_config));
     }
-    client_builder.finish()
+    Ok(client_builder.finish())
 }
 
 #[cfg(test)]

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -61,7 +61,8 @@ struct URLDetails {
     is_error: bool,
     error: Option<String>,
     path: String,
-    node: String,
+    full_url: String,
+    node_addr: String,
 }
 
 #[inline]
@@ -182,7 +183,7 @@ async fn dispatch(
         .map(|x| x.as_str())
         .unwrap_or("")
         .to_string();
-    let new_url = get_url(req.full_url().to_string()).await;
+    let new_url = get_url(&path).await;
     if new_url.is_error {
         return Ok(HttpResponse::ServiceUnavailable()
             .body(new_url.error.unwrap_or("internal server error".to_string())));
@@ -203,9 +204,9 @@ async fn dispatch(
     default_proxy(req, payload, client, new_url, start).await
 }
 
-async fn get_url(path: String) -> URLDetails {
+async fn get_url(path: &str) -> URLDetails {
     let node_type;
-    let is_querier_path = is_querier_route(&path);
+    let is_querier_path = is_querier_route(path);
 
     let nodes = if is_querier_path {
         node_type = Role::Querier;
@@ -219,7 +220,7 @@ async fn get_url(path: String) -> URLDetails {
             })
             .unwrap_or(RoleGroup::Interactive);
         let nodes = cluster::get_cached_online_querier_nodes(Some(node_group)).await;
-        if is_fixed_querier_route(&path) && nodes.is_some() && !nodes.as_ref().unwrap().is_empty() {
+        if is_fixed_querier_route(path) && nodes.is_some() && !nodes.as_ref().unwrap().is_empty() {
             nodes.map(|v| v.into_iter().take(1).collect())
         } else {
             nodes
@@ -228,33 +229,28 @@ async fn get_url(path: String) -> URLDetails {
         node_type = Role::Ingester;
         cluster::get_cached_online_ingester_nodes().await
     };
+
     if nodes.is_none() || nodes.as_ref().unwrap().is_empty() {
         return URLDetails {
             is_error: true,
             error: Some(format!("No online {node_type} nodes")),
-            path,
-            node: "".to_string(),
+            path: path.to_string(),
+            full_url: "".to_string(),
+            node_addr: "".to_string(),
         };
     }
 
     let nodes = nodes.unwrap();
     let node = get_rand_element(&nodes);
-    let (path, node) = if node.http_addr.contains("https://") {
-        (
-            path.replace("http://", "https://"),
-            node.http_addr.replace("https://", ""),
-        )
-    } else {
-        (
-            path.replace("https://", "http://"),
-            node.http_addr.replace("http://", ""),
-        )
-    };
     URLDetails {
         is_error: false,
         error: None,
-        path,
-        node,
+        path: path.to_string(),
+        full_url: format!("{}{}", node.http_addr, path),
+        node_addr: node
+            .http_addr
+            .replace("http://", "")
+            .replace("https://", ""),
     }
 }
 
@@ -266,24 +262,28 @@ async fn default_proxy(
     start: std::time::Instant,
 ) -> actix_web::Result<HttpResponse, Error> {
     // send query
-    let resp = client
-        .request_from(new_url.path.clone(), req.head())
-        .address(new_url.node.parse().unwrap())
-        .send_stream(payload)
-        .await;
-    if let Err(e) = resp {
-        log::error!(
-            "dispatch: {} to {}, proxy request error: {}, took: {} ms",
-            req.uri().path_and_query().map(|x| x.as_str()).unwrap_or(""),
-            new_url.node,
-            e,
-            start.elapsed().as_millis()
-        );
-        return Ok(HttpResponse::ServiceUnavailable().body(e.to_string()));
-    }
+    let req = if new_url.full_url.starts_with("https://") {
+        create_http_client()
+            .request_from(req.full_url().to_string(), req.head())
+            .address(new_url.node_addr.parse().unwrap())
+    } else {
+        client.request_from(&new_url.full_url, req.head())
+    };
+    let mut resp = match req.send_stream(payload).await {
+        Ok(resp) => resp,
+        Err(e) => {
+            log::error!(
+                "dispatch: {} to {}, proxy request error: {}, took: {} ms",
+                new_url.path,
+                new_url.node_addr,
+                e,
+                start.elapsed().as_millis()
+            );
+            return Ok(HttpResponse::ServiceUnavailable().body(e.to_string()));
+        }
+    };
 
     // handle response
-    let mut resp = resp.unwrap();
     let mut new_resp = HttpResponse::build(resp.status());
 
     // copy headers
@@ -303,8 +303,8 @@ async fn default_proxy(
         Err(e) => {
             log::error!(
                 "dispatch: {} to {}, proxy response error: {}, took: {} ms",
-                req.uri().path_and_query().map(|x| x.as_str()).unwrap_or(""),
-                new_url.node,
+                new_url.path,
+                new_url.node_addr,
                 e,
                 start.elapsed().as_millis()
             );
@@ -351,47 +351,40 @@ async fn proxy_querier_by_body(
     let Some(node) = cluster::get_cached_node_by_name(&node_name).await else {
         return Ok(HttpResponse::ServiceUnavailable().body("No online querier nodes"));
     };
-    let (path, node) = if node.http_addr.contains("https://") {
-        (
-            new_url.path.replace("http://", "https://"),
-            node.http_addr.replace("https://", ""),
-        )
-    } else {
-        (
-            new_url.path.replace("https://", "http://"),
-            node.http_addr.replace("http://", ""),
-        )
-    };
-    new_url.path = path;
-    new_url.node = node;
+    new_url.full_url = format!("{}{}", node.http_addr, new_url.path);
+    new_url.node_addr = node
+        .http_addr
+        .replace("http://", "")
+        .replace("https://", "");
 
     // send query
-    let resp = if let Some(payload) = payload {
-        client
-            .request_from(new_url.path.clone(), req.head())
-            .address(new_url.node.parse().unwrap())
-            .send_form(&payload)
-            .await
+    let req = if new_url.full_url.starts_with("https://") {
+        create_http_client()
+            .request_from(req.full_url().to_string(), req.head())
+            .address(new_url.node_addr.parse().unwrap())
     } else {
-        client
-            .request_from(new_url.path.clone(), req.head())
-            .address(new_url.node.parse().unwrap())
-            .send()
-            .await
+        client.request_from(&new_url.full_url, req.head())
     };
-    if let Err(e) = resp {
-        log::error!(
-            "dispatch: {} to {}, proxy request error: {}, took: {} ms",
-            req.uri().path_and_query().map(|x| x.as_str()).unwrap_or(""),
-            new_url.node,
-            e,
-            start.elapsed().as_millis()
-        );
-        return Ok(HttpResponse::ServiceUnavailable().body(e.to_string()));
-    }
+    let resp = if let Some(payload) = payload {
+        req.send_form(&payload).await
+    } else {
+        req.send().await
+    };
+    let mut resp = match resp {
+        Ok(resp) => resp,
+        Err(e) => {
+            log::error!(
+                "dispatch: {} to {}, proxy request error: {}, took: {} ms",
+                new_url.path,
+                new_url.node_addr,
+                e,
+                start.elapsed().as_millis()
+            );
+            return Ok(HttpResponse::ServiceUnavailable().body(e.to_string()));
+        }
+    };
 
     // handle response
-    let mut resp = resp.unwrap();
     let mut new_resp = HttpResponse::build(resp.status());
 
     // copy headers
@@ -411,8 +404,8 @@ async fn proxy_querier_by_body(
         Err(e) => {
             log::error!(
                 "dispatch: {} to {}, proxy response error: {}, took: {} ms",
-                req.uri().path_and_query().map(|x| x.as_str()).unwrap_or(""),
-                new_url.node,
+                new_url.path,
+                new_url.node_addr,
                 e,
                 start.elapsed().as_millis()
             );
@@ -431,7 +424,7 @@ async fn proxy_ws(
     let cfg = get_config();
     if cfg.common.websocket_enabled {
         // Convert the HTTP/HTTPS URL to a WebSocket URL (WS/WSS)
-        let ws_url = match ws::convert_to_websocket_url(&new_url.path, &new_url.node) {
+        let ws_url = match ws::convert_to_websocket_url(&new_url.path) {
             Ok(url) => url,
             Err(e) => {
                 log::error!("Error converting URL to WebSocket: {}", e);
@@ -460,6 +453,19 @@ async fn proxy_ws(
         );
         Ok(HttpResponse::NotFound().body("WebSocket is disabled"))
     }
+}
+
+pub fn create_http_client() -> awc::Client {
+    let cfg = get_config();
+    let mut client_builder = awc::Client::builder()
+        .connector(awc::Connector::new().limit(cfg.route.max_connections))
+        .timeout(std::time::Duration::from_secs(cfg.route.timeout))
+        .disable_redirects();
+    if cfg.http.tls_enabled {
+        let tls_config = crate::service::tls::client_tls_config().unwrap();
+        client_builder = client_builder.connector(awc::Connector::new().rustls_0_23(tls_config));
+    }
+    client_builder.finish()
 }
 
 #[cfg(test)]

--- a/src/router/http/ws.rs
+++ b/src/router/http/ws.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{net::SocketAddr, str::FromStr};
+use std::str::FromStr;
 
 use actix_web::{web, Error, HttpRequest, HttpResponse};
 use actix_ws::Message;
@@ -173,7 +173,7 @@ fn from_tungstenite_msg_to_actix_msg(msg: tungstenite::protocol::Message) -> Mes
 }
 
 /// Helper function to convert an HTTP/HTTPS URL to a WebSocket URL
-pub fn convert_to_websocket_url(url_str: &str, node: &str) -> Result<String, String> {
+pub fn convert_to_websocket_url(url_str: &str) -> Result<String, String> {
     let mut parsed_url = match Url::parse(url_str) {
         Ok(url) => url,
         Err(e) => {
@@ -197,17 +197,6 @@ pub fn convert_to_websocket_url(url_str: &str, node: &str) -> Result<String, Str
             return Err(format!("Unsupported URL scheme: {}", parsed_url.scheme()));
         }
     }
-
-    // set host and port
-    let parse_node = node
-        .parse::<SocketAddr>()
-        .map_err(|_| "Failed to parse node".to_string())?;
-    parsed_url
-        .set_host(Some(parse_node.ip().to_string().as_str()))
-        .map_err(|_| "Failed to set host".to_string())?;
-    parsed_url
-        .set_port(Some(parse_node.port()))
-        .map_err(|_| "Failed to set port".to_string())?;
 
     Ok(parsed_url.to_string())
 }

--- a/src/service/tls/mod.rs
+++ b/src/service/tls/mod.rs
@@ -19,6 +19,7 @@ use actix_tls::connect::rustls_0_23::{native_roots_cert_store, webpki_roots_cert
 use itertools::Itertools as _;
 use rustls::{ClientConfig, ServerConfig};
 use rustls_pemfile::{certs, private_key};
+
 pub fn http_tls_config() -> Result<ServerConfig, anyhow::Error> {
     let cfg = config::get_config();
     let cert_file =


### PR DESCRIPTION
Because of http connection pool, we can't reuse the default client with `address` method, it will always send the request to the first node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new HTTP TLS configuration method.
	- Introduced a new HTTP client creation function.

- **Refactor**
	- Restructured URL handling and routing logic.
	- Modified WebSocket URL conversion process.
	- Updated HTTP client instantiation method.

- **Bug Fixes**
	- Improved error handling in TLS and URL processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->