### PR TITLE
fix: dashboard on tab edit in dark mode input was not visible

### DIFF
--- a/web/src/components/dashboards/settings/AddSettingVariable.vue
+++ b/web/src/components/dashboards/settings/AddSettingVariable.vue
@@ -1229,6 +1229,7 @@ export default defineComponent({
     border: none;
     font-size: 12px;
     padding: 6px 4px;
+    color: black;
   }
 
   .button-left {

--- a/web/src/components/dashboards/settings/TabsSettings.vue
+++ b/web/src/components/dashboards/settings/TabsSettings.vue
@@ -70,6 +70,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             >
             <div v-else style="display: flex; flex-direction: row">
               <input
+                :class="store.state.theme === 'dark' ? 'bg-grey-10' : ''"
                 v-model="editTabObj.data.name"
                 class="edit-input"
                 data-test="dashboard-tab-settings-tab-name-edit"
@@ -380,6 +381,7 @@ export default defineComponent({
       selectedTabIdToEdit,
       currentDashboardData,
       refreshRequired,
+      store
     };
   },
 });


### PR DESCRIPTION
- #5747 

![image](https://github.com/user-attachments/assets/0bdf7158-c42a-4c6b-ab96-8ac9424318d3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
	- Enhanced input field styling to dynamically change background color based on current theme.
	- Improved visual feedback for dark theme mode in settings tab.
	- Updated button text color to black in the multi-select default value toggle for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->