### PR TITLE
chore: Optimize clone

### DIFF
--- a/src/common/infra/wal.rs
+++ b/src/common/infra/wal.rs
@@ -310,10 +310,10 @@ impl RwFile {
     pub async fn write(&self, data: &[u8]) {
         // metrics
         metrics::INGEST_WAL_USED_BYTES
-            .with_label_values(&[&self.org_id, self.stream_type.to_string().as_str()])
+            .with_label_values(&[&self.org_id, self.stream_type.as_str()])
             .add(data.len() as i64);
         metrics::INGEST_WAL_WRITE_BYTES
-            .with_label_values(&[&self.org_id, self.stream_type.to_string().as_str()])
+            .with_label_values(&[&self.org_id, self.stream_type.as_str()])
             .inc_by(data.len() as u64);
 
         self.file

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -64,7 +64,7 @@ impl StreamType {
         )
     }
 
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             StreamType::Logs => "logs",
             StreamType::Metrics => "metrics",

--- a/src/handler/grpc/request/metrics/querier.rs
+++ b/src/handler/grpc/request/metrics/querier.rs
@@ -43,14 +43,14 @@ impl Metrics for MetricsQuerier {
 
         let req: &MetricsQueryRequest = req.get_ref();
         let org_id = &req.org_id;
-        let stream_type = StreamType::Metrics.to_string();
+        let stream_type = StreamType::Metrics.as_str();
         let result = SearchService::grpc::search(req).await.map_err(|err| {
             let time = start.elapsed().as_secs_f64();
             metrics::GRPC_RESPONSE_TIME
-                .with_label_values(&["/metrics/query", "500", org_id, "", &stream_type])
+                .with_label_values(&["/metrics/query", "500", org_id, "", stream_type])
                 .observe(time);
             metrics::GRPC_INCOMING_REQUESTS
-                .with_label_values(&["/metrics/query", "500", org_id, "", &stream_type])
+                .with_label_values(&["/metrics/query", "500", org_id, "", stream_type])
                 .inc();
             let message = if let errors::Error::ErrorCode(code) = err {
                 code.to_json()

--- a/src/handler/http/request/promql/mod.rs
+++ b/src/handler/http/request/promql/mod.rs
@@ -168,7 +168,7 @@ async fn query(
         promql_parser::util::walk_expr(&mut visitor, &ast).unwrap();
 
         if !is_root_user(user_email) {
-            let stream_type_str = StreamType::Metrics.to_string();
+            let stream_type_str = StreamType::Metrics.as_str();
             for name in visitor.name {
                 let user: crate::common::meta::user::User = USERS
                     .get(&format!("{org_id}/{}", user_email))
@@ -182,8 +182,8 @@ async fn query(
                         o2_type: format!(
                             "{}:{}",
                             OFGA_MODELS
-                                .get(stream_type_str.as_str())
-                                .map_or(stream_type_str.as_str(), |model| model.key),
+                                .get(stream_type_str)
+                                .map_or(stream_type_str, |model| model.key),
                             name
                         ),
                         org_id: org_id.to_string(),
@@ -433,7 +433,7 @@ async fn query_range(
         promql_parser::util::walk_expr(&mut visitor, &ast).unwrap();
 
         if !is_root_user(user_email) {
-            let stream_type_str = StreamType::Metrics.to_string();
+            let stream_type_str = StreamType::Metrics.as_str();
             for name in visitor.name {
                 let user: crate::common::meta::user::User = USERS
                     .get(&format!("{org_id}/{}", user_email))
@@ -448,8 +448,8 @@ async fn query_range(
                             o2_type: format!(
                                 "{}:{}",
                                 OFGA_MODELS
-                                    .get(stream_type_str.as_str())
-                                    .map_or(stream_type_str.as_str(), |model| model.key),
+                                    .get(stream_type_str)
+                                    .map_or(stream_type_str, |model| model.key),
                                 name
                             ),
                             org_id: org_id.to_string(),
@@ -687,7 +687,7 @@ async fn series(
                 .get(&format!("{org_id}/{}", user_email))
                 .unwrap()
                 .clone();
-            let stream_type_str = StreamType::Metrics.to_string();
+            let stream_type_str = StreamType::Metrics.as_str();
             if user.is_external
                 && !crate::handler::http::auth::validator::check_permissions(
                     user_email,
@@ -697,8 +697,8 @@ async fn series(
                         o2_type: format!(
                             "{}:{}",
                             OFGA_MODELS
-                                .get(stream_type_str.as_str())
-                                .map_or(stream_type_str.as_str(), |model| model.key),
+                                .get(stream_type_str)
+                                .map_or(stream_type_str, |model| model.key),
                             metric_name
                         ),
                         org_id: org_id.to_string(),

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -241,7 +241,7 @@ pub async fn search_multi(
             if !is_root_user(user_id) {
                 let user: meta::user::User =
                     USERS.get(&format!("{org_id}/{user_id}")).unwrap().clone();
-                let stream_type_str = stream_type.to_string();
+                let stream_type_str = stream_type.as_str();
 
                 if !crate::handler::http::auth::validator::check_permissions(
                     user_id,
@@ -251,8 +251,8 @@ pub async fn search_multi(
                         o2_type: format!(
                             "{}:{}",
                             OFGA_MODELS
-                                .get(stream_type_str.as_str())
-                                .map_or(stream_type_str.as_str(), |model| model.key),
+                                .get(stream_type_str)
+                                .map_or(stream_type_str, |model| model.key),
                             stream_name
                         ),
                         org_id: org_id.clone(),
@@ -325,7 +325,7 @@ pub async fn search_multi(
                         "200",
                         &org_id,
                         "",
-                        stream_type.to_string().as_str(),
+                        stream_type.as_str(),
                     ])
                     .observe(time);
                 metrics::HTTP_INCOMING_REQUESTS
@@ -334,7 +334,7 @@ pub async fn search_multi(
                         "200",
                         &org_id,
                         "",
-                        stream_type.to_string().as_str(),
+                        stream_type.as_str(),
                     ])
                     .inc();
                 res.set_trace_id(trace_id);
@@ -419,7 +419,7 @@ pub async fn search_multi(
                         "500",
                         &org_id,
                         "",
-                        stream_type.to_string().as_str(),
+                        stream_type.as_str(),
                     ])
                     .observe(time);
                 metrics::HTTP_INCOMING_REQUESTS
@@ -428,7 +428,7 @@ pub async fn search_multi(
                         "500",
                         &org_id,
                         "",
-                        stream_type.to_string().as_str(),
+                        stream_type.as_str(),
                     ])
                     .inc();
 
@@ -692,7 +692,7 @@ pub async fn _search_partition_multi(
                     "200",
                     &org_id,
                     "",
-                    stream_type.to_string().as_str(),
+                    stream_type.as_str(),
                 ])
                 .observe(time);
             metrics::HTTP_INCOMING_REQUESTS
@@ -701,7 +701,7 @@ pub async fn _search_partition_multi(
                     "200",
                     &org_id,
                     "",
-                    stream_type.to_string().as_str(),
+                    stream_type.as_str(),
                 ])
                 .inc();
             Ok(HttpResponse::Ok().json(res))
@@ -714,7 +714,7 @@ pub async fn _search_partition_multi(
                     "500",
                     &org_id,
                     "",
-                    stream_type.to_string().as_str(),
+                    stream_type.as_str(),
                 ])
                 .observe(time);
             metrics::HTTP_INCOMING_REQUESTS
@@ -723,7 +723,7 @@ pub async fn _search_partition_multi(
                     "500",
                     &org_id,
                     "",
-                    stream_type.to_string().as_str(),
+                    stream_type.as_str(),
                 ])
                 .inc();
             log::error!("search error: {:?}", err);
@@ -962,7 +962,7 @@ pub async fn around_multi(
                         "500",
                         &org_id,
                         &stream_names,
-                        stream_type.to_string().as_str(),
+                        stream_type.as_str(),
                     ])
                     .observe(time);
                 metrics::HTTP_INCOMING_REQUESTS
@@ -971,7 +971,7 @@ pub async fn around_multi(
                         "500",
                         &org_id,
                         &stream_names,
-                        stream_type.to_string().as_str(),
+                        stream_type.as_str(),
                     ])
                     .inc();
                 log::error!("multi search around error: {:?}", err);
@@ -1038,7 +1038,7 @@ pub async fn around_multi(
                         "500",
                         &org_id,
                         &stream_names,
-                        stream_type.to_string().as_str(),
+                        stream_type.as_str(),
                     ])
                     .observe(time);
                 metrics::HTTP_INCOMING_REQUESTS
@@ -1047,7 +1047,7 @@ pub async fn around_multi(
                         "500",
                         &org_id,
                         &stream_names,
-                        stream_type.to_string().as_str(),
+                        stream_type.as_str(),
                     ])
                     .inc();
                 log::error!("multi search around error: {:?}", err);
@@ -1097,7 +1097,7 @@ pub async fn around_multi(
                 "200",
                 &org_id,
                 &stream_names,
-                stream_type.to_string().as_str(),
+                stream_type.as_str(),
             ])
             .observe(time);
         metrics::HTTP_INCOMING_REQUESTS
@@ -1106,7 +1106,7 @@ pub async fn around_multi(
                 "200",
                 &org_id,
                 &stream_names,
-                stream_type.to_string().as_str(),
+                stream_type.as_str(),
             ])
             .inc();
 

--- a/src/handler/http/request/search/search_job.rs
+++ b/src/handler/http/request/search/search_job.rs
@@ -128,7 +128,7 @@ pub async fn submit_job(
         &trace_id,
         &org_id,
         &user_id,
-        &stream_type.to_string(),
+        stream_type.as_str(),
         &stream_names,
         &json::to_string(&req).unwrap(),
         req.query.start_time,

--- a/src/handler/http/request/search/utils.rs
+++ b/src/handler/http/request/search/utils.rs
@@ -32,7 +32,7 @@ pub async fn check_stream_permissions(
 ) -> Option<HttpResponse> {
     if !is_root_user(user_id) {
         let user: meta::user::User = USERS.get(&format!("{org_id}/{}", user_id)).unwrap().clone();
-        let stream_type_str = stream_type.to_string();
+        let stream_type_str = stream_type.as_str();
 
         if !crate::handler::http::auth::validator::check_permissions(
             user_id,
@@ -42,8 +42,8 @@ pub async fn check_stream_permissions(
                 o2_type: format!(
                     "{}:{}",
                     OFGA_MODELS
-                        .get(stream_type_str.as_str())
-                        .map_or(stream_type_str.as_str(), |model| model.key),
+                        .get(stream_type_str)
+                        .map_or(stream_type_str, |model| model.key),
                     stream_name
                 ),
                 org_id: org_id.to_string(),

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -167,7 +167,7 @@ pub async fn get_latest_traces(
                 .get(&format!("{org_id}/{}", user_id.to_str().unwrap()))
                 .unwrap()
                 .clone();
-            let stream_type_str = StreamType::Traces.to_string();
+            let stream_type_str = StreamType::Traces.as_str();
 
             if !crate::handler::http::auth::validator::check_permissions(
                 user_id.to_str().unwrap(),
@@ -177,8 +177,8 @@ pub async fn get_latest_traces(
                     o2_type: format!(
                         "{}:{}",
                         OFGA_MODELS
-                            .get(stream_type_str.as_str())
-                            .map_or(stream_type_str.as_str(), |model| model.key),
+                            .get(stream_type_str)
+                            .map_or(stream_type_str, |model| model.key),
                         stream_name
                     ),
                     org_id: org_id.clone(),

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -321,7 +321,7 @@ pub async fn get_latest_traces(
                     "500",
                     &org_id,
                     "default",
-                    stream_type.to_string().as_str(),
+                    stream_type.as_str(),
                 ])
                 .observe(time);
             metrics::HTTP_INCOMING_REQUESTS
@@ -330,7 +330,7 @@ pub async fn get_latest_traces(
                     "500",
                     &org_id,
                     "default",
-                    stream_type.to_string().as_str(),
+                    stream_type.as_str(),
                 ])
                 .inc();
             log::error!("get traces latest data error: {:?}", err);
@@ -412,7 +412,7 @@ pub async fn get_latest_traces(
                         "500",
                         &org_id,
                         &stream_name,
-                        stream_type.to_string().as_str(),
+                        stream_type.as_str(),
                     ])
                     .observe(time);
                 metrics::HTTP_INCOMING_REQUESTS
@@ -421,7 +421,7 @@ pub async fn get_latest_traces(
                         "500",
                         &org_id,
                         &stream_name,
-                        stream_type.to_string().as_str(),
+                        stream_type.as_str(),
                     ])
                     .inc();
                 log::error!("get traces latest data error: {:?}", err);
@@ -505,7 +505,7 @@ pub async fn get_latest_traces(
             "200",
             &org_id,
             &stream_name,
-            stream_type.to_string().as_str(),
+            stream_type.as_str(),
         ])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
@@ -514,7 +514,7 @@ pub async fn get_latest_traces(
             "200",
             &org_id,
             &stream_name,
-            stream_type.to_string().as_str(),
+            stream_type.as_str(),
         ])
         .inc();
 

--- a/src/handler/http/request/websocket/utils.rs
+++ b/src/handler/http/request/websocket/utils.rs
@@ -52,12 +52,12 @@ pub mod enterprise_utils {
 
         // If the user is external, check permissions
         if user.is_external {
-            let stream_type_str = stream_type.to_string();
+            let stream_type_str = stream_type.as_str();
             let o2_type = format!(
                 "{}:{}",
                 OFGA_MODELS
-                    .get(stream_type_str.as_str())
-                    .map_or(stream_type_str.as_str(), |model| model.key),
+                    .get(stream_type_str)
+                    .map_or(stream_type_str, |model| model.key),
                 stream_name
             );
 

--- a/src/infra/src/schema/history/mysql.rs
+++ b/src/infra/src/schema/history/mysql.rs
@@ -69,7 +69,7 @@ INSERT IGNORE INTO schema_history (org, stream_type, stream_name, start_dt, valu
             "#,
         )
         .bind(org_id)
-        .bind(stream_type.to_string())
+        .bind(stream_type.as_str())
         .bind(stream_name)
         .bind(start_dt)
         .bind(value)

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -70,7 +70,7 @@ INSERT INTO schema_history (org, stream_type, stream_name, start_dt, value)
             "#,
         )
         .bind(org_id)
-        .bind(stream_type.to_string())
+        .bind(stream_type.as_str())
         .bind(stream_name)
         .bind(start_dt)
         .bind(value)

--- a/src/infra/src/schema/history/sqlite.rs
+++ b/src/infra/src/schema/history/sqlite.rs
@@ -67,7 +67,7 @@ INSERT INTO schema_history (org, stream_type, stream_name, start_dt, value)
         "#,
         )
         .bind(org_id)
-        .bind(stream_type.to_string())
+        .bind(stream_type.as_str())
         .bind(stream_name)
         .bind(start_dt)
         .bind(value)

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -561,10 +561,10 @@ async fn move_files(
 
             // metrics
             metrics::INGEST_WAL_READ_BYTES
-                .with_label_values(&[&org_id, stream_type.to_string().as_str()])
+                .with_label_values(&[&org_id, stream_type.as_str()])
                 .inc_by(file.meta.compressed_size as u64);
             metrics::INGEST_WAL_USED_BYTES
-                .with_label_values(&[&org_id, stream_type.to_string().as_str()])
+                .with_label_values(&[&org_id, stream_type.as_str()])
                 .sub(file.meta.compressed_size);
         }
 

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -882,7 +882,7 @@ pub(crate) async fn generate_index_on_ingester(
 
         crate::common::utils::auth::set_ownership(
             org_id,
-            &StreamType::Index.to_string(),
+            StreamType::Index.as_str(),
             Authz::new(&index_stream_name),
         )
         .await;

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -967,7 +967,7 @@ pub(crate) async fn generate_index_on_ingester(
     let writer = ingester::get_writer(
         0,
         org_id,
-        &StreamType::Index.to_string(),
+        StreamType::Index.as_str(),
         &index_stream_name,
     )
     .await;

--- a/src/job/metrics.rs
+++ b/src/job/metrics.rs
@@ -209,7 +209,7 @@ async fn update_metadata_metrics() -> Result<(), anyhow::Error> {
             let streams = db::schema::list_streams_from_cache(org_id, stream_type).await;
             if !streams.is_empty() {
                 metrics::META_NUM_STREAMS
-                    .with_label_values(&[org_id.as_str(), stream_type.to_string().as_str()])
+                    .with_label_values(&[org_id.as_str(), stream_type.as_str()])
                     .set(streams.len() as i64);
             }
         }

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -1015,7 +1015,7 @@ fn process_row_template(tpl: &String, alert: &Alert, rows: &[Map<String, Value>]
 
         resp = resp
             .replace("{org_name}", &alert.org_id)
-            .replace("{stream_type}", &alert.stream_type.to_string())
+            .replace("{stream_type}", alert.stream_type.as_str())
             .replace("{stream_name}", &alert.stream_name)
             .replace("{alert_name}", &alert.name)
             .replace("{alert_type}", alert_type)
@@ -1233,7 +1233,7 @@ async fn process_dest_template(
 
     let mut resp = tpl
         .replace("{org_name}", &alert.org_id)
-        .replace("{stream_type}", &alert.stream_type.to_string())
+        .replace("{stream_type}", alert.stream_type.as_str())
         .replace("{stream_name}", &alert.stream_name)
         .replace("{alert_name}", &alert.name)
         .replace("{alert_type}", alert_type)

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -593,10 +593,10 @@ pub async fn merge_by_stream(
     // metrics
     let time = start.elapsed().as_secs_f64();
     metrics::COMPACT_USED_TIME
-        .with_label_values(&[org_id, stream_type.to_string().as_str()])
+        .with_label_values(&[org_id, stream_type.as_str()])
         .inc_by(time);
     metrics::COMPACT_DELAY_HOURS
-        .with_label_values(&[org_id, stream_name, stream_type.to_string().as_str()])
+        .with_label_values(&[org_id, stream_name, stream_type.as_str()])
         .set((time_now_hour - offset_time_hour) / hour_micros(1));
 
     Ok(())
@@ -631,10 +631,10 @@ pub async fn merge_files(
         new_file_list.push(file.clone());
         // metrics
         metrics::COMPACT_MERGED_FILES
-            .with_label_values(&[org_id, stream_type.to_string().as_str()])
+            .with_label_values(&[org_id, stream_type.as_str()])
             .inc();
         metrics::COMPACT_MERGED_BYTES
-            .with_label_values(&[org_id, stream_type.to_string().as_str()])
+            .with_label_values(&[org_id, stream_type.as_str()])
             .inc_by(file.meta.original_size as u64);
     }
     // no files need to merge

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -202,7 +202,7 @@ pub async fn save_enrichment_data(
     let writer = ingester::get_writer(
         0,
         org_id,
-        &StreamType::EnrichmentTables.to_string(),
+        StreamType::EnrichmentTables.as_str(),
         stream_name,
     )
     .await;

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -119,7 +119,7 @@ pub fn apply_vrl_fn(
                 metrics::INGEST_ERRORS
                     .with_label_values(&[
                         org_id,
-                        StreamType::Logs.to_string().as_str(),
+                        StreamType::Logs.as_str(),
                         &format!("{:?}", stream_name),
                         TRANSFORM_FAILED,
                     ])
@@ -136,7 +136,7 @@ pub fn apply_vrl_fn(
             metrics::INGEST_ERRORS
                 .with_label_values(&[
                     org_id,
-                    StreamType::Logs.to_string().as_str(),
+                    StreamType::Logs.as_str(),
                     &format!("{:?}", stream_name),
                     TRANSFORM_FAILED,
                 ])

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -255,7 +255,7 @@ pub async fn ingest(
                             metrics::INGEST_ERRORS
                                 .with_label_values(&[
                                     org_id,
-                                    StreamType::Logs.to_string().as_str(),
+                                    StreamType::Logs.as_str(),
                                     &stream_name,
                                     TS_PARSE_FAILED,
                                 ])
@@ -283,7 +283,7 @@ pub async fn ingest(
                     metrics::INGEST_ERRORS
                         .with_label_values(&[
                             org_id,
-                            StreamType::Logs.to_string().as_str(),
+                            StreamType::Logs.as_str(),
                             &stream_name,
                             TS_PARSE_FAILED,
                         ])
@@ -337,7 +337,7 @@ pub async fn ingest(
                     metrics::INGEST_ERRORS
                         .with_label_values(&[
                             org_id,
-                            StreamType::Logs.to_string().as_str(),
+                            StreamType::Logs.as_str(),
                             &stream_name,
                             TRANSFORM_FAILED,
                         ])
@@ -410,7 +410,7 @@ pub async fn ingest(
                                         metrics::INGEST_ERRORS
                                             .with_label_values(&[
                                                 org_id,
-                                                StreamType::Logs.to_string().as_str(),
+                                                StreamType::Logs.as_str(),
                                                 &stream_name,
                                                 TS_PARSE_FAILED,
                                             ])
@@ -442,7 +442,7 @@ pub async fn ingest(
                                 metrics::INGEST_ERRORS
                                     .with_label_values(&[
                                         org_id,
-                                        StreamType::Logs.to_string().as_str(),
+                                        StreamType::Logs.as_str(),
                                         &stream_name,
                                         TS_PARSE_FAILED,
                                     ])
@@ -516,7 +516,7 @@ pub async fn ingest(
             metric_rpt_status_code,
             org_id,
             "",
-            StreamType::Logs.to_string().as_str(),
+            StreamType::Logs.as_str(),
         ])
         .observe(took_time);
     metrics::HTTP_INCOMING_REQUESTS
@@ -525,7 +525,7 @@ pub async fn ingest(
             metric_rpt_status_code,
             org_id,
             "",
-            StreamType::Logs.to_string().as_str(),
+            StreamType::Logs.as_str(),
         ])
         .inc();
 

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -235,7 +235,7 @@ pub async fn ingest(
                     metrics::INGEST_ERRORS
                         .with_label_values(&[
                             org_id,
-                            StreamType::Logs.to_string().as_str(),
+                            StreamType::Logs.as_str(),
                             &stream_name,
                             TS_PARSE_FAILED,
                         ])
@@ -269,7 +269,7 @@ pub async fn ingest(
                 metrics::INGEST_ERRORS
                     .with_label_values(&[
                         org_id,
-                        StreamType::Logs.to_string().as_str(),
+                        StreamType::Logs.as_str(),
                         &stream_name,
                         TRANSFORM_FAILED,
                     ])
@@ -323,7 +323,7 @@ pub async fn ingest(
                                 metrics::INGEST_ERRORS
                                     .with_label_values(&[
                                         org_id,
-                                        StreamType::Logs.to_string().as_str(),
+                                        StreamType::Logs.as_str(),
                                         &stream_name,
                                         TS_PARSE_FAILED,
                                     ])
@@ -391,7 +391,7 @@ pub async fn ingest(
             metric_rpt_status_code,
             org_id,
             &stream_name,
-            StreamType::Logs.to_string().as_str(),
+            StreamType::Logs.as_str(),
         ])
         .observe(took_time);
     metrics::HTTP_INCOMING_REQUESTS
@@ -400,7 +400,7 @@ pub async fn ingest(
             metric_rpt_status_code,
             org_id,
             &stream_name,
-            StreamType::Logs.to_string().as_str(),
+            StreamType::Logs.as_str(),
         ])
         .inc();
 

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -380,7 +380,7 @@ async fn write_logs(
                         metrics::INGEST_ERRORS
                             .with_label_values(&[
                                 org_id,
-                                StreamType::Logs.to_string().as_str(),
+                                StreamType::Logs.as_str(),
                                 stream_name,
                                 SCHEMA_CONFORMANCE_FAILED,
                             ])
@@ -392,7 +392,7 @@ async fn write_logs(
                         metrics::INGEST_ERRORS
                             .with_label_values(&[
                                 org_id,
-                                StreamType::Logs.to_string().as_str(),
+                                StreamType::Logs.as_str(),
                                 stream_name,
                                 SCHEMA_CONFORMANCE_FAILED,
                             ])
@@ -506,7 +506,7 @@ async fn write_logs(
     let writer = ingester::get_writer(
         thread_id,
         org_id,
-        &StreamType::Logs.to_string(),
+        StreamType::Logs.as_str(),
         stream_name,
     )
     .await;

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -146,7 +146,7 @@ pub async fn handle_grpc_request(
                     metrics::INGEST_ERRORS
                         .with_label_values(&[
                             org_id,
-                            StreamType::Logs.to_string().as_str(),
+                            StreamType::Logs.as_str(),
                             &stream_name,
                             TS_PARSE_FAILED,
                         ])
@@ -280,7 +280,7 @@ pub async fn handle_grpc_request(
                 metrics::INGEST_ERRORS
                     .with_label_values(&[
                         org_id,
-                        StreamType::Logs.to_string().as_str(),
+                        StreamType::Logs.as_str(),
                         &stream_name,
                         TRANSFORM_FAILED,
                     ])
@@ -406,7 +406,7 @@ pub async fn handle_grpc_request(
             metric_rpt_status_code,
             org_id,
             &stream_name,
-            StreamType::Logs.to_string().as_str(),
+            StreamType::Logs.as_str(),
         ])
         .observe(took_time);
     metrics::HTTP_INCOMING_REQUESTS
@@ -415,7 +415,7 @@ pub async fn handle_grpc_request(
             metric_rpt_status_code,
             org_id,
             &stream_name,
-            StreamType::Logs.to_string().as_str(),
+            StreamType::Logs.as_str(),
         ])
         .inc();
 

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -309,7 +309,7 @@ pub async fn logs_json_handler(
                     metrics::INGEST_ERRORS
                         .with_label_values(&[
                             org_id,
-                            StreamType::Logs.to_string().as_str(),
+                            StreamType::Logs.as_str(),
                             &stream_name,
                             TS_PARSE_FAILED,
                         ])
@@ -412,7 +412,7 @@ pub async fn logs_json_handler(
                 metrics::INGEST_ERRORS
                     .with_label_values(&[
                         org_id,
-                        StreamType::Logs.to_string().as_str(),
+                        StreamType::Logs.as_str(),
                         &stream_name,
                         TRANSFORM_FAILED,
                     ])
@@ -533,7 +533,7 @@ pub async fn logs_json_handler(
             metric_rpt_status_code,
             org_id,
             &stream_name,
-            StreamType::Logs.to_string().as_str(),
+            StreamType::Logs.as_str(),
         ])
         .observe(took_time);
     metrics::HTTP_INCOMING_REQUESTS
@@ -542,7 +542,7 @@ pub async fn logs_json_handler(
             metric_rpt_status_code,
             org_id,
             &stream_name,
-            StreamType::Logs.to_string().as_str(),
+            StreamType::Logs.as_str(),
         ])
         .inc();
 

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -186,7 +186,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
                 metrics::INGEST_ERRORS
                     .with_label_values(&[
                         org_id,
-                        StreamType::Logs.to_string().as_str(),
+                        StreamType::Logs.as_str(),
                         &stream_name,
                         TS_PARSE_FAILED,
                     ])
@@ -226,7 +226,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
                 metrics::INGEST_ERRORS
                     .with_label_values(&[
                         org_id,
-                        StreamType::Logs.to_string().as_str(),
+                        StreamType::Logs.as_str(),
                         &stream_name,
                         TRANSFORM_FAILED,
                     ])
@@ -280,7 +280,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
                                 metrics::INGEST_ERRORS
                                     .with_label_values(&[
                                         org_id,
-                                        StreamType::Logs.to_string().as_str(),
+                                        StreamType::Logs.as_str(),
                                         &stream_name,
                                         TS_PARSE_FAILED,
                                     ])
@@ -351,7 +351,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
             metric_rpt_status_code,
             org_id,
             &stream_name,
-            StreamType::Logs.to_string().as_str(),
+            StreamType::Logs.as_str(),
         ])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
@@ -360,7 +360,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
             metric_rpt_status_code,
             org_id,
             &stream_name,
-            StreamType::Logs.to_string().as_str(),
+            StreamType::Logs.as_str(),
         ])
         .inc();
 

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -292,7 +292,7 @@ impl Metadata for DistinctValues {
             let writer = ingester::get_writer(
                 0,
                 &org_id,
-                &StreamType::Metadata.to_string(),
+                StreamType::Metadata.as_str(),
                 &distinct_stream_name,
             )
             .await;

--- a/src/service/metadata/trace_list_index.rs
+++ b/src/service/metadata/trace_list_index.rs
@@ -122,7 +122,7 @@ impl Metadata for TraceListIndex {
         }
 
         let writer =
-            ingester::get_writer(0, org_id, &StreamType::Metadata.to_string(), STREAM_NAME).await;
+            ingester::get_writer(0, org_id, StreamType::Metadata.as_str(), STREAM_NAME).await;
         _ = ingestion::write_file(
             &writer,
             STREAM_NAME,
@@ -297,7 +297,7 @@ mod tests {
         let writer = ingester::get_writer(
             0,
             "openobserve",
-            &StreamType::Metadata.to_string(),
+            StreamType::Metadata.as_str(),
             STREAM_NAME,
         )
         .await;

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -440,7 +440,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
         }
 
         let writer =
-            ingester::get_writer(0, org_id, &StreamType::Metrics.to_string(), &stream_name).await;
+            ingester::get_writer(0, org_id, StreamType::Metrics.as_str(), &stream_name).await;
         // for performance issue, we will flush all when the app shutdown
         let fsync = false;
         let mut req_stats = write_file(&writer, &stream_name, stream_data, fsync).await;

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -351,7 +351,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
                     .await?;
                     crate::common::utils::auth::set_ownership(
                         org_id,
-                        &StreamType::Metrics.to_string(),
+                        StreamType::Metrics.as_str(),
                         Authz::new(&stream_name),
                     )
                     .await;
@@ -473,7 +473,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
             "200",
             org_id,
             "",
-            &StreamType::Metrics.to_string(),
+            StreamType::Metrics.as_str(),
         ])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
@@ -482,7 +482,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
             "200",
             org_id,
             "",
-            &StreamType::Metrics.to_string(),
+            StreamType::Metrics.as_str(),
         ])
         .inc();
 

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -544,7 +544,7 @@ pub async fn handle_otlp_request(
 
         // write to file
         let writer =
-            ingester::get_writer(0, org_id, &StreamType::Metrics.to_string(), &stream_name).await;
+            ingester::get_writer(0, org_id, StreamType::Metrics.as_str(), &stream_name).await;
         // for performance issue, we will flush all when the app shutdown
         let fsync = false;
         let mut req_stats = write_file(&writer, &stream_name, stream_data, fsync).await;

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -583,7 +583,7 @@ pub async fn handle_otlp_request(
             "200",
             org_id,
             "",
-            StreamType::Metrics.to_string().as_str(),
+            StreamType::Metrics.as_str(),
         ])
         .observe(time_took);
     metrics::HTTP_INCOMING_REQUESTS
@@ -592,7 +592,7 @@ pub async fn handle_otlp_request(
             "200",
             org_id,
             "",
-            StreamType::Metrics.to_string().as_str(),
+            StreamType::Metrics.as_str(),
         ])
         .inc();
 

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -161,7 +161,7 @@ pub async fn remote_write(
                 "200",
                 org_id,
                 "",
-                &StreamType::Metrics.to_string(),
+                StreamType::Metrics.as_str(),
             ])
             .observe(time);
         metrics::HTTP_INCOMING_REQUESTS
@@ -170,7 +170,7 @@ pub async fn remote_write(
                 "200",
                 org_id,
                 "",
-                &StreamType::Metrics.to_string(),
+                StreamType::Metrics.as_str(),
             ])
             .inc();
         return Ok(());
@@ -265,7 +265,7 @@ pub async fn remote_write(
                         "200",
                         org_id,
                         "",
-                        &StreamType::Metrics.to_string(),
+                        StreamType::Metrics.as_str(),
                     ])
                     .observe(time);
                 metrics::HTTP_INCOMING_REQUESTS
@@ -274,7 +274,7 @@ pub async fn remote_write(
                         "200",
                         org_id,
                         "",
-                        &StreamType::Metrics.to_string(),
+                        StreamType::Metrics.as_str(),
                     ])
                     .inc();
                 return Ok(());
@@ -560,7 +560,7 @@ pub async fn remote_write(
             "200",
             org_id,
             "",
-            &StreamType::Metrics.to_string(),
+            StreamType::Metrics.as_str(),
         ])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
@@ -569,7 +569,7 @@ pub async fn remote_write(
             "200",
             org_id,
             "",
-            &StreamType::Metrics.to_string(),
+            StreamType::Metrics.as_str(),
         ])
         .inc();
 

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -527,7 +527,7 @@ pub async fn remote_write(
 
         // write to file
         let writer =
-            ingester::get_writer(0, org_id, &StreamType::Metrics.to_string(), &stream_name).await;
+            ingester::get_writer(0, org_id, StreamType::Metrics.as_str(), &stream_name).await;
         // for performance issue, we will flush all when the app shutdown
         let fsync = false;
         let mut req_stats = write_file(&writer, &stream_name, stream_data, fsync).await;

--- a/src/service/schema.rs
+++ b/src/service/schema.rs
@@ -283,7 +283,7 @@ async fn handle_diff_schema(
     if is_new {
         crate::common::utils::auth::set_ownership(
             org_id,
-            &stream_type.to_string(),
+            stream_type.as_str(),
             Authz::new(stream_name),
         )
         .await;

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -326,7 +326,7 @@ pub async fn search_memtable(
 
     let mut batches = ingester::read_from_memtable(
         &query.org_id,
-        &query.stream_type.to_string(),
+        query.stream_type.as_str(),
         &query.stream_name,
         query.time_range,
         &filters,
@@ -336,7 +336,7 @@ pub async fn search_memtable(
     batches.extend(
         ingester::read_from_immutable(
             &query.org_id,
-            &query.stream_type.to_string(),
+            query.stream_type.as_str(),
             &query.stream_name,
             query.time_range,
             &filters,

--- a/src/service/search/grpc_search.rs
+++ b/src/service/search/grpc_search.rs
@@ -43,7 +43,7 @@ pub async fn grpc_search(
 
     let trace_id = trace_id.to_string();
     let org_id = org_id.to_string();
-    let stream_type = stream_type.to_string();
+    let stream_type = stream_type.as_str();
     let in_req = in_req.clone();
     let task = tokio::task::spawn(
         async move {
@@ -114,7 +114,6 @@ pub async fn grpc_search_partition(
 
     let trace_id = trace_id.to_string();
     let org_id = org_id.to_string();
-    let stream_type = stream_type.to_string();
     let in_req = in_req.clone();
     let task = tokio::task::spawn(
         async move {

--- a/src/service/self_reporting/mod.rs
+++ b/src/service/self_reporting/mod.rs
@@ -78,10 +78,10 @@ pub async fn report_request_usage_stats(
     timestamp: i64,
 ) {
     metrics::INGEST_RECORDS
-        .with_label_values(&[org_id, stream_name, stream_type.to_string().as_str()])
+        .with_label_values(&[org_id, stream_name, stream_type.as_str()])
         .inc_by(stats.records as u64);
     metrics::INGEST_BYTES
-        .with_label_values(&[org_id, stream_name, stream_type.to_string().as_str()])
+        .with_label_values(&[org_id, stream_name, stream_type.as_str()])
         .inc_by((stats.size * SIZE_IN_MB) as u64);
     let event: UsageEvent = usage_type.into();
     let now = DateTime::from_timestamp_micros(timestamp).unwrap();
@@ -316,21 +316,9 @@ pub fn http_report_metrics(
     let time = start.elapsed().as_secs_f64();
     let uri = format!("/api/org/{}", uri);
     metrics::HTTP_RESPONSE_TIME
-        .with_label_values(&[
-            &uri,
-            code,
-            org_id,
-            stream_name,
-            stream_type.to_string().as_str(),
-        ])
+        .with_label_values(&[&uri, code, org_id, stream_name, stream_type.as_str()])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
-        .with_label_values(&[
-            &uri,
-            code,
-            org_id,
-            stream_name,
-            stream_type.to_string().as_str(),
-        ])
+        .with_label_values(&[&uri, code, org_id, stream_name, stream_type.as_str()])
         .inc();
 }

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -632,7 +632,7 @@ pub async fn delete_stream(
 
     crate::common::utils::auth::remove_ownership(
         org_id,
-        &stream_type.to_string(),
+        stream_type.as_str(),
         Authz::new(stream_name),
     )
     .await;

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -86,8 +86,8 @@ pub async fn get_streams(
 
     let filtered_indices = if let Some(s_type) = stream_type {
         let s_type = match s_type {
-            StreamType::EnrichmentTables => "enrichment_table".to_string(),
-            _ => s_type.to_string(),
+            StreamType::EnrichmentTables => "enrichment_table",
+            _ => s_type.as_str(),
         };
         match permitted_streams {
             Some(permitted_streams) => {

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -543,7 +543,7 @@ pub async fn handle_otlp_request(
             "200",
             org_id,
             &traces_stream_name,
-            StreamType::Traces.to_string().as_str(),
+            StreamType::Traces.as_str(),
         ])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
@@ -552,7 +552,7 @@ pub async fn handle_otlp_request(
             "200",
             org_id,
             &traces_stream_name,
-            StreamType::Traces.to_string().as_str(),
+            StreamType::Traces.as_str(),
         ])
         .inc();
 
@@ -689,7 +689,7 @@ pub async fn ingest_json(
             "200",
             org_id,
             traces_stream_name,
-            StreamType::Traces.to_string().as_str(),
+            StreamType::Traces.as_str(),
         ])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
@@ -698,7 +698,7 @@ pub async fn ingest_json(
             "200",
             org_id,
             traces_stream_name,
-            StreamType::Traces.to_string().as_str(),
+            StreamType::Traces.as_str(),
         ])
         .inc();
 

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -953,7 +953,7 @@ async fn write_traces(
 
     // write data to wal
     let writer =
-        ingester::get_writer(0, org_id, &StreamType::Traces.to_string(), stream_name).await;
+        ingester::get_writer(0, org_id, StreamType::Traces.as_str(), stream_name).await;
     let req_stats = write_file(
         &writer,
         stream_name,


### PR DESCRIPTION
Optimize: avoiding StreamType String Clone when passed as &str

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated string conversion for `StreamType` enum across multiple services
	- Replaced `to_string()` with `as_str()` method for more efficient string representation
	- Simplified string handling in metrics, logging, and writer function calls

- **Performance**
	- Optimized string conversions to reduce unnecessary allocations
	- Improved efficiency in handling stream type representations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->