### PR TITLE
feat: wal file size limit & modify retry frequency and retry bug

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1565,11 +1565,11 @@ pub struct Pipeline {
     )]
     pub max_connections: usize,
     #[env_config(
-        name = "ZO_PIPELINE_DATA_RETENTION_SIZE_LIMIT",
-        default = 53687091200,
-        help = "pipeline wal dir data retention size limit, default 50GB"
+        name = "ZO_PIPELINE_DATA_RETENTION_SIZE_LIMIT_RATIO",
+        default = 10,
+        help = "pipeline wal dir data retention size limit ratio, base on cfg.disk_cache.max_size"
     )]
-    pub data_retention_size_limit: u64,
+    pub data_retention_size_limit: usize,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1564,6 +1564,12 @@ pub struct Pipeline {
         help = "pipeline exporter client max connections"
     )]
     pub max_connections: usize,
+    #[env_config(
+        name = "ZO_PIPELINE_DATA_RETENTION_SIZE_LIMIT",
+        default = 53687091200,
+        help = "pipeline wal dir data retention size limit, default 50GB"
+    )]
+    pub data_retention_size_limit: u64,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1565,11 +1565,11 @@ pub struct Pipeline {
     )]
     pub max_connections: usize,
     #[env_config(
-        name = "ZO_PIPELINE_DATA_RETENTION_SIZE_LIMIT_RATIO",
-        default = 10,
-        help = "pipeline wal dir data retention size limit ratio, base on cfg.disk_cache.max_size"
+        name = "ZO_PIPELINE_DATA_RETENTION_SIZE_LIMIT",
+        default = 53687091200,
+        help = "pipeline wal dir data retention size limit, default 50GB"
     )]
-    pub data_retention_size_limit: usize,
+    pub data_retention_size_limit: u64,
 }
 
 #[derive(EnvConfig)]

--- a/src/job/pipeline.rs
+++ b/src/job/pipeline.rs
@@ -101,19 +101,7 @@ async fn cleanup() -> Result<(), anyhow::Error> {
     }
 
     // clean up by size limit
-    let mut remote_wal_size_retention_limit =
-        config::get_config().pipeline.data_retention_size_limit;
-    if remote_wal_size_retention_limit == 0 || remote_wal_size_retention_limit > 100 {
-        log::error!(
-            "[PIPELINE] Invalid data_retention_size_limit: {}",
-            remote_wal_size_retention_limit
-        );
-        remote_wal_size_retention_limit = 100;
-    }
-
-    let max_cache_size = config::get_config().disk_cache.max_size;
-    let retention_limit = remote_wal_size_retention_limit.saturating_mul(max_cache_size);
-    while total_size > retention_limit as u128 {
+    while total_size > config::get_config().pipeline.data_retention_size_limit as u128 {
         if let Some((_, size, file_path)) = files_donot_delete.pop() {
             log::debug!("[PIPELINE] cleanup deleting: {}", file_path);
             if let Err(e) = tokio::fs::remove_file(&file_path).await {

--- a/src/job/pipeline.rs
+++ b/src/job/pipeline.rs
@@ -32,15 +32,21 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
 async fn cleanup_expired_remote_wal_files() {
     loop {
-        tokio::time::sleep(tokio::time::Duration::from_secs(600)).await; // 10 min interval
+        tokio::time::sleep(tokio::time::Duration::from_secs(60)).await; // 10 min interval
         log::debug!("[PIPELINE] Running data retention");
         let _ = cleanup().await;
     }
 }
 
 async fn cleanup() -> Result<(), anyhow::Error> {
+    use std::collections::BinaryHeap;
+
+    use crate::service::pipeline::pipeline_wal_writer::get_metadata_motified;
+
     let mut wal_file_iter = PipelineOffsetManager::get_all_remote_wal_file().await;
     let tmp_wal_file_iter = PipelineOffsetManager::get_all_remote_tmp_wal_file().await;
+    let mut total_size = 0;
+    let mut files_donot_delete: BinaryHeap<(u128, u64, String)> = BinaryHeap::new();
     wal_file_iter.extend(tmp_wal_file_iter);
     for wal_file in wal_file_iter.iter() {
         match PipelineReceiver::new(wal_file.clone(), ReadFrom::Beginning) {
@@ -55,6 +61,16 @@ async fn cleanup() -> Result<(), anyhow::Error> {
                             e
                         );
                     }
+                }
+
+                if let Ok(metadata) = tokio::fs::metadata(wal_file).await {
+                    total_size += metadata.len();
+                    let mod_time = get_metadata_motified(&metadata).elapsed().as_micros();
+                    files_donot_delete.push((
+                        mod_time,
+                        metadata.len(),
+                        fw.path.to_string_lossy().to_string(),
+                    ));
                 }
             }
             Err(e) => {
@@ -74,13 +90,87 @@ async fn cleanup() -> Result<(), anyhow::Error> {
         }
     }
 
+    // clean up by size limit
+    while total_size > config::get_config().pipeline.data_retention_size_limit {
+        if let Some((_, size, file_path)) = files_donot_delete.pop() {
+            log::debug!("pipeline cleanup deleting: {}", file_path);
+            if tokio::fs::remove_file(&file_path).await.is_ok() {
+                total_size -= size;
+            }
+        } else {
+            break;
+        }
+    }
+
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
+    use crate::service::pipeline::pipeline_wal_writer::get_metadata_motified;
+
     #[tokio::test]
     async fn test_cleanup() {
         super::cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_size_limit() {
+        use std::collections::BinaryHeap;
+        let dir = tempfile::tempdir().unwrap();
+        let file_path1 = dir.path().join("file1.txt");
+        let file_path2 = dir.path().join("file2.txt");
+
+        create_temp_file(&file_path1, 600_000).unwrap(); // 600 KB
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        create_temp_file(&file_path2, 600_000).unwrap(); // 600 KB
+
+        let wal_files = vec![
+            file_path1.to_string_lossy().to_string(),
+            file_path2.to_string_lossy().to_string(),
+        ];
+
+        // 1 MB
+        let size_limit = 1_000_000;
+
+        let mut total_size = 0;
+        let mut files_donot_delete: BinaryHeap<(u128, u64, String)> = BinaryHeap::new();
+
+        for wal_file in wal_files.iter() {
+            if let Ok(metadata) = tokio::fs::metadata(wal_file).await {
+                total_size += metadata.len();
+                let mod_time = get_metadata_motified(&metadata).elapsed().as_micros();
+                files_donot_delete.push((mod_time, metadata.len(), wal_file.clone()));
+            }
+        }
+
+        while total_size > size_limit {
+            if let Some((_, size, file_path)) = files_donot_delete.pop() {
+                println!("pipeline cleanup deleting: {}", file_path);
+                if tokio::fs::remove_file(&file_path).await.is_ok() {
+                    total_size -= size;
+                }
+            } else {
+                break;
+            }
+        }
+
+        let mut remaining_files_count = 0;
+        let mut dir_entries = tokio::fs::read_dir(dir.path()).await.unwrap();
+        while let Some(entry) = dir_entries.next_entry().await.unwrap() {
+            if entry.file_type().await.unwrap().is_file() {
+                remaining_files_count += 1;
+            }
+        }
+
+        assert!(remaining_files_count <= 1);
+    }
+
+    fn create_temp_file(path: &std::path::Path, size: usize) -> std::io::Result<()> {
+        let mut file = std::fs::File::create(path)?;
+        file.write_all(&vec![0; size])?;
+        Ok(())
     }
 }

--- a/src/service/pipeline/mod.rs
+++ b/src/service/pipeline/mod.rs
@@ -32,7 +32,7 @@ pub mod pipeline_file_server;
 mod pipeline_http_exporter_client;
 pub mod pipeline_offset_manager;
 pub(crate) mod pipeline_receiver;
-mod pipeline_wal_writer;
+pub mod pipeline_wal_writer;
 mod pipeline_watcher;
 
 #[tracing::instrument(skip(pipeline))]

--- a/src/service/pipeline/pipeline_exporter.rs
+++ b/src/service/pipeline/pipeline_exporter.rs
@@ -18,14 +18,18 @@ use std::{sync::Arc, time::Duration};
 use async_trait::async_trait;
 use config::Config;
 use infra::errors::Result;
+use ingester::Entry;
 use reqwest::ClientBuilder;
+use wal::FilePosition;
 
 use crate::service::pipeline::{
-    pipeline_entry::PipelineEntry, pipeline_http_exporter_client::PipelineHttpExporterClient,
+    pipeline_entry::{PipelineEntry, PipelineEntryBuilder},
+    pipeline_http_exporter_client::PipelineHttpExporterClient,
     pipeline_offset_manager::get_pipeline_offset_manager,
+    pipeline_receiver::PipelineReceiver,
 };
 
-const INITIAL_RETRY_DELAY_MS: u64 = 100;
+const INITIAL_RETRY_DELAY_MS: u64 = 1000;
 
 #[async_trait]
 pub trait PipelineRouter: Sync + Send {
@@ -66,10 +70,32 @@ impl PipelineExporter {
         Ok(Self::new(client))
     }
 
-    pub async fn export_entry(&self, entry: PipelineEntry, max_retry_time: u64) -> Result<()> {
+    pub async fn export_entry(
+        &self,
+        entry: Entry,
+        max_retry_time: u64,
+        file_position: FilePosition,
+        pr: &PipelineReceiver,
+    ) -> Result<()> {
         let mut attempts = 0;
         let mut delay = INITIAL_RETRY_DELAY_MS;
         loop {
+            log::debug!(
+                "Read entry from file, endpoint: {:?}, endpoint_header: {:?}, data: {:?}, path: {}",
+                pr.get_stream_endpoint().await,
+                pr.get_stream_endpoint_header().await,
+                entry.data,
+                pr.path.display(),
+            );
+            let endpoint = pr.get_stream_endpoint().await?;
+            let header = pr.get_stream_endpoint_header().await;
+            let entry = PipelineEntryBuilder::new()
+                .stream_path(pr.path.clone())
+                .stream_endpoint(endpoint)
+                .stream_header(header)
+                .set_entry_position_of_file(file_position)
+                .entry(entry.clone())
+                .build();
             // todo: if endpoint reponse partial success, we need to resovle the issue?
             // we assume that all the data is received successfully when the endpoint response 200.
             match self.router.export(entry.clone()).await {
@@ -112,12 +138,22 @@ impl PipelineExporter {
                     );
 
                     tokio::time::sleep(Duration::from_millis(delay)).await;
-                    delay *= 2;
+                    delay = Self::retry_backoff(delay);
                 }
             }
         }
 
         Ok(())
+    }
+
+    fn retry_backoff(delay: u64) -> u64 {
+        let max_delay = 3600000; // 1 hour
+        let mut new_delay = delay * 5;
+        if new_delay >= max_delay {
+            new_delay = max_delay;
+        }
+
+        new_delay
     }
 }
 
@@ -128,5 +164,19 @@ mod tests {
     #[test]
     fn test_pipeline_exporter_client_builder() {
         PipelineExporterClientBuilder::build(false).unwrap();
+    }
+
+    #[test]
+    fn test_retry_backoff() {
+        let mut delay = 100;
+        for i in 0..10 {
+            let new_delay = super::PipelineExporter::retry_backoff(delay);
+            println!("retry_backoff: {i} {} -> {}", delay, new_delay);
+            delay = new_delay;
+            match i {
+                v if v <= 5 => assert!(delay < 3600000),
+                _ => assert_eq!(delay, 3600000),
+            }
+        }
     }
 }

--- a/src/service/pipeline/pipeline_exporter.rs
+++ b/src/service/pipeline/pipeline_exporter.rs
@@ -29,7 +29,8 @@ use crate::service::pipeline::{
     pipeline_receiver::PipelineReceiver,
 };
 
-const INITIAL_RETRY_DELAY_MS: u64 = 1000;
+const INITIAL_RETRY_DELAY_MS: u64 = 100; // 100 ms
+const MAX_RETRY_TIME_LIMIT: u64 = 3600000; // 1 hour
 
 #[async_trait]
 pub trait PipelineRouter: Sync + Send {
@@ -147,10 +148,9 @@ impl PipelineExporter {
     }
 
     fn retry_backoff(delay: u64) -> u64 {
-        let max_delay = 3600000; // 1 hour
         let mut new_delay = delay * 5;
-        if new_delay >= max_delay {
-            new_delay = max_delay;
+        if new_delay >= MAX_RETRY_TIME_LIMIT {
+            new_delay = MAX_RETRY_TIME_LIMIT;
         }
 
         new_delay

--- a/src/service/pipeline/pipeline_receiver.rs
+++ b/src/service/pipeline/pipeline_receiver.rs
@@ -200,12 +200,37 @@ impl PipelineReceiver {
     }
 
     pub async fn get_stream_export_retry_time(&self) -> u64 {
-        // minitues to ms
+        // min to ms
         config::get_config().pipeline.remote_request_retry_time * 60 * 1000
     }
 
     pub async fn get_stream_data_retention_days(&self) -> i64 {
-        config::get_config().compact.data_retention_days
+        let pipeline_id = self.reader_header.get("pipeline_id").ok_or(Error::Message(
+            "get_stream_data_retention_days get pipeline_id fail".to_string(),
+        ));
+
+        if pipeline_id.is_err() {
+            return config::get_config().compact.data_retention_days;
+        }
+
+        let pipeline = db::pipeline::get_by_id(pipeline_id.unwrap().as_str()).await;
+
+        if pipeline.is_err() {
+            return config::get_config().compact.data_retention_days;
+        }
+
+        let stream_params = pipeline.unwrap().get_source_stream_params();
+        match infra::schema::get_settings(
+            stream_params.org_id.as_str(),
+            stream_params.stream_name.as_str(),
+            stream_params.stream_type,
+        )
+        .await
+        {
+            Some(settings) if settings.data_retention > 0 => settings.data_retention,
+            Some(_) => config::get_config().compact.data_retention_days,
+            None => config::get_config().compact.data_retention_days,
+        }
     }
 
     /// Read a entry from the wal file
@@ -253,13 +278,13 @@ impl PipelineReceiver {
     pub async fn should_delete_on_data_retention(&self) -> bool {
         if let Ok(metadata) = self.reader.metadata() {
             let modified = get_metadata_motified(&metadata);
-            log::debug!(
-                "PipelineReceiver should_delete_on_data_retention file {} modified elapsed: {} ",
-                self.reader.path().display(),
-                modified.elapsed().as_secs()
-            );
-
             let retention_time = self.get_stream_data_retention_days().await;
+            log::debug!(
+                "PipelineReceiver should_delete_on_data_retention file {} modified elapsed: {}, retention_time: {} ",
+                self.reader.path().display(),
+                modified.elapsed().as_secs(),
+                retention_time
+            );
             modified.elapsed().as_secs() > (retention_time * 24 * 3600) as u64
         } else {
             true

--- a/src/service/pipeline/pipeline_receiver.rs
+++ b/src/service/pipeline/pipeline_receiver.rs
@@ -199,9 +199,9 @@ impl PipelineReceiver {
         }
     }
 
-    pub async fn get_stream_export_retry_time(&self) -> u64 {
-        // min to ms
-        config::get_config().pipeline.remote_request_retry_time * 60 * 1000
+    // unit is seconds, need to convert to milliseconds
+    pub async fn get_stream_export_max_retry_time(&self) -> u64 {
+        config::get_config().pipeline.remote_request_max_retry_time * 1000
     }
 
     pub async fn get_stream_data_retention_days(&self) -> i64 {

--- a/src/service/pipeline/pipeline_watcher.rs
+++ b/src/service/pipeline/pipeline_watcher.rs
@@ -27,8 +27,8 @@ use tokio::{
 use wal::{FilePosition, ReadFrom};
 
 use crate::service::pipeline::{
-    pipeline_entry::PipelineEntryBuilder, pipeline_exporter::PipelineExporter,
-    pipeline_offset_manager::get_pipeline_offset_manager, pipeline_receiver::PipelineReceiver,
+    pipeline_exporter::PipelineExporter, pipeline_offset_manager::get_pipeline_offset_manager,
+    pipeline_receiver::PipelineReceiver,
 };
 
 #[derive(Debug)]
@@ -325,14 +325,6 @@ impl PipelineWatcher {
     ) -> Result<Option<()>> {
         match entry {
             Ok((Some(entry), file_position)) => {
-                log::debug!(
-                    "Read entry from file, endpoint: {:?}, endpoint_header: {:?}, data: {:?}, path: {}",
-                    pr.get_stream_endpoint().await,
-                    pr.get_stream_endpoint_header().await,
-                    entry.data,
-                    pr.path.display(),
-                );
-
                 if pr.pipeline_exporter.is_none() {
                     let dname = pr.get_destination_name().await?;
                     let skip_tl_verify = pr
@@ -341,20 +333,13 @@ impl PipelineWatcher {
                     pr.pipeline_exporter = Some(PipelineExporter::init(skip_tl_verify)?);
                 }
 
-                let endpoint = pr.get_stream_endpoint().await?;
-                let header = pr.get_stream_endpoint_header().await;
-                let data = PipelineEntryBuilder::new()
-                    .stream_path(pr.path.clone())
-                    .stream_endpoint(endpoint)
-                    .stream_header(header)
-                    .set_entry_position_of_file(file_position)
-                    .entry(entry)
-                    .build();
-
                 let max_retry_time = pr.get_stream_export_retry_time().await;
                 // if entry.data just has one record, it will be a performance issue for exporter
                 if let Some(exporter) = &pr.pipeline_exporter {
-                    if let Err(e) = exporter.export_entry(data, max_retry_time).await {
+                    if let Err(e) = exporter
+                        .export_entry(entry, max_retry_time, file_position, pr)
+                        .await
+                    {
                         log::error!(
                             "Failed to send entry to exporter: {}, data from file : {}",
                             e.to_string(),

--- a/src/service/pipeline/pipeline_watcher.rs
+++ b/src/service/pipeline/pipeline_watcher.rs
@@ -333,7 +333,7 @@ impl PipelineWatcher {
                     pr.pipeline_exporter = Some(PipelineExporter::init(skip_tl_verify)?);
                 }
 
-                let max_retry_time = pr.get_stream_export_retry_time().await;
+                let max_retry_time = pr.get_stream_export_max_retry_time().await;
                 // if entry.data just has one record, it will be a performance issue for exporter
                 if let Some(exporter) = &pr.pipeline_exporter {
                     if let Err(e) = exporter


### PR DESCRIPTION
continue implement https://github.com/openobserve/openobserve/pull/5744 todo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added configurable data retention size limit for pipeline WAL directory.
  - Enhanced pipeline cleanup logic with size-based retention policies.

- **Improvements**
  - Improved pipeline export functionality with detailed logging and enhanced retry mechanism.
  - Enhanced logic for determining data retention days in the pipeline receiver.

- **Technical Updates**
  - Made pipeline WAL writer module publicly accessible.
  - Streamlined logging in the pipeline watcher for reduced verbosity.
  - Updated configuration parameters for remote request retries and write-ahead log size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->