### PR TITLE
fix: dashboard color option issue with numeric field

### DIFF
--- a/web/src/utils/dashboard/colorPalette.ts
+++ b/web/src/utils/dashboard/colorPalette.ts
@@ -286,7 +286,7 @@ export const getSeriesColor = (
   chartMax: number,
 ): string | null => {
   if (!colorCfg) {
-    return classicColorPalette[getSeriesHash(seriesName)];
+    return classicColorPalette[getSeriesHash(seriesName?.toString() ?? "")];
   } else if (colorCfg.mode === "fixed") {
     return colorCfg?.fixedColor?.[0] ?? "#53ca53";
   } else if (colorCfg.mode === "shades") {
@@ -297,7 +297,7 @@ export const getSeriesColor = (
       chartMax,
     );
   } else if (colorCfg.mode === "palette-classic-by-series") {
-    return classicColorPalette[getSeriesHash(seriesName)];
+    return classicColorPalette[getSeriesHash(seriesName?.toString() ?? "")];
   } else if (colorCfg.mode === "palette-classic") {
     return null;
   } else {


### PR DESCRIPTION
- Color options issue with Numeric series name.

![image](https://github.com/user-attachments/assets/71b3304b-cf24-4130-b333-cb250ccbce9f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in color palette utility to prevent potential issues with null or undefined series names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->