### PR TITLE
fix: timestamp before pipeline processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,7 +2155,7 @@ dependencies = [
  "reqwest",
  "thiserror 1.0.69",
  "tokio",
- "zip",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -2493,6 +2493,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
+ "sea-orm",
  "segment",
  "serde",
  "serde_json",
@@ -3372,6 +3373,12 @@ checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
 ]
+
+[[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "delegate-attr"
@@ -5378,6 +5385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5453,6 +5466,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
 ]
 
 [[package]]
@@ -6187,6 +6210,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "tonic 0.12.3",
  "tracing",
  "tracing-appender",
@@ -6199,6 +6223,7 @@ dependencies = [
  "version-compare",
  "vrl",
  "wal",
+ "zip 2.2.2",
  "zstd",
 ]
 
@@ -6524,6 +6549,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -8020,9 +8055,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b24d72a69e89762982c29af249542b06c59fa131f87cc9d5b94be1f692b427a"
+checksum = "1a93194430b419da0801f404baf3b986399d6a2a4f43bc79bc96dea83f92ca43"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8065,9 +8100,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0497f4fd82ecb2a222bea5319b9048f8ab58d4e734d095b062987acbcdeecdda"
+checksum = "d19e8f22fb474a8a622eb516c46885a080535d8d559386188f525977eaad32b3"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -8441,6 +8476,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
@@ -10050,7 +10091,7 @@ dependencies = [
  "serde",
  "serde_json",
  "utoipa",
- "zip",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -10897,6 +10938,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "zerovec"
@@ -10930,6 +10985,49 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
+]
+
+[[package]]
+name = "zip"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "hmac",
+ "indexmap 2.7.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "rand",
+ "sha1",
+ "thiserror 2.0.8",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -193,12 +193,47 @@ pub async fn ingest(
         };
 
         if executable_pipeline.is_some() {
-            // buffer the records and originals for pipeline batch processing
+            // handle record's timestamp fist in case record is sent to remote destination
+            if let Err(e) = handle_timestamp(&mut item, min_ts) {
+                stream_status.status.failed += 1;
+                stream_status.status.error = e.to_string();
+                metrics::INGEST_ERRORS
+                    .with_label_values(&[
+                        org_id,
+                        StreamType::Logs.as_str(),
+                        &stream_name,
+                        TS_PARSE_FAILED,
+                    ])
+                    .inc();
+                log_failed_record(log_ingestion_errors, &item, &e.to_string());
+                continue;
+            };
+            // buffer the records, timestamp, and originals for pipeline batch processing
             pipeline_inputs.push(item);
             original_options.push(original_data);
         } else {
             // JSON Flattening
             let mut res = flatten::flatten_with_level(item, cfg.limit.ingest_flatten_level)?;
+
+            // handle timestamp
+            let timestamp = match handle_timestamp(&mut res, min_ts) {
+                Ok(ts) => ts,
+                Err(e) => {
+                    stream_status.status.failed += 1;
+                    stream_status.status.error = e.to_string();
+                    metrics::INGEST_ERRORS
+                        .with_label_values(&[
+                            org_id,
+                            StreamType::Logs.as_str(),
+                            &stream_name,
+                            TS_PARSE_FAILED,
+                        ])
+                        .inc();
+                    log_failed_record(log_ingestion_errors, &res, &e.to_string());
+                    continue;
+                }
+            };
+
             // get json object
             let mut local_val = match res.take() {
                 json::Value::Object(val) => val,
@@ -225,25 +260,6 @@ pub async fn ingest(
                     json::Value::String(record_id.to_string()),
                 );
             }
-
-            // handle timestamp
-            let timestamp = match handle_timestamp(&mut local_val, min_ts) {
-                Ok(ts) => ts,
-                Err(e) => {
-                    stream_status.status.failed += 1;
-                    stream_status.status.error = e.to_string();
-                    metrics::INGEST_ERRORS
-                        .with_label_values(&[
-                            org_id,
-                            StreamType::Logs.as_str(),
-                            &stream_name,
-                            TS_PARSE_FAILED,
-                        ])
-                        .inc();
-                    log_failed_record(log_ingestion_errors, &local_val, &e.to_string());
-                    continue;
-                }
-            };
 
             let (ts_data, fn_num) = json_data_by_stream
                 .entry(stream_name.clone())
@@ -314,23 +330,23 @@ pub async fn ingest(
                             );
                         }
 
-                        // handle timestamp
-                        let timestamp = match handle_timestamp(&mut local_val, min_ts) {
-                            Ok(ts) => ts,
-                            Err(e) => {
-                                stream_status.status.failed += 1;
-                                stream_status.status.error = e.to_string();
-                                metrics::INGEST_ERRORS
-                                    .with_label_values(&[
-                                        org_id,
-                                        StreamType::Logs.as_str(),
-                                        &stream_name,
-                                        TS_PARSE_FAILED,
-                                    ])
-                                    .inc();
-                                log_failed_record(log_ingestion_errors, &local_val, &e.to_string());
-                                continue;
-                            }
+                        let Some(timestamp) = local_val
+                            .get(&cfg.common.column_timestamp)
+                            .and_then(|ts| ts.as_i64())
+                        else {
+                            let err = "record _timestamp inserted before pipeline processing, but missing after pipeline processing";
+                            stream_status.status.failed += 1;
+                            stream_status.status.error = err.to_string();
+                            metrics::INGEST_ERRORS
+                                .with_label_values(&[
+                                    org_id,
+                                    StreamType::Logs.as_str(),
+                                    &stream_name,
+                                    TS_PARSE_FAILED,
+                                ])
+                                .inc();
+                            log_failed_record(log_ingestion_errors, &local_val, err);
+                            continue;
                         };
 
                         let (ts_data, fn_num) = json_data_by_stream
@@ -410,12 +426,11 @@ pub async fn ingest(
     ))
 }
 
-pub fn handle_timestamp(
-    local_val: &mut json::Map<String, json::Value>,
-    min_ts: i64,
-) -> Result<i64, anyhow::Error> {
+pub fn handle_timestamp(value: &mut json::Value, min_ts: i64) -> Result<i64, anyhow::Error> {
     let cfg = get_config();
-    // handle timestamp
+    let local_val = value
+        .as_object_mut()
+        .ok_or_else(|| anyhow::Error::msg("Value is not an object"))?;
     let timestamp = match local_val.get(&cfg.common.column_timestamp) {
         Some(v) => match parse_timestamp_micro_from_value(v) {
             Ok(t) => t,

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -428,8 +428,7 @@ pub async fn handle_otlp_request(
 
             let timestamp = val_map
                 .get(&cfg.common.column_timestamp)
-                .unwrap()
-                .as_i64()
+                .and_then(|ts| ts.as_i64())
                 .unwrap_or(Utc::now().timestamp_micros());
 
             let value_str = json::to_string(&val_map).unwrap();

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -323,8 +323,12 @@ pub async fn remote_write(
                 stream_executable_pipelines.insert(metric_name.clone(), pipeline_params);
             }
 
-            let value: json::Value = json::to_value(&metric).unwrap();
+            let mut value: json::Value = json::to_value(&metric).unwrap();
             let timestamp = parse_i64_to_timestamp_micros(sample.timestamp);
+            value.as_object_mut().unwrap().insert(
+                cfg.common.column_timestamp.clone(),
+                json::Value::Number(timestamp.into()),
+            );
 
             // ready to be buffered for downstream processing
             if stream_executable_pipelines

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -106,7 +106,6 @@ pub struct ExecutablePipelineBulkInputs {
 #[derive(Debug)]
 pub struct ExecutablePipelineTraceInputs {
     records: Vec<Value>,
-    timestamps: Vec<i64>,
     services: Vec<String>,
     span_names: Vec<String>,
     span_status_for_spanmetrics: Vec<String>,
@@ -419,7 +418,6 @@ impl ExecutablePipelineTraceInputs {
     pub fn new() -> Self {
         Self {
             records: Vec::new(),
-            timestamps: Vec::new(),
             services: Vec::new(),
             span_names: Vec::new(),
             span_status_for_spanmetrics: Vec::new(),
@@ -432,7 +430,6 @@ impl ExecutablePipelineTraceInputs {
     pub fn add_input(
         &mut self,
         record: Value,
-        ts: i64,
         service: String,
         span_name: String,
         span_status_for_spanmetric: String,
@@ -440,7 +437,6 @@ impl ExecutablePipelineTraceInputs {
         duration: f64,
     ) {
         self.records.push(record);
-        self.timestamps.push(ts);
         self.services.push(service);
         self.span_names.push(span_name);
         self.span_status_for_spanmetrics
@@ -454,7 +450,6 @@ impl ExecutablePipelineTraceInputs {
         self,
     ) -> (
         Vec<Value>,
-        Vec<i64>,
         Vec<String>,
         Vec<String>,
         Vec<String>,
@@ -463,7 +458,6 @@ impl ExecutablePipelineTraceInputs {
     ) {
         (
             self.records,
-            self.timestamps,
             self.services,
             self.span_names,
             self.span_status_for_spanmetrics,

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -359,11 +359,15 @@ pub async fn handle_otlp_request(
                 let span_status_for_spanmetric = local_val.span_status.clone();
 
                 let mut value: json::Value = json::to_value(local_val).unwrap();
+                // add timestamp
+                value.as_object_mut().unwrap().insert(
+                    cfg.common.column_timestamp.clone(),
+                    json::Value::Number(timestamp.into()),
+                );
 
                 if executable_pipeline.is_some() {
                     stream_pipeline_inputs.add_input(
                         value,
-                        timestamp,
                         service_name.to_owned(),
                         span.name,
                         span_status_for_spanmetric,
@@ -377,7 +381,7 @@ pub async fn handle_otlp_request(
                     })?;
 
                     // get json object
-                    let mut record_val = match value.take() {
+                    let record_val = match value.take() {
                         json::Value::Object(mut v) => {
                             // build span metrics item
                             let sm = crate::job::metrics::TraceMetricsItem {
@@ -411,11 +415,6 @@ pub async fn handle_otlp_request(
                         }
                     };
 
-                    // add timestamp
-                    record_val.insert(
-                        cfg.common.column_timestamp.clone(),
-                        json::Value::Number(timestamp.into()),
-                    );
                     let (ts_data, _) = json_data_by_stream
                         .entry(traces_stream_name.to_string())
                         .or_insert((Vec::new(), None));
@@ -429,7 +428,6 @@ pub async fn handle_otlp_request(
     if let Some(exec_pl) = &executable_pipeline {
         let (
             records,
-            timestamps,
             services,
             span_names,
             span_status_for_spanmetrics,
@@ -456,7 +454,7 @@ pub async fn handle_otlp_request(
 
                     for (idx, mut res) in stream_pl_results {
                         // get json object
-                        let mut record_val = match res.take() {
+                        let record_val = match res.take() {
                             json::Value::Object(mut v) => {
                                 // build span metrics item
                                 let sm = crate::job::metrics::TraceMetricsItem {
@@ -489,12 +487,12 @@ pub async fn handle_otlp_request(
                             }
                         };
 
-                        // add timestamp
-                        let timestamp = timestamps[idx];
-                        record_val.insert(
-                            cfg.common.column_timestamp.clone(),
-                            json::Value::Number(timestamp.into()),
-                        );
+                        let Some(timestamp) = record_val
+                            .get(&cfg.common.column_timestamp)
+                            .and_then(|ts| ts.as_i64())
+                        else {
+                            continue;
+                        };
                         let (ts_data, _) = json_data_by_stream
                             .entry(traces_stream_name.to_string())
                             .or_insert((Vec::new(), None));

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -491,6 +491,10 @@ pub async fn handle_otlp_request(
                             .get(&cfg.common.column_timestamp)
                             .and_then(|ts| ts.as_i64())
                         else {
+                            log::error!(
+                                "[TRACES:OTLP] skipping span due to missing inserted timestamp",
+                            );
+                            partial_success.rejected_spans += 1;
                             continue;
                         };
                         let (ts_data, _) = json_data_by_stream


### PR DESCRIPTION
Insert timestamp into json record before pipeline processing, to avoid inconsistent timestamps among different pipeline destinations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved timestamp handling across multiple service modules.
	- Enhanced error handling for timestamp parsing and processing.
	- Refined timestamp extraction and validation in log and metrics ingestion.

- **Refactor**
	- Streamlined timestamp management in pipeline and trace processing.
	- Simplified error reporting mechanisms for timestamp-related issues.
	- Removed timestamp tracking functionality in the pipeline execution struct.

- **Chores**
	- Updated code to improve robustness of timestamp handling.
	- Consolidated timestamp handling logic for clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->