### PR TITLE
fix: moved about option to help dropdown

### DIFF
--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -220,6 +220,13 @@ class="padding-none" />
                   </q-item-label>
                 </q-item-section>
               </q-item>
+              <q-item to="/about">
+                <q-item-section>
+                  <q-item-label>
+                    {{ t(`menu.about`) }}
+                  </q-item-label>
+                </q-item-section>
+              </q-item>
             </q-list>
           </q-menu>
         </q-btn>
@@ -688,12 +695,6 @@ export default defineComponent({
         link: "/iam",
         display: store.state?.currentuser?.role == "admin" ? true : false,
         name: "iam",
-      },
-      {
-        title: t("menu.about"),
-        icon: outlinedFormatListBulleted,
-        link: "/about",
-        name: "about",
       },
     ]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Navigation Updates**
	- Added a new "About" menu item to the dropdown menu.
	- Removed the previous "About" item from the main navigation while maintaining existing translation and routing for the About page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->