### PR TITLE
fix: UI omitting first row of results in logs page

### DIFF
--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -226,7 +226,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               ]
             }`"
             :style="{
-              transform: `translateY(${virtualRow.start}px)`,
+              transform: `translateY(${virtualRow.start + (isFirefox ? baseOffset : 0)}px)`,
               minWidth: '100%',
             }"
             :data-index="virtualRow.index"
@@ -603,19 +603,26 @@ watch(
 
 const parentRef = ref<HTMLElement | null>(null);
 
+const isFirefox = computed(() => {
+  return typeof navigator !== "undefined" && navigator.userAgent.includes("Firefox");
+});
+
+const baseOffset = isFirefox.value ? 20 : 0;
+
 const rowVirtualizerOptions = computed(() => {
   return {
     count: formattedRows.value.length,
     getScrollElement: () => parentRef.value,
-    estimateSize: () => 20,
+    estimateSize: () => 20, 
     overscan: 80,
     measureElement:
       typeof window !== "undefined" &&
-      navigator.userAgent.indexOf("Firefox") === -1
+      !isFirefox.value
         ? (element: any) => element?.getBoundingClientRect().height
         : undefined,
   };
 });
+
 
 const rowVirtualizer = useVirtualizer(rowVirtualizerOptions);
 

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -604,7 +604,9 @@ watch(
 const parentRef = ref<HTMLElement | null>(null);
 
 const isFirefox = computed(() => {
-  return typeof navigator !== "undefined" && navigator.userAgent.includes("Firefox");
+  return (
+    typeof document !== "undefined" && CSS.supports("-moz-appearance", "none")
+  );
 });
 
 const baseOffset = isFirefox.value ? 20 : 0;


### PR DESCRIPTION
This PR fixes the omitting the first row in firefox browser 
#5279 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved browser compatibility for Firefox in the virtualized table rendering.
	- Adjusted table row positioning and measurement to ensure consistent display across different browsers.
	- Enhanced vertical translation of rows based on browser type.
	- Minor formatting adjustments for consistent spacing in the rendering functions.
- **New Features**
	- Added a computed property to detect Firefox browser support.
	- Introduced a variable to adjust row positioning based on browser type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->