### PR TITLE
fix: disable mmdb_download on alert_manager

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -13,7 +13,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::cluster::LOCAL_NODE;
+use std::str::FromStr;
+
+use config::{cluster::LOCAL_NODE, meta::cluster::Role};
 use infra::file_list as infra_file_list;
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
@@ -75,7 +77,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
         .await;
     }
 
-    if !cfg.common.mmdb_disable_download {
+    if !cfg.common.mmdb_disable_download
+        && matches!(Role::from_str(&cfg.common.node_role), Ok(role) if role != Role::AlertManager)
+    {
         // Try to download the mmdb files, if its not disabled.
         tokio::task::spawn(async move { mmdb_downloader::run().await });
     }

--- a/tests/ui-testing/pages/logsPage.js
+++ b/tests/ui-testing/pages/logsPage.js
@@ -382,8 +382,8 @@ export class LogsPage {
   
     // Select the current date
     const date = new Date().getDate();
-    await this.page.locator(".q-date").getByText(date.toString(), { exact: true }).click();
-    await this.page.locator(".q-date").getByText(date.toString(), { exact: true }).click();
+    await this.page.getByRole('button', { name: date.toString(), exact: true }).click()
+    await this.page.getByRole('button', { name: date.toString(), exact: true }).click()
   
     // Fill the start time
     const startTimeInput = this.page.locator(".startEndTime td:nth-child(1) input");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced node role-based control for MMDB file downloads
- **Refactor**
  - Updated download condition logic to include role-specific checks
- **Bug Fixes**
  - Improved method for selecting the current date in the logs page UI tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->