### PR TITLE
fix: use folder id and dashboard id to generate ksuid hash in recreate folder migration

### DIFF
--- a/src/infra/src/table/migration/m20250109_092400_recreate_tables_with_ksuids.rs
+++ b/src/infra/src/table/migration/m20250109_092400_recreate_tables_with_ksuids.rs
@@ -306,7 +306,7 @@ mod legacy_dashboards {
         use sha1::{Digest, Sha1};
         let mut hasher = Sha1::new();
         hasher.update(dashboard.dashboard_id.clone());
-        hasher.update(folder_id.to_owned());
+        hasher.update(folder_id);
         let hash = hasher.finalize();
         svix_ksuid::Ksuid::from_bytes(hash.into())
     }


### PR DESCRIPTION
For super cluster, we need same ids for dashboards/folders/alerts in different clusters. This PR uses both folder id and dashboard id to generate the ksuid hash for a dashboard. In case there are multiple dashboards with same dashboard id (not expected but may happen when moving a dashboard from one folder to another - move is a two step process - create dashboard with same id in another folder and then delete the dashboard in the old folder. If the second step fails for some reason, there will be two dashboards with same dashboard id), the combination of folder and dashboard ids will create unique hash for every dashboard in the migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Database Migration**
	- Updated migration script to use KSUIDs as primary keys for folders and dashboards tables.
	- Enhanced data relationship integrity by incorporating folder references in KSUID generation for dashboards and alerts.
	- Improved error handling during data migration process for dashboards lacking associated folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->