### PR TITLE
fix: optimize job id for search

### DIFF
--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -26,7 +26,10 @@ use config::{
         self_reporting::usage::{RequestStats, UsageType},
         stream::StreamType,
     },
-    utils::time::{now_micros, second_micros},
+    utils::{
+        rand::generate_random_string,
+        time::{now_micros, second_micros},
+    },
 };
 use futures::future::try_join_all;
 use hashbrown::HashMap;
@@ -190,12 +193,9 @@ async fn search_in_cluster(
         partition_step
     };
 
-    // partition request, here plus 1 second, because division is integer, maybe
-    // lose some precision XXX-REFACTORME: move this into a function
-    let job_id = trace_id[0..6].to_string(); // take the last 6 characters as job id
     let job = cluster_rpc::Job {
         trace_id: trace_id.to_string(),
-        job: job_id,
+        job: generate_random_string(7),
         stage: 0,
         partition: 0,
     };

--- a/src/service/search/datafusion/distributed_plan/remote_scan.rs
+++ b/src/service/search/datafusion/distributed_plan/remote_scan.rs
@@ -26,7 +26,7 @@ use arrow_flight::{
     Ticket,
 };
 use arrow_schema::{Schema, SchemaRef};
-use config::meta::search::ScanStats;
+use config::{meta::search::ScanStats, utils::rand::generate_random_string};
 use datafusion::{
     common::{DataFusionError, Result, Statistics},
     execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext},
@@ -189,7 +189,7 @@ async fn get_remote_batch(
     let is_querier = remote_scan_node.is_querier(partition);
 
     let mut request = remote_scan_node.get_flight_search_request(partition);
-    request.set_job_id(config::ider::uuid());
+    request.set_job_id(generate_random_string(7));
     request.set_partition(partition);
 
     log::info!(

--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -503,7 +503,12 @@ export const formatSizeFromMB = (sizeInMB: string) => {
     index++;
   }
 
-  return `${size.toFixed(2)} ${units[index]}`;
+  let new_size = size.toFixed(2);
+  if (new_size == "0.00" && size > 0) {
+    new_size = "0.01";
+  }
+
+  return `${new_size} ${units[index]}`;
 };
 
 export const addCommasToNumber = (number: number) => {

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -294,10 +294,10 @@ export default defineComponent({
           summary.value = {
             streams_count: res.data.streams?.num_streams ?? 0,
             ingested_data: formatSizeFromMB(
-              res.data.streams?.total_storage_size.toFixed(2),
+              res.data.streams?.total_storage_size,
             ),
             compressed_data: formatSizeFromMB(
-              res.data.streams?.total_compressed_size.toFixed(2),
+              res.data.streams?.total_compressed_size,
             ),
             doc_count: addCommasToNumber(res.data.streams?.total_records ?? 0),
             index_size: formatSizeFromMB(


### PR DESCRIPTION
This PR shorted the job_id, now it is 7 chars, earlier it is 32 chars. Also fixed the issue UI shows zero if the size less than `0.01` MB.
