### PR TITLE
refactor: Split `openfga` and `dex` modules into their own crates

### DIFF
--- a/src/common/infra/ofga.rs
+++ b/src/common/infra/ofga.rs
@@ -19,14 +19,14 @@ use hashbrown::HashSet;
 use infra::dist_lock;
 use o2_enterprise::enterprise::{
     common::infra::config::get_config as get_o2_config,
-    openfga::{
-        authorizer::authz::{
-            add_tuple_for_pipeline, get_index_creation_tuples, get_org_creation_tuples,
-            get_ownership_all_org_tuple, get_user_role_tuple, update_tuples,
-        },
-        meta::mapping::{NON_OWNING_ORG, OFGA_MODELS},
-    },
     super_cluster::kv::ofga::{get_model, set_model},
+};
+use o2_openfga::{
+    authorizer::authz::{
+        add_tuple_for_pipeline, get_index_creation_tuples, get_org_creation_tuples,
+        get_ownership_all_org_tuple, get_user_role_tuple, update_tuples,
+    },
+    meta::mapping::{NON_OWNING_ORG, OFGA_MODELS},
 };
 
 use crate::{
@@ -38,9 +38,7 @@ use crate::{
 };
 
 pub async fn init() -> Result<(), anyhow::Error> {
-    use o2_enterprise::enterprise::openfga::{
-        authorizer::authz::get_tuple_for_new_index, get_all_init_tuples,
-    };
+    use o2_openfga::{authorizer::authz::get_tuple_for_new_index, get_all_init_tuples};
 
     let mut init_tuples = vec![];
     let mut migrate_native_objects = false;
@@ -48,13 +46,14 @@ pub async fn init() -> Result<(), anyhow::Error> {
     let mut need_pipeline_migration = false;
     let mut need_cipher_keys_migration = false;
     let mut need_action_scripts_migration = false;
-    let mut existing_meta = match db::ofga::get_ofga_model().await {
-        Ok(Some(model)) => Some(model),
-        Ok(None) | Err(_) => {
-            migrate_native_objects = true;
-            None
-        }
-    };
+    let mut existing_meta: Option<o2_openfga::meta::mapping::OFGAModel> =
+        match db::ofga::get_ofga_model().await {
+            Ok(Some(model)) => Some(model),
+            Ok(None) | Err(_) => {
+                migrate_native_objects = true;
+                None
+            }
+        };
 
     // sync with super cluster
     if get_o2_config().super_cluster.enabled {
@@ -88,7 +87,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         }
     }
 
-    let meta = o2_enterprise::enterprise::openfga::model::read_ofga_model().await;
+    let meta = o2_openfga::model::read_ofga_model().await;
     get_all_init_tuples(&mut init_tuples).await;
     if let Some(existing_model) = &existing_meta {
         if meta.version == existing_model.version {
@@ -141,8 +140,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
             if store_id.is_empty() {
                 log::error!("OFGA store id is empty");
             }
-            o2_enterprise::enterprise::common::infra::config::OFGA_STORE_ID
-                .insert("store_id".to_owned(), store_id);
+            o2_openfga::config::OFGA_STORE_ID.insert("store_id".to_owned(), store_id);
 
             let mut tuples = vec![];
             let r = infra::schema::STREAM_SCHEMAS.read().await;

--- a/src/common/migration/schema.rs
+++ b/src/common/migration/schema.rs
@@ -28,11 +28,11 @@ use infra::{
     scheduler,
 };
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
+use o2_openfga::add_init_ofga_tuples;
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::openfga::add_init_ofga_tuples;
+use o2_openfga::authorizer::authz::get_ownership_tuple;
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::openfga::authorizer::authz::get_ownership_tuple;
+use o2_openfga::config::get_config as get_openfga_config;
 
 use crate::{
     common::{
@@ -360,7 +360,7 @@ async fn migrate_report_names() -> Result<(), anyhow::Error> {
         log::info!("[Report:Migration]: Done migrating report: {}", key);
     }
     #[cfg(feature = "enterprise")]
-    if !write_tuples.is_empty() && get_o2_config().openfga.enabled {
+    if !write_tuples.is_empty() && get_openfga_config().openfga.enabled {
         add_init_ofga_tuples(write_tuples).await;
     }
     Ok(())
@@ -405,7 +405,7 @@ async fn migrate_alert_template_names() -> Result<(), anyhow::Error> {
         log::info!("[Template:Migration]: Done migrating template: {}", key);
     }
     #[cfg(feature = "enterprise")]
-    if !write_tuples.is_empty() && get_o2_config().openfga.enabled {
+    if !write_tuples.is_empty() && get_openfga_config().openfga.enabled {
         add_init_ofga_tuples(write_tuples).await;
     }
     Ok(())
@@ -470,7 +470,7 @@ async fn migrate_alert_destination_names() -> Result<(), anyhow::Error> {
         );
     }
     #[cfg(feature = "enterprise")]
-    if !write_tuples.is_empty() && get_o2_config().openfga.enabled {
+    if !write_tuples.is_empty() && get_openfga_config().openfga.enabled {
         add_init_ofga_tuples(write_tuples).await;
     }
     Ok(())
@@ -561,7 +561,7 @@ async fn migrate_alert_names() -> Result<(), anyhow::Error> {
     }
 
     #[cfg(feature = "enterprise")]
-    if !write_tuples.is_empty() && get_o2_config().openfga.enabled {
+    if !write_tuples.is_empty() && get_openfga_config().openfga.enabled {
         add_init_ofga_tuples(write_tuples).await;
     }
     Ok(())

--- a/src/common/migration/schema.rs
+++ b/src/common/migration/schema.rs
@@ -360,7 +360,7 @@ async fn migrate_report_names() -> Result<(), anyhow::Error> {
         log::info!("[Report:Migration]: Done migrating report: {}", key);
     }
     #[cfg(feature = "enterprise")]
-    if !write_tuples.is_empty() && get_openfga_config().openfga.enabled {
+    if !write_tuples.is_empty() && get_openfga_config().enabled {
         add_init_ofga_tuples(write_tuples).await;
     }
     Ok(())
@@ -405,7 +405,7 @@ async fn migrate_alert_template_names() -> Result<(), anyhow::Error> {
         log::info!("[Template:Migration]: Done migrating template: {}", key);
     }
     #[cfg(feature = "enterprise")]
-    if !write_tuples.is_empty() && get_openfga_config().openfga.enabled {
+    if !write_tuples.is_empty() && get_openfga_config().enabled {
         add_init_ofga_tuples(write_tuples).await;
     }
     Ok(())
@@ -470,7 +470,7 @@ async fn migrate_alert_destination_names() -> Result<(), anyhow::Error> {
         );
     }
     #[cfg(feature = "enterprise")]
-    if !write_tuples.is_empty() && get_openfga_config().openfga.enabled {
+    if !write_tuples.is_empty() && get_openfga_config().enabled {
         add_init_ofga_tuples(write_tuples).await;
     }
     Ok(())
@@ -561,7 +561,7 @@ async fn migrate_alert_names() -> Result<(), anyhow::Error> {
     }
 
     #[cfg(feature = "enterprise")]
-    if !write_tuples.is_empty() && get_openfga_config().openfga.enabled {
+    if !write_tuples.is_empty() && get_openfga_config().enabled {
         add_init_ofga_tuples(write_tuples).await;
     }
     Ok(())

--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -111,7 +111,7 @@ pub fn get_role(_role: UserRole) -> UserRole {
 
 #[cfg(feature = "enterprise")]
 pub async fn set_ownership(org_id: &str, obj_type: &str, obj: Authz) {
-    if get_openfga_config().openfga.enabled {
+    if get_openfga_config().enabled {
         use o2_openfga::{authorizer, meta::mapping::OFGA_MODELS};
 
         let obj_str = format!("{}:{}", OFGA_MODELS.get(obj_type).unwrap().key, obj.obj_id);
@@ -147,7 +147,7 @@ pub async fn set_ownership(_org_id: &str, _obj_type: &str, _obj: Authz) {}
 
 #[cfg(feature = "enterprise")]
 pub async fn remove_ownership(org_id: &str, obj_type: &str, obj: Authz) {
-    if get_openfga_config().openfga.enabled {
+    if get_openfga_config().enabled {
         use o2_openfga::{authorizer, meta::mapping::OFGA_MODELS};
         let obj_str = format!("{}:{}", OFGA_MODELS.get(obj_type).unwrap().key, obj.obj_id);
 

--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -21,9 +21,9 @@ use base64::Engine;
 use config::utils::json;
 use futures::future::{ready, Ready};
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
+use o2_openfga::config::get_config as get_openfga_config;
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+use o2_openfga::meta::mapping::OFGA_MODELS;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
@@ -100,7 +100,7 @@ pub(crate) fn is_root_user(user_id: &str) -> bool {
 pub fn get_role(role: UserRole) -> UserRole {
     use std::str::FromStr;
 
-    let role = o2_enterprise::enterprise::openfga::authorizer::roles::get_role(format!("{role}"));
+    let role = o2_openfga::authorizer::roles::get_role(format!("{role}"));
     UserRole::from_str(&role).unwrap()
 }
 
@@ -111,8 +111,8 @@ pub fn get_role(_role: UserRole) -> UserRole {
 
 #[cfg(feature = "enterprise")]
 pub async fn set_ownership(org_id: &str, obj_type: &str, obj: Authz) {
-    if get_o2_config().openfga.enabled {
-        use o2_enterprise::enterprise::openfga::{authorizer, meta::mapping::OFGA_MODELS};
+    if get_openfga_config().openfga.enabled {
+        use o2_openfga::{authorizer, meta::mapping::OFGA_MODELS};
 
         let obj_str = format!("{}:{}", OFGA_MODELS.get(obj_type).unwrap().key, obj.obj_id);
 
@@ -147,8 +147,8 @@ pub async fn set_ownership(_org_id: &str, _obj_type: &str, _obj: Authz) {}
 
 #[cfg(feature = "enterprise")]
 pub async fn remove_ownership(org_id: &str, obj_type: &str, obj: Authz) {
-    if get_o2_config().openfga.enabled {
-        use o2_enterprise::enterprise::openfga::{authorizer, meta::mapping::OFGA_MODELS};
+    if get_openfga_config().openfga.enabled {
+        use o2_openfga::{authorizer, meta::mapping::OFGA_MODELS};
         let obj_str = format!("{}:{}", OFGA_MODELS.get(obj_type).unwrap().key, obj.obj_id);
 
         let parent_type = if obj.parent_type.is_empty() {
@@ -205,7 +205,7 @@ impl FromRequest for AuthExtractor {
 
         use actix_web::web;
         use config::meta::stream::StreamType;
-        use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+        use o2_openfga::meta::mapping::OFGA_MODELS;
 
         use crate::common::utils::http::{get_folder, get_stream_type_from_request};
 

--- a/src/handler/http/auth/jwt.rs
+++ b/src/handler/http/auth/jwt.rs
@@ -63,7 +63,7 @@ pub async fn process_token(
     let openfga_cfg = get_openfga_config();
     let dec_token = res.1.unwrap();
 
-    let groups = match dec_token.claims.get(&dex_cfg.dex.group_claim) {
+    let groups = match dec_token.claims.get(&dex_cfg.group_claim) {
         None => vec![],
         Some(groups) => {
             if !groups.is_array() {
@@ -88,17 +88,17 @@ pub async fn process_token(
         let role = if let Some(role) = &res.0.user_role {
             role.clone()
         } else {
-            UserRole::from_str(&dex_cfg.dex.default_role).unwrap()
+            UserRole::from_str(&dex_cfg.default_role).unwrap()
         };
         source_orgs.push(UserOrg {
             role,
-            name: dex_cfg.dex.default_org.clone(),
+            name: dex_cfg.default_org.clone(),
             ..UserOrg::default()
         });
     } else {
         for group in groups {
             let role_org = parse_dn(group.as_str().unwrap()).unwrap();
-            if openfga_cfg.openfga.map_group_to_role {
+            if openfga_cfg.map_group_to_role {
                 custom_roles.push(format_role_name(
                     &role_org.org,
                     role_org.custom_role.unwrap(),
@@ -114,7 +114,7 @@ pub async fn process_token(
     }
 
     // Assign users custom roles in RBAC
-    if openfga_cfg.openfga.map_group_to_role {
+    if openfga_cfg.map_group_to_role {
         map_group_to_custom_role(&user_email, &name, custom_roles, res.0.user_role).await;
         return;
     }
@@ -125,7 +125,7 @@ pub async fn process_token(
     if db_user.is_none() {
         log::info!("User does not exist in the database");
 
-        if openfga_cfg.openfga.enabled {
+        if openfga_cfg.enabled {
             for (index, org) in source_orgs.iter().enumerate() {
                 let mut tuples = vec![];
                 get_user_creation_tuples(
@@ -167,7 +167,7 @@ pub async fn process_token(
         match users::update_db_user(updated_db_user).await {
             Ok(_) => {
                 log::info!("User added to the database");
-                if openfga_cfg.openfga.enabled {
+                if openfga_cfg.enabled {
                     for (_, tuples) in tuples_to_add {
                         match update_tuples(tuples, vec![]).await {
                             Ok(_) => {
@@ -307,7 +307,7 @@ pub async fn process_token(
                 }
             }
         }
-        if openfga_cfg.openfga.enabled {
+        if openfga_cfg.enabled {
             if write_tuples.is_empty() && delete_tuples.is_empty() {
                 log::info!("No changes to the user information tuples");
             } else {
@@ -339,30 +339,30 @@ fn parse_dn(dn: &str) -> Option<RoleOrg> {
 
     let dex_cfg = get_dex_config();
     let openfga_cfg = get_openfga_config();
-    if openfga_cfg.openfga.map_group_to_role {
+    if openfga_cfg.map_group_to_role {
         custom_role = Some(dn.to_owned());
-        org = &dex_cfg.dex.default_org;
+        org = &dex_cfg.default_org;
     } else {
         for part in dn.split(',') {
             let parts: Vec<&str> = part.split('=').collect();
             if parts.len() == 2 {
-                if parts[0].eq(&dex_cfg.dex.group_attribute) && org.is_empty() {
+                if parts[0].eq(&dex_cfg.group_attribute) && org.is_empty() {
                     org = parts[1];
                 }
-                if parts[0].eq(&dex_cfg.dex.role_attribute) && role.is_empty() {
+                if parts[0].eq(&dex_cfg.role_attribute) && role.is_empty() {
                     role = parts[1];
                 }
             }
         }
     }
     let role = if role.is_empty() {
-        UserRole::from_str(&dex_cfg.dex.default_role).unwrap()
+        UserRole::from_str(&dex_cfg.default_role).unwrap()
     } else {
         UserRole::from_str(role).unwrap()
     };
 
     if org.is_empty() {
-        org = &dex_cfg.dex.default_org;
+        org = &dex_cfg.default_org;
     }
     Some(RoleOrg {
         role,
@@ -391,12 +391,12 @@ async fn map_group_to_custom_role(
         let role = if let Some(role) = default_role {
             role
         } else {
-            UserRole::from_str(&dex_cfg.dex.default_role).unwrap()
+            UserRole::from_str(&dex_cfg.default_role).unwrap()
         };
 
-        if openfga_cfg.openfga.enabled {
+        if openfga_cfg.enabled {
             get_org_creation_tuples(
-                &dex_cfg.dex.default_org,
+                &dex_cfg.default_org,
                 &mut tuples,
                 OFGA_MODELS
                     .iter()
@@ -405,7 +405,7 @@ async fn map_group_to_custom_role(
                 NON_OWNING_ORG.to_vec(),
             )
             .await;
-            tuples.push(get_user_org_tuple(&dex_cfg.dex.default_org, user_email));
+            tuples.push(get_user_org_tuple(&dex_cfg.default_org, user_email));
             // this check added to avoid service accounts from logging in
             if !role.eq(&UserRole::ServiceAccount) {
                 tuples.push(get_user_org_tuple(user_email, user_email));
@@ -413,7 +413,7 @@ async fn map_group_to_custom_role(
             let start = std::time::Instant::now();
             check_and_get_crole_tuple_for_new_user(
                 user_email,
-                &dex_cfg.dex.default_org,
+                &dex_cfg.default_org,
                 custom_roles,
                 &mut tuples,
             )
@@ -432,7 +432,7 @@ async fn map_group_to_custom_role(
             salt: "".to_owned(),
             organizations: vec![UserOrg {
                 role,
-                name: dex_cfg.dex.default_org.clone(),
+                name: dex_cfg.default_org.clone(),
                 ..UserOrg::default()
             }],
             is_external: true,
@@ -442,7 +442,7 @@ async fn map_group_to_custom_role(
         match users::update_db_user(updated_db_user).await {
             Ok(_) => {
                 log::info!("group_to_custom_role: User added to the database");
-                if openfga_cfg.openfga.enabled {
+                if openfga_cfg.enabled {
                     let start = std::time::Instant::now();
                     match update_tuples(tuples, vec![]).await {
                         Ok(_) => {
@@ -495,7 +495,7 @@ async fn map_group_to_custom_role(
 
         check_and_get_crole_tuple_for_new_user(
             user_email,
-            &dex_cfg.dex.default_org,
+            &dex_cfg.default_org,
             new_roles,
             &mut add_tuples,
         )
@@ -506,7 +506,7 @@ async fn map_group_to_custom_role(
             remove_tuples
         );
 
-        if openfga_cfg.openfga.enabled {
+        if openfga_cfg.enabled {
             let start = std::time::Instant::now();
             match update_tuples(add_tuples, remove_tuples).await {
                 Ok(_) => {

--- a/src/handler/http/auth/token.rs
+++ b/src/handler/http/auth/token.rs
@@ -52,7 +52,7 @@ pub async fn token_validator(
     match jwt::verify_decode_token(
         auth_info.auth.strip_prefix("Bearer").unwrap().trim(),
         &keys,
-        &get_dex_config().dex.client_id,
+        &get_dex_config().client_id,
         false,
         true,
     )
@@ -128,7 +128,7 @@ pub async fn get_user_name_from_token(auth_str: &str) -> Option<String> {
     match jwt::verify_decode_token(
         auth_str.strip_prefix("Bearer").unwrap().trim(),
         &keys,
-        &get_dex_config().dex.client_id,
+        &get_dex_config().client_id,
         false,
         true,
     )

--- a/src/handler/http/auth/token.rs
+++ b/src/handler/http/auth/token.rs
@@ -20,9 +20,7 @@ use actix_web::{
     http::{header, Method},
 };
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::{
-    common::infra::config::get_config as get_o2_config, dex::service::auth::get_dex_jwks,
-};
+use o2_dex::{config::get_config as get_dex_config, service::auth::get_dex_jwks};
 
 use crate::common::utils::auth::AuthExtractor;
 #[cfg(feature = "enterprise")]
@@ -54,7 +52,7 @@ pub async fn token_validator(
     match jwt::verify_decode_token(
         auth_info.auth.strip_prefix("Bearer").unwrap().trim(),
         &keys,
-        &get_o2_config().dex.client_id,
+        &get_dex_config().dex.client_id,
         false,
         true,
     )
@@ -130,7 +128,7 @@ pub async fn get_user_name_from_token(auth_str: &str) -> Option<String> {
     match jwt::verify_decode_token(
         auth_str.strip_prefix("Bearer").unwrap().trim(),
         &keys,
-        &get_o2_config().dex.client_id,
+        &get_dex_config().dex.client_id,
         false,
         true,
     )

--- a/src/handler/http/auth/validator.rs
+++ b/src/handler/http/auth/validator.rs
@@ -184,7 +184,7 @@ pub async fn validate_credentials(
 
     #[cfg(feature = "enterprise")]
     {
-        if !get_dex_config().dex.native_login_enabled && !user.is_external {
+        if !get_dex_config().native_login_enabled && !user.is_external {
             return Ok(TokenValidationResponse {
                 is_valid: false,
                 user_email: "".to_string(),
@@ -196,7 +196,7 @@ pub async fn validate_credentials(
             });
         }
 
-        if get_dex_config().dex.root_only_login && !is_root_user(user_id) {
+        if get_dex_config().root_only_login && !is_root_user(user_id) {
             return Ok(TokenValidationResponse {
                 is_valid: false,
                 user_email: "".to_string(),
@@ -758,7 +758,7 @@ pub(crate) async fn check_permissions(
     role: UserRole,
     _is_external: bool,
 ) -> bool {
-    if !get_openfga_config().openfga.enabled || role.eq(&UserRole::Root) {
+    if !get_openfga_config().enabled || role.eq(&UserRole::Root) {
         return true;
     }
 
@@ -813,10 +813,7 @@ pub(crate) async fn list_objects_for_user(
     object_type: &str,
 ) -> Result<Option<Vec<String>>, Error> {
     let openfga_config = get_openfga_config();
-    if !is_root_user(user_id)
-        && openfga_config.openfga.enabled
-        && openfga_config.openfga.list_only_permitted
-    {
+    if !is_root_user(user_id) && openfga_config.enabled && openfga_config.list_only_permitted {
         match crate::handler::http::auth::validator::list_objects(
             user_id,
             permission,

--- a/src/handler/http/auth/validator.rs
+++ b/src/handler/http/auth/validator.rs
@@ -21,7 +21,9 @@ use actix_web::{
 };
 use config::{get_config, utils::base64};
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
+use o2_dex::config::get_config as get_dex_config;
+#[cfg(feature = "enterprise")]
+use o2_openfga::config::get_config as get_openfga_config;
 
 use crate::{
     common::{
@@ -182,11 +184,7 @@ pub async fn validate_credentials(
 
     #[cfg(feature = "enterprise")]
     {
-        if !o2_enterprise::enterprise::common::infra::config::get_config()
-            .dex
-            .native_login_enabled
-            && !user.is_external
-        {
+        if !get_dex_config().dex.native_login_enabled && !user.is_external {
             return Ok(TokenValidationResponse {
                 is_valid: false,
                 user_email: "".to_string(),
@@ -198,11 +196,7 @@ pub async fn validate_credentials(
             });
         }
 
-        if o2_enterprise::enterprise::common::infra::config::get_config()
-            .dex
-            .root_only_login
-            && !is_root_user(user_id)
-        {
+        if get_dex_config().dex.root_only_login && !is_root_user(user_id) {
             return Ok(TokenValidationResponse {
                 is_valid: false,
                 user_email: "".to_string(),
@@ -764,7 +758,7 @@ pub(crate) async fn check_permissions(
     role: UserRole,
     _is_external: bool,
 ) -> bool {
-    if !get_o2_config().openfga.enabled || role.eq(&UserRole::Root) {
+    if !get_openfga_config().openfga.enabled || role.eq(&UserRole::Root) {
         return true;
     }
 
@@ -780,7 +774,7 @@ pub(crate) async fn check_permissions(
         &auth_info.org_id
     };
 
-    o2_enterprise::enterprise::openfga::authorizer::authz::is_allowed(
+    o2_openfga::authorizer::authz::is_allowed(
         org_id,
         user_id,
         &auth_info.method,
@@ -808,13 +802,7 @@ async fn list_objects(
     object_type: &str,
     org_id: &str,
 ) -> Result<Vec<String>, anyhow::Error> {
-    o2_enterprise::enterprise::openfga::authorizer::authz::list_objects(
-        user_id,
-        permission,
-        object_type,
-        org_id,
-    )
-    .await
+    o2_openfga::authorizer::authz::list_objects(user_id, permission, object_type, org_id).await
 }
 
 #[cfg(feature = "enterprise")]
@@ -824,8 +812,11 @@ pub(crate) async fn list_objects_for_user(
     permission: &str,
     object_type: &str,
 ) -> Result<Option<Vec<String>>, Error> {
-    let o2cfg = get_o2_config();
-    if !is_root_user(user_id) && o2cfg.openfga.enabled && o2cfg.openfga.list_only_permitted {
+    let openfga_config = get_openfga_config();
+    if !is_root_user(user_id)
+        && openfga_config.openfga.enabled
+        && openfga_config.openfga.list_only_permitted
+    {
         match crate::handler::http::auth::validator::list_objects(
             user_id,
             permission,

--- a/src/handler/http/request/authz/fga.rs
+++ b/src/handler/http/request/authz/fga.rs
@@ -16,7 +16,7 @@ use std::io::Error;
 
 use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse};
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::dex::meta::auth::RoleRequest;
+use o2_dex::meta::auth::RoleRequest;
 
 use crate::common::meta::user::{UserGroup, UserGroupRequest, UserRoleRequest};
 
@@ -29,12 +29,7 @@ pub async fn create_role(
     let org_id = org_id.into_inner();
     let user_req = user_req.into_inner();
 
-    match o2_enterprise::enterprise::openfga::authorizer::roles::create_role(
-        &user_req.name,
-        &org_id,
-    )
-    .await
-    {
+    match o2_openfga::authorizer::roles::create_role(&user_req.name, &org_id).await {
         Ok(_) => Ok(HttpResponse::Ok().finish()),
         Err(err) => Ok(HttpResponse::InternalServerError().body(err.to_string())),
     }
@@ -54,9 +49,7 @@ pub async fn create_role(
 pub async fn delete_role(path: web::Path<(String, String)>) -> Result<HttpResponse, Error> {
     let (org_id, role_name) = path.into_inner();
 
-    match o2_enterprise::enterprise::openfga::authorizer::roles::delete_role(&org_id, &role_name)
-        .await
-    {
+    match o2_openfga::authorizer::roles::delete_role(&org_id, &role_name).await {
         Ok(_) => Ok(HttpResponse::Ok().finish()),
         Err(err) => Ok(HttpResponse::InternalServerError().body(err.to_string())),
     }
@@ -109,9 +102,7 @@ pub async fn get_roles(org_id: web::Path<String>, req: HttpRequest) -> Result<Ht
         permitted = Some(local_permitted);
     }
 
-    match o2_enterprise::enterprise::openfga::authorizer::roles::get_all_roles(&org_id, permitted)
-        .await
-    {
+    match o2_openfga::authorizer::roles::get_all_roles(&org_id, permitted).await {
         Ok(res) => Ok(HttpResponse::Ok().json(res)),
         Err(err) => Ok(HttpResponse::InternalServerError().body(err.to_string())),
     }
@@ -135,7 +126,7 @@ pub async fn update_role(
     let (org_id, role_id) = path.into_inner();
     let update_role = update_role.into_inner();
 
-    match o2_enterprise::enterprise::openfga::authorizer::roles::update_role(
+    match o2_openfga::authorizer::roles::update_role(
         &org_id,
         &role_id,
         update_role.add,
@@ -165,11 +156,7 @@ pub async fn get_role_permissions(
     path: web::Path<(String, String, String)>,
 ) -> Result<HttpResponse, Error> {
     let (org_id, role_id, resource) = path.into_inner();
-    match o2_enterprise::enterprise::openfga::authorizer::roles::get_role_permissions(
-        &org_id, &role_id, &resource,
-    )
-    .await
-    {
+    match o2_openfga::authorizer::roles::get_role_permissions(&org_id, &role_id, &resource).await {
         Ok(res) => Ok(HttpResponse::Ok().json(res)),
         Err(err) => Ok(HttpResponse::InternalServerError().body(err.to_string())),
     }
@@ -187,11 +174,7 @@ pub async fn get_role_permissions(
 #[get("/{org_id}/roles/{role_id}/users")]
 pub async fn get_users_with_role(path: web::Path<(String, String)>) -> Result<HttpResponse, Error> {
     let (org_id, role_id) = path.into_inner();
-    match o2_enterprise::enterprise::openfga::authorizer::roles::get_users_with_role(
-        &org_id, &role_id,
-    )
-    .await
-    {
+    match o2_openfga::authorizer::roles::get_users_with_role(&org_id, &role_id).await {
         Ok(res) => Ok(HttpResponse::Ok().json(res)),
         Err(err) => Ok(HttpResponse::InternalServerError().body(err.to_string())),
     }
@@ -212,7 +195,7 @@ pub async fn create_group(
     let org_id = org_id.into_inner();
     let user_grp = user_group.into_inner();
 
-    match o2_enterprise::enterprise::openfga::authorizer::groups::create_group(
+    match o2_openfga::authorizer::groups::create_group(
         &org_id,
         &user_grp.name,
         user_grp.users.unwrap_or_default(),
@@ -242,7 +225,7 @@ pub async fn update_group(
     let (org_id, group_name) = path.into_inner();
     let user_grp = user_group.into_inner();
 
-    match o2_enterprise::enterprise::openfga::authorizer::groups::update_group(
+    match o2_openfga::authorizer::groups::update_group(
         &org_id,
         &group_name,
         user_grp.add_users,
@@ -308,9 +291,7 @@ pub async fn get_groups(path: web::Path<String>, req: HttpRequest) -> Result<Htt
         permitted = Some(local_permitted);
     }
 
-    match o2_enterprise::enterprise::openfga::authorizer::groups::get_all_groups(&org_id, permitted)
-        .await
-    {
+    match o2_openfga::authorizer::groups::get_all_groups(&org_id, permitted).await {
         Ok(res) => Ok(HttpResponse::Ok().json(res)),
         Err(err) => Ok(HttpResponse::InternalServerError().body(err.to_string())),
     }
@@ -327,12 +308,7 @@ pub async fn get_groups(_path: web::Path<String>) -> Result<HttpResponse, Error>
 pub async fn get_group_details(path: web::Path<(String, String)>) -> Result<HttpResponse, Error> {
     let (org_id, group_name) = path.into_inner();
 
-    match o2_enterprise::enterprise::openfga::authorizer::groups::get_group_details(
-        &org_id,
-        &group_name,
-    )
-    .await
-    {
+    match o2_openfga::authorizer::groups::get_group_details(&org_id, &group_name).await {
         Ok(res) => Ok(HttpResponse::Ok().json(res)),
         Err(err) => Ok(HttpResponse::InternalServerError().body(err.to_string())),
     }
@@ -347,8 +323,8 @@ pub async fn get_group_details(_path: web::Path<(String, String)>) -> Result<Htt
 #[cfg(feature = "enterprise")]
 #[get("/{org_id}/resources")]
 pub async fn get_resources(_org_id: web::Path<String>) -> Result<HttpResponse, Error> {
-    use o2_enterprise::enterprise::openfga::meta::mapping::Resource;
-    let resources = o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS
+    use o2_openfga::meta::mapping::Resource;
+    let resources = o2_openfga::meta::mapping::OFGA_MODELS
         .values()
         .collect::<Vec<&Resource>>();
     Ok(HttpResponse::Ok().json(resources))
@@ -365,9 +341,7 @@ pub async fn get_resources(_org_id: web::Path<String>) -> Result<HttpResponse, E
 pub async fn delete_group(path: web::Path<(String, String)>) -> Result<HttpResponse, Error> {
     let (org_id, group_name) = path.into_inner();
 
-    match o2_enterprise::enterprise::openfga::authorizer::groups::delete_group(&org_id, &group_name)
-        .await
-    {
+    match o2_openfga::authorizer::groups::delete_group(&org_id, &group_name).await {
         Ok(_) => Ok(HttpResponse::Ok().finish()),
         Err(err) => Ok(HttpResponse::InternalServerError().body(err.to_string())),
     }

--- a/src/handler/http/request/pipeline.rs
+++ b/src/handler/http/request/pipeline.rs
@@ -96,7 +96,7 @@ async fn list_pipelines(
     // Get List of allowed objects
     #[cfg(feature = "enterprise")]
     {
-        use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+        use o2_openfga::meta::mapping::OFGA_MODELS;
 
         let user_id = _req.headers().get("user_id").unwrap();
         match crate::handler::http::auth::validator::list_objects_for_user(

--- a/src/handler/http/request/promql/mod.rs
+++ b/src/handler/http/request/promql/mod.rs
@@ -20,10 +20,7 @@ use config::utils::time::{parse_milliseconds, parse_str_to_timestamp_micros};
 use infra::errors;
 use promql_parser::parser;
 #[cfg(feature = "enterprise")]
-use {
-    config::meta::stream::StreamType,
-    o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS,
-};
+use {config::meta::stream::StreamType, o2_openfga::meta::mapping::OFGA_MODELS};
 
 use crate::{
     common::{meta::http::HttpResponse as MetaHttpResponse, utils::http::get_or_create_trace_id},

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -283,7 +283,7 @@ pub async fn search(
         for key in keys_used {
             // Check permissions on keys
             {
-                use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+                use o2_openfga::meta::mapping::OFGA_MODELS;
 
                 use crate::common::{
                     infra::config::USERS,

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -233,7 +233,7 @@ pub async fn search_multi(
         // Check permissions on stream
         #[cfg(feature = "enterprise")]
         {
-            use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+            use o2_openfga::meta::mapping::OFGA_MODELS;
 
             use crate::common::{
                 infra::config::USERS,

--- a/src/handler/http/request/search/utils.rs
+++ b/src/handler/http/request/search/utils.rs
@@ -15,7 +15,7 @@
 
 use actix_web::HttpResponse;
 use config::meta::stream::StreamType;
-use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+use o2_openfga::meta::mapping::OFGA_MODELS;
 
 use crate::common::{
     infra::config::USERS,

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -197,16 +197,16 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
     #[cfg(feature = "enterprise")]
     let openfga_cfg = get_openfga_config();
     #[cfg(feature = "enterprise")]
-    let sso_enabled = dex_cfg.dex.dex_enabled;
+    let sso_enabled = dex_cfg.dex_enabled;
     #[cfg(not(feature = "enterprise"))]
     let sso_enabled = false;
     #[cfg(feature = "enterprise")]
-    let native_login_enabled = dex_cfg.dex.native_login_enabled;
+    let native_login_enabled = dex_cfg.native_login_enabled;
     #[cfg(not(feature = "enterprise"))]
     let native_login_enabled = true;
 
     #[cfg(feature = "enterprise")]
-    let rbac_enabled = openfga_cfg.openfga.enabled;
+    let rbac_enabled = openfga_cfg.enabled;
     #[cfg(not(feature = "enterprise"))]
     let rbac_enabled = false;
 
@@ -500,7 +500,7 @@ pub async fn redirect(req: HttpRequest) -> Result<HttpResponse, Error> {
             let token_ver = verify_decode_token(
                 &access_token,
                 &keys,
-                &get_dex_config().dex.client_id,
+                &get_dex_config().client_id,
                 true,
                 true,
             )

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -47,14 +47,16 @@ use {
     },
     crate::service::self_reporting::audit,
     config::{ider, utils::base64},
-    o2_enterprise::enterprise::{
-        common::{
-            auditor::{AuditMessage, HttpMeta, Protocol},
-            infra::config::{get_config as get_o2_config, refresh_config as refresh_o2_config},
-            settings::{get_logo, get_logo_text},
-        },
-        dex::service::auth::{exchange_code, get_dex_jwks, get_dex_login, refresh_token},
+    o2_dex::{
+        config::get_config as get_dex_config,
+        service::auth::{exchange_code, get_dex_jwks, get_dex_login, refresh_token},
     },
+    o2_enterprise::enterprise::common::{
+        auditor::{AuditMessage, HttpMeta, Protocol},
+        infra::config::{get_config as get_o2_config, refresh_config as refresh_o2_config},
+        settings::{get_logo, get_logo_text},
+    },
+    o2_openfga::config::get_config as get_openfga_config,
     std::io::ErrorKind,
 };
 
@@ -191,16 +193,20 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
     #[cfg(feature = "enterprise")]
     let o2cfg = get_o2_config();
     #[cfg(feature = "enterprise")]
-    let sso_enabled = o2cfg.dex.dex_enabled;
+    let dex_cfg = get_dex_config();
+    #[cfg(feature = "enterprise")]
+    let openfga_cfg = get_openfga_config();
+    #[cfg(feature = "enterprise")]
+    let sso_enabled = dex_cfg.dex.dex_enabled;
     #[cfg(not(feature = "enterprise"))]
     let sso_enabled = false;
     #[cfg(feature = "enterprise")]
-    let native_login_enabled = o2cfg.dex.native_login_enabled;
+    let native_login_enabled = dex_cfg.dex.native_login_enabled;
     #[cfg(not(feature = "enterprise"))]
     let native_login_enabled = true;
 
     #[cfg(feature = "enterprise")]
-    let rbac_enabled = o2cfg.openfga.enabled;
+    let rbac_enabled = openfga_cfg.openfga.enabled;
     #[cfg(not(feature = "enterprise"))]
     let rbac_enabled = false;
 
@@ -494,7 +500,7 @@ pub async fn redirect(req: HttpRequest) -> Result<HttpResponse, Error> {
             let token_ver = verify_decode_token(
                 &access_token,
                 &keys,
-                &get_o2_config().dex.client_id,
+                &get_dex_config().dex.client_id,
                 true,
                 true,
             )
@@ -591,7 +597,7 @@ pub async fn redirect(req: HttpRequest) -> Result<HttpResponse, Error> {
 #[cfg(feature = "enterprise")]
 #[get("/dex_login")]
 pub async fn dex_login() -> Result<HttpResponse, Error> {
-    use o2_enterprise::enterprise::dex::meta::auth::PreLoginData;
+    use o2_dex::meta::auth::PreLoginData;
 
     let login_data: PreLoginData = get_dex_login();
     let state = login_data.state;

--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -390,7 +390,7 @@ async fn list(org_id: web::Path<String>, req: HttpRequest) -> impl Responder {
     // Get List of allowed objects
     #[cfg(feature = "enterprise")]
     {
-        use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+        use o2_openfga::meta::mapping::OFGA_MODELS;
 
         let user_id = req.headers().get("user_id").unwrap();
         if let Some(s_type) = &stream_type {

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -155,7 +155,7 @@ pub async fn get_latest_traces(
 
     #[cfg(feature = "enterprise")]
     {
-        use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+        use o2_openfga::meta::mapping::OFGA_MODELS;
 
         use crate::common::{
             infra::config::USERS,

--- a/src/handler/http/request/users/mod.rs
+++ b/src/handler/http/request/users/mod.rs
@@ -31,10 +31,8 @@ use strum::IntoEnumIterator;
 #[cfg(feature = "enterprise")]
 use {
     crate::service::self_reporting::audit,
-    o2_enterprise::enterprise::common::{
-        auditor::{AuditMessage, HttpMeta, Protocol},
-        infra::config::get_config as get_o2_config,
-    },
+    o2_dex::config::get_config as get_dex_config,
+    o2_enterprise::enterprise::common::auditor::{AuditMessage, HttpMeta, Protocol},
 };
 
 use crate::{
@@ -253,7 +251,7 @@ pub async fn authentication(
     _req: HttpRequest,
 ) -> Result<HttpResponse, Error> {
     #[cfg(feature = "enterprise")]
-    let native_login_enabled = get_o2_config().dex.native_login_enabled;
+    let native_login_enabled = get_dex_config().dex.native_login_enabled;
     #[cfg(not(feature = "enterprise"))]
     let native_login_enabled = true;
 
@@ -287,9 +285,7 @@ pub async fn authentication(
                 if auth_header.is_some() {
                     let auth_header = auth_header.unwrap().to_str().unwrap();
                     if let Some((name, password)) =
-                        o2_enterprise::enterprise::dex::service::auth::get_user_from_token(
-                            auth_header,
-                        )
+                        o2_dex::service::auth::get_user_from_token(auth_header)
                     {
                         SignInUser { name, password }
                     } else {
@@ -315,7 +311,7 @@ pub async fn authentication(
 
     #[cfg(feature = "enterprise")]
     {
-        if get_o2_config().dex.root_only_login
+        if get_dex_config().dex.root_only_login
             && !crate::common::utils::auth::is_root_user(&auth.name)
         {
             audit_unauthorized_error(audit_message).await;
@@ -513,7 +509,7 @@ pub async fn get_auth(_req: HttpRequest) -> Result<HttpResponse, Error> {
                 return unauthorized_error(resp);
             };
 
-            use o2_enterprise::enterprise::dex::service::auth::get_user_from_token;
+            use o2_dex::service::auth::get_user_from_token;
 
             use crate::handler::http::auth::validator::{
                 validate_user, validate_user_for_query_params,

--- a/src/handler/http/request/users/mod.rs
+++ b/src/handler/http/request/users/mod.rs
@@ -251,7 +251,7 @@ pub async fn authentication(
     _req: HttpRequest,
 ) -> Result<HttpResponse, Error> {
     #[cfg(feature = "enterprise")]
-    let native_login_enabled = get_dex_config().dex.native_login_enabled;
+    let native_login_enabled = get_dex_config().native_login_enabled;
     #[cfg(not(feature = "enterprise"))]
     let native_login_enabled = true;
 
@@ -311,8 +311,7 @@ pub async fn authentication(
 
     #[cfg(feature = "enterprise")]
     {
-        if get_dex_config().dex.root_only_login
-            && !crate::common::utils::auth::is_root_user(&auth.name)
+        if get_dex_config().root_only_login && !crate::common::utils::auth::is_root_user(&auth.name)
         {
             audit_unauthorized_error(audit_message).await;
             return unauthorized_error(resp);

--- a/src/handler/http/request/users/service_accounts.rs
+++ b/src/handler/http/request/users/service_accounts.rs
@@ -35,7 +35,7 @@ pub async fn exchange_token(
             let token_ver = verify_decode_token(
                 &response.access_token,
                 &keys,
-                &get_dex_config().dex.client_id,
+                &get_dex_config().client_id,
                 true,
                 false,
             )

--- a/src/handler/http/request/users/service_accounts.rs
+++ b/src/handler/http/request/users/service_accounts.rs
@@ -1,12 +1,8 @@
 use actix_web::{post, web, Error, HttpRequest, HttpResponse};
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::{
-    common::{
-        auditor::{AuditMessage, HttpMeta, Protocol},
-        infra::config::get_config as get_o2_config,
-    },
-    dex::service::auth::get_dex_jwks,
-};
+use o2_dex::{config::get_config as get_dex_config, service::auth::get_dex_jwks};
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::common::auditor::{AuditMessage, HttpMeta, Protocol};
 
 #[cfg(feature = "enterprise")]
 use crate::service::self_reporting::audit;
@@ -17,11 +13,9 @@ use crate::{common::utils::jwt::verify_decode_token, handler::http::auth::jwt::p
 #[post("/token")]
 pub async fn exchange_token(
     req: HttpRequest,
-    body: web::Json<o2_enterprise::enterprise::dex::meta::auth::TokenExchangeRequest>,
+    body: web::Json<o2_dex::meta::auth::TokenExchangeRequest>,
 ) -> Result<HttpResponse, Error> {
-    let result =
-        o2_enterprise::enterprise::dex::service::token_exchange::exchange_token(&body.into_inner())
-            .await;
+    let result = o2_dex::service::token_exchange::exchange_token(&body.into_inner()).await;
 
     let mut audit_message = AuditMessage {
         user_email: "".to_string(),
@@ -41,7 +35,7 @@ pub async fn exchange_token(
             let token_ver = verify_decode_token(
                 &response.access_token,
                 &keys,
-                &get_o2_config().dex.client_id,
+                &get_dex_config().dex.client_id,
                 true,
                 false,
             )

--- a/src/handler/http/request/websocket/utils.rs
+++ b/src/handler/http/request/websocket/utils.rs
@@ -32,7 +32,7 @@ pub mod enterprise_utils {
         user_id: &str,
         org_id: &str,
     ) -> Result<(), String> {
-        use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+        use o2_openfga::meta::mapping::OFGA_MODELS;
 
         use crate::common::{
             infra::config::USERS,

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -219,7 +219,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
     // RBAC model
     #[cfg(feature = "enterprise")]
-    if get_openfga_config().openfga.enabled {
+    if get_openfga_config().enabled {
         if let Err(e) = crate::common::infra::ofga::init().await {
             log::error!("OFGA init failed: {}", e);
         }

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -16,7 +16,7 @@
 use config::cluster::LOCAL_NODE;
 use infra::file_list as infra_file_list;
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
+use o2_openfga::config::get_config as get_openfga_config;
 use regex::Regex;
 
 use crate::{
@@ -210,7 +210,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     tokio::task::spawn(async move { pipeline::run().await });
 
     #[cfg(feature = "enterprise")]
-    o2_enterprise::enterprise::openfga::authorizer::authz::init_open_fga().await;
+    o2_openfga::authorizer::authz::init_open_fga().await;
 
     #[cfg(feature = "enterprise")]
     tokio::task::spawn(async move { cipher::run().await });
@@ -219,7 +219,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
     // RBAC model
     #[cfg(feature = "enterprise")]
-    if get_o2_config().openfga.enabled {
+    if get_openfga_config().openfga.enabled {
         if let Err(e) = crate::common::infra::ofga::init().await {
             log::error!("OFGA init failed: {}", e);
         }

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -36,9 +36,11 @@ pub mod reports;
 pub mod timed_annotations;
 
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::{
-    common::infra::config::get_config as get_o2_config,
-    openfga::authorizer::authz::{get_ofga_type, remove_parent_relation, set_parent_relation},
+use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
+#[cfg(feature = "enterprise")]
+use o2_openfga::{
+    authorizer::authz::{get_ofga_type, remove_parent_relation, set_parent_relation},
+    config::get_config as get_openfga_config,
 };
 
 /// An error that occurs interacting with dashboards.
@@ -437,7 +439,7 @@ pub async fn move_dashboard(
             )
             .await;
         }
-        if get_o2_config().openfga.enabled {
+        if get_openfga_config().openfga.enabled {
             set_parent_relation(
                 dashboard_id,
                 &get_ofga_type("dashboards"),
@@ -469,7 +471,7 @@ pub async fn move_dashboard(
             )
             .await;
         }
-        if get_o2_config().openfga.enabled {
+        if get_openfga_config().openfga.enabled {
             remove_parent_relation(
                 dashboard_id,
                 &get_ofga_type("dashboards"),

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -439,7 +439,7 @@ pub async fn move_dashboard(
             )
             .await;
         }
-        if get_openfga_config().openfga.enabled {
+        if get_openfga_config().enabled {
             set_parent_relation(
                 dashboard_id,
                 &get_ofga_type("dashboards"),
@@ -471,7 +471,7 @@ pub async fn move_dashboard(
             )
             .await;
         }
-        if get_openfga_config().openfga.enabled {
+        if get_openfga_config().enabled {
             remove_parent_relation(
                 dashboard_id,
                 &get_ofga_type("dashboards"),

--- a/src/service/db/ofga.rs
+++ b/src/service/db/ofga.rs
@@ -16,12 +16,10 @@
 use std::sync::Arc;
 
 use config::utils::json;
-use o2_enterprise::enterprise::{
-    common::infra::config::*,
-    openfga::{
-        meta::mapping::OFGAModel,
-        model::{create_open_fga_store, read_ofga_model, write_auth_models},
-    },
+use o2_openfga::{
+    config::OFGA_STORE_ID,
+    meta::mapping::OFGAModel,
+    model::{create_open_fga_store, read_ofga_model, write_auth_models},
 };
 
 use crate::service::db;

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -306,13 +306,13 @@ impl Metadata for DistinctValues {
 
             #[cfg(feature = "enterprise")]
             {
-                use o2_enterprise::enterprise::{
-                    common::infra::config::get_config as get_o2_config,
-                    openfga::authorizer::authz::set_ownership_if_not_exists,
+                use o2_openfga::{
+                    authorizer::authz::set_ownership_if_not_exists,
+                    config::get_config as get_openfga_config,
                 };
 
                 // set ownership only in the first time
-                if _is_new && get_o2_config().openfga.enabled {
+                if _is_new && get_openfga_config().openfga.enabled {
                     set_ownership_if_not_exists(
                         &org_id,
                         &format!("{}:{}", StreamType::Metadata, distinct_stream_name),

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -312,7 +312,7 @@ impl Metadata for DistinctValues {
                 };
 
                 // set ownership only in the first time
-                if _is_new && get_openfga_config().openfga.enabled {
+                if _is_new && get_openfga_config().enabled {
                     set_ownership_if_not_exists(
                         &org_id,
                         &format!("{}:{}", StreamType::Metadata, distinct_stream_name),

--- a/src/service/metadata/trace_list_index.rs
+++ b/src/service/metadata/trace_list_index.rs
@@ -133,13 +133,13 @@ impl Metadata for TraceListIndex {
 
         #[cfg(feature = "enterprise")]
         {
-            use o2_enterprise::enterprise::{
-                common::infra::config::get_config as get_o2_config,
-                openfga::authorizer::authz::set_ownership_if_not_exists,
+            use o2_openfga::{
+                authorizer::authz::set_ownership_if_not_exists,
+                config::get_config as get_openfga_config,
             };
 
             // set ownership only in the first time
-            if _is_new && get_o2_config().openfga.enabled {
+            if _is_new && get_openfga_config().openfga.enabled {
                 set_ownership_if_not_exists(
                     org_id,
                     &format!("{}:{}", StreamType::Metadata, STREAM_NAME),

--- a/src/service/metadata/trace_list_index.rs
+++ b/src/service/metadata/trace_list_index.rs
@@ -139,7 +139,7 @@ impl Metadata for TraceListIndex {
             };
 
             // set ownership only in the first time
-            if _is_new && get_openfga_config().openfga.enabled {
+            if _is_new && get_openfga_config().enabled {
                 set_ownership_if_not_exists(
                     org_id,
                     &format!("{}:{}", StreamType::Metadata, STREAM_NAME),

--- a/src/service/users.rs
+++ b/src/service/users.rs
@@ -74,7 +74,7 @@ pub async fn post_user(
     };
 
     #[cfg(feature = "enterprise")]
-    let is_allowed = if get_openfga_config().openfga.enabled {
+    let is_allowed = if get_openfga_config().enabled {
         // Permission already checked through RBAC
         true
     } else {
@@ -114,7 +114,7 @@ pub async fn post_user(
                     },
                     meta::mapping::{NON_OWNING_ORG, OFGA_MODELS},
                 };
-                if get_openfga_config().openfga.enabled {
+                if get_openfga_config().enabled {
                     let mut tuples = vec![];
                     get_user_role_tuple(
                         &usr_req.role.to_string(),
@@ -334,7 +334,7 @@ pub async fn update_user(
                             {
                                 use o2_openfga::authorizer::authz::update_user_role;
 
-                                if get_openfga_config().openfga.enabled
+                                if get_openfga_config().enabled
                                     && old_role.is_some()
                                     && new_role.is_some()
                                 {
@@ -465,7 +465,7 @@ pub async fn add_user_to_org(
                     },
                     meta::mapping::{NON_OWNING_ORG, OFGA_MODELS},
                 };
-                if get_openfga_config().openfga.enabled {
+                if get_openfga_config().enabled {
                     let mut tuples = vec![];
                     get_user_role_tuple(&role.to_string(), email, org_id, &mut tuples);
                     get_org_creation_tuples(
@@ -658,7 +658,7 @@ pub async fn remove_user_from_org(
                             } else {
                                 user_role.to_string()
                             };
-                            if get_openfga_config().openfga.enabled {
+                            if get_openfga_config().enabled {
                                 log::debug!("delete user single org, role: {}", &user_fga_role);
                                 delete_user_from_org(org_id, email_id, &user_fga_role).await;
                                 if user_role.eq(&UserRole::ServiceAccount) {
@@ -704,8 +704,7 @@ pub async fn remove_user_from_org(
                                     "user_fga_role, multi org: {}",
                                     _user_fga_role.as_ref().unwrap()
                                 );
-                                if get_openfga_config().openfga.enabled && _user_fga_role.is_some()
-                                {
+                                if get_openfga_config().enabled && _user_fga_role.is_some() {
                                     delete_user_from_org(
                                         org_id,
                                         email_id,

--- a/src/service/users.rs
+++ b/src/service/users.rs
@@ -18,9 +18,8 @@ use std::io::Error;
 use actix_web::{http, HttpResponse};
 use config::{get_config, ider, utils::rand::generate_random_string};
 #[cfg(feature = "enterprise")]
-use o2_enterprise::enterprise::{
-    common::infra::config::get_config as get_o2_config,
-    openfga::authorizer::authz::delete_service_account_from_org,
+use o2_openfga::{
+    authorizer::authz::delete_service_account_from_org, config::get_config as get_openfga_config,
 };
 use regex::Regex;
 
@@ -75,7 +74,7 @@ pub async fn post_user(
     };
 
     #[cfg(feature = "enterprise")]
-    let is_allowed = if get_o2_config().openfga.enabled {
+    let is_allowed = if get_openfga_config().openfga.enabled {
         // Permission already checked through RBAC
         true
     } else {
@@ -108,14 +107,14 @@ pub async fn post_user(
             // Update OFGA
             #[cfg(feature = "enterprise")]
             {
-                use o2_enterprise::enterprise::openfga::{
+                use o2_openfga::{
                     authorizer::authz::{
                         get_org_creation_tuples, get_service_account_creation_tuple,
                         get_user_role_tuple, update_tuples,
                     },
                     meta::mapping::{NON_OWNING_ORG, OFGA_MODELS},
                 };
-                if get_o2_config().openfga.enabled {
+                if get_openfga_config().openfga.enabled {
                     let mut tuples = vec![];
                     get_user_role_tuple(
                         &usr_req.role.to_string(),
@@ -333,9 +332,9 @@ pub async fn update_user(
 
                             #[cfg(feature = "enterprise")]
                             {
-                                use o2_enterprise::enterprise::openfga::authorizer::authz::update_user_role;
+                                use o2_openfga::authorizer::authz::update_user_role;
 
-                                if get_o2_config().openfga.enabled
+                                if get_openfga_config().openfga.enabled
                                     && old_role.is_some()
                                     && new_role.is_some()
                                 {
@@ -460,13 +459,13 @@ pub async fn add_user_to_org(
             // Update OFGA
             #[cfg(feature = "enterprise")]
             {
-                use o2_enterprise::enterprise::openfga::{
+                use o2_openfga::{
                     authorizer::authz::{
                         get_org_creation_tuples, get_user_role_tuple, update_tuples,
                     },
                     meta::mapping::{NON_OWNING_ORG, OFGA_MODELS},
                 };
-                if get_o2_config().openfga.enabled {
+                if get_openfga_config().openfga.enabled {
                     let mut tuples = vec![];
                     get_user_role_tuple(&role.to_string(), email, org_id, &mut tuples);
                     get_org_creation_tuples(
@@ -650,7 +649,7 @@ pub async fn remove_user_from_org(
                         let _ = db::user::delete(email_id).await;
                         #[cfg(feature = "enterprise")]
                         {
-                            use o2_enterprise::enterprise::openfga::authorizer::authz::delete_user_from_org;
+                            use o2_openfga::authorizer::authz::delete_user_from_org;
                             let user_role = &orgs[0].role;
                             let user_fga_role = if user_role.eq(&UserRole::ServiceAccount)
                                 || user_role.eq(&UserRole::User)
@@ -659,7 +658,7 @@ pub async fn remove_user_from_org(
                             } else {
                                 user_role.to_string()
                             };
-                            if get_o2_config().openfga.enabled {
+                            if get_openfga_config().openfga.enabled {
                                 log::debug!("delete user single org, role: {}", &user_fga_role);
                                 delete_user_from_org(org_id, email_id, &user_fga_role).await;
                                 if user_role.eq(&UserRole::ServiceAccount) {
@@ -700,12 +699,13 @@ pub async fn remove_user_from_org(
                             USERS.remove(&format!("{org_id}/{email_id}"));
                             #[cfg(feature = "enterprise")]
                             {
-                                use o2_enterprise::enterprise::openfga::authorizer::authz::delete_user_from_org;
+                                use o2_openfga::authorizer::authz::delete_user_from_org;
                                 log::debug!(
                                     "user_fga_role, multi org: {}",
                                     _user_fga_role.as_ref().unwrap()
                                 );
-                                if get_o2_config().openfga.enabled && _user_fga_role.is_some() {
+                                if get_openfga_config().openfga.enabled && _user_fga_role.is_some()
+                                {
                                     delete_user_from_org(
                                         org_id,
                                         email_id,


### PR DESCRIPTION
Note: This PR has an [accompanying PR](https://github.com/openobserve/o2-enterprise/pull/331) in the enterprise repo

This splits the `openfga` and `dex` modules into their own crates, `o2_openfga` and `o2_dex`.

**Why?** 
We want to be able to reference the `o2_enterprise::openfga` module from within the `infra::table` module so that we can perform OpenFGA data migrations as part of data transformation migrations in the `openobserve` app. However, the `o2_enterprise` module references the `infra::table` module in various places (eg: inside `o2_enterprise::enterprise::actions::action_manager`). Therefore we cannot reference `o2_enterprise::enterprise::openfga` from `infra::table` without introducing a circular dependency.

The solution presented by this PR is to move the `openfga` module into its own crate, so that `infra::table` can reference the new create without creating a circular dependency. As part of this PR we also move the `dex` module into its own crate since the `openfga` module depends on the `dex` module, and we do not want the new `o2_openfga` crate to depend on the `o2_enterprise` crate.

![Captura de pantalla 2025-02-04 a la(s) 3 53 42 p m](https://github.com/user-attachments/assets/bb2b748c-e40c-470f-a295-90087f4ed989)

![Captura de pantalla 2025-02-04 a la(s) 3 51 14 p m](https://github.com/user-attachments/assets/3237aa75-fc31-4821-bf80-3ec83e9c39bc)
