### PR TITLE
fix: rbac for GET for individual folders, destinations, alerts and templates

### DIFF
--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -365,6 +365,7 @@ impl FromRequest for AuthExtractor {
                 )
             } else if method.eq("GET")
                 && (path_columns[1].starts_with("dashboards")
+                    || path_columns[1].starts_with("folders")
                     || path_columns[1].starts_with("actions"))
             {
                 format!(
@@ -435,6 +436,19 @@ impl FromRequest for AuthExtractor {
                     OFGA_MODELS
                         .get(path_columns[1])
                         .map_or(path_columns[1], |model| model.key),
+                    path_columns[3]
+                )
+            } else if method.eq("GET")
+                && (path_columns[2].eq("templates")
+                    || path_columns[2].eq("destinations")
+                    || path_columns[2].eq("alerts"))
+            {
+                // To access templates, you need GET permission on the template
+                format!(
+                    "{}:{}",
+                    OFGA_MODELS
+                        .get(path_columns[2])
+                        .map_or(path_columns[2], |model| model.key),
                     path_columns[3]
                 )
             } else {

--- a/src/common/utils/auth_tests.rs
+++ b/src/common/utils/auth_tests.rs
@@ -3,6 +3,7 @@
 mod tests {
     use actix_http::Method;
     use actix_web::{test, FromRequest};
+    use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
 
     use super::super::auth::AuthExtractor;
 
@@ -31,6 +32,8 @@ mod tests {
     const PIPELINE_ID: &str = "TEST_PIPELINE_ID";
     const SHORT_URL_ID: &str = "TEST_SHORT_URL_ID";
     const WS_REQUEST_ID: &str = "TEST_WS_REQUEST_ID";
+    const ACTION_KSUID: &str = "TEST_ACTION_KSUID";
+    const CIPHER_KEY_ID: &str = "TEST_CIPHER_KEY_ID";
 
     const POST_METHOD: &str = "POST";
     const GET_METHOD: &str = "GET";
@@ -2666,11 +2669,251 @@ mod tests {
             format!("api{ORG_ID}/ws/{WS_REQUEST_ID}"),
             AuthExtractor {
                 auth: AUTH_HEADER_VAL.to_string(),
-                // Should these be empty strings?
                 method: format!(""),
                 o2_type: format!(""),
                 org_id: format!(""),
                 bypass_check: true,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    // Tests for routes defined in handler::http::request::actions.
+
+    #[tokio::test]
+    async fn delete_action() {
+        test_auth(
+            Method::DELETE,
+            format!("api/{ORG_ID}/actions/{ACTION_KSUID}"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: format!("{DELETE_METHOD}"),
+                o2_type: format!(
+                    "{}:{ACTION_KSUID}",
+                    OFGA_MODELS
+                        .get("actions")
+                        .map_or("actions", |model| model.key)
+                ),
+                org_id: format!("{ORG_ID}"),
+                bypass_check: false,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn serve_action_zip() {
+        test_auth(
+            Method::GET,
+            format!("api/{ORG_ID}/actions/download/{ACTION_KSUID}"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: format!("{GET_METHOD}"),
+                o2_type: format!(
+                    "{}:{ACTION_KSUID}",
+                    OFGA_MODELS
+                        .get("actions")
+                        .map_or("actions", |model| model.key)
+                ),
+                org_id: format!("{ORG_ID}"),
+                bypass_check: false,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn update_action() {
+        test_auth(
+            Method::PUT,
+            format!("api/{ORG_ID}/actions/{ACTION_KSUID}"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: format!("{PUT_METHOD}"),
+                o2_type: format!(
+                    "{}:{ACTION_KSUID}",
+                    OFGA_MODELS
+                        .get("actions")
+                        .map_or("actions", |model| model.key)
+                ),
+                org_id: format!("{ORG_ID}"),
+                bypass_check: false,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn list_actions() {
+        test_auth(
+            Method::GET,
+            format!("api/{ORG_ID}/actions"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: format!("{LIST_METHOD}"),
+                o2_type: format!(
+                    "{}:{ORG_ID}",
+                    OFGA_MODELS
+                        .get("actions")
+                        .map_or("actions", |model| model.key)
+                ),
+                org_id: format!("{ORG_ID}"),
+                bypass_check: false,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn get_single_action() {
+        test_auth(
+            Method::GET,
+            format!("api/{ORG_ID}/actions/{ACTION_KSUID}"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: format!("{GET_METHOD}"),
+                o2_type: format!(
+                    "{}:{ACTION_KSUID}",
+                    OFGA_MODELS
+                        .get("actions")
+                        .map_or("actions", |model| model.key)
+                ),
+                org_id: format!("{ORG_ID}"),
+                bypass_check: false,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn upload_action() {
+        test_auth(
+            Method::POST,
+            format!("api/{ORG_ID}/actions/upload"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: "".to_string(),
+                o2_type: "".to_string(),
+                org_id: "".to_string(),
+                bypass_check: true,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    // Tests for routes defined in handler::http::request::keys.
+
+    #[tokio::test]
+    async fn save_cipher_keys() {
+        test_auth(
+            Method::POST,
+            format!("api/{ORG_ID}/cipher_keys"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: format!("{POST_METHOD}"),
+                o2_type: format!(
+                    "{}:{ORG_ID}",
+                    OFGA_MODELS
+                        .get("cipher_keys")
+                        .map_or("cipher_keys", |model| model.key)
+                ),
+                org_id: format!("{ORG_ID}"),
+                bypass_check: false,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn get_cipher_key() {
+        test_auth(
+            Method::GET,
+            format!("api/{ORG_ID}/cipher_keys/{CIPHER_KEY_ID}"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: format!("{GET_METHOD}"),
+                o2_type: format!(
+                    "{}:{CIPHER_KEY_ID}",
+                    OFGA_MODELS
+                        .get("cipher_keys")
+                        .map_or("cipher_keys", |model| model.key)
+                ),
+                org_id: format!("{ORG_ID}"),
+                bypass_check: false,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn list_cipher_keys() {
+        test_auth(
+            Method::GET,
+            format!("api/{ORG_ID}/cipher_keys"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: format!("{LIST_METHOD}"),
+                o2_type: format!(
+                    "{}:{ORG_ID}",
+                    OFGA_MODELS
+                        .get("cipher_keys")
+                        .map_or("cipher_keys", |model| model.key)
+                ),
+                org_id: format!("{ORG_ID}"),
+                bypass_check: false,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn delete_cipher_key() {
+        test_auth(
+            Method::DELETE,
+            format!("api/{ORG_ID}/cipher_keys/{CIPHER_KEY_ID}"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: format!("{DELETE_METHOD}"),
+                o2_type: format!(
+                    "{}:{CIPHER_KEY_ID}",
+                    OFGA_MODELS
+                        .get("cipher_keys")
+                        .map_or("cipher_keys", |model| model.key)
+                ),
+                org_id: format!("{ORG_ID}"),
+                bypass_check: false,
+                parent_id: format!("default"),
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn update_cipher_key() {
+        test_auth(
+            Method::PUT,
+            format!("api/{ORG_ID}/cipher_keys/{CIPHER_KEY_ID}"),
+            AuthExtractor {
+                auth: AUTH_HEADER_VAL.to_string(),
+                method: format!("{PUT_METHOD}"),
+                o2_type: format!(
+                    "{}:{CIPHER_KEY_ID}",
+                    OFGA_MODELS
+                        .get("cipher_keys")
+                        .map_or("cipher_keys", |model| model.key)
+                ),
+                org_id: format!("{ORG_ID}"),
+                bypass_check: false,
                 parent_id: format!("default"),
             },
         )

--- a/src/common/utils/auth_tests.rs
+++ b/src/common/utils/auth_tests.rs
@@ -1702,8 +1702,7 @@ mod tests {
             AuthExtractor {
                 auth: AUTH_HEADER_VAL.to_string(),
                 method: format!("{GET_METHOD}"),
-                // Is this correct? Should it be dfolder:TEST_FOLDER_ID?
-                o2_type: format!("dfolder:{ORG_ID}"),
+                o2_type: format!("dfolder:{FOLDER_ID}"),
                 org_id: format!("{ORG_ID}"),
                 bypass_check: false,
                 parent_id: format!("default"),
@@ -1826,7 +1825,7 @@ mod tests {
                 method: format!("{GET_METHOD}"),
                 // Is this correct? Can two streams have the same name if they
                 // have different types?
-                o2_type: format!("{STREAM_NAME}:alerts"),
+                o2_type: format!("alert:{ALERT_NAME}"),
                 org_id: format!("{ORG_ID}"),
                 bypass_check: false,
                 parent_id: format!("default"),
@@ -1932,7 +1931,7 @@ mod tests {
             AuthExtractor {
                 auth: AUTH_HEADER_VAL.to_string(),
                 method: format!("{GET_METHOD}"),
-                o2_type: format!("alert:templates"), // Is this correct?
+                o2_type: format!("template:{TEMPLATE_NAME}"),
                 org_id: format!("{ORG_ID}"),
                 bypass_check: false,
                 parent_id: format!("default"),
@@ -2019,7 +2018,7 @@ mod tests {
             AuthExtractor {
                 auth: AUTH_HEADER_VAL.to_string(),
                 method: format!("{GET_METHOD}"),
-                o2_type: format!("alert:destinations"), // Is this correct?
+                o2_type: format!("destination:{DESTINATION_NAME}"), // Is this correct?
                 org_id: format!("{ORG_ID}"),
                 bypass_check: false,
                 parent_id: format!("default"),


### PR DESCRIPTION
Fixes #5826 

Also add new tests for cypher keys and action scripts rbac tests