### PR TITLE
fix: search api pagination when cache enabled

### DIFF
--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -60,6 +60,7 @@ pub async fn search(
     let start = std::time::Instant::now();
     let started_at = Utc::now().timestamp_micros();
     let cfg = get_config();
+    // result cache can be enable only when its from the start
     let use_cache = if in_req.query.from == 0 {
         in_req.use_cache.unwrap_or(false)
     } else {

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -60,7 +60,11 @@ pub async fn search(
     let start = std::time::Instant::now();
     let started_at = Utc::now().timestamp_micros();
     let cfg = get_config();
-    let use_cache = in_req.use_cache.unwrap_or(false);
+    let use_cache = if in_req.query.from == 0 {
+        in_req.use_cache.unwrap_or(false)
+    } else {
+        false
+    };
 
     // Result caching check start
     let mut origin_sql = in_req.query.sql.clone();


### PR DESCRIPTION
Result cache cannot be used when from is a value apart form zero, i.e. (100, 200, etc) when a request needs results from in between records present in cache. 