### PR TITLE
fix: stream stats with data retention

### DIFF
--- a/src/handler/http/router/middlewares/slow_log.rs
+++ b/src/handler/http/router/middlewares/slow_log.rs
@@ -100,7 +100,7 @@ where
 
             if duration > threshold {
                 log::warn!(
-                    "Slow request detected - remote_addr: {}, method: {}, path: {}, took: {:.6}",
+                    "slow request detected - remote_addr: {}, method: {}, path: {}, took: {:.6}",
                     remote_addr,
                     method,
                     path,

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -325,6 +325,14 @@ pub async fn merge_by_stream(
 
     // get schema
     let schema = infra::schema::get(org_id, stream_name, stream_type).await?;
+    if schema == Schema::empty() {
+        // the stream was deleted, mark the job as done
+        if let Err(e) = infra_file_list::set_job_done(&[job_id]).await {
+            log::error!("[COMPACT] set_job_done failed: {e}");
+        }
+        return Ok(());
+    }
+
     let stream_settings = unwrap_stream_settings(&schema).unwrap_or_default();
     let partition_time_level =
         unwrap_partition_time_level(stream_settings.partition_time_level, stream_type);

--- a/src/service/compact/retention.rs
+++ b/src/service/compact/retention.rs
@@ -299,15 +299,6 @@ pub async fn delete_all(
         stream_name
     );
 
-    // delete stream stats
-    infra_file_list::del_stream_stats(org_id, stream_type, stream_name).await?;
-    log::info!(
-        "deleted stream_stats for: {}/{}/{}/all",
-        org_id,
-        stream_type,
-        stream_name
-    );
-
     // mark delete done
     db::compact::retention::delete_stream_done(org_id, stream_type, stream_name, None).await?;
     log::info!(

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -600,9 +600,6 @@ pub async fn delete_stream(
         STREAM_RECORD_ID_GENERATOR.remove(&key);
     }
 
-    // delete stream stats cache
-    stats::remove_stream_stats(org_id, stream_name, stream_type);
-
     // delete stream compaction offset
     if let Err(e) = db::compact::files::del_offset(org_id, stream_type, stream_name).await {
         return Ok(


### PR DESCRIPTION
This PR fixed the issue that we deleted stream stats when we delete the stream, but we are using sortDelete for file_list, later the file will calculate again, that will cause the stream stats become negative.