### PR TITLE
fix: `disable_remove_filter` flag for sql

### DIFF
--- a/src/common/utils/websocket.rs
+++ b/src/common/utils/websocket.rs
@@ -195,4 +195,24 @@ mod tests {
             "Updated remaining query range should be correct"
         );
     }
+
+    #[test]
+    fn test_histogram_with_normal_where() {
+        let sql = "SELECT histogram(_timestamp, '30 seconds') AS time_bucket, COUNT(*) AS count FROM logs WHERE status = 500 AND level = 'error' GROUP BY time_bucket ORDER BY time_bucket ASC";
+        let histogram_interval = 30;
+
+        let result = update_histogram_interval_in_query(sql, histogram_interval).unwrap();
+
+        assert_eq!(result, sql);
+    }
+
+    #[test]
+    fn test_histogram_with_match_all_udf() {
+        let sql = "SELECT histogram(_timestamp, '10 second') AS zo_sql_key, COUNT(*) AS zo_sql_num FROM default WHERE match_all('.parquet') GROUP BY zo_sql_key ORDER BY zo_sql_key ASC";
+        let histogram_interval = 10;
+
+        let result = update_histogram_interval_in_query(sql, histogram_interval).unwrap();
+
+        assert_eq!(result, sql);
+    }
 }

--- a/src/handler/http/request/websocket/search.rs
+++ b/src/handler/http/request/websocket/search.rs
@@ -150,7 +150,8 @@ pub async fn handle_search_request(
     }
 
     // create new sql query with histogram interval
-    let sql = Sql::new(&req.payload.query.clone().into(), org_id, stream_type).await?;
+    // disable_remove_filter in sql while updating histogram interval
+    let sql = Sql::new(&req.payload.query.clone().into(), org_id, stream_type, true).await?;
     if let Some(interval) = sql.histogram_interval {
         // modify the sql query statement to include the histogram interval
         let updated_query = update_histogram_interval_in_query(&sql.sql, interval)?;

--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -97,7 +97,7 @@ pub async fn check_cache(
     let cfg = get_config();
 
     let query: SearchQuery = req.query.clone().into();
-    let sql = match Sql::new(&query, org_id, stream_type).await {
+    let sql = match Sql::new(&query, org_id, stream_type, true).await {
         Ok(v) => v,
         Err(e) => {
             log::error!("Error parsing sql: {:?}", e);

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -122,7 +122,7 @@ pub async fn search(
         .await
     } else {
         let query: SearchQuery = req.query.clone().into();
-        match crate::service::search::Sql::new(&query, org_id, stream_type).await {
+        match crate::service::search::Sql::new(&query, org_id, stream_type, false).await {
             Ok(v) => {
                 let (ts_column, is_descending) =
                     cacher::get_ts_col_order_by(&v, &cfg.common.column_timestamp, is_aggregate)
@@ -856,7 +856,7 @@ pub async fn check_cache_v2(
         resp
     } else {
         let query = req.query.into();
-        match crate::service::search::Sql::new(&query, org_id, stream_type).await {
+        match crate::service::search::Sql::new(&query, org_id, stream_type, true).await {
             Ok(v) => {
                 let (ts_column, is_descending) =
                     cacher::get_ts_col_order_by(&v, &cfg.common.column_timestamp, is_aggregate)

--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -45,7 +45,7 @@ pub async fn search(
     let track_total_hits = query.track_total_hits;
 
     // handle request time range
-    let meta = Sql::new_from_req(&req, &query).await?;
+    let meta = Sql::new_from_req(&req, &query, false).await?;
     let sql = Arc::new(meta);
 
     // set this value to null & use it later on results ,

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -561,7 +561,7 @@ pub async fn search_partition(
         sql: req.sql.to_string(),
         ..Default::default()
     };
-    let sql = Sql::new(&query, org_id, stream_type).await?;
+    let sql = Sql::new(&query, org_id, stream_type, false).await?;
 
     // check for vrl
     let apply_over_hits = match req.query_fn.as_ref() {

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -95,14 +95,19 @@ pub struct Sql {
 }
 
 impl Sql {
-    pub async fn new_from_req(req: &Request, query: &SearchQuery) -> Result<Sql, Error> {
-        Self::new(query, &req.org_id, req.stream_type).await
+    pub async fn new_from_req(
+        req: &Request,
+        query: &SearchQuery,
+        disable_remove_filter: bool,
+    ) -> Result<Sql, Error> {
+        Self::new(query, &req.org_id, req.stream_type, disable_remove_filter).await
     }
 
     pub async fn new(
         query: &SearchQuery,
         org_id: &str,
         stream_type: StreamType,
+        disable_remove_filter: bool,
     ) -> Result<Sql, Error> {
         let cfg = get_config();
         let sql = query.sql.clone();
@@ -246,6 +251,7 @@ impl Sql {
             && stream_names.len() == 1
             && cfg.common.inverted_index_enabled
             && use_inverted_index
+            && !disable_remove_filter
         {
             let is_remove_filter = cfg.common.feature_query_remove_filter_with_index;
             let mut index_visitor = IndexVisitor::new(&used_schemas, is_remove_filter);


### PR DESCRIPTION
1. all search expect for the update_histogram_interval in ws will always have `disable_remove_filter` flag enabled