### PR TITLE
fix: ws update histogram interval sql

### DIFF
--- a/src/common/utils/websocket.rs
+++ b/src/common/utils/websocket.rs
@@ -195,4 +195,24 @@ mod tests {
             "Updated remaining query range should be correct"
         );
     }
+
+    #[test]
+    fn test_histogram_with_normal_where() {
+        let sql = "SELECT histogram(_timestamp, '30 seconds') AS time_bucket, COUNT(*) AS count FROM logs WHERE status = 500 AND level = 'error' GROUP BY time_bucket ORDER BY time_bucket ASC";
+        let histogram_interval = 30;
+
+        let result = update_histogram_interval_in_query(sql, histogram_interval).unwrap();
+
+        assert_eq!(result, sql);
+    }
+
+    #[test]
+    fn test_histogram_with_match_all_udf() {
+        let sql = "SELECT histogram(_timestamp, '10 second') AS zo_sql_key, COUNT(*) AS zo_sql_num FROM default WHERE match_all('.parquet') GROUP BY zo_sql_key ORDER BY zo_sql_key ASC";
+        let histogram_interval = 10;
+
+        let result = update_histogram_interval_in_query(sql, histogram_interval).unwrap();
+
+        assert_eq!(result, sql);
+    }
 }

--- a/src/handler/http/request/websocket/search.rs
+++ b/src/handler/http/request/websocket/search.rs
@@ -153,7 +153,7 @@ pub async fn handle_search_request(
     let sql = Sql::new(&req.payload.query.clone().into(), org_id, stream_type).await?;
     if let Some(interval) = sql.histogram_interval {
         // modify the sql query statement to include the histogram interval
-        let updated_query = update_histogram_interval_in_query(&sql.sql, interval)?;
+        let updated_query = update_histogram_interval_in_query(&req.payload.query.sql, interval)?;
         req.payload.query.sql = updated_query;
         log::info!(
             "[WS_SEARCH] trace_id: {}; Updated query {}; with histogram interval: {}",


### PR DESCRIPTION
The`Sql::new()` has optimization where it removes all the filters in sql,  when the tantivy index is enable.

By using the sql from the original req, the above scenario can be avoided. 