### PR TITLE
perf: search improve

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -610,13 +610,13 @@ mod tests {
 
         // gxhash hash
         let data = [
-            ["test", "node-q-4", "node-c-8"],
-            ["test1", "node-q-6", "node-c-2"],
-            ["test2", "node-q-2", "node-c-0"],
-            ["test3", "node-q-6", "node-c-3"],
-            ["test4", "node-q-1", "node-c-6"],
-            ["test5", "node-q-1", "node-c-0"],
-            ["test6", "node-q-2", "node-c-1"],
+            ["test", "node-q-5", "node-c-7"],
+            ["test1", "node-q-6", "node-c-9"],
+            ["test2", "node-q-4", "node-c-6"],
+            ["test3", "node-q-9", "node-c-1"],
+            ["test4", "node-q-0", "node-c-4"],
+            ["test5", "node-q-6", "node-c-7"],
+            ["test6", "node-q-6", "node-c-0"],
         ];
 
         remove_node_from_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Interactive)).await;

--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -65,7 +65,7 @@ pub async fn add_node_to_consistent_hash(node: &Node, role: &Role, group: Option
     };
     let mut h = config::utils::hash::gxhash::new();
     for i in 0..get_config().limit.consistent_hash_vnodes {
-        let key = format!("{}:{}{}", CONSISTENT_HASH_PRIME, node.name, i);
+        let key = format!("{}:{}:{}", CONSISTENT_HASH_PRIME, node.name, i);
         let hash = h.sum64(&key);
         nodes.insert(hash, node.name.clone());
     }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1547,6 +1547,9 @@ pub struct S3 {
     pub max_retries: usize,
     #[env_config(name = "ZO_S3_MAX_IDLE_PER_HOST", default = 0)]
     pub max_idle_per_host: usize,
+    // https://github.com/hyperium/hyper/issues/2136#issuecomment-589488526
+    #[env_config(name = "ZO_S3_CONNECTION_KEEPALIVE_TIMEOUT", default = 20)] // seconds
+    pub keepalive_timeout: u64, // aws s3 by has timeout of 20 sec
 }
 
 #[derive(Debug, EnvConfig)]
@@ -2363,6 +2366,11 @@ fn check_s3_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     cfg.s3.provider = cfg.s3.provider.to_lowercase();
     if cfg.s3.provider.eq("swift") {
         std::env::set_var("AWS_EC2_METADATA_DISABLED", "true");
+    }
+
+    if cfg.s3.keepalive_timeout <= 0 {
+        // reset to default
+        cfg.s3.keepalive_timeout = 20;
     }
 
     Ok(())

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2243,7 +2243,28 @@ fn check_disk_cache_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
 
     if cfg.disk_cache.bucket_num == 0 {
-        cfg.disk_cache.bucket_num = 1;
+        // because we validate thread_query_num before this
+        // we can be sure here that that value is sane.
+
+        // following numbers are imperically decided, users can set the value
+        // directly if they know better, otherwise this was the best numbers
+        // for bucket_num based on thread count.
+        let threads = cfg.limit.query_thread_num;
+        if threads <= 16 {
+            // for less than 16 threads, same buckets would be good enough
+            // with 16 files in parallel we should not run into that many
+            // files going into same bucket, so ok.
+            cfg.disk_cache.bucket_num = cfg.limit.query_thread_num;
+        } else if threads > 16 && threads <= 64 {
+            // for 32 -> 64 ish range, there can be a lot of collisions
+            // so we set it to double the threads to avoid any collisions
+            cfg.disk_cache.bucket_num = 2 * threads;
+        } else {
+            // for > 64 threads, it was observed that even with 1.5 times buckets
+            // it is ok, not that many collisions. This is imperical, no concrete
+            // reasoning for 1.5
+            cfg.disk_cache.bucket_num = (threads as f64 * 1.5) as usize;
+        }
     }
     cfg.disk_cache.bucket_num = max(
         cfg.disk_cache.bucket_num,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2389,7 +2389,7 @@ fn check_s3_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         std::env::set_var("AWS_EC2_METADATA_DISABLED", "true");
     }
 
-    if cfg.s3.keepalive_timeout <= 0 {
+    if cfg.s3.keepalive_timeout == 0 {
         // reset to default
         cfg.s3.keepalive_timeout = 20;
     }

--- a/src/infra/src/storage/remote.rs
+++ b/src/infra/src/storage/remote.rs
@@ -236,6 +236,7 @@ fn init_aws_config() -> object_store::Result<object_store::aws::AmazonS3> {
         .with_connect_timeout(std::time::Duration::from_secs(cfg.s3.connect_timeout))
         .with_timeout(std::time::Duration::from_secs(cfg.s3.request_timeout))
         .with_allow_invalid_certificates(cfg.s3.allow_invalid_certificates)
+        .with_http2_keep_alive_timeout(Duration::from_secs(cfg.s3.keepalive_timeout))
         .with_allow_http(true);
     if cfg.s3.feature_http1_only {
         opts = opts.with_http1_only();


### PR DESCRIPTION
This pulls some of the search related improvements that I found out from the search perf testing.
- Adds keep alive timeout to object_store crate
- Sets the disk cache buckets based on query thread count
- Changes the hash template string for more uniform hashing