### PR TITLE
fix: Force cluster unit tests to run sequentially

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -572,10 +572,14 @@ mod tests {
         assert!(get_cached_online_query_nodes(None).await.is_some());
         assert!(get_cached_online_ingester_nodes().await.is_some());
         assert!(get_cached_online_querier_nodes(None).await.is_some());
-    }
 
-    #[tokio::test]
-    async fn test_consistent_hashing() {
+        // Reset the global state.
+        QUERIER_INTERACTIVE_CONSISTENT_HASH.write().await.clear();
+        QUERIER_BACKGROUND_CONSISTENT_HASH.write().await.clear();
+        COMPACTOR_CONSISTENT_HASH.write().await.clear();
+        FLATTEN_COMPACTOR_CONSISTENT_HASH.write().await.clear();
+
+        // Test consistent hash logic.
         let node = load_local_node();
         for i in 0..10 {
             let node_q = Node {
@@ -611,7 +615,7 @@ mod tests {
         // gxhash hash
         let data = [
             ["test", "node-q-5", "node-c-7"],
-            ["test1", "node-q-6", "node-c-9"],
+            ["test1", "node-q-6", "node-c-9"], //
             ["test2", "node-q-4", "node-c-6"],
             ["test3", "node-q-9", "node-c-1"],
             ["test4", "node-q-0", "node-c-4"],

--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -615,7 +615,7 @@ mod tests {
         // gxhash hash
         let data = [
             ["test", "node-q-5", "node-c-7"],
-            ["test1", "node-q-6", "node-c-9"], //
+            ["test1", "node-q-6", "node-c-9"],
             ["test2", "node-q-4", "node-c-6"],
             ["test3", "node-q-9", "node-c-1"],
             ["test4", "node-q-0", "node-c-4"],


### PR DESCRIPTION
## Problem

When the `test_consistent_hashing` unit test is ran alone it seems to pass consistently. However when it is ran along with `test_consistent_hashing` it seems to fail consistently.

`cargo test` runs tests in parallel by default, and functions under test in both of these unit tests mutate the global mutable `_CONSISTENT_HASH` state variables. I believe, therefore, that when these tests run concurrently they are contending for and mutating this global state concurrently, producing unexpected results.

## Quick fix

The quick fix presented here is to 
1. Combine these two tests into one test so that they run sequentially
2. "Reset" the state of the `_CONSISTENT_HASH` global mutable variables after the first stage of the test runs, so that the second stage of the test starts from a clean slate and produces the expected results.

## Longer term considerations

Although this is a quick fix, I admittedly don't think it's an ideal long term solution. Ideally I believe we should be able to run unit tests in parallel and independent of one another. 

I think we may want to consider an alternative long term solution of moving away from using global mutable state in function logic and instead using function parameters to pass dependencies. In general the use of global mutable state presents a number of challenges for unit testing.
1. As we're seeing here, it makes unit tests unpredictable when ran concurrently.
2. Additionally, making functions dependent on global mutable variables means that function implementations are tied to concrete types rather than interfaces, so you can't mock up the interfaces and easily write unit tests against those dependencies.

Refactoring to move away from the use of global mutable state would be a large undertaking, but for the reasons above I think it could be valuable. Even if such a change were not undertaken all at once we could, in theory, adopt a practice of 
- avoiding declaring new global mutable variables in new code 
- preferring instead to pass dependencies via function parameters