### PR TITLE
fix: reset cancel query on search error or new search request

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1238,6 +1238,10 @@ const useLogs = () => {
             })
             .catch((err: any) => {
               searchObj.loading = false;
+
+              // Reset cancel query on search error
+              searchObj.data.isOperationCancelled = false;
+
               let trace_id = "";
               searchObj.data.errorMsg =
                 "Error while processing partition request.";
@@ -1480,6 +1484,10 @@ const useLogs = () => {
 
   const getQueryData = async (isPagination = false) => {
     try {
+
+      // Reset cancel query on new search request initation
+      searchObj.data.isOperationCancelled = false;
+
       // get websocket enable config from store
       // window will have more priority
       // if window has use_web_socket property then use that
@@ -2002,6 +2010,10 @@ const useLogs = () => {
         })
         .catch((err) => {
           searchObj.loading = false;
+
+          // Reset cancel query on search error
+          searchObj.data.isOperationCancelled = false;
+
           let trace_id = "";
           searchObj.data.countErrorMsg =
             "Error while retrieving total events: ";
@@ -2301,6 +2313,10 @@ const useLogs = () => {
           // TODO OK : create handleError function, which will handle error and return error message and detail
 
           searchObj.loading = false;
+
+          // Reset cancel query on search error
+          searchObj.data.isOperationCancelled = false;
+
           let trace_id = "";
           searchObj.data.errorMsg =
             typeof err == "string" && err
@@ -2550,6 +2566,11 @@ const useLogs = () => {
           })
           .catch((err) => {
             searchObj.loadingHistogram = false;
+
+
+            // Reset cancel query on search error
+            searchObj.data.isOperationCancelled = false;
+
             let trace_id = "";
 
             if (err?.request?.status != 429) {


### PR DESCRIPTION
When a search request is canceled by the backend, we receive an error response with code 20009 (cancel query). However, in the cancel query API response, is_success is set to false, whereas it should be true since the search request was successfully canceled.

On the frontend, we were interpreting is_success: false as an indication that the search operation was not canceled, causing us to block further pending partitions or histogram/page-count search requests. This was unintentionally preventing new search requests from being initiated.

To resolve this, we should reset the cancel query state when a new request is initiated and when a search request encounters an error.