### PR TITLE
fix: web socket streaming aggregates search for dashboards and logs (#5970)

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -965,6 +965,8 @@ pub struct Common {
     pub fake_es_version: String,
     #[env_config(name = "ZO_WEBSOCKET_ENABLED", default = false)]
     pub websocket_enabled: bool,
+    #[env_config(name = "ZO_WEBSOCKET_CLOSE_FRAME_DELAY", default = 0)]
+    pub websocket_close_frame_delay: u64, // in milliseconds
     #[env_config(
         name = "ZO_MIN_AUTO_REFRESH_INTERVAL",
         default = 300,

--- a/src/config/src/meta/websocket.rs
+++ b/src/config/src/meta/websocket.rs
@@ -34,4 +34,6 @@ pub struct SearchEventReq {
     pub search_type: crate::meta::search::SearchEventType,
     #[serde(flatten)]
     pub search_event_context: Option<SearchEventContext>,
+    #[serde(default)]
+    pub fallback_order_by_col: Option<String>,
 }

--- a/src/handler/http/request/websocket/mod.rs
+++ b/src/handler/http/request/websocket/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod search;
 pub mod session;
+pub mod sort;
 pub mod utils;
 
 use actix_web::{get, web, Error, HttpRequest, HttpResponse};

--- a/src/handler/http/request/websocket/search.rs
+++ b/src/handler/http/request/websocket/search.rs
@@ -28,7 +28,7 @@ use config::{
 use infra::errors::{Error, ErrorCodes};
 use tracing::Instrument;
 
-use super::utils::cancellation_registry_cache_utils;
+use super::sort::order_search_results;
 #[allow(unused_imports)]
 use crate::handler::http::request::websocket::utils::enterprise_utils;
 use crate::{
@@ -43,7 +43,7 @@ use crate::{
     },
     handler::http::request::websocket::{
         session::send_message,
-        utils::{TimeOffset, WsServerEvents},
+        utils::{search_registry_utils, TimeOffset, WsServerEvents},
     },
     service::search::{
         self as SearchService, cache, datafusion::distributed_plan::streaming_aggs_exec, sql::Sql,
@@ -163,9 +163,6 @@ pub async fn handle_search_request(
         );
     }
     let order_by = sql.order_by.first().map(|v| v.1).unwrap_or_default();
-
-    // Set cancel flag to stop search when cancel event is received
-    cancellation_registry_cache_utils::add_cancellation_flag(&trace_id);
 
     // Search start
     log::info!(
@@ -470,6 +467,7 @@ async fn handle_cache_responses_and_deltas(
                     cached,
                     accumulated_results,
                     &mut curr_res_size,
+                    req.fallback_order_by_col.clone(),
                 )
                 .await?;
                 cached_resp_iter.next();
@@ -504,6 +502,7 @@ async fn handle_cache_responses_and_deltas(
                 cached,
                 accumulated_results,
                 &mut curr_res_size,
+                req.fallback_order_by_col.clone(),
             )
             .await?;
         }
@@ -576,7 +575,7 @@ async fn process_delta(
 
     for (idx, &[start_time, end_time]) in partitions.iter().enumerate() {
         // Check if the cancellation flag is set
-        if cancellation_registry_cache_utils::is_cancelled(&trace_id) {
+        if search_registry_utils::is_cancelled(&trace_id) {
             log::info!(
                 "[WS_SEARCH]: Cancellation detected for trace_id: {}, stopping delta search",
                 trace_id
@@ -606,6 +605,7 @@ async fn process_delta(
         );
 
         if !search_res.hits.is_empty() {
+            search_res = order_search_results(search_res, req.fallback_order_by_col);
             // for every partition, compute the queried range omitting the result cache ratio
             let queried_range =
                 calc_queried_range(start_time, end_time, search_res.result_cache_ratio);
@@ -745,8 +745,9 @@ async fn send_cached_responses(
     cached: &CachedQueryResponse,
     accumulated_results: &mut Vec<SearchResultType>,
     curr_res_size: &mut i64,
+    fallback_order_by_col: Option<String>,
 ) -> Result<(), Error> {
-    if cancellation_registry_cache_utils::is_cancelled(trace_id) {
+    if search_registry_utils::is_cancelled(trace_id) {
         log::info!(
             "[WS_SEARCH]: Cancellation detected for trace_id: {}, stopping cached response",
             trace_id
@@ -777,6 +778,8 @@ async fn send_cached_responses(
             cached.cached_response.total = cache_hits;
         }
     }
+
+    cached.cached_response = order_search_results(cached.cached_response, fallback_order_by_col);
 
     // Accumulate the result
     accumulated_results.push(SearchResultType::Cached(cached.cached_response.clone()));
@@ -872,7 +875,7 @@ async fn do_partitioned_search(
 
     for (idx, &[start_time, end_time]) in partitions.iter().enumerate() {
         // Check if the cancellation flag is set
-        if cancellation_registry_cache_utils::is_cancelled(trace_id) {
+        if search_registry_utils::is_cancelled(trace_id) {
             log::info!(
                 "[WS_SEARCH]: Cancellation detected for trace_id: {}, stopping partitioned search",
                 trace_id
@@ -895,6 +898,8 @@ async fn do_partitioned_search(
         curr_res_size += search_res.hits.len() as i64;
 
         if !search_res.hits.is_empty() {
+            search_res = order_search_results(search_res, req.fallback_order_by_col);
+
             // check range error
             if !range_error.is_empty() {
                 search_res.is_partial = true;

--- a/src/handler/http/request/websocket/sort.rs
+++ b/src/handler/http/request/websocket/sort.rs
@@ -1,0 +1,196 @@
+use config::meta::{search::Response, sql::OrderBy};
+use serde_json::Value;
+
+/// Represents different sorting strategies
+enum SortStrategy {
+    SqlOrderBy,
+    FallbackColumn(String, OrderBy),
+    AutoDetermine(String, bool), // (column, is_string)
+    NoSort,
+}
+
+/// Determines and applies sorting to search results
+pub(crate) fn order_search_results(
+    mut search_res: Response,
+    fallback_order_by_col: Option<String>,
+) -> Response {
+    if search_res.hits.is_empty() {
+        return search_res;
+    }
+
+    let strategy = determine_sort_strategy(&search_res, fallback_order_by_col);
+    apply_sort_strategy(&mut search_res, strategy);
+
+    search_res
+}
+
+/// Applies the chosen sort strategy to results
+fn apply_sort_strategy(search_res: &mut Response, strategy: SortStrategy) {
+    match strategy {
+        SortStrategy::FallbackColumn(col, order) => {
+            // Auto-detect column type from first hit
+            let is_string = search_res
+                .hits
+                .first()
+                .and_then(|hit| hit.get(&col))
+                .map(|v| !v.is_number())
+                .unwrap_or(true);
+
+            // Sorting behavior:
+            // - String columns: Always sort ascending (A->Z)
+            // - Numeric columns: Respect the specified order (ASC/DESC)
+            let is_descending = if is_string {
+                false // Strings always sort ascending
+            } else {
+                order == OrderBy::Desc // Numbers follow specified order
+            };
+
+            sort_by_column(search_res, &col, is_string, is_descending);
+            if search_res.order_by.is_none() {
+                search_res.order_by = Some(order);
+            }
+        }
+        SortStrategy::AutoDetermine(col, is_string) => {
+            sort_by_column(search_res, &col, is_string, !is_string);
+        }
+        _ => (),
+    }
+}
+
+/// Determines which sorting strategy to use
+fn determine_sort_strategy(
+    search_res: &Response,
+    fallback_order_by_col: Option<String>,
+) -> SortStrategy {
+    // Check SQL ORDER BY first
+    if let Some(order_by) = search_res.order_by {
+        log::info!(
+            "[trace_id: {}] Using user-specified ORDER BY: {:?}",
+            &search_res.trace_id,
+            order_by
+        );
+        return SortStrategy::SqlOrderBy;
+    }
+
+    // Check fallback column
+    // Default to descending order
+    if let Some(col) = find_fallback_column(search_res, fallback_order_by_col) {
+        return SortStrategy::FallbackColumn(col, OrderBy::Desc);
+    }
+
+    // Auto-determine as last resort
+    if let Some((col, is_string)) = determine_sort_column(&search_res.hits[0]) {
+        log::info!(
+            "[trace_id: {}] Auto-sorting by column: {}, type: {}",
+            &search_res.trace_id,
+            col,
+            if is_string { "string" } else { "numeric" }
+        );
+        return SortStrategy::AutoDetermine(col, is_string);
+    }
+
+    SortStrategy::NoSort
+}
+
+/// Finds and validates fallback column in results
+fn find_fallback_column(search_res: &Response, fallback_col: Option<String>) -> Option<String> {
+    let fallback_col = fallback_col?;
+    let first_hit = search_res.hits.first()?.as_object()?;
+
+    // Find case-insensitive match
+    first_hit
+        .keys()
+        .find(|k| k.eq_ignore_ascii_case(&fallback_col))
+        .map(|k| {
+            log::info!(
+                "[trace_id: {}] Using fallback ORDER BY: {}",
+                &search_res.trace_id,
+                k
+            );
+            k.to_string()
+        })
+}
+
+/// Sorts results by a specific column
+fn sort_by_column(search_res: &mut Response, column: &str, is_string: bool, descending: bool) {
+    search_res.hits.sort_by(|a, b| {
+        let ordering = if is_string {
+            compare_string_values(a, b, column)
+        } else {
+            compare_numeric_values(a, b, column)
+        };
+        if descending {
+            ordering.reverse()
+        } else {
+            ordering
+        }
+    });
+}
+
+/// Compares string values with null handling
+fn compare_string_values(a: &Value, b: &Value, column: &str) -> std::cmp::Ordering {
+    let a_val = a.get(column).and_then(|v| v.as_str());
+    let b_val = b.get(column).and_then(|v| v.as_str());
+    match (a_val, b_val) {
+        // When both values exist: "apple" vs "banana" -> normal alphabetical order
+        (Some(a), Some(b)) => a.cmp(b),
+
+        // When first value is null and second exists: null vs "apple" -> null goes last
+        // Example: [apple, banana, null] in ascending order
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+
+        // When first value exists and second is null: "apple" vs null -> non-null goes first
+        // Example: [apple, banana, null] in ascending order
+        (Some(_), None) => std::cmp::Ordering::Less,
+
+        // When both values are null: null vs null -> treat as equal
+        // Example: [null, null] -> order doesn't change
+        (None, None) => std::cmp::Ordering::Equal,
+    }
+}
+
+/// Compares numeric values with null handling
+fn compare_numeric_values(a: &Value, b: &Value, column: &str) -> std::cmp::Ordering {
+    let a_val = a.get(column).and_then(|v| v.as_f64());
+    let b_val = b.get(column).and_then(|v| v.as_f64());
+    match (a_val, b_val) {
+        // When both are numbers: 1 vs 2 -> normal numeric order
+        // If NaN encountered, treat values as equal
+        // Example: [1, 2, 3] in ascending order
+        (Some(a), Some(b)) => a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal),
+
+        // When first is null and second is a number: null vs 1 -> null goes last
+        // Example: [1, 2, null] in ascending order
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+
+        // When first is a number and second is null: 1 vs null -> number goes first
+        // Example: [1, 2, null] in ascending order
+        (Some(_), None) => std::cmp::Ordering::Less,
+
+        // When both are null: null vs null -> treat as equal
+        // Example: [null, null] -> order doesn't change
+        (None, None) => std::cmp::Ordering::Equal,
+    }
+}
+
+fn determine_sort_column(first_hit: &config::utils::json::Value) -> Option<(String, bool)> {
+    if let Some(obj) = first_hit.as_object() {
+        // First try to find non-numeric columns
+        for (key, value) in obj {
+            if !value.is_number() {
+                log::debug!("Using string column for sorting: {}", key);
+                return Some((key.clone(), true)); // (column, is_string)
+            }
+        }
+
+        // If no non-numeric column found, take first numeric column
+        for (key, value) in obj {
+            if value.is_number() {
+                log::debug!("Using numeric column for sorting: {}", key);
+                return Some((key.clone(), false)); // (column, is_string)
+            }
+        }
+    }
+    log::warn!("No suitable sort column found in results");
+    None
+}

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -90,6 +90,13 @@ export const usePanelDataLoader = (
     cancelSearchQueryBasedOnRequestId,
     closeSocketBasedOnRequestId,
   } = useSearchWebSocket();
+  const getFallbackOrderByCol = () => {
+    // from panelSchema, get first x axis field alias
+    if (panelSchema?.value?.queries?.[0]?.fields?.x) {
+      return panelSchema.value?.queries[0]?.fields?.x?.[0]?.alias ?? null;
+    }
+    return null;
+  };
 
   /**
    * Calculate cache key for panel
@@ -357,7 +364,7 @@ export const usePanelDataLoader = (
     addTraceId(traceId);
     try {
       // partition api call
-      const res = await callWithAbortController(
+      const res: any = await callWithAbortController(
         async () =>
           queryService.partition({
             org_identifier: store.state.selectedOrganization.identifier,
@@ -562,8 +569,17 @@ export const usePanelDataLoader = (
     // remove past error detail
     state.errorDetail = "";
 
+    // is streaming aggs
+    const streaming_aggs = searchRes?.content?.streaming_aggs ?? false;
+
+    // if streaming aggs, replace the state data
+    if (streaming_aggs) {
+      state.data[payload?.queryReq?.currentQueryIndex] = [
+        ...(searchRes?.content?.results?.hits ?? {}),
+      ];
+    }
     // if order by is desc, append new partition response at end
-    if (searchRes?.content?.results?.order_by?.toLowerCase() === "asc") {
+    else if (searchRes?.content?.results?.order_by?.toLowerCase() === "asc") {
       // else append new partition response at start
       state.data[payload?.queryReq?.currentQueryIndex] = [
         ...(searchRes?.content?.results?.hits ?? {}),
@@ -639,6 +655,7 @@ export const usePanelDataLoader = (
         use_cache: (window as any).use_cache ?? true,
         dashboard_id: dashboardId?.value,
         folder_id: folderId?.value,
+        fallback_order_by_col: getFallbackOrderByCol(),
       },
     });
   };


### PR DESCRIPTION
New Env:
```sh
ZO_WEBSOCKET_CLOSE_FRAME_DELAY=10
```

Changes:

- [x] add support to dashboard for streaming aggregate queries from in
memory cache
- [x] new sort logic for web socket search results
> - [x] introduced a new `optional` parameter `fallback_order_by_col`
for ws search req `SearchEventReq`
> - For queries where there is no `_timestamp` field and no `order_by`
specified:
```sql
SELECT level, COUNT(*) as count
FROM logs
GROUP BY level
```
> - The default sql behavior is to return the results in a non-ordered
manner.
> - However, with web sockets this behavior impacts the UX in both
`logs` and `dashboards` when `streaming aggregates` is `enabled` as the
results in page/dashboards will keep fluctuating.
> - To fix this there a new sort behavior introduced in web sockets

```rust
/// Represents different sorting strategies
enum SortStrategy {
    SqlOrderBy,
    FallbackColumn(String, OrderBy),
    AutoDetermine(String, bool), // (column, is_string)
    NoSort,
}
```
> 1. If `order_by` is already specified in the sql query and the search
service has populated the `order_by` field in its response for the
search, then there is no sort action required on the search results.
> 2. If `fallback_order_by_col` is specified that col is selected for
sort. This will mainly be used in `Dashboards`.
> 3. If none of the above is specified, there is `auto-determine`
strategy which would check for the `first non-numeric col` else the
`first numeric col`
> 4. `non-numeric` col i.e. `text/string` is always sorted in `asc`.
While, `numeric` col is sorted in `desc`. This applies to both
`FallbackColumn` & `AutoDetermine` strategies.

- [x] redesign web socket search event handling
> - Previously the `cleanup_and_close_session` used to happen inside the
search task thread. Which is suspected :suspect: to be one of the causes
for the `CloseFrame` description and the `DataFrame` data to get merged
and malform the message in the socket.
> - New behavior `cleanup_and_close_session` will happen outside of the
search task spawned once search is complete.
> - Since its suspected :suspect: that there is some race condition 🏃🏾
when the web socket frames are being sent the env variable
`ZO_WEBSOCKET_CLOSE_FRAME_DELAY` default `0` is created to introduce a
delay preferred `10 ms` to ` 100ms` before sending the `CloseFrame`
> - `SEARCH_REGISTRY` now will hold the different states of search which
are `Running`, `Cancelled` & `Completed`
> - The search task is modified to now listen for a `cancel` from the
`mpsc` channel and does `cleanup_search_resources`

Related Issues:
- #5967
- #5974

---------

Co-authored-by: loaki07 <rustyloaki@gmail.com>
Co-authored-by: Loakesh Indiran <66478092+Loaki07@users.noreply.github.com>
Co-authored-by: Hengfei Yang <hengfei.yang@gmail.com>