### PR TITLE
feat: Add temporary catch-all logic for fields on "put dashboard" super cluster messages

### DIFF
--- a/src/super_cluster_queue/dashboards.rs
+++ b/src/super_cluster_queue/dashboards.rs
@@ -28,6 +28,7 @@ pub(crate) async fn process_msg(msg: DashboardMessage) -> Result<()> {
             org_id,
             folder_id,
             dashboard,
+            ..
         } => {
             // `clone` is always true for super cluster
             table::dashboards::put(&org_id, &folder_id, dashboard, true).await?;


### PR DESCRIPTION
Add temporary catch-all logic for dashboard super cluster messages so that we can add a new "put dashboard" message field in [this other PR](https://github.com/openobserve/o2-enterprise/pull/349) without breaking the build.