### PR TITLE
ci: fix audit and license CIs

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+ignore = [
+  "RUSTSEC-2024-0421", # from idna, transitive dep of vrl
+  "RUSTSEC-2023-0071", # from rsa, transitive dep of sqlx
+]
+informational_warnings = ["unmaintained"] # warn for categories of informational advisories

--- a/.github/workflows/audit-checker.yml
+++ b/.github/workflows/audit-checker.yml
@@ -1,14 +1,14 @@
 name: Security audit
 on:
   push:
-    paths: 
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+
 jobs:
   security_audit:
-    runs-on: ubicloud-standard-8
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/audit-check@v1
+      - uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-audit
+      - name: run cargo audit
+        run: cargo audit

--- a/deny.toml
+++ b/deny.toml
@@ -30,11 +30,10 @@ exceptions = [
     { name = "error-code", allow = ["BSL-1.0"] },
     { name = "base16", allow = ["CC0-1.0"] },
     { name = "tiny-keccak", allow = ["CC0-1.0"] },
-    { name = "enum-iterator-derive", allow = ["0BSD"] },
     { name = "quoted_printable", allow = ["0BSD"] },
     { name = "ring", allow = ["BSD-4-Clause", "OpenSSL"] },
-    { name = "unicode-ident", allow = ["Unicode-DFS-2016"] },
     { name = "adler32", allow = ["Zlib"] },
+    { name = "inferno", allow = ["CDDL-1.0"] },
 ]
 
 allow = [


### PR DESCRIPTION
This fixes the failing CIs for security audit and license checking.
- audit.toml adds new exceptions for transitive deps which we cannot fix
- den.toml adds one dep exception and also removes two exceptions which no longer apply