### PR TITLE
fix: ws close wait (#6030)

### DIFF
--- a/src/router/http/ws.rs
+++ b/src/router/http/ws.rs
@@ -15,11 +15,12 @@
 
 use std::str::FromStr;
 
-use actix_web::{web, Error, HttpRequest, HttpResponse};
+use actix_web::{rt, web, Error, HttpRequest, HttpResponse};
 use actix_ws::Message;
 use config::get_config;
 use futures_util::{SinkExt, StreamExt};
 use reqwest::header::{HeaderName, HeaderValue};
+use tokio::sync::oneshot;
 use tokio_tungstenite::{connect_async, tungstenite};
 use url::Url;
 
@@ -62,67 +63,117 @@ pub async fn ws_proxy(
     // Split backend Websocket stream into sink and stream
     let (mut backend_ws_sink, mut backend_ws_stream) = backend_ws_stream.split();
 
-    // Spawn tasks to forward messages between client and backend WebSocket
-    let client_to_backend = async move {
-        while let Some(Ok(msg)) = client_msg_stream.next().await {
-            let ws_msg = from_actix_message(msg);
-            if backend_ws_sink.send(ws_msg).await.is_err() {
-                return;
-            }
-        }
-        log::warn!("[WS_PROXY]: Client connection closed unexpectedly");
-    };
+    // Add coordination channels for graceful shutdown
+    let (client_kill_tx, client_kill_rx) = oneshot::channel::<()>();
+    let (backend_kill_tx, backend_kill_rx) = oneshot::channel::<()>();
 
-    let backend_to_client = async move {
-        while let Some(Ok(msg)) = backend_ws_stream.next().await {
-            let ws_msg = from_tungstenite_msg_to_actix_msg(msg);
-
-            match ws_msg {
-                Message::Text(text) => {
-                    if session.text(text).await.is_err() {
-                        return;
+    let client_to_backend = {
+        let mut client_kill_rx = client_kill_rx; // Take ownership here
+        async move {
+            loop {
+                tokio::select! {
+                    Some(msg_result) = client_msg_stream.next() => {
+                        match msg_result {
+                            Ok(msg) => {
+                                // Convert actix message to tungstenite message
+                                let ws_msg = from_actix_message(msg);
+                                match ws_msg {
+                                    tungstenite::protocol::Message::Close(_) => {
+                                        log::info!("[WS_PROXY] Client initiated close");
+                                        let _ = backend_kill_tx.send(());
+                                        break;
+                                    }
+                                    _ => {
+                                        if backend_ws_sink.send(ws_msg).await.is_err() {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                log::error!("[WS_PROXY] Client error: {:?}", e);
+                                break;
+                            }
+                        }
                     }
-                }
-                Message::Binary(bin) => {
-                    if session.binary(bin).await.is_err() {
-                        return;
+                    _ = &mut client_kill_rx => {  // Use &mut reference
+                        log::info!("[WS_PROXY] Client task received shutdown signal");
+                        break;
                     }
-                }
-                Message::Ping(ping) => {
-                    if session.ping(&ping).await.is_err() {
-                        return;
-                    }
-                }
-                Message::Pong(pong) => {
-                    if session.pong(&pong).await.is_err() {
-                        return;
-                    }
-                }
-                Message::Close(reason) => {
-                    log::info!(
-                        "[WS_PROXY] Forwarding Close frame from backend to client: {:?}",
-                        reason
-                    );
-                    let _ = session.close(reason).await;
-                    break;
-                }
-                Message::Continuation(item) => {
-                    log::warn!(
-                        "[WS_PROXY] Unsupported message type from backend: {:?}",
-                        item
-                    );
-                }
-                Message::Nop => {
-                    log::warn!("[WS_PROXY] Unsupported message type from backend: Nop");
                 }
             }
         }
-        log::warn!("[WS_PROXY]: Backend connection closed unexpectedly");
     };
 
-    // Spawn async tasks for client to backend and backend to client message forwarding
-    actix_web::rt::spawn(client_to_backend);
-    actix_web::rt::spawn(backend_to_client);
+    let backend_to_client = {
+        let mut backend_kill_rx = backend_kill_rx;
+        let mut closed_normally = false;
+        async move {
+            loop {
+                tokio::select! {
+                    Some(msg_result) = backend_ws_stream.next() => {
+                        let ws_msg = from_tungstenite_msg_to_actix_msg(msg_result.unwrap());
+                        match ws_msg {
+                            Message::Close(reason) => {
+                                log::info!("[WS_PROXY] Backend initiated close: {:?}", reason);
+                                let _ = client_kill_tx.send(());
+                                let _ = session.close(reason).await;
+                                closed_normally = true;
+                                break;
+                            }
+                            Message::Text(text) => {
+                                if session.text(text).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Message::Binary(bin) => {
+                                if session.binary(bin).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Message::Ping(ping) => {
+                                if session.ping(&ping).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Message::Pong(pong) => {
+                                if session.pong(&pong).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Message::Continuation(_) => {
+                                log::warn!("[WS_PROXY] Unsupported message type from backend: {:?}", ws_msg);
+                            }
+                            Message::Nop => {
+                                log::warn!("[WS_PROXY] Unsupported message type from backend: Nop");
+                            }
+                        }
+                    }
+                    _ = &mut backend_kill_rx => {
+                        log::info!("[WS_PROXY] Backend task received shutdown signal");
+                        closed_normally = true;
+                        break;
+                    }
+                }
+            }
+
+            if !closed_normally {
+                log::warn!("[WS_PROXY] Backend connection closed unexpectedly");
+            } else {
+                log::info!("[WS_PROXY] Backend connection closed normally");
+            }
+        }
+    };
+
+    // Spawn tasks with cleanup
+    let backend_handle = rt::spawn(backend_to_client);
+    let client_handle = rt::spawn(client_to_backend);
+
+    // Join the tasks and log when they complete
+    rt::spawn(async move {
+        let _ = tokio::join!(backend_handle, client_handle);
+        log::info!("[WS_PROXY] backend and client tasks completed");
+    });
 
     // Return the WebSocket handshake response
     Ok(response)


### PR DESCRIPTION
Introduced a coordinator channel at `ws_proxy` to handle close frames between the `client_to_backend` and `backend_to_client` task threads.