### PR TITLE
fix: histogram visitor

### DIFF
--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -1308,9 +1308,10 @@ impl VisitorMut for HistogramIntervalVistor {
                     self.interval =
                         Some(convert_histogram_interval_to_seconds(&interval).unwrap_or_default());
                 }
+                return ControlFlow::Break(());
             }
         }
-        ControlFlow::Break(())
+        ControlFlow::Continue(())
     }
 }
 


### PR DESCRIPTION
Current behaviour is that we expect the first function in a query to be histogram. If any other function is present (for example `count`) prior to the histogram then the histogram interval is not set. 

We can be more lenient in our parsing and allow other functions to occur before histogram.

This PR fixes the HistogramVisitor to break the chain only when histogram function occurs.