### PR TITLE
feat: remove ENV ZO_COLUMN_TIMESTAMP

### DIFF
--- a/src/cli/data/export.rs
+++ b/src/cli/data/export.rs
@@ -18,10 +18,7 @@ use std::{collections::HashMap, fs, path::Path};
 use actix_web::web::Query;
 use async_trait::async_trait;
 use config::{
-    meta::{
-        search::{self},
-        stream::StreamType,
-    },
+    meta::{search, stream::StreamType},
     TIMESTAMP_COL_NAME,
 };
 

--- a/src/cli/data/export.rs
+++ b/src/cli/data/export.rs
@@ -17,9 +17,12 @@ use std::{collections::HashMap, fs, path::Path};
 
 use actix_web::web::Query;
 use async_trait::async_trait;
-use config::meta::{
-    search::{self},
-    stream::StreamType,
+use config::{
+    meta::{
+        search::{self},
+        stream::StreamType,
+    },
+    TIMESTAMP_COL_NAME,
 };
 
 use crate::{
@@ -44,7 +47,6 @@ impl Context for Export {
             Err(_) => return Ok(false),
         };
 
-        let cfg = config::get_config();
         let table = c.stream_name;
         let search_type = match get_search_type_from_request(&query_map) {
             Ok(v) => v,
@@ -56,7 +58,7 @@ impl Context for Export {
         let query = search::Query {
             sql: format!(
                 "select * from {} ORDER BY {} ASC",
-                table, cfg.common.column_timestamp
+                table, TIMESTAMP_COL_NAME
             ),
             from: 0,
             size: 100,

--- a/src/common/utils/stream.rs
+++ b/src/common/utils/stream.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -20,7 +20,7 @@ use arrow::array::{Int64Array, RecordBatch};
 use config::{
     get_config,
     meta::stream::{FileMeta, StreamType},
-    FILE_EXT_JSON,
+    FILE_EXT_JSON, TIMESTAMP_COL_NAME,
 };
 
 use crate::{
@@ -77,9 +77,8 @@ pub async fn populate_file_meta(
     if batches.is_empty() {
         return Ok(());
     }
-    let cfg = get_config();
-    let min_field = min_field.unwrap_or_else(|| cfg.common.column_timestamp.as_str());
-    let max_field = max_field.unwrap_or_else(|| cfg.common.column_timestamp.as_str());
+    let min_field = min_field.unwrap_or(TIMESTAMP_COL_NAME);
+    let max_field = max_field.unwrap_or(TIMESTAMP_COL_NAME);
 
     let total = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
     let mut min_val = i64::MAX;

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1669,7 +1669,7 @@ pub struct HealthCheck {
     pub enabled: bool,
     #[env_config(
         name = "ZO_HEALTH_CHECK_TIMEOUT",
-        default = 10,
+        default = 5,
         help = "Health check timeout in seconds"
     )]
     pub timeout: u64,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -77,6 +77,7 @@ pub const REQUIRED_DB_CONNECTIONS: u32 = 4;
 // Used for storing and querying unflattened original data
 pub const ORIGINAL_DATA_COL_NAME: &str = "_original";
 pub const ID_COL_NAME: &str = "_o2_id";
+pub const TIMESTAMP_COL_NAME: &str = "_timestamp";
 
 const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 7] =
     ["log", "message", "msg", "content", "data", "body", "json"];
@@ -626,8 +627,6 @@ pub struct Common {
     pub data_db_dir: String,
     #[env_config(name = "ZO_DATA_CACHE_DIR", default = "")] // ./data/openobserve/cache/
     pub data_cache_dir: String,
-    #[env_config(name = "ZO_COLUMN_TIMESTAMP", default = "_timestamp")]
-    pub column_timestamp: String,
     // TODO: should rename to column_all
     #[env_config(name = "ZO_CONCATENATED_SCHEMA_FIELD_NAME", default = "_all")]
     pub column_all: String,

--- a/src/config/src/meta/sql.rs
+++ b/src/config/src/meta/sql.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -32,7 +32,7 @@ use sqlparser::{
 use utoipa::ToSchema;
 
 use super::stream::StreamType;
-use crate::get_config;
+use crate::{get_config, TIMESTAMP_COL_NAME};
 
 pub const MAX_LIMIT: i64 = 100000;
 pub const MAX_OFFSET: i64 = 100000;
@@ -392,12 +392,7 @@ impl<'a> TryFrom<Timerange<'a>> for Option<(i64, i64)> {
     fn try_from(selection: Timerange<'a>) -> Result<Self, Self::Error> {
         let mut fields = Vec::new();
         if let Some(expr) = selection.0 {
-            parse_expr_for_field(
-                expr,
-                &SqlOperator::And,
-                &get_config().common.column_timestamp,
-                &mut fields,
-            )?
+            parse_expr_for_field(expr, &SqlOperator::And, TIMESTAMP_COL_NAME, &mut fields)?
         }
 
         let mut time_min = Vec::new();
@@ -628,10 +623,7 @@ fn parse_expr_check_field_name(s: &str, field: &str) -> bool {
         return true;
     }
     let cfg = get_config();
-    if field == "*"
-        && s != cfg.common.column_all.as_str()
-        && s != cfg.common.column_timestamp.as_str()
-    {
+    if field == "*" && s != cfg.common.column_all.as_str() && s != TIMESTAMP_COL_NAME {
         return true;
     }
 

--- a/src/config/src/utils/parquet.rs
+++ b/src/config/src/utils/parquet.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -48,11 +48,11 @@ pub fn new_parquet_writer<'a>(
         .set_max_row_group_size(PARQUET_MAX_ROW_GROUP_SIZE) // maximum number of rows in a row group
         .set_compression(Compression::ZSTD(Default::default()))
         .set_column_dictionary_enabled(
-            cfg.common.column_timestamp.as_str().into(),
+            TIMESTAMP_COL_NAME.into(),
             false,
         )
         .set_column_encoding(
-            cfg.common.column_timestamp.as_str().into(),
+            TIMESTAMP_COL_NAME.into(),
             Encoding::DELTA_BINARY_PACKED,
         );
     if write_metadata {

--- a/src/config/src/utils/record_batch_ext.rs
+++ b/src/config/src/utils/record_batch_ext.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -31,7 +31,7 @@ use super::{
     json::{get_bool_value, get_float_value, get_int_value, get_string_value, get_uint_value},
     schema_ext::SchemaExt,
 };
-use crate::{get_config, FxIndexMap};
+use crate::{FxIndexMap, TIMESTAMP_COL_NAME};
 
 const USIZE_SIZE: usize = std::mem::size_of::<usize>();
 
@@ -577,7 +577,7 @@ pub fn merge_record_batches(
     // 4. sort concatenated record batch by timestamp col in desc order
     let sort_indices = arrow::compute::sort_to_indices(
         concated_record_batch
-            .column_by_name(&get_config().common.column_timestamp)
+            .column_by_name(TIMESTAMP_COL_NAME)
             .ok_or_else(|| {
                 log::error!(
                     "[{job_name}:JOB:{thread_id}] merge small files failed to find _timestamp column from merged record batch.",

--- a/src/config/src/utils/schema.rs
+++ b/src/config/src/utils/schema.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -27,9 +27,8 @@ use serde_json::{Map, Value};
 
 use super::str::find;
 use crate::{
-    get_config,
     meta::{promql::HASH_LABEL, stream::StreamType},
-    FxIndexMap,
+    FxIndexMap, TIMESTAMP_COL_NAME,
 };
 
 const MAX_PARTITION_KEY_LENGTH: usize = 100;
@@ -232,13 +231,12 @@ fn fix_schema(schema: Schema, stream_type: StreamType) -> Schema {
             })
             .collect::<Vec<_>>()
     };
-    let cfg = get_config();
     fields = fields
         .into_iter()
         .map(|x| {
-            if x.name() == &cfg.common.column_timestamp {
+            if x.name() == TIMESTAMP_COL_NAME {
                 Arc::new(Field::new(
-                    cfg.common.column_timestamp.clone(),
+                    TIMESTAMP_COL_NAME.to_string(),
                     DataType::Int64,
                     false,
                 ))

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -28,7 +28,7 @@ use config::{
     },
     metrics,
     utils::{base64, json},
-    DISTINCT_FIELDS,
+    DISTINCT_FIELDS, TIMESTAMP_COL_NAME,
 };
 use infra::{cache::stats, errors};
 use tracing::{Instrument, Span};
@@ -813,10 +813,7 @@ async fn values_v1(
         }
     }
 
-    let default_sql = format!(
-        "SELECT {} FROM \"{stream_name}\"",
-        cfg.common.column_timestamp
-    );
+    let default_sql = format!("SELECT {} FROM \"{stream_name}\"", TIMESTAMP_COL_NAME);
     let mut query_sql = match query.get("filter") {
         None => default_sql,
         Some(v) => {

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -21,14 +21,14 @@ use config::{
     get_config,
     meta::{
         function::VRLResultResolver,
-        search,
-        search::PARTIAL_ERROR_RESPONSE_MESSAGE,
+        search::{self, PARTIAL_ERROR_RESPONSE_MESSAGE},
         self_reporting::usage::{RequestStats, UsageType},
         sql::resolve_stream_names,
         stream::StreamType,
     },
     metrics,
     utils::{base64, json},
+    TIMESTAMP_COL_NAME,
 };
 use infra::errors;
 use tracing::{Instrument, Span};
@@ -592,7 +592,7 @@ pub async fn search_multi(
         };
     }
 
-    let column_timestamp = get_config().common.column_timestamp.to_string();
+    let column_timestamp = TIMESTAMP_COL_NAME.to_string();
     multi_res.cached_ratio /= queries_len;
     multi_res.hits.sort_by(|a, b| {
         if a.get(&column_timestamp).is_none() || b.get(&column_timestamp).is_none() {

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -28,7 +28,7 @@ use config::{
     get_config, get_instance_id,
     meta::{cluster::NodeStatus, function::ZoFunction},
     utils::{json, schema_ext::SchemaExt},
-    Config, QUICK_MODEL_FIELDS, SQL_FULL_TEXT_SEARCH_FIELDS,
+    Config, QUICK_MODEL_FIELDS, SQL_FULL_TEXT_SEARCH_FIELDS, TIMESTAMP_COL_NAME,
 };
 use hashbrown::HashMap;
 use infra::{
@@ -268,7 +268,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         default_quick_mode_fields: QUICK_MODEL_FIELDS.to_vec(),
         default_functions: DEFAULT_FUNCTIONS.to_vec(),
         sql_base64_enabled: cfg.common.ui_sql_base64_enabled,
-        timestamp_column: cfg.common.column_timestamp.clone(),
+        timestamp_column: TIMESTAMP_COL_NAME.to_string(),
         syslog_enabled: *SYSLOG_ENABLED.read(),
         data_retention_days: cfg.compact.data_retention_days,
         extended_data_retention_days: cfg.compact.extended_data_retention_days,

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -16,7 +16,7 @@
 use std::{collections::HashMap, io::Error};
 
 use actix_web::{get, http, post, web, HttpRequest, HttpResponse};
-use config::{get_config, meta::stream::StreamType, metrics, utils::json};
+use config::{get_config, meta::stream::StreamType, metrics, utils::json, TIMESTAMP_COL_NAME};
 use infra::errors;
 use serde::Serialize;
 use tracing::{Instrument, Span};
@@ -266,7 +266,7 @@ pub async fn get_latest_traces(
     // search
     let query_sql = format!(
         "SELECT trace_id, min({}) as zo_sql_timestamp, min(start_time) as trace_start_time, max(end_time) as trace_end_time FROM {stream_name}",
-        cfg.common.column_timestamp
+        TIMESTAMP_COL_NAME
     );
     let query_sql = if filter.is_empty() {
         format!("{query_sql} GROUP BY trace_id ORDER BY zo_sql_timestamp DESC")
@@ -387,7 +387,7 @@ pub async fn get_latest_traces(
         .join("','");
     let query_sql = format!(
         "SELECT {}, trace_id, start_time, end_time, duration, service_name, operation_name, span_status FROM {stream_name} WHERE trace_id IN ('{}') ORDER BY {} ASC",
-        cfg.common.column_timestamp, trace_ids, cfg.common.column_timestamp,
+        TIMESTAMP_COL_NAME, trace_ids, TIMESTAMP_COL_NAME,
     );
     req.query.from = 0;
     req.query.size = 9999;

--- a/src/ingester/src/entry.rs
+++ b/src/ingester/src/entry.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -161,7 +161,7 @@ fn pop_time_range(
 ) -> (i64, i64) {
     let mut min_ts = 0;
     let mut max_ts = 0;
-    let time_field = config::get_config().common.column_timestamp.to_string();
+    let time_field = config::TIMESTAMP_COL_NAME.to_string();
     let min_field = min_field.unwrap_or(time_field.as_str());
     let max_field = max_field.unwrap_or(time_field.as_str());
     if min_field == max_field {

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -39,7 +39,7 @@ use config::{
         base64,
         json::{Map, Value},
     },
-    SMTP_CLIENT,
+    SMTP_CLIENT, TIMESTAMP_COL_NAME,
 };
 use cron::Schedule;
 use infra::{schema::unwrap_stream_settings, table};
@@ -984,7 +984,7 @@ fn process_row_template(tpl: &String, alert: &Alert, rows: &[Map<String, Value>]
             process_variable_replace(&mut resp, key, &VarValue::Str(&value), false);
 
             // calculate start and end time
-            if key == &get_config().common.column_timestamp {
+            if key == TIMESTAMP_COL_NAME {
                 let val = value.parse::<i64>().unwrap_or_default();
                 if alert_start_time == 0 || val < alert_start_time {
                     alert_start_time = val;
@@ -1349,12 +1349,10 @@ pub fn get_alert_start_end_time(
         return (start_time, rows_end_time);
     }
 
-    let cfg = get_config();
-
     // calculate start and end time
     let mut alert_start_time = 0;
     let mut alert_end_time = 0;
-    if let Some(values) = vars.get(&cfg.common.column_timestamp) {
+    if let Some(values) = vars.get(TIMESTAMP_COL_NAME) {
         for val in values {
             let val = val.parse::<i64>().unwrap_or_default();
             if alert_start_time == 0 || val < alert_start_time {

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -18,7 +18,7 @@ use arrow_schema::DataType;
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
 use config::{
-    get_config, ider,
+    ider,
     meta::{
         alerts::{AggFunction, Condition, Operator, QueryCondition, QueryType, TriggerCondition},
         search::{SearchEventContext, SearchEventType, SqlQuery},
@@ -29,6 +29,7 @@ use config::{
         base64,
         json::{Map, Value},
     },
+    TIMESTAMP_COL_NAME,
 };
 
 use super::promql;
@@ -591,15 +592,14 @@ async fn build_sql(
         AggFunction::P99 => format!("approx_percentile_cont(\"{}\", 0.99)", agg.having.column),
     };
 
-    let cfg = get_config();
     if let Some(group) = agg.group_by.as_ref() {
         if !group.is_empty() {
             sql = format!(
                 "SELECT {}, {} AS alert_agg_value, MIN({}) as zo_sql_min_time, MAX({}) AS zo_sql_max_time FROM \"{}\" {} GROUP BY {} HAVING {}",
                 group.join(", "),
                 func_expr,
-                cfg.common.column_timestamp,
-                cfg.common.column_timestamp,
+                TIMESTAMP_COL_NAME,
+                TIMESTAMP_COL_NAME,
                 stream_name,
                 where_sql,
                 group.join(", "),
@@ -611,8 +611,8 @@ async fn build_sql(
         sql = format!(
             "SELECT {} AS alert_agg_value, MIN({}) as zo_sql_min_time, MAX({}) AS zo_sql_max_time FROM \"{}\" {} HAVING {}",
             func_expr,
-            cfg.common.column_timestamp,
-            cfg.common.column_timestamp,
+            TIMESTAMP_COL_NAME,
+            TIMESTAMP_COL_NAME,
             stream_name,
             where_sql,
             having_expr

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -37,7 +37,7 @@ use config::{
         schema_ext::SchemaExt,
         time::{day_micros, hour_micros},
     },
-    FILE_EXT_PARQUET,
+    FILE_EXT_PARQUET, TIMESTAMP_COL_NAME,
 };
 use hashbrown::{HashMap, HashSet};
 use infra::{
@@ -1219,8 +1219,8 @@ pub fn generate_inverted_idx_recordbatch(
         return Ok(None);
     }
     // add _timestamp column to columns_to_index
-    if !inverted_idx_columns.contains(&cfg.common.column_timestamp) {
-        inverted_idx_columns.push(cfg.common.column_timestamp.to_string());
+    if !inverted_idx_columns.contains(&TIMESTAMP_COL_NAME.to_string()) {
+        inverted_idx_columns.push(TIMESTAMP_COL_NAME.to_string());
     }
 
     let mut inverted_idx_batches = Vec::with_capacity(batches.len());
@@ -1259,7 +1259,7 @@ pub fn generate_inverted_idx_recordbatch(
 
         if matches!(
             new_batch.schema().fields().len(),
-            0 | 1 if new_batch.schema().field(0).name() == &cfg.common.column_timestamp
+            0 | 1 if new_batch.schema().field(0).name() == TIMESTAMP_COL_NAME
         ) {
             Ok(None)
         } else {

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -30,7 +30,7 @@ use config::{
         stream::{PartitionTimeLevel, StreamType},
     },
     utils::{flatten::format_key, json, schema_ext::SchemaExt},
-    SIZE_IN_MB,
+    SIZE_IN_MB, TIMESTAMP_COL_NAME,
 };
 use futures::{StreamExt, TryStreamExt};
 use infra::{
@@ -131,12 +131,12 @@ pub async fn save_enrichment_data(
     let mut records_size = 0;
     let timestamp = Utc::now().timestamp_micros();
     for mut json_record in payload {
-        let timestamp = match json_record.get(&cfg.common.column_timestamp) {
+        let timestamp = match json_record.get(TIMESTAMP_COL_NAME) {
             Some(v) => v.as_i64().unwrap_or(timestamp),
             None => timestamp,
         };
         json_record.insert(
-            cfg.common.column_timestamp.clone(),
+            TIMESTAMP_COL_NAME.to_string(),
             json::Value::Number(timestamp.into()),
         );
 

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -22,7 +22,6 @@ use anyhow::{anyhow, Result};
 use chrono::{Duration, TimeZone, Utc};
 use config::{
     cluster::{LOCAL_NODE, LOCAL_NODE_ID},
-    get_config,
     ider::SnowflakeIdGenerator,
     meta::{
         alerts::alert::Alert,
@@ -34,7 +33,7 @@ use config::{
     },
     metrics,
     utils::{flatten, json::*, schema::format_partition_key},
-    SIZE_IN_MB,
+    SIZE_IN_MB, TIMESTAMP_COL_NAME,
 };
 use infra::schema::STREAM_RECORD_ID_GENERATOR;
 use proto::cluster_rpc::IngestionType;
@@ -498,7 +497,6 @@ pub async fn get_uds_and_original_data_streams(
     user_defined_schema_map: &mut HashMap<String, HashSet<String>>,
     streams_need_original: &mut HashSet<String>,
 ) {
-    let cfg = get_config();
     for stream in streams {
         if user_defined_schema_map.contains_key(stream.stream_name.as_str()) {
             continue;
@@ -513,8 +511,8 @@ pub async fn get_uds_and_original_data_streams(
         if let Some(fields) = &stream_settings.defined_schema_fields {
             if !fields.is_empty() {
                 let mut fields: HashSet<_> = fields.iter().cloned().collect();
-                if !fields.contains(&cfg.common.column_timestamp) {
-                    fields.insert(cfg.common.column_timestamp.to_string());
+                if !fields.contains(TIMESTAMP_COL_NAME) {
+                    fields.insert(TIMESTAMP_COL_NAME.to_string());
                 }
                 user_defined_schema_map.insert(stream.stream_name.to_string(), fields);
             }

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -29,7 +29,7 @@ use config::{
     },
     metrics,
     utils::{flatten, json, time::parse_timestamp_micro_from_value},
-    BLOCKED_STREAMS, ID_COL_NAME, ORIGINAL_DATA_COL_NAME,
+    BLOCKED_STREAMS, ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME,
 };
 
 use super::{ingestion_log_enabled, log_failed_record};
@@ -227,7 +227,7 @@ pub async fn ingest(
                     );
                     continue;
                 };
-                let timestamp = match local_val.get(&cfg.common.column_timestamp) {
+                let timestamp = match local_val.get(TIMESTAMP_COL_NAME) {
                     Some(v) => match parse_timestamp_micro_from_value(v) {
                         Ok(t) => t,
                         Err(_e) => {
@@ -256,7 +256,7 @@ pub async fn ingest(
                     None => Utc::now().timestamp_micros(),
                 };
                 local_val.insert(
-                    cfg.common.column_timestamp.clone(),
+                    TIMESTAMP_COL_NAME.to_string(),
                     json::Value::Number(timestamp.into()),
                 );
 
@@ -302,7 +302,7 @@ pub async fn ingest(
                 }
 
                 // handle timestamp
-                let timestamp = match local_val.get(&cfg.common.column_timestamp) {
+                let timestamp = match local_val.get(TIMESTAMP_COL_NAME) {
                     Some(v) => match parse_timestamp_micro_from_value(v) {
                         Ok(t) => t,
                         Err(_e) => {
@@ -356,7 +356,7 @@ pub async fn ingest(
                     continue;
                 }
                 local_val.insert(
-                    cfg.common.column_timestamp.clone(),
+                    TIMESTAMP_COL_NAME.to_string(),
                     json::Value::Number(timestamp.into()),
                 );
 
@@ -456,9 +456,8 @@ pub async fn ingest(
                                 );
                             }
 
-                            let Some(timestamp) = local_val
-                                .get(&cfg.common.column_timestamp)
-                                .and_then(|ts| ts.as_i64())
+                            let Some(timestamp) =
+                                local_val.get(TIMESTAMP_COL_NAME).and_then(|ts| ts.as_i64())
                             else {
                                 bulk_res.errors = true;
                                 metrics::INGEST_ERRORS
@@ -512,7 +511,7 @@ pub async fn ingest(
                                 continue;
                             }
                             local_val.insert(
-                                cfg.common.column_timestamp.clone(),
+                                TIMESTAMP_COL_NAME.to_string(),
                                 json::Value::Number(timestamp.into()),
                             );
 

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -787,7 +787,7 @@ fn construct_values_from_open_telemetry_v1_metric(
                         "region": resource_attributes.get("cloud.region").unwrap(),
                         "namespace": summary_attributes.get("Namespace").unwrap(),
                         "metric_name": summary_attributes.get("MetricName").unwrap(),
-                        TIMESTAMP_COL_NAME.to_string(): std::time::Duration::from_nanos(i_sum.time_unix_nano).as_millis(),
+                        TIMESTAMP_COL_NAME: std::time::Duration::from_nanos(i_sum.time_unix_nano).as_millis(),
                         "unit": m.unit,
                         "count": i_sum.count,
                         "sum": i_sum.sum,

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -22,14 +22,13 @@ use actix_web::http;
 use anyhow::Result;
 use chrono::{Duration, Utc};
 use config::{
-    get_config,
     meta::{
         self_reporting::usage::UsageType,
         stream::{StreamParams, StreamType},
     },
     metrics,
     utils::{flatten, json, time::parse_timestamp_micro_from_value},
-    ID_COL_NAME, ORIGINAL_DATA_COL_NAME,
+    ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME,
 };
 use flate2::read::GzDecoder;
 use opentelemetry_proto::tonic::{
@@ -330,9 +329,8 @@ pub async fn ingest(
                             );
                         }
 
-                        let Some(timestamp) = local_val
-                            .get(&cfg.common.column_timestamp)
-                            .and_then(|ts| ts.as_i64())
+                        let Some(timestamp) =
+                            local_val.get(TIMESTAMP_COL_NAME).and_then(|ts| ts.as_i64())
                         else {
                             let err = "record _timestamp inserted before pipeline processing, but missing after pipeline processing";
                             stream_status.status.failed += 1;
@@ -427,11 +425,10 @@ pub async fn ingest(
 }
 
 pub fn handle_timestamp(value: &mut json::Value, min_ts: i64) -> Result<i64, anyhow::Error> {
-    let cfg = get_config();
     let local_val = value
         .as_object_mut()
         .ok_or_else(|| anyhow::Error::msg("Value is not an object"))?;
-    let timestamp = match local_val.get(&cfg.common.column_timestamp) {
+    let timestamp = match local_val.get(TIMESTAMP_COL_NAME) {
         Some(v) => match parse_timestamp_micro_from_value(v) {
             Ok(t) => t,
             Err(_) => return Err(anyhow::Error::msg("Can't parse timestamp")),
@@ -443,7 +440,7 @@ pub fn handle_timestamp(value: &mut json::Value, min_ts: i64) -> Result<i64, any
         return Err(get_upto_discard_error());
     }
     local_val.insert(
-        cfg.common.column_timestamp.clone(),
+        TIMESTAMP_COL_NAME.to_string(),
         json::Value::Number(timestamp.into()),
     );
     Ok(timestamp)
@@ -648,10 +645,7 @@ fn deserialize_aws_record_from_vec(data: Vec<u8>, request_id: &str) -> Result<Ve
                         local_val.insert("message".to_owned(), local_msg.into());
                     }
 
-                    local_val.insert(
-                        get_config().common.column_timestamp.clone(),
-                        event.timestamp.into(),
-                    );
+                    local_val.insert(TIMESTAMP_COL_NAME.to_string(), event.timestamp.into());
 
                     value = local_val.clone().into();
                     events.push(value);
@@ -689,10 +683,7 @@ fn deserialize_aws_record_from_vec(data: Vec<u8>, request_id: &str) -> Result<Ve
                     .insert("metric_dimensions".to_owned(), metric_dimensions.into());
                 local_parsed_metric_value.remove("dimensions");
 
-                local_parsed_metric_value.insert(
-                    get_config().common.column_timestamp.clone(),
-                    timestamp.into(),
-                );
+                local_parsed_metric_value.insert(TIMESTAMP_COL_NAME.to_string(), timestamp.into());
                 local_parsed_metric_value.remove("timestamp");
 
                 value = local_parsed_metric_value.clone().into();
@@ -796,7 +787,7 @@ fn construct_values_from_open_telemetry_v1_metric(
                         "region": resource_attributes.get("cloud.region").unwrap(),
                         "namespace": summary_attributes.get("Namespace").unwrap(),
                         "metric_name": summary_attributes.get("MetricName").unwrap(),
-                        get_config().common.column_timestamp.clone(): std::time::Duration::from_nanos(i_sum.time_unix_nano).as_millis(),
+                        TIMESTAMP_COL_NAME.to_string(): std::time::Duration::from_nanos(i_sum.time_unix_nano).as_millis(),
                         "unit": m.unit,
                         "count": i_sum.count,
                         "sum": i_sum.sum,

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -27,7 +27,7 @@ use config::{
     },
     metrics,
     utils::{flatten, json},
-    ID_COL_NAME, ORIGINAL_DATA_COL_NAME,
+    ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME,
 };
 use opentelemetry::trace::{SpanId, TraceId};
 use opentelemetry_proto::tonic::collector::logs::v1::{
@@ -159,7 +159,7 @@ pub async fn handle_grpc_request(
                     continue;
                 }
 
-                rec[cfg.common.column_timestamp.clone()] = timestamp.into();
+                rec[TIMESTAMP_COL_NAME.to_string()] = timestamp.into();
                 rec["severity"] = if !log_record.severity_text.is_empty() {
                     log_record.severity_text.to_owned().into()
                 } else {

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -27,7 +27,7 @@ use config::{
     },
     metrics,
     utils::{flatten, json},
-    ID_COL_NAME, ORIGINAL_DATA_COL_NAME,
+    ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME,
 };
 use opentelemetry::trace::{SpanId, TraceId};
 use opentelemetry_proto::tonic::collector::logs::v1::{
@@ -322,7 +322,7 @@ pub async fn logs_json_handler(
                     continue;
                 }
                 local_val.insert(
-                    cfg.common.column_timestamp.clone(),
+                    TIMESTAMP_COL_NAME.to_string(),
                     json::Value::Number(timestamp.into()),
                 );
 

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -29,7 +29,7 @@ use config::{
     },
     metrics,
     utils::{flatten, json},
-    ID_COL_NAME, ORIGINAL_DATA_COL_NAME,
+    ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME,
 };
 use syslog_loose::{Message, ProcId, Protocol};
 
@@ -286,9 +286,8 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
                         }
 
                         // handle timestamp
-                        let Some(timestamp) = local_val
-                            .get(&cfg.common.column_timestamp)
-                            .and_then(|ts| ts.as_i64())
+                        let Some(timestamp) =
+                            local_val.get(TIMESTAMP_COL_NAME).and_then(|ts| ts.as_i64())
                         else {
                             let err = "record _timestamp inserted before pipeline processing, but missing after pipeline processing";
                             stream_status.status.failed += 1;

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -26,7 +26,7 @@ use config::{
     get_config,
     meta::stream::StreamType,
     utils::{json, schema::infer_json_schema_from_map},
-    FxIndexMap,
+    FxIndexMap, TIMESTAMP_COL_NAME,
 };
 use infra::{
     errors::{Error, Result},
@@ -152,11 +152,7 @@ impl Metadata for DistinctValues {
         // distinct values will always have _timestamp and
         // count, rest will be dynamically determined
         Arc::new(Schema::new(vec![
-            Field::new(
-                get_config().common.column_timestamp.as_str(),
-                DataType::Int64,
-                false,
-            ),
+            Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
             Field::new("count", DataType::Int64, false),
         ]))
     }
@@ -264,7 +260,7 @@ impl Metadata for DistinctValues {
                 let data = data.as_object_mut().unwrap();
                 data.insert("count".to_string(), json::Value::Number(count.into()));
                 data.insert(
-                    cfg.common.column_timestamp.clone(),
+                    TIMESTAMP_COL_NAME.to_string(),
                     json::Value::Number(timestamp.into()),
                 );
                 let hour_key = ingestion::get_write_partition_key(

--- a/src/service/metadata/trace_list_index.rs
+++ b/src/service/metadata/trace_list_index.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -27,6 +27,7 @@ use config::{
     get_config,
     meta::stream::{StreamPartition, StreamSettings, StreamType},
     utils::{json, schema_ext::SchemaExt},
+    TIMESTAMP_COL_NAME,
 };
 use infra::schema::unwrap_partition_time_level;
 use once_cell::sync::Lazy;
@@ -64,11 +65,7 @@ pub struct TraceListItem {
 impl Metadata for TraceListIndex {
     fn generate_schema(&self) -> Arc<Schema> {
         Arc::new(Schema::new(vec![
-            Field::new(
-                get_config().common.column_timestamp.as_str(),
-                DataType::Int64,
-                false,
-            ),
+            Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
             Field::new("stream_name", DataType::Utf8, false),
             Field::new("service_name", DataType::Utf8, false),
             Field::new("trace_id", DataType::Utf8, false),
@@ -272,7 +269,7 @@ mod tests {
         let mut data = json::to_value(item).unwrap();
         let data = data.as_object_mut().unwrap();
         data.insert(
-            config::get_config().common.column_timestamp.clone(),
+            config::TIMESTAMP_COL_NAME.to_string(),
             json::Value::Number(timestamp.into()),
         );
         let hour_key = ingestion::get_write_partition_key(

--- a/src/service/metrics/mod.rs
+++ b/src/service/metrics/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -68,7 +68,7 @@ pub fn signature_without_labels(
 fn get_exclude_labels() -> Vec<&'static str> {
     let vec: Vec<&str> = EXCLUDE_LABELS.to_vec();
     // TODO: fixed _timestamp
-    // let column_timestamp = config::get_config().common.column_timestamp.as_str();
+    // let column_timestamp = config::TIMESTAMP_COL_NAME.as_str();
     // vec.push(column_timestamp);
     vec
 }

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -24,7 +24,6 @@ use bytes::BytesMut;
 use chrono::Utc;
 use config::{
     cluster::LOCAL_NODE,
-    get_config,
     meta::{
         alerts::alert,
         otlp::OtlpRequestType,
@@ -34,6 +33,7 @@ use config::{
     },
     metrics,
     utils::{flatten, json, schema_ext::SchemaExt},
+    TIMESTAMP_COL_NAME,
 };
 use hashbrown::HashSet;
 use infra::schema::{unwrap_partition_time_level, update_setting, SchemaCache};
@@ -164,7 +164,6 @@ pub async fn handle_otlp_request(
     let mut stream_alerts_map: HashMap<String, Vec<alert::Alert>> = HashMap::new();
     let mut stream_trigger_map: HashMap<String, Option<TriggerAlertData>> = HashMap::new();
 
-    let cfg = get_config();
     let mut partial_success = ExportMetricsPartialSuccess::default();
 
     // records buffer
@@ -427,7 +426,7 @@ pub async fn handle_otlp_request(
                 rec.as_object_mut().unwrap();
 
             let timestamp = val_map
-                .get(&cfg.common.column_timestamp)
+                .get(TIMESTAMP_COL_NAME)
                 .and_then(|ts| ts.as_i64())
                 .unwrap_or(Utc::now().timestamp_micros());
 
@@ -729,7 +728,7 @@ fn process_data_point(rec: &mut json::Value, data_point: &NumberDataPoint) {
         rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
     }
     rec[VALUE_LABEL] = get_metric_val(&data_point.value);
-    rec[&get_config().common.column_timestamp] = (data_point.time_unix_nano / 1000).into();
+    rec[TIMESTAMP_COL_NAME] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
     rec["flag"] = if data_point.flags == 1 {
         DataPointFlags::NoRecordedValueMask.as_str_name()
@@ -749,7 +748,7 @@ fn process_hist_data_point(
     for attr in &data_point.attributes {
         rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
     }
-    rec[&get_config().common.column_timestamp] = (data_point.time_unix_nano / 1000).into();
+    rec[TIMESTAMP_COL_NAME] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
     rec["flag"] = if data_point.flags == 1 {
         DataPointFlags::NoRecordedValueMask.as_str_name()
@@ -811,7 +810,7 @@ fn process_exp_hist_data_point(
     for attr in &data_point.attributes {
         rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
     }
-    rec[&get_config().common.column_timestamp] = (data_point.time_unix_nano / 1000).into();
+    rec[TIMESTAMP_COL_NAME] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
     rec["flag"] = if data_point.flags == 1 {
         DataPointFlags::NoRecordedValueMask.as_str_name()
@@ -868,7 +867,7 @@ fn process_summary_data_point(
     for attr in &data_point.attributes {
         rec[format_label_name(attr.key.as_str())] = get_val(&attr.value.as_ref());
     }
-    rec[&get_config().common.column_timestamp] = (data_point.time_unix_nano / 1000).into();
+    rec[TIMESTAMP_COL_NAME] = (data_point.time_unix_nano / 1000).into();
     rec["start_time"] = data_point.start_time_unix_nano.to_string().into();
     rec["flag"] = if data_point.flags == 1 {
         DataPointFlags::NoRecordedValueMask.as_str_name()
@@ -906,8 +905,7 @@ fn process_exemplars(rec: &mut json::Value, exemplars: &Vec<Exemplar>) {
             exemplar_rec[attr.key.as_str()] = get_val(&attr.value.as_ref());
         }
         exemplar_rec[VALUE_LABEL] = get_exemplar_val(&exemplar.value);
-        exemplar_rec[&get_config().common.column_timestamp] =
-            (exemplar.time_unix_nano / 1000).into();
+        exemplar_rec[TIMESTAMP_COL_NAME] = (exemplar.time_unix_nano / 1000).into();
 
         match TraceId::from_bytes(exemplar.trace_id.as_slice().try_into().unwrap_or_default()) {
             TraceId::INVALID => {}

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -28,7 +28,7 @@ use config::{
     },
     metrics,
     utils::{json, schema_ext::SchemaExt, time::parse_i64_to_timestamp_micros},
-    FxIndexMap,
+    FxIndexMap, TIMESTAMP_COL_NAME,
 };
 use datafusion::arrow::datatypes::Schema;
 use hashbrown::HashSet;
@@ -326,7 +326,7 @@ pub async fn remote_write(
             let mut value: json::Value = json::to_value(&metric).unwrap();
             let timestamp = parse_i64_to_timestamp_micros(sample.timestamp);
             value.as_object_mut().unwrap().insert(
-                cfg.common.column_timestamp.clone(),
+                TIMESTAMP_COL_NAME.to_string(),
                 json::Value::Number(timestamp.into()),
             );
 
@@ -417,7 +417,7 @@ pub async fn remote_write(
             let hash = super::signature_without_labels(val_map, &[VALUE_LABEL]);
             val_map.insert(HASH_LABEL.to_string(), json::Value::Number(hash.into()));
             val_map.insert(
-                cfg.common.column_timestamp.clone(),
+                TIMESTAMP_COL_NAME.to_string(),
                 json::Value::Number(timestamp.into()),
             );
             let value_str = config::utils::json::to_string(&val_map).unwrap();
@@ -689,13 +689,12 @@ pub(crate) async fn get_series(
         // `db::schema::get` never fails, so it's safe to unwrap
         .unwrap();
 
-    let cfg = get_config();
     // Comma-separated list of label names
     let label_names = schema
         .fields()
         .iter()
         .map(|f| f.name().as_str())
-        .filter(|&s| s != cfg.common.column_timestamp && s != VALUE_LABEL && s != HASH_LABEL)
+        .filter(|&s| s != TIMESTAMP_COL_NAME && s != VALUE_LABEL && s != HASH_LABEL)
         .collect::<Vec<_>>()
         .join("\", \"");
     if label_names.is_empty() {
@@ -706,7 +705,7 @@ pub(crate) async fn get_series(
     let mut sql_where = Vec::new();
     if let Some(selector) = selector {
         for mat in selector.matchers.matchers.iter() {
-            if mat.name == cfg.common.column_timestamp
+            if mat.name == TIMESTAMP_COL_NAME
                 || mat.name == VALUE_LABEL
                 || schema.field_with_name(&mat.name).is_err()
             {
@@ -781,7 +780,6 @@ pub(crate) async fn get_labels(
         Ok(schemas) => schemas,
     };
     let mut label_names = hashbrown::HashSet::new();
-    let cfg = get_config();
     for schema in stream_schemas {
         if let Some(ref metric_name) = opt_metric_name {
             if *metric_name != schema.stream_name {
@@ -797,9 +795,7 @@ pub(crate) async fn get_labels(
                 .fields()
                 .iter()
                 .map(|f| f.name())
-                .filter(|&s| {
-                    s != &cfg.common.column_timestamp && s != VALUE_LABEL && s != HASH_LABEL
-                })
+                .filter(|&s| s != TIMESTAMP_COL_NAME && s != VALUE_LABEL && s != HASH_LABEL)
                 .cloned();
             label_names.extend(field_names);
         }

--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -18,9 +18,9 @@ use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
 use arrow::array::Array;
 use async_recursion::async_recursion;
 use config::{
-    get_config,
     meta::promql::{HashLabelValue, EXEMPLARS_LABEL, HASH_LABEL, NAME_LABEL, VALUE_LABEL},
     utils::json,
+    TIMESTAMP_COL_NAME,
 };
 use datafusion::{
     arrow::{
@@ -1120,9 +1120,9 @@ async fn selector_load_data_from_datafusion(
     let table_name = selector.name.as_ref().unwrap();
     let mut df_group = match ctx.table(table_name).await {
         Ok(v) => v.filter(
-            col(&cfg.common.column_timestamp)
+            col(TIMESTAMP_COL_NAME)
                 .gt(lit(start))
-                .and(col(&cfg.common.column_timestamp).lt_eq(lit(end))),
+                .and(col(TIMESTAMP_COL_NAME).lt_eq(lit(end))),
         )?,
         Err(_) => {
             return Ok(HashMap::default());
@@ -1142,7 +1142,7 @@ async fn selector_load_data_from_datafusion(
         .iter()
         .filter_map(|field| {
             let name = field.name();
-            if name == &cfg.common.column_timestamp
+            if name == TIMESTAMP_COL_NAME
                 || name == VALUE_LABEL
                 || name == EXEMPLARS_LABEL
                 || name == NAME_LABEL
@@ -1166,7 +1166,7 @@ async fn selector_load_data_from_datafusion(
         .clone()
         .aggregate(
             vec![col(HASH_LABEL)],
-            vec![max(col(&cfg.common.column_timestamp)).alias(&cfg.common.column_timestamp)],
+            vec![max(col(TIMESTAMP_COL_NAME)).alias(TIMESTAMP_COL_NAME)],
         )?
         .sort(vec![col(HASH_LABEL).sort(true, true)])?
         .limit(0, Some(max_series))?
@@ -1180,7 +1180,7 @@ async fn selector_load_data_from_datafusion(
                 .iter()
                 .flat_map(|batch| {
                     let ts = batch
-                        .column_by_name(&cfg.common.column_timestamp)
+                        .column_by_name(TIMESTAMP_COL_NAME)
                         .unwrap()
                         .as_any()
                         .downcast_ref::<Int64Array>()
@@ -1201,7 +1201,7 @@ async fn selector_load_data_from_datafusion(
                 .iter()
                 .flat_map(|batch| {
                     let ts = batch
-                        .column_by_name(&cfg.common.column_timestamp)
+                        .column_by_name(TIMESTAMP_COL_NAME)
                         .unwrap()
                         .as_any()
                         .downcast_ref::<Int64Array>()
@@ -1230,7 +1230,7 @@ async fn selector_load_data_from_datafusion(
     // get series
     let series = df_group
         .clone()
-        .filter(col(&cfg.common.column_timestamp).in_list(timestamp_values, false))?
+        .filter(col(TIMESTAMP_COL_NAME).in_list(timestamp_values, false))?
         .select(label_cols)?
         .collect()
         .await?;
@@ -1340,9 +1340,8 @@ async fn load_samples_from_datafusion(
     df: DataFrame,
 ) -> Result<()> {
     let start_time = std::time::Instant::now();
-    let cfg = get_config();
     let streams = df
-        .select_columns(&[&cfg.common.column_timestamp, HASH_LABEL, VALUE_LABEL])?
+        .select_columns(&[TIMESTAMP_COL_NAME, HASH_LABEL, VALUE_LABEL])?
         .execute_stream_partitioned()
         .await?;
 
@@ -1357,12 +1356,11 @@ async fn load_samples_from_datafusion(
         let mut series = metrics.clone();
         let task: tokio::task::JoinHandle<Result<HashMap<HashLabelValue, RangeValue>>> =
             tokio::task::spawn(async move {
-                let cfg = get_config();
                 loop {
                     match stream.try_next().await {
                         Ok(Some(batch)) => {
                             let time_values = batch
-                                .column_by_name(&cfg.common.column_timestamp)
+                                .column_by_name(TIMESTAMP_COL_NAME)
                                 .unwrap()
                                 .as_any()
                                 .downcast_ref::<Int64Array>()

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -22,6 +22,7 @@ use config::{
         search::{ScanStats, Session as SearchSession, StorageType},
         stream::{FileKey, PartitionTimeLevel, StreamParams, StreamPartition, StreamType},
     },
+    TIMESTAMP_COL_NAME,
 };
 use datafusion::{
     arrow::datatypes::Schema,
@@ -334,9 +335,8 @@ fn convert_matchers_to_index_condition(
     index_fields: &HashSet<String>,
 ) -> Result<IndexCondition> {
     let mut index_condition = IndexCondition::default();
-    let cfg = get_config();
     for mat in matchers.matchers.iter() {
-        if mat.name == cfg.common.column_timestamp
+        if mat.name == TIMESTAMP_COL_NAME
             || mat.name == VALUE_LABEL
             || !index_fields.contains(&mat.name)
             || schema.field_with_name(&mat.name).is_err()

--- a/src/service/promql/search/grpc/wal.rs
+++ b/src/service/promql/search/grpc/wal.rs
@@ -22,6 +22,7 @@ use arrow::record_batch::RecordBatch;
 use config::{
     get_config,
     meta::{cluster::IntoArcVec, search::ScanStats, stream::StreamType},
+    TIMESTAMP_COL_NAME,
 };
 use datafusion::{
     arrow::datatypes::Schema,
@@ -142,9 +143,9 @@ async fn get_wal_batches(
     let (start, end) = time_range;
     let mut df = match ctx.table(stream_name).await {
         Ok(df) => df.filter(
-            col(&cfg.common.column_timestamp)
+            col(TIMESTAMP_COL_NAME)
                 .gt(lit(start))
-                .and(col(&cfg.common.column_timestamp).lt_eq(lit(end))),
+                .and(col(TIMESTAMP_COL_NAME).lt_eq(lit(end))),
         )?,
         Err(_) => {
             return Ok((ScanStats::new(), vec![], Arc::new(Schema::empty())));

--- a/src/service/promql/utils.rs
+++ b/src/service/promql/utils.rs
@@ -16,8 +16,8 @@
 use std::collections::HashSet;
 
 use config::{
-    get_config,
     meta::promql::{BUCKET_LABEL, HASH_LABEL, VALUE_LABEL},
+    TIMESTAMP_COL_NAME,
 };
 use datafusion::{
     arrow::datatypes::Schema,
@@ -29,10 +29,9 @@ use promql_parser::label::{MatchOp, Matchers};
 use crate::service::search::datafusion::udf::regexp_udf::{REGEX_MATCH_UDF, REGEX_NOT_MATCH_UDF};
 
 pub fn apply_matchers(df: DataFrame, schema: &Schema, matchers: &Matchers) -> Result<DataFrame> {
-    let cfg = get_config();
     let mut df = df;
     for mat in matchers.matchers.iter() {
-        if mat.name == cfg.common.column_timestamp
+        if mat.name == TIMESTAMP_COL_NAME
             || mat.name == VALUE_LABEL
             || schema.field_with_name(&mat.name).is_err()
         {
@@ -64,7 +63,6 @@ pub fn apply_label_selector(
     schema: &Schema,
     label_selectors: &Option<HashSet<String>>,
 ) -> Option<DataFrame> {
-    let cfg = get_config();
     let mut df = df;
     if let Some(label_selector) = label_selectors {
         if !label_selector.is_empty() {
@@ -77,7 +75,7 @@ pub fn apply_label_selector(
                 HASH_LABEL.to_string(),
                 VALUE_LABEL.to_string(),
                 BUCKET_LABEL.to_string(),
-                cfg.common.column_timestamp.to_string(),
+                TIMESTAMP_COL_NAME.to_string(),
             ];
             for label in label_selector.iter() {
                 if def_labels.contains(label) {

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -26,6 +26,7 @@ use config::{
     },
     metrics,
     utils::{base64, hash::Sum64, json, sql::is_aggregate_query},
+    TIMESTAMP_COL_NAME,
 };
 use infra::{
     cache::{file_data::disk::QUERY_RESULT_CACHE, meta::ResultCacheMeta},
@@ -135,7 +136,7 @@ pub async fn search(
         match crate::service::search::Sql::new(&query, org_id, stream_type).await {
             Ok(v) => {
                 let (ts_column, is_descending) =
-                    cacher::get_ts_col_order_by(&v, &cfg.common.column_timestamp, is_aggregate)
+                    cacher::get_ts_col_order_by(&v, TIMESTAMP_COL_NAME, is_aggregate)
                         .unwrap_or_default();
 
                 MultiCachedQueryResponse {
@@ -807,8 +808,6 @@ pub async fn check_cache_v2(
     in_req: &search::Request,
     use_cache: bool,
 ) -> Result<MultiCachedQueryResponse, Error> {
-    let cfg = get_config();
-
     // Result caching check start
     let mut origin_sql = in_req.query.sql.clone();
     origin_sql = origin_sql.replace('\n', " ");
@@ -869,7 +868,7 @@ pub async fn check_cache_v2(
         match crate::service::search::Sql::new(&query, org_id, stream_type).await {
             Ok(v) => {
                 let (ts_column, is_descending) =
-                    cacher::get_ts_col_order_by(&v, &cfg.common.column_timestamp, is_aggregate)
+                    cacher::get_ts_col_order_by(&v, TIMESTAMP_COL_NAME, is_aggregate)
                         .unwrap_or_default();
 
                 MultiCachedQueryResponse {

--- a/src/service/search/cluster/mod.rs
+++ b/src/service/search/cluster/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,7 @@
 use std::sync::Arc;
 
 use ::datafusion::arrow::datatypes::Schema;
-use config::{get_config, utils::json};
+use config::{utils::json, TIMESTAMP_COL_NAME};
 use hashbrown::HashMap;
 #[cfg(feature = "enterprise")]
 use {
@@ -165,25 +165,24 @@ pub fn handle_metrics_response(sources: Vec<json::Value>) -> Vec<json::Value> {
     // handle metrics response
     let mut results_metrics: HashMap<String, json::Value> = HashMap::with_capacity(16);
     let mut results_values: HashMap<String, Vec<[json::Value; 2]>> = HashMap::with_capacity(16);
-    let cfg = get_config();
     for source in sources {
         let fields = source.as_object().unwrap();
         let mut key = Vec::with_capacity(fields.len());
         fields.iter().for_each(|(k, v)| {
-            if *k != cfg.common.column_timestamp && k != "value" {
+            if *k != TIMESTAMP_COL_NAME && k != "value" {
                 key.push(format!("{k}_{v}"));
             }
         });
         let key = key.join("_");
         if !results_metrics.contains_key(&key) {
             let mut fields = fields.clone();
-            fields.remove(&cfg.common.column_timestamp);
+            fields.remove(TIMESTAMP_COL_NAME);
             fields.remove("value");
             results_metrics.insert(key.clone(), json::Value::Object(fields));
         }
         let entry = results_values.entry(key).or_default();
         let value = [
-            fields.get(&cfg.common.column_timestamp).unwrap().to_owned(),
+            fields.get(TIMESTAMP_COL_NAME).unwrap().to_owned(),
             json::Value::String(fields.get("value").unwrap().to_string()),
         ];
         entry.push(value);

--- a/src/service/search/datafusion/distributed_plan/empty_exec.rs
+++ b/src/service/search/datafusion/distributed_plan/empty_exec.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,7 @@
 use std::{any::Any, sync::Arc};
 
 use arrow_schema::SortOptions;
-use config::get_config;
+use config::TIMESTAMP_COL_NAME;
 use datafusion::{
     arrow::{array::RecordBatch, datatypes::SchemaRef},
     common::{internal_err, Result, Statistics},
@@ -92,14 +92,14 @@ impl NewEmptyExec {
         n_partitions: usize,
         sorted_by_time: bool,
     ) -> PlanProperties {
-        let index = schema.index_of(&get_config().common.column_timestamp);
+        let index = schema.index_of(TIMESTAMP_COL_NAME);
         let eq_properties = if !sorted_by_time {
             EquivalenceProperties::new(schema)
         } else {
             match index {
                 Ok(index) => {
                     let ordering = vec![LexOrdering::new(vec![PhysicalSortExpr {
-                        expr: Arc::new(Column::new(&get_config().common.column_timestamp, index)),
+                        expr: Arc::new(Column::new(TIMESTAMP_COL_NAME, index)),
                         options: SortOptions {
                             descending: true,
                             nulls_first: false,

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -23,7 +23,7 @@ use config::{
         stream::{FileKey, FileMeta, StreamType},
     },
     utils::{parquet::new_parquet_writer, schema_ext::SchemaExt},
-    PARQUET_BATCH_SIZE,
+    PARQUET_BATCH_SIZE, TIMESTAMP_COL_NAME,
 };
 use datafusion::{
     arrow::datatypes::{DataType, Schema},
@@ -117,7 +117,7 @@ pub async fn merge_parquet_files(
     let sql = if stream_type == StreamType::Index {
         format!(
             "SELECT * FROM tbl WHERE file_name NOT IN (SELECT file_name FROM tbl WHERE deleted IS TRUE ORDER BY {} DESC) ORDER BY {} DESC",
-            cfg.common.column_timestamp, cfg.common.column_timestamp
+            TIMESTAMP_COL_NAME, TIMESTAMP_COL_NAME
         )
     } else if cfg.limit.distinct_values_hourly
         && stream_type == StreamType::Metadata
@@ -126,23 +126,16 @@ pub async fn merge_parquet_files(
         let fields = schema
             .fields()
             .iter()
-            .filter(|f| f.name() != &cfg.common.column_timestamp && f.name() != "count")
+            .filter(|f| f.name() != TIMESTAMP_COL_NAME && f.name() != "count")
             .map(|x| x.name().to_string())
             .collect::<Vec<_>>();
         let fields_str = fields.join(", ");
         format!(
             "SELECT MIN({}) AS {}, SUM(count) as count, {} FROM tbl GROUP BY {} ORDER BY {} DESC",
-            cfg.common.column_timestamp,
-            cfg.common.column_timestamp,
-            fields_str,
-            fields_str,
-            cfg.common.column_timestamp
+            TIMESTAMP_COL_NAME, TIMESTAMP_COL_NAME, fields_str, fields_str, TIMESTAMP_COL_NAME
         )
     } else {
-        format!(
-            "SELECT * FROM tbl ORDER BY {} DESC",
-            cfg.common.column_timestamp
-        )
+        format!("SELECT * FROM tbl ORDER BY {} DESC", TIMESTAMP_COL_NAME)
     };
     log::debug!("merge_parquet_files sql: {}", sql);
 
@@ -493,10 +486,9 @@ pub async fn register_table(
     rules: HashMap<String, DataType>,
     sort_key: &[(String, bool)],
 ) -> Result<SessionContext> {
-    let cfg = get_config();
     // only sort by timestamp desc
     let sorted_by_time =
-        sort_key.len() == 1 && sort_key[0].0 == cfg.common.column_timestamp && sort_key[0].1;
+        sort_key.len() == 1 && sort_key[0].0 == TIMESTAMP_COL_NAME && sort_key[0].1;
 
     let ctx = prepare_datafusion_context(
         session.work_group.clone(),
@@ -564,7 +556,7 @@ pub async fn create_parquet_table(
         // specify sort columns for parquet file
         listing_options =
             listing_options.with_file_sort_order(vec![vec![datafusion::logical_expr::SortExpr {
-                expr: Expr::Column(Column::new_unqualified(cfg.common.column_timestamp.clone())),
+                expr: Expr::Column(Column::new_unqualified(TIMESTAMP_COL_NAME.to_string())),
                 asc: false,
                 nulls_first: false,
             }]]);
@@ -595,15 +587,15 @@ pub async fn create_parquet_table(
     };
 
     let mut config = ListingTableConfig::new(prefix).with_listing_options(listing_options);
-    let timestamp_field = schema.field_with_name(&cfg.common.column_timestamp);
+    let timestamp_field = schema.field_with_name(TIMESTAMP_COL_NAME);
     let schema = if timestamp_field.is_ok() && timestamp_field.unwrap().is_nullable() {
         let new_fields = schema
             .fields()
             .iter()
             .map(|x| {
-                if x.name() == &cfg.common.column_timestamp {
+                if x.name() == TIMESTAMP_COL_NAME {
                     Arc::new(Field::new(
-                        cfg.common.column_timestamp.clone(),
+                        TIMESTAMP_COL_NAME.to_string(),
                         DataType::Int64,
                         false,
                     ))
@@ -658,10 +650,7 @@ fn generate_downsampling_sql(schema: &Arc<Schema>, rule: &DownsamplingRule) -> S
         .fields()
         .iter()
         .filter_map(|f| {
-            if f.name() != HASH_LABEL
-                && f.name() != VALUE_LABEL
-                && f.name() != &cfg.common.column_timestamp
-            {
+            if f.name() != HASH_LABEL && f.name() != VALUE_LABEL && f.name() != TIMESTAMP_COL_NAME {
                 Some(format!("max({}) as {}", f.name(), f.name()))
             } else {
                 None
@@ -674,7 +663,7 @@ fn generate_downsampling_sql(schema: &Arc<Schema>, rule: &DownsamplingRule) -> S
             "{}({} ORDER BY {} ASC) as {}",
             rule.function.fun(),
             VALUE_LABEL,
-            cfg.common.column_timestamp,
+            TIMESTAMP_COL_NAME,
             VALUE_LABEL
         )
     } else {
@@ -690,7 +679,7 @@ fn generate_downsampling_sql(schema: &Arc<Schema>, rule: &DownsamplingRule) -> S
         "SELECT {}, to_unixtime(date_bin(interval '{} second', to_timestamp_micros({}), to_timestamp('2001-01-01T00:00:00'))) * 1000000 as {}, {}, {} FROM tbl GROUP BY {}, {}",
         HASH_LABEL,
         step,
-        cfg.common.column_timestamp,
+        TIMESTAMP_COL_NAME,
         TIMESTAMP_ALIAS,
         fields.join(", "),
         fun_str,
@@ -702,10 +691,7 @@ fn generate_downsampling_sql(schema: &Arc<Schema>, rule: &DownsamplingRule) -> S
         .fields()
         .iter()
         .filter_map(|f| {
-            if f.name() != HASH_LABEL
-                && f.name() != VALUE_LABEL
-                && f.name() != &cfg.common.column_timestamp
-            {
+            if f.name() != HASH_LABEL && f.name() != VALUE_LABEL && f.name() != TIMESTAMP_COL_NAME {
                 Some(f.name().to_string())
             } else {
                 None
@@ -718,7 +704,7 @@ fn generate_downsampling_sql(schema: &Arc<Schema>, rule: &DownsamplingRule) -> S
         VALUE_LABEL,
         fields.join(", "),
         TIMESTAMP_ALIAS,
-        cfg.common.column_timestamp,
+        TIMESTAMP_COL_NAME,
         sql,
         TIMESTAMP_ALIAS,
     )
@@ -728,7 +714,7 @@ fn generate_downsampling_sql(schema: &Arc<Schema>, rule: &DownsamplingRule) -> S
 fn get_max_timestamp(record_batch: &RecordBatch) -> i64 {
     let cfg = get_config();
     let timestamp = record_batch
-        .column_by_name(&cfg.common.column_timestamp)
+        .column_by_name(TIMESTAMP_COL_NAME)
         .unwrap()
         .as_any()
         .downcast_ref::<Int64Array>()
@@ -740,7 +726,7 @@ fn get_max_timestamp(record_batch: &RecordBatch) -> i64 {
 fn get_min_timestamp(record_batch: &RecordBatch) -> i64 {
     let cfg = get_config();
     let timestamp = record_batch
-        .column_by_name(&cfg.common.column_timestamp)
+        .column_by_name(TIMESTAMP_COL_NAME)
         .unwrap()
         .as_any()
         .downcast_ref::<Int64Array>()

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -644,7 +644,6 @@ async fn get_cpu_and_mem_limit(
 
 #[cfg(feature = "enterprise")]
 fn generate_downsampling_sql(schema: &Arc<Schema>, rule: &DownsamplingRule) -> String {
-    let cfg = get_config();
     let step = rule.step;
     let fields = schema
         .fields()
@@ -712,7 +711,6 @@ fn generate_downsampling_sql(schema: &Arc<Schema>, rule: &DownsamplingRule) -> S
 
 #[cfg(feature = "enterprise")]
 fn get_max_timestamp(record_batch: &RecordBatch) -> i64 {
-    let cfg = get_config();
     let timestamp = record_batch
         .column_by_name(TIMESTAMP_COL_NAME)
         .unwrap()
@@ -724,7 +722,6 @@ fn get_max_timestamp(record_batch: &RecordBatch) -> i64 {
 
 #[cfg(feature = "enterprise")]
 fn get_min_timestamp(record_batch: &RecordBatch) -> i64 {
-    let cfg = get_config();
     let timestamp = record_batch
         .column_by_name(TIMESTAMP_COL_NAME)
         .unwrap()

--- a/src/service/search/datafusion/optimizer/add_timestamp.rs
+++ b/src/service/search/datafusion/optimizer/add_timestamp.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use config::get_config;
+use config::TIMESTAMP_COL_NAME;
 use datafusion::{
     common::{tree_node::Transformed, Result},
     logical_expr::{and, col, lit, Expr, Filter, LogicalPlan},
@@ -33,7 +33,7 @@ pub struct AddTimestampRule {
 impl AddTimestampRule {
     #[allow(missing_docs)]
     pub fn new(start_time: i64, end_time: i64) -> Self {
-        let column_timestamp = get_config().common.column_timestamp.clone();
+        let column_timestamp = TIMESTAMP_COL_NAME.to_string();
         Self {
             filter: and(
                 col(&column_timestamp).gt_eq(lit(start_time)),

--- a/src/service/search/datafusion/optimizer/utils.rs
+++ b/src/service/search/datafusion/optimizer/utils.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use config::get_config;
+use config::TIMESTAMP_COL_NAME;
 use datafusion::{
     common::{
         tree_node::{
@@ -82,7 +82,6 @@ impl TreeNodeRewriter for AddSortAndLimit {
     type Node = LogicalPlan;
 
     fn f_down(&mut self, node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
-        let cfg = config::get_config();
         if self.limit == 0 {
             return Ok(Transformed::new(node, false, TreeNodeRecursion::Stop));
         }
@@ -160,12 +159,9 @@ impl TreeNodeRewriter for AddSortAndLimit {
                 });
             }
 
-            if schema
-                .field_with_name(None, cfg.common.column_timestamp.as_str())
-                .is_ok()
-            {
+            if schema.field_with_name(None, TIMESTAMP_COL_NAME).is_ok() {
                 sort_columns.push(SortExpr {
-                    expr: col(cfg.common.column_timestamp.clone()),
+                    expr: col(TIMESTAMP_COL_NAME.to_string()),
                     asc: false,
                     nulls_first: false,
                 });
@@ -210,17 +206,13 @@ fn generate_sort_plan(
     input: Arc<LogicalPlan>,
     limit: usize,
 ) -> (LogicalPlan, Option<Arc<DFSchema>>) {
-    let config = get_config();
     let timestamp = SortExpr {
-        expr: col(config.common.column_timestamp.clone()),
+        expr: col(TIMESTAMP_COL_NAME),
         asc: false,
         nulls_first: false,
     };
     let schema = input.schema().clone();
-    if schema
-        .field_with_name(None, config.common.column_timestamp.as_str())
-        .is_err()
-    {
+    if schema.field_with_name(None, TIMESTAMP_COL_NAME).is_err() {
         let mut input = input.as_ref().clone();
         input = input
             .rewrite(&mut ChangeTableScanSchema::new())
@@ -293,8 +285,7 @@ impl TreeNodeRewriter for ChangeTableScanSchema {
         let mut transformed = match node {
             LogicalPlan::TableScan(scan) => {
                 let schema = scan.source.schema();
-                let timestamp_idx =
-                    schema.index_of(get_config().common.column_timestamp.as_str())?;
+                let timestamp_idx = schema.index_of(TIMESTAMP_COL_NAME)?;
                 let mut projection = scan.projection.clone().unwrap();
                 projection.push(timestamp_idx);
                 let mut table_scan = TableScan::try_new(

--- a/src/service/search/datafusion/plan/deduplication_exec.rs
+++ b/src/service/search/datafusion/plan/deduplication_exec.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -21,6 +21,7 @@ use std::{
 
 use arrow::array::{BooleanArray, Float64Array, Int64Array, RecordBatch, StringArray, UInt64Array};
 use arrow_schema::{DataType, SortOptions};
+use config::TIMESTAMP_COL_NAME;
 use datafusion::{
     arrow::datatypes::SchemaRef,
     common::{internal_err, Result, Statistics},
@@ -135,7 +136,6 @@ impl ExecutionPlan for DeduplicationExec {
     // if don't have this, the optimizer will not merge the SortExec
     // and get wrong result
     fn required_input_ordering(&self) -> Vec<Option<LexRequirement>> {
-        let cfg = config::get_config();
         let mut sort_requirment = self
             .deduplication_columns
             .iter()
@@ -146,9 +146,9 @@ impl ExecutionPlan for DeduplicationExec {
                 )
             })
             .collect_vec();
-        if let Some((index, _)) = self.schema().column_with_name(&cfg.common.column_timestamp) {
+        if let Some((index, _)) = self.schema().column_with_name(TIMESTAMP_COL_NAME) {
             sort_requirment.push(PhysicalSortRequirement::new(
-                Arc::new(Column::new(&cfg.common.column_timestamp, index)) as _,
+                Arc::new(Column::new(TIMESTAMP_COL_NAME, index)) as _,
                 Some(SortOptions::new(true, false)),
             ));
         }

--- a/src/service/search/datafusion/table_provider/memtable.rs
+++ b/src/service/search/datafusion/table_provider/memtable.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -139,7 +139,7 @@ impl TableProvider for NewMemTable {
 
 // create sort exec by _timestamp
 fn wrap_sort(exec: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
-    let column_timestamp = config::get_config().common.column_timestamp.to_string();
+    let column_timestamp = config::TIMESTAMP_COL_NAME.to_string();
     let index = exec.schema().index_of(&column_timestamp);
     (match index {
         Ok(index) => {

--- a/src/service/search/index.rs
+++ b/src/service/search/index.rs
@@ -1,3 +1,18 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use std::{
     fmt::{self, Debug, Formatter},
     sync::Arc,

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -33,6 +33,7 @@ use config::{
         schema::filter_source_by_partition_key,
         sql::{is_aggregate_query, is_simple_aggregate_query},
     },
+    TIMESTAMP_COL_NAME,
 };
 use datafusion::distributed_plan::streaming_aggs_exec;
 use hashbrown::HashMap;
@@ -501,7 +502,7 @@ pub async fn search_multi(
         multi_res.hits
     };
     log::debug!("multi_res len after applying vrl: {}", multi_res.hits.len());
-    let column_timestamp = get_config().common.column_timestamp.to_string();
+    let column_timestamp = TIMESTAMP_COL_NAME.to_string();
     multi_res.cached_ratio /= queries_len;
     multi_res.hits.sort_by(|a, b| {
         if a.get(&column_timestamp).is_none() || b.get(&column_timestamp).is_none() {
@@ -578,7 +579,7 @@ pub async fn search_partition(
 
     // if there is no _timestamp field in the query, return single partitions
     let is_aggregate = is_aggregate_query(&req.sql).unwrap_or(false);
-    let res_ts_column = get_ts_col_order_by(&sql, &cfg.common.column_timestamp, is_aggregate);
+    let res_ts_column = get_ts_col_order_by(&sql, TIMESTAMP_COL_NAME, is_aggregate);
     let ts_column = res_ts_column.map(|(v, _)| v);
     let is_streaming_aggregate = ts_column.is_none()
         && is_simple_aggregate_query(&req.sql).unwrap_or(false)

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -29,7 +29,7 @@ use config::{
     },
     metrics,
     utils::{flatten, json, schema_ext::SchemaExt},
-    DISTINCT_FIELDS,
+    DISTINCT_FIELDS, TIMESTAMP_COL_NAME,
 };
 use hashbrown::HashSet;
 use infra::schema::{unwrap_partition_time_level, SchemaCache};
@@ -361,7 +361,7 @@ pub async fn handle_otlp_request(
                 let mut value: json::Value = json::to_value(local_val).unwrap();
                 // add timestamp
                 value.as_object_mut().unwrap().insert(
-                    cfg.common.column_timestamp.clone(),
+                    TIMESTAMP_COL_NAME.to_string(),
                     json::Value::Number(timestamp.into()),
                 );
 
@@ -492,7 +492,7 @@ pub async fn handle_otlp_request(
                         };
 
                         let Some(timestamp) = record_val
-                            .get(&cfg.common.column_timestamp)
+                            .get(TIMESTAMP_COL_NAME)
                             .and_then(|ts| ts.as_i64())
                         else {
                             log::error!(
@@ -619,7 +619,7 @@ pub async fn ingest_json(
     let mut json_data_by_stream = HashMap::new();
     let mut partial_success = ExportTracePartialSuccess::default();
     for mut value in json_values {
-        let timestamp = value[&cfg.common.column_timestamp].as_i64().unwrap_or(
+        let timestamp = value[TIMESTAMP_COL_NAME].as_i64().unwrap_or(
             value["start_time"]
                 .as_i64()
                 .map(|ts| ts / 1000)
@@ -658,7 +658,7 @@ pub async fn ingest_json(
 
         // add timestamp
         record_val.insert(
-            cfg.common.column_timestamp.clone(),
+            TIMESTAMP_COL_NAME.to_string(),
             json::Value::Number(timestamp.into()),
         );
         let (ts_data, _) = json_data_by_stream


### PR DESCRIPTION
The `_timestamp` is a special column and it used for everywhere, change the column name maybe cause unknown so we remove the option to change it.