### PR TITLE
fix: health check shouldn't remove node for etcd

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -186,9 +186,13 @@ pub async fn register_and_keep_alive() -> Result<()> {
             .build()
             .unwrap();
         let ttl_keep_alive = min(10, (cfg.limit.node_heartbeat_ttl / 2) as u64);
+        let is_nats = matches!(
+            cfg.common.cluster_coordinator.as_str().into(),
+            MetaStore::Nats
+        );
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(ttl_keep_alive)).await;
-            if let Err(e) = check_nodes_status(&client).await {
+            if let Err(e) = check_nodes_status(&client, is_nats).await {
                 log::error!("[CLUSTER] check_nodes_status failed: {}", e);
             }
         }
@@ -412,7 +416,7 @@ async fn watch_node_list() -> Result<()> {
     Ok(())
 }
 
-async fn check_nodes_status(client: &reqwest::Client) -> Result<()> {
+async fn check_nodes_status(client: &reqwest::Client, is_nats: bool) -> Result<()> {
     let cfg = get_config();
     if !cfg.health_check.enabled {
         return Ok(());
@@ -437,7 +441,7 @@ async fn check_nodes_status(client: &reqwest::Client) -> Result<()> {
             let mut w = NODES_HEALTH_CHECK.write().await;
             let entry = w.entry(node.uuid.clone()).or_insert(0);
             *entry += 1;
-            if *entry >= cfg.health_check.failed_times {
+            if is_nats && *entry >= cfg.health_check.failed_times {
                 log::error!(
                     "[CLUSTER] node {}[{}] health check failed {} times, remove it",
                     node.name,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1670,13 +1670,13 @@ pub struct HealthCheck {
     pub enabled: bool,
     #[env_config(
         name = "ZO_HEALTH_CHECK_TIMEOUT",
-        default = 10,
+        default = 5,
         help = "Health check timeout in seconds"
     )]
     pub timeout: u64,
     #[env_config(
         name = "ZO_HEALTH_CHECK_FAILED_TIMES",
-        default = 5,
+        default = 3,
         help = "The node will be removed from consistent hash if health check failed exceed this times"
     )]
     pub failed_times: usize,

--- a/src/config/src/meta/meta_store.rs
+++ b/src/config/src/meta/meta_store.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -40,7 +40,7 @@ fn connect() -> Pool<MySql> {
     let db_opts = MySqlConnectOptions::from_str(&cfg.common.meta_mysql_dsn)
         .expect("mysql connect options create failed");
 
-    let acquire_timeout = zero_or(cfg.limit.sql_db_connections_idle_timeout, 30);
+    let acquire_timeout = zero_or(cfg.limit.sql_db_connections_acquire_timeout, 30);
     let idle_timeout = zero_or(cfg.limit.sql_db_connections_idle_timeout, 600);
     let max_lifetime = zero_or(cfg.limit.sql_db_connections_max_lifetime, 1800);
 

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -40,7 +40,7 @@ fn connect() -> Pool<Postgres> {
     let db_opts = PgConnectOptions::from_str(&cfg.common.meta_postgres_dsn)
         .expect("postgres connect options create failed");
 
-    let acquire_timeout = zero_or(cfg.limit.sql_db_connections_idle_timeout, 30);
+    let acquire_timeout = zero_or(cfg.limit.sql_db_connections_acquire_timeout, 30);
     let idle_timeout = zero_or(cfg.limit.sql_db_connections_idle_timeout, 600);
     let max_lifetime = zero_or(cfg.limit.sql_db_connections_max_lifetime, 1800);
 

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -56,7 +56,7 @@ fn connect_rw() -> Pool<Sqlite> {
         _ = std::fs::remove_file(format!("{url}-wal"));
     }
 
-    let acquire_timeout = zero_or(cfg.limit.sql_db_connections_idle_timeout, 30);
+    let acquire_timeout = zero_or(cfg.limit.sql_db_connections_acquire_timeout, 30);
     let idle_timeout = zero_or(cfg.limit.sql_db_connections_idle_timeout, 600);
     let max_lifetime = zero_or(cfg.limit.sql_db_connections_max_lifetime, 1800);
 


### PR DESCRIPTION
- Health check shouldn't remove node for etcd only print error message. because etcd didn't keep send events for node heartbeat then the node never online again. we will lost the node permanent.
- Also fixed the issue that we need to pickup fields from UDS when we enabled and UDS and quick_mode.

