### PR TITLE
fix: pipeline destination update

### DIFF
--- a/src/config/src/meta/pipeline/components.rs
+++ b/src/config/src/meta/pipeline/components.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -57,6 +59,8 @@ pub struct DerivedStream {
 pub struct Node {
     pub id: String,
     pub data: NodeData,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<HashMap<String, String>>,
     position: Position,
     io_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -74,6 +78,7 @@ impl Node {
         Self {
             id,
             data,
+            meta: None,
             position: Position { x: pos_x, y: pos_y },
             io_type,
             style: None,

--- a/src/handler/grpc/request/ingest.rs
+++ b/src/handler/grpc/request/ingest.rs
@@ -110,11 +110,19 @@ impl Ingest for Ingester {
                             })
                             .collect()
                     });
+                let append_data = match req.metadata {
+                    Some(metadata) => metadata
+                        .data
+                        .get("append_data")
+                        .and_then(|v| v.parse::<bool>().ok())
+                        .unwrap_or(true),
+                    None => true,
+                };
                 match crate::service::enrichment_table::save_enrichment_data(
                     &org_id,
                     &stream_name,
                     json_records,
-                    true,
+                    append_data,
                 )
                 .await
                 {

--- a/src/job/promql_self_consume.rs
+++ b/src/job/promql_self_consume.rs
@@ -53,6 +53,7 @@ async fn send_metrics(config: &config::Config, metrics: Vec<Value>) -> Result<()
         stream_type: StreamType::Metrics.to_string(),
         data: Some(IngestionData::from(metrics)),
         ingestion_type: Some(IngestionType::Json.into()),
+        metadata: None,
     };
     let org_header_key: MetadataKey<_> = config.grpc.org_header_key.parse().unwrap();
     let token: MetadataValue<_> = get_internal_grpc_token().parse().unwrap();

--- a/src/proto/proto/cluster/ingest.proto
+++ b/src/proto/proto/cluster/ingest.proto
@@ -17,11 +17,12 @@ message IngestionData {
 }
 
 message IngestionRequest {
-    string                         org_id = 1;
-    string                    stream_type = 2;
-    string                    stream_name = 3;
-    IngestionData                    data = 4;
-    optional IngestionType ingestion_type = 5;
+    string                           org_id = 1;
+    string                      stream_type = 2;
+    string                      stream_name = 3;
+    IngestionData                      data = 4;
+    optional IngestionType   ingestion_type = 5;
+    optional IngestRequestMetadata metadata = 6;
 }
 
 enum IngestionType {
@@ -31,6 +32,10 @@ enum IngestionType {
     KINESISFH = 3;
     RUM       = 4;
     USAGE     = 5;
+}
+
+message IngestRequestMetadata {
+    map<string, string> data = 1;
 }
 
 message IngestionResponse {

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -1720,6 +1720,17 @@ pub struct IngestionRequest {
     pub data: ::core::option::Option<IngestionData>,
     #[prost(enumeration = "IngestionType", optional, tag = "5")]
     pub ingestion_type: ::core::option::Option<i32>,
+    #[prost(message, optional, tag = "6")]
+    pub metadata: ::core::option::Option<IngestRequestMetadata>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IngestRequestMetadata {
+    #[prost(map = "string, string", tag = "1")]
+    pub data: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/service/self_reporting/ingestion.rs
+++ b/src/service/self_reporting/ingestion.rs
@@ -249,6 +249,7 @@ pub(super) async fn ingest_reporting_data(
             stream_type,
             data: Some(cluster_rpc::IngestionData::from(reporting_data_json)),
             ingestion_type: Some(cluster_rpc::IngestionType::Usage.into()),
+            metadata: None,
         };
 
         match service::ingestion::ingestion_service::ingest(req).await {

--- a/web/src/components/logstream/AddStream.vue
+++ b/web/src/components/logstream/AddStream.vue
@@ -139,8 +139,7 @@ const { t } = useI18n();
 const streamTypes = [
   { label: "Logs", value: "logs" },
   { label: "Metrics", value: "metrics" },
-  { label: "Traces", value: "traces" },
-  { label: "Enrichment_Tables", value: "enrichment_tables" },
+  { label: "Traces", value: "traces" }
 ];
 
 const emits = defineEmits(["streamAdded", "close","added:stream-aded"]);

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -193,7 +193,7 @@ const streams: any = ref({});
 const usedStreams: any = ref([]);
 const streamTypes = ["logs", "metrics", "traces"];
 //for testing purpose but remove metrics and traces as discuessedf
-const outputStreamTypes = ["logs", "metrics", "traces"];
+const outputStreamTypes = ["logs", "metrics", "traces","enrichment_tables"];
 const stream_name = ref((pipelineObj.currentSelectedNodeData?.data as { stream_name?: string })?.stream_name || {label: "", value: "", isDisable: false});
 const dynamic_stream_name = ref((pipelineObj.currentSelectedNodeData?.data as { stream_name?: string })?.stream_name || {label: "", value: "", isDisable: false});
 

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -211,7 +211,7 @@ const outputStreamTypes = ["logs", "metrics", "traces","enrichment_tables"];
 const stream_name = ref((pipelineObj.currentSelectedNodeData?.data as { stream_name?: string })?.stream_name || {label: "", value: "", isDisable: false});
 const dynamic_stream_name = ref((pipelineObj.currentSelectedNodeData?.data as { stream_name?: string })?.stream_name || {label: "", value: "", isDisable: false});
 
-const appendData = ref(pipelineObj.currentSelectedNodeData?.data.hasOwnProperty("append_data") ? pipelineObj.currentSelectedNodeData.data.append_data : false);
+const appendData = ref((pipelineObj.currentSelectedNodeData?.data as { meta?: { append_data?: boolean } })?.meta?.append_data || false);
 
 const stream_type = ref((pipelineObj.currentSelectedNodeData?.data as { stream_type?: string })?.stream_type || "logs");
 const selectedNodeType = ref((pipelineObj.currentSelectedNodeData as { io_type?: string })?.io_type || "");
@@ -357,16 +357,22 @@ const deleteNode = () => {
   emit("cancel:hideform");
 };
 
+
+
 const saveStream = () => {
+  // Validate pipeline configuration
+
   const streamNodeData: any = {
     stream_type: stream_type,
     stream_name: stream_name,
     org_id: store.state.selectedOrganization.identifier,
     node_type: "stream",
   };
+
   if(stream_type.value == 'enrichment_tables'){
-    streamNodeData.append_data = appendData.value;
+    streamNodeData.meta = { append_data: appendData.value };
   }
+
   if( typeof stream_name.value === 'object' && stream_name.value !== null && stream_name.value.hasOwnProperty('value') && stream_name.value.value === ""){
     $q.notify({
       message: "Please select Stream from the list",

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -106,8 +106,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           </div>
           <div v-if="selectedNodeType == 'output'" style="font-size: 14px;" class="note-message" >
-          <span class="tw-flex tw-items-center"> <q-icon name="info" class="q-pr-xs"</q-icon> Use curly braces '{}' to configure stream name dynamically. e.g. static_text_{fieldname}_postfix. Static text before/after {} is optional</span>
+            <span class="tw-flex tw-items-center"> <q-icon name="info" class="q-pr-xs"</q-icon>
+              Enrichment_tables as destination stream is only available for scheduled pipelines
+             </span>
+
+          <span class="tw-flex"> <q-icon name="info" class="q-pr-xs q-pt-xs"</q-icon> Use curly braces '{}' to configure stream name dynamically. e.g. static_text_{fieldname}_postfix. Static text before/after {} is optional</span>
             </div>
+
         </div>
 
         <div

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -89,8 +89,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :rules="[(val: any) => !!val || 'Field is required!']"
             :option-disable="(option : any)  => option.isDisable"
             @input-value="handleDynamicStreamName"
-           
             />
+
+
+            <q-toggle
+            v-if="stream_type == 'enrichment_tables' && selectedNodeType == 'output'"
+              class="col-12 q-py-md text-grey-8 text-bold"
+              v-model="appendData"
+              :label="t('function.appendData')"
+            />
+
+
 
 
 
@@ -196,6 +205,8 @@ const streamTypes = ["logs", "metrics", "traces"];
 const outputStreamTypes = ["logs", "metrics", "traces","enrichment_tables"];
 const stream_name = ref((pipelineObj.currentSelectedNodeData?.data as { stream_name?: string })?.stream_name || {label: "", value: "", isDisable: false});
 const dynamic_stream_name = ref((pipelineObj.currentSelectedNodeData?.data as { stream_name?: string })?.stream_name || {label: "", value: "", isDisable: false});
+
+const appendData = ref(pipelineObj.currentSelectedNodeData?.data.hasOwnProperty("append_data") ? pipelineObj.currentSelectedNodeData.data.append_data : false);
 
 const stream_type = ref((pipelineObj.currentSelectedNodeData?.data as { stream_type?: string })?.stream_type || "logs");
 const selectedNodeType = ref((pipelineObj.currentSelectedNodeData as { io_type?: string })?.io_type || "");
@@ -342,12 +353,15 @@ const deleteNode = () => {
 };
 
 const saveStream = () => {
-  const streamNodeData = {
+  const streamNodeData: any = {
     stream_type: stream_type,
     stream_name: stream_name,
     org_id: store.state.selectedOrganization.identifier,
     node_type: "stream",
   };
+  if(stream_type.value == 'enrichment_tables'){
+    streamNodeData.append_data = appendData.value;
+  }
   if( typeof stream_name.value === 'object' && stream_name.value !== null && stream_name.value.hasOwnProperty('value') && stream_name.value.value === ""){
     $q.notify({
       message: "Please select Stream from the list",

--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -211,7 +211,7 @@ const outputStreamTypes = ["logs", "metrics", "traces","enrichment_tables"];
 const stream_name = ref((pipelineObj.currentSelectedNodeData?.data as { stream_name?: string })?.stream_name || {label: "", value: "", isDisable: false});
 const dynamic_stream_name = ref((pipelineObj.currentSelectedNodeData?.data as { stream_name?: string })?.stream_name || {label: "", value: "", isDisable: false});
 
-const appendData = ref((pipelineObj.currentSelectedNodeData?.data as { meta?: { append_data?: boolean } })?.meta?.append_data || false);
+const appendData = ref((pipelineObj.currentSelectedNodeData as any)?.meta?.append_data || false);
 
 const stream_type = ref((pipelineObj.currentSelectedNodeData?.data as { stream_type?: string })?.stream_type || "logs");
 const selectedNodeType = ref((pipelineObj.currentSelectedNodeData as { io_type?: string })?.io_type || "");

--- a/web/src/components/pipeline/PipelineEditor.vue
+++ b/web/src/components/pipeline/PipelineEditor.vue
@@ -634,13 +634,37 @@ const confirmSaveBasicPipeline = async () => {
   confirmDialogBasicPipeline.value = false;
   await onSubmitPipeline();
 };
+const validatePipeline = () => {
+  // Find input node
+  const inputNode = pipelineObj.currentSelectedPipeline.nodes?.find((node: any) => node.type === 'input');
+
+  const outputNode = pipelineObj.currentSelectedPipeline.nodes?.find((node: any) => node.type === 'output');
+  
+
+  // If trying to use enrichment_tables with stream input, return false
+  if ( inputNode.data?.node_type === 'stream' && outputNode.data?.node_type === 'stream' && outputNode.data?.stream_type === 'enrichment_tables') {
+    q.notify({
+      message: "Enrichment tables as destination stream is only available for scheduled pipelines",
+      color: "negative",
+      position: "bottom",
+      timeout: 2000,
+    });
+    return false;
+  }
+
+  return true;
+};
 
 const onSubmitPipeline = async () => {
+  if(!validatePipeline()){
+    return;
+  }
   const dismiss = q.notify({
     message: "Saving pipeline...",
     position: "bottom",
     spinner: true,
   });
+
   const saveOperation = pipelineObj.isEditPipeline
     ? pipelineService.updatePipeline({
         data: pipelineObj.currentSelectedPipeline,

--- a/web/src/plugins/pipelines/useDnD.ts
+++ b/web/src/plugins/pipelines/useDnD.ts
@@ -506,6 +506,12 @@ export default function useDragAndDrop() {
         newEdge,
       ];
     }
+    if(newNode.hasOwnProperty('meta') && newNode.meta.hasOwnProperty('append_data')){
+      pipelineObj.currentSelectedNodeData.meta = newNode.meta;
+      delete newNode.meta;
+      delete pipelineObj.currentSelectedNodeData.data.meta;
+    }
+
   }
 
   function editNode(updatedNode:any) {


### PR DESCRIPTION
1. with this PR we have added a enrichment_tables as a stream_type for destination node while selecting but removed it from creation tab
2. added info about only enrichment_tables stream type is allowed for scheduled pipelines and not supported for realtime pipelines
3. added a toggle when user selected enrichment_tables as stream_type --> append data to the existing stream 