### PR TITLE
fix: parallel download

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2.0.6
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           # The command to run with cargo-deny
           command: check licenses

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1064,6 +1064,8 @@ pub struct Limit {
     pub usage_reporting_thread_num: usize,
     #[env_config(name = "ZO_QUERY_THREAD_NUM", default = 0)]
     pub query_thread_num: usize,
+    #[env_config(name = "ZO_FILE_DOWNLOAD_THREAD_NUM", default = 0)]
+    pub file_download_thread_num: usize,
     #[env_config(name = "ZO_QUERY_TIMEOUT", default = 600)]
     pub query_timeout: u64,
     #[env_config(name = "ZO_QUERY_INGESTER_TIMEOUT", default = 0)]
@@ -1796,6 +1798,11 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
             cfg.limit.query_thread_num = cpu_num * 4;
         }
     }
+
+    if cfg.limit.file_download_thread_num == 0 {
+        cfg.limit.file_download_thread_num = cfg.limit.query_thread_num;
+    }
+
     // HACK for move_file_thread_num equal to CPU core
     if cfg.limit.file_move_thread_num == 0 {
         if cfg.common.local_mode {

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -36,7 +36,7 @@ impl DownloadQueue {
     }
 }
 
-const FILE_DOWNLOAD_QUEUE_SIZE: usize = 500;
+const FILE_DOWNLOAD_QUEUE_SIZE: usize = 10000;
 static FILE_DOWNLOAD_CHANNEL: Lazy<DownloadQueue> = Lazy::new(|| {
     let (tx, rx) =
         tokio::sync::mpsc::channel::<(String, String, CacheType)>(FILE_DOWNLOAD_QUEUE_SIZE);

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -1,0 +1,129 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use config::get_config;
+use infra::cache::file_data::{self, CacheType};
+use once_cell::sync::Lazy;
+use tokio::sync::{
+    Mutex,
+    mpsc::{Receiver, Sender},
+};
+
+type FileInfo = (String, String, CacheType);
+
+struct DownloadQueue {
+    sender: Sender<FileInfo>,
+    receiver: Arc<Mutex<Receiver<FileInfo>>>,
+}
+
+impl DownloadQueue {
+    fn new(sender: Sender<FileInfo>, receiver: Arc<Mutex<Receiver<FileInfo>>>) -> Self {
+        Self { sender, receiver }
+    }
+}
+
+const FILE_DOWNLOAD_QUEUE_SIZE: usize = 500;
+static FILE_DOWNLOAD_CHANNEL: Lazy<DownloadQueue> = Lazy::new(|| {
+    let (tx, rx) =
+        tokio::sync::mpsc::channel::<(String, String, CacheType)>(FILE_DOWNLOAD_QUEUE_SIZE);
+
+    DownloadQueue::new(tx, Arc::new(Mutex::new(rx)))
+});
+
+pub async fn run() -> Result<(), anyhow::Error> {
+    let cfg = get_config();
+    // move files
+    for _ in 0..cfg.limit.file_download_thread_num {
+        let rx = FILE_DOWNLOAD_CHANNEL.receiver.clone();
+        tokio::spawn(async move {
+            loop {
+                let ret = rx.lock().await.recv().await;
+                match ret {
+                    None => {
+                        log::debug!("[FILE_CACHE_DOWNLOAD:JOB] Receiving channel is closed");
+                        break;
+                    }
+                    Some((trace_id, file, cache)) => {
+                        if let Err(e) = download_file(&trace_id, &file, cache).await {
+                            log::error!(
+                                "[trace_id {trace_id}] search->storage: download file {} to cache {:?} err: {}",
+                                file,
+                                cache,
+                                e,
+                            );
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    Ok(())
+}
+
+async fn download_file(
+    trace_id: &str,
+    file_name: &str,
+    cache_type: CacheType,
+) -> Result<(), anyhow::Error> {
+    let cfg = get_config();
+    let ret = match cache_type {
+        file_data::CacheType::Memory => {
+            let mut disk_exists = false;
+            let mem_exists = file_data::memory::exist(file_name).await;
+            if !mem_exists && !cfg.memory_cache.skip_disk_check {
+                // when skip_disk_check = false, need to check disk cache
+                disk_exists = file_data::disk::exist(file_name).await;
+            }
+            if !mem_exists && (cfg.memory_cache.skip_disk_check || !disk_exists) {
+                file_data::memory::download(trace_id, file_name).await.err()
+            } else {
+                None
+            }
+        }
+        file_data::CacheType::Disk => {
+            if !file_data::disk::exist(file_name).await {
+                file_data::disk::download(trace_id, file_name).await.err()
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+    match ret {
+        Some(e) => Err(e),
+        None => {
+            log::debug!(
+                "[trace_id {trace_id}] successfully downloaded file {file_name} into cache {:?}",
+                cache_type
+            );
+            Ok(())
+        }
+    }
+}
+
+pub async fn queue_background_download(
+    trace_id: &str,
+    file: &str,
+    cache_type: CacheType,
+) -> Result<(), anyhow::Error> {
+    FILE_DOWNLOAD_CHANNEL
+        .sender
+        .send((trace_id.to_owned(), file.to_owned(), cache_type))
+        .await?;
+    Ok(())
+}

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -31,6 +31,7 @@ mod alert_manager;
 #[cfg(feature = "enterprise")]
 mod cipher;
 mod compactor;
+mod file_downloader;
 pub(crate) mod files;
 mod flatten_compactor;
 pub mod metrics;
@@ -41,6 +42,7 @@ mod stats;
 pub(crate) mod syslog_server;
 mod telemetry;
 
+pub use file_downloader::queue_background_download;
 pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 
 pub async fn init() -> Result<(), anyhow::Error> {
@@ -202,6 +204,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     tokio::task::spawn(async move { metrics::run().await });
     tokio::task::spawn(async move { promql::run().await });
     tokio::task::spawn(async move { alert_manager::run().await });
+    tokio::task::spawn(async move { file_downloader::run().await });
 
     // load metrics disk cache
     tokio::task::spawn(async move { crate::service::promql::search::init().await });

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -320,7 +320,7 @@ pub fn create_session_config(
 ) -> Result<SessionConfig> {
     let cfg = get_config();
     let mut target_partitions = if target_partitions == 0 {
-        cfg.limit.cpu_num
+        cfg.limit.query_thread_num
     } else {
         std::cmp::max(cfg.limit.datafusion_min_partition_num, target_partitions)
     };
@@ -527,7 +527,7 @@ pub async fn create_parquet_table(
 ) -> Result<Arc<dyn TableProvider>> {
     let cfg = get_config();
     let target_partitions = if session.target_partitions == 0 {
-        cfg.limit.cpu_num
+        cfg.limit.query_thread_num
     } else {
         std::cmp::max(
             cfg.limit.datafusion_min_partition_num,

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -320,7 +320,7 @@ pub fn create_session_config(
 ) -> Result<SessionConfig> {
     let cfg = get_config();
     let mut target_partitions = if target_partitions == 0 {
-        cfg.limit.query_thread_num
+        cfg.limit.cpu_num
     } else {
         std::cmp::max(cfg.limit.datafusion_min_partition_num, target_partitions)
     };
@@ -527,7 +527,7 @@ pub async fn create_parquet_table(
 ) -> Result<Arc<dyn TableProvider>> {
     let cfg = get_config();
     let target_partitions = if session.target_partitions == 0 {
-        cfg.limit.query_thread_num
+        cfg.limit.cpu_num
     } else {
         std::cmp::max(
             cfg.limit.datafusion_min_partition_num,

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -41,28 +41,25 @@ use infra::{
     errors::{Error, ErrorCodes},
 };
 use itertools::Itertools;
-use once_cell::sync::Lazy;
 use tantivy::Directory;
 use tokio::sync::Semaphore;
 use tracing::Instrument;
 
-static DOWNLOAD_SEMAPHORE: Lazy<std::sync::Arc<Semaphore>> = Lazy::new(|| {
-    let cfg = get_config();
-    std::sync::Arc::new(Semaphore::new(cfg.limit.file_download_thread_num))
-});
-
-use crate::service::{
-    db, file_list,
-    search::{
-        datafusion::exec,
-        generate_search_schema_diff,
-        index::IndexCondition,
-        tantivy::puffin_directory::{
-            caching_directory::CachingDirectory,
-            convert_puffin_file_to_tantivy_dir,
-            footer_cache::FooterCache,
-            reader::{PuffinDirReader, warm_up_terms},
-            reader_cache,
+use crate::{
+    job,
+    service::{
+        db, file_list,
+        search::{
+            datafusion::exec,
+            generate_search_schema_diff,
+            index::IndexCondition,
+            tantivy::puffin_directory::{
+                caching_directory::CachingDirectory,
+                convert_puffin_file_to_tantivy_dir,
+                footer_cache::FooterCache,
+                reader::{PuffinDirReader, warm_up_terms},
+                reader_cache,
+            },
         },
     },
 };
@@ -361,28 +358,28 @@ async fn cache_files(
     let files = files.iter().map(|f| f.to_string()).collect_vec();
     let file_type = file_type.to_string();
     tokio::spawn(async move {
-        let start = std::time::Instant::now();
         let files = files.iter().map(|f| f.as_str()).collect_vec();
-        match cache_files_inner(&trace_id, &files, cache_type).await {
-            Err(e) => {
-                log::error!(
-                    "[trace_id {}] search->storage: cache {} files in background error: {:?}",
-                    trace_id,
-                    file_type,
-                    e
-                );
-            }
-            Ok(cache_type) => {
-                log::info!(
-                    "[trace_id {}] search->storage: cache {} files in background into {:?} cache done, downloaded {} files, took: {} ms",
-                    trace_id,
-                    file_type,
-                    cache_type,
-                    files.len(),
-                    start.elapsed().as_millis()
-                );
+        for file in &files {
+            match job::queue_background_download(&trace_id, file, cache_type).await {
+                Ok(_) => {
+                    log::debug!(
+                        "[trace_id {trace_id}] file {file} successfully queued for download"
+                    );
+                }
+                Err(e) => {
+                    log::error!(
+                        "[trace_id {trace_id}] error in queuing file {file} for background download : {e}"
+                    );
+                }
             }
         }
+        log::info!(
+            "[trace_id {}] search->storage: successfully enqueued {} files of {} for background download into {:?} ",
+            trace_id,
+            files.len(),
+            file_type,
+            cache_type,
+        );
     });
 
     // if cached file less than 50% of the total files, return None
@@ -392,69 +389,6 @@ async fn cache_files(
     } else {
         Ok(cache_type)
     }
-}
-
-#[tracing::instrument(name = "service:search:grpc:storage:cache_files_inner", skip_all)]
-async fn cache_files_inner(
-    trace_id: &str,
-    files: &[&str],
-    cache_type: file_data::CacheType,
-) -> Result<file_data::CacheType, Error> {
-    let mut tasks = Vec::new();
-    for file in files.iter() {
-        let trace_id = trace_id.to_string();
-        let file_name = file.to_string();
-        let permit = DOWNLOAD_SEMAPHORE.clone().acquire_owned().await.unwrap();
-        let task: tokio::task::JoinHandle<()> = tokio::task::spawn(async move {
-            let cfg = get_config();
-            let ret = match cache_type {
-                file_data::CacheType::Memory => {
-                    let mut disk_exists = false;
-                    let mem_exists = file_data::memory::exist(&file_name).await;
-                    if !mem_exists && !cfg.memory_cache.skip_disk_check {
-                        // when skip_disk_check = false, need to check disk cache
-                        disk_exists = file_data::disk::exist(&file_name).await;
-                    }
-                    if !mem_exists && (cfg.memory_cache.skip_disk_check || !disk_exists) {
-                        file_data::memory::download(&trace_id, &file_name)
-                            .await
-                            .err()
-                    } else {
-                        None
-                    }
-                }
-                file_data::CacheType::Disk => {
-                    if !file_data::disk::exist(&file_name).await {
-                        file_data::disk::download(&trace_id, &file_name).await.err()
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            };
-            // return file_name if download failed
-            if let Some(e) = ret {
-                log::warn!(
-                    "[trace_id {trace_id}] search->storage: download file to cache err: {}, file: {}",
-                    e,
-                    file_name
-                );
-            }
-            drop(permit);
-        });
-        tasks.push(task);
-    }
-
-    for task in tasks {
-        if let Err(e) = task.await {
-            log::error!(
-                "[trace_id {trace_id}] search->storage: load file task err: {}",
-                e
-            );
-        }
-    }
-
-    Ok(cache_type)
 }
 
 /// Filter file list using inverted index


### PR DESCRIPTION
This uses background jobs in order to download files asynchronously, and a mpsc queue in order to send file names to the jobs threads. This limits the number of threads we spawn to a fixed number configurable via config var.