### PR TITLE
fix: dashboard freeze issue with more than 100 series in single panel

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1310,6 +1310,12 @@ pub struct Limit {
         help = "Default data type for LongText compliant DB's"
     )]
     pub db_text_data_type: String,
+    #[env_config(
+        name = "ZO_MAX_DASHBORD_SERIES",
+        default = 100,
+        help = "maximum series to display in charts"
+    )]
+    pub max_dashboard_series: usize,
 }
 
 #[derive(EnvConfig)]
@@ -1858,6 +1864,11 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
 
     if cfg.limit.consistent_hash_vnodes == 0 {
         cfg.limit.consistent_hash_vnodes = 100;
+    }
+
+    // reset to default if given zero
+    if cfg.limit.max_dashboard_series == 0 {
+        cfg.limit.max_dashboard_series = 100;
     }
 
     // check for uds

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1311,7 +1311,7 @@ pub struct Limit {
     )]
     pub db_text_data_type: String,
     #[env_config(
-        name = "ZO_MAX_DASHBORD_SERIES",
+        name = "ZO_MAX_DASHBOARD_SERIES",
         default = 100,
         help = "maximum series to display in charts"
     )]

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -124,6 +124,7 @@ struct ConfigResponse<'a> {
     websocket_enabled: bool,
     min_auto_refresh_interval: u32,
     query_default_limit: i64,
+    max_dashboard_series: usize,
 }
 
 #[derive(Serialize)]
@@ -307,6 +308,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         websocket_enabled: cfg.websocket.enabled,
         min_auto_refresh_interval: cfg.common.min_auto_refresh_interval,
         query_default_limit: cfg.limit.query_default_limit,
+        max_dashboard_series: cfg.limit.max_dashboard_series,
     }))
 }
 

--- a/web/src/components/dashboards/PanelContainer.vue
+++ b/web/src/components/dashboards/PanelContainer.vue
@@ -133,6 +133,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           size="xs"
           padding="2px"
           data-test="dashboard-panel-limit-number-of-series-warning"
+          class="warning"
         >
           <q-tooltip anchor="bottom right" self="top right">
             <div style="white-space: pre-wrap">

--- a/web/src/components/dashboards/PanelContainer.vue
+++ b/web/src/components/dashboards/PanelContainer.vue
@@ -128,7 +128,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </q-btn>
         <q-btn
           v-if="limitNumberOfSeriesWarningMessage"
-          :icon="outlinedWarning"
+          :icon="symOutlinedDataInfoAlert"
           flat
           size="xs"
           padding="2px"
@@ -355,6 +355,7 @@ import {
   outlinedWarning,
   outlinedRunningWithErrors,
 } from "@quasar/extras/material-icons-outlined";
+import { symOutlinedDataInfoAlert } from "@quasar/extras/material-symbols-outlined";
 import SinglePanelMove from "@/components/dashboards/settings/SinglePanelMove.vue";
 import RelativeTime from "@/components/common/RelativeTime.vue";
 import { getFunctionErrorMessage } from "@/utils/zincutils";
@@ -758,6 +759,7 @@ export default defineComponent({
       deletePanelDialog,
       isCurrentlyHoveredPanel,
       outlinedWarning,
+      symOutlinedDataInfoAlert,
       outlinedRunningWithErrors,
       store,
       metaDataValue,

--- a/web/src/components/dashboards/PanelContainer.vue
+++ b/web/src/components/dashboards/PanelContainer.vue
@@ -127,6 +127,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </q-tooltip>
         </q-btn>
         <q-btn
+          v-if="limitNumberOfSeriesWarningMessage"
+          :icon="outlinedWarning"
+          flat
+          size="xs"
+          padding="2px"
+          data-test="dashboard-panel-limit-number-of-series-warning"
+        >
+          <q-tooltip anchor="bottom right" self="top right">
+            <div style="white-space: pre-wrap">
+              {{ limitNumberOfSeriesWarningMessage }}
+            </div>
+          </q-tooltip>
+        </q-btn>
+        <q-btn
           v-if="isCachedDataDifferWithCurrentTimeRange"
           :icon="outlinedRunningWithErrors"
           flat
@@ -282,6 +296,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :report-id="props.reportId"
       @loading-state-change="handleLoadingStateChange"
       @metadata-update="metaDataValue"
+      @limit-number-of-series-warning-message-update="
+        handleLimitNumberOfSeriesWarningMessageUpdate
+      "
       @result-metadata-update="handleResultMetadataUpdate"
       @last-triggered-at-update="handleLastTriggeredAtUpdate"
       @is-cached-data-differ-with-current-time-range-update="
@@ -403,6 +420,8 @@ export default defineComponent({
 
     const maxQueryRange: any = ref([]);
 
+    const limitNumberOfSeriesWarningMessage = ref("");
+
     const handleResultMetadataUpdate = (metadata: any) => {
       const combinedWarnings: any[] = [];
       metadata.forEach((query: any) => {
@@ -440,6 +459,10 @@ export default defineComponent({
       isDiffer: boolean,
     ) => {
       isCachedDataDifferWithCurrentTimeRange.value = isDiffer;
+    };
+
+    const handleLimitNumberOfSeriesWarningMessageUpdate = (message: string) => {
+      limitNumberOfSeriesWarningMessage.value = message;
     };
 
     const showText = ref(false);
@@ -758,6 +781,8 @@ export default defineComponent({
       errorData,
       isPanelLoading,
       handleLoadingStateChange,
+      limitNumberOfSeriesWarningMessage,
+      handleLimitNumberOfSeriesWarningMessageUpdate,
     };
   },
   methods: {

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -601,10 +601,8 @@ export default defineComponent({
               loading.value,
             );
 
-            if (panelData.value?.extras?.limitNumberOfSeriesWarningMessage) {
-              limitNumberOfSeriesWarningMessage.value =
-                panelData.value?.extras?.limitNumberOfSeriesWarningMessage;
-            }
+            limitNumberOfSeriesWarningMessage.value =
+              panelData.value?.extras?.limitNumberOfSeriesWarningMessage ?? "";
 
             errorDetail.value = "";
           } catch (error: any) {

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -381,6 +381,7 @@ export default defineComponent({
     "update:initialVariableValues",
     "updated:vrlFunctionFieldList",
     "loading-state-change",
+    "limit-number-of-series-warning-message-update",
   ],
   setup(props, { emit }) {
     const store = useStore();
@@ -394,6 +395,8 @@ export default defineComponent({
     const selectedAnnotationData: any = ref([]);
     const drilldownPopUpRef: any = ref(null);
     const annotationPopupRef: any = ref(null);
+
+    const limitNumberOfSeriesWarningMessage: any = ref("");
 
     const chartPanelStyle = ref({
       height: "100%",
@@ -598,6 +601,11 @@ export default defineComponent({
               loading.value,
             );
 
+            if (panelData.value?.extras?.limitNumberOfSeriesWarningMessage) {
+              limitNumberOfSeriesWarningMessage.value =
+                panelData.value?.extras?.limitNumberOfSeriesWarningMessage;
+            }
+
             errorDetail.value = "";
           } catch (error: any) {
             console.error("error", error);
@@ -631,6 +639,18 @@ export default defineComponent({
       metadata,
       () => {
         emit("metadata-update", metadata.value);
+      },
+      { deep: true },
+    );
+
+    // when we get the new limitNumberOfSeriesWarningMessage from the convertPanelData, emit the limitNumberOfSeriesWarningMessage
+    watch(
+      limitNumberOfSeriesWarningMessage,
+      () => {
+        emit(
+          "limit-number-of-series-warning-message-update",
+          limitNumberOfSeriesWarningMessage.value,
+        );
       },
       { deep: true },
     );

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -1236,7 +1236,7 @@ export const usePanelDataLoader = (
                 );
               }
 
-              // saveCurrentStateToCache();
+              saveCurrentStateToCache();
             }
           }
 

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -626,6 +626,7 @@ export const usePanelDataLoader = (
       }
 
       if (response.type === "end") {
+        saveCurrentStateToCache();
         // set loading to false
         state.loading = false;
         state.isOperationCancelled = false;
@@ -1235,7 +1236,7 @@ export const usePanelDataLoader = (
                 );
               }
 
-              saveCurrentStateToCache();
+              // saveCurrentStateToCache();
             }
           }
 

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -626,7 +626,6 @@ export const usePanelDataLoader = (
       }
 
       if (response.type === "end") {
-        saveCurrentStateToCache();
         // set loading to false
         state.loading = false;
         state.isOperationCancelled = false;

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -113,7 +113,8 @@ export const convertPromQLData = async (
 
   // Add warning if total number of series exceeds limit
   if (totalSeries > (store.state?.zoConfig?.max_dashboard_series ?? 100)) {
-    extras.limitNumberOfSeriesWarningMessage = `Response contains over ${store.state?.zoConfig?.max_dashboard_series ?? 100} unique breakdown values. Only the top ${store.state?.zoConfig?.max_dashboard_series ?? 100} will be displayed.`;
+    extras.limitNumberOfSeriesWarningMessage =
+      "Limiting the displayed series to ensure optimal performance";
   }
 
   // flag to check if the data is time seriesc

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -120,6 +120,8 @@ export const convertSQLData = async (
   chartPanelStyle: any,
   annotations: any,
 ) => {
+  const extras: any = {};
+
   // if no data than return it
   if (
     !Array.isArray(searchQueryData) ||
@@ -222,7 +224,7 @@ export const convertSQLData = async (
 
     const { top_results, top_results_others } = panelSchema.config;
     const innerDataArray = data[0];
-    if (!top_results || !breakDownKeys.length) {
+    if (!breakDownKeys.length) {
       return innerDataArray;
     }
 
@@ -241,10 +243,16 @@ export const convertSQLData = async (
     }, {});
 
     // Step 2: Sort and extract the top keys based on the configured number of top results
-    const topKeys = Object.entries(breakdown)
-      .sort(([, a]: any, [, b]: any) => b - a)
-      .slice(0, top_results)
-      .map(([key]) => key);
+    const allKeys = Object.entries(breakdown).sort(
+      ([, a]: any, [, b]: any) => b - a,
+    );
+
+    if (allKeys.length > 100) {
+      extras.limitNumberOfSeriesWarningMessage =
+        "Response contains over 100 unique breakdown values. Only the top 100 will be displayed.";
+    }
+
+    const topKeys = allKeys.slice(0, top_results ?? 100).map(([key]) => key);
 
     // Step 3: Initialize result array and others object for aggregation
     const resultArray: any[] = [];
@@ -2606,7 +2614,11 @@ export const convertSQLData = async (
 
   return {
     options,
-    extras: { panelId: panelSchema?.id, isTimeSeries: isTimeSeriesFlag },
+    extras: {
+      ...extras,
+      panelId: panelSchema?.id,
+      isTimeSeries: isTimeSeriesFlag,
+    },
   };
 };
 

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -265,7 +265,8 @@ export const convertSQLData = async (
       (!top_results &&
         allKeys.length > (store.state?.zoConfig?.max_dashboard_series ?? 100))
     ) {
-      extras.limitNumberOfSeriesWarningMessage = `Response contains over ${store.state?.zoConfig?.max_dashboard_series ?? 100} unique breakdown values. Only the top ${store.state?.zoConfig?.max_dashboard_series ?? 100} will be displayed.`;
+      extras.limitNumberOfSeriesWarningMessage =
+        "Limiting the displayed series to ensure optimal performance";
     }
 
     const topKeys = allKeys.slice(0, limitSeries).map(([key]) => key);

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -228,8 +228,10 @@ export const convertSQLData = async (
     // if top_results is enabled then use the top_results value
     // otherwise use the max_dashboard_series value
     const limitSeries = top_results
-      ? (Math.min(top_results, store.state?.zoConfig?.max_dashboard_series) ??
-        100)
+      ? (Math.min(
+          top_results,
+          store.state?.zoConfig?.max_dashboard_series ?? 100,
+        ) ?? 100)
       : (store.state?.zoConfig?.max_dashboard_series ?? 100);
 
     const innerDataArray = data[0];
@@ -260,7 +262,7 @@ export const convertSQLData = async (
     // if top_results is not enabled and the number of unique breakdown values is greater than the max_dashboard_series, add a warning message
     if (
       (top_results &&
-        top_results > store.state?.zoConfig?.max_dashboard_series &&
+        top_results > (store.state?.zoConfig?.max_dashboard_series ?? 100) &&
         allKeys.length > top_results) ||
       (!top_results &&
         allKeys.length > (store.state?.zoConfig?.max_dashboard_series ?? 100))

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -247,7 +247,9 @@ export const convertSQLData = async (
       ([, a]: any, [, b]: any) => b - a,
     );
 
-    if (allKeys.length > 100) {
+    // if allKeys.length > 100 and top_results is not set or if set and is greater than 100,
+    // add a warning message
+    if (allKeys.length > 100 && (!top_results || top_results > 100)) {
       extras.limitNumberOfSeriesWarningMessage =
         "Response contains over 100 unique breakdown values. Only the top 100 will be displayed.";
     }


### PR DESCRIPTION
- #6015 


- Introduced new Env variable `ZO_MAX_DASHBOARD_SERIES`, to limit number of series per panel.
![image](https://github.com/user-attachments/assets/dc034fe6-bade-4952-9ec1-13dfae600bad)

- Comparison against series will not be counted. 
- Additionally, for multiple Y-axes, there will be a limit per individual Y-axis
