### PR TITLE
feat: add source_node to triggers stream

### DIFF
--- a/src/config/src/meta/self_reporting/usage.rs
+++ b/src/config/src/meta/self_reporting/usage.rs
@@ -71,6 +71,7 @@ pub struct TriggerData {
     pub is_partial: Option<bool>,
     pub delay_in_secs: Option<i64>,
     pub evaluation_took_in_secs: Option<f64>,
+    pub source_node: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/config/src/meta/triggers.rs
+++ b/src/config/src/meta/triggers.rs
@@ -9,7 +9,9 @@ pub enum TriggerStatus {
     Completed,
 }
 
-#[derive(Debug, Clone, sqlx::Type, PartialEq, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, sqlx::Type, PartialEq, Serialize, Deserialize, Default, Eq, std::hash::Hash,
+)]
 #[repr(i32)]
 pub enum TriggerModule {
     Report,

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -529,7 +529,7 @@ WHERE id IN ({});",
         DB_QUERY_NUMS
             .with_label_values(&["update", "scheduled_jobs"])
             .inc();
-        sqlx::query(
+        let res = sqlx::query(
             r#"UPDATE scheduled_jobs
 SET status = ?, retries = retries + 1
 WHERE status = ? AND end_time <= ?
@@ -540,6 +540,10 @@ WHERE status = ? AND end_time <= ?
         .bind(now)
         .execute(&pool)
         .await?;
+        log::debug!(
+            "[SCHEDULER] watch_timeout for scheduler updated {} rows",
+            res.rows_affected()
+        );
         Ok(())
     }
 

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -486,7 +486,7 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
             .with_label_values(&["update", "scheduled_jobs"])
             .inc();
         let now = chrono::Utc::now().timestamp_micros();
-        sqlx::query(
+        let res = sqlx::query(
             r#"UPDATE scheduled_jobs
 SET status = $1, retries = retries + 1
 WHERE status = $2 AND end_time <= $3;
@@ -497,6 +497,10 @@ WHERE status = $2 AND end_time <= $3;
         .bind(now)
         .execute(&pool)
         .await?;
+        log::debug!(
+            "[SCHEDULER] watch_timeout for scheduler updated {} rows",
+            res.rows_affected()
+        );
         Ok(())
     }
 

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -26,11 +26,11 @@ pub async fn run() -> Result<(), anyhow::Error> {
     }
 
     let cfg = get_config();
-    log::info!(
-        "Spawning embedded report server {}",
-        cfg.report_server.enable_report_server
-    );
     if cfg.report_server.enable_report_server {
+        log::info!(
+            "Spawning embedded report server {}",
+            cfg.report_server.enable_report_server
+        );
         tokio::task::spawn(async move {
             if let Err(e) = report_server::spawn_server().await {
                 log::error!("report server failed to spawn {}", e);

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -75,8 +75,8 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
     if !triggers.is_empty() {
         let mut grouped_triggers: std::collections::HashMap<
-            infra::scheduler::TriggerModule,
-            Vec<&infra::scheduler::Trigger>,
+            db::scheduler::TriggerModule,
+            Vec<&db::scheduler::Trigger>,
         > = HashMap::new();
 
         // Group triggers by module

--- a/src/service/alerts/scheduler.rs
+++ b/src/service/alerts/scheduler.rs
@@ -101,12 +101,21 @@ pub async fn run() -> Result<(), anyhow::Error> {
     for (i, trigger) in triggers.into_iter().enumerate() {
         let trace_id = format!("{}-{}", trace_id, i);
         let task = tokio::task::spawn(async move {
+            let key = format!("{}-{}/{}", trigger.module, trigger.org, trigger.module_key);
+            log::debug!(
+                "[SCHEDULER trace_id {trace_id}] start processing trigger: {}",
+                key
+            );
             if let Err(e) = handle_triggers(&trace_id, trigger).await {
                 log::error!(
                     "[SCHEDULER trace_id {trace_id}] Error handling trigger: {}",
                     e
                 );
             }
+            log::debug!(
+                "[SCHEDULER trace_id {trace_id}] finished processing trigger: {}",
+                key
+            );
         });
         tasks.push(task);
     }

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -241,6 +241,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
             is_partial: None,
             delay_in_secs: None,
             evaluation_took_in_secs: None,
+            source_node: Some(LOCAL_NODE.name.clone()),
         };
         match alert.send_notification(val, now, None, now).await {
             Err(e) => {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1878,7 +1878,8 @@ mod tests {
             data: "{}".to_string(),
         };
 
-        let res = handle_triggers(trigger).await;
+        let trace_id = "test_trace_id";
+        let res = handle_triggers(trace_id, trigger).await;
         // This alert has an invalid destination
         assert!(res.is_ok());
 
@@ -1914,7 +1915,8 @@ mod tests {
             data: "{}".to_string(),
         };
 
-        let res = handle_triggers(trigger).await;
+        let trace_id = "test_trace_id";
+        let res = handle_triggers(trace_id, trigger).await;
         // This alert has an invalid destination
         assert!(res.is_ok());
 
@@ -1982,7 +1984,8 @@ mod tests {
             data: "{}".to_string(),
         };
 
-        let res = handle_triggers(trigger).await;
+        let trace_id = "test_trace_id";
+        let res = handle_triggers(trace_id, trigger).await;
         // In case of alert evaluation errors, this error is returned
         assert!(res.is_err());
 


### PR DESCRIPTION
This PR adds a `source_node` field to the `triggers` stream to indicate which alert manager processed the particular trigger. This is the name of the node.