### PR TITLE
feat: add some cli command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6241,6 +6241,7 @@ dependencies = [
  "parking_lot",
  "parquet",
  "pprof",
+ "prettytable-rs",
  "prometheus",
  "promql-parser",
  "prost 0.13.4",
@@ -6937,6 +6938,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
 dependencies = [
+ "csv",
  "encode_unicode",
  "is-terminal",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ prometheus.workspace = true
 promql-parser = "0.4"
 prost.workspace = true
 proto.workspace = true
+prettytable-rs = "0.10.0"
 pyroscope = { version = "0.5.6", optional = true }
 pyroscope_pprofrs = { version = "0.2.5", optional = true }
 rand.workspace = true

--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -142,6 +142,12 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                     .action(clap::ArgAction::SetTrue)
                     .help("insert file list into db"),
             ]),
+            clap::Command::new("node").about("node command").subcommands([
+                clap::Command::new("offline").about("offline node"),
+                clap::Command::new("online").about("online node"),
+                clap::Command::new("flush").about("flush memtable to disk"),
+                clap::Command::new("list").about("list cached nodes"),
+            ]),
         ])
         .get_matches();
 
@@ -323,6 +329,26 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
             let prefix = command.get_one::<String>("prefix").unwrap();
             let insert = command.get_flag("insert");
             super::load::load_file_list_from_s3(prefix, insert).await?;
+        }
+        "node" => {
+            let command = command.subcommand();
+            match command {
+                Some(("offline", _)) => {
+                    super::http::node_offline().await?;
+                }
+                Some(("online", _)) => {
+                    super::http::node_online().await?;
+                }
+                Some(("flush", _)) => {
+                    super::http::node_flush().await?;
+                }
+                Some(("list", _)) => {
+                    super::http::node_list().await?;
+                }
+                _ => {
+                    return Err(anyhow::anyhow!("unsupported sub command: {name}"));
+                }
+            }
         }
         _ => {
             return Err(anyhow::anyhow!("unsupported sub command: {name}"));

--- a/src/cli/basic/http.rs
+++ b/src/cli/basic/http.rs
@@ -1,0 +1,109 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use prettytable::{Cell, Row, Table};
+
+pub async fn node_offline() -> Result<(), anyhow::Error> {
+    let url = "/node/enable?value=false";
+    let response = request(url, reqwest::Method::PUT).await?;
+    if response.is_some() {
+        println!("node offline successfully");
+    } else {
+        println!("node offline failed");
+    }
+    Ok(())
+}
+pub async fn node_online() -> Result<(), anyhow::Error> {
+    let url = "/node/enable?value=true";
+    let response = request(url, reqwest::Method::PUT).await?;
+    if response.is_some() {
+        println!("node online successfully");
+    } else {
+        println!("node online failed");
+    }
+    Ok(())
+}
+
+pub async fn node_flush() -> Result<(), anyhow::Error> {
+    let url = "/node/flush";
+    let response = request(url, reqwest::Method::POST).await?;
+    if response.is_some() {
+        println!("node flush successfully");
+    } else {
+        println!("node flush failed");
+    }
+    Ok(())
+}
+
+pub async fn node_list() -> Result<(), anyhow::Error> {
+    let url = "/node/list";
+    let response = request(url, reqwest::Method::GET).await?;
+    let Some(body) = response else {
+        return Err(anyhow::anyhow!("node list failed"));
+    };
+    let mut nodes: Vec<config::meta::cluster::Node> = serde_json::from_str(&body)?;
+    nodes.sort_by_key(|node| node.id);
+
+    let mut table = Table::new();
+    table.add_row(Row::new(vec![
+        Cell::new("ID"),
+        Cell::new("UUID"),
+        Cell::new("Name"),
+        Cell::new("HTTP Address"),
+        Cell::new("Status"),
+        Cell::new("Scheduled"),
+        Cell::new("CPU Usage"),
+        Cell::new("Memory Usage"),
+    ]));
+
+    for node in nodes {
+        table.add_row(Row::new(vec![
+            Cell::new(&node.id.to_string()),
+            Cell::new(&node.uuid),
+            Cell::new(&node.name),
+            Cell::new(&node.http_addr),
+            Cell::new(&format!("{:?}", node.status)),
+            Cell::new(&node.scheduled.to_string()),
+            Cell::new(&format!("{:.2}%", node.metrics.cpu_usage)),
+            Cell::new(&format!(
+                "{}",
+                config::utils::size::bytes_to_human_readable(node.metrics.memory_usage as f64)
+            )),
+        ]));
+    }
+
+    table.printstd();
+    Ok(())
+}
+
+async fn request(url: &str, method: reqwest::Method) -> Result<Option<String>, anyhow::Error> {
+    let cfg = config::get_config();
+    let client = reqwest::Client::new();
+    let local = config::cluster::load_local_node();
+    let url = format!("{}{}", local.http_addr, url);
+    let user = cfg.auth.root_user_email.clone();
+    let password = cfg.auth.root_user_password.clone();
+    let response = client
+        .request(method, url)
+        .basic_auth(user, Some(password))
+        .send()
+        .await?;
+    if response.status().is_success() {
+        let body = response.text().await?;
+        Ok(Some(body))
+    } else {
+        Ok(None)
+    }
+}

--- a/src/config/src/utils/mod.rs
+++ b/src/config/src/utils/mod.rs
@@ -23,6 +23,7 @@ pub mod hash;
 pub mod inverted_index;
 pub mod json;
 pub mod md5;
+pub mod size;
 pub mod parquet;
 pub mod prom_json_encoder;
 pub mod rand;

--- a/src/config/src/utils/size.rs
+++ b/src/config/src/utils/size.rs
@@ -13,6 +13,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod cli;
-mod http;
-mod load;
+/// Convert bytes to human readable format
+pub fn bytes_to_human_readable(bytes: f64) -> String {
+    let units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+    let mut bytes = bytes;
+    let mut index = 0;
+
+    if bytes == 0.0 {
+        return "0 B".to_string();
+    }
+
+    while bytes >= 1024.0 && index < units.len() - 1 {
+        bytes /= 1024.0;
+        index += 1;
+    }
+
+    format!("{:.2} {}", bytes, units[index])
+}


### PR DESCRIPTION
Add some CLI commands can help easy to operate with local node via HTTP API.
```
./target/debug/openobserve node -h
node command

Usage: openobserve node [COMMAND]

Commands:
  offline  offline node
  online   online node
  flush    flush memtable to disk
  list     list cached nodes
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

For example
```
$./openobserve node list

+----+-----------------------------+----------------------------+---------------------------+--------+-----------+-----------+--------------+
| ID | UUID                        | Name                       | HTTP Address              | Status | Scheduled | CPU Usage | Memory Usage |
+----+-----------------------------+----------------------------+---------------------------+--------+-----------+-----------+--------------+
| 1  | 2tX6kt34yOCBmgopB1KeJnyVgAw | Hengfeis-MacBook-Pro.local | http://192.168.8.194:5080 | Online | false     | 0.00%     | 113.72 MB    |
+----+-----------------------------+----------------------------+---------------------------+--------+-----------+-----------+--------------+
```
