### PR TITLE
feat: Alert manager improve pb (move last_satisfied_at and use mpsc)

### DIFF
--- a/src/common/migration/schema.rs
+++ b/src/common/migration/schema.rs
@@ -19,7 +19,13 @@
 // the changes in executing different migration logic.
 
 use chrono::Utc;
-use config::{meta::dashboards::reports::Report, utils::json};
+use config::{
+    meta::{
+        dashboards::reports::Report,
+        triggers::{Trigger, TriggerModule, TriggerStatus},
+    },
+    utils::json,
+};
 use datafusion::arrow::datatypes::Schema;
 use infra::{
     db::{self as infra_db, NO_NEED_WATCH},
@@ -209,14 +215,14 @@ async fn upgrade_trigger() -> Result<(), anyhow::Error> {
         };
         let data: json::Value = json::from_slice(&val).unwrap();
         let data = data.as_object().unwrap();
-        scheduler::push(scheduler::Trigger {
+        scheduler::push(Trigger {
             org: org_id.to_string(),
-            module: scheduler::TriggerModule::Alert,
+            module: TriggerModule::Alert,
             module_key: module_key.to_string(),
             next_run_at: data.get("next_run_at").unwrap().as_i64().unwrap(),
             is_realtime: data.get("is_realtime").unwrap().as_bool().unwrap(),
             is_silenced: data.get("is_silenced").unwrap().as_bool().unwrap(),
-            status: scheduler::TriggerStatus::Waiting,
+            status: TriggerStatus::Waiting,
             ..Default::default()
         })
         .await?;

--- a/src/config/src/meta/mod.rs
+++ b/src/config/src/meta/mod.rs
@@ -30,4 +30,5 @@ pub mod self_reporting;
 pub mod short_url;
 pub mod sql;
 pub mod stream;
+pub mod triggers;
 pub mod websocket;

--- a/src/config/src/meta/triggers.rs
+++ b/src/config/src/meta/triggers.rs
@@ -1,0 +1,75 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, sqlx::Type, PartialEq, Serialize, Deserialize, Default)]
+#[repr(i32)]
+pub enum TriggerStatus {
+    #[default]
+    Waiting,
+    Processing,
+    Completed,
+}
+
+#[derive(
+    Debug, Clone, sqlx::Type, PartialEq, Serialize, Deserialize, Default, Eq, std::hash::Hash,
+)]
+#[repr(i32)]
+pub enum TriggerModule {
+    Report,
+    #[default]
+    Alert,
+    DerivedStream,
+}
+
+impl std::fmt::Display for TriggerModule {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            TriggerModule::Alert => write!(f, "alert"),
+            TriggerModule::Report => write!(f, "report"),
+            TriggerModule::DerivedStream => write!(f, "derived_stream"),
+        }
+    }
+}
+
+#[derive(sqlx::FromRow, Debug, Clone, Default)]
+pub struct TriggerId {
+    pub id: i64,
+}
+
+#[derive(sqlx::FromRow, Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Trigger {
+    pub org: String,
+    pub module: TriggerModule,
+    pub module_key: String,
+    pub next_run_at: i64,
+    pub is_realtime: bool,
+    pub is_silenced: bool,
+    pub status: TriggerStatus,
+    // #[sqlx(default)] only works when the column itself is missing.
+    // For NULL value it does not work.
+    // TODO: See https://github.com/launchbadge/sqlx/issues/1106
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_time: Option<i64>,
+    pub retries: i32,
+    #[serde(default)]
+    pub data: String,
+}
+
+#[derive(Default, Serialize, Deserialize, Debug)]
+pub struct ScheduledTriggerData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub period_end_time: Option<i64>,
+    #[serde(default)]
+    pub tolerance: i64,
+    #[serde(default)]
+    pub last_satisfied_at: Option<i64>,
+}
+
+impl ScheduledTriggerData {
+    /// Does not reset the last_satisfied_at field
+    pub fn reset(&mut self) {
+        self.period_end_time = None;
+        self.tolerance = 0;
+    }
+}

--- a/src/handler/http/models/alerts/responses.rs
+++ b/src/handler/http/models/alerts/responses.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::{alerts::alert as meta_alerts, folder as meta_folders};
+use config::meta::{alerts::alert as meta_alerts, folder as meta_folders, triggers::Trigger};
 use serde::Serialize;
 use svix_ksuid::Ksuid;
 use utoipa::ToSchema;
@@ -50,17 +50,19 @@ pub struct EnableAlertResponseBody {
     pub enabled: bool,
 }
 
-impl From<meta_alerts::Alert> for GetAlertResponseBody {
-    fn from(value: meta_alerts::Alert) -> Self {
+impl From<(meta_alerts::Alert, Option<Trigger>)> for GetAlertResponseBody {
+    fn from(value: (meta_alerts::Alert, Option<Trigger>)) -> Self {
         Self(value.into())
     }
 }
 
-impl TryFrom<Vec<(meta_folders::Folder, meta_alerts::Alert)>> for ListAlertsResponseBody {
+impl TryFrom<Vec<(meta_folders::Folder, meta_alerts::Alert, Option<Trigger>)>>
+    for ListAlertsResponseBody
+{
     type Error = ();
 
     fn try_from(
-        value: Vec<(meta_folders::Folder, meta_alerts::Alert)>,
+        value: Vec<(meta_folders::Folder, meta_alerts::Alert, Option<Trigger>)>,
     ) -> Result<Self, Self::Error> {
         let rslt: Result<Vec<_>, _> = value
             .into_iter()
@@ -70,12 +72,21 @@ impl TryFrom<Vec<(meta_folders::Folder, meta_alerts::Alert)>> for ListAlertsResp
     }
 }
 
-impl TryFrom<(meta_folders::Folder, meta_alerts::Alert)> for ListAlertsResponseBodyItem {
+impl TryFrom<(meta_folders::Folder, meta_alerts::Alert, Option<Trigger>)>
+    for ListAlertsResponseBodyItem
+{
     type Error = ();
 
-    fn try_from(value: (meta_folders::Folder, meta_alerts::Alert)) -> Result<Self, Self::Error> {
+    fn try_from(
+        value: (meta_folders::Folder, meta_alerts::Alert, Option<Trigger>),
+    ) -> Result<Self, Self::Error> {
         let folder = value.0;
         let alert = value.1;
+        let trigger = value.2;
+        let (last_triggered_at, last_satisfied_at) = (
+            alert.get_last_triggered_at(trigger.as_ref()),
+            alert.get_last_satisfied_at(trigger.as_ref()),
+        );
         Ok(Self {
             alert_id: alert.id.ok_or(())?,
             folder_id: folder.folder_id,
@@ -84,8 +95,8 @@ impl TryFrom<(meta_folders::Folder, meta_alerts::Alert)> for ListAlertsResponseB
             owner: alert.owner,
             description: Some(alert.description).filter(|d| !d.is_empty()),
             condition: alert.query_condition.into(),
-            last_triggered_at: alert.last_triggered_at,
-            last_satisfied_at: alert.last_satisfied_at,
+            last_triggered_at,
+            last_satisfied_at,
         })
     }
 }

--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -14,7 +14,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse};
-use config::meta::{alerts::alert::Alert as MetaAlert, folder::DEFAULT_FOLDER};
+use config::meta::{
+    alerts::alert::Alert as MetaAlert,
+    folder::DEFAULT_FOLDER,
+    triggers::{Trigger, TriggerModule},
+};
+use hashbrown::HashMap;
 use infra::db::{connect_to_orm, ORM_CLIENT};
 use svix_ksuid::Ksuid;
 
@@ -27,7 +32,10 @@ use crate::{
         },
         responses::{EnableAlertResponseBody, GetAlertResponseBody, ListAlertsResponseBody},
     },
-    service::alerts::alert::{self, AlertError},
+    service::{
+        alerts::alert::{self, AlertError},
+        db::scheduler,
+    },
 };
 
 #[allow(deprecated)]
@@ -133,7 +141,11 @@ async fn get_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
     match alert::get_by_id(client, &org_id, alert_id).await {
         Ok(alert) => {
-            let resp_body: GetAlertResponseBody = alert.into();
+            let key = alert.get_unique_key();
+            let scheduled_job = scheduler::get(&org_id, TriggerModule::Alert, &key)
+                .await
+                .ok();
+            let resp_body: GetAlertResponseBody = (alert, scheduled_job).into();
             MetaHttpResponse::json(resp_body)
         }
         Err(e) => e.into(),
@@ -237,11 +249,28 @@ async fn list_alerts(path: web::Path<String>, req: HttpRequest) -> HttpResponse 
     };
 
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
-    let folders_and_alerts = match alert::list_v2(client, user_id, query.into(&org_id)).await {
-        Ok(f_a) => f_a,
-        Err(e) => return e.into(),
-    };
-    let Ok(resp_body) = ListAlertsResponseBody::try_from(folders_and_alerts) else {
+    let scheduled_jobs = scheduler::list_by_org(&org_id, Some(TriggerModule::Alert))
+        .await
+        .unwrap_or_default();
+    let mut scheduled_jobs: HashMap<String, Trigger> = scheduled_jobs
+        .into_iter()
+        .map(|t| (t.module_key.clone(), t))
+        .collect();
+    let folders_and_alerts_scheduled_job =
+        match alert::list_v2(client, user_id, query.into(&org_id)).await {
+            Ok(f_a) => {
+                let f_a: Vec<_> = f_a
+                    .into_iter()
+                    .map(|(folder, alert)| {
+                        let key = alert.get_unique_key();
+                        (folder, alert, scheduled_jobs.remove(&key))
+                    })
+                    .collect();
+                f_a
+            }
+            Err(e) => return e.into(),
+        };
+    let Ok(resp_body) = ListAlertsResponseBody::try_from(folders_and_alerts_scheduled_job) else {
         return MetaHttpResponse::internal_error("");
     };
     MetaHttpResponse::json(resp_body)

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -52,7 +52,7 @@ pub trait Scheduler: Sync + Send + 'static {
         retries: i32,
         data: Option<&str>,
     ) -> Result<()>;
-    async fn update_trigger(&self, trigger: Trigger) -> Result<()>;
+    async fn update_trigger(&self, trigger: Trigger, clone: bool) -> Result<()>;
     async fn pull(
         &self,
         concurrency: i64,
@@ -110,8 +110,8 @@ pub async fn update_status(
 /// only be used by the node that is currently processing the trigger.
 /// Use `pull()` method to set the status of the job from `Waiting` to `Processing`.
 #[inline]
-pub async fn update_trigger(trigger: Trigger) -> Result<()> {
-    CLIENT.update_trigger(trigger).await
+pub async fn update_trigger(trigger: Trigger, clone: bool) -> Result<()> {
+    CLIENT.update_trigger(trigger, clone).await
 }
 
 /// Scheduler pulls only those triggers that match the conditions-

--- a/src/infra/src/scheduler/mod.rs
+++ b/src/infra/src/scheduler/mod.rs
@@ -14,9 +14,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
-use config::meta::meta_store::MetaStore;
+use config::meta::{
+    meta_store::MetaStore,
+    triggers::{Trigger, TriggerId, TriggerModule, TriggerStatus},
+};
 use once_cell::sync::Lazy;
-use serde::{Deserialize, Serialize};
 
 use crate::errors::Result;
 
@@ -48,6 +50,7 @@ pub trait Scheduler: Sync + Send + 'static {
         key: &str,
         status: TriggerStatus,
         retries: i32,
+        data: Option<&str>,
     ) -> Result<()>;
     async fn update_trigger(&self, trigger: Trigger) -> Result<()>;
     async fn pull(
@@ -58,68 +61,13 @@ pub trait Scheduler: Sync + Send + 'static {
     ) -> Result<Vec<Trigger>>;
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger>;
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>>;
+    async fn list_by_org(&self, org: &str, module: Option<TriggerModule>) -> Result<Vec<Trigger>>;
     async fn clean_complete(&self) -> Result<()>;
     async fn watch_timeout(&self) -> Result<()>;
     async fn len_module(&self, module: TriggerModule) -> usize;
     async fn len(&self) -> usize;
     async fn is_empty(&self) -> bool;
     async fn clear(&self) -> Result<()>;
-}
-
-#[derive(Debug, Clone, sqlx::Type, PartialEq, Serialize, Deserialize, Default)]
-#[repr(i32)]
-pub enum TriggerStatus {
-    #[default]
-    Waiting,
-    Processing,
-    Completed,
-}
-
-#[derive(
-    Debug, Clone, sqlx::Type, PartialEq, Serialize, Deserialize, Default, Eq, std::hash::Hash,
-)]
-#[repr(i32)]
-pub enum TriggerModule {
-    Report,
-    #[default]
-    Alert,
-    DerivedStream,
-}
-
-impl std::fmt::Display for TriggerModule {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            TriggerModule::Alert => write!(f, "alert"),
-            TriggerModule::Report => write!(f, "report"),
-            TriggerModule::DerivedStream => write!(f, "derived_stream"),
-        }
-    }
-}
-
-#[derive(sqlx::FromRow, Debug, Clone, Default)]
-pub struct TriggerId {
-    pub id: i64,
-}
-
-#[derive(sqlx::FromRow, Debug, Clone, Serialize, Deserialize, Default)]
-pub struct Trigger {
-    pub org: String,
-    pub module: TriggerModule,
-    pub module_key: String,
-    pub next_run_at: i64,
-    pub is_realtime: bool,
-    pub is_silenced: bool,
-    pub status: TriggerStatus,
-    // #[sqlx(default)] only works when the column itself is missing.
-    // For NULL value it does not work.
-    // TODO: See https://github.com/launchbadge/sqlx/issues/1106
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_time: Option<i64>,
-    pub retries: i32,
-    #[serde(default)]
-    pub data: String,
 }
 
 /// Initializes the scheduler - creates table and index
@@ -150,9 +98,10 @@ pub async fn update_status(
     key: &str,
     status: TriggerStatus,
     retries: i32,
+    data: Option<&str>,
 ) -> Result<()> {
     CLIENT
-        .update_status(org, module, key, status, retries)
+        .update_status(org, module, key, status, retries, data)
         .await
 }
 
@@ -223,6 +172,12 @@ pub async fn len() -> usize {
 #[inline]
 pub async fn list(module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
     CLIENT.list(module).await
+}
+
+/// List the jobs for the given module
+#[inline]
+pub async fn list_by_org(org: &str, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
+    CLIENT.list_by_org(org, module).await
 }
 
 #[inline]

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -267,27 +267,47 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         Ok(())
     }
 
-    async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
+    async fn update_trigger(&self, trigger: Trigger, clone: bool) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
             .with_label_values(&["update", "scheduled_jobs"])
             .inc();
-        sqlx::query(
-            r#"UPDATE scheduled_jobs
-SET status = ?, retries = ?, next_run_at = ?, is_realtime = ?, is_silenced = ?, data = ?
-WHERE org = ? AND module_key = ? AND module = ?;"#,
-        )
-        .bind(trigger.status)
-        .bind(trigger.retries)
-        .bind(trigger.next_run_at)
-        .bind(trigger.is_realtime)
-        .bind(trigger.is_silenced)
-        .bind(&trigger.data)
-        .bind(&trigger.org)
-        .bind(&trigger.module_key)
-        .bind(&trigger.module)
-        .execute(&pool)
-        .await?;
+
+        let query = if clone {
+            sqlx::query(
+                r#"UPDATE scheduled_jobs
+    SET status = ?, start_time = ?, end_time = ?, retries = ?, next_run_at = ?, is_realtime = ?, is_silenced = ?, data = ?
+    WHERE org = ? AND module_key = ? AND module = ?;"#,
+            )
+            .bind(trigger.status)
+            .bind(trigger.start_time)
+            .bind(trigger.end_time)
+            .bind(trigger.retries)
+            .bind(trigger.next_run_at)
+            .bind(trigger.is_realtime)
+            .bind(trigger.is_silenced)
+            .bind(&trigger.data)
+            .bind(&trigger.org)
+            .bind(&trigger.module_key)
+            .bind(&trigger.module)
+        } else {
+            sqlx::query(
+                r#"UPDATE scheduled_jobs
+    SET status = ?, retries = ?, next_run_at = ?, is_realtime = ?, is_silenced = ?, data = ?
+    WHERE org = ? AND module_key = ? AND module = ?;"#,
+            )
+            .bind(trigger.status)
+            .bind(trigger.retries)
+            .bind(trigger.next_run_at)
+            .bind(trigger.is_realtime)
+            .bind(trigger.is_silenced)
+            .bind(&trigger.data)
+            .bind(&trigger.org)
+            .bind(&trigger.module_key)
+            .bind(&trigger.module)
+        };
+
+        query.execute(&pool).await?;
 
         // For now, only send realtime alert triggers
         if trigger.module == TriggerModule::Alert && trigger.is_realtime {

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -265,27 +265,46 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         Ok(())
     }
 
-    async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
+    async fn update_trigger(&self, trigger: Trigger, clone: bool) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
             .with_label_values(&["update", "scheduled_jobs"])
             .inc();
-        sqlx::query(
-            r#"UPDATE scheduled_jobs
-SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5, data = $6
-WHERE org = $7 AND module_key = $8 AND module = $9;"#,
-        )
-        .bind(trigger.status)
-        .bind(trigger.retries)
-        .bind(trigger.next_run_at)
-        .bind(trigger.is_realtime)
-        .bind(trigger.is_silenced)
-        .bind(&trigger.data)
-        .bind(&trigger.org)
-        .bind(&trigger.module_key)
-        .bind(&trigger.module)
-        .execute(&pool)
-        .await?;
+        let query = if clone {
+            sqlx::query(
+                r#"UPDATE scheduled_jobs
+    SET status = $1, start_time = $2, end_time = $3, retries = $4, next_run_at = $5, is_realtime = $6, is_silenced = $7, data = $8
+    WHERE org = $9 AND module_key = $10 AND module = $11;"#,
+            )
+            .bind(trigger.status)
+            .bind(trigger.start_time)
+            .bind(trigger.end_time)
+            .bind(trigger.retries)
+            .bind(trigger.next_run_at)
+            .bind(trigger.is_realtime)
+            .bind(trigger.is_silenced)
+            .bind(&trigger.data)
+            .bind(&trigger.org)
+            .bind(&trigger.module_key)
+            .bind(&trigger.module)
+        } else {
+            sqlx::query(
+                r#"UPDATE scheduled_jobs
+    SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5, data = $6
+    WHERE org = $7 AND module_key = $8 AND module = $9;"#,
+            )
+            .bind(trigger.status)
+            .bind(trigger.retries)
+            .bind(trigger.next_run_at)
+            .bind(trigger.is_realtime)
+            .bind(trigger.is_silenced)
+            .bind(&trigger.data)
+            .bind(&trigger.org)
+            .bind(&trigger.module_key)
+            .bind(&trigger.module)
+        };
+
+        query.execute(&pool).await?;
 
         // For now, only send realtime alert triggers
         if trigger.module == TriggerModule::Alert && trigger.is_realtime {

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -220,18 +220,34 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         key: &str,
         status: TriggerStatus,
         retries: i32,
+        data: Option<&str>,
     ) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
-        sqlx::query(
-            r#"UPDATE scheduled_jobs SET status = $1, retries = $2 WHERE org = $3 AND module_key = $4 AND module = $5;"#
-        )
-        .bind(status)
-        .bind(retries)
-        .bind(org)
-        .bind(key)
-        .bind(&module)
-        .execute(&*client).await?;
+        let query = match data {
+            Some(data) => {
+                sqlx::query(
+                    r#"UPDATE scheduled_jobs SET status = $1, retries = $2, data = $3 WHERE org = $4 AND module_key = $5 AND module = $6;"#,
+                )
+                .bind(status)
+                .bind(retries)
+                .bind(data)
+                .bind(org)
+                .bind(key)
+                .bind(&module)
+            },
+            None => {
+                sqlx::query(
+                    r#"UPDATE scheduled_jobs SET status = $1, retries = $2 WHERE org = $3 AND module_key = $4 AND module = $5;"#,
+                )
+                .bind(status)
+                .bind(retries)
+                .bind(org)
+                .bind(key)
+                .bind(&module)
+            },
+        };
+        query.execute(&*client).await?;
 
         drop(client);
 
@@ -382,6 +398,27 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
         Ok(jobs)
     }
 
+    /// List all the jobs for the given module and organization
+    async fn list_by_org(&self, org: &str, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
+        let client = CLIENT_RO.clone();
+        let jobs: Vec<Trigger> = if let Some(module) = module {
+            let query =
+                r#"SELECT * FROM scheduled_jobs WHERE org = $1 AND module = $2 ORDER BY id;"#;
+            sqlx::query_as::<_, Trigger>(query)
+                .bind(org)
+                .bind(module)
+                .fetch_all(&client)
+                .await?
+        } else {
+            let query = r#"SELECT * FROM scheduled_jobs WHERE org = $1 ORDER BY id;"#;
+            sqlx::query_as::<_, Trigger>(query)
+                .bind(org)
+                .fetch_all(&client)
+                .await?
+        };
+        Ok(jobs)
+    }
+
     /// Background job that frequently (30 secs interval) cleans "Completed" jobs or jobs with
     /// retries >= threshold set through environment
     async fn clean_complete(&self) -> Result<()> {
@@ -391,11 +428,15 @@ WHERE org = $1 AND module = $2 AND module_key = $3;"#;
         if include_max {
             max_retries += 1;
         }
-        sqlx::query(r#"DELETE FROM scheduled_jobs WHERE status = $1 OR retries >= $2;"#)
-            .bind(TriggerStatus::Completed)
-            .bind(max_retries)
-            .execute(&*client)
-            .await?;
+        // Since alert scheduled_jobs contain last_satisfied_at field, we should not delete them
+        sqlx::query(
+            r#"DELETE FROM scheduled_jobs WHERE (status = $1 OR retries >= $2) AND module != $3;"#,
+        )
+        .bind(TriggerStatus::Completed)
+        .bind(max_retries)
+        .bind(TriggerModule::Alert)
+        .execute(&*client)
+        .await?;
         Ok(())
     }
 

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -257,25 +257,44 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         Ok(())
     }
 
-    async fn update_trigger(&self, trigger: Trigger) -> Result<()> {
+    async fn update_trigger(&self, trigger: Trigger, clone: bool) -> Result<()> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
-        sqlx::query(
-            r#"UPDATE scheduled_jobs
-SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5, data = $6
-WHERE org = $7 AND module_key = $8 AND module = $9;"#,
-        )
-        .bind(&trigger.status)
-        .bind(trigger.retries)
-        .bind(trigger.next_run_at)
-        .bind(trigger.is_realtime)
-        .bind(trigger.is_silenced)
-        .bind(&trigger.data)
-        .bind(&trigger.org)
-        .bind(&trigger.module_key)
-        .bind(&trigger.module)
-        .execute(&*client)
-        .await?;
+        let query = if clone {
+            sqlx::query(
+                r#"UPDATE scheduled_jobs
+    SET status = $1, start_time = $2, end_time = $3, retries = $4, next_run_at = $5, is_realtime = $6, is_silenced = $7, data = $8
+    WHERE org = $9 AND module_key = $10 AND module = $11;"#,
+            )
+            .bind(&trigger.status)
+            .bind(trigger.start_time)
+            .bind(trigger.end_time)
+            .bind(trigger.retries)
+            .bind(trigger.next_run_at)
+            .bind(trigger.is_realtime)
+            .bind(trigger.is_silenced)
+            .bind(&trigger.data)
+            .bind(&trigger.org)
+            .bind(&trigger.module_key)
+            .bind(&trigger.module)
+        } else {
+            sqlx::query(
+                r#"UPDATE scheduled_jobs
+    SET status = $1, retries = $2, next_run_at = $3, is_realtime = $4, is_silenced = $5, data = $6
+    WHERE org = $7 AND module_key = $8 AND module = $9;"#,
+            )
+            .bind(&trigger.status)
+            .bind(trigger.retries)
+            .bind(trigger.next_run_at)
+            .bind(trigger.is_realtime)
+            .bind(trigger.is_silenced)
+            .bind(&trigger.data)
+            .bind(&trigger.org)
+            .bind(&trigger.module_key)
+            .bind(&trigger.module)
+        };
+
+        query.execute(&*client).await?;
 
         // release lock
         drop(client);

--- a/src/infra/src/table/alerts/mod.rs
+++ b/src/infra/src/table/alerts/mod.rs
@@ -97,50 +97,50 @@ impl TryFrom<alerts::Model> for MetaAlert {
             .and_then(|secs| Utc.timestamp_opt(secs, 0).single())
             .map(|dt| dt.into());
 
-        let alert = Self {
-            id: Some(id),
-            name: value.name,
-            org_id: value.org,
-            stream_type: stream_type.into(),
-            stream_name: value.stream_name,
-            is_real_time: value.is_real_time,
-            destinations,
-            context_attributes,
-            row_template: value.row_template.unwrap_or_default(),
-            description: value.description.unwrap_or_default(),
-            enabled: value.enabled,
-            tz_offset: value.tz_offset,
-            last_triggered_at: value.last_triggered_at,
-            last_satisfied_at: value.last_satisfied_at,
-            owner: value.owner,
-            updated_at: updated_at_utc,
-            last_edited_by: value.last_edited_by,
-            query_condition: MetaQueryCondition {
-                query_type: query_type.into(),
-                conditions: query_conditions.map(|cs| cs.into_iter().map(|c| c.into()).collect()),
-                sql: value.query_sql,
-                promql: value.query_promql,
-                promql_condition: query_promql_condition.map(|c| c.into()),
-                aggregation: query_aggregation.map(|a| a.into()),
-                vrl_function: value.query_vrl_function,
-                search_event_type: query_search_event_type.map(|t| t.into()),
-                multi_time_range: query_multi_time_range
-                    .map(|ds| ds.into_iter().map(|d| d.into()).collect()),
-            },
-            trigger_condition: MetaTriggerCondition {
-                // DB model stores period in seconds, but service layer stores
-                // minutes.
-                period: value.trigger_period_seconds / 60,
-                operator: trigger_threshold_operator.into(),
-                threshold: value.trigger_threshold_count,
-                frequency: value.trigger_frequency_seconds,
-                cron: value.trigger_frequency_cron.unwrap_or_default(),
-                frequency_type: trigger_frequency_type.into(),
-                silence: value.trigger_silence_seconds / 60,
-                timezone: value.trigger_frequency_cron_timezone,
-                tolerance_in_secs: value.trigger_tolerance_seconds,
-            },
+        let mut alert: MetaAlert = Default::default();
+        alert.id = Some(id);
+        alert.name = value.name;
+        alert.org_id = value.org;
+        alert.stream_type = stream_type.into();
+        alert.stream_name = value.stream_name;
+        alert.is_real_time = value.is_real_time;
+        alert.destinations = destinations;
+        alert.context_attributes = context_attributes;
+        alert.row_template = value.row_template.unwrap_or_default();
+        alert.description = value.description.unwrap_or_default();
+        alert.enabled = value.enabled;
+        alert.tz_offset = value.tz_offset;
+        alert.owner = value.owner;
+        alert.last_edited_by = value.last_edited_by;
+        alert.updated_at = updated_at_utc;
+        alert.query_condition = MetaQueryCondition {
+            query_type: query_type.into(),
+            conditions: query_conditions.map(|cs| cs.into_iter().map(|c| c.into()).collect()),
+            sql: value.query_sql,
+            promql: value.query_promql,
+            promql_condition: query_promql_condition.map(|c| c.into()),
+            aggregation: query_aggregation.map(|a| a.into()),
+            vrl_function: value.query_vrl_function,
+            search_event_type: query_search_event_type.map(|t| t.into()),
+            multi_time_range: query_multi_time_range
+                .map(|ds| ds.into_iter().map(|d| d.into()).collect()),
         };
+        alert.trigger_condition = MetaTriggerCondition {
+            // DB model stores period in seconds, but service layer stores
+            // minutes.
+            period: value.trigger_period_seconds / 60,
+            operator: trigger_threshold_operator.into(),
+            threshold: value.trigger_threshold_count,
+            frequency: value.trigger_frequency_seconds,
+            cron: value.trigger_frequency_cron.unwrap_or_default(),
+            frequency_type: trigger_frequency_type.into(),
+            silence: value.trigger_silence_seconds / 60,
+            timezone: value.trigger_frequency_cron_timezone,
+            tolerance_in_secs: value.trigger_tolerance_seconds,
+        };
+        alert.set_last_satisfied_at(value.last_satisfied_at);
+        alert.set_last_triggered_at(value.last_triggered_at);
+
         Ok(alert)
     }
 }
@@ -581,6 +581,8 @@ fn update_mutable_fields(
     alert_am: &mut alerts::ActiveModel,
     alert: MetaAlert,
 ) -> Result<(), errors::Error> {
+    let last_triggered_at = alert.get_last_triggered_at_from_table();
+    let last_satisfied_at = alert.get_last_satisfied_at_from_table();
     let is_real_time = alert.is_real_time;
     let destinations = serde_json::to_value(alert.destinations)?;
     let context_attributes = alert
@@ -591,8 +593,6 @@ fn update_mutable_fields(
     let description = Some(alert.description).filter(|s| !s.is_empty());
     let enabled = alert.enabled;
     let tz_offset = alert.tz_offset;
-    let last_triggered_at = alert.last_triggered_at;
-    let last_satisfied_at = alert.last_satisfied_at;
     let query_type: i16 = intermediate::QueryType::from(alert.query_condition.query_type).into();
     let query_conditions = alert
         .query_condition

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -18,8 +18,6 @@ use config::{cluster::LOCAL_NODE, get_config};
 use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
 use tokio::time;
 
-use crate::service;
-
 pub async fn run() -> Result<(), anyhow::Error> {
     if !LOCAL_NODE.is_alert_manager() {
         return Ok(());
@@ -71,16 +69,9 @@ pub async fn run() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Runs the schedule jobs
 async fn run_schedule_jobs() -> Result<(), anyhow::Error> {
-    let interval = get_config().limit.alert_schedule_interval;
-    let mut interval = time::interval(time::Duration::from_secs(interval as u64));
-    interval.tick().await; // trigger the first run
-    loop {
-        interval.tick().await;
-        if let Err(e) = service::alerts::scheduler::run().await {
-            log::error!("[ALERT MANAGER] run schedule jobs error: {}", e);
-        }
-    }
+    crate::service::alerts::scheduler::run().await
 }
 
 async fn clean_complete_jobs() -> Result<(), anyhow::Error> {
@@ -93,7 +84,7 @@ async fn clean_complete_jobs() -> Result<(), anyhow::Error> {
     loop {
         interval.tick().await;
         if let Err(e) = infra::scheduler::clean_complete().await {
-            log::error!("[ALERT MANAGER] clean complete jobs error: {}", e);
+            log::error!("[SCHEDULER] clean complete jobs error: {}", e);
         }
     }
 }
@@ -108,7 +99,7 @@ async fn watch_timeout_jobs() -> Result<(), anyhow::Error> {
     loop {
         interval.tick().await;
         if let Err(e) = infra::scheduler::watch_timeout().await {
-            log::error!("[ALERT MANAGER] watch timeout jobs error: {}", e);
+            log::error!("[SCHEDULER] watch timeout jobs error: {}", e);
         }
     }
 }

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -18,6 +18,9 @@ use config::{cluster::LOCAL_NODE, get_config};
 use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
 use tokio::time;
 
+#[cfg(feature = "enterprise")]
+use crate::service;
+
 pub async fn run() -> Result<(), anyhow::Error> {
     if !LOCAL_NODE.is_alert_manager() {
         return Ok(());

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -215,8 +215,8 @@ async fn prepare_alert(
             if create {
                 return Err(AlertError::CreateAlreadyExists);
             }
-            alert.last_triggered_at = old_alert.last_triggered_at;
-            alert.last_satisfied_at = old_alert.last_satisfied_at;
+            alert.set_last_triggered_at(old_alert.get_last_triggered_at_from_table());
+            alert.set_last_satisfied_at(old_alert.get_last_satisfied_at_from_table());
             alert.owner = old_alert.owner;
         }
         Ok(None) => {
@@ -1493,10 +1493,8 @@ mod tests {
         let org_id = "default";
         let stream_name = "default";
         let alert_name = "abc/alert";
-        let alert = Alert {
-            name: alert_name.to_string(),
-            ..Default::default()
-        };
+        let mut alert: Alert = Default::default();
+        alert.name = alert_name.to_string();
         let ret = save(org_id, stream_name, alert_name, alert, true).await;
         // alert name should not contain /
         assert!(ret.is_err());

--- a/src/service/alerts/scheduler/mod.rs
+++ b/src/service/alerts/scheduler/mod.rs
@@ -1,0 +1,118 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+
+use config::{get_config, ider};
+use futures::future::try_join_all;
+
+use crate::service::db;
+
+pub mod handlers;
+pub mod worker;
+
+pub async fn run_old() -> Result<(), anyhow::Error> {
+    let trace_id = ider::generate();
+    log::debug!("[SCHEDULER trace_id {trace_id}] Pulling jobs from scheduler");
+    let cfg = get_config();
+
+    // Scheduler pulls only those triggers that match the conditions-
+    // - trigger.next_run_at <= now
+    // - !(trigger.is_realtime && !trigger.is_silenced)
+    // - trigger.status == "Waiting"
+    let triggers = db::scheduler::pull(
+        cfg.limit.alert_schedule_concurrency,
+        cfg.limit.alert_schedule_timeout,
+        cfg.limit.report_schedule_timeout,
+    )
+    .await?;
+
+    log::info!(
+        "[SCHEDULER trace_id {trace_id}] Pulled {} jobs from scheduler",
+        triggers.len()
+    );
+
+    if !triggers.is_empty() {
+        let mut grouped_triggers: std::collections::HashMap<
+            db::scheduler::TriggerModule,
+            Vec<&db::scheduler::Trigger>,
+        > = HashMap::new();
+
+        // Group triggers by module
+        for trigger in &triggers {
+            grouped_triggers
+                .entry(trigger.module.clone())
+                .or_default()
+                .push(trigger);
+        }
+
+        // Print counts for each module
+        for (module, triggers) in grouped_triggers {
+            log::info!(
+                "[SCHEDULER trace_id {trace_id}] Pulled {:?}: {} jobs",
+                module,
+                triggers.len()
+            );
+        }
+    }
+
+    let mut tasks = Vec::new();
+    for (i, trigger) in triggers.into_iter().enumerate() {
+        let trace_id = format!("{}-{}", trace_id, i);
+        let task = tokio::task::spawn(async move {
+            let key = format!("{}-{}/{}", trigger.module, trigger.org, trigger.module_key);
+            log::debug!(
+                "[SCHEDULER trace_id {trace_id}] start processing trigger: {}",
+                key
+            );
+            // if let Err(e) = handle_triggers(&trace_id, trigger).await {
+            //     log::error!(
+            //         "[SCHEDULER trace_id {trace_id}] Error handling trigger: {}",
+            //         e
+            //     );
+            // }
+            log::debug!(
+                "[SCHEDULER trace_id {trace_id}] finished processing trigger: {}",
+                key
+            );
+        });
+        tasks.push(task);
+    }
+    if let Err(e) = try_join_all(tasks).await {
+        log::error!(
+            "[SCHEDULER trace_id {trace_id}] Error handling triggers: {}",
+            e
+        );
+    }
+    Ok(())
+}
+
+// The main function that creates and runs the scheduler
+pub async fn run() -> Result<(), anyhow::Error> {
+    // Get configuration
+    let cfg = get_config();
+
+    // Create scheduler config
+    let scheduler_config = worker::SchedulerConfig {
+        alert_schedule_concurrency: cfg.limit.alert_schedule_concurrency as usize,
+        alert_schedule_timeout: cfg.limit.alert_schedule_timeout,
+        report_schedule_timeout: cfg.limit.report_schedule_timeout,
+        poll_interval_secs: cfg.limit.alert_schedule_interval as u64, // Can be configurable
+    };
+
+    // Create and run scheduler
+    let scheduler = worker::Scheduler::new(scheduler_config);
+    scheduler.run().await
+}

--- a/src/service/alerts/scheduler/worker.rs
+++ b/src/service/alerts/scheduler/worker.rs
@@ -1,0 +1,321 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+use std::{collections::HashMap, sync::Arc};
+
+use anyhow::Result;
+use tokio::{
+    sync::{mpsc, Mutex, Semaphore},
+    time,
+};
+
+use super::handlers::handle_triggers;
+use crate::service::db::scheduler::{pull as scheduler_pull, Trigger, TriggerModule};
+
+#[derive(Debug, Clone)]
+pub struct ScheduledJob {
+    pub trace_id: String,
+    pub trigger: Trigger,
+}
+
+/// Configuration for the scheduler
+#[derive(Clone)]
+pub struct SchedulerConfig {
+    pub alert_schedule_concurrency: usize,
+    pub alert_schedule_timeout: i64,
+    pub report_schedule_timeout: i64,
+    pub poll_interval_secs: u64,
+}
+
+/// Scheduler worker for processing triggers
+#[derive(Clone)]
+pub struct SchedulerWorker {
+    pub id: usize,
+    pub rx: Arc<Mutex<mpsc::Receiver<ScheduledJob>>>,
+    pub available_workers: Arc<Semaphore>,
+}
+
+/// Scheduler job puller that fetches jobs from the database
+#[derive(Clone)]
+pub struct SchedulerJobPuller {
+    pub tx: mpsc::Sender<ScheduledJob>,
+    pub available_workers: Arc<Semaphore>,
+    pub config: SchedulerConfig,
+}
+
+/// Main scheduler that coordinates workers and the job puller
+pub struct Scheduler {
+    pub config: SchedulerConfig,
+    pub workers: Vec<SchedulerWorker>,
+    pub job_puller: SchedulerJobPuller,
+    pub tx: mpsc::Sender<ScheduledJob>,
+    pub rx: Arc<Mutex<mpsc::Receiver<ScheduledJob>>>,
+    pub available_workers: Arc<Semaphore>,
+}
+
+impl SchedulerWorker {
+    pub fn new(
+        id: usize,
+        rx: Arc<Mutex<mpsc::Receiver<ScheduledJob>>>,
+        available_workers: Arc<Semaphore>,
+    ) -> Self {
+        Self {
+            id,
+            rx,
+            available_workers,
+        }
+    }
+
+    pub async fn run(&self) -> Result<()> {
+        loop {
+            // Try to get next trigger
+            let trigger = {
+                let mut rx = self.rx.lock().await;
+                rx.recv().await
+            };
+
+            match trigger {
+                Some(trigger) => {
+                    // Acquire permit before processing
+                    let _permit = self.available_workers.acquire().await?;
+
+                    // Process the trigger
+                    if let Err(e) = self
+                        .handle_trigger(&trigger.trace_id, trigger.trigger)
+                        .await
+                    {
+                        log::error!(
+                            "[SCHEDULER][Worker-{}] trace_id: {} Error handling trigger: {}",
+                            self.id,
+                            trigger.trace_id,
+                            e
+                        );
+                    }
+
+                    // Permit is automatically released when _permit is dropped
+                }
+                None => {
+                    // Channel closed, no more work
+                    log::info!(
+                        "[SCHEDULER][Worker-{}] Channel closed, no more work",
+                        self.id
+                    );
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Handles a given trigger
+    pub async fn handle_trigger(&self, trace_id: &str, trigger: Trigger) -> Result<()> {
+        handle_triggers(trace_id, trigger).await
+    }
+}
+
+impl SchedulerJobPuller {
+    pub fn new(
+        tx: mpsc::Sender<ScheduledJob>,
+        available_workers: Arc<Semaphore>,
+        config: SchedulerConfig,
+    ) -> Self {
+        Self {
+            tx,
+            available_workers,
+            config,
+        }
+    }
+
+    /// Runs the job puller. Pulls jobs from the database and sends them to the workers.
+    /// When pulling jobs, it will only pull as many jobs as the number of available workers
+    /// which is determined by the semaphore and can have the maximum value of
+    /// `alert_schedule_concurrency` The advantage of this approach is that the scheduler does
+    /// not need to wait for all the workers to complete the job before pulling more jobs. It
+    /// will keep pulling jobs at the configured poll interval. The number of jobs pulled will
+    /// be the number of available workers.
+    pub async fn run(&self) -> Result<()> {
+        let interval = self.config.poll_interval_secs;
+        let mut interval = time::interval(time::Duration::from_secs(interval));
+        interval.tick().await; // The first tick
+        loop {
+            // Check how many workers are available
+            let available_count = self.available_workers.available_permits();
+            let trace_id = config::ider::uuid();
+            log::info!(
+                "[SCHEDULER][JobPuller-{}] Available workers: {}",
+                trace_id,
+                available_count
+            );
+
+            if available_count > 0 {
+                // Pull only as many jobs as we have available workers
+                let triggers = self.pull(available_count).await?;
+
+                log::info!(
+                    "[SCHEDULER][JobPuller-{}] Pulled {} jobs from scheduler",
+                    trace_id,
+                    triggers.len()
+                );
+
+                // Print counts for each module
+                if !triggers.is_empty() {
+                    let mut grouped_triggers: std::collections::HashMap<
+                        TriggerModule,
+                        Vec<&Trigger>,
+                    > = HashMap::new();
+
+                    // Group triggers by module
+                    for trigger in &triggers {
+                        grouped_triggers
+                            .entry(trigger.module.clone())
+                            .or_default()
+                            .push(trigger);
+                    }
+
+                    // Print counts for each module
+                    for (module, triggers) in grouped_triggers {
+                        log::info!(
+                            "[SCHEDULER JobPuller trace_id {trace_id}] Pulled {:?}: {} jobs",
+                            module,
+                            triggers.len()
+                        );
+                    }
+                }
+
+                // Send all triggers to be processed
+                for trigger in triggers {
+                    let scheduled_job = ScheduledJob {
+                        trace_id: trace_id.clone(),
+                        trigger,
+                    };
+                    if self.tx.send(scheduled_job).await.is_err() {
+                        // Channel closed, exit loop
+                        log::error!(
+                            "[SCHEDULER][JobPuller-{}] Channel closed, exiting job puller",
+                            trace_id
+                        );
+                        return Ok(());
+                    }
+                }
+            }
+
+            // Wait for the next tick
+            interval.tick().await;
+
+            // Check if channel is closed
+            if self.tx.is_closed() {
+                break;
+            }
+        }
+        log::info!("[SCHEDULER] Job puller exiting");
+        Ok(())
+    }
+
+    pub async fn pull(&self, limit: usize) -> Result<Vec<Trigger>> {
+        match scheduler_pull(
+            limit as i64,
+            self.config.alert_schedule_timeout,
+            self.config.report_schedule_timeout,
+        )
+        .await
+        {
+            Ok(triggers) => Ok(triggers),
+            Err(e) => {
+                log::error!("[SCHEDULER] Error pulling triggers: {}", e);
+                Ok(vec![])
+            }
+        }
+    }
+}
+
+impl Scheduler {
+    pub fn new(config: SchedulerConfig) -> Self {
+        let max_workers = config.alert_schedule_concurrency;
+
+        // Create a channel for work distribution with capacity for max workers
+        let (tx, rx) = mpsc::channel(max_workers);
+
+        // Share receiver between workers
+        let rx = Arc::new(Mutex::new(rx));
+
+        // Track available workers with a semaphore
+        let available_workers = Arc::new(Semaphore::new(max_workers));
+
+        // Create workers
+        let workers = (0..max_workers)
+            .map(|id| SchedulerWorker::new(id, rx.clone(), available_workers.clone()))
+            .collect();
+
+        // Create job puller
+        let job_puller =
+            SchedulerJobPuller::new(tx.clone(), available_workers.clone(), config.clone());
+
+        Self {
+            config,
+            workers,
+            job_puller,
+            tx,
+            rx,
+            available_workers,
+        }
+    }
+
+    pub async fn run(&self) -> Result<()> {
+        log::debug!("Starting scheduler");
+
+        // Spawn worker tasks
+        let worker_handles: Vec<_> = self
+            .workers
+            .iter()
+            .map(|worker| {
+                let worker = worker.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = worker.run().await {
+                        log::error!("[SCHEDULER][Worker] Error in worker: {}", e);
+                    }
+                })
+            })
+            .collect();
+
+        // Spawn job puller task
+        let puller_handle = {
+            let puller = self.job_puller.clone();
+            tokio::spawn(async move {
+                if let Err(e) = puller.run().await {
+                    log::error!("[SCHEDULER] Error in job puller: {}", e);
+                }
+            })
+        };
+
+        // Wait for shutdown signal
+        // ...
+
+        // Wait for puller to complete
+        if let Err(e) = puller_handle.await {
+            log::error!("[SCHEDULER] Error waiting for puller to complete: {}", e);
+        }
+
+        // When shutting down:
+        drop(self.tx.clone()); // Signal no more work
+
+        // Wait for workers to complete
+        if let Err(e) = futures::future::try_join_all(worker_handles).await {
+            log::error!("[SCHEDULER] Error waiting for workers to complete: {}", e);
+        }
+
+        // Ideally should never reach here
+        log::info!("[SCHEDULER] Shutdown complete");
+        Ok(())
+    }
+}

--- a/src/service/db/alerts/realtime_triggers.rs
+++ b/src/service/db/alerts/realtime_triggers.rs
@@ -50,7 +50,7 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                     if ev.value.is_none() || ev.value.as_ref().unwrap().is_empty() {
                         match db::scheduler::get(
                             columns.0,
-                            infra::scheduler::TriggerModule::Alert,
+                            config::meta::triggers::TriggerModule::Alert,
                             columns.1,
                         )
                         .await

--- a/src/service/db/scheduler.rs
+++ b/src/service/db/scheduler.rs
@@ -13,26 +13,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use infra::scheduler::{Trigger, TriggerModule, TriggerStatus, TRIGGERS_KEY};
+pub use config::meta::triggers::{Trigger, TriggerModule, TriggerStatus};
+pub use infra::scheduler::TRIGGERS_KEY;
 use infra::{
     errors::Result,
     scheduler::{self as infra_scheduler},
 };
-use serde::{Deserialize, Serialize};
 #[cfg(feature = "enterprise")]
 use {
     infra::errors::Error,
     o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config,
     o2_enterprise::enterprise::super_cluster,
 };
-
-#[derive(Default, Serialize, Deserialize, Debug)]
-pub struct ScheduledTriggerData {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub period_end_time: Option<i64>,
-    #[serde(default)]
-    pub tolerance: i64,
-}
 
 #[inline]
 pub async fn push(trigger: Trigger) -> Result<()> {
@@ -90,13 +82,14 @@ pub async fn update_status(
     key: &str,
     status: TriggerStatus,
     retries: i32,
+    data: Option<&str>,
 ) -> Result<()> {
-    infra_scheduler::update_status(org, module.clone(), key, status.clone(), retries).await?;
+    infra_scheduler::update_status(org, module.clone(), key, status.clone(), retries, data).await?;
 
     // super cluster
     #[cfg(feature = "enterprise")]
     if get_o2_config().super_cluster.enabled {
-        super_cluster::queue::scheduler_update_status(org, module, key, status, retries)
+        super_cluster::queue::scheduler_update_status(org, module, key, status, retries, data)
             .await
             .map_err(|e| Error::Message(e.to_string()))?;
     }
@@ -140,6 +133,12 @@ pub async fn len() -> usize {
 #[inline]
 pub async fn list(module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
     infra_scheduler::list(module).await
+}
+
+/// List the jobs for the given module
+#[inline]
+pub async fn list_by_org(org: &str, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
+    infra_scheduler::list_by_org(org, module).await
 }
 
 #[inline]

--- a/src/service/db/scheduler.rs
+++ b/src/service/db/scheduler.rs
@@ -62,7 +62,7 @@ pub async fn delete(org: &str, module: TriggerModule, key: &str) -> Result<()> {
 pub async fn update_trigger(trigger: Trigger) -> Result<()> {
     #[cfg(feature = "enterprise")]
     let trigger_clone = trigger.clone();
-    infra_scheduler::update_trigger(trigger).await?;
+    infra_scheduler::update_trigger(trigger, false).await?;
 
     // super cluster
     #[cfg(feature = "enterprise")]

--- a/src/super_cluster_queue/scheduler.rs
+++ b/src/super_cluster_queue/scheduler.rs
@@ -63,7 +63,8 @@ async fn push(msg: Message) -> Result<()> {
 
 async fn update(msg: Message) -> Result<()> {
     let trigger: Trigger = json::from_slice(&msg.value.unwrap())?;
-    if let Err(e) = scheduler::update_trigger(trigger.clone()).await {
+    // Update trigger in super cluster with clone = true, so that it copies everything
+    if let Err(e) = scheduler::update_trigger(trigger.clone(), true).await {
         log::error!(
             "[SUPER_CLUSTER:sync] Failed to update scheduler: {}/{:?}/{}, error: {}",
             trigger.org,

--- a/src/super_cluster_queue/scheduler.rs
+++ b/src/super_cluster_queue/scheduler.rs
@@ -13,10 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::utils::json;
+use config::{meta::triggers::Trigger, utils::json};
 use infra::{
     errors::{Error, Result},
-    scheduler::{self, Trigger},
+    scheduler,
 };
 use o2_enterprise::enterprise::super_cluster::queue::{Message, MessageType};
 
@@ -84,6 +84,12 @@ async fn update_status(msg: Message) -> Result<()> {
         &trigger.module_key,
         trigger.status,
         trigger.retries,
+        // Only update trigger data if it is not empty
+        if trigger.data.is_empty() {
+            None
+        } else {
+            Some(&trigger.data)
+        },
     )
     .await
     {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -31,10 +31,10 @@ mod tests {
                 Operator, QueryCondition, TriggerCondition,
             },
             dashboards::{v1, Dashboard},
+            triggers::Trigger,
         },
         utils::json,
     };
-    use infra::scheduler::Trigger;
     use openobserve::{
         handler::{
             grpc::{auth::check_auth, flight::FlightServiceImpl},
@@ -1737,7 +1737,7 @@ mod tests {
 
         let trigger = openobserve::service::db::scheduler::exists(
             "e2e",
-            infra::scheduler::TriggerModule::Alert,
+            config::meta::triggers::TriggerModule::Alert,
             "logs/olympics_schema/alert_multi_range",
         )
         .await;
@@ -1769,7 +1769,7 @@ mod tests {
 
         let trigger = openobserve::service::db::scheduler::exists(
             "e2e",
-            infra::scheduler::TriggerModule::Alert,
+            config::meta::triggers::TriggerModule::Alert,
             "logs/olympics_schema/alert_multi_range",
         )
         .await;
@@ -1826,7 +1826,7 @@ mod tests {
 
         let trigger = openobserve::service::db::scheduler::exists(
             "e2e",
-            infra::scheduler::TriggerModule::Alert,
+            config::meta::triggers::TriggerModule::Alert,
             "logs/olympics_schema/alertChk",
         )
         .await;
@@ -1867,14 +1867,14 @@ mod tests {
                 .unwrap();
         let trigger = Trigger {
             org: "e2e".to_string(),
-            module: infra::scheduler::TriggerModule::Alert,
+            module: config::meta::triggers::TriggerModule::Alert,
             module_key: "logs/olympics_schema/alertChk".to_string(),
             start_time: Some(now),
             end_time: Some(mins_3_later),
             next_run_at: now,
             is_realtime: false,
             is_silenced: false,
-            status: infra::scheduler::TriggerStatus::Processing,
+            status: config::meta::triggers::TriggerStatus::Processing,
             retries: 2,
             data: "{}".to_string(),
         };
@@ -1886,7 +1886,7 @@ mod tests {
 
         let trigger = openobserve::service::db::scheduler::get(
             "e2e",
-            infra::scheduler::TriggerModule::Alert,
+            config::meta::triggers::TriggerModule::Alert,
             "logs/olympics_schema/alertChk",
         )
         .await;
@@ -1904,14 +1904,14 @@ mod tests {
                 .unwrap();
         let trigger = Trigger {
             org: "e2e".to_string(),
-            module: infra::scheduler::TriggerModule::Alert,
+            module: config::meta::triggers::TriggerModule::Alert,
             module_key: "logs/olympics_schema/alertChk".to_string(),
             start_time: Some(now),
             end_time: Some(mins_3_later),
             next_run_at: now,
             is_realtime: false,
             is_silenced: false,
-            status: infra::scheduler::TriggerStatus::Processing,
+            status: config::meta::triggers::TriggerStatus::Processing,
             retries: 3,
             data: "{}".to_string(),
         };
@@ -1923,7 +1923,7 @@ mod tests {
 
         let trigger = openobserve::service::db::scheduler::get(
             "e2e",
-            infra::scheduler::TriggerModule::Alert,
+            config::meta::triggers::TriggerModule::Alert,
             "logs/olympics_schema/alertChk",
         )
         .await;
@@ -1933,29 +1933,27 @@ mod tests {
     }
 
     async fn e2e_handle_alert_after_evaluation_retries() {
-        let alert = Alert {
-            name: "test_alert_wrong_sql".to_string(),
-            stream_type: "logs".into(),
-            stream_name: "olympics_schema".to_string(),
-            is_real_time: false,
-            enabled: true,
-            query_condition: QueryCondition {
-                query_type: "sql".into(),
-                conditions: None,
-                sql: Some("SELEC country FROM \"olympics_schema\"".to_string()),
-                ..Default::default()
-            },
-            trigger_condition: TriggerCondition {
-                period: 60,
-                threshold: 1,
-                silence: 0,
-                frequency: 3600,
-                operator: Operator::GreaterThanEquals,
-                ..Default::default()
-            },
-            destinations: vec!["slack".to_string()],
+        let mut alert: Alert = Default::default();
+        alert.name = "test_alert_wrong_sql".to_string();
+        alert.stream_type = "logs".into();
+        alert.stream_name = "olympics_schema".to_string();
+        alert.is_real_time = false;
+        alert.enabled = true;
+        alert.query_condition = QueryCondition {
+            query_type: "sql".into(),
+            conditions: None,
+            sql: Some("SELEC country FROM \"olympics_schema\"".to_string()),
             ..Default::default()
         };
+        alert.trigger_condition = TriggerCondition {
+            period: 60,
+            threshold: 1,
+            silence: 0,
+            frequency: 3600,
+            operator: Operator::GreaterThanEquals,
+            ..Default::default()
+        };
+        alert.destinations = vec!["slack".to_string()];
 
         let res = openobserve::service::db::alerts::alert::set(
             "e2e",
@@ -1975,14 +1973,14 @@ mod tests {
                 .unwrap();
         let trigger = Trigger {
             org: "e2e".to_string(),
-            module: infra::scheduler::TriggerModule::Alert,
+            module: config::meta::triggers::TriggerModule::Alert,
             module_key: "logs/olympics_schema/test_alert_wrong_sql".to_string(),
             start_time: Some(now),
             end_time: Some(mins_3_later),
             next_run_at: now,
             is_realtime: false,
             is_silenced: false,
-            status: infra::scheduler::TriggerStatus::Processing,
+            status: config::meta::triggers::TriggerStatus::Processing,
             retries: 2,
             data: "{}".to_string(),
         };
@@ -1994,7 +1992,7 @@ mod tests {
 
         let trigger = openobserve::service::db::scheduler::get(
             "e2e",
-            infra::scheduler::TriggerModule::Alert,
+            config::meta::triggers::TriggerModule::Alert,
             "logs/olympics_schema/test_alert_wrong_sql",
         )
         .await;
@@ -2038,7 +2036,7 @@ mod tests {
 
         let trigger = openobserve::service::db::scheduler::exists(
             "e2e",
-            infra::scheduler::TriggerModule::Alert,
+            config::meta::triggers::TriggerModule::Alert,
             "logs/olympics_schema/alertChk",
         )
         .await;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -40,7 +40,7 @@ mod tests {
             grpc::{auth::check_auth, flight::FlightServiceImpl},
             http::router::*,
         },
-        service::{alerts::scheduler::handle_triggers, search::SEARCH_SERVER},
+        service::{alerts::scheduler::handlers::handle_triggers, search::SEARCH_SERVER},
     };
     use prost::Message;
     use proto::{cluster_rpc::search_server::SearchServer, prometheus_rpc};


### PR DESCRIPTION
- Moves the `last_satisfied_at` to scheduled_jobs table.
- Uses mpsc channels for scheduler

### The new design is -
- We spawn the same number of worker threads as the configured max concurreny env.
- After pulling jobs, it sends to each worker through the mpsc channel
- Each worker processes the received trigger
- After the scheduler interval, the puller job checks how many workers are still available i.e. how many workers are done with processing triggers.
- It only pulls the same number of jobs from db as the number of available workers at that particular time.
The cycle continues.

So, the scheduler pulls at max the "max concurrency" number of jobs at a time depending on the availability of worker threads.