### PR TITLE
fix: filter dashboard list based on dashboard:{dashboar_id}

### DIFF
--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -573,6 +573,10 @@ async fn filter_permitted_dashboards(
                 || permitted_objects
                     .as_ref()
                     .unwrap()
+                    .contains(&format!("dashboard:{dashboard_id}"))
+                || permitted_objects
+                    .as_ref()
+                    .unwrap()
                     .contains(&format!("dashboard:_all_{org_id}"))
         })
         .collect();


### PR DESCRIPTION
Apart from filtering dashboard list based on `dashboard:{folder_id}/dashboard_id` and `dashboard:_all_{org_id}`, filter with `dashboard:{dashboard_id}` as well.