### PR TITLE
feat: ws v2

### DIFF
--- a/src/handler/http/request/websocket/utils.rs
+++ b/src/handler/http/request/websocket/utils.rs
@@ -372,4 +372,8 @@ impl WsServerEvents {
             },
         }
     }
+
+    pub fn from_json(value: serde_json::Value) -> serde_json::Result<Self> {
+        serde_json::from_value(value)
+    }
 }

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -32,6 +32,7 @@ use actix_web::{
 use crate::common::{infra::cluster, utils::http::get_search_type_from_request};
 
 mod ws;
+mod ws_v2;
 
 const QUERIER_ROUTES: [&str; 20] = [
     "/config",

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use ::config::{
     get_config,
@@ -28,11 +28,24 @@ use actix_web::{
     http::{Error, Method},
     route, web,
 };
+use once_cell::sync::Lazy;
 
 use crate::common::{infra::cluster, utils::http::get_search_type_from_request};
 
 mod ws;
 mod ws_v2;
+
+// Initialize WsHandler global instance
+static WS_HANDLER: Lazy<Arc<ws_v2::WsHandler>> = Lazy::new(|| {
+    tokio::task::block_in_place(|| {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            ws_v2::init()
+                .await
+                .expect("Failed to initialize WebSocket v2 handler")
+        })
+    })
+});
 
 const QUERIER_ROUTES: [&str; 20] = [
     "/config",
@@ -195,15 +208,15 @@ async fn dispatch(
             .body(new_url.error.unwrap_or("internal server error".to_string())));
     }
 
+    // check if the request is a websocket request
+    let path_columns: Vec<&str> = path.split('/').collect();
+    if path_columns.get(3).unwrap_or(&"").starts_with("ws") {
+        return proxy_ws(req, payload, new_url, start).await;
+    }
+
     // check if the request need to be proxied by body
     if cfg.common.metrics_cache_enabled && is_querier_route_by_body(&path) {
         return proxy_querier_by_body(req, payload, client, new_url, start).await;
-    }
-
-    // check if the request is a websocket request
-    let path_columns: Vec<&str> = path.split('/').collect();
-    if *path_columns.get(3).unwrap_or(&"") == "ws" {
-        return proxy_ws(req, payload, new_url, start).await;
     }
 
     // send query
@@ -429,31 +442,72 @@ async fn proxy_ws(
 ) -> actix_web::Result<HttpResponse, Error> {
     let cfg = get_config();
     if cfg.websocket.enabled {
-        // Convert the HTTP/HTTPS URL to a WebSocket URL (WS/WSS)
-        let ws_url = match ws::convert_to_websocket_url(&new_url.full_url) {
-            Ok(url) => url,
-            Err(e) => {
-                log::error!("Error converting URL to WebSocket: {:?}", e);
-                return Ok(HttpResponse::BadRequest()
+        // Check if this is a WebSocket v2 request (e.g., contains a specific path segment or
+        // header)
+        let path = req.uri().path();
+        if path.contains("/ws_v2/") {
+            // Extract client ID from the path or query parameters
+            // Path format example: /api/{org_id}/ws_v2/{client_id}
+            let path_parts: Vec<&str> = path.split('/').collect();
+            let client_id = if path_parts.len() >= 4 {
+                // Get client ID from path
+                path_parts[path_parts.len() - 1].to_string()
+            } else {
+                // Fallback to a default or query parameter
+                req.query_string()
+                    .split('&')
+                    .find_map(|pair| {
+                        if pair.starts_with("client_id=") {
+                            Some(pair[10..].to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| "anonymous".to_string())
+            };
+
+            log::info!(
+                "[WS_V2_ROUTER] Handling WS v2 connection for client: {}, took: {} ms",
+                client_id,
+                start.elapsed().as_millis()
+            );
+
+            // Use the WebSocket v2 handler
+            match WS_HANDLER.handle_connection(req, payload, client_id).await {
+                Ok(response) => Ok(response),
+                Err(e) => {
+                    log::error!("[WS_V2_ROUTER] failed: {}", e);
+                    Ok(HttpResponse::InternalServerError().body("WebSocket v2 error"))
+                }
+            }
+        } else {
+            // Use the legacy WebSocket proxy implementation
+            // Convert the HTTP/HTTPS URL to a WebSocket URL (WS/WSS)
+            let ws_url = match ws::convert_to_websocket_url(&new_url.full_url) {
+                Ok(url) => url,
+                Err(e) => {
+                    log::error!("Error converting URL to WebSocket: {:?}", e);
+                    return Ok(HttpResponse::BadRequest()
                     .force_close()
                     .body("Invalid WebSocket URL"));
-            }
-        };
+                }
+            };
 
-        match ws::ws_proxy(req, payload, &ws_url).await {
-            Ok(res) => {
-                log::info!(
-                    "[WS_ROUTER] Successfully proxied WebSocket connection to backend: {}, took: {} ms",
-                    ws_url,
-                    start.elapsed().as_millis()
-                );
-                Ok(res)
-            }
-            Err(e) => {
-                log::error!("[WS_ROUTER] failed: {:?}", e);
-                Ok(HttpResponse::InternalServerError()
+            match ws::ws_proxy(req, payload, &ws_url).await {
+                Ok(res) => {
+                    log::info!(
+                            "[WS_ROUTER] Successfully proxied WebSocket connection to backend: {}, took: {} ms",
+                            ws_url,
+                            start.elapsed().as_millis()
+                        );
+                    Ok(res)
+                }
+                Err(e) => {
+                    log::error!("[WS_ROUTER] failed: {:?}", e);
+                    Ok(HttpResponse::InternalServerError()
                     .force_close()
                     .body("WebSocket proxy error"))
+                }
             }
         }
     } else {

--- a/src/router/http/ws_v2/config.rs
+++ b/src/router/http/ws_v2/config.rs
@@ -1,0 +1,57 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WsConfig {
+    pub pool_size: usize,
+    pub connection_timeout_secs: u64,
+    pub max_connections_per_querier: usize,
+    pub retry_config: RetryConfig,
+    pub circuit_breaker_config: CircuitBreakerConfig,
+    pub health_check_config: HealthCheckConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RetryConfig {
+    pub max_retries: u32,
+    pub initial_retry_delay_ms: u64,
+    pub max_retry_delay_ms: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CircuitBreakerConfig {
+    pub failure_threshold: u32,
+    pub reset_timeout_secs: u64,
+    pub half_open_timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HealthCheckConfig {
+    pub interval_secs: u64,
+    pub timeout_secs: u64,
+}
+
+impl Default for WsConfig {
+    fn default() -> Self {
+        Self {
+            pool_size: 100,
+            connection_timeout_secs: 30,
+            max_connections_per_querier: 10,
+            retry_config: RetryConfig {
+                max_retries: 3,
+                initial_retry_delay_ms: 100,
+                max_retry_delay_ms: 5000,
+            },
+            circuit_breaker_config: CircuitBreakerConfig {
+                failure_threshold: 5,
+                reset_timeout_secs: 60,
+                half_open_timeout_secs: 30,
+            },
+            health_check_config: HealthCheckConfig {
+                interval_secs: 15,
+                timeout_secs: 5,
+            },
+        }
+    }
+}

--- a/src/router/http/ws_v2/connection.rs
+++ b/src/router/http/ws_v2/connection.rs
@@ -17,20 +17,20 @@ pub trait Connection: Send + Sync {
     async fn disconnect(&self) -> WsResult<()>;
     async fn send_message(&self, message: Message) -> WsResult<()>;
     async fn is_connected(&self) -> bool;
-    fn get_id(&self) -> &QuerierId;
+    fn get_name(&self) -> &QuerierName;
 }
 
 pub struct QuerierConnection {
-    id: QuerierId,
+    name: QuerierName,
     stream: Arc<Mutex<Option<WsStreamType>>>,
     url: String,
     last_active: std::sync::atomic::AtomicI64,
 }
 
 impl QuerierConnection {
-    pub async fn new(id: QuerierId, url: String) -> WsResult<Self> {
+    pub async fn new(name: QuerierName, url: String) -> WsResult<Self> {
         let conn = Self {
-            id,
+            name,
             stream: Arc::new(Mutex::new(None)),
             url,
             last_active: std::sync::atomic::AtomicI64::new(chrono::Utc::now().timestamp_micros()),
@@ -95,8 +95,8 @@ impl Connection for QuerierConnection {
         stream_guard.is_some()
     }
 
-    fn get_id(&self) -> &QuerierId {
-        &self.id
+    fn get_name(&self) -> &QuerierName {
+        &self.name
     }
 }
 

--- a/src/router/http/ws_v2/connection.rs
+++ b/src/router/http/ws_v2/connection.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use tokio::{net::TcpStream, sync::Mutex};
+use tokio_tungstenite::{
+    connect_async, tungstenite::protocol::Message as WsMessage, MaybeTlsStream, WebSocketStream,
+};
+
+use crate::router::http::ws_v2::{error::*, types::*};
+
+type WsStreamType = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+#[async_trait]
+pub trait Connection: Send + Sync {
+    async fn connect(&self) -> WsResult<()>;
+    async fn disconnect(&self) -> WsResult<()>;
+    async fn send_message(&self, message: Message) -> WsResult<()>;
+    async fn is_connected(&self) -> bool;
+    fn get_id(&self) -> &QuerierId;
+}
+
+pub struct QuerierConnection {
+    id: QuerierId,
+    stream: Arc<Mutex<Option<WsStreamType>>>,
+    url: String,
+    last_active: std::sync::atomic::AtomicI64,
+}
+
+impl QuerierConnection {
+    pub async fn new(id: QuerierId, url: String) -> WsResult<Self> {
+        let conn = Self {
+            id,
+            stream: Arc::new(Mutex::new(None)),
+            url,
+            last_active: std::sync::atomic::AtomicI64::new(chrono::Utc::now().timestamp_micros()),
+        };
+        conn.connect().await?;
+        Ok(conn)
+    }
+
+    fn update_last_active(&self) {
+        self.last_active.store(
+            chrono::Utc::now().timestamp_micros(),
+            std::sync::atomic::Ordering::SeqCst,
+        );
+    }
+}
+
+#[async_trait]
+impl Connection for QuerierConnection {
+    async fn connect(&self) -> WsResult<()> {
+        let mut stream_guard = self.stream.lock().await;
+        if stream_guard.is_none() {
+            let (ws_stream, _) = connect_async(&self.url)
+                .await
+                .map_err(|e| WsError::ConnectionError(e.to_string()))?;
+            *stream_guard = Some(ws_stream);
+        }
+        Ok(())
+    }
+
+    async fn disconnect(&self) -> WsResult<()> {
+        let mut stream_guard = self.stream.lock().await;
+        if let Some(stream) = stream_guard.as_mut() {
+            stream
+                .close(None)
+                .await
+                .map_err(|e| WsError::ConnectionError(e.to_string()))?;
+            *stream_guard = None;
+        }
+        Ok(())
+    }
+
+    async fn send_message(&self, message: Message) -> WsResult<()> {
+        let mut stream_guard = self.stream.lock().await;
+        if let Some(stream) = stream_guard.as_mut() {
+            let ws_message = WsMessage::Text(
+                serde_json::to_string(&message)
+                    .map_err(|e| WsError::MessageError(e.to_string()))?,
+            );
+            stream
+                .send(ws_message)
+                .await
+                .map_err(|e| WsError::MessageError(e.to_string()))?;
+            self.update_last_active();
+            Ok(())
+        } else {
+            Err(WsError::ConnectionError("Not connected".into()))
+        }
+    }
+
+    async fn is_connected(&self) -> bool {
+        let stream_guard = self.stream.lock().await;
+        stream_guard.is_some()
+    }
+
+    fn get_id(&self) -> &QuerierId {
+        &self.id
+    }
+}
+
+impl QuerierConnection {
+    pub async fn receive_message(&self) -> WsResult<Option<Message>> {
+        let mut stream_guard = self.stream.lock().await;
+        if let Some(stream) = stream_guard.as_mut() {
+            match stream.next().await {
+                Some(Ok(WsMessage::Text(text))) => serde_json::from_str(&text)
+                    .map(Some)
+                    .map_err(|e| WsError::MessageError(e.to_string())),
+                Some(Ok(WsMessage::Close(_))) => Ok(None),
+                Some(Err(e)) => Err(WsError::MessageError(e.to_string())),
+                _ => Ok(None),
+            }
+        } else {
+            Err(WsError::ConnectionError("Not connected".into()))
+        }
+    }
+}

--- a/src/router/http/ws_v2/error.rs
+++ b/src/router/http/ws_v2/error.rs
@@ -1,0 +1,42 @@
+use actix_web::{error::ResponseError, http::StatusCode};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum WsError {
+    #[error("Connection error: {0}")]
+    ConnectionError(String),
+
+    #[error("Session error: {0}")]
+    SessionError(String),
+
+    #[error("Message error: {0}")]
+    MessageError(String),
+
+    #[error("Querier not available: {0}")]
+    QuerierNotAvailable(String),
+
+    #[error("Circuit breaker open for querier: {0}")]
+    CircuitBreakerOpen(String),
+
+    #[error("Timeout error: {0}")]
+    Timeout(String),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl ResponseError for WsError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            WsError::ConnectionError(_) => StatusCode::SERVICE_UNAVAILABLE,
+            WsError::SessionError(_) => StatusCode::BAD_REQUEST,
+            WsError::MessageError(_) => StatusCode::BAD_REQUEST,
+            WsError::QuerierNotAvailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+            WsError::CircuitBreakerOpen(_) => StatusCode::SERVICE_UNAVAILABLE,
+            WsError::Timeout(_) => StatusCode::REQUEST_TIMEOUT,
+            WsError::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+pub type WsResult<T> = Result<T, WsError>;

--- a/src/router/http/ws_v2/error.rs
+++ b/src/router/http/ws_v2/error.rs
@@ -9,6 +9,9 @@ pub enum WsError {
     #[error("Session error: {0}")]
     SessionError(String),
 
+    #[error("Session not found: {0}")]
+    SessionNotFound(String),
+
     #[error("Message error: {0}")]
     MessageError(String),
 
@@ -30,6 +33,7 @@ impl ResponseError for WsError {
         match self {
             WsError::ConnectionError(_) => StatusCode::SERVICE_UNAVAILABLE,
             WsError::SessionError(_) => StatusCode::BAD_REQUEST,
+            WsError::SessionNotFound(_) => StatusCode::BAD_REQUEST,
             WsError::MessageError(_) => StatusCode::BAD_REQUEST,
             WsError::QuerierNotAvailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             WsError::CircuitBreakerOpen(_) => StatusCode::SERVICE_UNAVAILABLE,

--- a/src/router/http/ws_v2/handler.rs
+++ b/src/router/http/ws_v2/handler.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use actix_web::{web, Error, HttpRequest, HttpResponse};
+use futures_util::StreamExt;
+use serde_json::json;
+
+use super::{error::*, message::*, session::*, types::*};
+
+pub struct WsHandler {
+    session_manager: Arc<RouterSessionManager>,
+    message_bus: Arc<RouterMessageBus>,
+}
+
+impl WsHandler {
+    pub fn new(
+        session_manager: Arc<RouterSessionManager>,
+        message_bus: Arc<RouterMessageBus>,
+    ) -> Self {
+        Self {
+            session_manager,
+            message_bus,
+        }
+    }
+
+    pub async fn handle_connection(
+        &self,
+        req: HttpRequest,
+        stream: web::Payload,
+        client_id: ClientId,
+    ) -> Result<HttpResponse, Error> {
+        let (response, ws_session, mut msg_stream) = actix_ws::handle(&req, stream)?;
+
+        // Create session
+        let session_info = self
+            .session_manager
+            .create_session(client_id)
+            .await
+            .map_err(Error::from)?;
+
+        // Setup message channel
+        let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+        self.message_bus
+            .register_client(session_info.session_id.clone(), tx)
+            .await
+            .map_err(Error::from)?;
+
+        let session_id = session_info.session_id.clone();
+        let message_bus = self.message_bus.clone();
+
+        // Spawn message handling tasks
+        actix_web::rt::spawn(async move {
+            let mut ws_session = ws_session;
+
+            // Handle incoming messages
+            let handle_incoming = async {
+                while let Some(msg) = msg_stream.next().await {
+                    match msg {
+                        Ok(actix_ws::Message::Text(text)) => {
+                            if let Ok(message) = serde_json::from_str::<Message>(&text) {
+                                if let Err(e) =
+                                    message_bus.forward_to_querier(&session_id, message).await
+                                {
+                                    log::error!("Error forwarding message: {}", e);
+                                }
+                            }
+                        }
+                        Ok(actix_ws::Message::Close(_)) => break,
+                        _ => {}
+                    }
+                }
+            };
+
+            // Handle outgoing messages
+            let handle_outgoing = async {
+                while let Some(message) = rx.recv().await {
+                    if let Err(e) = ws_session.text(serde_json::to_string(&message)?).await {
+                        log::error!("Error sending message to client: {}", e);
+                        break;
+                    }
+                }
+                Ok::<_, Error>(())
+            };
+
+            // Run both tasks concurrently
+            let _ = tokio::join!(handle_incoming, handle_outgoing);
+
+            // Cleanup
+            message_bus.unregister_client(&session_id).await.ok();
+        });
+
+        Ok(response)
+    }
+
+    pub async fn shutdown(&self) -> WsResult<()> {
+        for client in self.message_bus.get_all_clients().await {
+            let message = Message::new(
+                "system".into(),
+                MessageType::Error,
+                json!({ "error": "Server shutting down" }),
+            );
+            let _ = self.message_bus.forward_to_client(&client, message).await;
+        }
+        self.message_bus.close_all().await
+    }
+}

--- a/src/router/http/ws_v2/handler.rs
+++ b/src/router/http/ws_v2/handler.rs
@@ -7,11 +7,11 @@ use serde_json::json;
 use super::{error::*, message::*, types::*};
 
 pub struct WsHandler {
-    message_bus: Arc<RouterMessageBus>,
+    message_bus: Arc<RouterWsManager>,
 }
 
 impl WsHandler {
-    pub fn new(message_bus: Arc<RouterMessageBus>) -> Self {
+    pub fn new(message_bus: Arc<RouterWsManager>) -> Self {
         Self { message_bus }
     }
 
@@ -56,6 +56,8 @@ impl WsHandler {
                                 {
                                     log::error!("Error forwarding message: {}", e);
                                 }
+                            } else {
+                                log::error!("Invalid message: {}", text);
                             }
                         }
                         Ok(actix_ws::Message::Close(_)) => break,

--- a/src/router/http/ws_v2/message.rs
+++ b/src/router/http/ws_v2/message.rs
@@ -38,6 +38,18 @@ impl RouterMessageBus {
         Ok(())
     }
 
+    pub async fn start(&self) {
+        // needs 2 tasks
+
+        // 'stream' from connect_async -> split to sink, stream
+        // sink forward_to_querier
+        
+        
+        // backward to router
+        // stream listens from querier
+        
+    }
+
     pub async fn forward_to_querier(
         &self,
         session_id: &SessionId,

--- a/src/router/http/ws_v2/message.rs
+++ b/src/router/http/ws_v2/message.rs
@@ -1,0 +1,131 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::sync::mpsc;
+
+use super::{connection::Connection, error::*, pool::*, session::*, types::*};
+
+pub struct RouterMessageBus {
+    session_manager: Arc<RouterSessionManager>,
+    connection_pool: Arc<QuerierConnectionPool>,
+    client_channels: DashMap<SessionId, mpsc::Sender<Message>>,
+}
+
+impl RouterMessageBus {
+    pub fn new(
+        session_manager: Arc<RouterSessionManager>,
+        connection_pool: Arc<QuerierConnectionPool>,
+    ) -> Self {
+        Self {
+            session_manager,
+            connection_pool,
+            client_channels: DashMap::new(),
+        }
+    }
+
+    pub async fn register_client(
+        &self,
+        session_id: SessionId,
+        sender: mpsc::Sender<Message>,
+    ) -> WsResult<()> {
+        self.client_channels.insert(session_id, sender);
+        Ok(())
+    }
+
+    pub async fn unregister_client(&self, session_id: &SessionId) -> WsResult<()> {
+        self.client_channels.remove(session_id);
+        Ok(())
+    }
+
+    pub async fn forward_to_querier(
+        &self,
+        session_id: &SessionId,
+        message: Message,
+    ) -> WsResult<()> {
+        let start = std::time::Instant::now();
+
+        // Get session info
+        let _session = self
+            .session_manager
+            .get_session(session_id)
+            .await
+            .ok_or_else(|| WsError::SessionError("Session not found".into()))?;
+
+        // Get or assign querier for this trace
+        let querier_id = if let Some(querier_id) = self
+            .session_manager
+            .get_querier_for_trace(&message.trace_id)
+            .await
+        {
+            querier_id
+        } else {
+            // Use consistent hashing to select querier
+            let querier_id = self.select_querier(&message.trace_id).await?;
+            self.session_manager
+                .set_querier_for_trace(message.trace_id.clone(), querier_id.clone())
+                .await?;
+            querier_id
+        };
+
+        // Get connection to querier
+        let conn = self.connection_pool.get_connection(&querier_id).await?;
+
+        // Send message
+        conn.send_message(message).await?;
+
+        Ok(())
+    }
+
+    pub async fn forward_to_client(
+        &self,
+        session_id: &SessionId,
+        message: Message,
+    ) -> WsResult<()> {
+        let start = std::time::Instant::now();
+
+        if let Some(sender) = self.client_channels.get(session_id) {
+            sender
+                .send(message)
+                .await
+                .map_err(|e| WsError::MessageError(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    async fn select_querier(&self, trace_id: &str) -> WsResult<QuerierId> {
+        use crate::common::infra::cluster;
+
+        // Get online querier nodes
+        let _nodes = cluster::get_cached_online_querier_nodes(Some(
+            config::meta::cluster::RoleGroup::Interactive,
+        ))
+        .await
+        .ok_or_else(|| WsError::QuerierNotAvailable("No queriers available".into()))?;
+
+        // Use consistent hashing to select querier
+        let node = cluster::get_node_from_consistent_hash(
+            trace_id,
+            &config::meta::cluster::Role::Querier,
+            None,
+        )
+        .await
+        .ok_or_else(|| WsError::QuerierNotAvailable("Failed to select querier".into()))?;
+
+        Ok(node)
+    }
+
+    pub async fn get_all_clients(&self) -> Vec<SessionId> {
+        self.client_channels
+            .iter()
+            .map(|r| r.key().clone())
+            .collect()
+    }
+
+    pub async fn close_all(&self) -> WsResult<()> {
+        for client in self.client_channels.iter() {
+            let _ = self.unregister_client(client.key()).await;
+        }
+        Ok(())
+    }
+}

--- a/src/router/http/ws_v2/mod.rs
+++ b/src/router/http/ws_v2/mod.rs
@@ -6,13 +6,14 @@ mod message;
 mod pool;
 mod session;
 mod types;
+mod utils;
 
 use std::sync::Arc;
 
 pub use config::WsConfig;
 pub use error::WsResult;
 pub use handler::WsHandler;
-pub use message::RouterMessageBus;
+pub use message::RouterWsManager;
 pub use pool::QuerierConnectionPool;
 pub use session::RouterSessionManager;
 
@@ -21,7 +22,7 @@ pub async fn init() -> WsResult<Arc<WsHandler>> {
     let session_manager = Arc::new(RouterSessionManager::new());
     let connection_pool = Arc::new(QuerierConnectionPool::new(config.clone()));
 
-    let message_bus = Arc::new(RouterMessageBus::new(
+    let message_bus = Arc::new(RouterWsManager::new(
         session_manager,
         connection_pool.clone(),
     ));

--- a/src/router/http/ws_v2/mod.rs
+++ b/src/router/http/ws_v2/mod.rs
@@ -1,0 +1,38 @@
+mod config;
+mod connection;
+mod error;
+mod handler;
+mod message;
+mod pool;
+mod session;
+mod types;
+
+use std::sync::Arc;
+
+pub use config::WsConfig;
+pub use error::WsResult;
+pub use handler::WsHandler;
+pub use message::RouterMessageBus;
+pub use pool::QuerierConnectionPool;
+pub use session::RouterSessionManager;
+
+pub async fn init() -> WsResult<Arc<WsHandler>> {
+    let config = WsConfig::default();
+    let session_manager = Arc::new(RouterSessionManager::new());
+    let connection_pool = Arc::new(QuerierConnectionPool::new(config.clone()));
+
+    let message_bus = Arc::new(RouterMessageBus::new(
+        session_manager.clone(),
+        connection_pool.clone(),
+    ));
+
+    let handler = Arc::new(WsHandler::new(session_manager, message_bus));
+
+    // Start connection maintenance task
+    let pool = connection_pool.clone();
+    tokio::spawn(async move {
+        pool.maintain_connections().await;
+    });
+
+    Ok(handler)
+}

--- a/src/router/http/ws_v2/mod.rs
+++ b/src/router/http/ws_v2/mod.rs
@@ -22,16 +22,15 @@ pub async fn init() -> WsResult<Arc<WsHandler>> {
     let connection_pool = Arc::new(QuerierConnectionPool::new(config.clone()));
 
     let message_bus = Arc::new(RouterMessageBus::new(
-        session_manager.clone(),
+        session_manager,
         connection_pool.clone(),
     ));
 
-    let handler = Arc::new(WsHandler::new(session_manager, message_bus));
+    let handler = Arc::new(WsHandler::new(message_bus));
 
     // Start connection maintenance task
-    let pool = connection_pool.clone();
     tokio::spawn(async move {
-        pool.maintain_connections().await;
+        connection_pool.maintain_connections().await;
     });
 
     Ok(handler)

--- a/src/router/http/ws_v2/pool.rs
+++ b/src/router/http/ws_v2/pool.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::sync::Mutex;
+
+use super::{
+    config::*,
+    connection::{Connection, QuerierConnection},
+    error::*,
+    types::*,
+};
+use crate::common::infra::cluster;
+
+pub struct QuerierConnectionPool {
+    connections: DashMap<QuerierId, Arc<QuerierConnection>>,
+    config: WsConfig,
+}
+
+impl QuerierConnectionPool {
+    pub fn new(config: WsConfig) -> Self {
+        Self {
+            connections: DashMap::new(),
+            config,
+        }
+    }
+
+    pub async fn get_connection(&self, querier_id: &QuerierId) -> WsResult<Arc<QuerierConnection>> {
+        if let Some(conn) = self.connections.get(querier_id) {
+            return Ok(conn.clone());
+        }
+
+        // Create new connection
+        let conn = self.create_connection(querier_id).await?;
+        self.connections.insert(querier_id.clone(), conn.clone());
+        Ok(conn)
+    }
+
+    async fn create_connection(&self, querier_id: &QuerierId) -> WsResult<Arc<QuerierConnection>> {
+        // Get querier info from cluster
+        let node = cluster::get_cached_node_by_name(querier_id)
+            .await
+            .ok_or_else(|| WsError::QuerierNotAvailable(querier_id.clone()))?;
+
+        // Convert HTTP URL to WebSocket URL
+        let ws_url = crate::router::http::ws::convert_to_websocket_url(&node.http_addr)
+            .map_err(|e| WsError::ConnectionError(e))?;
+
+        let conn = QuerierConnection::new(querier_id.clone(), ws_url).await?;
+        Ok(Arc::new(conn))
+    }
+
+    pub async fn remove_connection(&self, querier_id: &QuerierId) -> WsResult<()> {
+        if let Some((_, conn)) = self.connections.remove(querier_id) {
+            conn.disconnect().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn maintain_connections(&self) {
+        loop {
+            for conn_ref in self.connections.iter() {
+                let conn = conn_ref.value();
+                if !conn.is_connected().await {
+                    if let Err(e) = conn.connect().await {
+                        log::error!("Failed to reconnect to querier {}: {}", conn.get_id(), e);
+                    }
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(
+                self.config.health_check_config.interval_secs,
+            ))
+            .await;
+        }
+    }
+}

--- a/src/router/http/ws_v2/pool.rs
+++ b/src/router/http/ws_v2/pool.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use actix_web::rt;
 use dashmap::DashMap;
 use tokio::sync::Mutex;
 
@@ -12,8 +13,8 @@ use super::{
 use crate::common::infra::cluster;
 
 pub struct QuerierConnectionPool {
-    connections: DashMap<QuerierName, Arc<QuerierConnection>>,
-    config: WsConfig,
+    pub connections: DashMap<QuerierName, Arc<QuerierConnection>>,
+    pub config: WsConfig,
 }
 
 impl QuerierConnectionPool {

--- a/src/router/http/ws_v2/pool.rs
+++ b/src/router/http/ws_v2/pool.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::common::infra::cluster;
 
 pub struct QuerierConnectionPool {
-    connections: DashMap<QuerierId, Arc<QuerierConnection>>,
+    connections: DashMap<QuerierName, Arc<QuerierConnection>>,
     config: WsConfig,
 }
 
@@ -24,33 +24,39 @@ impl QuerierConnectionPool {
         }
     }
 
-    pub async fn get_connection(&self, querier_id: &QuerierId) -> WsResult<Arc<QuerierConnection>> {
-        if let Some(conn) = self.connections.get(querier_id) {
+    pub async fn get_connection(
+        &self,
+        querier_name: &QuerierName,
+    ) -> WsResult<Arc<QuerierConnection>> {
+        if let Some(conn) = self.connections.get(querier_name) {
             return Ok(conn.clone());
         }
 
         // Create new connection
-        let conn = self.create_connection(querier_id).await?;
-        self.connections.insert(querier_id.clone(), conn.clone());
+        let conn = self.create_connection(querier_name).await?;
+        self.connections.insert(querier_name.clone(), conn.clone());
         Ok(conn)
     }
 
-    async fn create_connection(&self, querier_id: &QuerierId) -> WsResult<Arc<QuerierConnection>> {
+    async fn create_connection(
+        &self,
+        querier_name: &QuerierName,
+    ) -> WsResult<Arc<QuerierConnection>> {
         // Get querier info from cluster
-        let node = cluster::get_cached_node_by_name(querier_id)
+        let node = cluster::get_cached_node_by_name(querier_name)
             .await
-            .ok_or_else(|| WsError::QuerierNotAvailable(querier_id.clone()))?;
+            .ok_or_else(|| WsError::QuerierNotAvailable(querier_name.clone()))?;
 
         // Convert HTTP URL to WebSocket URL
         let ws_url = crate::router::http::ws::convert_to_websocket_url(&node.http_addr)
             .map_err(|e| WsError::ConnectionError(e))?;
 
-        let conn = QuerierConnection::new(querier_id.clone(), ws_url).await?;
+        let conn = QuerierConnection::new(querier_name.clone(), ws_url).await?;
         Ok(Arc::new(conn))
     }
 
-    pub async fn remove_connection(&self, querier_id: &QuerierId) -> WsResult<()> {
-        if let Some((_, conn)) = self.connections.remove(querier_id) {
+    pub async fn remove_connection(&self, querier_name: &QuerierName) -> WsResult<()> {
+        if let Some((_, conn)) = self.connections.remove(querier_name) {
             conn.disconnect().await?;
         }
         Ok(())
@@ -58,14 +64,27 @@ impl QuerierConnectionPool {
 
     pub async fn maintain_connections(&self) {
         loop {
+            let mut to_remove = Vec::new();
+
             for conn_ref in self.connections.iter() {
+                let querier_name = conn_ref.key().clone();
                 let conn = conn_ref.value();
+
                 if !conn.is_connected().await {
+                    // Try to reconnect
                     if let Err(e) = conn.connect().await {
-                        log::error!("Failed to reconnect to querier {}: {}", conn.get_id(), e);
+                        log::error!("Failed to reconnect to querier {}: {}", conn.get_name(), e);
+                        to_remove.push(querier_name);
                     }
                 }
             }
+
+            // Remove connections that failed to reconnect
+            for querier in to_remove {
+                log::warn!("Removing disconnected connection to querier: {}", querier);
+                self.connections.remove(&querier);
+            }
+
             tokio::time::sleep(std::time::Duration::from_secs(
                 self.config.health_check_config.interval_secs,
             ))

--- a/src/router/http/ws_v2/session.rs
+++ b/src/router/http/ws_v2/session.rs
@@ -1,0 +1,85 @@
+use std::collections::HashSet;
+
+use dashmap::DashMap;
+use sea_orm::prelude::Uuid;
+
+use super::{error::*, types::*};
+
+pub struct RouterSessionManager {
+    sessions: DashMap<SessionId, SessionInfo>,
+    client_sessions: DashMap<ClientId, HashSet<SessionId>>,
+    querier_mappings: DashMap<TraceId, QuerierId>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionInfo {
+    pub session_id: SessionId,
+    pub client_id: ClientId,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub last_active: chrono::DateTime<chrono::Utc>,
+}
+
+impl RouterSessionManager {
+    pub fn new() -> Self {
+        Self {
+            sessions: DashMap::new(),
+            client_sessions: DashMap::new(),
+            querier_mappings: DashMap::new(),
+        }
+    }
+
+    pub async fn create_session(&self, client_id: ClientId) -> WsResult<SessionInfo> {
+        let session_id = Uuid::new_v4().to_string();
+        let now = chrono::Utc::now();
+
+        let session_info = SessionInfo {
+            session_id: session_id.clone(),
+            client_id: client_id.clone(),
+            created_at: now,
+            last_active: now,
+        };
+
+        self.sessions
+            .insert(session_id.clone(), session_info.clone());
+
+        self.client_sessions
+            .entry(client_id)
+            .or_insert_with(HashSet::new)
+            .insert(session_id);
+
+        Ok(session_info)
+    }
+
+    pub async fn get_session(&self, session_id: &SessionId) -> Option<SessionInfo> {
+        self.sessions.get(session_id).map(|s| s.clone())
+    }
+
+    pub async fn update_session_activity(&self, session_id: &SessionId) -> WsResult<()> {
+        if let Some(mut session) = self.sessions.get_mut(session_id) {
+            session.last_active = chrono::Utc::now();
+        }
+        Ok(())
+    }
+
+    pub async fn remove_session(&self, session_id: &SessionId) -> WsResult<()> {
+        if let Some((_, session)) = self.sessions.remove(session_id) {
+            if let Some(mut client_sessions) = self.client_sessions.get_mut(&session.client_id) {
+                client_sessions.remove(session_id);
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn set_querier_for_trace(
+        &self,
+        trace_id: TraceId,
+        querier_id: QuerierId,
+    ) -> WsResult<()> {
+        self.querier_mappings.insert(trace_id, querier_id);
+        Ok(())
+    }
+
+    pub async fn get_querier_for_trace(&self, trace_id: &TraceId) -> Option<QuerierId> {
+        self.querier_mappings.get(trace_id).map(|q| q.clone())
+    }
+}

--- a/src/router/http/ws_v2/session.rs
+++ b/src/router/http/ws_v2/session.rs
@@ -56,7 +56,7 @@ impl RouterSessionManager {
 
     pub async fn update_session_activity(&self, session_id: &SessionId) -> WsResult<()> {
         if let Some(mut session) = self.sessions.get_mut(session_id) {
-            session.last_active = chrono::Utc::now();
+            session.last_active = chrono::Utc::timestamp_micros();
         }
         Ok(())
     }

--- a/src/router/http/ws_v2/types.rs
+++ b/src/router/http/ws_v2/types.rs
@@ -1,0 +1,106 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::handler::http::request::websocket::utils::{TimeOffset, WsClientEvents, WsServerEvents};
+
+pub type SessionId = String;
+pub type ClientId = String;
+pub type QuerierId = String;
+pub type TraceId = String;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub trace_id: String,
+    pub message_type: MessageType,
+    pub payload: serde_json::Value,
+    #[serde(skip)]
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageType {
+    Search,
+    SearchResponse,
+    #[cfg(feature = "enterprise")]
+    Cancel,
+    #[cfg(feature = "enterprise")]
+    CancelResponse,
+    Error,
+    End,
+    Benchmark,
+}
+
+impl Message {
+    pub fn new(trace_id: String, message_type: MessageType, payload: serde_json::Value) -> Self {
+        Self {
+            trace_id,
+            message_type,
+            payload,
+            timestamp: Utc::now(),
+        }
+    }
+
+    pub fn from_client_event(event: WsClientEvents) -> Self {
+        match event {
+            WsClientEvents::Search(req) => {
+                let trace_id = req.trace_id.clone();
+                Self::new(
+                    trace_id,
+                    MessageType::Search,
+                    serde_json::to_value(&req).unwrap_or_default(),
+                )
+            }
+            #[cfg(feature = "enterprise")]
+            WsClientEvents::Cancel { trace_id } => Self::new(
+                trace_id.clone(),
+                MessageType::Cancel,
+                serde_json::json!({"trace_id": trace_id}),
+            ),
+            WsClientEvents::Benchmark { id } => Self::new(
+                id.clone(),
+                MessageType::Benchmark,
+                serde_json::json!({"id": id}),
+            ),
+        }
+    }
+
+    pub fn to_server_event(&self) -> Option<WsServerEvents> {
+        match self.message_type {
+            MessageType::SearchResponse => {
+                let response: Box<config::meta::search::Response> =
+                    serde_json::from_value(self.payload.clone()).ok()?;
+                Some(WsServerEvents::SearchResponse {
+                    trace_id: self.trace_id.clone(),
+                    results: response,
+                    time_offset: TimeOffset {
+                        start_time: 0,
+                        end_time: 0,
+                    },
+                    streaming_aggs: false,
+                })
+            }
+            MessageType::Error => {
+                let error: ErrorPayload = serde_json::from_value(self.payload.clone()).ok()?;
+                Some(WsServerEvents::Error {
+                    code: error.code,
+                    message: error.message,
+                    error_detail: error.error_detail,
+                    trace_id: Some(self.trace_id.clone()),
+                    request_id: None,
+                })
+            }
+            MessageType::End => Some(WsServerEvents::End {
+                trace_id: Some(self.trace_id.clone()),
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ErrorPayload {
+    code: u16,
+    message: String,
+    error_detail: Option<String>,
+}

--- a/src/router/http/ws_v2/utils.rs
+++ b/src/router/http/ws_v2/utils.rs
@@ -1,0 +1,98 @@
+use actix_ws::Message;
+use tokio_tungstenite::tungstenite;
+
+/// Convert tungstenite WebSocket message to actix-web message format
+pub fn from_tungstenite_msg_to_actix_msg(msg: tungstenite::protocol::Message) -> Message {
+    match msg {
+        tungstenite::protocol::Message::Text(text) => {
+            log_frame_details("Converting Text ->", &text, false);
+            Message::Text(text.into())
+        }
+        tungstenite::protocol::Message::Binary(bin) => Message::Binary(bin.into()),
+        tungstenite::protocol::Message::Ping(msg) => Message::Ping(msg.into()),
+        tungstenite::protocol::Message::Pong(msg) => Message::Pong(msg.into()),
+        tungstenite::protocol::Message::Close(reason) => {
+            if let Some(r) = &reason {
+                log_frame_details("Converting Close ->", &r.reason, true);
+            }
+            Message::Close(reason.map(|r| actix_ws::CloseReason {
+                code: u16::from(r.code).into(),
+                description: if r.reason.is_empty() {
+                    None
+                } else {
+                    Some(r.reason.to_string())
+                },
+            }))
+        }
+        _ => {
+            log::info!("[WS_PROXY] Unsupported message type {:?}", msg);
+            Message::Close(None)
+        }
+    }
+}
+
+/// Convert actix-web WebSocket message to tungstenite message format
+pub fn from_actix_message(msg: Message) -> tungstenite::protocol::Message {
+    match msg {
+        Message::Text(text) => tungstenite::protocol::Message::Text(text.to_string()),
+        Message::Binary(bin) => tungstenite::protocol::Message::Binary(bin.to_vec()),
+        Message::Ping(msg) => tungstenite::protocol::Message::Ping(msg.to_vec()),
+        Message::Pong(msg) => tungstenite::protocol::Message::Pong(msg.to_vec()),
+        Message::Close(reason) => {
+            log::info!(
+                "[WS_PROXY] Received a Message::Close with reason: {:#?}, closing connection to proxied server",
+                reason
+            );
+            tungstenite::protocol::Message::Close(reason.map(|r| {
+                tungstenite::protocol::CloseFrame {
+                    code: u16::from(r.code).into(),
+                    reason: r.description.unwrap_or_default().into(),
+                }
+            }))
+        }
+        _ => {
+            log::info!("[WS_PROXY] Unsupported message type {:?}", msg);
+            tungstenite::protocol::Message::Close(None)
+        }
+    }
+}
+
+/// Add this helper function
+pub fn log_frame_details(prefix: &str, text: &str, is_close: bool) {
+    // 7b is '{' in JSON
+    log::debug!(
+        "[WS_FRAME] {} Length: {}, First 50 bytes: {}, Is close: {}",
+        prefix,
+        text.len(),
+        hex::encode(&text.as_bytes()[..std::cmp::min(50, text.len())]),
+        is_close
+    );
+}
+
+// Add helper function to debug frame details
+pub fn debug_ws_message(prefix: &str, msg: &Message) {
+    match msg {
+        Message::Text(text) => {
+            log::debug!(
+                "[WS_PROXY] {} Text frame: len={}, content_start='{}'",
+                prefix,
+                text.len(),
+                &text[..text.len().min(50)]
+            );
+        }
+        Message::Close(reason) => {
+            if let Some(r) = reason {
+                log::debug!(
+                    "[WS_PROXY] {} Close frame: code={:?}, desc={:?}, desc_len={}",
+                    prefix,
+                    r.code,
+                    r.description,
+                    r.description.as_ref().map(|d| d.len()).unwrap_or(0)
+                );
+            } else {
+                log::debug!("[WS_PROXY] {} Close frame: no reason", prefix);
+            }
+        }
+        _ => log::debug!("[WS_PROXY] {} Other frame type: {:?}", prefix, msg),
+    }
+}


### PR DESCRIPTION
This pr was recreated based on #6105 created by @Loaki07, since we wanted to work to be based off of `main`

Websockets v2 Message Flow:


```mermaid
graph TB
		title[OpenObserve WebSocket v2 Message Flow]
    style title fill:none,stroke:none
    
    subgraph "Client Layer"
        C[Client WebSocket]
        style C fill:grey,stroke:#333
    end

    subgraph "Router Layer (ws_v2)"
        RT[WsHandler]
        RM[RouterMessageBus]
        SM[RouterSessionManager]
        QP[QuerierConnectionPool]
        
        subgraph "Connection Management"
            QC[QuerierConnection]
        end

        style RT fill:grey,stroke:#333
        style RM fill:grey,stroke:#333
        style SM fill:grey,stroke:#333
        style QP fill:grey,stroke:#333
        style QC fill:grey,stroke:#333
    end

    subgraph "Querier Layer"
        Q1[Querier Node]
        Q2[Querier Node]
        style Q1 fill:grey,stroke:#333
        style Q2 fill:grey,stroke:#333
    end

    %% Client Flow with Message Types
    C -->|"WsClientEvents::Search<br/>WsClientEvents::Cancel<br/>WsClientEvents::Benchmark"| RT
    RT -->|"SessionInfo"| SM
    RT -->|"Message"| RM

    %% Message Flow
    RM -->|"Message{type: MessageType}"| QP
    QP -->|"QuerierConnection"| QC
    QC -->|"WsMessage::Text"| Q1 & Q2

    %% Session Management
    SM -->|"SessionInfo"| RM
    SM -->|"TraceId -> QuerierId"| RM

    %% Connection Management
    QP -->|"maintain_connections()"| QC
    QP -->|"is_connected()"| QC

    %% Response Flow
    Q1 & Q2 -->|"WsServerEvents::SearchResponse<br/>WsServerEvents::Error<br/>WsServerEvents::End"| QC
    QC -->|"Message"| RM
    RM -->|"Message"| RT
    RT -->|"WsServerEvents"| C

    %% Styling
    classDef default fill:grey,stroke:#333,stroke-width:1px;
```