### PR TITLE
fix: Misc V2 alerts routes fixes

### DIFF
--- a/src/config/src/meta/alerts/alert.rs
+++ b/src/config/src/meta/alerts/alert.rs
@@ -195,6 +195,9 @@ pub struct ListAlertsParams {
     /// The optional folder ID surrogate key with which to filter alerts.
     pub folder_id: Option<String>,
 
+    /// The optional case-insensitive alert name substring with which to filter alerts.
+    pub name_substring: Option<String>,
+
     /// The optional stream type and stream name with which to filter alerts.
     ///
     /// The stream name can only be provided if the stream type is also provide.
@@ -219,6 +222,7 @@ impl ListAlertsParams {
         Self {
             org_id: org_id.to_owned(),
             folder_id: None,
+            name_substring: None,
             stream_type_and_name: None,
             enabled: None,
             owner: None,
@@ -226,9 +230,15 @@ impl ListAlertsParams {
         }
     }
 
-    /// Filter dashboards by the given folder ID surrogate key.
+    /// Filter alerts by the given folder ID surrogate key.
     pub fn in_folder(mut self, folder_id: &str) -> Self {
         self.folder_id = Some(folder_id.to_string());
+        self
+    }
+
+    /// Filter alerts by the given case-insensitive name substring.
+    pub fn with_name_substring(mut self, name_substring: &str) -> Self {
+        self.name_substring = Some(name_substring.to_string());
         self
     }
 

--- a/src/handler/http/models/alerts/requests.rs
+++ b/src/handler/http/models/alerts/requests.rs
@@ -54,6 +54,17 @@ pub struct ListAlertsQuery {
     /// Optional folder ID filter parameter.
     pub folder: Option<String>,
 
+    /// Optional stream type filter parameter.
+    pub stream_type: Option<StreamType>,
+
+    /// Optional stream name filter parameter.
+    ///
+    /// This parameter is only used if `stream_type` is also provided.
+    pub stream_name: Option<String>,
+
+    /// Optional case-insensitive name substring filter parameter.
+    pub alert_name_substring: Option<String>,
+
     /// Optional owner user filter parameter.
     pub owner: Option<String>,
 
@@ -68,14 +79,6 @@ pub struct ListAlertsQuery {
     ///
     /// This parameter is only used if `page_size` is also set.
     pub page_idx: Option<u64>,
-
-    /// Optional stream type filter parameter.
-    pub stream_type: Option<StreamType>,
-
-    /// Optional stream name filter parameter.
-    ///
-    /// This parameter is only used if `stream_type` is also provided.
-    pub stream_name: Option<String>,
 }
 
 /// HTTP URL query component that contains parameters for enabling alerts.
@@ -104,6 +107,7 @@ impl ListAlertsQuery {
         meta_alerts::ListAlertsParams {
             org_id: org_id.to_string(),
             folder_id: self.folder,
+            name_substring: self.alert_name_substring,
             stream_type_and_name: self
                 .stream_type
                 .map(|stream_type| (stream_type.into(), self.stream_name)),

--- a/src/handler/http/models/alerts/responses.rs
+++ b/src/handler/http/models/alerts/responses.rs
@@ -40,6 +40,7 @@ pub struct ListAlertsResponseBodyItem {
     pub owner: Option<String>,
     pub description: Option<String>,
     pub condition: QueryCondition,
+    pub enabled: bool,
     pub last_triggered_at: Option<i64>,
     pub last_satisfied_at: Option<i64>,
 }
@@ -95,6 +96,7 @@ impl TryFrom<(meta_folders::Folder, meta_alerts::Alert, Option<Trigger>)>
             owner: alert.owner,
             description: Some(alert.description).filter(|d| !d.is_empty()),
             condition: alert.query_condition.into(),
+            enabled: alert.enabled,
             last_triggered_at,
             last_satisfied_at,
         })

--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse};
+use actix_web::{delete, get, patch, post, put, web, HttpRequest, HttpResponse};
 use config::meta::{
     alerts::alert::Alert as MetaAlert,
     folder::DEFAULT_FOLDER,
@@ -298,7 +298,7 @@ async fn list_alerts(path: web::Path<String>, req: HttpRequest) -> HttpResponse 
         (status = 500, description = "Failure",  content_type = "application/json", body = HttpResponse),
     )
 )]
-#[put("/v2/{org_id}/alerts/{alert_id}/enable")]
+#[patch("/v2/{org_id}/alerts/{alert_id}/enable")]
 async fn enable_alert(path: web::Path<(String, Ksuid)>, req: HttpRequest) -> HttpResponse {
     let (org_id, alert_id) = path.into_inner();
     let Ok(query) = web::Query::<EnableAlertQuery>::from_query(req.query_string()) else {
@@ -336,7 +336,7 @@ async fn enable_alert(path: web::Path<(String, Ksuid)>, req: HttpRequest) -> Htt
         (status = 500, description = "Failure",  content_type = "application/json", body = HttpResponse),
     )
 )]
-#[put("/v2/{org_id}/alerts/{alert_id}/trigger")]
+#[patch("/v2/{org_id}/alerts/{alert_id}/trigger")]
 async fn trigger_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
     let (org_id, alert_id) = path.into_inner();
 
@@ -365,7 +365,7 @@ async fn trigger_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
         (status = 500, description = "Failure",  content_type = "application/json", body = HttpResponse),
     )
 )]
-#[put("/v2/{org_id}/alerts/move")]
+#[patch("/v2/{org_id}/alerts/move")]
 async fn move_alerts(
     path: web::Path<String>,
     req_body: web::Json<MoveAlertsRequestBody>,

--- a/tests/api-testing/tests/test_alertsnew.py
+++ b/tests/api-testing/tests/test_alertsnew.py
@@ -545,7 +545,7 @@ def test_put_alertnew_disable(create_session, base_url):
         print(f"Alert {alert_id} exists and is retrievable.")
     
     # Proceed to disable the alert
-        resp_alertnew_disable = session.put(f"{url}api/v2/{org_id}/alerts/{alert_id}/enable?value=false&type=logs")
+        resp_alertnew_disable = session.patch(f"{url}api/v2/{org_id}/alerts/{alert_id}/enable?value=false&type=logs")
         print(f"Disable Alert Response: {resp_alertnew_disable.text}")
         assert resp_alertnew_disable.status_code == 200, f"Failed to disable alert {alert_id}"
         print(f"Successfully disabled alert {alert_id}")
@@ -603,7 +603,7 @@ def test_put_alertnew_enable(create_session, base_url):
 
 
     # Proceed to enable the alert
-        resp_alertnew_enable = session.put(f"{url}api/v2/{org_id}/alerts/{alert_id}/enable?value=true&type=logs")
+        resp_alertnew_enable = session.patch(f"{url}api/v2/{org_id}/alerts/{alert_id}/enable?value=true&type=logs")
         print(f"Enable Alert Response: {resp_alertnew_enable.text}")
         assert resp_alertnew_enable.status_code == 200, f"Failed to enable alert {alert_id}"
         print(f"Successfully enabled alert {alert_id}")
@@ -668,7 +668,7 @@ def test_put_alertnew_trigger(create_session, base_url, caplog):
         # Trigger the alert
         logger.info(f"Attempting to trigger alert with ID: {alert_id}")
 
-        resp_alertnew_trigger = session.put(f"{url}api/v2/{org_id}/alerts/{alert_id}/trigger?type=logs")
+        resp_alertnew_trigger = session.patch(f"{url}api/v2/{org_id}/alerts/{alert_id}/trigger?type=logs")
 
     # Log response details for debugging
         print(f"Trigger Alert Response Status Code: {resp_alertnew_trigger.status_code}")


### PR DESCRIPTION
Makes the following fixes to these routes:
- `ListAlerts`
  - adds `enabled` to the response body
  - adds `name_substring` to the request body
- `MoveAlerts`
  - changes the method type to `PATCH` since this is a non-idempotent update
  - changing to `PATCH` coincidentally happens to fix a routing issue where requests to `MoveAlerts` were being routed to the `UpdateAlerts` handler
- `EnableAlert`
  - changes the method type to `PATCH` since this is a non-idempotent update
- `TriggerAlert`
  - changes the method type to `PATCH` since this is a non-idempotent update