### PR TITLE
fix: scheduled pipeline don't pause after retries

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1154,8 +1154,10 @@ pub struct Limit {
     pub report_schedule_timeout: i64,
     #[env_config(name = "ZO_DERIVED_STREAM_SCHEDULE_INTERVAL", default = 300)] // seconds
     pub derived_stream_schedule_interval: i64,
-    #[env_config(name = "ZO_SCHEDULER_MAX_RETRIES", default = 20)]
+    #[env_config(name = "ZO_SCHEDULER_MAX_RETRIES", default = 3)]
     pub scheduler_max_retries: i32,
+    #[env_config(name = "ZO_SCHEDULER_PIPELINE_MAX_RETRIES", default = 20)]
+    pub scheduler_pipeline_max_retries: i32,
     #[env_config(name = "ZO_SCHEDULER_PAUSE_ALERT_AFTER_RETRIES", default = false)]
     pub pause_alerts_on_retries: bool,
     #[env_config(

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1154,7 +1154,7 @@ pub struct Limit {
     pub report_schedule_timeout: i64,
     #[env_config(name = "ZO_DERIVED_STREAM_SCHEDULE_INTERVAL", default = 300)] // seconds
     pub derived_stream_schedule_interval: i64,
-    #[env_config(name = "ZO_SCHEDULER_MAX_RETRIES", default = 3)]
+    #[env_config(name = "ZO_SCHEDULER_MAX_RETRIES", default = 20)]
     pub scheduler_max_retries: i32,
     #[env_config(name = "ZO_SCHEDULER_PAUSE_ALERT_AFTER_RETRIES", default = false)]
     pub pause_alerts_on_retries: bool,

--- a/src/config/src/meta/alerts/mod.rs
+++ b/src/config/src/meta/alerts/mod.rs
@@ -16,7 +16,10 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::{meta::search::SearchEventType, utils::json::Value};
+use crate::{
+    meta::search::SearchEventType,
+    utils::json::{Map, Value},
+};
 
 pub mod alert;
 pub mod destinations;
@@ -45,6 +48,13 @@ pub struct TriggerCondition {
     /// (seconds)
     #[serde(default)]
     pub tolerance_in_secs: Option<i64>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct TriggerEvalResults {
+    pub data: Option<Vec<Map<String, Value>>>,
+    pub end_time: i64,
+    pub query_took: Option<i64>,
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, ToSchema, PartialEq)]

--- a/src/config/src/meta/self_reporting/usage.rs
+++ b/src/config/src/meta/self_reporting/usage.rs
@@ -72,6 +72,7 @@ pub struct TriggerData {
     pub delay_in_secs: Option<i64>,
     pub evaluation_took_in_secs: Option<f64>,
     pub source_node: Option<String>,
+    pub query_took: Option<i64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -26,7 +26,7 @@ use config::{
         alerts::{
             alert::{Alert, AlertListFilter, ListAlertsParams},
             destinations::{DestinationType, DestinationWithTemplate, HTTPType},
-            FrequencyType, Operator, QueryType,
+            FrequencyType, Operator, QueryType, TriggerEvalResults,
         },
         folder::{Folder, FolderType, DEFAULT_FOLDER},
         search::{SearchEventContext, SearchEventType},
@@ -666,7 +666,7 @@ pub trait AlertExt: Sync + Send + 'static {
         &self,
         row: Option<&Map<String, Value>>,
         (start_time, end_time): (Option<i64>, i64),
-    ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error>;
+    ) -> Result<TriggerEvalResults, anyhow::Error>;
 
     /// Returns a tuple containing a boolean - if all the send notification jobs successfully
     /// and the error message if any
@@ -685,7 +685,7 @@ impl AlertExt for Alert {
         &self,
         row: Option<&Map<String, Value>>,
         (start_time, end_time): (Option<i64>, i64),
-    ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error> {
+    ) -> Result<TriggerEvalResults, anyhow::Error> {
         if self.is_real_time {
             self.query_condition.evaluate_realtime(row).await
         } else {

--- a/src/service/alerts/derived_streams.rs
+++ b/src/service/alerts/derived_streams.rs
@@ -20,12 +20,11 @@ use chrono::Utc;
 use config::{
     get_config,
     meta::{
-        alerts::{FrequencyType, QueryType},
+        alerts::{FrequencyType, QueryType, TriggerEvalResults},
         pipeline::components::DerivedStream,
         search::{SearchEventContext, SearchEventType},
         sql::resolve_stream_names,
     },
-    utils::json::{Map, Value},
 };
 use cron::Schedule;
 
@@ -165,7 +164,7 @@ pub trait DerivedStreamExt: Sync + Send + 'static {
         &self,
         (start_time, end_time): (Option<i64>, i64),
         module_key: &str,
-    ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error>;
+    ) -> Result<TriggerEvalResults, anyhow::Error>;
 }
 
 #[async_trait]
@@ -181,7 +180,7 @@ impl DerivedStreamExt for DerivedStream {
         &self,
         (start_time, end_time): (Option<i64>, i64),
         module_key: &str,
-    ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error> {
+    ) -> Result<TriggerEvalResults, anyhow::Error> {
         self.query_condition
             .evaluate_scheduled(
                 &self.org_id,

--- a/src/service/alerts/derived_streams.rs
+++ b/src/service/alerts/derived_streams.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 OpenObserve Inc.
+// Copyright 2025 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -107,8 +107,13 @@ pub async fn save(
     // test derived_stream
     let trigger_module_key = derived_stream.get_scheduler_module_key(pipeline_name, pipeline_id);
     let test_end_time = Utc::now().timestamp_micros();
+    let test_start_time = test_end_time
+        - chrono::Duration::try_seconds(5)
+            .unwrap()
+            .num_microseconds()
+            .unwrap();
     if let Err(e) = &derived_stream
-        .evaluate((None, test_end_time), &trigger_module_key)
+        .evaluate((Some(test_start_time), test_end_time), &trigger_module_key)
         .await
     {
         return Err(anyhow::anyhow!(

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -20,7 +20,10 @@ use chrono::{Duration, Utc};
 use config::{
     get_config, ider,
     meta::{
-        alerts::{AggFunction, Condition, Operator, QueryCondition, QueryType, TriggerCondition},
+        alerts::{
+            AggFunction, Condition, Operator, QueryCondition, QueryType, TriggerCondition,
+            TriggerEvalResults,
+        },
         search::{SearchEventContext, SearchEventType, SqlQuery},
         sql::resolve_stream_names,
         stream::StreamType,
@@ -45,7 +48,7 @@ pub trait QueryConditionExt: Sync + Send + 'static {
     async fn evaluate_realtime(
         &self,
         row: Option<&Map<String, Value>>,
-    ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error>;
+    ) -> Result<TriggerEvalResults, anyhow::Error>;
 
     #[allow(clippy::too_many_arguments)]
     async fn evaluate_scheduled(
@@ -57,7 +60,7 @@ pub trait QueryConditionExt: Sync + Send + 'static {
         (start_time, end_time): (Option<i64>, i64),
         search_type: Option<SearchEventType>,
         search_event_context: Option<SearchEventContext>,
-    ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error>;
+    ) -> Result<TriggerEvalResults, anyhow::Error>;
 }
 
 #[async_trait]
@@ -65,27 +68,32 @@ impl QueryConditionExt for QueryCondition {
     async fn evaluate_realtime(
         &self,
         row: Option<&Map<String, Value>>,
-    ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error> {
+    ) -> Result<TriggerEvalResults, anyhow::Error> {
         let now = Utc::now().timestamp_micros();
+        let mut eval_results = TriggerEvalResults {
+            end_time: now,
+            ..Default::default()
+        };
         let row = match row {
             Some(row) => row,
             None => {
-                return Ok((None, now));
+                return Ok(eval_results);
             }
         };
         if self.conditions.is_none() {
-            return Ok((None, now));
+            return Ok(eval_results);
         }
         let conditions = self.conditions.as_ref().unwrap();
         if conditions.is_empty() {
-            return Ok((None, now));
+            return Ok(eval_results);
         }
         for condition in conditions.iter() {
             if !condition.evaluate(row).await {
-                return Ok((None, now));
+                return Ok(eval_results);
             }
         }
-        Ok((Some(vec![row.to_owned()]), now))
+        eval_results.data = Some(vec![row.to_owned()]);
+        return Ok(eval_results);
     }
 
     async fn evaluate_scheduled(
@@ -97,32 +105,36 @@ impl QueryConditionExt for QueryCondition {
         (start_time, end_time): (Option<i64>, i64),
         search_type: Option<SearchEventType>,
         search_event_context: Option<SearchEventContext>,
-    ) -> Result<(Option<Vec<Map<String, Value>>>, i64), anyhow::Error> {
+    ) -> Result<TriggerEvalResults, anyhow::Error> {
+        let mut eval_results = TriggerEvalResults {
+            end_time,
+            ..Default::default()
+        };
         let sql = match self.query_type {
             QueryType::Custom => {
                 let (Some(stream_name), Some(v)) = (stream_name, self.conditions.as_ref()) else {
                     // CustomQuery type needs to provide source StreamName.
                     // CustomQuery is only used by Alerts' triggers.
-                    return Ok((None, end_time));
+                    return Ok(eval_results);
                 };
                 build_sql(org_id, stream_name, stream_type, self, v).await?
             }
             QueryType::SQL => {
                 let Some(v) = self.sql.as_ref() else {
-                    return Ok((None, end_time));
+                    return Ok(eval_results);
                 };
                 if v.is_empty() {
-                    return Ok((None, end_time));
+                    return Ok(eval_results);
                 } else {
                     v.to_string()
                 }
             }
             QueryType::PromQL => {
                 let Some(v) = self.promql.as_ref() else {
-                    return Ok((None, end_time));
+                    return Ok(eval_results);
                 };
                 if v.is_empty() {
-                    return Ok((None, end_time));
+                    return Ok(eval_results);
                 }
                 let start = if let Some(start_time) = start_time {
                     start_time
@@ -157,7 +169,7 @@ impl QueryConditionExt for QueryCondition {
                 let resp = match promql::search::search("", org_id, &req, "", 0).await {
                     Ok(v) => v,
                     Err(_) => {
-                        return Ok((None, end_time));
+                        return Ok(eval_results);
                     }
                 };
                 let promql::value::Value::Matrix(value) = resp else {
@@ -166,41 +178,34 @@ impl QueryConditionExt for QueryCondition {
                         v,
                         resp
                     );
-                    return Ok((None, end_time));
+                    return Ok(eval_results);
                 };
                 // TODO calculate the sample in a row, suddenly a sample can be ignored
                 let value = value
                     .into_iter()
                     .filter(|f| f.samples.len() >= trigger_condition.threshold as usize)
                     .collect::<Vec<_>>();
-                return if value.is_empty() {
-                    return Ok((None, end_time));
-                } else {
-                    Ok((
-                        Some(
-                            value
-                                .iter()
-                                .map(|v| {
-                                    let mut val = Map::with_capacity(v.labels.len() + 2);
-                                    for label in v.labels.iter() {
-                                        val.insert(
-                                            label.name.to_string(),
-                                            label.value.to_string().into(),
-                                        );
-                                    }
-                                    let last_sample = v.samples.last().unwrap();
+                if !value.is_empty() {
+                    eval_results.data = Some(
+                        value
+                            .iter()
+                            .map(|v| {
+                                let mut val = Map::with_capacity(v.labels.len() + 2);
+                                for label in v.labels.iter() {
                                     val.insert(
-                                        "_timestamp".to_string(),
-                                        last_sample.timestamp.into(),
+                                        label.name.to_string(),
+                                        label.value.to_string().into(),
                                     );
-                                    val.insert("value".to_string(), last_sample.value.into());
-                                    val
-                                })
-                                .collect(),
-                        ),
-                        end_time,
-                    ))
-                };
+                                }
+                                let last_sample = v.samples.last().unwrap();
+                                val.insert("_timestamp".to_string(), last_sample.timestamp.into());
+                                val.insert("value".to_string(), last_sample.value.into());
+                                val
+                            })
+                            .collect(),
+                    );
+                }
+                return Ok(eval_results);
             }
         };
 
@@ -406,46 +411,23 @@ impl QueryConditionExt for QueryCondition {
             }
         });
         log::debug!("alert resp hits len:{:#?}", records.len());
-        let records = Some(records);
-        if self.search_event_type.is_none() {
+        eval_results.query_took = Some(resp.took as i64);
+        eval_results.data = if self.search_event_type.is_none() {
             let threshold = trigger_condition.threshold as usize;
             match trigger_condition.operator {
-                Operator::EqualTo => {
-                    if records.as_ref().unwrap().len() == threshold {
-                        return Ok((records, end_time));
-                    }
-                }
-                Operator::NotEqualTo => {
-                    if records.as_ref().unwrap().len() != threshold {
-                        return Ok((records, end_time));
-                    }
-                }
-                Operator::GreaterThan => {
-                    if records.as_ref().unwrap().len() > threshold {
-                        return Ok((records, end_time));
-                    }
-                }
-                Operator::GreaterThanEquals => {
-                    if records.as_ref().unwrap().len() >= threshold {
-                        return Ok((records, end_time));
-                    }
-                }
-                Operator::LessThan => {
-                    if records.as_ref().unwrap().len() < threshold {
-                        return Ok((records, end_time));
-                    }
-                }
-                Operator::LessThanEquals => {
-                    if records.as_ref().unwrap().len() <= threshold {
-                        return Ok((records, end_time));
-                    }
-                }
-                _ => {}
+                Operator::EqualTo => (records.len() == threshold).then_some(records),
+                Operator::NotEqualTo => (records.len() != threshold).then_some(records),
+                Operator::GreaterThan => (records.len() > threshold).then_some(records),
+                Operator::GreaterThanEquals => (records.len() >= threshold).then_some(records),
+                Operator::LessThan => (records.len() < threshold).then_some(records),
+                Operator::LessThanEquals => (records.len() <= threshold).then_some(records),
+                _ => None,
             }
-            Ok((None, end_time))
         } else {
-            Ok((records, end_time))
-        }
+            Some(records)
+        };
+
+        Ok(eval_results)
     }
 }
 

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -766,7 +766,7 @@ async fn handle_derived_stream_triggers(
         "[SCHEDULER trace_id {trace_id}] Inside handle_derived_stream_triggers processing trigger: {}",
         trigger.module_key
     );
-    let (_, max_retries) = get_scheduler_max_retries();
+    let max_retries = get_config().limit.scheduler_pipeline_max_retries;
 
     // module_key format: stream_type/org_id/pipeline_name/pipeline_id
     let columns = trigger.module_key.split('/').collect::<Vec<_>>();

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -1109,7 +1109,7 @@ async fn handle_derived_stream_triggers(
             // at the next batch immediately Once it reaches max retries, the trigger
             // will be run again at the next scheduled time.
             if !(trigger_data_stream.status == TriggerDataStatus::Failed
-                && new_trigger.retries >= max_retries)
+                && new_trigger.retries < max_retries)
             {
                 // Go to the next nun at, but use the same trigger start time
                 if derived_stream.trigger_condition.frequency_type == FrequencyType::Cron {

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -349,10 +349,6 @@ async fn handle_alert_triggers(
         return Err(err);
     }
 
-    // let (ret, end_time) = {
-    //     let res = result.unwrap();
-    //     res.
-    // };
     let trigger_results = result.unwrap();
     trigger_data_stream.query_took = trigger_results.query_took;
     log::debug!(

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::HashMap, str::FromStr, time::Instant};
+use std::{collections::HashMap, intrinsics::needs_drop, str::FromStr, time::Instant};
 
 use chrono::{Duration, FixedOffset, Utc};
 use config::{
@@ -1165,6 +1165,7 @@ async fn handle_derived_stream_triggers(
             error_source: ErrorSource::Pipeline(pipeline_error),
         })
         .await;
+        new_trigger.retries = 0; // start over
     }
 
     if let Err(e) = db::scheduler::update_trigger(new_trigger).await {

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::HashMap, intrinsics::needs_drop, str::FromStr, time::Instant};
+use std::{collections::HashMap str::FromStr, time::Instant};
 
 use chrono::{Duration, FixedOffset, Utc};
 use config::{
@@ -766,7 +766,7 @@ async fn handle_derived_stream_triggers(
         "[SCHEDULER trace_id {trace_id}] Inside handle_derived_stream_triggers processing trigger: {}",
         trigger.module_key
     );
-    let max_retries = get_config().limit.scheduler_pipeline_max_retries;
+    let (_, max_retries) = get_scheduler_max_retries();
 
     // module_key format: stream_type/org_id/pipeline_name/pipeline_id
     let columns = trigger.module_key.split('/').collect::<Vec<_>>();

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::HashMap str::FromStr, time::Instant};
+use std::{collections::HashMap, str::FromStr, time::Instant};
 
 use chrono::{Duration, FixedOffset, Utc};
 use config::{

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -243,6 +243,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
             delay_in_secs: None,
             evaluation_took_in_secs: None,
             source_node: Some(LOCAL_NODE.name.clone()),
+            query_took: None,
         };
         match alert.send_notification(val, now, None, now).await {
             Err(e) => {

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -435,11 +435,12 @@ async fn write_logs(
                     if evaluated_alerts.contains(&key) {
                         continue;
                     }
-                    if let Ok((Some(v), _)) =
-                        alert.evaluate(Some(&record_val), (None, end_time)).await
-                    {
-                        triggers.push((alert.clone(), v));
-                        evaluated_alerts.insert(key);
+                    match alert.evaluate(Some(&record_val), (None, end_time)).await {
+                        Ok(trigger_results) if trigger_results.data.is_some() => {
+                            triggers.push((alert.clone(), trigger_results.data.unwrap()));
+                            evaluated_alerts.insert(key);
+                        }
+                        _ => {}
                     }
                 }
             }

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -413,10 +413,11 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
                     let alert_end_time = chrono::Utc::now().timestamp_micros();
                     for alert in alerts {
-                        if let Ok((Some(v), _)) =
-                            alert.evaluate(Some(record), (None, alert_end_time)).await
-                        {
-                            trigger_alerts.push((alert.clone(), v));
+                        match alert.evaluate(Some(record), (None, alert_end_time)).await {
+                            Ok(res) if res.data.is_some() => {
+                                trigger_alerts.push((alert.clone(), res.data.unwrap()))
+                            }
+                            _ => {}
                         }
                     }
                     stream_trigger_map.insert(stream_name.clone(), Some(trigger_alerts));

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -511,10 +511,11 @@ pub async fn handle_otlp_request(
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
                     let alert_end_time = chrono::Utc::now().timestamp_micros();
                     for alert in alerts {
-                        if let Ok((Some(v), _)) =
-                            alert.evaluate(Some(val_map), (None, alert_end_time)).await
-                        {
-                            trigger_alerts.push((alert.clone(), v));
+                        match alert.evaluate(Some(val_map), (None, alert_end_time)).await {
+                            Ok(res) if res.data.is_some() => {
+                                trigger_alerts.push((alert.clone(), res.data.unwrap()))
+                            }
+                            _ => {}
                         }
                     }
                     stream_trigger_map.insert(local_metric_name.clone(), Some(trigger_alerts));

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -494,10 +494,11 @@ pub async fn remote_write(
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
                     let alert_end_time = chrono::Utc::now().timestamp_micros();
                     for alert in alerts {
-                        if let Ok((Some(v), _)) =
-                            alert.evaluate(Some(val_map), (None, alert_end_time)).await
-                        {
-                            trigger_alerts.push((alert.clone(), v));
+                        match alert.evaluate(Some(val_map), (None, alert_end_time)).await {
+                            Ok(res) if res.data.is_some() => {
+                                trigger_alerts.push((alert.clone(), res.data.unwrap()))
+                            }
+                            _ => {}
                         }
                     }
                     stream_trigger_map.insert(stream_name.clone(), Some(trigger_alerts));

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -918,12 +918,15 @@ async fn write_traces(
                     if evaluated_alerts.contains(&key) {
                         continue;
                     }
-                    if let Ok((Some(v), _)) = alert
+                    match alert
                         .evaluate(Some(&record_val), (None, alert_end_time))
                         .await
                     {
-                        triggers.push((alert.clone(), v));
-                        evaluated_alerts.insert(key);
+                        Ok(res) if res.data.is_some() => {
+                            triggers.push((alert.clone(), res.data.unwrap()));
+                            evaluated_alerts.insert(key);
+                        }
+                        _ => {}
                     }
                 }
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1875,7 +1875,7 @@ mod tests {
             is_realtime: false,
             is_silenced: false,
             status: config::meta::triggers::TriggerStatus::Processing,
-            retries: 19,
+            retries: 2,
             data: "{}".to_string(),
         };
 
@@ -1912,7 +1912,7 @@ mod tests {
             is_realtime: false,
             is_silenced: false,
             status: config::meta::triggers::TriggerStatus::Processing,
-            retries: 20,
+            retries: 3,
             data: "{}".to_string(),
         };
 
@@ -1981,7 +1981,7 @@ mod tests {
             is_realtime: false,
             is_silenced: false,
             status: config::meta::triggers::TriggerStatus::Processing,
-            retries: 19,
+            retries: 2,
             data: "{}".to_string(),
         };
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1875,7 +1875,7 @@ mod tests {
             is_realtime: false,
             is_silenced: false,
             status: config::meta::triggers::TriggerStatus::Processing,
-            retries: 2,
+            retries: 19,
             data: "{}".to_string(),
         };
 
@@ -1912,7 +1912,7 @@ mod tests {
             is_realtime: false,
             is_silenced: false,
             status: config::meta::triggers::TriggerStatus::Processing,
-            retries: 3,
+            retries: 20,
             data: "{}".to_string(),
         };
 
@@ -1981,7 +1981,7 @@ mod tests {
             is_realtime: false,
             is_silenced: false,
             status: config::meta::triggers::TriggerStatus::Processing,
-            retries: 2,
+            retries: 19,
             data: "{}".to_string(),
         };
 

--- a/web/src/components/pipeline/NodeForm/Query.vue
+++ b/web/src/components/pipeline/NodeForm/Query.vue
@@ -468,7 +468,12 @@ const validateSqlQuery = () => {
 
   delete query.aggs;
 
+  // We get 15 minutes time range for the query, so reducing it by 14 minutes and 55 seconds to get 5 seconds of data as the query is just for validation purpose
+
+  query.query.start_time = query.query.start_time + 895000000;
+
   query.query.sql = streamRoute.value.query_condition.sql;
+
 
 
   validateSqlQueryPromise.value = new Promise((resolve, reject) => {

--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -415,7 +415,6 @@ const getColumnsForActiveTab = (tab : any) => {
     { name: "stream_type", field: "stream_type", label: "Stream Type", align: "left", sortable: true },
     { name: "frequency", field: "frequency", label: "Frequency", align: "left", sortable: true },
     { name: "period", field: "period", label: "Period", align: "left", sortable: true },
-    { name: "silence", field: "silence", label: "Silence", align: "left", sortable: true },
     { name: "cron", field: "cron", label: "Cron", align: "left", sortable: false },
     { name: "sql_query", field: "sql_query", label: "SQL Query", align: "left", sortable: false
       ,
@@ -485,7 +484,6 @@ const getPipelines = async () => {
             pipeline.stream_type = pipeline.source.stream_type;
             pipeline.frequency = pipeline.source.trigger_condition.frequency + " Mins";
             pipeline.period = pipeline.source.trigger_condition.period + " Mins";
-            pipeline.silence = pipeline.source.trigger_condition.silence + " Mins";
             pipeline.cron = pipeline.cron && pipeline.cron !== "" ? pipeline.source.trigger_condition.cron : 'False';
             pipeline.sql_query = pipeline.source.query_condition.sql;
           }


### PR DESCRIPTION
Fixes three problems -
- [x] Pipeline pauses automatically after reaching max retries.
- [x] There could be some data loss if `(now - start_time)` is not a multiple of `period_num_microseconds + 1`.
- [x] If derived stream fails, it should retry immediately in the next batch until it reaches max retries. After reaching max retries, it should retry at the next scheduled run.