### PR TITLE
fix: ws malformed data

### DIFF
--- a/src/handler/http/request/websocket/session.rs
+++ b/src/handler/http/request/websocket/session.rs
@@ -241,7 +241,7 @@ pub async fn handle_text_message(
                     let _ = send_message(req_id, res.to_json().to_string()).await;
                     let close_reason = Some(CloseReason {
                         code: CloseCode::Normal,
-                        description: Some(format!("trace_id {} Search canceled", trace_id)),
+                        description: None,
                     });
 
                     #[cfg(feature = "enterprise")]
@@ -288,7 +288,7 @@ pub async fn handle_text_message(
                     let _ = send_message(req_id, response.to_string()).await;
                     let close_reason = Some(CloseReason {
                         code: CloseCode::Normal,
-                        description: Some(format!("id {} benchmark completed", id)),
+                        description: None,
                     });
                     cleanup_and_close_session(req_id, close_reason).await;
                 }
@@ -305,7 +305,7 @@ pub async fn handle_text_message(
             let _ = send_message(req_id, err_res.to_json().to_string()).await;
             let close_reason = Some(CloseReason {
                 code: CloseCode::Error,
-                description: Some(format!("req_id {} Request Error", req_id)),
+                description: None,
             });
             let mut session = if let Some(session) = sessions_cache_utils::get_mut_session(req_id) {
                 session
@@ -472,7 +472,7 @@ async fn handle_search_event(
 
                         let close_reason = CloseReason {
                             code: CloseCode::Normal,
-                            description: Some(format!("trace_id {} Search completed", trace_id_for_task)),
+                            description: None,
                         };
 
                         // Add audit before closing
@@ -586,7 +586,7 @@ async fn handle_search_error(e: Error, req_id: &str, trace_id: &str) -> Option<C
     // Close with error
     let close_reason = CloseReason {
         code: CloseCode::Error,
-        description: Some(format!("trace_id {} Search Error", trace_id)),
+        description: None,
     };
 
     // Update registry state

--- a/src/router/http/ws.rs
+++ b/src/router/http/ws.rs
@@ -354,7 +354,7 @@ pub fn convert_actix_to_tungstenite_request(
 /// Add this helper function
 fn log_frame_details(prefix: &str, text: &str, is_close: bool) {
     // 7b is '{' in JSON
-    log::debug!(
+    log::info!(
         "[WS_FRAME] {} Length: {}, First 50 bytes: {}, Is close: {}",
         prefix,
         text.len(),

--- a/src/router/http/ws.rs
+++ b/src/router/http/ws.rs
@@ -163,7 +163,7 @@ pub async fn ws_proxy(
                             let ws_msg = from_tungstenite_msg_to_actix_msg(msg);
                             match ws_msg {
                                 Message::Text(text) => {
-                                    log::debug!("[WS_PROXY] Backend -> Router text: {}", text);
+                                    log::info!("[WS_PROXY] Backend -> Router text: {}", text);
                                     // Validate JSON before forwarding
                                     if let Ok(_) = serde_json::from_str::<serde_json::Value>(&text) {
                                         if session.text(text).await.is_err() {


### PR DESCRIPTION
Issue: Close frame description field causes frame malformation in Chrome/Brave
- Description field causes inconsistent frame encoding
- Firefox handles it fine, but Chrome/Brave show malformed data
- Workaround: Skip description field in close frames

Actions:
- Set `CloseFrame` description at both `router` & `querier` to `None`
