### PR TITLE
fix: ws malformed data (#6157)

### DIFF
--- a/src/handler/http/request/websocket/session.rs
+++ b/src/handler/http/request/websocket/session.rs
@@ -13,10 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
-    sync::atomic::{AtomicBool, Ordering},
-    time::Duration,
-};
+use std::time::Duration;
 
 use actix_http::ws::{CloseCode, CloseReason};
 use actix_ws::{MessageStream, Session};
@@ -56,7 +53,6 @@ pub struct WsSession {
     last_activity_ts: i64,
     // Utc timestamp in microseconds
     created_ts: i64,
-    message_in_flight: AtomicBool,
 }
 
 impl WsSession {
@@ -66,7 +62,6 @@ impl WsSession {
             inner: Some(inner),
             last_activity_ts: now,
             created_ts: now,
-            message_in_flight: AtomicBool::new(false),
         }
     }
 
@@ -241,7 +236,7 @@ pub async fn handle_text_message(
                     let _ = send_message(req_id, res.to_json().to_string()).await;
                     let close_reason = Some(CloseReason {
                         code: CloseCode::Normal,
-                        description: Some(format!("trace_id {} Search canceled", trace_id)),
+                        description: None,
                     });
 
                     #[cfg(feature = "enterprise")]
@@ -288,7 +283,7 @@ pub async fn handle_text_message(
                     let _ = send_message(req_id, response.to_string()).await;
                     let close_reason = Some(CloseReason {
                         code: CloseCode::Normal,
-                        description: Some(format!("id {} benchmark completed", id)),
+                        description: None,
                     });
                     cleanup_and_close_session(req_id, close_reason).await;
                 }
@@ -305,7 +300,7 @@ pub async fn handle_text_message(
             let _ = send_message(req_id, err_res.to_json().to_string()).await;
             let close_reason = Some(CloseReason {
                 code: CloseCode::Error,
-                description: Some(format!("req_id {} Request Error", req_id)),
+                description: None,
             });
             let mut session = if let Some(session) = sessions_cache_utils::get_mut_session(req_id) {
                 session
@@ -328,45 +323,12 @@ pub async fn send_message(req_id: &str, msg: String) -> Result<(), Error> {
         )));
     };
 
-    // Try to acquire the in-flight flag with retries
-    let mut attempts = 0;
-    while attempts < 3 {
-        match session.message_in_flight.compare_exchange(
-            false,
-            true,
-            Ordering::SeqCst,
-            Ordering::SeqCst,
-        ) {
-            Ok(_) => {
-                // Got the lock, proceed with send
-                log::debug!("[WS_HANDLER]: req_id: {} sending message: {}", req_id, msg);
-                let result = session.text(msg).await.map_err(|e| {
-                    log::error!("[WS_HANDLER]: Failed to send message: {:?}", e);
-                    Error::Message(e.to_string())
-                });
+    log::debug!("[WS_HANDLER]: req_id: {} sending message: {}", req_id, msg);
 
-                // Reset the in-flight flag
-                session.message_in_flight.store(false, Ordering::SeqCst);
-                return result;
-            }
-            Err(_) => {
-                // Message in flight, wait a tiny bit and retry
-                attempts += 1;
-                if attempts < 3 {
-                    tokio::task::yield_now().await;
-                }
-            }
-        }
-    }
-
-    log::error!(
-        "[WS_HANDLER]: req_id: {} Failed to send message after retries",
-        req_id
-    );
-
-    Err(Error::Message(
-        "Failed to send message after retries".to_string(),
-    ))
+    session.text(msg).await.map_err(|e| {
+        log::error!("[WS_HANDLER]: Failed to send message: {:?}", e);
+        Error::Message(e.to_string())
+    })
 }
 
 async fn cleanup_and_close_session(req_id: &str, close_reason: Option<CloseReason>) {
@@ -376,21 +338,6 @@ async fn cleanup_and_close_session(req_id: &str, close_reason: Option<CloseReaso
                 "[WS_HANDLER]: req_id: {} Closing session with reason: {:?}",
                 req_id,
                 reason
-            );
-        }
-
-        // Wait for any in-flight message to complete
-        let mut retries = 0;
-        while session.message_in_flight.load(Ordering::SeqCst) && retries < 3 {
-            tokio::task::yield_now().await;
-            retries += 1;
-        }
-
-        if session.message_in_flight.load(Ordering::SeqCst) {
-            log::warn!(
-                "[WS_HANDLER]: req_id: {} Closing with message in flight after {} retries",
-                req_id,
-                retries
             );
         }
 
@@ -472,7 +419,7 @@ async fn handle_search_event(
 
                         let close_reason = CloseReason {
                             code: CloseCode::Normal,
-                            description: Some(format!("trace_id {} Search completed", trace_id_for_task)),
+                            description: None,
                         };
 
                         // Add audit before closing
@@ -586,7 +533,7 @@ async fn handle_search_error(e: Error, req_id: &str, trace_id: &str) -> Option<C
     // Close with error
     let close_reason = CloseReason {
         code: CloseCode::Error,
-        description: Some(format!("trace_id {} Search Error", trace_id)),
+        description: None,
     };
 
     // Update registry state

--- a/src/router/http/ws.rs
+++ b/src/router/http/ws.rs
@@ -277,7 +277,11 @@ fn from_tungstenite_msg_to_actix_msg(msg: tungstenite::protocol::Message) -> Mes
             }
             Message::Close(reason.map(|r| actix_ws::CloseReason {
                 code: u16::from(r.code).into(),
-                description: Some(r.reason.to_string()),
+                description: if r.reason.is_empty() {
+                    None
+                } else {
+                    Some(r.reason.to_string())
+                },
             }))
         }
         _ => {

--- a/src/router/http/ws.rs
+++ b/src/router/http/ws.rs
@@ -15,10 +15,11 @@
 
 use std::{str::FromStr, sync::Arc};
 
-use actix_web::{Error, HttpRequest, HttpResponse, rt, web};
-use actix_ws::Message;
+use actix_web::{rt, web, Error, HttpRequest, HttpResponse};
+use actix_ws::{CloseCode, CloseReason, Message};
 use config::get_config;
 use futures_util::{SinkExt, StreamExt};
+use hex;
 use reqwest::header::{HeaderName, HeaderValue};
 use tokio::sync::Mutex;
 use tokio_tungstenite::{connect_async, tungstenite};
@@ -154,58 +155,74 @@ pub async fn ws_proxy(
 
     // Task 2: Backend to Client
     let backend_to_client = async move {
-        tokio::select! {
-            _ = async {
-                while let Some(msg_result) = backend_ws_stream.next().await {
-                    match msg_result {
-                        Ok(msg) => {
-                            let ws_msg = from_tungstenite_msg_to_actix_msg(msg);
-                            match ws_msg {
-                                Message::Close(reason) => {
-                                    log::info!("[WS_PROXY] Backend -> Router close");
-
-                                    let mut sink = backend_ws_sink2.lock().await;
-                                    // 1. Forward close to client
-                                    if let Err(e) = session.close(reason.clone()).await {
-                                        log::error!("[WS_PROXY] Failed to close client: {}", e);
-                                    }
-
-                                    // Close sink to backend
-                                    if let Err(e) = sink.close().await {
-                                        log::error!("[WS_PROXY] Failed to close backend sink: {}", e);
-                                    }
-                                    break;
-                                }
-                                Message::Text(text) => {
-                                    if session.text(text).await.is_err() {
-                                        break;
-                                    }
-                                }
-                                Message::Binary(bin) => {
-                                    if session.binary(bin).await.is_err() {
-                                        break;
-                                    }
-                                }
-                                Message::Ping(ping) => {
-                                    if session.ping(&ping).await.is_err() {
-                                        break;
-                                    }
-                                }
-                                Message::Pong(pong) => {
-                                    if session.pong(&pong).await.is_err() {
-                                        break;
-                                    }
-                                }
-                                _ => log::warn!("[WS_PROXY] Unsupported message type: {:?}", ws_msg),
+        while let Some(msg_result) = backend_ws_stream.next().await {
+            match msg_result {
+                Ok(msg) => {
+                    let ws_msg = from_tungstenite_msg_to_actix_msg(msg);
+                    match ws_msg {
+                        Message::Text(text) => {
+                            log_frame_details("Sending Text Frame ->", &text, false);
+                            if let Err(e) = session.text(text).await {
+                                log::error!("[WS_PROXY] Failed to send message: {}", e);
+                                break;
                             }
                         }
-                        Err(e) => {
-                            log::error!("[WS_PROXY] Backend error: {:?}", e);
+                        Message::Close(reason) => {
+                            log::info!("[WS_PROXY] Backend -> Router close {:?}", reason);
+
+                            // Debug incoming close frame
+                            debug_ws_message(
+                                "Received from backend",
+                                &Message::Close(reason.clone()),
+                            );
+
+                            // Create clean close
+                            let clean_close = CloseReason {
+                                code: reason.as_ref().map(|r| r.code).unwrap_or(CloseCode::Normal),
+                                // Skip description to avoid frame mixing
+                                description: None,
+                            };
+
+                            // Debug outgoing close frame
+                            debug_ws_message(
+                                "Sending to client",
+                                &Message::Close(Some(clean_close.clone())),
+                            );
+
+                            if let Err(e) = session.close(Some(clean_close)).await {
+                                log::error!("[WS_PROXY] Failed to close client: {}", e);
+                            }
+
+                            // Close backend sink
+                            let mut sink = backend_ws_sink2.lock().await;
+                            if let Err(e) = sink.close().await {
+                                log::error!("[WS_PROXY] Failed to close backend sink: {}", e);
+                            }
                             break;
                         }
+                        Message::Binary(bin) => {
+                            if session.binary(bin).await.is_err() {
+                                break;
+                            }
+                        }
+                        Message::Ping(ping) => {
+                            if session.ping(&ping).await.is_err() {
+                                break;
+                            }
+                        }
+                        Message::Pong(pong) => {
+                            if session.pong(&pong).await.is_err() {
+                                break;
+                            }
+                        }
+                        _ => log::warn!("[WS_PROXY] Unsupported message type: {:?}", ws_msg),
                     }
                 }
-            } => {}
+                Err(e) => {
+                    log::error!("[WS_PROXY] Backend error: {:?}", e);
+                    break;
+                }
+            }
         }
     };
 
@@ -247,11 +264,17 @@ fn from_actix_message(msg: Message) -> tungstenite::protocol::Message {
 /// Convert tungstenite WebSocket message to actix-web message format
 fn from_tungstenite_msg_to_actix_msg(msg: tungstenite::protocol::Message) -> Message {
     match msg {
-        tungstenite::protocol::Message::Text(text) => Message::Text(text.into()),
+        tungstenite::protocol::Message::Text(text) => {
+            log_frame_details("Converting Text ->", &text, false);
+            Message::Text(text.into())
+        }
         tungstenite::protocol::Message::Binary(bin) => Message::Binary(bin.into()),
         tungstenite::protocol::Message::Ping(msg) => Message::Ping(msg.into()),
         tungstenite::protocol::Message::Pong(msg) => Message::Pong(msg.into()),
         tungstenite::protocol::Message::Close(reason) => {
+            if let Some(r) = &reason {
+                log_frame_details("Converting Close ->", &r.reason, true);
+            }
             Message::Close(reason.map(|r| actix_ws::CloseReason {
                 code: u16::from(r.code).into(),
                 description: Some(r.reason.to_string()),
@@ -340,4 +363,44 @@ pub fn convert_actix_to_tungstenite_request(
     let ws_request = request_builder.body(())?;
 
     Ok(ws_request)
+}
+
+/// Add this helper function
+fn log_frame_details(prefix: &str, text: &str, is_close: bool) {
+    // 7b is '{' in JSON
+    log::debug!(
+        "[WS_FRAME] {} Length: {}, First 50 bytes: {}, Is close: {}",
+        prefix,
+        text.len(),
+        hex::encode(&text.as_bytes()[..std::cmp::min(50, text.len())]),
+        is_close
+    );
+}
+
+// Add helper function to debug frame details
+fn debug_ws_message(prefix: &str, msg: &Message) {
+    match msg {
+        Message::Text(text) => {
+            log::debug!(
+                "[WS_PROXY] {} Text frame: len={}, content_start='{}'",
+                prefix,
+                text.len(),
+                &text[..text.len().min(50)]
+            );
+        }
+        Message::Close(reason) => {
+            if let Some(r) = reason {
+                log::debug!(
+                    "[WS_PROXY] {} Close frame: code={:?}, desc={:?}, desc_len={}",
+                    prefix,
+                    r.code,
+                    r.description,
+                    r.description.as_ref().map(|d| d.len()).unwrap_or(0)
+                );
+            } else {
+                log::debug!("[WS_PROXY] {} Close frame: no reason", prefix);
+            }
+        }
+        _ => log::debug!("[WS_PROXY] {} Other frame type: {:?}", prefix, msg),
+    }
 }


### PR DESCRIPTION
Ref: https://github.com/openobserve/openobserve/issues/5974

Issue: Close frame description field causes frame malformation in
Chrome/Brave
- Description field causes inconsistent frame encoding
- Firefox handles it fine, but Chrome/Brave show malformed data
- Workaround: Skip description field in close frames

Actions:
- Set `CloseFrame` description at both `router` & `querier` to `None`