### PR TITLE
feat: improve router scheduler with weight 2/2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,21 +1975,20 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b89e7c29231c673a61a46e722602bcd138298f6b9e81e71119693534585f5c"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
  "bzip2-sys",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.12+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -2936,7 +2935,7 @@ dependencies = [
  "async-compression",
  "async-trait",
  "bytes",
- "bzip2 0.5.1",
+ "bzip2 0.5.2",
  "chrono",
  "datafusion-catalog",
  "datafusion-common",
@@ -7337,9 +7336,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -7356,9 +7355,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -7366,9 +7365,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -7376,9 +7375,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -7388,9 +7387,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -43,6 +43,9 @@ use once_cell::sync::Lazy;
 
 mod etcd;
 mod nats;
+mod scheduler;
+
+pub use scheduler::select_best_node;
 
 const CONSISTENT_HASH_PRIME: u32 = 16777619;
 

--- a/src/common/infra/cluster/scheduler.rs
+++ b/src/common/infra/cluster/scheduler.rs
@@ -1,0 +1,239 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use config::{
+    meta::cluster::{Node, NodeStatus},
+    utils::sysinfo::NodeMetrics,
+};
+
+// Adjust MAX_EXPECTED_CONNECTIONS based on your environment
+const MAX_EXPECTED_CONNECTIONS: f64 = 2000.0;
+const CONNECTION_WEIGHT: f64 = 0.5; // Connections is the most important factor
+const CPU_WEIGHT: f64 = 0.3; // CPU is second most important
+const MEMORY_WEIGHT: f64 = 0.2; // Memory is third
+
+fn calculate_load_score(stats: &NodeMetrics) -> f64 {
+    // Normalize values to 0.0-1.0 range
+    let cpu_usage_normalized = stats.cpu_usage as f64 / 100.0;
+    let memory_usage_normalized = stats.memory_usage as f64 / stats.memory_total as f64;
+
+    // Connection load factor - normalize based on reasonable maximum
+    let connection_factor = (stats.tcp_conns as f64) / MAX_EXPECTED_CONNECTIONS;
+    let connection_factor = connection_factor.min(1.0); // Cap at 1.0
+
+    // Assign weights to each factor (these should be tuned for your specific workload)
+    // Calculate weighted score
+    let score = (cpu_usage_normalized * CPU_WEIGHT)
+        + (memory_usage_normalized * MEMORY_WEIGHT)
+        + (connection_factor * CONNECTION_WEIGHT);
+
+    // Consider CPU capacity - a higher capacity node can handle more load
+    // This gives preference to more powerful nodes when load is equal
+    let capacity_factor = 1.0 - ((stats.cpu_total as f64 - 1.0) * 0.05).min(0.5);
+
+    // Final score adjusted for capacity
+    score * capacity_factor
+}
+
+pub fn select_best_node(nodes: &[Node]) -> Option<&Node> {
+    let trace_id = config::ider::uuid();
+    for node in nodes.iter() {
+        log::debug!(
+            "[ROUTER trace_id: {:?}] node: {:?}, score: {:?}, cpu_usage: {:?}, memory_usage: {:?}, connections: {:?}",
+            trace_id,
+            node.name,
+            calculate_load_score(&node.metrics),
+            node.metrics.cpu_usage,
+            node.metrics.memory_usage,
+            node.metrics.tcp_conns
+        );
+    }
+
+    let ret = nodes
+        .iter()
+        .filter(|node| node.status == NodeStatus::Online)
+        .min_by(|a, b| {
+            let score_a = calculate_load_score(&a.metrics);
+            let score_b = calculate_load_score(&b.metrics);
+            score_a
+                .partial_cmp(&score_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+    log::debug!(
+        "[ROUTER trace_id: {:?}] selected node: {:?}",
+        trace_id,
+        ret.map(|node| node.name.clone())
+    );
+    ret
+}
+
+#[cfg(test)]
+mod tests {
+
+    use config::meta::cluster::{Role, RoleGroup};
+
+    use super::*;
+
+    fn create_test_node(
+        id: i32,
+        cpu_usage: f64,
+        memory_usage_pct: f64,
+        connections: usize,
+    ) -> Node {
+        let memory_total = 16 * 1024 * 1024 * 1024; // 16GB
+        Node {
+            id,
+            uuid: id.to_string(),
+            name: id.to_string(),
+            http_addr: format!("http://node-{}.example.com", id),
+            grpc_addr: format!("grpc://node-{}.example.com", id),
+            role: vec![Role::Ingester],
+            role_group: RoleGroup::None,
+            scheduled: true,
+            broadcasted: true,
+            status: NodeStatus::Online,
+            cpu_num: 0,
+            metrics: NodeMetrics {
+                cpu_total: 8,
+                cpu_usage: cpu_usage as f32,
+                memory_total,
+                memory_usage: (memory_total as f64 * memory_usage_pct / 100.0) as usize,
+                tcp_conns: connections + 10, // add some non-established connections
+                tcp_conns_established: connections,
+                tcp_conns_close_wait: 3,
+                tcp_conns_time_wait: 5,
+            },
+        }
+    }
+
+    #[test]
+    fn test_select_best_node_basic_load_balancing() {
+        // Arrange
+        let nodes = vec![
+            create_test_node(1, 80.0, 70.0, 1000),
+            create_test_node(2, 30.0, 50.0, 500),
+            create_test_node(3, 60.0, 60.0, 800),
+        ];
+
+        // Act
+        let selected = select_best_node(&nodes);
+
+        // Assert
+        assert!(selected.is_some());
+        assert_eq!(selected.unwrap().id, 2); // Node 2 has lowest load
+    }
+
+    #[test]
+    fn test_select_best_node_prefers_more_powerful_nodes() {
+        // Arrange
+        let mut nodes = vec![
+            create_test_node(1, 50.0, 50.0, 500),
+            create_test_node(2, 50.0, 50.0, 500),
+        ];
+
+        // Make node 2 more powerful (16 cores vs 8)
+        nodes[1].metrics.cpu_total = 16;
+
+        // Act
+        let selected = select_best_node(&nodes);
+
+        // Assert
+        assert!(selected.is_some());
+        assert_eq!(selected.unwrap().id, 2); // Should prefer the more powerful node
+    }
+
+    #[test]
+    fn test_select_best_node_prioritizes_connections() {
+        // Arrange
+        let nodes = vec![
+            create_test_node(1, 50.0, 30.0, 300), // High CPU, low memory & connections
+            create_test_node(2, 40.0, 30.0, 800), // Low CPU, low memory, high connections
+            create_test_node(3, 30.0, 30.0, 800), // Low CPU, low memory, high connections
+        ];
+
+        // Act
+        let selected = select_best_node(&nodes);
+
+        // Assert
+        assert!(selected.is_some());
+        assert_eq!(selected.unwrap().id, 1); // Low connections are prioritized over high cpu
+    }
+
+    #[test]
+    fn test_select_best_node_prioritizes_cpu() {
+        // Arrange
+        let nodes = vec![
+            create_test_node(1, 80.0, 30.0, 300), // High CPU, low memory & connections
+            create_test_node(2, 30.0, 80.0, 300), // Low CPU, high memory, same connections
+            create_test_node(3, 30.0, 30.0, 800), // Low CPU, low memory, high connections
+        ];
+
+        // Act
+        let selected = select_best_node(&nodes);
+
+        // Assert
+        assert!(selected.is_some());
+        assert_eq!(selected.unwrap().id, 2); // Low CPU is prioritized over memory
+    }
+
+    #[test]
+    fn test_select_best_node_empty_list() {
+        // Arrange
+        let nodes: Vec<Node> = vec![];
+
+        // Act
+        let selected = select_best_node(&nodes);
+
+        // Assert
+        assert!(selected.is_none());
+    }
+
+    #[test]
+    fn test_select_best_node_all_unhealthy() {
+        // Arrange
+        let mut nodes = vec![
+            create_test_node(1, 40.0, 50.0, 400),
+            create_test_node(2, 30.0, 40.0, 300),
+        ];
+
+        nodes[0].status = NodeStatus::Offline;
+        nodes[1].status = NodeStatus::Offline;
+
+        // Act
+        let selected = select_best_node(&nodes);
+
+        // Assert
+        assert!(selected.is_none()); // No healthy nodes available
+    }
+
+    #[test]
+    fn test_select_best_node_one_partially_unhealthy() {
+        // Arrange
+        let mut nodes = vec![
+            create_test_node(1, 40.0, 50.0, 400),
+            create_test_node(2, 30.0, 40.0, 300),
+        ];
+
+        nodes[1].status = NodeStatus::Offline;
+
+        // Act
+        let selected = select_best_node(&nodes);
+
+        // Assert
+        assert!(selected.is_some());
+        assert_eq!(selected.unwrap().id, 1); // Only node still considered available
+    }
+}

--- a/src/common/infra/cluster/scheduler.rs
+++ b/src/common/infra/cluster/scheduler.rs
@@ -42,7 +42,7 @@ pub fn select_best_node(nodes: &[Node]) -> Option<&Node> {
     let trace_id = config::ider::uuid();
     for node in nodes.iter() {
         log::debug!(
-            "[ROUTER trace_id: {:?}] node: {:?}, score: {:?}, cpu_usage: {:?}, mem_usage: {:?}, conns: {:?}",
+            "[ROUTER trace_id: {}] node: {}, score: {:.2}, cpu_usage: {:.2}, mem_usage: {:.2}, conns: {}",
             trace_id,
             node.name,
             calculate_load_score(&node.metrics),
@@ -64,9 +64,9 @@ pub fn select_best_node(nodes: &[Node]) -> Option<&Node> {
         });
 
     log::debug!(
-        "[ROUTER trace_id: {:?}] selected node: {:?}",
+        "[ROUTER trace_id: {}] selected node: {}",
         trace_id,
-        ret.map(|node| node.name.clone())
+        ret.map(|node| node.name.clone()).unwrap_or_default()
     );
     ret
 }

--- a/src/common/infra/cluster/scheduler.rs
+++ b/src/common/infra/cluster/scheduler.rs
@@ -42,7 +42,7 @@ pub fn select_best_node(nodes: &[Node]) -> Option<&Node> {
     let trace_id = config::ider::uuid();
     for node in nodes.iter() {
         log::debug!(
-            "[ROUTER trace_id: {}] node: {}, score: {:.2}, cpu_usage: {:.2}, mem_usage: {:.2}, conns: {}",
+            "[ROUTER trace_id: {}] node: {}, score: {:.5}, cpu_usage: {:.2}, mem_usage: {:.2}, conns: {}",
             trace_id,
             node.name,
             calculate_load_score(&node.metrics),

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -246,7 +246,7 @@ async fn get_url(path: &str) -> URLDetails {
     }
 
     let nodes = nodes.unwrap();
-    let node = get_rand_element(&nodes);
+    let node = cluster::select_best_node(&nodes).unwrap_or(get_rand_element(&nodes));
     URLDetails {
         is_error: false,
         error: None,


### PR DESCRIPTION
The router will select node with weight by node status (CPU, MEM, CONNECTIONS) with this PR.

And the total weight is 1, each part has different weight:

- TCP Conns: `0.5`
- CPU Usage:`0.3`
- MEM Usage: `0.2`

And set a const variable `MAX_EXPECTED_CONNECTIONS=2000`

The score formula is:
```
(tcp_conns / 2000 * 0.5) + (cpu_usage / 100 * 0.3) + (mem_usage / mem_total * 0.2)
```

Select the node which has minimal score.
