### PR TITLE
fix: Individual level Fine grained RBAC permission for Dashboards

### DIFF
--- a/src/handler/http/request/dashboards/mod.rs
+++ b/src/handler/http/request/dashboards/mod.rs
@@ -63,6 +63,7 @@ impl From<DashboardError> for HttpResponse {
                 ))
             }
             DashboardError::ListPermittedDashboardsError(err) => MetaHttpResponse::forbidden(err),
+            DashboardError::UserNotFound => MetaHttpResponse::unauthorized("User not found"),
         }
     }
 }

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -102,6 +102,10 @@ pub enum DashboardError {
     #[error("error in updating distinct values")]
     DistinctValueError,
 
+    /// Error that occurs when the user making the api call is not found.
+    #[error("user not found")]
+    UserNotFound,
+
     /// Error that occurs when trying to get the list of dashboards that a user is permitted to
     /// get.
     #[error(transparent)]
@@ -369,8 +373,9 @@ pub async fn list_dashboards(
     params: ListDashboardsParams,
 ) -> Result<Vec<(Folder, Dashboard)>, DashboardError> {
     let org_id = params.org_id.clone();
+    let folder_id = params.folder_id.clone();
     let dashboards = table::dashboards::list(params).await?;
-    let dashboards = filter_permitted_dashboards(&org_id, user_id, dashboards).await?;
+    let dashboards = filter_permitted_dashboards(&org_id, user_id, dashboards, folder_id).await?;
     Ok(dashboards)
 }
 
@@ -537,6 +542,7 @@ async fn filter_permitted_dashboards(
     _org_id: &str,
     _user_id: &str,
     dashboards: Vec<(Folder, Dashboard)>,
+    _folder_id: Option<String>,
 ) -> Result<Vec<(Folder, Dashboard)>, DashboardError> {
     Ok(dashboards)
 }
@@ -547,11 +553,53 @@ async fn filter_permitted_dashboards(
     org_id: &str,
     user_id: &str,
     dashboards: Vec<(Folder, Dashboard)>,
+    folder_id: Option<String>,
 ) -> Result<Vec<(Folder, Dashboard)>, DashboardError> {
+    // This function assumes the user already has `LIST` permission on the folder.
+    // Otherwise, the user will not be able to see the folder in the first place.
+
+    // So, we check for the `GET` permission on the folder.
+    // If the user has `GET` permission on the folder, then they will be able to see the folder and
+    // all its contents. This includes the dashboards inside the folder.
+
+    use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+
+    use crate::{common::utils::auth::AuthExtractor, service::db::user::get as get_user};
+
+    if let Some(folder_id) = folder_id {
+        let user_role = match get_user(Some(org_id), user_id).await {
+            Ok(Some(user)) => user.role,
+            _ => return Err(DashboardError::UserNotFound),
+        };
+        let permitted = crate::handler::http::auth::validator::check_permissions(
+            user_id,
+            AuthExtractor {
+                org_id: org_id.to_string(),
+                o2_type: format!("{}:{folder_id}", OFGA_MODELS.get("folders").unwrap().key,),
+                method: "GET".to_string(),
+                bypass_check: false,
+                parent_id: "".to_string(),
+                auth: "".to_string(), // We don't need to pass the auth token here.
+            },
+            user_role,
+            false,
+        )
+        .await;
+        if permitted {
+            // The user has `GET` permission on the folder.
+            // So, they will be able to see all the dashboards inside the folder.
+            return Ok(dashboards);
+        }
+    }
+
+    // We also check for the `GET_INDIVIDUAL` permission on the dashboards.
+    // If the user has `GET_INDIVIDUAL` permission on a dashboard, then they will be able to see the
+    // dashboard. This is used to check if the user has permission to see a specific dashboard.
+
     let permitted_objects = crate::handler::http::auth::validator::list_objects_for_user(
         org_id,
         user_id,
-        "GET",
+        "GET_INDIVIDUAL",
         "dashboard",
     )
     .await

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -562,7 +562,7 @@ async fn filter_permitted_dashboards(
     // If the user has `GET` permission on the folder, then they will be able to see the folder and
     // all its contents. This includes the dashboards inside the folder.
 
-    use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+    use o2_openfga::meta::mapping::OFGA_MODELS;
 
     use crate::{common::utils::auth::AuthExtractor, service::db::user::get as get_user};
 

--- a/src/service/folders.rs
+++ b/src/service/folders.rs
@@ -271,13 +271,59 @@ async fn permitted_folders(
     org_id: &str,
     user_id: Option<&str>,
 ) -> Result<Option<Vec<String>>, FolderError> {
+    use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+    let folder_ofga_model = OFGA_MODELS.get("folders").unwrap().key;
+
     let Some(user_id) = user_id else {
         return Err(FolderError::PermittedFoldersMissingUser);
     };
-    let stream_list = crate::handler::http::auth::validator::list_objects_for_user(
-        org_id, user_id, "GET", "dfolder",
+
+    // Get the list of folders that the user has `GET` permission on.
+    let mut folder_list = crate::handler::http::auth::validator::list_objects_for_user(
+        org_id,
+        user_id,
+        "GET",
+        OFGA_MODELS.get("folders").unwrap().key,
     )
     .await
     .map_err(|err| FolderError::PermittedFoldersValidator(err.to_string()))?;
-    Ok(stream_list)
+
+    // In some cases, there might not be direct `GET` permission on the folder.
+    // So, we need to check if the user has `GET` permission on any of the dashboards
+    // inside the folder.
+
+    let permitted_dashboards = crate::handler::http::auth::validator::list_objects_for_user(
+        org_id,
+        user_id,
+        "GET_INDIVIDUAL_FROM_ROLE",
+        OFGA_MODELS.get("dashboards").unwrap().key,
+    )
+    .await
+    .map_err(|err| FolderError::PermittedFoldersValidator(err.to_string()))?;
+
+    log::info!("permitted_dashboards: {:?}", permitted_dashboards);
+    if permitted_dashboards.is_some() {
+        let mut folder_list_with_roles = vec![];
+        for dashboard in permitted_dashboards.unwrap() {
+            let Some((_, folder_id)) = dashboard.split_once(":") else {
+                continue;
+            };
+            // The folder_id is of the format `{folder_id}/{dashboard_id}`.
+            // So, we need to extract the folder_id from the dashboard string.
+            let Some((folder_id, _)) = folder_id.split_once("/") else {
+                continue;
+            };
+            log::info!("folder_id: {:?}", folder_id);
+            folder_list_with_roles.push(format!("{}:{}", folder_ofga_model, folder_id));
+        }
+        if folder_list.is_some() {
+            let folder_list = folder_list.as_mut().unwrap();
+            folder_list.extend(folder_list_with_roles);
+        } else {
+            folder_list = Some(folder_list_with_roles);
+        }
+    }
+    log::info!("folder_list: {:?}", folder_list);
+
+    Ok(folder_list)
 }

--- a/src/service/folders.rs
+++ b/src/service/folders.rs
@@ -271,7 +271,7 @@ async fn permitted_folders(
     org_id: &str,
     user_id: Option<&str>,
 ) -> Result<Option<Vec<String>>, FolderError> {
-    use o2_enterprise::enterprise::openfga::meta::mapping::OFGA_MODELS;
+    use o2_openfga::meta::mapping::OFGA_MODELS;
     let folder_ofga_model = OFGA_MODELS.get("folders").unwrap().key;
 
     let Some(user_id) = user_id else {

--- a/web/src/services/dashboards.ts
+++ b/web/src/services/dashboards.ts
@@ -26,14 +26,14 @@ const dashboards = {
     folderId: string,
     title: string
   ) => {
-    const params :any = {
+    const params: any = {
       page_num,
       page_size,
       sort_by,
       desc,
       name,
     };
-    if(folderId) {
+    if (folderId) {
       params.folder = folderId;
     }
     // Only add title if it is provided
@@ -51,13 +51,12 @@ const dashboards = {
   },
   delete: (organization: string, dashboardID: string, folderId?: string) => {
     return http().delete(
-      `/api/${organization}/dashboards/${dashboardID}?folder=${
-        folderId ?? "default"
+      `/api/${organization}/dashboards/${dashboardID}?folder=${folderId ?? "default"
       }`
     );
   },
-  get_Dashboard: (org_identifier: string, dashboardID: string) => {
-    return http().get(`/api/${org_identifier}/dashboards/${dashboardID}`);
+  get_Dashboard: (org_identifier: string, dashboardID: string, folderId?: string) => {
+    return http().get(`/api/${org_identifier}/dashboards/${dashboardID}?folder=${folderId ?? "default"}`);
   },
   save: (
     organization: string,
@@ -67,8 +66,7 @@ const dashboards = {
     hash?: any
   ) => {
     return http().put(
-      `/api/${organization}/dashboards/${dashboardID}?folder=${
-        folderId ?? "default"
+      `/api/${organization}/dashboards/${dashboardID}?folder=${folderId ?? "default"
       }&hash=${hash}`,
       data,
       { headers: { "Content-Type": "application/json; charset=UTF-8" } }

--- a/web/src/utils/commons.ts
+++ b/web/src/utils/commons.ts
@@ -497,6 +497,7 @@ export const updateDashboard = async (
     const apiResponse = await dashboardService.get_Dashboard(
       store.state.selectedOrganization.identifier,
       dashboardId,
+      folderId,
     );
 
     await retrieveAndStoreDashboardData(
@@ -518,18 +519,19 @@ export const getDashboard = async (
   dashboardId: any,
   folderId: any,
 ) => {
-   // check if dashboard data is present in store
+  // check if dashboard data is present in store
   if (store.state.organizationData.allDashboardData[dashboardId]) {
     return store.state.organizationData.allDashboardData[dashboardId];
   }
-  
-  if(!dashboardId){
+
+  if (!dashboardId) {
     return {};
   }
 
   const apiResponse = await dashboardService.get_Dashboard(
     store.state.selectedOrganization.identifier,
     dashboardId,
+    folderId,
   );
 
   return await retrieveAndStoreDashboardData(


### PR DESCRIPTION
Currently, individual level RBAC permission does not work for dashboards. This pr fixes that. So a role permission like below 
<img width="1399" alt="Screenshot 2025-03-04 at 5 27 11 PM" src="https://github.com/user-attachments/assets/06c2030d-4227-4109-b73f-dc2337151362" />

will allow the user to access only the dashboards with `Get` and `All` permission even if the `Get` permission for the folder is not specified.