### PR TITLE
feat: remove stream level metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,21 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-web-prometheus"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5228fd1a6b5d0f60d636776c2a70acc9fc667034bb4ac02ec4259f0eeeab6c"
-dependencies = [
- "actix-service",
- "actix-web",
- "futures-lite 1.13.0",
- "pin-project",
- "prometheus",
- "quanta 0.10.1",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "actix-web-rust-embed-responder"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,7 +999,7 @@ checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
  "async-lock",
  "blocking",
- "futures-lite 2.5.0",
+ "futures-lite",
 ]
 
 [[package]]
@@ -1138,7 +1123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f6338023cbfc0555eccb8e83d3d4dcf1183b51ca9140a03b1dbb8a559193db"
 dependencies = [
  "async-fs",
- "futures-lite 2.5.0",
+ "futures-lite",
 ]
 
 [[package]]
@@ -1215,7 +1200,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "hex",
  "http 0.2.12",
  "ring",
@@ -1253,7 +1238,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
  "once_cell",
@@ -1437,7 +1422,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -1826,7 +1811,7 @@ dependencies = [
  "async-channel",
  "async-task",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite",
  "piper",
 ]
 
@@ -2456,7 +2441,6 @@ dependencies = [
 name = "config"
 version = "0.1.0"
 dependencies = [
- "actix-web-prometheus",
  "aes-siv",
  "ahash 0.8.11",
  "anyhow",
@@ -3865,15 +3849,6 @@ checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
@@ -4071,26 +4046,11 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -4201,7 +4161,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -5241,7 +5201,7 @@ dependencies = [
  "chumsky",
  "email-encoding",
  "email_address",
- "fastrand 2.3.0",
+ "fastrand",
  "futures-io",
  "futures-util",
  "hostname 0.4.0",
@@ -5581,15 +5541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5725,7 +5676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -5737,7 +5688,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -5756,7 +5707,7 @@ dependencies = [
  "futures-util",
  "once_cell",
  "parking_lot",
- "quanta 0.12.4",
+ "quanta",
  "rustc_version",
  "smallvec",
  "tagptr",
@@ -6222,7 +6173,6 @@ dependencies = [
  "actix-web-httpauth",
  "actix-web-lab",
  "actix-web-opentelemetry",
- "actix-web-prometheus",
  "actix-web-rust-embed-responder",
  "actix-ws",
  "ahash 0.8.11",
@@ -6854,7 +6804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.3.0",
+ "fastrand",
  "futures-io",
 ]
 
@@ -7430,22 +7380,6 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "mach",
- "once_cell",
- "raw-cpuid 10.7.0",
- "wasi 0.10.2+wasi-snapshot-preview1",
- "web-sys",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "quanta"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773ce68d0bb9bc7ef20be3536ffe94e223e1f365bd374108b2659fac0c65cfe6"
@@ -7453,8 +7387,8 @@ dependencies = [
  "crossbeam-utils",
  "libc",
  "once_cell",
- "raw-cpuid 11.2.0",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "raw-cpuid",
+ "wasi",
  "web-sys",
  "winapi 0.3.9",
 ]
@@ -7611,15 +7545,6 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "10.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -9493,7 +9418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
- "fastrand 2.3.0",
+ "fastrand",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -10507,12 +10432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "wal"
 version = "0.1.0"
 dependencies = [
@@ -10546,12 +10465,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ actix-web.workspace = true
 actix-web-httpauth = "0.8"
 actix-web-lab = "0.21"
 actix-web-opentelemetry = { version = "0.19", features = ["metrics"] }
-actix-web-prometheus.workspace = true
 actix-web-rust-embed-responder = { version = "2.2", default-features = false, features = [
     "support-rust-embed-for-web",
     "base64",
@@ -216,7 +215,6 @@ report_server = { path = "src/report_server" }
 aes-siv = "0.7.0"
 ahash = { version = "0.8", features = ["serde"] }
 actix-web = { version = "4.9", features = ["rustls-0_23"] }
-actix-web-prometheus = "0.1"
 actix-tls = { version = "3.4", features = [
     "connect",
     "uri",

--- a/src/common/utils/auth_tests.rs
+++ b/src/common/utils/auth_tests.rs
@@ -3111,7 +3111,6 @@ mod tests {
                 report_user_password: String::default(),
                 report_server_url: String::default(),
                 report_server_skip_tls_verify: bool::default(),
-                schema_cache_compress_enabled: bool::default(),
                 skip_formatting_stream_name: bool::default(),
                 bulk_api_response_errors_only: bool::default(),
                 allow_user_defined_schemas: bool::default(),

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -9,7 +9,6 @@ default = ["gxhash"]
 gxhash = ["dep:gxhash"]
 
 [dependencies]
-actix-web-prometheus.workspace = true
 aes-siv.workspace = true
 ahash.workspace = true
 anyhow.workspace = true

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -912,8 +912,6 @@ pub struct Common {
     pub report_server_url: String,
     #[env_config(name = "ZO_REPORT_SERVER_SKIP_TLS_VERIFY", default = false)]
     pub report_server_skip_tls_verify: bool,
-    #[env_config(name = "ZO_SCHEMA_CACHE_COMPRESS_ENABLED", default = false)]
-    pub schema_cache_compress_enabled: bool,
     #[env_config(name = "ZO_SKIP_FORMAT_STREAM_NAME", default = false)]
     pub skip_formatting_stream_name: bool,
     #[env_config(name = "ZO_BULK_RESPONSE_INCLUDE_ERRORS_ONLY", default = false)]

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -25,6 +25,8 @@ pub use config::*;
 pub async fn init() -> Result<(), anyhow::Error> {
     // init ider
     ider::init();
+    // init metrics
+    metrics::init();
 
     // initialize chrome launch options, so that if chrome download is
     // needed, it will happen now and not during serving report API

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -110,7 +110,7 @@ pub static INGEST_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &["organization", "stream_type", "error_type"],
+        &["organization", "stream_type", "stream", "error_type"],
     )
     .expect("Metric created")
 });

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -15,10 +15,10 @@
 
 use std::collections::HashMap;
 
-use actix_web_prometheus::{PrometheusMetrics, PrometheusMetricsBuilder};
 use once_cell::sync::Lazy;
 use prometheus::{
-    CounterVec, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry,
+    CounterVec, Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry,
+    TextEncoder,
 };
 
 pub const NAMESPACE: &str = "zo";
@@ -33,17 +33,11 @@ pub static HTTP_INCOMING_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "http_incoming_requests",
-            "HTTP incoming requests. ".to_owned() + HELP_SUFFIX,
+            "HTTP incoming requests.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &[
-            "endpoint",
-            "status",
-            "organization",
-            "stream",
-            "stream_type",
-        ],
+        &["endpoint", "status", "organization", "stream_type"],
     )
     .expect("Metric created")
 });
@@ -51,17 +45,11 @@ pub static HTTP_RESPONSE_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     HistogramVec::new(
         HistogramOpts::new(
             "http_response_time",
-            "HTTP response time. ".to_owned() + HELP_SUFFIX,
+            "HTTP response time.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &[
-            "endpoint",
-            "status",
-            "organization",
-            "stream",
-            "stream_type",
-        ],
+        &["endpoint", "status", "organization", "stream_type"],
     )
     .expect("Metric created")
 });
@@ -71,17 +59,11 @@ pub static GRPC_INCOMING_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "grpc_incoming_requests",
-            "gRPC incoming requests. ".to_owned() + HELP_SUFFIX,
+            "gRPC incoming requests.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &[
-            "endpoint",
-            "status",
-            "organization",
-            "stream",
-            "stream_type",
-        ],
+        &["endpoint", "status", "organization", "stream_type"],
     )
     .expect("Metric created")
 });
@@ -89,17 +71,11 @@ pub static GRPC_RESPONSE_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     HistogramVec::new(
         HistogramOpts::new(
             "grpc_response_time",
-            "gRPC response time. ".to_owned() + HELP_SUFFIX,
+            "gRPC response time.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &[
-            "endpoint",
-            "status",
-            "organization",
-            "stream",
-            "stream_type",
-        ],
+        &["endpoint", "status", "organization", "stream_type"],
     )
     .expect("Metric created")
 });
@@ -109,20 +85,20 @@ pub static INGEST_RECORDS: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "ingest_records",
-            "Ingested records. ".to_owned() + HELP_SUFFIX,
+            "Ingested records.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &["organization", "stream", "stream_type"],
+        &["organization", "stream_type"],
     )
     .expect("Metric created")
 });
 pub static INGEST_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
-        Opts::new("ingest_bytes", "Ingested bytes. ".to_owned() + HELP_SUFFIX)
+        Opts::new("ingest_bytes", "Ingested bytes.".to_owned() + HELP_SUFFIX)
             .namespace(NAMESPACE)
             .const_labels(create_const_labels()),
-        &["organization", "stream", "stream_type"],
+        &["organization", "stream_type"],
     )
     .expect("Metric created")
 });
@@ -134,7 +110,7 @@ pub static INGEST_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &["organization", "stream_type", "stream", "error_type"],
+        &["organization", "stream_type", "error_type"],
     )
     .expect("Metric created")
 });
@@ -142,7 +118,7 @@ pub static INGEST_WAL_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
             "ingest_wal_used_bytes",
-            "Ingestor WAL used bytes. ".to_owned() + HELP_SUFFIX,
+            "Ingestor WAL used bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -154,7 +130,7 @@ pub static INGEST_WAL_WRITE_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "ingest_wal_write_bytes",
-            "Ingestor WAL write bytes. ".to_owned() + HELP_SUFFIX,
+            "Ingestor WAL write bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -166,7 +142,7 @@ pub static INGEST_WAL_READ_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "ingest_wal_read_bytes",
-            "Ingestor WAL read bytes. ".to_owned() + HELP_SUFFIX,
+            "Ingestor WAL read bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -254,7 +230,7 @@ pub static QUERY_MEMORY_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
             "query_memory_cache_used_bytes",
-            "Querier memory cache used bytes. ".to_owned() + HELP_SUFFIX,
+            "Querier memory cache used bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -266,7 +242,7 @@ pub static QUERY_MEMORY_CACHE_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
             "query_memory_cache_files",
-            "Querier memory cached files. ".to_owned() + HELP_SUFFIX,
+            "Querier memory cached files.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -292,7 +268,7 @@ pub static QUERY_DISK_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
             "query_disk_cache_used_bytes",
-            "Querier diskcache used bytes. ".to_owned() + HELP_SUFFIX,
+            "Querier diskcache used bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -304,7 +280,7 @@ pub static QUERY_DISK_CACHE_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
             "query_disk_cache_files",
-            "Querier disk cached files. ".to_owned() + HELP_SUFFIX,
+            "Querier disk cached files.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -318,7 +294,7 @@ pub static QUERY_DISK_RESULT_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| 
     IntGaugeVec::new(
         Opts::new(
             "query_disk_result_cache_used_bytes",
-            "Querier disk result cache used bytes. ".to_owned() + HELP_SUFFIX,
+            "Querier disk result cache used bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -330,7 +306,7 @@ pub static QUERY_DISK_METRICS_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(||
     IntGaugeVec::new(
         Opts::new(
             "query_disk_metrics_cache_used_bytes",
-            "Querier disk metrics result cached bytes. ".to_owned() + HELP_SUFFIX,
+            "Querier disk metrics result cached bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -344,7 +320,7 @@ pub static QUERY_METRICS_CACHE_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "query_metrics_cache_requests",
-            "Querier metrics cache requests. ".to_owned() + HELP_SUFFIX,
+            "Querier metrics cache requests.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -356,7 +332,7 @@ pub static QUERY_METRICS_CACHE_HITS: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "query_metrics_cache_hits",
-            "Querier metrics cache hits. ".to_owned() + HELP_SUFFIX,
+            "Querier metrics cache hits.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -370,7 +346,7 @@ pub static COMPACT_USED_TIME: Lazy<CounterVec> = Lazy::new(|| {
     CounterVec::new(
         Opts::new(
             "compact_used_time",
-            "Compactor used time. ".to_owned() + HELP_SUFFIX,
+            "Compactor used time.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -382,7 +358,7 @@ pub static COMPACT_MERGED_FILES: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "compact_merged_files",
-            "Compactor merged files. ".to_owned() + HELP_SUFFIX,
+            "Compactor merged files.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -394,7 +370,7 @@ pub static COMPACT_MERGED_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "compact_merged_bytes",
-            "Compactor merged bytes. ".to_owned() + HELP_SUFFIX,
+            "Compactor merged bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -421,11 +397,11 @@ pub static STORAGE_ORIGINAL_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
             "storage_original_bytes",
-            "Storage original bytes. ".to_owned() + HELP_SUFFIX,
+            "Storage original bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &["organization", "stream", "stream_type"],
+        &["organization", "stream_type"],
     )
     .expect("Metric created")
 });
@@ -433,20 +409,20 @@ pub static STORAGE_COMPRESSED_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
             "storage_compressed_bytes",
-            "Storage compressed bytes. ".to_owned() + HELP_SUFFIX,
+            "Storage compressed bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &["organization", "stream", "stream_type"],
+        &["organization", "stream_type"],
     )
     .expect("Metric created")
 });
 pub static STORAGE_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
-        Opts::new("storage_files", "Storage files. ".to_owned() + HELP_SUFFIX)
+        Opts::new("storage_files", "Storage files.".to_owned() + HELP_SUFFIX)
             .namespace(NAMESPACE)
             .const_labels(create_const_labels()),
-        &["organization", "stream", "stream_type"],
+        &["organization", "stream_type"],
     )
     .expect("Metric created")
 });
@@ -454,11 +430,11 @@ pub static STORAGE_RECORDS: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
             "storage_records",
-            "Storage records. ".to_owned() + HELP_SUFFIX,
+            "Storage records.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &["organization", "stream", "stream_type"],
+        &["organization", "stream_type"],
     )
     .expect("Metric created")
 });
@@ -466,7 +442,7 @@ pub static STORAGE_WRITE_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "storage_write_requests",
-            "Storage write requests. ".to_owned() + HELP_SUFFIX,
+            "Storage write requests.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -478,7 +454,7 @@ pub static STORAGE_READ_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "storage_read_requests",
-            "Storage read requests. ".to_owned() + HELP_SUFFIX,
+            "Storage read requests.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -490,7 +466,7 @@ pub static STORAGE_WRITE_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "storage_write_bytes",
-            "Storage write bytes. ".to_owned() + HELP_SUFFIX,
+            "Storage write bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -502,7 +478,7 @@ pub static STORAGE_READ_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
             "storage_read_bytes",
-            "Storage read bytes. ".to_owned() + HELP_SUFFIX,
+            "Storage read bytes.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -514,7 +490,7 @@ pub static STORAGE_TIME: Lazy<CounterVec> = Lazy::new(|| {
     CounterVec::new(
         Opts::new(
             "storage_time",
-            "Storage response time. ".to_owned() + HELP_SUFFIX,
+            "Storage response time.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -591,11 +567,11 @@ pub static META_NUM_FUNCTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
             "meta_num_functions",
-            "Metadata function nums. ".to_owned() + HELP_SUFFIX,
+            "Metadata function nums.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &["organization", "stream", "stream_type", "function_type"],
+        &["organization", "stream_type", "function_type"],
     )
     .expect("Metric created")
 });
@@ -603,11 +579,11 @@ pub static META_NUM_ALERTS: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
             "meta_num_alerts",
-            "Metadata alert nums. ".to_owned() + HELP_SUFFIX,
+            "Metadata alert nums.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &["organization", "stream", "stream_type"],
+        &["organization", "stream_type"],
     )
     .expect("Metric created")
 });
@@ -672,7 +648,7 @@ pub static DB_QUERY_NUMS: Lazy<IntCounterVec> = Lazy::new(|| {
 
 pub static DB_QUERY_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     HistogramVec::new(
-        HistogramOpts::new("db_query_time", "db query time. ".to_owned())
+        HistogramOpts::new("db_query_time", "db query time.".to_owned())
             .namespace(NAMESPACE)
             .const_labels(create_const_labels()),
         &["operation", "table"],
@@ -968,20 +944,15 @@ fn create_const_labels() -> HashMap<String, String> {
     labels
 }
 
-pub fn create_prometheus_handler() -> PrometheusMetrics {
-    let cfg = crate::config::get_config();
-    let mut srv = PrometheusMetricsBuilder::new(NAMESPACE);
-    if cfg.common.prometheus_enabled {
-        srv = srv.endpoint(format!("{}/metrics", cfg.common.base_uri).as_str());
-    };
-    srv.const_labels(create_const_labels())
-        .registry(get_registry())
-        .build()
-        .expect("Prometheus build failed")
+pub fn gather() -> String {
+    let registry = prometheus::default_registry();
+    let mut buffer = vec![];
+    TextEncoder::new()
+        .encode(&registry.gather(), &mut buffer)
+        .unwrap();
+    String::from_utf8(buffer).unwrap()
 }
 
-pub fn get_registry() -> Registry {
-    let registry = prometheus::Registry::new();
-    register_metrics(&registry);
-    registry
+pub fn init() {
+    register_metrics(prometheus::default_registry());
 }

--- a/src/handler/grpc/flight/mod.rs
+++ b/src/handler/grpc/flight/mod.rs
@@ -309,10 +309,10 @@ impl Drop for FlightSenderStream {
         // metrics
         let time = self.start.elapsed().as_secs_f64();
         metrics::GRPC_RESPONSE_TIME
-            .with_label_values(&["/search/flight/do_get", "200", "", "", ""])
+            .with_label_values(&["/search/flight/do_get", "200", "", ""])
             .observe(time);
         metrics::GRPC_INCOMING_REQUESTS
-            .with_label_values(&["/search/flight/do_get", "200", "", "", ""])
+            .with_label_values(&["/search/flight/do_get", "200", "", ""])
             .inc();
 
         if let Some(defer) = self.defer.take() {

--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -90,10 +90,10 @@ impl Event for Eventer {
         // metrics
         let time = start.elapsed().as_secs_f64();
         metrics::GRPC_RESPONSE_TIME
-            .with_label_values(&["/event/send_file_list", "200", "", "", ""])
+            .with_label_values(&["/event/send_file_list", "200", "", ""])
             .observe(time);
         metrics::GRPC_INCOMING_REQUESTS
-            .with_label_values(&["/event/send_file_list", "200", "", "", ""])
+            .with_label_values(&["/event/send_file_list", "200", "", ""])
             .inc();
 
         Ok(Response::new(EmptyResponse {}))

--- a/src/handler/grpc/request/ingest.rs
+++ b/src/handler/grpc/request/ingest.rs
@@ -167,10 +167,10 @@ impl Ingest for Ingester {
         // metrics
         let time = start.elapsed().as_secs_f64();
         metrics::GRPC_RESPONSE_TIME
-            .with_label_values(&["/ingest/inner", "200", "", "", ""])
+            .with_label_values(&["/ingest/inner", "200", "", ""])
             .observe(time);
         metrics::GRPC_INCOMING_REQUESTS
-            .with_label_values(&["/ingest/inner", "200", "", "", ""])
+            .with_label_values(&["/ingest/inner", "200", "", ""])
             .inc();
 
         Ok(Response::new(reply))

--- a/src/handler/grpc/request/logs.rs
+++ b/src/handler/grpc/request/logs.rs
@@ -71,10 +71,10 @@ impl LogsService for LogsServer {
                 // metrics
                 let time = start.elapsed().as_secs_f64();
                 metrics::GRPC_RESPONSE_TIME
-                    .with_label_values(&["/otlp/v1/logs", "200", "", "", ""])
+                    .with_label_values(&["/otlp/v1/logs", "200", "", ""])
                     .observe(time);
                 metrics::GRPC_INCOMING_REQUESTS
-                    .with_label_values(&["/otlp/v1/logs", "200", "", "", ""])
+                    .with_label_values(&["/otlp/v1/logs", "200", "", ""])
                     .inc();
 
                 Ok(Response::new(ExportLogsServiceResponse {

--- a/src/handler/grpc/request/metrics/ingester.rs
+++ b/src/handler/grpc/request/metrics/ingester.rs
@@ -57,10 +57,10 @@ impl MetricsService for MetricsIngester {
             // metrics
             let time = start.elapsed().as_secs_f64();
             metrics::GRPC_RESPONSE_TIME
-                .with_label_values(&["/otlp/v1/metrics", "200", "", "", ""])
+                .with_label_values(&["/otlp/v1/metrics", "200", "", ""])
                 .observe(time);
             metrics::GRPC_INCOMING_REQUESTS
-                .with_label_values(&["/otlp/v1/metrics", "200", "", "", ""])
+                .with_label_values(&["/otlp/v1/metrics", "200", "", ""])
                 .inc();
             return Ok(Response::new(ExportMetricsServiceResponse {
                 partial_success: None,

--- a/src/handler/grpc/request/metrics/querier.rs
+++ b/src/handler/grpc/request/metrics/querier.rs
@@ -47,10 +47,10 @@ impl Metrics for MetricsQuerier {
         let result = SearchService::grpc::search(req).await.map_err(|err| {
             let time = start.elapsed().as_secs_f64();
             metrics::GRPC_RESPONSE_TIME
-                .with_label_values(&["/metrics/query", "500", org_id, "", stream_type])
+                .with_label_values(&["/metrics/query", "500", org_id, stream_type])
                 .observe(time);
             metrics::GRPC_INCOMING_REQUESTS
-                .with_label_values(&["/metrics/query", "500", org_id, "", stream_type])
+                .with_label_values(&["/metrics/query", "500", org_id, stream_type])
                 .inc();
             let message = if let errors::Error::ErrorCode(code) = err {
                 code.to_json()
@@ -62,10 +62,10 @@ impl Metrics for MetricsQuerier {
 
         let time = start.elapsed().as_secs_f64();
         metrics::GRPC_RESPONSE_TIME
-            .with_label_values(&["/metrics/query", "200", org_id, "", stream_type])
+            .with_label_values(&["/metrics/query", "200", org_id, stream_type])
             .observe(time);
         metrics::GRPC_INCOMING_REQUESTS
-            .with_label_values(&["/metrics/query", "200", org_id, "", stream_type])
+            .with_label_values(&["/metrics/query", "200", org_id, stream_type])
             .inc();
 
         Ok(Response::new(result))

--- a/src/handler/grpc/request/traces.rs
+++ b/src/handler/grpc/request/traces.rs
@@ -65,10 +65,10 @@ impl TraceService for TraceServer {
             // metrics
             let time = start.elapsed().as_secs_f64();
             metrics::GRPC_RESPONSE_TIME
-                .with_label_values(&["/otlp/v1/traces", "200", "", "", ""])
+                .with_label_values(&["/otlp/v1/traces", "200", "", ""])
                 .observe(time);
             metrics::GRPC_INCOMING_REQUESTS
-                .with_label_values(&["/otlp/v1/traces", "200", "", "", ""])
+                .with_label_values(&["/otlp/v1/traces", "200", "", ""])
                 .inc();
             return Ok(Response::new(ExportTraceServiceResponse {
                 partial_success: None,

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -1363,13 +1363,7 @@ pub async fn search_history(
     let mut search_res = match search_res {
         Ok(res) => res,
         Err(err) => {
-            http_report_metrics(
-                start,
-                &org_id,
-                stream_type,
-                "500",
-                "_search_history",
-            );
+            http_report_metrics(start, &org_id, stream_type, "500", "_search_history");
             log::error!("[trace_id {}] Search history error : {:?}", trace_id, err);
             return Ok(match err {
                 errors::Error::ErrorCode(code) => HttpResponse::InternalServerError().json(
@@ -1404,13 +1398,7 @@ pub async fn search_history(
     search_res.trace_id = trace_id.clone();
 
     // report http metrics
-    http_report_metrics(
-        start,
-        &org_id,
-        stream_type,
-        "200",
-        "_search_history",
-    );
+    http_report_metrics(start, &org_id, stream_type, "200", "_search_history");
 
     // prepare usage metrics
     let time_taken = start.elapsed().as_secs_f64();

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -333,7 +333,7 @@ pub async fn search(
     match res {
         Ok(res) => Ok(HttpResponse::Ok().json(res)),
         Err(err) => {
-            http_report_metrics(start, &org_id, stream_type, "", "500", "_search");
+            http_report_metrics(start, &org_id, stream_type, "500", "_search");
             log::error!("[trace_id {trace_id}] search error: {}", err);
             Ok(match err {
                 errors::Error::ErrorCode(code) => match code {
@@ -549,7 +549,7 @@ pub async fn around(
     let resp_forward = match search_res {
         Ok(res) => res,
         Err(err) => {
-            http_report_metrics(start, &org_id, stream_type, &stream_name, "500", "_around");
+            http_report_metrics(start, &org_id, stream_type, "500", "_around");
             log::error!("search around error: {:?}", err);
             return Ok(match err {
                 errors::Error::ErrorCode(code) => match code {
@@ -605,7 +605,7 @@ pub async fn around(
     let resp_backward = match search_res {
         Ok(res) => res,
         Err(err) => {
-            http_report_metrics(start, &org_id, stream_type, &stream_name, "500", "_around");
+            http_report_metrics(start, &org_id, stream_type, "500", "_around");
             log::error!("search around error: {:?}", err);
             return Ok(match err {
                 errors::Error::ErrorCode(code) => match code {
@@ -644,7 +644,7 @@ pub async fn around(
     resp.cached_ratio = (resp_forward.cached_ratio + resp_backward.cached_ratio) / 2;
 
     let time = start.elapsed().as_secs_f64();
-    http_report_metrics(start, &org_id, stream_type, &stream_name, "200", "_around");
+    http_report_metrics(start, &org_id, stream_type, "200", "_around");
 
     let req_stats = RequestStats {
         records: resp.hits.len() as i64,
@@ -1002,7 +1002,7 @@ async fn values_v1(
         let resp_search = match search_res {
             Ok(res) => res,
             Err(err) => {
-                http_report_metrics(start, org_id, stream_type, stream_name, "500", "_values/v1");
+                http_report_metrics(start, org_id, stream_type, "500", "_values/v1");
                 log::error!("search values error: {:?}", err);
                 return Ok(match err {
                     errors::Error::ErrorCode(code) => match code {
@@ -1078,7 +1078,7 @@ async fn values_v1(
     resp.took = start.elapsed().as_millis() as usize;
 
     let time = start.elapsed().as_secs_f64();
-    http_report_metrics(start, org_id, stream_type, stream_name, "200", "_values/v1");
+    http_report_metrics(start, org_id, stream_type, "200", "_values/v1");
 
     let req_stats = RequestStats {
         records: resp.hits.len() as i64,
@@ -1195,11 +1195,11 @@ pub async fn search_partition(
     // do search
     match search_res {
         Ok(res) => {
-            http_report_metrics(start, &org_id, stream_type, "", "200", "_search_partition");
+            http_report_metrics(start, &org_id, stream_type, "200", "_search_partition");
             Ok(HttpResponse::Ok().json(res))
         }
         Err(err) => {
-            http_report_metrics(start, &org_id, stream_type, "", "500", "_search_partition");
+            http_report_metrics(start, &org_id, stream_type, "500", "_search_partition");
             log::error!("search error: {:?}", err);
             Ok(match err {
                 errors::Error::ErrorCode(code) => HttpResponse::InternalServerError().json(
@@ -1367,7 +1367,6 @@ pub async fn search_history(
                 start,
                 &org_id,
                 stream_type,
-                stream_name,
                 "500",
                 "_search_history",
             );
@@ -1409,7 +1408,6 @@ pub async fn search_history(
         start,
         &org_id,
         stream_type,
-        stream_name,
         "200",
         "_search_history",
     );

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -364,7 +364,6 @@ pub async fn search_multi(
                         "/api/org/_search_multi",
                         "200",
                         &org_id,
-                        "",
                         stream_type.as_str(),
                     ])
                     .observe(time);
@@ -373,7 +372,6 @@ pub async fn search_multi(
                         "/api/org/_search_multi",
                         "200",
                         &org_id,
-                        "",
                         stream_type.as_str(),
                     ])
                     .inc();
@@ -458,7 +456,6 @@ pub async fn search_multi(
                         "/api/org/_search_multi",
                         "500",
                         &org_id,
-                        "",
                         stream_type.as_str(),
                     ])
                     .observe(time);
@@ -467,7 +464,6 @@ pub async fn search_multi(
                         "/api/org/_search_multi",
                         "500",
                         &org_id,
-                        "",
                         stream_type.as_str(),
                     ])
                     .inc();
@@ -728,7 +724,6 @@ pub async fn _search_partition_multi(
                     "/api/org/_search_partition_multi",
                     "200",
                     &org_id,
-                    "",
                     stream_type.as_str(),
                 ])
                 .observe(time);
@@ -737,7 +732,6 @@ pub async fn _search_partition_multi(
                     "/api/org/_search_partition_multi",
                     "200",
                     &org_id,
-                    "",
                     stream_type.as_str(),
                 ])
                 .inc();
@@ -750,7 +744,6 @@ pub async fn _search_partition_multi(
                     "/api/org/_search_partition_multi",
                     "500",
                     &org_id,
-                    "",
                     stream_type.as_str(),
                 ])
                 .observe(time);
@@ -759,7 +752,6 @@ pub async fn _search_partition_multi(
                     "/api/org/_search_partition_multi",
                     "500",
                     &org_id,
-                    "",
                     stream_type.as_str(),
                 ])
                 .inc();
@@ -995,7 +987,6 @@ pub async fn around_multi(
                         "/api/org/_around_multi",
                         "500",
                         &org_id,
-                        &stream_names,
                         stream_type.as_str(),
                     ])
                     .observe(time);
@@ -1004,7 +995,6 @@ pub async fn around_multi(
                         "/api/org/_around_multi",
                         "500",
                         &org_id,
-                        &stream_names,
                         stream_type.as_str(),
                     ])
                     .inc();
@@ -1073,7 +1063,6 @@ pub async fn around_multi(
                         "/api/org/_around_multi",
                         "500",
                         &org_id,
-                        &stream_names,
                         stream_type.as_str(),
                     ])
                     .observe(time);
@@ -1082,7 +1071,6 @@ pub async fn around_multi(
                         "/api/org/_around_multi",
                         "500",
                         &org_id,
-                        &stream_names,
                         stream_type.as_str(),
                     ])
                     .inc();
@@ -1132,7 +1120,6 @@ pub async fn around_multi(
                 "/api/org/_around_multi",
                 "200",
                 &org_id,
-                &stream_names,
                 stream_type.as_str(),
             ])
             .observe(time);
@@ -1141,7 +1128,6 @@ pub async fn around_multi(
                 "/api/org/_around_multi",
                 "200",
                 &org_id,
-                &stream_names,
                 stream_type.as_str(),
             ])
             .inc();

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -34,7 +34,7 @@ use hashbrown::HashMap;
 use infra::{
     cache::{self, file_data::disk::FileType},
     file_list,
-    schema::{STREAM_SCHEMAS, STREAM_SCHEMAS_COMPRESSED, STREAM_SCHEMAS_LATEST},
+    schema::{STREAM_SCHEMAS, STREAM_SCHEMAS_LATEST},
 };
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -427,13 +427,6 @@ async fn get_stream_schema_status() -> (usize, usize, usize) {
             stream_schema_num += 1;
             mem_size += schema.1.size();
         }
-    }
-    drop(r);
-    let r = STREAM_SCHEMAS_COMPRESSED.read().await;
-    for (key, val) in r.iter() {
-        stream_num += 1;
-        mem_size += key.len();
-        mem_size += val.len();
     }
     drop(r);
     let r = STREAM_SCHEMAS_LATEST.read().await;

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -320,7 +320,6 @@ pub async fn get_latest_traces(
                     "/api/org/traces/latest",
                     "500",
                     &org_id,
-                    "default",
                     stream_type.as_str(),
                 ])
                 .observe(time);
@@ -329,7 +328,6 @@ pub async fn get_latest_traces(
                     "/api/org/traces/latest",
                     "500",
                     &org_id,
-                    "default",
                     stream_type.as_str(),
                 ])
                 .inc();
@@ -411,7 +409,6 @@ pub async fn get_latest_traces(
                         "/api/org/traces/latest",
                         "500",
                         &org_id,
-                        &stream_name,
                         stream_type.as_str(),
                     ])
                     .observe(time);
@@ -420,7 +417,6 @@ pub async fn get_latest_traces(
                         "/api/org/traces/latest",
                         "500",
                         &org_id,
-                        &stream_name,
                         stream_type.as_str(),
                     ])
                     .inc();
@@ -504,7 +500,6 @@ pub async fn get_latest_traces(
             "/api/org/traces/latest",
             "200",
             &org_id,
-            &stream_name,
             stream_type.as_str(),
         ])
         .observe(time);
@@ -513,7 +508,6 @@ pub async fn get_latest_traces(
             "/api/org/traces/latest",
             "200",
             &org_id,
-            &stream_name,
             stream_type.as_str(),
         ])
         .inc();

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -19,6 +19,7 @@ use actix_cors::Cors;
 use actix_web::{
     HttpRequest, HttpResponse,
     body::MessageBody,
+    get,
     dev::{Service, ServiceRequest, ServiceResponse},
     http::header,
     middleware, web,
@@ -144,6 +145,21 @@ async fn audit_middleware(
     next: Next<impl MessageBody>,
 ) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
     next.call(req).await
+}
+
+#[get("/metrics")]
+async fn get_metrics() -> Result<HttpResponse, actix_web::Error> {
+    let body = if config::get_config().common.prometheus_enabled {
+        config::metrics::gather()
+    } else {
+        "".to_string()
+    };
+    let mut resp = HttpResponse::Ok().body(body);
+    resp.headers_mut().insert(
+        header::CONTENT_TYPE,
+        header::HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
+    );
+    Ok(resp)
 }
 
 /// This is a very trivial proxy to overcome the cors errors while

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -19,8 +19,8 @@ use actix_cors::Cors;
 use actix_web::{
     HttpRequest, HttpResponse,
     body::MessageBody,
-    get,
     dev::{Service, ServiceRequest, ServiceResponse},
+    get,
     http::header,
     middleware, web,
 };

--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -601,7 +601,7 @@ impl super::Db for NatsDb {
                 loop {
                     match entries.next().await {
                         None => {
-                            log::error!("watching prefix: {}, get message error", prefix);
+                            log::error!("[NATS:watch] prefix: {}, get message error", prefix);
                             break;
                         }
                         Some(entry) => {
@@ -609,7 +609,7 @@ impl super::Db for NatsDb {
                                 Ok(entry) => entry,
                                 Err(e) => {
                                     log::error!(
-                                        "watching prefix: {}, get message error: {}",
+                                        "[NATS:watch] prefix: {}, get message error: {}",
                                         prefix,
                                         e
                                     );

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -24,7 +24,6 @@ use config::{
     utils::{json, schema_ext::SchemaExt},
 };
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef, Schema, SchemaRef};
-use futures::{StreamExt, TryStreamExt};
 use once_cell::sync::Lazy;
 use serde::Serialize;
 
@@ -36,8 +35,6 @@ use crate::{
 pub mod history;
 
 pub static STREAM_SCHEMAS: Lazy<RwAHashMap<String, Vec<(i64, Schema)>>> =
-    Lazy::new(Default::default);
-pub static STREAM_SCHEMAS_COMPRESSED: Lazy<RwAHashMap<String, Vec<(i64, bytes::Bytes)>>> =
     Lazy::new(Default::default);
 pub static STREAM_SCHEMAS_LATEST: Lazy<RwAHashMap<String, SchemaCache>> =
     Lazy::new(Default::default);
@@ -127,79 +124,37 @@ pub async fn get_versions(
 ) -> Result<Vec<Schema>> {
     let key = mk_key(org_id, stream_type, stream_name);
     let cache_key = key.strip_prefix("/schema/").unwrap();
-
-    let cfg = get_config();
+ 
     let (min_ts, max_ts) = time_range.unwrap_or((0, 0));
-    if cfg.common.schema_cache_compress_enabled {
-        let mut last_schema_index = None;
-        let r = STREAM_SCHEMAS_COMPRESSED.read().await;
-        if let Some(versions) = r.get(cache_key) {
-            let mut compressed_schemas = Vec::new();
+    let mut last_schema_index = None;
+    let r = STREAM_SCHEMAS.read().await;
+    if let Some(versions) = r.get(cache_key) {
+        let mut schemas = Vec::new();
 
-            for (index, (start_dt, data)) in versions.iter().enumerate() {
-                if *start_dt >= min_ts && (max_ts == 0 || *start_dt <= max_ts) {
-                    compressed_schemas.push(data.clone());
-                    if last_schema_index.is_none() {
-                        last_schema_index = Some(index);
-                    }
+        for (index, (start_dt, data)) in versions.iter().enumerate() {
+            if *start_dt >= min_ts && (max_ts == 0 || *start_dt <= max_ts) {
+                schemas.push(data.clone());
+                if last_schema_index.is_none() {
+                    last_schema_index = Some(index);
                 }
             }
-
-            if let Some(last_index) = last_schema_index {
-                if last_index > 0 {
-                    if let Some((_, data)) = versions.get(last_index - 1) {
-                        // older version of schema before start_dt hence added in start
-                        compressed_schemas.insert(0, data.clone());
-                    }
-                }
-            } else {
-                // this is latest version of schema hence added in end
-                compressed_schemas.push(versions.last().unwrap().1.clone());
-            }
-            let schemas = futures::stream::iter(compressed_schemas)
-                .map(|data| async move {
-                    let de_bytes = zstd::decode_all(data.as_ref())?;
-                    let mut schemas: Vec<Schema> = json::from_slice(&de_bytes)?;
-                    Ok::<Option<Schema>, Error>(schemas.pop())
-                })
-                .buffer_unordered(cfg.limit.cpu_num)
-                .try_collect::<Vec<Option<Schema>>>()
-                .await
-                .map_err(|e| Error::Message(e.to_string()))?;
-            return Ok(schemas.into_iter().flatten().collect());
         }
-        drop(r);
-    } else {
-        let mut last_schema_index = None;
-        let r = STREAM_SCHEMAS.read().await;
-        if let Some(versions) = r.get(cache_key) {
-            let mut schemas = Vec::new();
 
-            for (index, (start_dt, data)) in versions.iter().enumerate() {
-                if *start_dt >= min_ts && (max_ts == 0 || *start_dt <= max_ts) {
-                    schemas.push(data.clone());
-                    if last_schema_index.is_none() {
-                        last_schema_index = Some(index);
-                    }
+        if let Some(last_index) = last_schema_index {
+            if last_index > 0 {
+                if let Some((_, data)) = versions.get(last_index - 1) {
+                    // older version of schema before start_dt should be added in start
+                    schemas.insert(0, data.clone());
                 }
             }
-
-            if let Some(last_index) = last_schema_index {
-                if last_index > 0 {
-                    if let Some((_, data)) = versions.get(last_index - 1) {
-                        // older version of schema before start_dt should be added in start
-                        schemas.insert(0, data.clone());
-                    }
-                }
-            } else {
-                // this is latest version of schema hence added in end
-                schemas.push(versions.last().unwrap().1.clone());
-            }
-
-            return Ok(schemas);
+        } else {
+            // this is latest version of schema hence added in end
+            schemas.push(versions.last().unwrap().1.clone());
         }
-        drop(r);
+
+        return Ok(schemas);
     }
+    drop(r);
 
     let db = infra_db::get_db().await;
     Ok(match db.get(&key).await {

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -124,7 +124,7 @@ pub async fn get_versions(
 ) -> Result<Vec<Schema>> {
     let key = mk_key(org_id, stream_type, stream_name);
     let cache_key = key.strip_prefix("/schema/").unwrap();
- 
+
     let (min_ts, max_ts) = time_range.unwrap_or((0, 0));
     let mut last_schema_index = None;
     let r = STREAM_SCHEMAS.read().await;

--- a/src/job/metrics.rs
+++ b/src/job/metrics.rs
@@ -152,6 +152,10 @@ async fn load_ingest_wal_used_bytes() -> Result<(), anyhow::Error> {
 }
 
 async fn update_metadata_metrics() -> Result<(), anyhow::Error> {
+    if !config::cluster::LOCAL_NODE.is_compactor() {
+        return Ok(());
+    }
+    
     let db = get_db().await;
     let stats = db.stats().await?;
     metrics::META_STORAGE_BYTES
@@ -239,12 +243,12 @@ async fn update_metadata_metrics() -> Result<(), anyhow::Error> {
         if columns.len() <= 2 {
             // query functions
             metrics::META_NUM_FUNCTIONS
-                .with_label_values(&[columns[0], "", "", "query"])
+                .with_label_values(&[columns[0], "", "query"])
                 .inc();
         } else {
             // ingest functions
             metrics::META_NUM_FUNCTIONS
-                .with_label_values(&[columns[0], columns[2], columns[1], "ingest"])
+                .with_label_values(&[columns[0], columns[1], "ingest"])
                 .inc();
         }
     }
@@ -256,20 +260,24 @@ async fn update_metadata_metrics() -> Result<(), anyhow::Error> {
 }
 
 async fn update_storage_metrics() -> Result<(), anyhow::Error> {
-    let stats = cache::stats::get_stats();
+    if !config::cluster::LOCAL_NODE.is_compactor() {
+        return Ok(());
+    }
+    
+     let stats = cache::stats::get_stats();
     for (key, stat) in stats {
         let columns = key.split('/').collect::<Vec<&str>>();
         metrics::STORAGE_ORIGINAL_BYTES
-            .with_label_values(&[columns[0], columns[2], columns[1]])
+            .with_label_values(&[columns[0], columns[1]])
             .set(stat.storage_size as i64);
         metrics::STORAGE_COMPRESSED_BYTES
-            .with_label_values(&[columns[0], columns[2], columns[1]])
+            .with_label_values(&[columns[0], columns[1]])
             .set(stat.compressed_size as i64);
         metrics::STORAGE_FILES
-            .with_label_values(&[columns[0], columns[2], columns[1]])
+            .with_label_values(&[columns[0], columns[1]])
             .set(stat.file_num);
         metrics::STORAGE_RECORDS
-            .with_label_values(&[columns[0], columns[2], columns[1]])
+            .with_label_values(&[columns[0], columns[1]])
             .set(stat.doc_num);
     }
     Ok(())

--- a/src/job/metrics.rs
+++ b/src/job/metrics.rs
@@ -155,7 +155,7 @@ async fn update_metadata_metrics() -> Result<(), anyhow::Error> {
     if !config::cluster::LOCAL_NODE.is_compactor() {
         return Ok(());
     }
-    
+
     let db = get_db().await;
     let stats = db.stats().await?;
     metrics::META_STORAGE_BYTES
@@ -263,8 +263,8 @@ async fn update_storage_metrics() -> Result<(), anyhow::Error> {
     if !config::cluster::LOCAL_NODE.is_compactor() {
         return Ok(());
     }
-    
-     let stats = cache::stats::get_stats();
+
+    let stats = cache::stats::get_stats();
     for (key, stat) in stats {
         let columns = key.split('/').collect::<Vec<&str>>();
         metrics::STORAGE_ORIGINAL_BYTES

--- a/src/job/promql_self_consume.rs
+++ b/src/job/promql_self_consume.rs
@@ -18,7 +18,6 @@ use config::{
     cluster::LOCAL_NODE,
     get_config,
     meta::{cluster::get_internal_grpc_token, stream::StreamType},
-    metrics::get_registry,
     utils::{prom_json_encoder::JsonEncoder, util::zero_or},
 };
 use hashbrown::HashSet;
@@ -92,13 +91,12 @@ pub async fn run() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    let registry = get_registry();
-
     // Set up the interval timer for periodic fetching
     let timeout = zero_or(config.common.self_metrics_consumption_interval, 60);
     let mut interval = time::interval(Duration::from_secs(timeout));
     interval.tick().await; // Trigger the first run
 
+    let registry = prometheus::default_registry();
     loop {
         // Wait for the interval before running the task again
         interval.tick().await;

--- a/src/job/stats.rs
+++ b/src/job/stats.rs
@@ -58,7 +58,7 @@ async fn file_list_update_stats() -> Result<(), anyhow::Error> {
 }
 
 async fn cache_stream_stats() -> Result<(), anyhow::Error> {
-    if !LOCAL_NODE.is_querier() {
+    if !LOCAL_NODE.is_querier() && !LOCAL_NODE.is_compactor() {
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1010,8 +1010,6 @@ fn enable_tracing() -> Result<(), anyhow::Error> {
 #[cfg(feature = "enterprise")]
 async fn init_script_server() -> Result<(), anyhow::Error> {
     let cfg = get_config();
-    // metrics
-    let prometheus = config::metrics::create_prometheus_handler();
 
     let thread_id = Arc::new(AtomicU16::new(0));
     let haddr: SocketAddr = if cfg.http.ipv6_enabled {
@@ -1046,10 +1044,8 @@ async fn init_script_server() -> Result<(), anyhow::Error> {
             haddr,
             local_id
         );
-        let mut app = App::new().wrap(prometheus.clone());
-
+        let mut app = App::new();
         app = app.service(web::scope(&cfg.common.base_uri).configure(get_script_server_routes));
-
         app.app_data(web::JsonConfig::default().limit(cfg.limit.req_json_limit))
             .app_data(web::PayloadConfig::new(cfg.limit.req_payload_limit)) // size is in bytes
             .app_data(web::Data::new(local_id))

--- a/src/main.rs
+++ b/src/main.rs
@@ -627,8 +627,6 @@ async fn init_router_grpc_server(
 
 async fn init_http_server() -> Result<(), anyhow::Error> {
     let cfg = get_config();
-    // metrics
-    let prometheus = config::metrics::create_prometheus_handler();
 
     let thread_id = Arc::new(AtomicU16::new(0));
     let haddr: SocketAddr = if cfg.http.ipv6_enabled {
@@ -659,7 +657,7 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
             haddr,
             local_id
         );
-        let mut app = App::new().wrap(prometheus.clone());
+        let mut app = App::new();
         if config::cluster::LOCAL_NODE.is_router() {
             let http_client =
                 router::http::create_http_client().expect("Failed to create http tls client");
@@ -672,6 +670,7 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
                             cfg.limit.circuit_breaker_enabled,
                         ))
                         .wrap(from_fn(middlewares::check_keep_alive))
+                        .service(get_metrics)
                         .service(router::http::config)
                         .service(router::http::config_paths)
                         .service(router::http::api)
@@ -690,6 +689,7 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
                         cfg.limit.circuit_breaker_enabled,
                     ))
                     .wrap(from_fn(middlewares::check_keep_alive))
+                    .service(get_metrics)
                     .configure(get_config_routes)
                     .configure(get_service_routes)
                     .configure(get_other_service_routes)
@@ -736,9 +736,6 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
 
 async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
     let cfg = get_config();
-    // metrics
-    let prometheus = config::metrics::create_prometheus_handler();
-
     let thread_id = Arc::new(AtomicU16::new(0));
     let haddr: SocketAddr = if cfg.http.ipv6_enabled {
         format!("[::]:{}", cfg.http.port).parse()?
@@ -770,7 +767,7 @@ async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
             local_id
         );
 
-        let mut app = App::new().wrap(prometheus.clone());
+        let mut app = App::new();
         if config::cluster::LOCAL_NODE.is_router() {
             let http_client =
                 router::http::create_http_client().expect("Failed to create http tls client");
@@ -783,6 +780,7 @@ async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
                             cfg.limit.circuit_breaker_enabled,
                         ))
                         .wrap(from_fn(middlewares::check_keep_alive))
+                        .service(get_metrics)
                         .service(router::http::config)
                         .service(router::http::config_paths)
                         .service(router::http::api)
@@ -801,6 +799,7 @@ async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
                         cfg.limit.circuit_breaker_enabled,
                     ))
                     .wrap(from_fn(middlewares::check_keep_alive))
+                    .service(get_metrics)
                     .configure(get_config_routes)
                     .configure(get_service_routes)
                     .configure(get_other_service_routes)

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -36,8 +36,8 @@ use futures::{StreamExt, TryStreamExt};
 use infra::{
     cache::stats,
     schema::{
-        STREAM_RECORD_ID_GENERATOR, STREAM_SCHEMAS, STREAM_SCHEMAS_COMPRESSED,
-        STREAM_SCHEMAS_LATEST, STREAM_SETTINGS, SchemaCache,
+        STREAM_RECORD_ID_GENERATOR, STREAM_SCHEMAS, STREAM_SCHEMAS_LATEST, STREAM_SETTINGS,
+        SchemaCache,
     },
 };
 
@@ -267,9 +267,6 @@ async fn delete_enrichment_table(org_id: &str, stream_name: &str, stream_type: S
     // delete stream schema cache
     let key = format!("{org_id}/{stream_type}/{stream_name}");
     let mut w = STREAM_SCHEMAS.write().await;
-    w.remove(&key);
-    drop(w);
-    let mut w = STREAM_SCHEMAS_COMPRESSED.write().await;
     w.remove(&key);
     drop(w);
     let mut w = STREAM_SCHEMAS_LATEST.write().await;

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -564,7 +564,6 @@ pub async fn ingest(
             "/api/org/ingest/logs/_bulk",
             metric_rpt_status_code,
             org_id,
-            "",
             StreamType::Logs.as_str(),
         ])
         .observe(took_time);
@@ -573,7 +572,6 @@ pub async fn ingest(
             "/api/org/ingest/logs/_bulk",
             metric_rpt_status_code,
             org_id,
-            "",
             StreamType::Logs.as_str(),
         ])
         .inc();

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -404,7 +404,6 @@ pub async fn ingest(
             endpoint,
             metric_rpt_status_code,
             org_id,
-            &stream_name,
             StreamType::Logs.as_str(),
         ])
         .observe(took_time);
@@ -413,7 +412,6 @@ pub async fn ingest(
             endpoint,
             metric_rpt_status_code,
             org_id,
-            &stream_name,
             StreamType::Logs.as_str(),
         ])
         .inc();

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -404,7 +404,6 @@ pub async fn handle_grpc_request(
             ep,
             metric_rpt_status_code,
             org_id,
-            &stream_name,
             StreamType::Logs.as_str(),
         ])
         .observe(took_time);
@@ -413,7 +412,6 @@ pub async fn handle_grpc_request(
             ep,
             metric_rpt_status_code,
             org_id,
-            &stream_name,
             StreamType::Logs.as_str(),
         ])
         .inc();

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -531,7 +531,6 @@ pub async fn logs_json_handler(
             "/api/otlp/v1/logs",
             metric_rpt_status_code,
             org_id,
-            &stream_name,
             StreamType::Logs.as_str(),
         ])
         .observe(took_time);
@@ -540,7 +539,6 @@ pub async fn logs_json_handler(
             "/api/otlp/v1/logs",
             metric_rpt_status_code,
             org_id,
-            &stream_name,
             StreamType::Logs.as_str(),
         ])
         .inc();

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -363,7 +363,6 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
             "/api/org/ingest/logs/_syslog",
             metric_rpt_status_code,
             org_id,
-            &stream_name,
             StreamType::Logs.as_str(),
         ])
         .observe(time);
@@ -372,7 +371,6 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
             "/api/org/ingest/logs/_syslog",
             metric_rpt_status_code,
             org_id,
-            &stream_name,
             StreamType::Logs.as_str(),
         ])
         .inc();

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -479,7 +479,6 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
             "/api/org/ingest/metrics/_json",
             "200",
             org_id,
-            "",
             StreamType::Metrics.as_str(),
         ])
         .observe(time);
@@ -488,7 +487,6 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
             "/api/org/ingest/metrics/_json",
             "200",
             org_id,
-            "",
             StreamType::Metrics.as_str(),
         ])
         .inc();

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -577,10 +577,10 @@ pub async fn handle_otlp_request(
 
     let time_took = start.elapsed().as_secs_f64();
     metrics::HTTP_RESPONSE_TIME
-        .with_label_values(&[ep, "200", org_id, "", StreamType::Metrics.as_str()])
+        .with_label_values(&[ep, "200", org_id, StreamType::Metrics.as_str()])
         .observe(time_took);
     metrics::HTTP_INCOMING_REQUESTS
-        .with_label_values(&[ep, "200", org_id, "", StreamType::Metrics.as_str()])
+        .with_label_values(&[ep, "200", org_id, StreamType::Metrics.as_str()])
         .inc();
 
     // only one trigger per request, as it updates etcd

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -160,7 +160,6 @@ pub async fn remote_write(
                 "/prometheus/api/v1/write",
                 "200",
                 org_id,
-                "",
                 StreamType::Metrics.as_str(),
             ])
             .observe(time);
@@ -169,7 +168,6 @@ pub async fn remote_write(
                 "/prometheus/api/v1/write",
                 "200",
                 org_id,
-                "",
                 StreamType::Metrics.as_str(),
             ])
             .inc();
@@ -264,7 +262,6 @@ pub async fn remote_write(
                         "/prometheus/api/v1/write",
                         "200",
                         org_id,
-                        "",
                         StreamType::Metrics.as_str(),
                     ])
                     .observe(time);
@@ -273,7 +270,6 @@ pub async fn remote_write(
                         "/prometheus/api/v1/write",
                         "200",
                         org_id,
-                        "",
                         StreamType::Metrics.as_str(),
                     ])
                     .inc();
@@ -564,7 +560,6 @@ pub async fn remote_write(
             "/prometheus/api/v1/write",
             "200",
             org_id,
-            "",
             StreamType::Metrics.as_str(),
         ])
         .observe(time);
@@ -573,7 +568,6 @@ pub async fn remote_write(
             "/prometheus/api/v1/write",
             "200",
             org_id,
-            "",
             StreamType::Metrics.as_str(),
         ])
         .inc();

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -296,7 +296,7 @@ pub async fn search(
 
     // do search
     let time = start.elapsed().as_secs_f64();
-    http_report_metrics(start, org_id, stream_type, "", "200", "_search");
+    http_report_metrics(start, org_id, stream_type, "200", "_search");
     res.set_trace_id(trace_id.to_string());
     res.set_local_took(start.elapsed().as_millis() as usize, ext_took_wait);
 

--- a/src/service/self_reporting/mod.rs
+++ b/src/service/self_reporting/mod.rs
@@ -82,10 +82,10 @@ pub async fn report_request_usage_stats(
     timestamp: i64,
 ) {
     metrics::INGEST_RECORDS
-        .with_label_values(&[org_id, stream_name, stream_type.as_str()])
+        .with_label_values(&[org_id, stream_type.as_str()])
         .inc_by(stats.records as u64);
     metrics::INGEST_BYTES
-        .with_label_values(&[org_id, stream_name, stream_type.as_str()])
+        .with_label_values(&[org_id, stream_type.as_str()])
         .inc_by((stats.size * SIZE_IN_MB) as u64);
     let event: UsageEvent = usage_type.into();
     let now = DateTime::from_timestamp_micros(timestamp).unwrap();
@@ -316,16 +316,15 @@ pub fn http_report_metrics(
     start: std::time::Instant,
     org_id: &str,
     stream_type: StreamType,
-    stream_name: &str,
     code: &str,
     uri: &str,
 ) {
     let time = start.elapsed().as_secs_f64();
     let uri = format!("/api/org/{}", uri);
     metrics::HTTP_RESPONSE_TIME
-        .with_label_values(&[&uri, code, org_id, stream_name, stream_type.as_str()])
+        .with_label_values(&[&uri, code, org_id, stream_type.as_str()])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
-        .with_label_values(&[&uri, code, org_id, stream_name, stream_type.as_str()])
+        .with_label_values(&[&uri, code, org_id, stream_type.as_str()])
         .inc();
 }

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -33,9 +33,8 @@ use hashbrown::HashMap;
 use infra::{
     cache::stats,
     schema::{
-        STREAM_RECORD_ID_GENERATOR, STREAM_SCHEMAS,
-        STREAM_SCHEMAS_LATEST, STREAM_SETTINGS, unwrap_partition_time_level,
-        unwrap_stream_settings,
+        STREAM_RECORD_ID_GENERATOR, STREAM_SCHEMAS, STREAM_SCHEMAS_LATEST, STREAM_SETTINGS,
+        unwrap_partition_time_level, unwrap_stream_settings,
     },
     table::distinct_values::{DistinctFieldRecord, OriginType, check_field_use},
 };

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -33,7 +33,7 @@ use hashbrown::HashMap;
 use infra::{
     cache::stats,
     schema::{
-        STREAM_RECORD_ID_GENERATOR, STREAM_SCHEMAS, STREAM_SCHEMAS_COMPRESSED,
+        STREAM_RECORD_ID_GENERATOR, STREAM_SCHEMAS,
         STREAM_SCHEMAS_LATEST, STREAM_SETTINGS, unwrap_partition_time_level,
         unwrap_stream_settings,
     },
@@ -581,9 +581,6 @@ pub async fn delete_stream(
     // delete stream schema cache
     let key = format!("{org_id}/{stream_type}/{stream_name}");
     let mut w = STREAM_SCHEMAS.write().await;
-    w.remove(&key);
-    drop(w);
-    let mut w = STREAM_SCHEMAS_COMPRESSED.write().await;
     w.remove(&key);
     drop(w);
     let mut w = STREAM_SCHEMAS_LATEST.write().await;

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -544,20 +544,10 @@ pub async fn handle_otlp_request(
     }
 
     metrics::HTTP_RESPONSE_TIME
-        .with_label_values(&[
-            ep,
-            "200",
-            org_id,
-            StreamType::Traces.as_str(),
-        ])
+        .with_label_values(&[ep, "200", org_id, StreamType::Traces.as_str()])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
-        .with_label_values(&[
-            ep,
-            "200",
-            org_id,
-            StreamType::Traces.as_str(),
-        ])
+        .with_label_values(&[ep, "200", org_id, StreamType::Traces.as_str()])
         .inc();
 
     format_response(partial_success, req_type)
@@ -688,20 +678,10 @@ pub async fn ingest_json(
     };
 
     metrics::HTTP_RESPONSE_TIME
-        .with_label_values(&[
-            ep,
-            "200",
-            org_id,
-            StreamType::Traces.as_str(),
-        ])
+        .with_label_values(&[ep, "200", org_id, StreamType::Traces.as_str()])
         .observe(time);
     metrics::HTTP_INCOMING_REQUESTS
-        .with_label_values(&[
-            ep,
-            "200",
-            org_id,
-            StreamType::Traces.as_str(),
-        ])
+        .with_label_values(&[ep, "200", org_id, StreamType::Traces.as_str()])
         .inc();
 
     format_response(partial_success, req_type)

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -548,7 +548,6 @@ pub async fn handle_otlp_request(
             ep,
             "200",
             org_id,
-            &traces_stream_name,
             StreamType::Traces.as_str(),
         ])
         .observe(time);
@@ -557,7 +556,6 @@ pub async fn handle_otlp_request(
             ep,
             "200",
             org_id,
-            &traces_stream_name,
             StreamType::Traces.as_str(),
         ])
         .inc();
@@ -694,7 +692,6 @@ pub async fn ingest_json(
             ep,
             "200",
             org_id,
-            traces_stream_name,
             StreamType::Traces.as_str(),
         ])
         .observe(time);
@@ -703,7 +700,6 @@ pub async fn ingest_json(
             ep,
             "200",
             org_id,
-            traces_stream_name,
             StreamType::Traces.as_str(),
         ])
         .inc();


### PR DESCRIPTION
We have over 10k streams, the stream level metrics caused the `/metrics` page pretty large then it can't parse. so we want to reduce it.