### PR TITLE
fix: pipeline query node improvements

### DIFF
--- a/web/src/components/alerts/PipelinesDestinationList.vue
+++ b/web/src/components/alerts/PipelinesDestinationList.vue
@@ -90,7 +90,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           <QTablePagination
             :scope="scope"
-            :pageTitle="t('alert_destinations.header')"
+            :pageTitle="t('pipeline_destinations.header')"
             :position="'top'"
             :resultTotal="resultTotal"
             :perPageOptions="perPageOptions"

--- a/web/src/components/common/sidebar/FieldList.vue
+++ b/web/src/components/common/sidebar/FieldList.vue
@@ -79,7 +79,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <div class="field_label ellipsis">
                       {{ props.row.name }}
                     </div>
-                    <div class="field_overlay">
+                    <div v-if="!hideAddSearchTerm" class="field_overlay">
                       <q-btn
                         :data-test="`log-search-index-list-filter-${props.row.name}-field-btn`"
                         :icon="outlinedAdd"
@@ -88,6 +88,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         class="q-mr-sm"
                         @click.stop="addSearchTerm(`${props.row.name}=''`)"
                         round
+                      />
+                    </div>
+                    <div v-if="!hideCopyValue" style="background-color: #E8E8E8;"  class="field_overlay">
+                      <q-btn
+                        :data-test="`log-search-index-list-filter-${props.row.name}-copy-btn`"
+                        icon="content_copy"
+                        size="10px"
+                        class="q-mr-sm"
+                        @click.stop="copyContentValue(props.row.name)"
+                        round
+                        flat
+                        dense
                       />
                     </div>
                   </div>
@@ -192,7 +204,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                               "
                             >
                               <q-btn
-                                class="q-ml-sm"
+                                class="q-ml-md"
                                 size="8px"
                                 title="Copy Value"
                                 round
@@ -285,6 +297,10 @@ export default defineComponent({
     hideCopyValue:{
       type: Boolean,
       default: true,
+    },
+    hideAddSearchTerm:{
+      type: Boolean,
+      default: false,
     }
   },
   emits: ["event-emitted"],

--- a/web/src/components/functions/EnrichmentTableList.vue
+++ b/web/src/components/functions/EnrichmentTableList.vue
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :filter="filterQuery"
         :filter-method="filterData"
         style="width: 100%"
+        dense
       >
         <template #no-data>
           <NoData />

--- a/web/src/components/functions/FullViewContainer.vue
+++ b/web/src/components/functions/FullViewContainer.vue
@@ -7,7 +7,7 @@
       <div class="tw-flex tw-items-center">
         <q-icon
           name="keyboard_arrow_up"
-          @click="expanded = !expanded"
+          @click.stop="expanded = !expanded"
           class="tw-mr-1 tw-cursor-pointer tw-transition-all"
           :class="[
             store.state.theme === 'dark'
@@ -18,6 +18,7 @@
           size="20px"
         />
         <div
+          @click="expanded = !expanded"
           class="tw-text-[14px] tw-font-bold"
           :class="[
             store.state.theme === 'dark'

--- a/web/src/components/functions/FunctionList.vue
+++ b/web/src/components/functions/FunctionList.vue
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :filter="filterQuery"
         :filter-method="filterData"
         style="width: 100%"
+        dense
       >
         <template #no-data>
           <NoData />

--- a/web/src/components/pipeline/NodeForm/Query.vue
+++ b/web/src/components/pipeline/NodeForm/Query.vue
@@ -248,10 +248,6 @@ const getDefaultStreamRoute: any = () => {
 };
 
 onMounted(() => {
-
-  if(scheduledPipelineRef.value){
-    console.log("scheduledPipelineRef.value", scheduledPipelineRef.value)
-  }
   
   if (pipelineObj.isEditNode) {
     streamRoute.value = pipelineObj.currentSelectedNodeData

--- a/web/src/components/pipeline/NodeForm/Query.vue
+++ b/web/src/components/pipeline/NodeForm/Query.vue
@@ -37,9 +37,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :disableVrlFunction="true"
             :isValidSqlQuery="isValidSqlQuery"
             :disableQueryTypeSelection="true"
+            :expandedLogs="expandedLogs"
+
             v-model:trigger="streamRoute.trigger_condition"
             v-model:sql="streamRoute.query_condition.sql"
             v-model:promql="streamRoute.query_condition.promql"
+            v-model:promql_condition="streamRoute.query_condition.promql_condition"
             v-model:query_type="streamRoute.query_condition.type"
             v-model:aggregation="streamRoute.query_condition.aggregation"
             v-model:stream_type="streamRoute.stream_type"
@@ -50,6 +53,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             @delete:node="openDeleteDialog"
             @update:fullscreen="updateFullscreenMode"
             @update:stream_type="updateStreamType"
+            @expandLog="toggleExpandLog"
             class="q-mt-sm"
           />
         </div>
@@ -80,10 +84,11 @@ import { useRouter } from "vue-router";
 import useStreams from "@/composables/useStreams";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import { useQuasar } from "quasar";
-import ScheduledPipeline from "@/components/pipeline/NodeForm/ScheduledPipeline.vue";
 import useQuery from "@/composables/useQuery";
 import searchService from "@/services/search";
 import useDragAndDrop from "@/plugins/pipelines/useDnD";
+
+import ScheduledPipeline from "@/components/pipeline/NodeForm/ScheduledPipeline.vue";
 
 const VariablesInput = defineAsyncComponent(
   () => import("@/components/alerts/VariablesInput.vue"),
@@ -103,6 +108,11 @@ interface StreamRoute {
   query_condition: {
     sql: string;
     promql: string | null;
+    promql_condition: {
+      column: string;
+      operator: string;
+      value: any;
+    } | null;
     type: string;
     aggregation: {
       group_by: string[];
@@ -161,6 +171,7 @@ const filteredColumns: any = ref([]);
 
 const isValidSqlQuery = ref(true);
 
+const expandedLogs = ref([]);
 const validateSqlQueryPromise = ref<Promise<unknown>>();
 
 const scheduledPipelineRef = ref<any>(null);
@@ -212,6 +223,11 @@ const getDefaultStreamRoute: any = () => {
       sql: "",
       type: "sql",
       aggregation: null,
+      promql_condition: {
+        column: "",
+        operator: "",
+        value: "",
+      },
     },
     trigger_condition: {
       period: 15,
@@ -232,6 +248,11 @@ const getDefaultStreamRoute: any = () => {
 };
 
 onMounted(() => {
+
+  if(scheduledPipelineRef.value){
+    console.log("scheduledPipelineRef.value", scheduledPipelineRef.value)
+  }
+  
   if (pipelineObj.isEditNode) {
     streamRoute.value = pipelineObj.currentSelectedNodeData
       ?.data as StreamRoute;
@@ -494,6 +515,10 @@ const updateQueryType = (val: string) => {
   if (val == "promql") {
     streamRoute.value.query_condition.sql = "";
   }
+};
+
+const toggleExpandLog = (index: number) => {
+  expandedLogs.value = [];
 };
 </script>
 

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -1261,16 +1261,16 @@ onBeforeMount(async ()=>{
 
 
 onMounted(async ()=>{
-  getStreamList();
+  await getStreamList();
 
-setTimeout(() => {
-  if(tab.value === 'sql' && query.value != ""){
-  const parsedQuery = parser.parse(query.value);
-  selectedStreamName.value = parsedQuery.ast.from[0].table;
+  setTimeout(() => {
+    if(tab.value === 'sql' && query.value != ""){
+    const parsedQuery = parser?.parse(query.value);
+    selectedStreamName.value = parsedQuery.ast.from[0].table;
 
-  getStreamFields();
-}
-}, 100);
+    getStreamFields();
+  }
+  }, 200);
   
 })
 

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -918,7 +918,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   label="Output"
                   class="tw-mt-1"
                 />
-                {{ expandedLogs }}
                   <TenstackTable
 
                     v-if="rows.length > 0 && tab == 'sql'"
@@ -1740,10 +1739,10 @@ const getStreamFields = () => {
         });
       })
       .finally(() => {
-        if(tab.value === 'sql'){
+        if(tab.value === 'sql' && query.value == ""){
           query.value = `SELECT * FROM "${selectedStreamName.value}"`;
         }
-        else if (tab.value === 'promql'){
+        else if (tab.value === 'promql' && query.value == ""){
           query.value = `${selectedStreamName.value}{}`;
         }
         expandState.value.query = true;

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -930,7 +930,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 />
                 </span>
                   <TenstackTable
-
                     v-if="rows.length > 0 && tab == 'sql'"
                     style="height: calc(100vh - 190px) !important;"
                     v-show="expandState.output"
@@ -1394,7 +1393,7 @@ const currentTimezone =
 const browserTimezone = ref(currentTimezone);
 const streamTypes = ["logs", "metrics", "traces"];
 
-const rows = ref([ ])
+const rows = ref([])
 
 // @ts-ignore
 let timezoneOptions = Intl.supportedValuesOf("timeZone").map((tz: any) => {
@@ -1947,7 +1946,9 @@ const focusQueryEditor = () => {
 }
 
 const expandLog = (index: any) => {
-  expandedLogs.value = [];
+  if (expandedLogs.value.includes(index))
+    expandedLogs.value = expandedLogs.value.filter((item) => item != index);
+  else expandedLogs.value.push(index);
 }
 const copyLogToClipboard = (log: any, copyAsJson: boolean = true) => {
   const copyData = copyAsJson ? JSON.stringify(log) : log;

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -930,9 +930,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 />
                 </span>
                   <TenstackTable
-                    v-if="rows.length > 0 && tab == 'sql'"
                     style="height: calc(100vh - 190px) !important;"
-                    v-show="expandState.output"
+                    v-show="expandState.output && rows.length > 0 && tab == 'sql'"
                     ref="searchTableRef"
                     :columns="getColumns"
                     :rows="rows"

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -1211,7 +1211,7 @@ const functionEditorPlaceholderFlag = ref(true);
 
 const queryEditorPlaceholderFlag = ref(true);
 const  pipelineEditorRef : any = ref(null);
-const expandedLogs = ref([]);
+const expandedLogs = ref<any[]>([]);
 const cursorPosition = ref(-1);
 const splitterModel = ref(30);
 const step = ref(1);

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -988,7 +988,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 />
                 <q-btn
                   data-test="stream-routing-query-save-btn"
-                  :label="t('alerts.save')"
+                  :label="'Validate and Close'"
                   class="text-bold no-border q-ml-md"
                   color="secondary"
                   padding="sm xl"

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -110,12 +110,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             >
             <template #before>
                             <!-- fieldlist section -->
+                <span @click.stop="expandState.buildQuery = !expandState.buildQuery">
                 <FullViewContainer
                   name="query"
                   v-model:is-expanded="expandState.buildQuery"
                   label="Build Query"
                   class="tw-mt-1"
                 />
+              </span>
               <div class="q-pt-sm" v-show="expandState.buildQuery"  >
                 
               <div >
@@ -181,6 +183,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </div>
             </template>
             <template #after>
+              <span @click.stop="expandState.setVariables = !expandState.setVariables">
+
               <!-- set variables part -->
               <FullViewContainer
                   name="query"
@@ -188,6 +192,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   label="Set Variables"
                   class="tw-mt-1"
                 />
+              </span>
               <div v-show="expandState.setVariables"  class="flex justify-between q-pl-sm full-height" style="overflow-y: auto !important;">
               <div>
               <div
@@ -888,12 +893,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
              
               <div class="full-width" style="height: calc(100vh - 140px) !important;" >
               <div class="query-editor-container scheduled-pipelines">
+                <span @click.stop="expandState.query = !expandState.query">
                 <FullViewContainer
                   name="query"
                   v-model:is-expanded="expandState.query"
                   :label="tab === 'sql' ? 'Sql Query' : 'PromQL Query'"
                   class="tw-mt-1"
                 />
+                </span>
                 <query-editor
                   v-show="expandState.query"
                   data-test="scheduled-pipeline-sql-editor"
@@ -911,13 +918,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               
              
               </div>
+
               <div>
+                <span @click.stop="expandState.output = !expandState.output">
                 <FullViewContainer
                   name="output"
                   v-model:is-expanded="expandState.output"
                   label="Output"
                   class="tw-mt-1"
                 />
+                </span>
                   <TenstackTable
 
                     v-if="rows.length > 0 && tab == 'sql'"

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -1039,6 +1039,7 @@ import {
   defineAsyncComponent,
   nextTick,
   onMounted,
+  onBeforeMount,
 } from "vue";
 import FieldsInput from "@/components/alerts/FieldsInput.vue";
 import { useI18n } from "vue-i18n";
@@ -1127,6 +1128,7 @@ const emits = defineEmits([
 const {  pipelineObj } = useDragAndDrop();
 const { searchObj } = useLogs();
 const { getStream, getStreams } = useStreams ();
+let parser: any;
 
 const selectedStreamName = ref("");
 
@@ -1242,12 +1244,32 @@ watch(()=> selectedStreamName.value, (val)=>{
   searchObj.data.stream.pipelineQueryStream = [val];
 })
 
+onBeforeMount(async ()=>{
+  await importSqlParser();
+})
+
 
 
 
 onMounted(async ()=>{
   getStreamList();
+
+setTimeout(() => {
+  if(tab.value === 'sql' && query.value != ""){
+  const parsedQuery = parser.parse(query.value);
+  selectedStreamName.value = parsedQuery.ast.from[0].table;
+
+  getStreamFields();
+}
+}, 100);
+  
 })
+
+const importSqlParser = async () => {
+    const useSqlParser: any = await import("@/composables/useParser");
+    const { sqlParser }: any = useSqlParser.default();
+    parser = await sqlParser();
+  };
 
 const filteredTimezone: any = ref([]);
 const expandState =ref( {

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -177,6 +177,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     }"
                     :hideIncludeExlcude="true"
                     :hideCopyValue="false"
+                    :hideAddSearchTerm="true"
                 />
                
                 

--- a/web/src/components/pipeline/PipelineEditor.vue
+++ b/web/src/components/pipeline/PipelineEditor.vue
@@ -81,7 +81,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <q-separator class="q-mb-md" />
 
       <div class="flex q-mt-sm">
-        <NodeSidebar :nodeTypes="nodeTypes" />
+        <NodeSidebar v-show="!pipelineObj.dialog.show || pipelineObj.dialog.name != 'query'" :nodeTypes="nodeTypes"  />
       </div>
     </div>
     <div

--- a/web/src/components/pipeline/PipelineEditor.vue
+++ b/web/src/components/pipeline/PipelineEditor.vue
@@ -89,6 +89,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       ref="chartContainerRef"
       class="relative-position pipeline-chart-container o2vf_node"
       :class="store.state.theme === 'dark' ? '' : 'bg-grey-2'"
+      v-show="!pipelineObj.dialog.show || pipelineObj.dialog.name != 'query'"
     >
       <PipelineFlow />
     </div>

--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -38,9 +38,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           style="cursor: pointer"
           @click="triggerExpand(props)"
         >
-        <q-tooltip position="bottom">
-                <PipelineView :pipeline="props.row" />
-              </q-tooltip>
           <q-td v-if="activeTab == 'scheduled' "  >
             
             <q-btn
@@ -98,6 +95,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :title="t('alerts.delete')"
               @click.stop="openDeleteDialog(props.row)"
             ></q-btn>
+            <q-btn
+              :data-test="`pipeline-list-${props.row.name}-view-pipeline`"
+              :icon="outlinedVisibility"
+              class="q-ml-xs"
+              padding="sm"
+              unelevated
+              size="sm"
+              round
+              flat
+              :title="t('alerts.view')"
+            >
+            <q-tooltip position="bottom">
+              <PipelineView :pipeline="props.row" />
+            </q-tooltip>
+          </q-btn>
           </template>
         </q-td>
 
@@ -224,7 +236,7 @@ import { useQuasar, type QTableProps  } from "quasar";
 import type { QTableColumn } from 'quasar';
 
 import NoData from "../shared/grid/NoData.vue";
-import { outlinedDelete , outlinedPause , outlinedPlayArrow } from "@quasar/extras/material-icons-outlined";
+import { outlinedDelete , outlinedPause , outlinedPlayArrow, outlinedVisibility } from "@quasar/extras/material-icons-outlined";
 import QTablePagination from "@/components/shared/grid/Pagination.vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import useDragAndDrop from "@/plugins/pipelines/useDnD";

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -916,7 +916,8 @@
     "lastRunAt":"Last Run At",
     "lastSuccessfulAt":"Last Successfull At",
     "status":"Status",
-    "numOfEvents": "Number of Events"
+    "numOfEvents": "Number of Events",
+    "view":"View"
   },
   "alert_templates": {
     "header": "Templates",

--- a/web/src/plugins/pipelines/CustomNode.vue
+++ b/web/src/plugins/pipelines/CustomNode.vue
@@ -57,9 +57,6 @@ const hanldeMouseOver = () => {
 
 
 const onFunctionClick = (data,event,id) =>{
-  console.log(data,"data")
-  console.log(id,"id")
-  console.log(event,"event")
   pipelineObj.userSelectedNode = data;
   const dataToOpen  =   {
     label: "Function",
@@ -77,7 +74,6 @@ const onFunctionClick = (data,event,id) =>{
 
 const onConditionClick = (data,event,id) =>{
   data.label = id;
-  console.log(data,"data")
   pipelineObj.userSelectedNode = data;
 
   const dataToOpen  =   {
@@ -149,7 +145,6 @@ const editNode = (id) => {
   const fullNode = pipelineObj.currentSelectedPipeline.nodes.find(
     (node) => node.id === id
   );
-  console.log(fullNode,'full node')
   pipelineObj.isEditNode = true;
   pipelineObj.currentSelectedNodeData = fullNode;
   pipelineObj.currentSelectedNodeID = id;


### PR DESCRIPTION
1.  validate and close  text instead of save button 
2. when user selects stream name query wipes out if any previous query is there
3.add the click event on whole expand bar 
4. after opening the sidebar clicking on the SQL editor moves the focus away from the SQL editor
5. remove the pipeline view on the row and introduce a eye icon in actions section
6. when user clicks on edit the schema should auto populate respective to the query