### PR TITLE
fix: ignore count field from user stream for distinct values

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,5 +2,6 @@
 ignore = [
   "RUSTSEC-2024-0421", # from idna, transitive dep of vrl
   "RUSTSEC-2023-0071", # from rsa, transitive dep of sqlx
+  "RUSTSEC-2025-0009", # from ring, transitive dep of reqwest
 ]
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories

--- a/src/common/migration/dashboards.rs
+++ b/src/common/migration/dashboards.rs
@@ -13,9 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::{
-    dashboards::Dashboard,
-    stream::{DistinctField, StreamSettings, StreamType},
+use config::{
+    TIMESTAMP_COL_NAME,
+    meta::{
+        dashboards::Dashboard,
+        stream::{DistinctField, StreamSettings, StreamType},
+    },
 };
 use hashbrown::HashMap;
 use infra::{
@@ -59,6 +62,11 @@ async fn add_distinct_from_dashboard(
         };
 
         for f in fields {
+            if f == "count" || f == TIMESTAMP_COL_NAME {
+                // these two are reserved for oo use, so cannot be added as
+                // separate distinct fields
+                continue;
+            }
             let record = DistinctFieldRecord::new(
                 OriginType::Dashboard,
                 dashboard_id,

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -86,6 +86,12 @@ async fn can_use_distinct_stream(
         if DISTINCT_FIELDS.contains(f) {
             return true;
         }
+        if f == "count" {
+            // count is reserved field from oo side, so if user has count field
+            // in original stream, it won't actually be in the distinct stream, so
+            // we need to fallback to normal search
+            return false;
+        }
         stream_settings
             .distinct_value_fields
             .iter()
@@ -106,6 +112,12 @@ async fn can_use_distinct_stream(
     let all_query_fields_distinct = query_fields.iter().all(|f| {
         if DISTINCT_FIELDS.contains(f) {
             return true;
+        }
+        if f == "count" {
+            // count is reserved field from oo side, so if user has count field
+            // in original stream, it won't actually be in the distinct stream, so
+            // we need to fallback to normal search
+            return false;
         }
         stream_settings
             .distinct_value_fields

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -681,6 +681,7 @@ async fn merge_files(
     // use the shared fields to create a new schema and with empty metadata
     let mut fields = shared_fields.into_iter().collect::<Vec<_>>();
     fields.sort_by(|a, b| a.name().cmp(b.name()));
+    fields.dedup_by(|a, b| a.name() == b.name());
     let schema = Arc::new(Schema::new(fields));
     let schema_key = schema.hash_key();
 
@@ -1158,9 +1159,9 @@ async fn prepare_index_record_batches(
         Field::new("max_ts", DataType::Int64, true),
         Field::new("field", DataType::Utf8, true),
         Field::new("term", DataType::Utf8, true),
-        Field::new("file_name", DataType::Utf8, false),
-        Field::new("_count", DataType::Int64, false),
-        Field::new("deleted", DataType::Boolean, false),
+        Field::new("file_name", DataType::Utf8, true),
+        Field::new("_count", DataType::Int64, true),
+        Field::new("deleted", DataType::Boolean, true),
         Field::new("segment_ids", DataType::Binary, true), // bitmap
     ]));
 

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use config::{
-    ider,
+    TIMESTAMP_COL_NAME, ider,
     meta::{
         dashboards::{Dashboard, ListDashboardsParams},
         folder::{DEFAULT_FOLDER, Folder, FolderType},
@@ -188,6 +188,11 @@ async fn update_distinct_variables(
             for f in fields.iter() {
                 // we ignore full text search no matter what
                 if stream_settings.full_text_search_keys.contains(f) {
+                    continue;
+                }
+
+                if f == "count" || f == TIMESTAMP_COL_NAME {
+                    // these are reserved fields
                     continue;
                 }
                 // we add entry for all the fields, because we need mappings for each individual

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -152,7 +152,7 @@ impl Metadata for DistinctValues {
         // count, rest will be dynamically determined
         Arc::new(Schema::new(vec![
             Field::new(TIMESTAMP_COL_NAME, DataType::Int64, false),
-            Field::new("count", DataType::Int64, false),
+            Field::new("count", DataType::Int64, true),
         ]))
     }
 

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -159,7 +159,10 @@ impl Metadata for DistinctValues {
     async fn write(&self, org_id: &str, data: Vec<MetadataItem>) -> Result<()> {
         let mut group_items: FxIndexMap<DvItem, u32> = FxIndexMap::default();
         for item in data {
-            if let MetadataItem::DistinctValues(item) = item {
+            if let MetadataItem::DistinctValues(mut item) = item {
+                // these two are reserved, so we remove them if present
+                item.value.remove("count");
+                item.value.remove(TIMESTAMP_COL_NAME);
                 let count = group_items.entry(item).or_default();
                 *count += 1;
             }


### PR DESCRIPTION
fixes #6202 

We use field `count` ourselves to mark the number of occurrences for a certain field combination. However if user stream also has a field with same name, and they use it in dashboard variables, then it can cause issues at file merge as schemas might differ. In any case because we use it as a field internally, we should never allow user stream's count field in distinct stream. Thus in this PR we ignore that field at all places, and simply fall back to the normal search in case distinct values of count are requested.

- tested that adding count as dashboard variable does not add it to distinct fields
- tested getting distinct values on count uses normal stream search and not distinct stream
- tested using any other field that is distinct correctly uses distinct stream.