### PR TITLE
perf: improve file move job

### DIFF
--- a/src/config/src/utils/async_file.rs
+++ b/src/config/src/utils/async_file.rs
@@ -29,7 +29,7 @@ pub async fn get_file_meta(path: impl AsRef<Path>) -> Result<Metadata, std::io::
 }
 
 #[inline(always)]
-pub async fn get_file_len(path: impl AsRef<Path>) -> Result<u64, std::io::Error> {
+pub async fn get_file_size(path: impl AsRef<Path>) -> Result<u64, std::io::Error> {
     let file = File::open(path).await?;
     file.metadata().await.map(|m| m.len())
 }

--- a/src/config/src/utils/file.rs
+++ b/src/config/src/utils/file.rs
@@ -29,7 +29,7 @@ pub fn get_file_meta(path: impl AsRef<Path>) -> Result<Metadata, std::io::Error>
 }
 
 #[inline(always)]
-pub fn get_file_len(path: impl AsRef<Path>) -> Result<u64, std::io::Error> {
+pub fn get_file_size(path: impl AsRef<Path>) -> Result<u64, std::io::Error> {
     let file = File::open(path)?;
     file.metadata().map(|m| m.len())
 }

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -155,7 +155,7 @@ impl FileData {
 
     async fn get_size(&self, file: &str) -> Option<usize> {
         let file_path = format!("{}{}{}", self.root_dir, self.choose_multi_dir(file), file);
-        match get_file_len(&file_path) {
+        match get_file_size(&file_path) {
             Ok(v) => Some(v as usize),
             Err(_) => None,
         }

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -107,6 +107,7 @@ pub trait FileList: Sync + Send + 'static {
         time_max: i64,
         limit: i64,
     ) -> Result<Vec<FileListDeleted>>;
+    async fn list_deleted(&self) -> Result<Vec<FileListDeleted>>;
     // stream stats
     async fn get_min_ts(
         &self,
@@ -319,6 +320,11 @@ pub async fn query_deleted(
     limit: i64,
 ) -> Result<Vec<FileListDeleted>> {
     CLIENT.query_deleted(org_id, time_max, limit).await
+}
+
+#[inline]
+pub async fn list_deleted() -> Result<Vec<FileListDeleted>> {
+    CLIENT.list_deleted().await
 }
 
 #[inline]

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -654,6 +654,26 @@ SELECT date
             .collect())
     }
 
+    async fn list_deleted(&self) -> Result<Vec<FileListDeleted>> {
+        let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "file_list_deleted"])
+            .inc();
+        let ret = sqlx::query_as::<_, super::FileDeletedRecord>(
+            r#"SELECT stream, date, file, index_file, flattened FROM file_list_deleted;"#,
+        )
+        .fetch_all(&pool)
+        .await?;
+        Ok(ret
+            .iter()
+            .map(|r| FileListDeleted {
+                file: format!("files/{}/{}/{}", r.stream, r.date, r.file),
+                index_file: r.index_file,
+                flattened: r.flattened,
+            })
+            .collect())
+    }
+
     async fn get_min_ts(
         &self,
         org_id: &str,

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -664,6 +664,26 @@ SELECT date
             .collect())
     }
 
+    async fn list_deleted(&self) -> Result<Vec<FileListDeleted>> {
+        let pool = CLIENT.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "file_list_deleted"])
+            .inc();
+        let ret = sqlx::query_as::<_, super::FileDeletedRecord>(
+            r#"SELECT stream, date, file, index_file, flattened FROM file_list_deleted;"#,
+        )
+        .fetch_all(&pool)
+        .await?;
+        Ok(ret
+            .iter()
+            .map(|r| FileListDeleted {
+                file: format!("files/{}/{}/{}", r.stream, r.date, r.file),
+                index_file: r.index_file,
+                flattened: r.flattened,
+            })
+            .collect())
+    }
+
     async fn get_min_ts(
         &self,
         org_id: &str,

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -592,6 +592,23 @@ SELECT date
             .collect())
     }
 
+    async fn list_deleted(&self) -> Result<Vec<FileListDeleted>> {
+        let pool = CLIENT_RO.clone();
+        let ret = sqlx::query_as::<_, super::FileDeletedRecord>(
+            r#"SELECT stream, date, file, index_file, flattened FROM file_list_deleted;"#,
+        )
+        .fetch_all(&pool)
+        .await?;
+        Ok(ret
+            .iter()
+            .map(|r| FileListDeleted {
+                file: format!("files/{}/{}/{}", r.stream, r.date, r.file),
+                index_file: r.index_file,
+                flattened: r.flattened,
+            })
+            .collect())
+    }
+
     async fn get_min_ts(
         &self,
         org_id: &str,

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -64,7 +64,9 @@ pub struct Writer {
 
 // check total memory size
 pub fn check_memtable_size() -> Result<()> {
-    let total_mem_size = metrics::NODE_MEMORY_USAGE.with_label_values(&[]).get();
+    let total_mem_size = metrics::INGEST_MEMTABLE_ARROW_BYTES
+        .with_label_values(&[])
+        .get();
     if total_mem_size >= get_config().limit.mem_table_max_size as i64 {
         Err(Error::MemoryTableOverflowError {})
     } else {

--- a/src/job/files/mod.rs
+++ b/src/job/files/mod.rs
@@ -21,13 +21,16 @@ use config::{
 };
 
 pub mod broadcast;
-pub mod idx;
+mod idx;
 pub mod parquet;
 
 pub async fn run() -> Result<(), anyhow::Error> {
     if !LOCAL_NODE.is_ingester() {
         return Ok(()); // not an ingester, no need to init job
     }
+
+    // load pending delete files to memory cache
+    crate::service::db::file_list::local::load_pending_delete().await?;
 
     tokio::task::spawn(async move { parquet::run().await });
     tokio::task::spawn(async move { broadcast::run().await });

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -15,6 +15,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
+    fs::remove_file,
     path::Path,
     sync::Arc,
     time::UNIX_EPOCH,
@@ -45,7 +46,7 @@ use config::{
     utils::{
         arrow::record_batches_to_json_rows,
         async_file::get_file_meta,
-        file::scan_files_with_channel,
+        file::{get_file_size, scan_files_with_channel},
         inverted_index::{convert_parquet_idx_file_name_to_tantivy_file, split_token},
         json,
         parquet::{
@@ -86,8 +87,6 @@ use crate::{
 };
 
 static PROCESSING_FILES: Lazy<RwLock<HashSet<String>>> = Lazy::new(|| RwLock::new(HashSet::new()));
-static SKIPPED_LOCK_FILES: Lazy<RwLock<HashSet<String>>> =
-    Lazy::new(|| RwLock::new(HashSet::new()));
 
 pub async fn run() -> Result<(), anyhow::Error> {
     let cfg = get_config();
@@ -225,24 +224,36 @@ async fn prepare_files(
         };
         // check if the file is processing
         if PROCESSING_FILES.read().await.contains(&file_key) {
-            // check if the file is still locking
-            if SKIPPED_LOCK_FILES.read().await.contains(&file_key)
+            // check if the file is still in pending delete
+            if db::file_list::local::exist_pending_delete(&file_key).await
                 && !wal::lock_files_exists(&file_key)
             {
                 log::warn!(
                     "[INGESTER:JOB] the file was released, delete it: {}",
                     file_key
                 );
-                if tokio::fs::remove_file(&wal_dir.join(&file_key))
-                    .await
-                    .is_ok()
-                {
+                let file = wal_dir.join(&file_key);
+                let Ok(file_size) = get_file_size(&file) else {
+                    continue;
+                };
+                if remove_file(&file).is_ok() {
                     // delete metadata from cache
                     WAL_PARQUET_METADATA.write().await.remove(&file_key);
                     // need release all the files
                     PROCESSING_FILES.write().await.remove(&file_key);
                     // delete from skip list
-                    SKIPPED_LOCK_FILES.write().await.remove(&file_key);
+                    if let Err(e) = db::file_list::local::remove_pending_delete(&file_key).await {
+                        log::error!(
+                            "[INGESTER:JOB] Failed to remove pending delete file: {}, {}",
+                            file_key,
+                            e
+                        );
+                    }
+                    // deleted successfully then update metrics
+                    let (org_id, stream_type, ..) = split_perfix(&file_key);
+                    metrics::INGEST_WAL_USED_BYTES
+                        .with_label_values(&[&org_id, stream_type.as_str()])
+                        .sub(file_size as i64);
                 }
             }
             continue;
@@ -260,7 +271,7 @@ async fn prepare_files(
                 "[INGESTER:JOB] the file is empty, just delete file: {}",
                 file
             );
-            if let Err(e) = tokio::fs::remove_file(wal_dir.join(&file)).await {
+            if let Err(e) = remove_file(wal_dir.join(&file)) {
                 log::error!(
                     "[INGESTER:JOB] Failed to remove parquet file from disk: {}, {}",
                     file,
@@ -300,20 +311,9 @@ async fn move_files(
         return Ok(());
     }
 
-    let columns = prefix.split('/').collect::<Vec<&str>>();
-    // removed thread_id from prefix, so there is no thread_id in the path
-    // eg: files/default/logs/olympics/2023/08/21/08/8b8a5451bbe1c44b/
-    // eg: files/default/traces/default/2023/09/04/05/default/service_name=ingester/
-    // let _ = columns[0].to_string(); // files/
-    let org_id = columns[1].to_string();
-    let stream_type = StreamType::from(columns[2]);
-    let stream_name = columns[3].to_string();
-    let prefix_date = format!("{}-{}-{}", columns[4], columns[5], columns[6]);
-
-    // log::debug!("[INGESTER:JOB:{thread_id}] check deletion for partition: {}", prefix);
-
     let cfg = get_config();
     let wal_dir = Path::new(&cfg.common.data_wal_dir).canonicalize().unwrap();
+    let (org_id, stream_type, stream_name, prefix_date) = split_perfix(prefix);
 
     // check if we are allowed to ingest or just delete the file
     if db::compact::retention::is_deleting_stream(&org_id, stream_type, &stream_name, None) {
@@ -325,7 +325,7 @@ async fn move_files(
                 &stream_name,
                 file.key,
             );
-            if let Err(e) = tokio::fs::remove_file(wal_dir.join(&file.key)).await {
+            if let Err(e) = remove_file(wal_dir.join(&file.key)) {
                 log::error!(
                     "[INGESTER:JOB:{thread_id}] Failed to remove parquet file from disk: {}, {}",
                     file.key,
@@ -369,7 +369,7 @@ async fn move_files(
                 &stream_name,
                 file.key,
             );
-            if let Err(e) = tokio::fs::remove_file(wal_dir.join(&file.key)).await {
+            if let Err(e) = remove_file(wal_dir.join(&file.key)) {
                 log::error!(
                     "[INGESTER:JOB:{thread_id}] Failed to remove parquet file from disk: {}, {}",
                     file.key,
@@ -402,7 +402,7 @@ async fn move_files(
                     &stream_name,
                     file.key,
                 );
-                if let Err(e) = tokio::fs::remove_file(wal_dir.join(&file.key)).await {
+                if let Err(e) = remove_file(wal_dir.join(&file.key)) {
                     log::error!(
                         "[INGESTER:JOB:{thread_id}] Failed to remove parquet file from disk: {}, {}",
                         file.key,
@@ -514,59 +514,55 @@ async fn move_files(
 
         // check if allowed to delete the file
         for file in new_file_list.iter() {
-            let mut need_skip = true;
-            // wait for 5s
-            for _ in 0..50 {
-                if wal::lock_files_exists(&file.key) {
-                    log::warn!(
-                        "[INGESTER:JOB:{thread_id}] the file is still in use, waiting for a few ms: {}",
-                        file.key
-                    );
-                    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-                } else {
-                    need_skip = false;
-                    break;
-                }
-            }
-            if need_skip {
+            if wal::lock_files_exists(&file.key) {
                 log::warn!(
-                    "[INGESTER:JOB:{thread_id}] the file is still in use, add it to the skip_list: {}",
+                    "[INGESTER:JOB:{thread_id}] the file is in use, set to pending delete list: {}",
                     file.key
                 );
-                SKIPPED_LOCK_FILES.write().await.insert(file.key.clone());
-                continue;
-            }
-
-            let ret = tokio::fs::remove_file(&wal_dir.join(&file.key)).await;
-            if let Err(e) = ret {
-                log::error!(
-                    "[INGESTER:JOB:{thread_id}] Failed to remove parquet file from disk: {}, {}",
-                    file.key,
-                    e.to_string()
-                );
-                // delete metadata from cache
-                WAL_PARQUET_METADATA.write().await.remove(&file.key);
-                // need release all the files
-                for file in files_with_size.iter() {
-                    PROCESSING_FILES.write().await.remove(&file.key);
+                // add to pending delete list
+                if let Err(e) = db::file_list::local::add_pending_delete(&org_id, &file.key).await {
+                    log::error!(
+                        "[INGESTER:JOB:{thread_id}] Failed to add pending delete file: {}, {}",
+                        file.key,
+                        e.to_string()
+                    );
                 }
-                return Ok(());
+            } else {
+                match remove_file(wal_dir.join(&file.key)) {
+                    Err(e) => {
+                        log::warn!(
+                            "[INGESTER:JOB:{thread_id}] Failed to remove parquet file from disk, set to pending delete list: {}, {}",
+                            file.key,
+                            e.to_string()
+                        );
+                        // add to pending delete list
+                        if let Err(e) =
+                            db::file_list::local::add_pending_delete(&org_id, &file.key).await
+                        {
+                            log::error!(
+                                "[INGESTER:JOB:{thread_id}] Failed to add pending delete file: {}, {}",
+                                file.key,
+                                e.to_string()
+                            );
+                        }
+                    }
+                    Ok(_) => {
+                        // delete metadata from cache
+                        WAL_PARQUET_METADATA.write().await.remove(&file.key);
+                        // remove the file from processing set
+                        PROCESSING_FILES.write().await.remove(&file.key);
+                        // deleted successfully then update metrics
+                        metrics::INGEST_WAL_USED_BYTES
+                            .with_label_values(&[&org_id, stream_type.as_str()])
+                            .sub(file.meta.compressed_size);
+                    }
+                }
             }
-
-            // delete metadata from cache
-            WAL_PARQUET_METADATA.write().await.remove(&file.key);
-
-            // remove the file from processing set
-            // log::debug!("Processing files deleted: {:?}", file.key);
-            PROCESSING_FILES.write().await.remove(&file.key);
 
             // metrics
             metrics::INGEST_WAL_READ_BYTES
                 .with_label_values(&[&org_id, stream_type.as_str()])
                 .inc_by(file.meta.compressed_size as u64);
-            metrics::INGEST_WAL_USED_BYTES
-                .with_label_values(&[&org_id, stream_type.as_str()])
-                .sub(file.meta.compressed_size);
         }
 
         // delete files from file list
@@ -837,6 +833,19 @@ async fn merge_files(
     }
 
     Ok((new_file_key, new_file_meta, retain_file_list))
+}
+
+fn split_perfix(prefix: &str) -> (String, StreamType, String, String) {
+    let columns = prefix.split('/').collect::<Vec<&str>>();
+    // removed thread_id from prefix, so there is no thread_id in the path
+    // eg: files/default/logs/olympics/2023/08/21/08/8b8a5451bbe1c44b/
+    // eg: files/default/traces/default/2023/09/04/05/default/service_name=ingester/
+    // let _ = columns[0].to_string(); // files/
+    let org_id = columns[1].to_string();
+    let stream_type = StreamType::from(columns[2]);
+    let stream_name = columns[3].to_string();
+    let prefix_date = format!("{}-{}-{}", columns[4], columns[5], columns[6]);
+    (org_id, stream_type, stream_name, prefix_date)
 }
 
 /// Create an inverted index file for the given file

--- a/src/service/db/file_list/local.rs
+++ b/src/service/db/file_list/local.rs
@@ -86,6 +86,10 @@ pub async fn remove_pending_delete(file: &str) -> Result<()> {
         .await
 }
 
+pub async fn get_pending_delete() -> Vec<String> {
+    PENDING_DELETE_FILES.read().await.iter().cloned().collect()
+}
+
 pub async fn filter_by_pending_delete(mut files: Vec<String>) -> Vec<String> {
     let r = PENDING_DELETE_FILES.read().await;
     files.retain(|file| !r.contains(file));

--- a/src/service/db/file_list/local.rs
+++ b/src/service/db/file_list/local.rs
@@ -13,15 +13,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::stream::{FileKey, FileMeta};
+use config::meta::stream::{FileKey, FileListDeleted, FileMeta};
+use hashbrown::HashSet;
+use infra::errors::Result;
 use once_cell::sync::Lazy;
 use tokio::sync::RwLock;
+
+static PENDING_DELETE_FILES: Lazy<RwLock<HashSet<String>>> =
+    Lazy::new(|| RwLock::new(HashSet::new()));
 
 /// use queue to batch send broadcast to other nodes
 pub static BROADCAST_QUEUE: Lazy<RwLock<Vec<FileKey>>> =
     Lazy::new(|| RwLock::new(Vec::with_capacity(2048)));
 
-pub async fn set(key: &str, meta: Option<FileMeta>, deleted: bool) -> Result<(), anyhow::Error> {
+pub async fn set(key: &str, meta: Option<FileMeta>, deleted: bool) -> Result<()> {
     let file_data = FileKey::new(key.to_string(), meta.clone().unwrap_or_default(), deleted);
 
     // write into file_list storage
@@ -43,5 +48,54 @@ pub async fn set(key: &str, meta: Option<FileMeta>, deleted: bool) -> Result<(),
         q.push(file_data);
     }
 
+    Ok(())
+}
+
+pub async fn exist_pending_delete(file: &str) -> bool {
+    PENDING_DELETE_FILES.read().await.contains(file)
+}
+
+pub async fn add_pending_delete(org_id: &str, file: &str) -> Result<()> {
+    // add to memory cache
+    {
+        PENDING_DELETE_FILES.write().await.insert(file.to_string());
+    }
+    // add to local db for persistence
+    let ts = config::utils::time::now_micros();
+    infra::file_list::LOCAL_CACHE
+        .batch_add_deleted(
+            org_id,
+            ts,
+            &[FileListDeleted {
+                file: file.to_string(),
+                index_file: false,
+                flattened: false,
+            }],
+        )
+        .await
+}
+
+pub async fn remove_pending_delete(file: &str) -> Result<()> {
+    // remove from memory cache
+    {
+        PENDING_DELETE_FILES.write().await.remove(file);
+    }
+    // remove from local db for persistence
+    infra::file_list::LOCAL_CACHE
+        .batch_remove_deleted(&[file.to_string()])
+        .await
+}
+
+pub async fn filter_by_pending_delete(mut files: Vec<String>) -> Vec<String> {
+    let r = PENDING_DELETE_FILES.read().await;
+    files.retain(|file| !r.contains(file));
+    files
+}
+
+pub async fn load_pending_delete() -> Result<()> {
+    let files = infra::file_list::LOCAL_CACHE.list_deleted().await?;
+    for file in files {
+        PENDING_DELETE_FILES.write().await.insert(file.file);
+    }
     Ok(())
 }

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -490,6 +490,9 @@ async fn get_file_list_inner(
         wal_dir, query.org_id, query.stream_type, query.stream_name
     );
     let files = scan_files(&pattern, file_ext, None).unwrap_or_default();
+
+    // filter by pending delete
+    let files = crate::service::db::file_list::local::filter_by_pending_delete(files).await;
     if files.is_empty() {
         return Ok(vec![]);
     }


### PR DESCRIPTION
The move file job will be stuck when there are many search requests on the ingester because we need to check if the file is using by search before deleting a local parquet in WAL.

This PR introduces a new concept: `PENDING_DELETE_FILES`.

We will verify if the file is in use when deleting a local parquet from WAL after uploading it to S3.

- If the file is in use, it will be added to `PENDING_DELETE_FILES`.
- If the file is not in use, it will be deleted.

Before starting each subsequent move job, we will first check `PENDING_DELETE_FILES` and delete files that are not being used by searches.

We also add to local database to persistently store files added to `PENDING_DELETE_FILES`. If the node restarts but files remain in `PENDING_DELETE_FILES`, we will load them from the local database and continue checking. Once they are no longer used, we will delete them.

This change will not block the file move when there are a lot of search requests. let the move file faster.