### PR TITLE
fix: cherry pick perf related changed from main

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -63,9 +63,14 @@ pub async fn add_node_to_consistent_hash(node: &Node, role: &Role, group: Option
         Role::FlattenCompactor => FLATTEN_COMPACTOR_CONSISTENT_HASH.write().await,
         _ => return,
     };
+    let config = get_config();
     let mut h = config::utils::hash::gxhash::new();
-    for i in 0..get_config().limit.consistent_hash_vnodes {
-        let key = format!("{}:{}:{}", CONSISTENT_HASH_PRIME, node.name, i);
+    for i in 0..config.limit.consistent_hash_vnodes {
+        let key = if config.disk_cache.new_hash_format {
+            format!("{}:{}:{}", CONSISTENT_HASH_PRIME, node.name, i)
+        } else {
+            format!("{}:{}{}", CONSISTENT_HASH_PRIME, node.name, i)
+        };
         let hash = h.sum64(&key);
         nodes.insert(hash, node.name.clone());
     }

--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -63,14 +63,9 @@ pub async fn add_node_to_consistent_hash(node: &Node, role: &Role, group: Option
         Role::FlattenCompactor => FLATTEN_COMPACTOR_CONSISTENT_HASH.write().await,
         _ => return,
     };
-    let config = get_config();
     let mut h = config::utils::hash::gxhash::new();
-    for i in 0..config.limit.consistent_hash_vnodes {
-        let key = if config.disk_cache.new_hash_format {
-            format!("{}:{}:{}", CONSISTENT_HASH_PRIME, node.name, i)
-        } else {
-            format!("{}:{}{}", CONSISTENT_HASH_PRIME, node.name, i)
-        };
+    for i in 0..get_config().limit.consistent_hash_vnodes {
+        let key = format!("{}:{}:{}", CONSISTENT_HASH_PRIME, node.name, i);
         let hash = h.sum64(&key);
         nodes.insert(hash, node.name.clone());
     }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1428,8 +1428,6 @@ pub struct DiskCache {
     pub gc_interval: u64,
     #[env_config(name = "ZO_DISK_CACHE_MULTI_DIR", default = "")] // dir1,dir2,dir3...
     pub multi_dir: String,
-    #[env_config(name = "ZO_DISK_CACHE_NEW_HASH_FORMAT", default = false)]
-    pub new_hash_format: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1426,6 +1426,8 @@ pub struct DiskCache {
     pub gc_interval: u64,
     #[env_config(name = "ZO_DISK_CACHE_MULTI_DIR", default = "")] // dir1,dir2,dir3...
     pub multi_dir: String,
+    #[env_config(name = "ZO_DISK_CACHE_NEW_HASH_FORMAT", default = false)]
+    pub new_hash_format: bool
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1067,6 +1067,8 @@ pub struct Limit {
     pub usage_reporting_thread_num: usize,
     #[env_config(name = "ZO_QUERY_THREAD_NUM", default = 0)]
     pub query_thread_num: usize,
+    #[env_config(name = "ZO_FILE_DOWNLOAD_THREAD_NUM", default = 0)]
+    pub file_download_thread_num: usize,
     #[env_config(name = "ZO_QUERY_TIMEOUT", default = 600)]
     pub query_timeout: u64,
     #[env_config(name = "ZO_QUERY_INGESTER_TIMEOUT", default = 0)]
@@ -1427,7 +1429,7 @@ pub struct DiskCache {
     #[env_config(name = "ZO_DISK_CACHE_MULTI_DIR", default = "")] // dir1,dir2,dir3...
     pub multi_dir: String,
     #[env_config(name = "ZO_DISK_CACHE_NEW_HASH_FORMAT", default = false)]
-    pub new_hash_format: bool
+    pub new_hash_format: bool,
 }
 
 #[derive(EnvConfig)]
@@ -1681,6 +1683,11 @@ pub fn init() -> Config {
             cfg.limit.query_thread_num = cpu_num * 4;
         }
     }
+
+    if cfg.limit.file_download_thread_num == 0 {
+        cfg.limit.file_download_thread_num = cfg.limit.query_thread_num;
+    }
+
     // HACK for move_file_thread_num equal to CPU core
     if cfg.limit.file_move_thread_num == 0 {
         if cfg.common.local_mode {

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1067,8 +1067,6 @@ pub struct Limit {
     pub usage_reporting_thread_num: usize,
     #[env_config(name = "ZO_QUERY_THREAD_NUM", default = 0)]
     pub query_thread_num: usize,
-    #[env_config(name = "ZO_FILE_DOWNLOAD_THREAD_NUM", default = 0)]
-    pub file_download_thread_num: usize,
     #[env_config(name = "ZO_QUERY_TIMEOUT", default = 600)]
     pub query_timeout: u64,
     #[env_config(name = "ZO_QUERY_INGESTER_TIMEOUT", default = 0)]
@@ -1680,10 +1678,6 @@ pub fn init() -> Config {
         } else {
             cfg.limit.query_thread_num = cpu_num * 4;
         }
-    }
-
-    if cfg.limit.file_download_thread_num == 0 {
-        cfg.limit.file_download_thread_num = cfg.limit.query_thread_num;
     }
 
     // HACK for move_file_thread_num equal to CPU core

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -1,0 +1,129 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use config::get_config;
+use infra::cache::file_data::{self, CacheType};
+use once_cell::sync::Lazy;
+use tokio::sync::{
+    mpsc::{Receiver, Sender},
+    Mutex,
+};
+
+type FileInfo = (String, String, CacheType);
+
+struct DownloadQueue {
+    sender: Sender<FileInfo>,
+    receiver: Arc<Mutex<Receiver<FileInfo>>>,
+}
+
+impl DownloadQueue {
+    fn new(sender: Sender<FileInfo>, receiver: Arc<Mutex<Receiver<FileInfo>>>) -> Self {
+        Self { sender, receiver }
+    }
+}
+
+const FILE_DOWNLOAD_QUEUE_SIZE: usize = 10000;
+static FILE_DOWNLOAD_CHANNEL: Lazy<DownloadQueue> = Lazy::new(|| {
+    let (tx, rx) =
+        tokio::sync::mpsc::channel::<(String, String, CacheType)>(FILE_DOWNLOAD_QUEUE_SIZE);
+
+    DownloadQueue::new(tx, Arc::new(Mutex::new(rx)))
+});
+
+pub async fn run() -> Result<(), anyhow::Error> {
+    let cfg = get_config();
+    // move files
+    for _ in 0..cfg.limit.file_download_thread_num {
+        let rx = FILE_DOWNLOAD_CHANNEL.receiver.clone();
+        tokio::spawn(async move {
+            loop {
+                let ret = rx.lock().await.recv().await;
+                match ret {
+                    None => {
+                        log::debug!("[FILE_CACHE_DOWNLOAD:JOB] Receiving channel is closed");
+                        break;
+                    }
+                    Some((trace_id, file, cache)) => {
+                        if let Err(e) = download_file(&trace_id, &file, cache).await {
+                            log::error!(
+                                "[trace_id {trace_id}] search->storage: download file {} to cache {:?} err: {}",
+                                file,
+                                cache,
+                                e,
+                            );
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    Ok(())
+}
+
+async fn download_file(
+    trace_id: &str,
+    file_name: &str,
+    cache_type: CacheType,
+) -> Result<(), anyhow::Error> {
+    let cfg = get_config();
+    let ret = match cache_type {
+        file_data::CacheType::Memory => {
+            let mut disk_exists = false;
+            let mem_exists = file_data::memory::exist(file_name).await;
+            if !mem_exists && !cfg.memory_cache.skip_disk_check {
+                // when skip_disk_check = false, need to check disk cache
+                disk_exists = file_data::disk::exist(file_name).await;
+            }
+            if !mem_exists && (cfg.memory_cache.skip_disk_check || !disk_exists) {
+                file_data::memory::download(trace_id, file_name).await.err()
+            } else {
+                None
+            }
+        }
+        file_data::CacheType::Disk => {
+            if !file_data::disk::exist(file_name).await {
+                file_data::disk::download(trace_id, file_name).await.err()
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+    match ret {
+        Some(e) => Err(e),
+        None => {
+            log::debug!(
+                "[trace_id {trace_id}] successfully downloaded file {file_name} into cache {:?}",
+                cache_type
+            );
+            Ok(())
+        }
+    }
+}
+
+pub async fn queue_background_download(
+    trace_id: &str,
+    file: &str,
+    cache_type: CacheType,
+) -> Result<(), anyhow::Error> {
+    FILE_DOWNLOAD_CHANNEL
+        .sender
+        .send((trace_id.to_owned(), file.to_owned(), cache_type))
+        .await?;
+    Ok(())
+}

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -47,7 +47,7 @@ static FILE_DOWNLOAD_CHANNEL: Lazy<DownloadQueue> = Lazy::new(|| {
 pub async fn run() -> Result<(), anyhow::Error> {
     let cfg = get_config();
     // move files
-    for _ in 0..cfg.limit.file_download_thread_num {
+    for _ in 0..cfg.limit.query_thread_num {
         let rx = FILE_DOWNLOAD_CHANNEL.receiver.clone();
         tokio::spawn(async move {
             loop {

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -29,6 +29,7 @@ use crate::{
 
 mod alert_manager;
 mod compactor;
+mod file_downloader;
 pub(crate) mod files;
 mod flatten_compactor;
 pub mod metrics;
@@ -39,6 +40,7 @@ mod stats;
 pub(crate) mod syslog_server;
 mod telemetry;
 
+pub use file_downloader::queue_background_download;
 pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 
 pub async fn init() -> Result<(), anyhow::Error> {
@@ -200,6 +202,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     tokio::task::spawn(async move { metrics::run().await });
     tokio::task::spawn(async move { promql::run().await });
     tokio::task::spawn(async move { alert_manager::run().await });
+    tokio::task::spawn(async move { file_downloader::run().await });
 
     // load metrics disk cache
     tokio::task::spawn(async move { crate::service::promql::search::init().await });

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -45,18 +45,21 @@ use tantivy::Directory;
 use tokio::sync::Semaphore;
 use tracing::Instrument;
 
-use crate::service::{
-    db, file_list,
-    search::{
-        datafusion::exec,
-        generate_search_schema_diff,
-        index::IndexCondition,
-        tantivy::puffin_directory::{
-            caching_directory::CachingDirectory,
-            convert_puffin_file_to_tantivy_dir,
-            footer_cache::FooterCache,
-            reader::{warm_up_terms, PuffinDirReader},
-            reader_cache,
+use crate::{
+    job,
+    service::{
+        db, file_list,
+        search::{
+            datafusion::exec,
+            generate_search_schema_diff,
+            index::IndexCondition,
+            tantivy::puffin_directory::{
+                caching_directory::CachingDirectory,
+                convert_puffin_file_to_tantivy_dir,
+                footer_cache::FooterCache,
+                reader::{warm_up_terms, PuffinDirReader},
+                reader_cache,
+            },
         },
     },
 };
@@ -228,24 +231,25 @@ pub async fn search(
 
     // load files to local cache
     let cache_start = std::time::Instant::now();
-    let (cache_type, deleted_files) = cache_files(
+    let cache_type = cache_files(
         &query.trace_id,
         &files.iter().map(|f| f.key.as_ref()).collect_vec(),
         &mut scan_stats,
+        "parquet",
     )
     .instrument(enter_span.clone())
     .await?;
-    if !deleted_files.is_empty() {
-        // remove deleted files from files_group
-        for (_, g_files) in files_group.iter_mut() {
-            g_files.retain(|f| !deleted_files.contains(&f.key));
-        }
-    }
+
+    let download_msg = if cache_type == file_data::CacheType::None {
+        "".to_string()
+    } else {
+        format!("downloading others into {:?} in background,", cache_type)
+    };
 
     scan_stats.idx_took = idx_took as i64;
     scan_stats.querier_files = scan_stats.files;
     log::info!(
-        "[trace_id {}] search->storage: stream {}/{}/{}, load files {}, memory cached {}, disk cached {}, download others into {:?} cache done, took: {} ms",
+        "[trace_id {}] search->storage: stream {}/{}/{}, load files {}, memory cached {}, disk cached {}, {download_msg}, took: {} ms",
         query.trace_id,
         query.org_id,
         query.stream_type,
@@ -253,7 +257,6 @@ pub async fn search(
         scan_stats.querier_files,
         scan_stats.querier_memory_cached_files,
         scan_stats.querier_disk_cached_files,
-        cache_type,
         cache_start.elapsed().as_millis()
     );
 
@@ -317,7 +320,23 @@ async fn cache_files(
     trace_id: &str,
     files: &[&str],
     scan_stats: &mut ScanStats,
-) -> Result<(file_data::CacheType, Vec<String>), Error> {
+    file_type: &str,
+) -> Result<file_data::CacheType, Error> {
+    // check how many files already cached
+    for file in files.iter() {
+        if file_data::memory::exist(file).await {
+            scan_stats.querier_memory_cached_files += 1;
+        } else if file_data::disk::exist(file).await {
+            scan_stats.querier_disk_cached_files += 1;
+        }
+    }
+    if files.len() as i64
+        == scan_stats.querier_memory_cached_files + scan_stats.querier_disk_cached_files
+    {
+        // all files are cached
+        return Ok(file_data::CacheType::None);
+    }
+
     let cfg = get_config();
     let cache_type = if cfg.memory_cache.enabled
         && scan_stats.compressed_size < cfg.memory_cache.skip_size as i64
@@ -331,91 +350,38 @@ async fn cache_files(
         // if scan_compressed_size < ZO_DISK_CACHE_SKIP_SIZE, use disk cache
         file_data::CacheType::Disk
     } else {
-        // no cache
-        return Ok((file_data::CacheType::None, vec![]));
+        // no cache, the files are too big than cache size
+        return Ok(file_data::CacheType::None);
     };
 
-    let mut tasks = Vec::new();
-    let semaphore = std::sync::Arc::new(Semaphore::new(cfg.limit.query_thread_num));
-    for file in files.iter() {
-        let trace_id = trace_id.to_string();
-        let file_name = file.to_string();
-        let permit = semaphore.clone().acquire_owned().await.unwrap();
-        let task: tokio::task::JoinHandle<(Option<String>, bool, bool)> =
-            tokio::task::spawn(async move {
-                let cfg = get_config();
-                let ret = match cache_type {
-                    file_data::CacheType::Memory => {
-                        let mut disk_exists = false;
-                        let mem_exists = file_data::memory::exist(&file_name).await;
-                        if !mem_exists && !cfg.memory_cache.skip_disk_check {
-                            // when skip_disk_check = false, need to check disk cache
-                            disk_exists = file_data::disk::exist(&file_name).await;
-                        }
-                        if !mem_exists && (cfg.memory_cache.skip_disk_check || !disk_exists) {
-                            (
-                                file_data::memory::download(&trace_id, &file_name)
-                                    .await
-                                    .err(),
-                                false,
-                                false,
-                            )
-                        } else {
-                            (None, mem_exists, disk_exists)
-                        }
-                    }
-                    file_data::CacheType::Disk => {
-                        if !file_data::disk::exist(&file_name).await {
-                            (
-                                file_data::disk::download(&trace_id, &file_name).await.err(),
-                                false,
-                                false,
-                            )
-                        } else {
-                            (None, false, true)
-                        }
-                    }
-                    _ => (None, false, false),
-                };
-                // return file_name if download failed
-                let file_name = if let Some(e) = ret.0 {
-                    log::warn!(
-                        "[trace_id {trace_id}] search->storage: download file to cache err: {}",
-                        e
+    let trace_id = trace_id.to_string();
+    let files = files.iter().map(|f| f.to_string()).collect_vec();
+    let file_type = file_type.to_string();
+    tokio::spawn(async move {
+        let files = files.iter().map(|f| f.as_str()).collect_vec();
+        for file in &files {
+            match job::queue_background_download(&trace_id, file, cache_type).await {
+                Ok(_) => {
+                    log::debug!(
+                        "[trace_id {trace_id}] file {file} successfully queued for download"
                     );
-                    Some(file_name)
-                } else {
-                    None
-                };
-                drop(permit);
-                (file_name, ret.1, ret.2)
-            });
-        tasks.push(task);
-    }
-
-    let mut delete_files = Vec::new();
-    for task in tasks {
-        match task.await {
-            Ok((file, mem_exists, disk_exists)) => {
-                if mem_exists {
-                    scan_stats.querier_memory_cached_files += 1;
-                } else if disk_exists {
-                    scan_stats.querier_disk_cached_files += 1;
                 }
-                if let Some(file) = file {
-                    delete_files.push(file);
+                Err(e) => {
+                    log::error!(
+                        "[trace_id {trace_id}] error in queuing file {file} for background download : {e}"
+                    );
                 }
-            }
-            Err(e) => {
-                log::error!(
-                    "[trace_id {trace_id}] search->storage: load file task err: {}",
-                    e
-                );
             }
         }
-    }
-
-    Ok((cache_type, delete_files))
+        log::info!(
+            "[trace_id {}] search->storage: successfully enqueued {} files of {} for background download into {:?} ",
+            trace_id,
+            files.len(),
+            file_type,
+            cache_type,
+        );
+    });
+    Ok(cache_type)
 }
 
 /// Filter file list using inverted index
@@ -452,18 +418,25 @@ pub async fn filter_file_list_by_tantivy_index(
         })
         .collect_vec();
     scan_stats.querier_files = index_file_names.len() as i64;
-    let (cache_type, _) = cache_files(
+    let cache_type = cache_files(
         &query.trace_id,
         &index_file_names
             .iter()
             .map(|(ttv_file, _)| ttv_file.as_str())
             .collect_vec(),
         &mut scan_stats,
+        "index",
     )
     .await?;
 
+    let download_msg = if cache_type == file_data::CacheType::None {
+        "".to_string()
+    } else {
+        format!("downloading others into {:?} in background,", cache_type)
+    };
+
     log::info!(
-        "[trace_id {}] search->tantivy: stream {}/{}/{}, load puffin index files {}, memory cached {}, disk cached {}, download others into {:?} cache done, took: {} ms",
+        "[trace_id {}] search->tantivy: stream {}/{}/{}, load puffin index files {}, memory cached {}, disk cached {}, {download_msg} took: {} ms",
         query.trace_id,
         query.org_id,
         query.stream_type,
@@ -471,7 +444,6 @@ pub async fn filter_file_list_by_tantivy_index(
         scan_stats.querier_files,
         scan_stats.querier_memory_cached_files,
         scan_stats.querier_disk_cached_files,
-        cache_type,
         start.elapsed().as_millis()
     );
 


### PR DESCRIPTION
This takes the following changes from main. Not directly cherry picked, as their commits also had some other changes in them.

- ~Change the hash format string we use for file allocation to queriers. This is behind a new config , by default picks the existing one.~ This is already present.
- Change the cache download to background thread. This is not configurable, and is always on.