### PR TITLE
feat: report node config over super cluster

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -91,7 +91,7 @@ pub async fn remove_node_from_consistent_hash(node: &Node, role: &Role, group: O
     };
     let mut h = config::utils::hash::gxhash::new();
     for i in 0..get_config().limit.consistent_hash_vnodes {
-        let key = format!("{}:{}{}", CONSISTENT_HASH_PRIME, node.name, i);
+        let key = format!("{}:{}:{}", CONSISTENT_HASH_PRIME, node.name, i);
         let hash = h.sum64(&key);
         nodes.remove(&hash);
     }

--- a/src/common/meta/organization.rs
+++ b/src/common/meta/organization.rs
@@ -239,7 +239,7 @@ impl NodeListResponse {
         let cluster_entry = region_entry
             .clusters
             .entry(cluster_name.clone())
-            .or_insert_with(|| Vec::new());
+            .or_default();
 
         cluster_entry.push(node);
     }
@@ -256,8 +256,6 @@ impl NodeListResponse {
 impl RegionInfo {
     /// Adds a cluster to this region if it doesn't exist
     pub fn add_cluster(&mut self, cluster_name: String) -> &mut Vec<Node> {
-        self.clusters
-            .entry(cluster_name.clone())
-            .or_insert_with(|| Vec::new())
+        self.clusters.entry(cluster_name.clone()).or_default()
     }
 }

--- a/src/common/meta/organization.rs
+++ b/src/common/meta/organization.rs
@@ -256,6 +256,6 @@ impl NodeListResponse {
 impl RegionInfo {
     /// Adds a cluster to this region if it doesn't exist
     pub fn add_cluster(&mut self, cluster_name: String) -> &mut Vec<Node> {
-        self.clusters.entry(cluster_name.clone()).or_default()
+        self.clusters.entry(cluster_name).or_default()
     }
 }

--- a/src/common/meta/organization.rs
+++ b/src/common/meta/organization.rs
@@ -20,6 +20,8 @@ pub const DEFAULT_ORG: &str = "default";
 pub const CUSTOM: &str = "custom";
 pub const THRESHOLD: i64 = 9383939382;
 
+use config::meta::cluster::Node;
+
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
 pub struct Organization {
     pub identifier: String,
@@ -187,4 +189,35 @@ impl Default for OrganizationSetting {
 #[derive(Serialize, ToSchema, Deserialize, Debug, Clone)]
 pub struct OrganizationSettingResponse {
     pub data: OrganizationSetting,
+}
+
+/// Request struct for node listing with region filtering
+///
+/// Regions can be provided in the request body to filter nodes by region.
+/// If no regions are provided, all nodes will be returned.
+#[derive(Serialize, Deserialize, Default)]
+pub struct NodeListRequest {
+    /// List of region names to filter by
+    pub regions: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct NodeListResponse {
+    pub nodes: Vec<FederatedNode>,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct FederatedNode {
+    #[serde(flatten)]
+    pub node: Node,
+    pub region: String,
+    pub cluster_name: String,
+}
+
+pub fn to_federated_node(node: Node, region: String, cluster_name: String) -> FederatedNode {
+    FederatedNode {
+        node,
+        region,
+        cluster_name,
+    }
 }

--- a/src/config/src/meta/cluster.rs
+++ b/src/config/src/meta/cluster.rs
@@ -20,7 +20,6 @@ use serde::{Deserialize, Serialize};
 use crate::{
     get_config, get_instance_id, meta::search::SearchEventType, utils::sysinfo::NodeMetrics,
 };
-
 pub trait NodeInfo: Debug + Send + Sync {
     fn is_querier(&self) -> bool {
         true
@@ -30,6 +29,8 @@ pub trait NodeInfo: Debug + Send + Sync {
     }
     fn get_grpc_addr(&self) -> String;
     fn get_auth_token(&self) -> String;
+    fn get_region(&self) -> String;
+    fn get_cluster_name(&self) -> String;
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -137,6 +138,14 @@ impl Default for Node {
 impl NodeInfo for Node {
     fn is_querier(&self) -> bool {
         self.is_querier()
+    }
+
+    fn get_region(&self) -> String {
+        "local".to_string()
+    }
+
+    fn get_cluster_name(&self) -> String {
+        "local".to_string()
     }
 
     fn is_ingester(&self) -> bool {

--- a/src/config/src/meta/cluster.rs
+++ b/src/config/src/meta/cluster.rs
@@ -29,8 +29,12 @@ pub trait NodeInfo: Debug + Send + Sync {
     }
     fn get_grpc_addr(&self) -> String;
     fn get_auth_token(&self) -> String;
-    fn get_region(&self) -> String;
-    fn get_cluster_name(&self) -> String;
+    fn get_region(&self) -> String {
+        "openobserve".to_string()
+    }
+    fn get_cluster_name(&self) -> String {
+        crate::config::get_cluster_name()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -138,14 +142,6 @@ impl Default for Node {
 impl NodeInfo for Node {
     fn is_querier(&self) -> bool {
         self.is_querier()
-    }
-
-    fn get_region(&self) -> String {
-        "local".to_string()
-    }
-
-    fn get_cluster_name(&self) -> String {
-        "local".to_string()
     }
 
     fn is_ingester(&self) -> bool {

--- a/src/handler/http/request/organization/org.rs
+++ b/src/handler/http/request/organization/org.rs
@@ -407,7 +407,7 @@ async fn node_list(
     }
 
     // Extract regions from query params
-    let regions = query.get("regions").map_or_else(Vec::new, |regions_str| {
+    let _regions = query.get("regions").map_or_else(Vec::new, |regions_str| {
         regions_str
             .split(',')
             .filter(|s| !s.is_empty())
@@ -419,7 +419,7 @@ async fn node_list(
     #[cfg(feature = "enterprise")]
     let response = if get_o2_config().super_cluster.enabled {
         // Super cluster is enabled, get nodes from super cluster
-        match get_super_cluster_nodes(&regions).await {
+        match get_super_cluster_nodes(&_regions).await {
             Ok(response) => response,
             Err(e) => return Ok(MetaHttpResponse::bad_request(e)),
         }

--- a/src/handler/http/request/organization/org.rs
+++ b/src/handler/http/request/organization/org.rs
@@ -16,15 +16,21 @@
 use std::{collections::HashSet, io::Error};
 
 use actix_web::{HttpResponse, Result, get, http, post, put, web};
+use config::meta::cluster::NodeInfo;
 use infra::schema::STREAM_SCHEMAS_LATEST;
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::common::infra::config::get_config as get_o2_config;
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::super_cluster::kv::cluster::get_grpc_addr;
 
 use crate::{
     common::{
-        infra::config::USERS,
+        infra::{cluster, config::USERS},
         meta::{
             http::HttpResponse as MetaHttpResponse,
             organization::{
-                CUSTOM, DEFAULT_ORG, OrgDetails, OrgUser, Organization, OrganizationResponse,
+                to_federated_node, FederatedNode, NodeListRequest, NodeListResponse, CUSTOM, DEFAULT_ORG, OrgDetails,
+                OrgUser, Organization, OrganizationResponse,
                 PasscodeResponse, RumIngestionResponse, THRESHOLD,
             },
         },
@@ -356,4 +362,120 @@ async fn create_org(
         Ok(_) => Ok(HttpResponse::Ok().json(org)),
         Err(err) => Err(err),
     }
+}
+
+/// GetNodeList
+///
+/// This endpoint returns a list of all nodes in the OpenObserve cluster along with their
+/// versions and other essential information. It can be useful for:
+///
+/// - Monitoring which nodes are online/offline in a distributed deployment
+/// - Checking version consistency across the cluster
+/// - Identifying nodes by their roles
+/// - Filtering nodes by region when using a multi-region setup
+///
+/// NOTE: This endpoint is only accessible through the "_meta" organization and requires
+/// the user to have access to this special organization.
+#[utoipa::path(
+    context_path = "/api",
+    tag = "Organizations",
+    operation_id = "GetMetaOrganizationNodeList",
+    security(
+        ("Authorization"= [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Must be '_meta'")
+    ),
+    request_body(content = NodeListRequest, description = "Request with regions to filter by", content_type = "application/json"),
+    responses(
+        (status = 200, description = "Success", content_type = "application/json", body = NodeListResponse),
+        (status = 403, description = "Forbidden - Not the _meta organization", content_type = "application/json", body = HttpResponse),
+        (status = 404, description = "NotFound", content_type = "application/json", body = HttpResponse),
+        (status = 400, description = "Bad Request - Invalid JSON body", content_type = "application/json", body = HttpResponse),
+    )
+)]
+#[get("/{org_id}/node/list")]
+async fn node_list(org_id: web::Path<String>, payload: web::Bytes) -> Result<HttpResponse, Error> {
+    let org = org_id.into_inner();
+    // Ensure this API is only available for the "_meta" organization
+    if org != "_meta" {
+        return Ok(HttpResponse::Forbidden().json(MetaHttpResponse::error(
+            http::StatusCode::FORBIDDEN.into(),
+            "This API is only available for the _meta organization".to_string(),
+        )));
+    }
+
+    let req: NodeListRequest = match serde_json::from_slice(&payload) {
+        Ok(v) => v,
+        Err(e) => {
+            return Ok(MetaHttpResponse::bad_request(e));
+        }
+    };
+
+    // Check if super cluster is enabled
+    #[cfg(feature = "enterprise")]
+    let super_cluster_enabled = get_o2_config().super_cluster.enabled;
+
+    #[cfg(not(feature = "enterprise"))]
+    let super_cluster_enabled = false;
+
+    // Get all nodes from cache
+    let mut nodes: Vec<FederatedNode> = match cluster::get_cached_nodes(|_| true).await {
+        Some(nodes) => nodes
+            .iter()
+            .map(|node| to_federated_node(node.clone(), node.get_region(), node.get_cluster_name()))
+            .collect(),
+        None => Vec::new(),
+    };
+
+    #[cfg(feature = "enterprise")]
+    if super_cluster_enabled {
+        let super_cluster_nodes =
+            match o2_enterprise::enterprise::super_cluster::search::get_cluster_nodes(
+                "list_nodes",
+                req.regions.clone(),
+                vec![],
+            )
+            .await
+            {
+                Ok(nodes) => nodes,
+                Err(e) => {
+                    log::error!("Failed to get super cluster nodes: {:?}", e);
+                    Vec::new()
+                }
+            };
+
+        // For each node in the super cluster
+        for node in super_cluster_nodes {
+            // Skip the current node
+            if node.get_grpc_addr() == get_grpc_addr() {
+                continue;
+            }
+
+            let region = node.get_region();
+            let cluster_name = node.get_cluster_name();
+
+            match crate::service::node::get_node_list(node).await {
+                Ok(cluster_nodes) => {
+                    for node in cluster_nodes {
+                        nodes.push(to_federated_node(
+                            node.clone(),
+                            region.clone(),
+                            cluster_name.clone(),
+                        ));
+                    }
+                }
+                Err(e) => {
+                    log::error!("Failed to get node list: {:?}", e);
+                    return Ok(MetaHttpResponse::internal_error(format!(
+                        "Failed to get node list: {:?}",
+                        e
+                    )));
+                }
+            }
+        }
+    }
+
+    // Return response with nodes
+    Ok(HttpResponse::Ok().json(NodeListResponse { nodes }))
 }

--- a/src/handler/http/request/organization/org.rs
+++ b/src/handler/http/request/organization/org.rs
@@ -29,9 +29,9 @@ use crate::{
         meta::{
             http::HttpResponse as MetaHttpResponse,
             organization::{
-                to_federated_node, FederatedNode, NodeListRequest, NodeListResponse, CUSTOM, DEFAULT_ORG, OrgDetails,
-                OrgUser, Organization, OrganizationResponse,
-                PasscodeResponse, RumIngestionResponse, THRESHOLD,
+                CUSTOM, DEFAULT_ORG, FederatedNode, NodeListRequest, NodeListResponse, OrgDetails,
+                OrgUser, Organization, OrganizationResponse, PasscodeResponse,
+                RumIngestionResponse, THRESHOLD, to_federated_node,
             },
         },
         utils::auth::{UserEmail, is_root_user},

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -360,6 +360,7 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(organization::org::create_user_rumtoken)
         .service(organization::org::get_user_rumtoken)
         .service(organization::org::update_user_rumtoken)
+        .service(organization::org::node_list)
         .service(organization::es::org_index)
         .service(organization::es::org_license)
         .service(organization::es::org_xpack)

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,10 @@ use openobserve::{
         http::router::*,
     },
     job, router,
-    service::{db, metadata, node::NodeService, search::SEARCH_SERVER, self_reporting, tls::http_tls_config},
+    service::{
+        db, metadata, node::NodeService, search::SEARCH_SERVER, self_reporting,
+        tls::http_tls_config,
+    },
 };
 use opentelemetry::{KeyValue, global, trace::TracerProvider};
 use opentelemetry_otlp::WithExportConfig;
@@ -73,8 +76,7 @@ use opentelemetry_sdk::{Resource, propagation::TraceContextPropagator};
 use proto::cluster_rpc::{
     event_server::EventServer, ingest_server::IngestServer, metrics_server::MetricsServer,
     node_service_server::NodeServiceServer, query_cache_server::QueryCacheServer,
-    search_server::SearchServer,
-    streams_server::StreamsServer,
+    search_server::SearchServer, streams_server::StreamsServer,
 };
 #[cfg(feature = "profiling")]
 use pyroscope::PyroscopeAgent;

--- a/src/proto/build.rs
+++ b/src/proto/build.rs
@@ -64,6 +64,7 @@ fn main() -> Result<()> {
                 "proto/cluster/ingest.proto",
                 "proto/cluster/querycache.proto",
                 "proto/cluster/plan.proto",
+                "proto/cluster/node.proto",
                 "proto/cluster/stream.proto",
             ],
             &["proto"],

--- a/src/proto/proto/cluster/node.proto
+++ b/src/proto/proto/cluster/node.proto
@@ -52,6 +52,7 @@ enum Role {
   ROUTER = 4;
   ALERT_MANAGER = 5;
   FLATTEN_COMPACTOR = 6;
+  SCRIPT_SERVER = 7;
 }
 
 // Role group enum

--- a/src/proto/proto/cluster/node.proto
+++ b/src/proto/proto/cluster/node.proto
@@ -20,6 +20,18 @@ message GetNodesResponse {
   repeated NodeDetails nodes = 1;
 }
 
+// Node metrics representation
+message NodeMetrics {
+  uint64 cpu_total = 1;
+  float cpu_usage = 2;
+  uint64 memory_total = 3;
+  uint64 memory_usage = 4;
+  uint64 tcp_conns = 5;
+  uint64 tcp_conns_established = 6;
+  uint64 tcp_conns_close_wait = 7;
+  uint64 tcp_conns_time_wait = 8;
+}
+
 // Node representation
 message NodeDetails {
   int32 id = 1;
@@ -34,6 +46,7 @@ message NodeDetails {
   bool scheduled = 10;
   bool broadcasted = 11;
   string version = 12;
+  NodeMetrics metrics = 13;
 }
 
 // Node status enum

--- a/src/proto/proto/cluster/node.proto
+++ b/src/proto/proto/cluster/node.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.openobserve.cluster";
+option java_outer_classname = "nodeProto";
+
+package cluster;
+
+import "cluster/common.proto";
+
+// Node Service for fetching node information
+service NodeService {
+  // Get list of nodes from a cluster
+  rpc GetNodes(EmptyRequest) returns (GetNodesResponse) {}
+}
+
+// Response message for GetNodes
+message GetNodesResponse {
+  // List of nodes
+  repeated NodeDetails nodes = 1;
+}
+
+// Node representation
+message NodeDetails {
+  int32 id = 1;
+  string uuid = 2;
+  string name = 3;
+  string http_addr = 4;
+  string grpc_addr = 5;
+  repeated Role roles = 6;
+  RoleGroup role_group = 7;
+  uint64 cpu_num = 8;
+  NodeStatus status = 9;
+  bool scheduled = 10;
+  bool broadcasted = 11;
+  string version = 12;
+}
+
+// Node status enum
+enum NodeStatus {
+  PREPARE = 0;
+  ONLINE = 1;
+  OFFLINE = 2;
+}
+
+// Role enum
+enum Role {
+  ALL = 0;
+  INGESTER = 1;
+  QUERIER = 2;
+  COMPACTOR = 3;
+  ROUTER = 4;
+  ALERT_MANAGER = 5;
+  FLATTEN_COMPACTOR = 6;
+}
+
+// Role group enum
+enum RoleGroup {
+  NONE = 0;
+  INTERACTIVE = 1;
+  BACKGROUND = 2;
+}

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -2807,6 +2807,7 @@ pub enum Role {
     Router = 4,
     AlertManager = 5,
     FlattenCompactor = 6,
+    ScriptServer = 7,
 }
 impl Role {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2822,6 +2823,7 @@ impl Role {
             Role::Router => "ROUTER",
             Role::AlertManager => "ALERT_MANAGER",
             Role::FlattenCompactor => "FLATTEN_COMPACTOR",
+            Role::ScriptServer => "SCRIPT_SERVER",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2834,6 +2836,7 @@ impl Role {
             "ROUTER" => Some(Self::Router),
             "ALERT_MANAGER" => Some(Self::AlertManager),
             "FLATTEN_COMPACTOR" => Some(Self::FlattenCompactor),
+            "SCRIPT_SERVER" => Some(Self::ScriptServer),
             _ => None,
         }
     }

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -2729,6 +2729,440 @@ pub struct KvItem {
     #[prost(string, tag = "2")]
     pub value: ::prost::alloc::string::String,
 }
+/// Response message for GetNodes
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetNodesResponse {
+    /// List of nodes
+    #[prost(message, repeated, tag = "1")]
+    pub nodes: ::prost::alloc::vec::Vec<NodeDetails>,
+}
+/// Node representation
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NodeDetails {
+    #[prost(int32, tag = "1")]
+    pub id: i32,
+    #[prost(string, tag = "2")]
+    pub uuid: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub http_addr: ::prost::alloc::string::String,
+    #[prost(string, tag = "5")]
+    pub grpc_addr: ::prost::alloc::string::String,
+    #[prost(enumeration = "Role", repeated, tag = "6")]
+    pub roles: ::prost::alloc::vec::Vec<i32>,
+    #[prost(enumeration = "RoleGroup", tag = "7")]
+    pub role_group: i32,
+    #[prost(uint64, tag = "8")]
+    pub cpu_num: u64,
+    #[prost(enumeration = "NodeStatus", tag = "9")]
+    pub status: i32,
+    #[prost(bool, tag = "10")]
+    pub scheduled: bool,
+    #[prost(bool, tag = "11")]
+    pub broadcasted: bool,
+    #[prost(string, tag = "12")]
+    pub version: ::prost::alloc::string::String,
+}
+/// Node status enum
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum NodeStatus {
+    Prepare = 0,
+    Online = 1,
+    Offline = 2,
+}
+impl NodeStatus {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            NodeStatus::Prepare => "PREPARE",
+            NodeStatus::Online => "ONLINE",
+            NodeStatus::Offline => "OFFLINE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "PREPARE" => Some(Self::Prepare),
+            "ONLINE" => Some(Self::Online),
+            "OFFLINE" => Some(Self::Offline),
+            _ => None,
+        }
+    }
+}
+/// Role enum
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Role {
+    All = 0,
+    Ingester = 1,
+    Querier = 2,
+    Compactor = 3,
+    Router = 4,
+    AlertManager = 5,
+    FlattenCompactor = 6,
+}
+impl Role {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Role::All => "ALL",
+            Role::Ingester => "INGESTER",
+            Role::Querier => "QUERIER",
+            Role::Compactor => "COMPACTOR",
+            Role::Router => "ROUTER",
+            Role::AlertManager => "ALERT_MANAGER",
+            Role::FlattenCompactor => "FLATTEN_COMPACTOR",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "ALL" => Some(Self::All),
+            "INGESTER" => Some(Self::Ingester),
+            "QUERIER" => Some(Self::Querier),
+            "COMPACTOR" => Some(Self::Compactor),
+            "ROUTER" => Some(Self::Router),
+            "ALERT_MANAGER" => Some(Self::AlertManager),
+            "FLATTEN_COMPACTOR" => Some(Self::FlattenCompactor),
+            _ => None,
+        }
+    }
+}
+/// Role group enum
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum RoleGroup {
+    None = 0,
+    Interactive = 1,
+    Background = 2,
+}
+impl RoleGroup {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            RoleGroup::None => "NONE",
+            RoleGroup::Interactive => "INTERACTIVE",
+            RoleGroup::Background => "BACKGROUND",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "NONE" => Some(Self::None),
+            "INTERACTIVE" => Some(Self::Interactive),
+            "BACKGROUND" => Some(Self::Background),
+            _ => None,
+        }
+    }
+}
+/// Generated client implementations.
+pub mod node_service_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    /// Node Service for fetching node information
+    #[derive(Debug, Clone)]
+    pub struct NodeServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl NodeServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> NodeServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> NodeServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            NodeServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// Get list of nodes from a cluster
+        pub async fn get_nodes(
+            &mut self,
+            request: impl tonic::IntoRequest<super::EmptyRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetNodesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cluster.NodeService/GetNodes",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cluster.NodeService", "GetNodes"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod node_service_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with NodeServiceServer.
+    #[async_trait]
+    pub trait NodeService: Send + Sync + 'static {
+        /// Get list of nodes from a cluster
+        async fn get_nodes(
+            &self,
+            request: tonic::Request<super::EmptyRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetNodesResponse>,
+            tonic::Status,
+        >;
+    }
+    /// Node Service for fetching node information
+    #[derive(Debug)]
+    pub struct NodeServiceServer<T: NodeService> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: NodeService> NodeServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for NodeServiceServer<T>
+    where
+        T: NodeService,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/cluster.NodeService/GetNodes" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetNodesSvc<T: NodeService>(pub Arc<T>);
+                    impl<T: NodeService> tonic::server::UnaryService<super::EmptyRequest>
+                    for GetNodesSvc<T> {
+                        type Response = super::GetNodesResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::EmptyRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as NodeService>::get_nodes(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetNodesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: NodeService> Clone for NodeServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: NodeService> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: NodeService> tonic::server::NamedService for NodeServiceServer<T> {
+        const NAME: &'static str = "cluster.NodeService";
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamStatsRequest {

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -2737,6 +2737,27 @@ pub struct GetNodesResponse {
     #[prost(message, repeated, tag = "1")]
     pub nodes: ::prost::alloc::vec::Vec<NodeDetails>,
 }
+/// Node metrics representation
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NodeMetrics {
+    #[prost(uint64, tag = "1")]
+    pub cpu_total: u64,
+    #[prost(float, tag = "2")]
+    pub cpu_usage: f32,
+    #[prost(uint64, tag = "3")]
+    pub memory_total: u64,
+    #[prost(uint64, tag = "4")]
+    pub memory_usage: u64,
+    #[prost(uint64, tag = "5")]
+    pub tcp_conns: u64,
+    #[prost(uint64, tag = "6")]
+    pub tcp_conns_established: u64,
+    #[prost(uint64, tag = "7")]
+    pub tcp_conns_close_wait: u64,
+    #[prost(uint64, tag = "8")]
+    pub tcp_conns_time_wait: u64,
+}
 /// Node representation
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2765,6 +2786,8 @@ pub struct NodeDetails {
     pub broadcasted: bool,
     #[prost(string, tag = "12")]
     pub version: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "13")]
+    pub metrics: ::core::option::Option<NodeMetrics>,
 }
 /// Node status enum
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/src/service/grpc.rs
+++ b/src/service/grpc.rs
@@ -247,7 +247,7 @@ pub async fn make_grpc_node_client<T>(
         .await
         .map_err(|err| {
             log::error!(
-                "search->grpc: node: {}, connect err: {:?}",
+                "node->grpc: node: {}, connect err: {:?}",
                 &node.get_grpc_addr(),
                 err
             );

--- a/src/service/grpc.rs
+++ b/src/service/grpc.rs
@@ -18,7 +18,10 @@ use std::sync::Arc;
 use config::{RwAHashMap, get_config, meta::cluster::NodeInfo, utils::rand::get_rand_element};
 use infra::errors::{Error, ErrorCodes};
 use once_cell::sync::Lazy;
-use proto::cluster_rpc::{self, metrics_client::MetricsClient, search_client::SearchClient};
+use proto::cluster_rpc::{
+    self, metrics_client::MetricsClient, node_service_client::NodeServiceClient,
+    search_client::SearchClient,
+};
 use tonic::{
     Request, Status,
     codec::CompressionEncoding,
@@ -214,4 +217,52 @@ pub async fn make_grpc_metrics_client<T>(
         .max_decoding_message_size(cfg.grpc.max_message_size * 1024 * 1024)
         .max_encoding_message_size(cfg.grpc.max_message_size * 1024 * 1024);
     Ok(client)
+}
+
+#[tracing::instrument(name = "grpc:node:make_client", skip_all)]
+pub async fn make_grpc_node_client<T>(
+    request: &mut Request<T>,
+    node: &Arc<dyn NodeInfo>,
+) -> Result<
+    NodeServiceClient<
+        InterceptedService<Channel, impl Fn(Request<()>) -> Result<Request<()>, Status>>,
+    >,
+    Error,
+> {
+    let cfg = get_config();
+    request.set_timeout(std::time::Duration::from_secs(cfg.limit.query_timeout));
+
+    opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(
+            &tracing::Span::current().context(),
+            &mut MetadataMap(request.metadata_mut()),
+        )
+    });
+
+    let token: MetadataValue<_> = node
+        .get_auth_token()
+        .parse()
+        .map_err(|_| Error::Message("invalid token".to_string()))?;
+    let channel = get_cached_channel(&node.get_grpc_addr())
+        .await
+        .map_err(|err| {
+            log::error!(
+                "search->grpc: node: {}, connect err: {:?}",
+                &node.get_grpc_addr(),
+                err
+            );
+            Error::ErrorCode(ErrorCodes::ServerInternalError(err.to_string()))
+        })?;
+    let client = cluster_rpc::node_service_client::NodeServiceClient::with_interceptor(
+        channel,
+        move |mut req: Request<()>| {
+            req.metadata_mut().insert("authorization", token.clone());
+            Ok(req)
+        },
+    );
+    Ok(client
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .max_decoding_message_size(cfg.grpc.max_message_size * 1024 * 1024)
+        .max_encoding_message_size(cfg.grpc.max_message_size * 1024 * 1024))
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -32,6 +32,7 @@ pub mod kv;
 pub mod logs;
 pub mod metadata;
 pub mod metrics;
+pub mod node;
 pub mod organization;
 pub mod pipeline;
 pub mod promql;

--- a/src/service/node.rs
+++ b/src/service/node.rs
@@ -1,0 +1,199 @@
+// Copyright 2024 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use config::meta::cluster::{Node as ConfigNode, NodeInfo, NodeStatus, Role, RoleGroup};
+use proto::cluster_rpc::{
+    EmptyRequest, GetNodesResponse, NodeDetails, NodeStatus as ProtoNodeStatus, Role as ProtoRole,
+    RoleGroup as ProtoRoleGroup,
+};
+use tonic::{Request, Response, Status};
+
+use crate::common::infra::cluster;
+
+pub struct NodeService;
+
+// Convert from ConfigNode to proto Node
+pub fn config_node_to_proto(node: ConfigNode) -> NodeDetails {
+    let roles = node
+        .role
+        .iter()
+        .map(|r| match r {
+            Role::All => ProtoRole::All as i32,
+            Role::Ingester => ProtoRole::Ingester as i32,
+            Role::Querier => ProtoRole::Querier as i32,
+            Role::Compactor => ProtoRole::Compactor as i32,
+            Role::Router => ProtoRole::Router as i32,
+            Role::AlertManager => ProtoRole::AlertManager as i32,
+            Role::FlattenCompactor => ProtoRole::FlattenCompactor as i32,
+        })
+        .collect();
+
+    let role_group = match node.role_group {
+        RoleGroup::None => ProtoRoleGroup::None as i32,
+        RoleGroup::Interactive => ProtoRoleGroup::Interactive as i32,
+        RoleGroup::Background => ProtoRoleGroup::Background as i32,
+    };
+
+    let status = match node.status {
+        NodeStatus::Prepare => ProtoNodeStatus::Prepare as i32,
+        NodeStatus::Online => ProtoNodeStatus::Online as i32,
+        NodeStatus::Offline => ProtoNodeStatus::Offline as i32,
+    };
+
+    NodeDetails {
+        id: node.id,
+        uuid: node.uuid,
+        name: node.name,
+        http_addr: node.http_addr,
+        grpc_addr: node.grpc_addr,
+        roles,
+        role_group,
+        cpu_num: node.cpu_num,
+        status,
+        scheduled: node.scheduled,
+        broadcasted: node.broadcasted,
+        version: node.version,
+    }
+}
+
+// Convert from proto Node to ConfigNode
+pub fn proto_node_to_config(node: NodeDetails) -> ConfigNode {
+    let role = node
+        .roles
+        .iter()
+        .filter_map(|&r| match r {
+            r if r == ProtoRole::All as i32 => Some(Role::All),
+            r if r == ProtoRole::Ingester as i32 => Some(Role::Ingester),
+            r if r == ProtoRole::Querier as i32 => Some(Role::Querier),
+            r if r == ProtoRole::Compactor as i32 => Some(Role::Compactor),
+            r if r == ProtoRole::Router as i32 => Some(Role::Router),
+            r if r == ProtoRole::AlertManager as i32 => Some(Role::AlertManager),
+            r if r == ProtoRole::FlattenCompactor as i32 => Some(Role::FlattenCompactor),
+            _ => None,
+        })
+        .collect();
+
+    let role_group = match node.role_group {
+        r if r == ProtoRoleGroup::None as i32 => RoleGroup::None,
+        r if r == ProtoRoleGroup::Interactive as i32 => RoleGroup::Interactive,
+        r if r == ProtoRoleGroup::Background as i32 => RoleGroup::Background,
+        _ => RoleGroup::None,
+    };
+
+    let status = match node.status {
+        s if s == ProtoNodeStatus::Prepare as i32 => NodeStatus::Prepare,
+        s if s == ProtoNodeStatus::Online as i32 => NodeStatus::Online,
+        s if s == ProtoNodeStatus::Offline as i32 => NodeStatus::Offline,
+        _ => NodeStatus::Prepare,
+    };
+
+    ConfigNode {
+        id: node.id,
+        uuid: node.uuid,
+        name: node.name,
+        http_addr: node.http_addr,
+        grpc_addr: node.grpc_addr,
+        role,
+        role_group,
+        cpu_num: node.cpu_num,
+        status,
+        scheduled: node.scheduled,
+        broadcasted: node.broadcasted,
+        version: node.version,
+    }
+}
+
+#[tonic::async_trait]
+impl proto::cluster_rpc::node_service_server::NodeService for NodeService {
+    async fn get_nodes(
+        &self,
+        _request: Request<EmptyRequest>,
+    ) -> Result<Response<GetNodesResponse>, Status> {
+        // Get all nodes from cache
+        let nodes = cluster::get_cached_nodes(|_| true)
+            .await
+            .unwrap_or_default();
+
+        // Convert config nodes to proto nodes
+        let proto_nodes = nodes.into_iter().map(config_node_to_proto).collect();
+
+        // Create the response
+        let response = GetNodesResponse { nodes: proto_nodes };
+
+        Ok(Response::new(response))
+    }
+}
+
+pub async fn get_node_list(node: Arc<dyn NodeInfo>) -> Result<Vec<ConfigNode>, anyhow::Error> {
+    let mut nodes = Vec::new();
+
+    // Create a task to fetch nodes from this cluster node
+    let task: tokio::task::JoinHandle<Result<Vec<NodeDetails>, infra::errors::Error>> =
+        tokio::task::spawn(async move {
+            let mut client =
+                super::grpc::make_grpc_node_client(&mut Request::new(EmptyRequest {}), &node)
+                    .await?;
+            let nodes = match client.get_nodes(Request::new(EmptyRequest {})).await {
+                Ok(remote_nodes) => remote_nodes.into_inner().nodes,
+                Err(err) => {
+                    log::error!(
+                        "Failed to get nodes from cluster node {}: {:?}",
+                        node.get_grpc_addr(),
+                        err
+                    );
+                    Vec::new()
+                }
+            };
+            Ok(nodes)
+        });
+
+    // Wait for the task and handle the result
+    match task.await {
+        Ok(res) => {
+            match res {
+                Ok(remote_nodes) => {
+                    // Add nodes that don't already exist in our list
+                    for remote_node in remote_nodes {
+                        if !nodes
+                            .iter()
+                            .any(|n: &ConfigNode| n.uuid == remote_node.uuid)
+                        {
+                            nodes.push(proto_node_to_config(remote_node));
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::error!("Error getting nodes from cluster node: {:?}", e);
+                    return Err(anyhow::anyhow!(
+                        "Error getting nodes from cluster node: {:?}",
+                        e
+                    ));
+                }
+            }
+        }
+        Err(e) => {
+            log::error!("Error awaiting task: {:?}", e);
+            return Err(anyhow::anyhow!("Error awaiting task: {:?}", e));
+        }
+    }
+
+    Ok(nodes)
+}
+
+pub fn node_service() -> proto::cluster_rpc::node_service_server::NodeServiceServer<NodeService> {
+    proto::cluster_rpc::node_service_server::NodeServiceServer::new(NodeService)
+}


### PR DESCRIPTION
This PR adds a new endpoint `/{org}/node/list` for `_meta` org, which displays the node info of all the nodes in all clusters. 
 - The hierarchy of the response is as follows `regions -> clusters -> nodes`. 
 - Filtering is also enabled on the api where region names can be provided as query params as comma separated values
