### PR TITLE
perf: only download the file not in cache

### DIFF
--- a/src/infra/src/storage/local.rs
+++ b/src/infra/src/storage/local.rs
@@ -168,7 +168,7 @@ impl ObjectStore for Local {
                 .inc();
             let time = start.elapsed().as_secs_f64();
             metrics::STORAGE_TIME
-                .with_label_values(&[columns[1], columns[2], "get", "local"])
+                .with_label_values(&[columns[1], columns[2], "get_opts", "local"])
                 .inc_by(time);
         }
 
@@ -195,7 +195,7 @@ impl ObjectStore for Local {
                 .inc();
             let time = start.elapsed().as_secs_f64();
             metrics::STORAGE_TIME
-                .with_label_values(&[columns[1], columns[2], "get", "local"])
+                .with_label_values(&[columns[1], columns[2], "get_range", "local"])
                 .inc_by(time);
         }
 

--- a/src/infra/src/storage/remote.rs
+++ b/src/infra/src/storage/remote.rs
@@ -157,7 +157,7 @@ impl ObjectStore for Remote {
                 .inc();
             let time = start.elapsed().as_secs_f64();
             metrics::STORAGE_TIME
-                .with_label_values(&[columns[1], columns[2], "get", "remote"])
+                .with_label_values(&[columns[1], columns[2], "get_opts", "remote"])
                 .inc_by(time);
         }
 
@@ -184,7 +184,7 @@ impl ObjectStore for Remote {
                 .inc();
             let time = start.elapsed().as_secs_f64();
             metrics::STORAGE_TIME
-                .with_label_values(&[columns[1], columns[2], "get", "remote"])
+                .with_label_values(&[columns[1], columns[2], "get_range", "remote"])
                 .inc_by(time);
         }
 

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -323,11 +323,14 @@ async fn cache_files(
     file_type: &str,
 ) -> Result<file_data::CacheType, Error> {
     // check how many files already cached
+    let mut cached_files = HashSet::with_capacity(files.len());
     for file in files.iter() {
         if file_data::memory::exist(file).await {
             scan_stats.querier_memory_cached_files += 1;
+            cached_files.insert(file);
         } else if file_data::disk::exist(file).await {
             scan_stats.querier_disk_cached_files += 1;
+            cached_files.insert(file);
         }
     }
     let files_num = files.len() as i64;
@@ -355,7 +358,16 @@ async fn cache_files(
     };
 
     let trace_id = trace_id.to_string();
-    let files = files.iter().map(|f| f.to_string()).collect_vec();
+    let files = files
+        .iter()
+        .filter_map(|f| {
+            if cached_files.contains(f) {
+                None
+            } else {
+                Some(f.to_string())
+            }
+        })
+        .collect_vec();
     let file_type = file_type.to_string();
     tokio::spawn(async move {
         let files = files.iter().map(|f| f.as_str()).collect_vec();


### PR DESCRIPTION
This PR optimized the background download for cache, we don't need download the file which already in cache.

Also update the metrics for object_store.

```
zo_storage_time{org, stream_type, method_type, storage_type}
```
- We can check `zo_storage_time{method_type="get_range"}` to check how much time we spent on range request.
- We can check `zo_storage_time{method_type="get"}` to check how much time we spent on download file.