### PR TITLE
fix: replace * in alert cron expression with the current second

### DIFF
--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -386,10 +386,11 @@ async fn prepare_alert(
 }
 
 pub fn update_cron_expression(cron_exp: &str, now: u32) -> String {
-    let mut cron_exp = cron_exp.trim().to_owned();
+    let mut cron_exp: String = cron_exp.trim().to_owned();
     if cron_exp.starts_with("*") {
         let (_, rest) = cron_exp.split_once("*").unwrap();
-        cron_exp = format!("{now}{rest}");
+        let rest = rest.trim();
+        cron_exp = format!("{now} {rest}");
     }
     cron_exp
 }
@@ -1522,7 +1523,7 @@ mod tests {
         let cron_exp = "**/15 21-23,0-8 * * *";
         let now = Utc::now().second();
         let new_cron_exp = update_cron_expression(&cron_exp, now);
-        let updated = format!("{}*/15 21-23,0-8 * * *", now);
+        let updated = format!("{} */15 21-23,0-8 * * *", now);
         assert_eq!(new_cron_exp, updated);
     }
 
@@ -1531,7 +1532,7 @@ mod tests {
         let cron_exp = "*10*****";
         let now = Utc::now().second();
         let new_cron_exp = update_cron_expression(&cron_exp, now);
-        let updated = format!("{}10*****", now);
+        let updated = format!("{} 10*****", now);
         assert_eq!(new_cron_exp, updated);
     }
 

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -230,17 +230,8 @@ async fn prepare_alert(
     }
 
     if alert.trigger_condition.frequency_type == FrequencyType::Cron {
-        let cron_exp = alert.trigger_condition.cron.clone();
-        if cron_exp.starts_with("* ") {
-            let (_, rest) = cron_exp.split_once(" ").unwrap();
-            let now = Utc::now().second().to_string();
-            alert.trigger_condition.cron = format!("{now} {rest}");
-            log::debug!(
-                "New cron expression for alert {}: {}",
-                alert.name,
-                alert.trigger_condition.cron
-            );
-        }
+        let now = Utc::now().second();
+        alert.trigger_condition.cron = update_cron_expression(&alert.trigger_condition.cron, now);
         // Check the cron expression
         Schedule::from_str(&alert.trigger_condition.cron).map_err(AlertError::ParseCron)?;
     } else if alert.trigger_condition.frequency == 0 {
@@ -392,6 +383,15 @@ async fn prepare_alert(
     // }
 
     Ok(())
+}
+
+pub fn update_cron_expression(cron_exp: &str, now: u32) -> String {
+    let mut cron_exp = cron_exp.trim().to_owned();
+    if cron_exp.starts_with("*") {
+        let (_, rest) = cron_exp.split_once("*").unwrap();
+        cron_exp = format!("{now}{rest}");
+    }
+    cron_exp
 }
 
 /// Creates a new alert in the specified folder.
@@ -1498,5 +1498,49 @@ mod tests {
         let ret = save(org_id, stream_name, alert_name, alert, true).await;
         // alert name should not contain /
         assert!(ret.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_update_cron_expression_1() {
+        let cron_exp = "* * * * * * *";
+        let now = Utc::now().second();
+        let new_cron_exp = update_cron_expression(&cron_exp, now);
+        let updated = format!("{} * * * * * *", now);
+        assert_eq!(new_cron_exp, updated);
+    }
+
+    #[tokio::test]
+    async fn test_update_cron_expression_2() {
+        let cron_exp = "47*/12 * * * * *";
+        let now = Utc::now().second();
+        let new_cron_exp = update_cron_expression(&cron_exp, now);
+        assert_eq!(new_cron_exp, "47*/12 * * * * *");
+    }
+
+    #[tokio::test]
+    async fn test_update_cron_expression_3() {
+        let cron_exp = "**/15 21-23,0-8 * * *";
+        let now = Utc::now().second();
+        let new_cron_exp = update_cron_expression(&cron_exp, now);
+        let updated = format!("{}*/15 21-23,0-8 * * *", now);
+        assert_eq!(new_cron_exp, updated);
+    }
+
+    #[tokio::test]
+    async fn test_update_cron_expression_4() {
+        let cron_exp = "*10*****";
+        let now = Utc::now().second();
+        let new_cron_exp = update_cron_expression(&cron_exp, now);
+        let updated = format!("{}10*****", now);
+        assert_eq!(new_cron_exp, updated);
+    }
+
+    #[tokio::test]
+    async fn test_update_cron_expression_5() {
+        let cron_exp = "* */10 2 * * * *";
+        let now = Utc::now().second();
+        let new_cron_exp = update_cron_expression(&cron_exp, now);
+        let updated = format!("{} */10 2 * * * *", now);
+        assert_eq!(new_cron_exp, updated);
     }
 }

--- a/src/service/alerts/derived_streams.rs
+++ b/src/service/alerts/derived_streams.rs
@@ -16,7 +16,7 @@
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{Timelike, Utc};
 use config::{
     get_config,
     meta::{
@@ -95,7 +95,12 @@ pub async fn save(
 
     // 2. update the frequency
     if derived_stream.trigger_condition.frequency_type == FrequencyType::Cron {
-        // Check the cron expression
+        let now = chrono::Utc::now().second();
+        derived_stream.trigger_condition.cron = super::super::alerts::alert::update_cron_expression(
+            &derived_stream.trigger_condition.cron,
+            now,
+        );
+        // Check if the cron expression is valid
         Schedule::from_str(&derived_stream.trigger_condition.cron)?;
     } else if derived_stream.trigger_condition.frequency == 0 {
         // default 3 mins, set min at 1 minutes

--- a/src/service/dashboards/reports.rs
+++ b/src/service/dashboards/reports.rs
@@ -88,17 +88,9 @@ pub async fn save(
     }
 
     if report.frequency.frequency_type == ReportFrequencyType::Cron {
-        let cron_exp = report.frequency.cron.clone();
-        if cron_exp.starts_with("* ") {
-            let (_, rest) = cron_exp.split_once(" ").unwrap();
-            let now = chrono::Utc::now().second().to_string();
-            report.frequency.cron = format!("{now} {rest}");
-            log::debug!(
-                "New cron expression for report {}: {}",
-                report.name,
-                report.frequency.cron
-            );
-        }
+        let now = chrono::Utc::now().second();
+        report.frequency.cron =
+            super::super::alerts::alert::update_cron_expression(&report.frequency.cron, now);
         // Check if the cron expression is valid
         Schedule::from_str(&report.frequency.cron)?;
     } else if report.frequency.interval == 0 {


### PR DESCRIPTION
- Replaces the first `*` in cron expression with a value between `0-59` for alert and report.
- Fixes the issue where `error` field contains empty string even for `failed` status.