### PR TITLE
fix: check base64 parts for camelCase tokenizer

### DIFF
--- a/src/config/src/utils/tantivy/tokenizer/mod.rs
+++ b/src/config/src/utils/tantivy/tokenizer/mod.rs
@@ -28,12 +28,12 @@ pub fn o2_tokenizer_build() -> TextAnalyzer {
         .inverted_index_camel_case_tokenizer_disabled
     {
         tantivy::tokenizer::TextAnalyzer::builder(SimpleTokenizer::default())
-            .filter(tantivy::tokenizer::RemoveLongFilter::limit(40))
+            .filter(tantivy::tokenizer::RemoveLongFilter::limit(64))
             .filter(tantivy::tokenizer::LowerCaser)
             .build()
     } else {
         tantivy::tokenizer::TextAnalyzer::builder(O2Tokenizer::default())
-            .filter(tantivy::tokenizer::RemoveLongFilter::limit(40))
+            .filter(tantivy::tokenizer::RemoveLongFilter::limit(64))
             .filter(tantivy::tokenizer::LowerCaser)
             .build()
     }

--- a/src/config/src/utils/tantivy/tokenizer/o2_tokenizer.rs
+++ b/src/config/src/utils/tantivy/tokenizer/o2_tokenizer.rs
@@ -117,6 +117,9 @@ impl TokenStream for O2TokenStream<'_> {
 }
 
 fn split_camel_case(input: &str) -> Vec<&str> {
+    if looks_like_base64(input) {
+        return vec![input];
+    }
     let mut words = Vec::new();
     let mut start = 0;
     let mut prev_was_upper = false;
@@ -142,6 +145,21 @@ fn split_camel_case(input: &str) -> Vec<&str> {
 
     words.push(&input[start..]);
     words
+}
+
+// Add this helper function to detect base64-like strings
+fn looks_like_base64(s: &str) -> bool {
+    // Base64 characteristics:
+    // 1. Only contains [A-Za-z0-9], the tokenizer will remove all non-alphanumeric characters
+    // 2. Should be reasonably long (to avoid false positives)
+    const MIN_BASE64_LENGTH: usize = 1024; // Adjust this threshold as needed
+
+    if s.len() < MIN_BASE64_LENGTH {
+        return false;
+    }
+
+    s.chars()
+        .all(|c| matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' ))
 }
 
 #[cfg(test)]
@@ -200,5 +218,26 @@ mod tests {
         assert_token(&tokens[15], 15, "And", 64, 67);
         assert_token(&tokens[16], 16, "HTTP", 67, 71);
         assert_token(&tokens[17], 17, "Response", 71, 79);
+    }
+
+    #[test]
+    fn test_o2_tokenizer_camel_case() {
+        let tokens = token_stream_helper("CamelCase");
+        assert_eq!(tokens.len(), 2);
+        assert_token(&tokens[0], 0, "Camel", 0, 5);
+        assert_token(&tokens[1], 1, "Case", 5, 9);
+    }
+
+    #[test]
+    fn test_o2_tokenizer_camel_case_with_base64() {
+        let body = "2025-03-13 INFO Current Users : Ly8gQWRkIHRoaXMgaGVscGVyIGZ1bmN0aW9uIHRvIGRldGVjdCBiYXNlNjQtbGlrZSBzdHJpbmdzCmZuIGxvb2tzX2xpa2VfYmFzZTY0KHM6ICZzdHIpIC0xIGJvb2wgewogICAgLy8gQmFzZTY0IGNoYXJhY3RlcmlzdGljczoKICAgIC8vIDEuIExlbmd0aCBzaG91bGQgYmUgbXVsdGlwbGUgb2YgNCAoZXhjZXB0IGZvciBwYWRkZWQgc3RyaW5ncykKICAgIC8vIDIuIE9ubHkgY29udGFpbnMgW0EtWmEtejAtOSsvPV0KICAgIC8vIDMuIFNob3VsZCBiZSByZWFzb25hYmx5IGxvbmcgKHRvIGF2b2lkIGZhbHNlIHBvc2l0aXZlcykKICAgIGNvbnN0IE1JTl9CQVNFNjRfTEVOR1RIOiB1c2l6ZSA9IDE2OyAvLyBBZGp1c3QgdGhpcyB0aHJlc2hvbGQgYXMgbmVlZGVkCiAgICAKICAgIGlmIHMubGVuKCkgPCBNSU5fQkFTRTY0X0xFTkdUSCB7c3NzCiAgICAgICAgcmV0dXJuIGZhbHNlO3gKICAgIH0KICAgIC8vIEFkZCB0aGlzIGhlbHBlciBmdW5jdGlvbiB0byBkZXRlY3QgYmFzZTY0LWxpa2Ugc3RyaW5ncwpmbiBsb29rc19saWtlX2Jhc2U2NChzOiAmc3RyKSAtPiBib29sIHsKICAgIC8vIEJhc2U2NCBjaGFyYWN0ZXJpc3RpY3M6CiAgICAvLyAxLiBMZW5ndGggc2hvdWxkIGJlIG11bHRpcGxlIG9mIDQgKGV4Y2VwdCBmb3IgcGFkZGVkIHN0cmluZ3MpCiAgICAvLyAyLiBPbmx5IGNvbnRhaW5zIFtBLVphLXowLTkrLz1dCiAgICAvLyAzLiBTaG91bGQgYmUgcmVhc29uYWJseSBsb25nICh0byBhdm9pZCBmYWxzZSBwb3NpdGl2ZXMpCiAgICBjb25zdCBNSU5fQkFTRTY0X0xFTkdUSDogdXNpemUgPSAxNjsgLy8gQWRqdXN0IHRoaXMgdGhyZXNob2xkIGFzIG5lZWRlZAogICAgCiAgICBpZiBzLmxlbigpIDwgTUlOX0JBU0U2NF9MRU5HVEggewogICAgICAgIHJldHVybiBmYWxzZTsKICAgIH0KICAgIA==";
+        let tokens = token_stream_helper(body);
+        assert_eq!(tokens.len(), 7);
+        assert_token(&tokens[0], 0, "2025", 0, 4);
+        assert_token(&tokens[1], 1, "03", 5, 7);
+        assert_token(&tokens[2], 2, "13", 8, 10);
+        assert_token(&tokens[3], 3, "INFO", 11, 15);
+        assert_token(&tokens[4], 4, "Current", 16, 23);
+        assert_token(&tokens[5], 5, "Users", 24, 29);
     }
 }

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -794,7 +794,10 @@ pub async fn merge_files(
     let mut fi = 0;
     for file in new_file_list.iter() {
         fi += 1;
-        log::info!("[COMPACTOR:WORKER:{thread_id}:{fi}] merge small file: {}", &file.key);
+        log::info!(
+            "[COMPACTOR:WORKER:{thread_id}:{fi}] merge small file: {}",
+            &file.key
+        );
         let buf = file_data::get(&file.key, None).await?;
         let schema = read_schema_from_bytes(&buf).await?;
         let schema = schema.as_ref().clone().with_metadata(Default::default());


### PR DESCRIPTION
This PR fixed the case camelCase tokenizer with base64 data, it will a lot of time, in our case one 3764 events parquet took over `30mins` to do tokenizer.

This PR add a check of base64 data if one token over `1KB` and all of `[0-9a-zA-Z]` we will skip camelCase check and let it be a single token.

With the PR the file earlier need `30mins`, now only need `200ms`.