### PR TITLE
perf: add auto check if we can remove filter

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -590,6 +590,9 @@ async fn set_node_status_metrics(node: &Node) {
 fn update_node_status_metrics() -> NodeMetrics {
     let node_status = get_node_metrics();
 
+    config::metrics::NODE_UP
+        .with_label_values(&[config::VERSION])
+        .set(1);
     config::metrics::NODE_CPU_TOTAL
         .with_label_values(&[])
         .set(node_status.cpu_total as i64);

--- a/src/config/src/meta/self_reporting/usage.rs
+++ b/src/config/src/meta/self_reporting/usage.rs
@@ -162,27 +162,14 @@ impl std::fmt::Display for UsageEvent {
 
 impl From<UsageType> for UsageEvent {
     fn from(usage: UsageType) -> UsageEvent {
-        match usage {
-            UsageType::Bulk
-            | UsageType::Json
-            | UsageType::Multi
-            | UsageType::KinesisFirehose
-            | UsageType::GCPSubscription
-            | UsageType::Logs
-            | UsageType::Traces
-            | UsageType::Metrics
-            | UsageType::PrometheusRemoteWrite
-            | UsageType::JsonMetrics
-            | UsageType::RUM
-            | UsageType::EnrichmentTable
-            | UsageType::Syslog => UsageEvent::Ingestion,
-            UsageType::Search
-            | UsageType::SearchAround
-            | UsageType::SearchTopNValues
-            | UsageType::MetricSearch
-            | UsageType::SearchHistory => UsageEvent::Search,
-            UsageType::Functions => UsageEvent::Functions,
-            UsageType::Retention => UsageEvent::Other,
+        if usage.is_ingestion() {
+            UsageEvent::Ingestion
+        } else if usage.is_search() {
+            UsageEvent::Search
+        } else if usage.is_function() {
+            UsageEvent::Functions
+        } else {
+            UsageEvent::Other
         }
     }
 }
@@ -229,6 +216,42 @@ pub enum UsageType {
     Syslog,
     #[serde(rename = "enrichment_table")]
     EnrichmentTable,
+}
+
+impl UsageType {
+    pub fn is_search(&self) -> bool {
+        matches!(
+            self,
+            UsageType::Search
+                | UsageType::SearchAround
+                | UsageType::SearchTopNValues
+                | UsageType::SearchHistory
+                | UsageType::MetricSearch
+        )
+    }
+
+    pub fn is_ingestion(&self) -> bool {
+        matches!(
+            self,
+            UsageType::Bulk
+                | UsageType::Json
+                | UsageType::Multi
+                | UsageType::KinesisFirehose
+                | UsageType::GCPSubscription
+                | UsageType::Logs
+                | UsageType::Traces
+                | UsageType::Metrics
+                | UsageType::PrometheusRemoteWrite
+                | UsageType::JsonMetrics
+                | UsageType::RUM
+                | UsageType::EnrichmentTable
+                | UsageType::Syslog
+        )
+    }
+
+    pub fn is_function(&self) -> bool {
+        matches!(self, UsageType::Functions)
+    }
 }
 
 impl std::fmt::Display for UsageType {

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -683,6 +683,15 @@ pub static FILE_LIST_CACHE_HIT_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 // Node status metrics
+pub static NODE_UP: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new("node_up", "Node is up")
+            .namespace(NAMESPACE)
+            .const_labels(create_const_labels()),
+        &["version"],
+    )
+    .expect("Metric created")
+});
 pub static NODE_CPU_TOTAL: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new("node_cpu_total", "Total CPU usage")
@@ -938,6 +947,9 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
 
     // node status metrics
+    registry
+        .register(Box::new(NODE_UP.clone()))
+        .expect("Metric registered");
     registry
         .register(Box::new(NODE_CPU_TOTAL.clone()))
         .expect("Metric registered");

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -726,11 +726,16 @@ impl VisitorMut for IndexVisitor {
             if let Some(expr) = select.selection.as_mut() {
                 let (index, other_expr) = get_index_condition_from_expr(&self.index_fields, expr);
                 self.index_condition = index;
+                let can_remove_filter = self
+                    .index_condition
+                    .as_ref()
+                    .map(|v| v.can_remove_filter())
+                    .unwrap_or(true);
                 // make sure all filter in where clause can be used in inverted index
-                if other_expr.is_none() && select.selection.is_some() {
+                if other_expr.is_none() && select.selection.is_some() && can_remove_filter {
                     self.can_optimize = true;
                 }
-                if self.is_remove_filter {
+                if self.is_remove_filter && can_remove_filter {
                     select.selection = other_expr;
                 }
             }


### PR DESCRIPTION
This PR add an optimizer to check the `match_all` conditions, if it has only `[0-9a-zA-Z]` and `space` we will apply the optimize rule:
- ZO_INVERTED_INDEX_COUNT_OPTIMIZER_ENABLED
- ZO_FEATURE_QUERY_REMOVE_FILTER_WITH_INDEX
Otherwise, we will disable the rules. user don't need manually disable these two environment.