### PR TITLE
feat: exact limit from SQL when the query limit is known

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -442,6 +442,7 @@ pub struct SearchPartitionResponse {
     pub max_query_range: i64, // hours, for histogram
     pub partitions: Vec<[i64; 2]>,
     pub order_by: OrderBy,
+    pub limit: i64,
     pub streaming_output: bool,
     pub streaming_aggs: bool,
     pub streaming_id: Option<String>,

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -705,6 +705,7 @@ pub async fn search_partition(
         histogram_interval: sql.histogram_interval,
         partitions: vec![],
         order_by: OrderBy::Desc,
+        limit: sql.limit,
         streaming_output: req.streaming_output,
         streaming_aggs: req.streaming_output && is_streaming_aggregate,
         streaming_id: streaming_id.clone(),


### PR DESCRIPTION
If the query body have no `limit` but the SQL has a `limit` we will exact it and apply to query limit.