### PR TITLE
perf: use querier as leader for AlertManager

### DIFF
--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -24,6 +24,7 @@ use config::{
             AggFunction, Condition, Operator, QueryCondition, QueryType, TriggerCondition,
             TriggerEvalResults,
         },
+        cluster::RoleGroup,
         search::{SearchEventContext, SearchEventType, SqlQuery},
         sql::resolve_stream_names,
         stream::StreamType,
@@ -384,7 +385,16 @@ impl QueryConditionExt for QueryCondition {
                 "evaluate_scheduled begin to call SearchService::search, {:?}",
                 req
             );
-            SearchService::search(&trace_id, org_id, stream_type, None, &req).await
+            // SearchService::search(&trace_id, org_id, stream_type, None, &req).await
+            SearchService::grpc_search::grpc_search(
+                &trace_id,
+                org_id,
+                stream_type,
+                None,
+                &req,
+                Some(RoleGroup::Background),
+            )
+            .await
         };
 
         // Resp hits can be of two types -

--- a/src/service/search/grpc_search.rs
+++ b/src/service/search/grpc_search.rs
@@ -16,7 +16,7 @@
 use std::sync::Arc;
 
 use config::{
-    meta::{search, stream::StreamType},
+    meta::{cluster::RoleGroup, search, stream::StreamType},
     utils::json,
 };
 use infra::errors::{Error, ErrorCodes};
@@ -35,8 +35,9 @@ pub async fn grpc_search(
     stream_type: StreamType,
     user_id: Option<String>,
     in_req: &search::Request,
+    node_group: Option<RoleGroup>,
 ) -> Result<search::Response, Error> {
-    let mut nodes = match infra_cluster::get_cached_online_query_nodes(None).await {
+    let mut nodes = match infra_cluster::get_cached_online_query_nodes(node_group).await {
         Some(nodes) => nodes,
         None => {
             log::error!("search->grpc: no querier node online");
@@ -105,9 +106,10 @@ pub async fn grpc_search_partition(
     org_id: &str,
     stream_type: StreamType,
     in_req: &search::SearchPartitionRequest,
+    node_group: Option<RoleGroup>,
     skip_max_query_range: bool,
 ) -> Result<search::SearchPartitionResponse, Error> {
-    let mut nodes = match infra_cluster::get_cached_online_query_nodes(None).await {
+    let mut nodes = match infra_cluster::get_cached_online_query_nodes(node_group).await {
         Some(nodes) => nodes,
         None => {
             log::error!("search->grpc: no querier node online");

--- a/src/service/search_jobs.rs
+++ b/src/service/search_jobs.rs
@@ -16,6 +16,7 @@
 use chrono::{DateTime, Datelike, TimeZone, Utc};
 use config::{
     meta::{
+        cluster::RoleGroup,
         search::{self, Response, SearchPartitionRequest},
         stream::StreamType,
     },
@@ -167,6 +168,7 @@ async fn handle_search_partition(job: &Job) -> Result<(), anyhow::Error> {
         &job.org_id,
         stream_type,
         &partition_req,
+        Some(RoleGroup::Interactive),
         true,
     )
     .await?;
@@ -216,6 +218,7 @@ async fn run_partition_job(
         stream_type,
         Some(job.user_id.clone()),
         &req,
+        Some(RoleGroup::Interactive),
     )
     .await;
     if let Err(e) = res {


### PR DESCRIPTION
This PR implement use querier node as query leader for AlertManager.

> Only for single stream query(standard search request), there is no gRPC for MultipleStreamQuery request for now.