### PR TITLE
fix: pipeline query node validation issue

### DIFF
--- a/web/src/components/pipeline/NodeForm/Query.vue
+++ b/web/src/components/pipeline/NodeForm/Query.vue
@@ -38,6 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :isValidSqlQuery="isValidSqlQuery"
             :disableQueryTypeSelection="true"
             :expandedLogs="expandedLogs"
+            :validatingSqlQuery="validatingSqlQuery"
 
             v-model:trigger="streamRoute.trigger_condition"
             v-model:sql="streamRoute.query_condition.sql"
@@ -170,6 +171,8 @@ const isUpdating = ref(false);
 const filteredColumns: any = ref([]);
 
 const isValidSqlQuery = ref(true);
+
+const validatingSqlQuery = ref(false);
 
 const expandedLogs = ref([]);
 const validateSqlQueryPromise = ref<Promise<unknown>>();
@@ -457,8 +460,10 @@ const removeVariable = (variable: any) => {
 };
 
 const validateSqlQuery = () => {
+  validatingSqlQuery.value = true;
   if (streamRoute.value.query_condition.type == "promql") {
     isValidSqlQuery.value = true;
+    validatingSqlQuery.value = false;
     return;
   }
   const query = buildQueryPayload({
@@ -483,9 +488,11 @@ const validateSqlQuery = () => {
       })
       .then((res: any) => {
         isValidSqlQuery.value = true;
+        validatingSqlQuery.value = false;
         resolve("");
       })
       .catch((err: any) => {
+        validatingSqlQuery.value = false;
         if (err) {
           isValidSqlQuery.value = false;
           const message = err?.response?.data?.message

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -996,13 +996,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 />
                 <q-btn
                   data-test="stream-routing-query-save-btn"
-                  :label="'Validate and Close'"
+                  :label="validatingSqlQuery ? 'Validating...' : 'Validate and Close'"
                   class="text-bold no-border q-ml-md"
                   color="secondary"
                   padding="sm xl"
                   no-caps
                   type="submit"
                   @click="$emit('submit:form')"
+                  :disable="validatingSqlQuery"
                 />
                 <q-btn
                   v-if="pipelineObj.isEditNode"
@@ -1109,7 +1110,8 @@ const props = defineProps([
   "disableVrlFunction",
   "disableQueryTypeSelection",
   "showTimezoneWarning",
-  "streamType"
+  "streamType",
+  "validatingSqlQuery"
 ]);
 
 const emits = defineEmits([


### PR DESCRIPTION
this PR will introduce a validation check that if the query is validating then we need to disable the validate and close button so that user don't click on it multiple times and also changed text from validate and close to validating while the query is validating.