### PR TITLE
fix: Partial error fix main

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -200,8 +200,8 @@ pub struct Response {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub trace_id: String,
     #[serde(default)]
-    #[serde(skip_serializing_if = "String::is_empty")]
-    pub function_error: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub function_error: Vec<String>,
     #[serde(default)]
     pub is_partial: bool,
     #[serde(default)]
@@ -266,7 +266,7 @@ impl Response {
             hits: Vec::new(),
             response_type: "".to_string(),
             trace_id: "".to_string(),
-            function_error: "".to_string(),
+            function_error: Vec::new(),
             is_partial: false,
             histogram_interval: None,
             new_start_time: None,
@@ -359,9 +359,9 @@ impl Response {
     pub fn set_partial(&mut self, is_partial: bool, msg: String) {
         self.is_partial = is_partial;
         if self.function_error.is_empty() {
-            self.function_error = msg;
+            self.function_error = vec![msg];
         } else {
-            self.function_error = format!("{} \n {}", self.function_error, msg);
+            self.function_error.push(msg);
         }
     }
 

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -358,10 +358,12 @@ impl Response {
 
     pub fn set_partial(&mut self, is_partial: bool, msg: String) {
         self.is_partial = is_partial;
-        if self.function_error.is_empty() {
-            self.function_error = vec![msg];
-        } else {
-            self.function_error.push(msg);
+        if !msg.is_empty() {
+            if self.function_error.is_empty() {
+                self.function_error = vec![msg];
+            } else {
+                self.function_error.push(msg);
+            }
         }
     }
 

--- a/src/handler/http/request/websocket/search.rs
+++ b/src/handler/http/request/websocket/search.rs
@@ -333,12 +333,11 @@ async fn do_search(
 fn handle_partial_response(mut res: Response) -> Response {
     if res.is_partial {
         res.function_error = if res.function_error.is_empty() {
-            PARTIAL_ERROR_RESPONSE_MESSAGE.to_string()
+            vec![PARTIAL_ERROR_RESPONSE_MESSAGE.to_string()]
         } else {
-            format!(
-                "{} \n {}",
-                PARTIAL_ERROR_RESPONSE_MESSAGE, res.function_error
-            )
+            res.function_error
+                .push(PARTIAL_ERROR_RESPONSE_MESSAGE.to_string());
+            res.function_error
         };
     }
     res
@@ -900,9 +899,10 @@ async fn do_partitioned_search(
             if !range_error.is_empty() {
                 search_res.is_partial = true;
                 search_res.function_error = if search_res.function_error.is_empty() {
-                    range_error.clone()
+                    vec![range_error.clone()]
                 } else {
-                    format!("{} \n {}", range_error, search_res.function_error)
+                    search_res.function_error.push(range_error.clone());
+                    search_res.function_error
                 };
                 search_res.new_start_time = Some(modified_start_time);
                 search_res.new_end_time = Some(modified_end_time);
@@ -983,7 +983,7 @@ async fn send_partial_search_resp(
     };
     let s_resp = Response {
         is_partial: true,
-        function_error: error,
+        function_error: vec![error],
         new_start_time: Some(new_start_time),
         new_end_time: Some(new_end_time),
         order_by,
@@ -1038,7 +1038,7 @@ async fn write_results_to_cache(
         }
     }
 
-    let merged_response = cache::merge_response(
+    let mut merged_response = cache::merge_response(
         &c_resp.trace_id,
         &mut cached_responses,
         &mut search_responses,
@@ -1053,12 +1053,22 @@ async fn write_results_to_cache(
     // 2. Super cluster error
     // 3. Range error (max_query_limit)
     // Cache partial results only if there is a range error
-    let skip_cache_results = (merged_response.is_partial
-        && (merged_response.new_start_time.is_none() || merged_response.new_end_time.is_none()))
-        || (!merged_response.function_error.is_empty()
-            && merged_response.function_error.contains("vrl"));
+    // let skip_cache_results = (merged_response.is_partial
+    //     && (merged_response.new_start_time.is_none() || merged_response.new_end_time.is_none()))
+    //     || (!merged_response.function_error.is_empty()
+    //         && merged_response.function_error.contains("vrl"));
 
-    if cfg.common.result_cache_enabled && !skip_cache_results {
+    let mut should_cache_results = merged_response.new_start_time.is_some()
+        || merged_response.new_end_time.is_some()
+        || merged_response.function_error.is_empty();
+
+    merged_response.function_error.retain(|err| {
+        !err.contains("Query duration is modified due to query range restriction of")
+    });
+
+    should_cache_results = should_cache_results && merged_response.function_error.is_empty();
+
+    if cfg.common.result_cache_enabled && should_cache_results {
         cache::write_results_v2(
             &c_resp.trace_id,
             &c_resp.ts_column,

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -413,7 +413,10 @@ impl QueryConditionExt for QueryCondition {
                     "",
                 );
                 if v.is_partial {
-                    return Err(anyhow::anyhow!("Partial response: {}", v.function_error));
+                    return Err(anyhow::anyhow!(
+                        "Partial response: {}",
+                        v.function_error.join(", ")
+                    ));
                 } else {
                     v
                 }

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -390,7 +390,7 @@ pub async fn search(
     let mut should_cache_results =
         res.new_start_time.is_some() || res.new_end_time.is_some() || res.function_error.is_empty();
 
-    if !res.function_error.is_empty() {
+    if !res.function_error.is_empty() && !range_error.is_empty() {
         res.function_error.retain(|err| !err.contains(&range_error));
         should_cache_results = should_cache_results && res.function_error.is_empty();
     }

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -362,17 +362,20 @@ pub async fn search(
     if res.is_partial {
         let partial_err = "Please be aware that the response is based on partial data";
         res.function_error = if res.function_error.is_empty() {
-            partial_err.to_string()
+            vec![partial_err.to_string()]
         } else {
-            format!("{} \n {}", partial_err, res.function_error)
+            res.function_error.push(partial_err.to_string());
+            res.function_error
         };
     }
     if !range_error.is_empty() {
         res.is_partial = true;
+        let range_error_str = range_error.clone();
         res.function_error = if res.function_error.is_empty() {
-            range_error
+            vec![range_error_str]
         } else {
-            format!("{} \n {}", range_error, res.function_error)
+            res.function_error.push(range_error_str);
+            res.function_error
         };
         res.new_start_time = Some(req.query.start_time);
         res.new_end_time = Some(req.query.end_time);
@@ -383,15 +386,20 @@ pub async fn search(
     // 2. Super cluster error
     // 3. Range error (max_query_limit)
     // Cache partial results only if there is a range error
-    let skip_cache_results = (res.is_partial
-        && (res.new_start_time.is_none() || res.new_end_time.is_none()))
-        || (!res.function_error.is_empty() && res.function_error.contains("vrl"));
+
+    let mut should_cache_results =
+        res.new_start_time.is_some() || res.new_end_time.is_some() || res.function_error.is_empty();
+
+    if !res.function_error.is_empty() {
+        res.function_error.retain(|err| !err.contains(&range_error));
+        should_cache_results = should_cache_results && res.function_error.is_empty();
+    }
 
     // result cache save changes start
     if cfg.common.result_cache_enabled
         && should_exec_query
         && c_resp.cache_query_response
-        && !skip_cache_results
+        && should_cache_results
         && (results.first().is_some_and(|res| !res.hits.is_empty())
             || results.last().is_some_and(|res| !res.hits.is_empty()))
     {
@@ -430,7 +438,7 @@ pub fn merge_response(
     if cache_responses.is_empty() && search_response.is_empty() {
         return config::meta::search::Response::default();
     }
-    let mut fn_error = String::new();
+    let mut fn_error = vec![];
 
     let mut cache_response = if cache_responses.is_empty() {
         config::meta::search::Response::default()
@@ -448,7 +456,7 @@ pub fn merge_response(
             resp.hits.extend(res.hits.clone());
             resp.histogram_interval = res.histogram_interval;
             if !res.function_error.is_empty() {
-                fn_error = res.function_error.clone();
+                fn_error.extend(res.function_error.clone());
             }
         }
         resp.took = cache_took;
@@ -468,7 +476,7 @@ pub fn merge_response(
             cache_response.took += res.took;
             cache_response.histogram_interval = res.histogram_interval;
             if !res.function_error.is_empty() {
-                fn_error = res.function_error.clone();
+                fn_error.extend(res.function_error.clone());
             }
         }
         cache_response.function_error = fn_error;
@@ -507,7 +515,7 @@ pub fn merge_response(
             res_took.nodes.append(&mut took_details.nodes);
         }
         if !res.function_error.is_empty() {
-            fn_error = res.function_error.clone();
+            fn_error.extend(res.function_error.clone());
         }
 
         cache_response.hits.extend(res.hits.clone());
@@ -536,7 +544,7 @@ pub fn merge_response(
         / ((result_cache_len + cache_hits_len) as f64))
         as usize;
     if !fn_error.is_empty() {
-        cache_response.function_error = fn_error;
+        cache_response.function_error.extend(fn_error);
     }
     cache_response
 }

--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -130,7 +130,7 @@ pub async fn search(
                     }
                     Err(err) => {
                         log::error!("[trace_id {trace_id}] search->vrl: compile err: {:?}", err);
-                        result.function_error = err.to_string();
+                        result.function_error = vec![err.to_string()];
                         None
                     }
                 };

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -407,7 +407,7 @@ pub async fn search_multi(
                 } else {
                     // Error in subsequent queries, add the error to the response and break
                     // No need to run the remaining queries
-                    multi_res.function_error = format!("{};{:?}", multi_res.function_error, e);
+                    multi_res.function_error.push(e.to_string());
                     multi_res.is_partial = true;
                     break;
                 }
@@ -436,7 +436,8 @@ pub async fn search_multi(
             }
             Err(err) => {
                 log::error!("[trace_id {trace_id}] search->vrl: compile err: {:?}", err);
-                multi_res.function_error = format!("{};{:?}", multi_res.function_error, err);
+                multi_res.function_error.push(err.to_string());
+                multi_res.is_partial = true;
                 None
             }
         };

--- a/src/service/search_jobs.rs
+++ b/src/service/search_jobs.rs
@@ -414,7 +414,7 @@ pub async fn merge_response(
         resp.idx_scan_size += r.idx_scan_size;
         resp.scan_records += r.scan_records;
         if !r.function_error.is_empty() {
-            resp.function_error = format!("{} \n {}", resp.function_error, r.function_error);
+            resp.function_error.extend(r.function_error);
             resp.is_partial = true;
         }
     }


### PR DESCRIPTION
The search response should be cached only when it is not a partial error or if it is so, only for range errors we should cache the result. This is a hacky fix which caches the result when the above condition is satisfied.

Partly addresses #6311 (does not fix the root cause where is_partial is false even when there is function error).