### PR TITLE
fix: alert and pipeline frequency warning message change

### DIFF
--- a/web/src/components/alerts/ScheduledAlert.vue
+++ b/web/src/components/alerts/ScheduledAlert.vue
@@ -1372,7 +1372,7 @@ const validateFrequency = (frequency: {
 
     if (frequency.frequency < intervalInMins) {
       cronJobError.value =
-        "Frequency should be greater than " + (intervalInMins - 1);
+        "Minimum frequency should be " + (intervalInMins) + " minutes";
       return;
     }
   }

--- a/web/src/components/pipeline/NodeForm/Query.vue
+++ b/web/src/components/pipeline/NodeForm/Query.vue
@@ -39,7 +39,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :disableQueryTypeSelection="true"
             :expandedLogs="expandedLogs"
             :validatingSqlQuery="validatingSqlQuery"
-
             v-model:trigger="streamRoute.trigger_condition"
             v-model:sql="streamRoute.query_condition.sql"
             v-model:promql="streamRoute.query_condition.promql"
@@ -237,6 +236,7 @@ const getDefaultStreamRoute: any = () => {
       frequency_type: "minutes",
       cron: "",
       frequency: frequency <= 15 ? 15 : frequency,
+      timezone: "UTC",
     },
     context_attributes: [
       {

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -1748,7 +1748,7 @@ const validateFrequency = () => {
 
     if (triggerData.value.frequency < intervalInMins) {
       cronJobError.value =
-        "Frequency should be greater than " + (intervalInMins - 1);
+        "Minimum frequency should be " + (intervalInMins) + " minutes";
       return;
     }
   }

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -689,7 +689,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         type="number"
                         dense
                         filled
-                        min="1"
+                        :min="
+                          Math.ceil(
+                            store.state?.zoConfig?.min_auto_refresh_interval / 60,
+                          ) || 1
+                        "
                         style="background: none"
                         @update:model-value="updateFrequency"
                       />
@@ -1254,6 +1258,16 @@ watch(()=> splitterModel.value ,  (val)=>{
 watch(()=> selectedStreamName.value, (val)=>{
   searchObj.data.stream.pipelineQueryStream = [val];
 })
+watch(()=>triggerData.value.frequency_type, (val)=>{
+  if(val == 'minutes'){
+    triggerData.value.period = Number(triggerData.value.frequency) || 15
+  }else{
+    const periodValue = convertCronToMinutes(triggerData.value.cron) 
+    triggerData.value.period = periodValue > 0 ? periodValue : Number(triggerData.value.frequency) || 15
+  }
+})
+
+
 
 onBeforeMount(async ()=>{
   await importSqlParser();
@@ -1436,6 +1450,7 @@ const updateQueryValue = (value: string) => {
 };
 
 const updateTrigger = () => {
+
   emits("update:trigger", triggerData.value);
   emits("input:update", "period", triggerData.value);
 };


### PR DESCRIPTION
This PR fixes couple of issues 
1. changed the warning message to minimum frequency should be -- minutes when user tries to give less than minimum frequency interval  in alert and pipeline
2. other is made period in sync with frequency so whenever user toggles the cron so in pipelines we are auto selecting the period according the frequency so toggling not picking up the latest values of freq to period
