### PR TITLE
fix: alert move rbac issues

### DIFF
--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -403,9 +403,6 @@ impl FromRequest for AuthExtractor {
             // Handle /v2 alert apis
             if path_columns[0].eq(V2_API_PREFIX) {
                 if path_columns[2].eq("alerts") {
-                    if method.eq("PATCH") {
-                        method = "PUT".to_string();
-                    }
                     format!(
                         "{}:{}",
                         OFGA_MODELS
@@ -656,6 +653,17 @@ impl FromRequest for AuthExtractor {
                 }));
             }
 
+            if method.eq("PATCH") && object_type.eq("alert:move") {
+                return ready(Ok(AuthExtractor {
+                    auth: auth_str.to_owned(),
+                    method: "".to_string(),
+                    o2_type: "".to_string(),
+                    org_id: "".to_string(),
+                    bypass_check: true, // bypass check permissions
+                    parent_id: folder,
+                }));
+            }
+
             return ready(Ok(AuthExtractor {
                 auth: auth_str.to_owned(),
                 method,
@@ -807,6 +815,7 @@ pub async fn check_permissions(
     user_id: &str,
     object_type: &str,
     method: &str,
+    parent_id: &str,
 ) -> bool {
     if !is_root_user(user_id) {
         let user: meta::user::User = match USERS.get(&format!("{org_id}/{}", user_id)) {
@@ -834,7 +843,7 @@ pub async fn check_permissions(
                 ),
                 org_id: org_id.to_string(),
                 bypass_check: false,
-                parent_id: "".to_string(),
+                parent_id: parent_id.to_string(),
             },
             user.role,
             user.is_external,

--- a/src/handler/http/request/actions/action.rs
+++ b/src/handler/http/request/actions/action.rs
@@ -539,6 +539,7 @@ pub async fn upload_zipped_action(
         &user_email.user_id,
         "actions",
         method,
+        "",
     )
     .await
     {

--- a/src/handler/http/request/actions/operations.rs
+++ b/src/handler/http/request/actions/operations.rs
@@ -62,6 +62,7 @@ pub async fn test_action(
         &user_email.user_id,
         "actions",
         "POST",
+        "",
     )
     .await
     {

--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -75,6 +75,8 @@ impl From<AlertError> for HttpResponse {
             AlertError::PermittedAlertsMissingUser => MetaHttpResponse::forbidden(""),
             AlertError::PermittedAlertsValidator(err) => MetaHttpResponse::forbidden(err),
             AlertError::NotSupportedAlertDestinationType(err) => MetaHttpResponse::forbidden(err),
+            AlertError::PermissionDenied => MetaHttpResponse::forbidden("Unauthorized access"),
+            AlertError::UserNotFound => MetaHttpResponse::forbidden("Unauthorized access"),
         }
     }
 }
@@ -369,6 +371,7 @@ async fn trigger_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
 async fn move_alerts(
     path: web::Path<String>,
     req_body: web::Json<MoveAlertsRequestBody>,
+    user_email: UserEmail,
 ) -> HttpResponse {
     let org_id = path.into_inner();
     let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
@@ -377,6 +380,7 @@ async fn move_alerts(
         &org_id,
         &req_body.alert_ids,
         &req_body.dst_folder_id,
+        &user_email.user_id,
     )
     .await
     {

--- a/src/handler/http/request/service_accounts/mod.rs
+++ b/src/handler/http/request/service_accounts/mod.rs
@@ -52,16 +52,17 @@ use crate::{
     )
 )]
 #[get("/{org_id}/service_accounts")]
-pub async fn list(org_id: web::Path<String>, _req: HttpRequest) -> Result<HttpResponse, Error> {
+pub async fn list(org_id: web::Path<String>, req: HttpRequest) -> Result<HttpResponse, Error> {
     let org_id = org_id.into_inner();
+    let user_id = req.headers().get("user_id").unwrap();
+    let user_id = user_id.to_str().unwrap();
     let mut _user_list_from_rbac = None;
     // Get List of allowed objects
     #[cfg(feature = "enterprise")]
     {
-        let user_id = _req.headers().get("user_id").unwrap();
         match crate::handler::http::auth::validator::list_objects_for_user(
             &org_id,
-            user_id.to_str().unwrap(),
+            user_id,
             "GET",
             "service_accounts",
         )
@@ -79,6 +80,7 @@ pub async fn list(org_id: web::Path<String>, _req: HttpRequest) -> Result<HttpRe
         // Get List of allowed objects ends
     }
     users::list_users(
+        user_id,
         &org_id,
         Some(UserRole::ServiceAccount),
         _user_list_from_rbac,

--- a/src/handler/http/request/users/mod.rs
+++ b/src/handler/http/request/users/mod.rs
@@ -29,9 +29,11 @@ use serde::Serialize;
 use strum::IntoEnumIterator;
 #[cfg(feature = "enterprise")]
 use {
+    crate::common::utils::auth::check_permissions,
     crate::service::self_reporting::audit,
     o2_dex::config::get_config as get_dex_config,
     o2_enterprise::enterprise::common::auditor::{AuditMessage, HttpMeta, Protocol},
+    o2_openfga::config::get_config as get_openfga_config,
 };
 
 use crate::{
@@ -66,9 +68,26 @@ pub mod service_accounts;
     )
 )]
 #[get("/{org_id}/users")]
-pub async fn list(org_id: web::Path<String>) -> Result<HttpResponse, Error> {
+pub async fn list(org_id: web::Path<String>, user_email: UserEmail) -> Result<HttpResponse, Error> {
     let org_id = org_id.into_inner();
-    users::list_users(&org_id, None, None).await
+    let mut _user_list_from_rbac = None;
+
+    #[cfg(feature = "enterprise")]
+    // Check if user has access to get users
+    if get_openfga_config().enabled
+        && check_permissions(
+            Some(format!("_all_{}", org_id)),
+            &org_id,
+            &user_email.user_id,
+            "users",
+            "GET",
+            "",
+        )
+        .await
+    {
+        _user_list_from_rbac = Some(vec![]);
+    }
+    users::list_users(&user_email.user_id, &org_id, None, _user_list_from_rbac).await
 }
 
 /// CreateUser

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -663,7 +663,7 @@ pub async fn list_v2<C: ConnectionTrait>(
             is_all_permitted
                 // Include the alert if the alert is permitted with the old OpenFGA identifier.
                 || permissions.contains(&format!("alert:{}", a.name))
-                || permissions.contains(&format!("alert:{}/{}", f.folder_id, a.id.as_ref().unwrap().to_string()))
+                || permissions.contains(&format!("alert:{}/{}", f.folder_id, a.id.as_ref().unwrap()))
                 // Include the alert if the alert is permitted with the new OpenFGA identifier.
                 || a.id
                     .filter(|id| permissions.contains(&format!("alert:{id}")))

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -646,19 +646,14 @@ pub async fn list_v2<C: ConnectionTrait>(
     user_id: Option<&str>,
     params: ListAlertsParams,
 ) -> Result<Vec<(Folder, Alert)>, AlertError> {
-    let (permissions, is_all_permitted) = match permitted_alerts(
-        &params.org_id,
-        user_id,
-        params.folder_id.as_ref().map(|x| x.as_str()),
-    )
-    .await?
-    {
-        Some(ps) => {
-            let org_all_permitted = ps.contains(&format!("alert:_all_{}", params.org_id));
-            (ps, org_all_permitted)
-        }
-        None => (vec![], true),
-    };
+    let (permissions, is_all_permitted) =
+        match permitted_alerts(&params.org_id, user_id, params.folder_id.as_deref()).await? {
+            Some(ps) => {
+                let org_all_permitted = ps.contains(&format!("alert:_all_{}", params.org_id));
+                (ps, org_all_permitted)
+            }
+            None => (vec![], true),
+        };
 
     let alerts = db::alerts::alert::list_with_folders(conn, params)
         .await?

--- a/src/service/folders.rs
+++ b/src/service/folders.rs
@@ -176,10 +176,13 @@ pub async fn list_folders(
 ) -> Result<Vec<Folder>, FolderError> {
     let permitted_folders = permitted_folders(org_id, user_id, folder_type).await?;
     let folders = table::folders::list_folders(org_id, folder_type).await?;
+    #[cfg(feature = "enterprise")]
     let folder_ofga_model = match folder_type {
         FolderType::Dashboards => OFGA_MODELS.get("folders").unwrap().key,
         FolderType::Alerts => OFGA_MODELS.get("alert_folders").unwrap().key,
     };
+    #[cfg(not(feature = "enterprise"))]
+    let folder_ofga_model = "";
 
     let filtered = match permitted_folders {
         Some(permitted_folders) => {
@@ -288,7 +291,6 @@ async fn permitted_folders(
     user_id: Option<&str>,
     folder_type: FolderType,
 ) -> Result<Option<Vec<String>>, FolderError> {
-    use o2_openfga::meta::mapping::OFGA_MODELS;
     let (folder_ofga_model, child_ofga_model) = match folder_type {
         FolderType::Dashboards => (
             OFGA_MODELS.get("folders").unwrap().key,

--- a/src/service/users.rs
+++ b/src/service/users.rs
@@ -564,10 +564,7 @@ pub async fn list_users(
     // If the role is not
     #[cfg(feature = "enterprise")]
     if get_openfga_config().enabled {
-        let need_check_permission = match role {
-            Some(UserRole::ServiceAccount) => false,
-            _ => true,
-        };
+        let need_check_permission = !matches!(role, Some(UserRole::ServiceAccount));
 
         if need_check_permission && permitted.is_none() {
             let mut user_list = vec![];

--- a/src/service/users.rs
+++ b/src/service/users.rs
@@ -556,10 +556,34 @@ pub async fn get_user_by_token(org_id: &str, token: &str) -> Option<User> {
 }
 
 pub async fn list_users(
+    _user_id: &str,
     org_id: &str,
     role: Option<UserRole>,
     permitted: Option<Vec<String>>,
 ) -> Result<HttpResponse, Error> {
+    // If the role is not
+    #[cfg(feature = "enterprise")]
+    if get_openfga_config().enabled {
+        let need_check_permission = match role {
+            Some(UserRole::ServiceAccount) => false,
+            _ => true,
+        };
+
+        if need_check_permission && permitted.is_none() {
+            let mut user_list = vec![];
+            if let Some(user) = USERS.get(&format!("{org_id}/{_user_id}")) {
+                user_list.push(UserResponse {
+                    email: user.value().email.clone(),
+                    role: user.value().role.clone(),
+                    first_name: user.value().first_name.clone(),
+                    last_name: user.value().last_name.clone(),
+                    is_external: user.value().is_external,
+                });
+            }
+            return Ok(HttpResponse::Ok().json(UserList { data: user_list }));
+        }
+    }
+
     let mut user_list: Vec<UserResponse> = USERS
         .iter()
         .filter(|user| user.key().starts_with(&format!("{org_id}/"))) // Filter by organization ID
@@ -827,7 +851,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_users() {
         set_up().await;
-        assert!(list_users("dummy", None, None).await.is_ok())
+        assert!(list_users("", "dummy", None, None).await.is_ok())
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Fixes 403 error when alert move api is called
- 403 error when trying to create alert in default folder even after having permission
- Fixes # Regular user without `GET` user permission should not be able to get list of all users