### PR TITLE
feat: add variables for trigger time in seconds, millis for alert template

### DIFF
--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -1380,6 +1380,8 @@ async fn process_dest_template(
         }
     };
 
+    let evaluation_timestamp_millis = evaluation_timestamp / 1000;
+    let evaluation_timestamp_seconds = evaluation_timestamp_millis / 1000;
     let mut resp = tpl
         .replace("{org_name}", &alert.org_id)
         .replace("{stream_type}", alert.stream_type.as_str())
@@ -1403,6 +1405,14 @@ async fn process_dest_template(
         .replace("{alert_end_time}", &alert_end_time_str)
         .replace("{alert_url}", &alert_url)
         .replace("{alert_trigger_time}", &evaluation_timestamp.to_string())
+        .replace(
+            "{alert_trigger_time_millis}",
+            &evaluation_timestamp_millis.to_string(),
+        )
+        .replace(
+            "{alert_trigger_time_seconds}",
+            &evaluation_timestamp_seconds.to_string(),
+        )
         .replace("{alert_trigger_time_str}", &evaluation_timestamp_str);
 
     if let Some(contidion) = &alert.query_condition.promql_condition {

--- a/web/src/components/alerts/AddTemplate.vue
+++ b/web/src/components/alerts/AddTemplate.vue
@@ -165,7 +165,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div>alert_period, alert_operator, alert_threshold</div>
             <div>alert_count, alert_agg_value</div>
             <div>alert_start_time, alert_end_time, alert_url</div>
-            <div>alert_trigger_time, alert_trigger_time_str</div>
+            <div>alert_trigger_time, alert_trigger_time_millis, alert_trigger_time_seconds, alert_trigger_time_str</div>
             <div><b>rows</b> multiple lines of row template</div>
             <div><b>All of the stream fields are variables.</b></div>
             <div>{rows:N} {var:N} used to limit rows or string length.</div>


### PR DESCRIPTION
This pr adds two more variables to alert templates - `alert_trigger_time_millis` (the alert trigger occurance time in epoch milliseconds) and `alert_trigger_time_seconds` (the alert trigger occurance time in epoch seconds). Note that the `alert_trigger_time` is alert trigger occurance time in UTC epoch microseconds.