### PR TITLE
fix: alert enable or disable is not updated in the UI when filter applied

### DIFF
--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -1313,6 +1313,10 @@ export default defineComponent({
       // Find the alert based on uuid
       const alertToBeExported = await getAlertById(row.alert_id)
 
+      if(alertToBeExported.hasOwnProperty('id')){
+        delete alertToBeExported.id;
+      }
+
       // Ensure that the alert exists before proceeding
       if (alertToBeExported) {
 
@@ -1494,6 +1498,9 @@ const updateActiveFolderId = (newVal: any) => {
         const alertsData = await Promise.all(
           selectedAlerts.map(async (alertId: string) => {
             const alertData = await getAlertById(alertId);
+            if(alertData.hasOwnProperty('id')){
+              delete alertData.id;
+            }
             return alertData;
           })
         );

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -1265,6 +1265,11 @@ export default defineComponent({
               alertsList.value.forEach((alert: any) => {
                 alert.uuid === row.uuid ? (alert.enabled = isEnabled) : null;
               });
+              if(searchAcrossFolders.value && searchQuery.value != ""){
+                store.state.organizationData.allAlertsListByFolderId[row.folder_name.id].forEach((alert: any) => {
+                  alert?.alert_id === row?.alert_id ? (alert.enabled = isEnabled) : null;
+                });
+              }  
               $q.notify({
                 type: "positive",
                 message: isEnabled ? "Alert Resumed Successfully" : "Alert Paused Successfully",

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -1262,7 +1262,7 @@ export default defineComponent({
             )
             .then((res: any) => {
               const isEnabled = res.data.enabled;
-              alertsRows.value.forEach((alert) => {
+              alertsList.value.forEach((alert: any) => {
                 alert.uuid === row.uuid ? (alert.enabled = isEnabled) : null;
               });
               $q.notify({


### PR DESCRIPTION
1. This PR fixes that alert enable is not updated in the UI when filter is applied 
2. This PR also fixes the alert enable disable in search across folders
3. This PR also removes the id from exported alert