### PR TITLE
fix: remove clean_complete job in scheduler

### DIFF
--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -336,11 +336,6 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         alert_timeout: i64,
         report_timeout: i64,
     ) -> Result<Vec<Trigger>> {
-        let (include_max, mut max_retries) = get_scheduler_max_retries();
-        if include_max {
-            max_retries += 1;
-        }
-
         log::debug!("Start pulling scheduled_job");
         let now = chrono::Utc::now().timestamp_micros();
         let report_max_time = now
@@ -419,7 +414,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         let job_ids: Vec<TriggerId> = match sqlx::query_as::<_, TriggerId>(
             r#"SELECT id
 FROM scheduled_jobs
-WHERE status = ? AND next_run_at <= ? AND retries < ? AND NOT (is_realtime = ? AND is_silenced = ?)
+WHERE status = ? AND next_run_at <= ? AND NOT (is_realtime = ? AND is_silenced = ?)
 ORDER BY next_run_at
 LIMIT ?
 FOR UPDATE;
@@ -427,7 +422,6 @@ FOR UPDATE;
         )
         .bind(TriggerStatus::Waiting)
         .bind(now)
-        .bind(max_retries)
         .bind(true)
         .bind(false)
         .bind(concurrency)

--- a/src/infra/src/scheduler/postgres.rs
+++ b/src/infra/src/scheduler/postgres.rs
@@ -334,10 +334,6 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         report_timeout: i64,
     ) -> Result<Vec<Trigger>> {
         let pool = CLIENT.clone();
-        let (include_max, mut max_retries) = get_scheduler_max_retries();
-        if include_max {
-            max_retries += 1;
-        }
 
         let now = chrono::Utc::now().timestamp_micros();
         let report_max_time = now
@@ -359,9 +355,9 @@ SET status = $1, start_time = $2,
 WHERE id IN (
     SELECT id
     FROM scheduled_jobs
-    WHERE status = $6 AND next_run_at <= $7 AND retries < $8 AND NOT (is_realtime = $9 AND is_silenced = $10)
+    WHERE status = $6 AND next_run_at <= $7 AND NOT (is_realtime = $8 AND is_silenced = $9) 
     ORDER BY next_run_at
-    LIMIT $11
+    LIMIT $10
     FOR UPDATE
 )
 RETURNING *;"#;
@@ -398,7 +394,6 @@ RETURNING *;"#;
             .bind(report_max_time)
             .bind(TriggerStatus::Waiting)
             .bind(now)
-            .bind(max_retries)
             .bind(true)
             .bind(false)
             .bind(concurrency)

--- a/src/infra/src/scheduler/sqlite.rs
+++ b/src/infra/src/scheduler/sqlite.rs
@@ -329,10 +329,6 @@ INSERT INTO scheduled_jobs (org, module, module_key, is_realtime, is_silenced, s
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
 
-        let (include_max, mut max_retries) = get_scheduler_max_retries();
-        if include_max {
-            max_retries += 1;
-        }
         let now = chrono::Utc::now().timestamp_micros();
         let report_max_time = now
             + Duration::try_seconds(report_timeout)
@@ -353,9 +349,9 @@ SET status = $1, start_time = $2,
 WHERE id IN (
     SELECT id
     FROM scheduled_jobs
-    WHERE status = $6 AND next_run_at <= $7 AND retries < $8 AND NOT (is_realtime = $9 AND is_silenced = $10)
+    WHERE status = $6 AND next_run_at <= $7 AND NOT (is_realtime = $8 AND is_silenced = $9)
     ORDER BY next_run_at
-    LIMIT $11
+    LIMIT $10
 )
 RETURNING *;"#;
 
@@ -367,7 +363,6 @@ RETURNING *;"#;
             .bind(report_max_time)
             .bind(TriggerStatus::Waiting)
             .bind(now)
-            .bind(max_retries)
             .bind(true)
             .bind(false)
             .bind(concurrency)

--- a/src/service/pipeline/mod.rs
+++ b/src/service/pipeline/mod.rs
@@ -53,6 +53,7 @@ pub async fn save_pipeline(mut pipeline: Pipeline) -> Result<(), PipelineError> 
             derived_stream.clone(),
             &pipeline.name,
             &pipeline.id,
+            true,
         )
         .await
         {
@@ -125,6 +126,7 @@ pub async fn update_pipeline(mut pipeline: Pipeline) -> Result<(), PipelineError
             derived_stream.clone(),
             &pipeline.name,
             &pipeline.id,
+            true,
         )
         .await
         {
@@ -184,6 +186,7 @@ pub async fn enable_pipeline(
                 derived_stream.clone(),
                 &pipeline.name,
                 pipeline_id,
+                false,
             )
             .await
             .map_err(|e| PipelineError::InvalidDerivedStream(e.to_string()))?;


### PR DESCRIPTION
The `clean_complete` scheduler job is not really required as in the handler job we can check if the job has exceeded max retries, if it does exceed, we will skip to the next scheduled trigger.