### PR TITLE
fix: router incorrectly route routes to querier

### DIFF
--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -88,21 +88,24 @@ struct URLDetails {
 
 #[inline]
 fn is_querier_route(path: &str) -> bool {
-    let segments = path
-        .split('/')
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>();
-
     QUERIER_ROUTES.iter().any(|(route, skip_segments)| {
-        // check if we have enough segments
-        if segments.len() <= *skip_segments {
-            return false;
+        if path.contains(route) {
+            let segments = path
+                .split('/')
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>();
+            // check if we have enough segments
+            if segments.len() <= *skip_segments {
+                return false;
+            }
+            let route_part = segments[*skip_segments..].join("/");
+            route_part.starts_with(route)
+                && INGESTER_ROUTES
+                    .iter()
+                    .all(|ingest_route| !route_part.ends_with(ingest_route))
+        } else {
+            false
         }
-        let route_part = segments[*skip_segments..].join("/");
-        route_part.starts_with(route)
-            && INGESTER_ROUTES
-                .iter()
-                .all(|ingest_route| !route_part.ends_with(ingest_route))
     })
 }
 

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -34,33 +34,49 @@ use crate::common::{infra::cluster, utils::http::get_search_type_from_request};
 mod ws;
 pub(crate) mod ws_v2;
 
-const QUERIER_ROUTES: [&str; 20] = [
-    "/config",
-    "/summary",
-    "/organizations",
-    "/settings",
-    "/schema",
-    "/streams",
-    "/clusters",
-    "/query_manager",
-    "/ws",
-    "/_search",
-    "/_around",
-    "/_values",
-    "/functions?page_num=",
-    "/prometheus/api/v1/series",
-    "/prometheus/api/v1/query",
-    "/prometheus/api/v1/query_range",
-    "/prometheus/api/v1/query_exemplars",
-    "/prometheus/api/v1/metadata",
-    "/prometheus/api/v1/labels",
-    "/prometheus/api/v1/label/",
+/// usize indicates the number of parts to skip based on their actual paths.
+const QUERIER_ROUTES: [(&str, usize); 20] = [
+    ("config", 0),                            // /config
+    ("summary", 2),                           // /api/{org_id}/summary
+    ("organizations", 1),                     // /api/organizations
+    ("settings", 2),                          // /api/{org_id}/settings/...
+    ("schema", 3),                            // /api/{org_id}/streams/{stream_name}/schema
+    ("streams", 2),                           // /api/{org_id}/streams/...
+    ("clusters", 1),                          // /api/clusters
+    ("query_manager", 2),                     // /api/{org_id}/query_manager/...
+    ("ws", 2),                                // /api/{org_id}/ws
+    ("_search", 2),                           // /api/{org_id}/_search
+    ("_around", 3),                           // /api/{org_id}/{stream_name}/_around
+    ("_values", 3),                           // /api/{org_id}/{stream_name}/_values
+    ("functions?page_num=", 2),               // /api/{org_id}/functions
+    ("prometheus/api/v1/series", 2),          // /api/{org_id}/prometheus/api/v1/series
+    ("prometheus/api/v1/query", 2),           // /api/{org_id}/prometheus/api/v1/query
+    ("prometheus/api/v1/query_range", 2),     // /api/{org_id}/prometheus/api/v1/query_range
+    ("prometheus/api/v1/query_exemplars", 2), // /api/{org_id}/prometheus/api/v1/query_exemplars
+    ("prometheus/api/v1/metadata", 2),        // /api/{org_id}/prometheus/api/v1/metadata
+    ("prometheus/api/v1/labels", 2),          // /api/{org_id}/prometheus/api/v1/labels
+    ("prometheus/api/v1/label/", 2),          /* /api/{org_id}/prometheus/api/v1/label/
+                                               * {label_name}/
+                                               * values */
 ];
 const QUERIER_ROUTES_BY_BODY: [&str; 2] = [
     "/prometheus/api/v1/query_range",
     "/prometheus/api/v1/query_exemplars",
 ];
 const FIXED_QUERIER_ROUTES: [&str; 3] = ["/summary", "/schema", "/streams"];
+const INGESTER_ROUTES: [&str; 11] = [
+    "/_bulk",
+    "/_multi",
+    "/_json",
+    "/_kinesis_firehose",
+    "/__sub",
+    "/v1/logs",
+    "/ingest/metrics/_json",
+    "/v1/metrics",
+    "/traces",
+    "/v1/traces",
+    "/traces/latest",
+];
 
 struct URLDetails {
     is_error: bool,
@@ -72,7 +88,22 @@ struct URLDetails {
 
 #[inline]
 fn is_querier_route(path: &str) -> bool {
-    QUERIER_ROUTES.iter().any(|x| path.contains(x))
+    let segments = path
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+
+    QUERIER_ROUTES.iter().any(|(route, skip_segments)| {
+        // check if we have enough segments
+        if segments.len() <= *skip_segments {
+            return false;
+        }
+        let route_part = segments[*skip_segments..].join("/");
+        route_part.starts_with(route)
+            && INGESTER_ROUTES
+                .iter()
+                .all(|ingest_route| !route_part.ends_with(ingest_route))
+    })
 }
 
 #[inline]
@@ -549,12 +580,16 @@ mod tests {
 
     #[test]
     fn test_router_is_querier_route() {
-        assert!(is_querier_route("/api/_search"));
-        assert!(is_querier_route("/api/_around"));
-        assert!(!is_querier_route("/api/_bulk"));
+        assert!(is_querier_route("/api/default/_search"));
+        assert!(is_querier_route("/api/default/default/_around"));
+        assert!(is_querier_route("/config"));
         assert!(is_querier_route(
-            "https://test.com/api/default/prometheus/api/v1/query_range"
+            "/api/default/prometheus/api/v1/query_range"
         ));
+        assert!(!is_querier_route("/api/config/_bulk"));
+        assert!(!is_querier_route("/api/clusters/_bulk"));
+        assert!(!is_querier_route("/api/clusters/ws/_multi"));
+        assert!(!is_querier_route("/api/default/config/_json"));
     }
 
     #[test]

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -35,13 +35,14 @@ mod ws;
 pub(crate) mod ws_v2;
 
 /// usize indicates the number of parts to skip based on their actual paths.
-const QUERIER_ROUTES: [(&str, usize); 20] = [
+const QUERIER_ROUTES: [(&str, usize); 21] = [
     ("config", 0),                            // /config
     ("summary", 2),                           // /api/{org_id}/summary
     ("organizations", 1),                     // /api/organizations
     ("settings", 2),                          // /api/{org_id}/settings/...
     ("schema", 3),                            // /api/{org_id}/streams/{stream_name}/schema
     ("streams", 2),                           // /api/{org_id}/streams/...
+    ("traces/latest", 3),                     // /api/{org_id}/{stream_name}/traces/latest
     ("clusters", 1),                          // /api/clusters
     ("query_manager", 2),                     // /api/{org_id}/query_manager/...
     ("ws", 2),                                // /api/{org_id}/ws
@@ -69,7 +70,7 @@ const INGESTER_ROUTES: [&str; 11] = [
     "/_multi",
     "/_json",
     "/_kinesis_firehose",
-    "/__sub",
+    "/_sub",
     "/v1/logs",
     "/ingest/metrics/_json",
     "/v1/metrics",


### PR DESCRIPTION
when dynamic part of the path contains querier routes

fix #6413 