### PR TITLE
fix: let the scheduled only work for ingestion

### DIFF
--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -269,7 +269,7 @@ async fn get_url(path: &str) -> URLDetails {
         }
     } else {
         node_type = Role::Ingester;
-        cluster::get_cached_online_ingester_nodes().await
+        cluster::get_cached_schedulable_ingester_nodes().await
     };
 
     if nodes.is_none() || nodes.as_ref().unwrap().is_empty() {

--- a/src/service/grpc.rs
+++ b/src/service/grpc.rs
@@ -44,7 +44,7 @@ pub(crate) async fn get_ingester_channel() -> Result<(String, Channel), tonic::S
 }
 
 async fn get_rand_ingester_addr() -> Result<String, tonic::Status> {
-    let nodes = cluster::get_cached_online_ingester_nodes().await;
+    let nodes = cluster::get_cached_schedulable_ingester_nodes().await;
     if nodes.is_none() || nodes.as_ref().unwrap().is_empty() {
         Err(tonic::Status::internal(
             "No online ingester nodes".to_string(),


### PR DESCRIPTION
The ingester will still can be search when it set to unscheduled