### PR TITLE
fix: ws session drain

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -430,12 +430,8 @@ pub struct WebSocket {
     pub session_gc_interval_secs: i64,
     #[env_config(name = "ZO_WEBSOCKET_PING_INTERVAL_SECS", default = 15)]
     pub ping_interval_secs: i64,
-    #[env_config(name = "ZO_WEBSOCKET_CHECK_COOKIE_EXPIRY", default = true)]
-    pub check_cookie_expiry: bool,
     #[env_config(name = "ZO_WEBSOCKET_HEALTH_CHECK_INTERVAL_SECS", default = 60)]
     pub health_check_interval: i64,
-    #[env_config(name = "ZO_WEBSOCKET_IS_SESSION_DRAIN_ENABLED", default = false)]
-    pub is_session_drain_enabled: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/handler/http/request/ws_v2/mod.rs
+++ b/src/handler/http/request/ws_v2/mod.rs
@@ -55,7 +55,7 @@ pub async fn websocket(
         .to_string();
 
     #[cfg(feature = "enterprise")]
-    let cookie_expiry = if cfg.websocket.check_cookie_expiry && cfg.common.local_mode {
+    let cookie_expiry = if cfg.common.local_mode {
         let (cookie_expiry, _) = extract_auth_expiry_and_user_id(&req).await;
         cookie_expiry.map(|expiry| expiry.timestamp_micros())
     } else {

--- a/src/router/http/ws_v2/error.rs
+++ b/src/router/http/ws_v2/error.rs
@@ -113,10 +113,10 @@ impl ErrorMessage {
             // client should not retry on the same ws session, only when cookie is expired
             should_client_retry: false,
         };
-        let should_disconnect = !config::get_config().websocket.is_session_drain_enabled;
         Self {
             ws_server_events,
-            should_disconnect,
+            // cookie expired, don't disconnect the ws session until the session is drained
+            should_disconnect: false,
         }
     }
 }

--- a/src/router/http/ws_v2/handler.rs
+++ b/src/router/http/ws_v2/handler.rs
@@ -180,12 +180,11 @@ impl WsHandler {
                                                 }
                                             }
                                             if is_session_drain_state.load(Ordering::SeqCst) {
-                                                // Don't forward to querier, return unauthorized error instead
                                                 let err_msg = ErrorMessage::new_unauthorized(Some(message.get_trace_id()));
                                                 if let Err(e) = disconnect_tx.send(Some(DisconnectMessage::Error(err_msg))).await {
                                                     log::error!("[WS::Router::Handler] Error sending error: {e}");
                                                 }
-                                                continue; // Skip forwarding to querier
+                                                continue;
                                             }
                                             // end of cookie check
 

--- a/src/router/http/ws_v2/handler.rs
+++ b/src/router/http/ws_v2/handler.rs
@@ -42,7 +42,6 @@ pub type TraceId = String;
 pub struct WsHandler {
     pub session_manager: Arc<SessionManager>,
     pub connection_pool: Arc<QuerierConnectionPool>,
-    pub is_session_drain_state: Arc<AtomicBool>,
 }
 
 impl WsHandler {
@@ -53,7 +52,6 @@ impl WsHandler {
         Self {
             session_manager,
             connection_pool,
-            is_session_drain_state: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -95,7 +93,7 @@ impl WsHandler {
         let connection_pool = self.connection_pool.clone();
 
         // Before spawning the async task, clone the drain state
-        let is_session_drain_state = self.is_session_drain_state.clone();
+        let is_session_drain_state = session_manager.is_session_drain_state(&client_id).await;
 
         // Spawn message handling tasks between client and router
         actix_web::rt::spawn(async move {

--- a/src/router/http/ws_v2/handler.rs
+++ b/src/router/http/ws_v2/handler.rs
@@ -50,7 +50,7 @@ pub struct WsHandler {
 
 impl Drop for WsHandler {
     fn drop(&mut self) {
-        log::info!("[WS::Router::Handler] WsHandler dropped");
+        log::debug!("[WS::Router::Handler] WsHandler dropped");
     }
 }
 

--- a/src/router/http/ws_v2/handler.rs
+++ b/src/router/http/ws_v2/handler.rs
@@ -99,6 +99,7 @@ impl WsHandler {
             ));
             ping_interval.tick().await; // first tick is immediate
 
+            let mut count = 1;
             // Handle incoming messages from client
             let handle_incoming = async {
                 loop {
@@ -166,8 +167,13 @@ impl WsHandler {
                                         Ok(mut message) => {
                                             // check if cookie is valid for each client event only
                                             // for enterprise
-                                            if cfg.websocket.check_cookie_expiry
-                                                && !session_manager.is_client_cookie_valid(&client_id).await
+                                            let mut is_cookie_not_valid = !session_manager.is_client_cookie_valid(&client_id).await;
+                                            if cfg.websocket.is_session_drain_enabled{
+                                                if count != 1 && count % 5 == 0 {
+                                                    is_cookie_not_valid = !is_cookie_not_valid;
+                                                }
+                                            }
+                                            if cfg.websocket.check_cookie_expiry && is_cookie_not_valid
                                             {
                                                 log::info!(
                                                     "[WS::Router::Handler] Client cookie expired. Disconnect..."
@@ -259,6 +265,7 @@ impl WsHandler {
                                                     break;
                                                 }
                                             }
+                                            count += 1;
                                         }
                                     }
                                 }

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -564,7 +564,11 @@ export const usePanelDataLoader = (
   };
 
   const handleHistogramResponse = async (payload: any, searchRes: any) => {
-    console.log("handleHistogramResponse", searchRes.content.trace_id, searchRes.content);
+    console.log(
+      "handleHistogramResponse",
+      searchRes.content.trace_id,
+      searchRes.content,
+    );
     // remove past error detail
     state.errorDetail = "";
 
@@ -636,7 +640,7 @@ export const usePanelDataLoader = (
     }
 
     console.log("sendSearchMessage", payload.traceId);
-    
+
     sendSearchMessageBasedOnRequestId({
       type: "search",
       content: {
@@ -668,7 +672,6 @@ export const usePanelDataLoader = (
       processApiError(response?.content, "sql");
     }
 
-
     const errorCodes = [1001, 1006, 1010, 1011, 1012, 1013];
 
     if (errorCodes.includes(response.code)) {
@@ -679,7 +682,7 @@ export const usePanelDataLoader = (
           trace_id: payload.traceId,
           code: response.code,
           error_detail: "",
-        }
+        },
       });
     }
 
@@ -693,19 +696,9 @@ export const usePanelDataLoader = (
 
   const handleSearchReset = (payload: any, traceId?: string) => {
     console.log("handleSearchReset", traceId);
-    // reset old state data
-    state.data = [];
-    state.resultMetaData = [];
 
-    getDataThroughWebSocket(
-      payload.queryReq.query,
-      payload.queryReq.it,
-      payload.queryReq.startISOTimestamp,
-      payload.queryReq.endISOTimestamp,
-      payload.pageType,
-      payload.currentQueryIndex,
-    );
-  }
+    loadData();
+  };
 
   const handleSearchError = (payload: any, response: any) => {
     removeTraceId(payload.traceId);
@@ -855,7 +848,7 @@ export const usePanelDataLoader = (
 
       // remove past error detail
       state.errorDetail = "";
-      
+
       // Check if the query type is "promql"
       if (panelSchema.value.queryType == "promql") {
         // Iterate through each query in the panel schema
@@ -928,7 +921,6 @@ export const usePanelDataLoader = (
         const abortControllerRef = abortController;
 
         try {
-
           // Call search API
           state.data = [];
           state.metadata = {
@@ -937,7 +929,7 @@ export const usePanelDataLoader = (
           state.resultMetaData = [];
           state.annotations = [];
           state.isOperationCancelled = false;
-          
+
           // Get the page type from the first query in the panel schema
           const pageType = panelSchema.value.queries[0]?.fields?.stream_type;
 

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -688,8 +688,10 @@ export const usePanelDataLoader = (
     saveCurrentStateToCache();
   };
 
-  const handleSearchReset = (payload: any) => {
+  const handleSearchReset = (payload: any, traceId?: string) => {
     // reset old state data
+    console.log("handleSearchReset", traceId, structuredClone(payload));
+
     state.data = [];
     state.resultMetaData = [];
 

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -564,11 +564,6 @@ export const usePanelDataLoader = (
   };
 
   const handleHistogramResponse = async (payload: any, searchRes: any) => {
-    console.log(
-      "handleHistogramResponse",
-      searchRes.content.trace_id,
-      searchRes.content,
-    );
     // remove past error detail
     state.errorDetail = "";
 
@@ -639,7 +634,6 @@ export const usePanelDataLoader = (
       return;
     }
 
-    console.log("sendSearchMessage", payload.traceId);
 
     sendSearchMessageBasedOnRequestId({
       type: "search",
@@ -695,8 +689,6 @@ export const usePanelDataLoader = (
   };
 
   const handleSearchReset = (payload: any, traceId?: string) => {
-    console.log("handleSearchReset", traceId);
-
     loadData();
   };
 
@@ -722,7 +714,6 @@ export const usePanelDataLoader = (
       const { traceId } = generateTraceContext();
       addTraceId(traceId);
 
-      console.log("getDataThroughWebSocket", traceId);
       const payload: {
         queryReq: any;
         type: "search" | "histogram" | "pageCount";
@@ -1169,7 +1160,6 @@ export const usePanelDataLoader = (
               );
               state.annotations = annotations;
               if (isWebSocketEnabled()) {
-                console.log("getDataThroughWebSocket");
                 await getDataThroughWebSocket(
                   query,
                   it,

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -564,6 +564,7 @@ export const usePanelDataLoader = (
   };
 
   const handleHistogramResponse = async (payload: any, searchRes: any) => {
+    console.log("handleHistogramResponse", searchRes.content.trace_id, searchRes.content);
     // remove past error detail
     state.errorDetail = "";
 
@@ -634,6 +635,8 @@ export const usePanelDataLoader = (
       return;
     }
 
+    console.log("sendSearchMessage", payload.traceId);
+    
     sendSearchMessageBasedOnRequestId({
       type: "search",
       content: {
@@ -689,9 +692,8 @@ export const usePanelDataLoader = (
   };
 
   const handleSearchReset = (payload: any, traceId?: string) => {
+    console.log("handleSearchReset", traceId);
     // reset old state data
-    console.log("handleSearchReset", traceId, structuredClone(payload));
-
     state.data = [];
     state.resultMetaData = [];
 
@@ -727,6 +729,7 @@ export const usePanelDataLoader = (
       const { traceId } = generateTraceContext();
       addTraceId(traceId);
 
+      console.log("getDataThroughWebSocket", traceId);
       const payload: {
         queryReq: any;
         type: "search" | "histogram" | "pageCount";
@@ -1174,6 +1177,7 @@ export const usePanelDataLoader = (
               );
               state.annotations = annotations;
               if (isWebSocketEnabled()) {
+                console.log("getDataThroughWebSocket");
                 await getDataThroughWebSocket(
                   query,
                   it,

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -4875,6 +4875,8 @@ const useLogs = () => {
         }
       }
 
+      console.log("getDataThroughWebSocket", structuredClone(queryReq));
+
       const payload = buildWebSocketPayload(queryReq, isPagination, "search");
       const requestId = initializeWebSocketConnection(payload);
 
@@ -4932,7 +4934,10 @@ const useLogs = () => {
   };
 
 
-  const handleSearchReset = async (data: any) => {
+  const handleSearchReset = async (data: any, traceId?: string) => {
+
+    console.log("handleSearchReset", traceId, structuredClone(data));
+
     // reset query data
     try {
       if(data.type === "search") {

--- a/web/src/composables/useSearchWebSocket.ts
+++ b/web/src/composables/useSearchWebSocket.ts
@@ -122,9 +122,11 @@ const useSearchWebSocket = () => {
         socketId.value = null;        
         isInDrainMode.value = true;
 
+        const traceIdToRetry = response.content.trace_id;
+
         // Mark all traces from old socket as inactive
         Object.keys(traces).forEach(traceId => {
-          if (traces[traceId].socketId === inactiveSocketId.value) {
+          if ((traces[traceId].socketId === inactiveSocketId.value) && (traceId !== traceIdToRetry)) {
             traces[traceId].isActive = false;
           }
         }); 
@@ -132,8 +134,6 @@ const useSearchWebSocket = () => {
         await resetAuthToken();
 
         debugger;
-
-        const traceIdToRetry = response.content.trace_id;
 
         if(traceIdToRetry) retryActiveTrace(traceIdToRetry, response);
 

--- a/web/src/composables/useSearchWebSocket.ts
+++ b/web/src/composables/useSearchWebSocket.ts
@@ -201,7 +201,7 @@ const useSearchWebSocket = () => {
       reset: (data: any, response: any) => void;
     }  
   ) => {
-      console.log("fetchQueryDataWithWebSocket", data.traceId, socketId.value);
+    console.log("fetchQueryDataWithWebSocket", data.traceId, socketId.value, isInDrainMode.value);
     try {
       traces[data.traceId] = {
         open: [],
@@ -262,7 +262,7 @@ const useSearchWebSocket = () => {
   const sendSearchMessageBasedOnRequestId = (data: any) => {
     try {
 
-      console.log("sendSearchMessageBasedOnRequestId", { ...traces[data.content.traceId]} );
+      console.log("sendSearchMessageBasedOnRequestId",  data.content.traceId, structuredClone(traces[data.content.traceId]) );
       
       if(!traces[data.content.traceId]?.isActive && inactiveSocketId.value) {
         webSocket.sendMessage(inactiveSocketId.value as string, JSON.stringify(data));
@@ -334,7 +334,7 @@ const useSearchWebSocket = () => {
 
   const retryActiveTrace = (traceId: string, response: any) => {
     traces[traceId]?.close.forEach((handler: any) => handler(response));
-    traces[traceId]?.reset.forEach((handler: any) => handler(traces[traceId].data));
+    traces[traceId]?.reset.forEach((handler: any) => handler(traces[traceId].data, traceId));
     cleanUpListeners(traceId);   
   }
 

--- a/web/src/composables/useSearchWebSocket.ts
+++ b/web/src/composables/useSearchWebSocket.ts
@@ -90,7 +90,7 @@ const useSearchWebSocket = () => {
       // console.log("shouldRetry", JSON.parse(JSON.stringify(traces)));
       setTimeout(() => {
         Object.keys(traces).forEach((traceId) => {
-          if((traces[traceId].socketId === _socketId) && traces[traceId].isInitiated) {
+          if(((traces[traceId].socketId === _socketId) && traces[traceId].isInitiated) || !traces[traceId].socketId) {
             response.code = 1000;
             traces[traceId]?.close.forEach((handler: any) => handler(response));
             traces[traceId]?.reset.forEach((handler: any) => handler(traces[traceId].data));

--- a/web/src/composables/useSearchWebSocket.ts
+++ b/web/src/composables/useSearchWebSocket.ts
@@ -122,17 +122,20 @@ const useSearchWebSocket = () => {
         // Store the current socketId as inactive and clear it
         // console.log("socketMeta ----------",traces[response.content.trace_id].socketId, socketMeta.value[traces[response.content.trace_id].socketId as string].isReadOnly);
 
-        const isReadOnly = socketMeta.value[traces[response.content.trace_id].socketId as string].isReadOnly;
+        const currentSocketId = traces[response.content.trace_id]?.socketId;
+        if (!currentSocketId) return;
+
+        const isReadOnly = socketMeta.value[traces[response.content.trace_id]?.socketId as string]?.isReadOnly;
+                
         if (!isReadOnly) {
           // console.log("rest socket");
           inactiveSocketId.value = socketId.value;
           socketId.value = null;        
           isInDrainMode.value = true;
+          socketMeta.value[traces[response.content.trace_id].socketId as string].isReadOnly = true;
         }
 
         const traceIdToRetry = response.content.trace_id;
-
-        socketMeta.value[traces[response.content.trace_id].socketId as string].isReadOnly = true;
 
         if (!isReadOnly) await resetAuthToken();
 

--- a/web/src/composables/useSearchWebSocket.ts
+++ b/web/src/composables/useSearchWebSocket.ts
@@ -341,9 +341,8 @@ const useSearchWebSocket = () => {
   const resetAuthToken = async () => {
     // console.log("reset auth token");
     isInDrainMode.value = true;
-    return new Promise(async (resolve) => {
-      // Added timeout to test the auth token refresh
-      setTimeout(() => {
+    return new Promise(async (resolve, reject) => {
+      authService.refresh_token().then((res: any) => {
         isInDrainMode.value = false;
         // Retry the request
         Object.keys(traces).forEach((traceId) => {
@@ -357,29 +356,13 @@ const useSearchWebSocket = () => {
             });
           }
         });
-        resolve("");
-      }, 500)
-      // authService.refresh_token().then((res: any) => {
-      //   isInDrainMode.value = false;
-      //   // Retry the request
-      //   Object.keys(traces).forEach((traceId) => {
-      //     if(!traces[traceId].isInitiated) {
-      //       initiateSocketConnection(traces[traceId].data, {
-      //         open: traces[traceId].open[0],
-      //         message: traces[traceId].message[0],
-      //         close: traces[traceId].close[0],
-      //         error: traces[traceId].error[0],
-      //         reset: traces[traceId].reset[0],
-      //       });
-      //     }
-      //   });
-      //   resolve(res);
-      // }).catch((err: any) => {
-      //   console.error("Error in refreshing auth token", err);
-      //   reject(err);
-      // }).finally(() => {
-      //   isInDrainMode.value = false;
-      // });
+        resolve(res);
+      }).catch((err: any) => {
+        console.error("Error in refreshing auth token", err);
+        reject(err);
+      }).finally(() => {
+        isInDrainMode.value = false;
+      });
     })
   }
 

--- a/web/src/composables/useWebSocket.ts
+++ b/web/src/composables/useWebSocket.ts
@@ -2,10 +2,10 @@
 
 import { onBeforeUnmount } from "vue";
 
-type MessageHandler = (event: MessageEvent) => void;
-type OpenHandler = (event: Event) => void;
+type MessageHandler = (event: MessageEvent, socketId: string) => void;
+type OpenHandler = (event: Event, socketId: string) => void;
 type CloseHandler = (event: CloseEvent, socketId: string) => void;
-type ErrorHandler = (event: Event) => void;
+type ErrorHandler = (event: Event, socketId: string) => void;
 
 type WebSocketHandler =
   | MessageHandler
@@ -51,18 +51,18 @@ const connect = (socketId: string, url: string) => {
 };
 
 const onOpen = (socketId: string, event: Event) => {
-  openHandlers[socketId]?.forEach((handler) => handler(event));
+  openHandlers[socketId]?.forEach((handler) => handler(event, socketId));
 };
 
 const onMessage = (socketId: string, event: MessageEvent) => {
   const data = JSON.parse(event.data);
 
   if (data.type === "error") {
-    errorHandlers[socketId]?.forEach((handler) => handler(data));
+    errorHandlers[socketId]?.forEach((handler) => handler(data, socketId));
     return;
   }
 
-  messageHandlers[socketId]?.forEach((handler) => handler(data));
+  messageHandlers[socketId]?.forEach((handler) => handler(data, socketId));
 };
 
 const onClose = (socketId: string, event: CloseEvent) => {
@@ -75,7 +75,7 @@ const onClose = (socketId: string, event: CloseEvent) => {
 };
 
 const onError = (socketId: string, event: Event) => {
-  errorHandlers[socketId]?.forEach((handler) => handler(event));
+  errorHandlers[socketId]?.forEach((handler) => handler(event, socketId));
 };
 
 // Message and handler functions


### PR DESCRIPTION
- [x] fix: `session_drain` i.e. when a cookie expires no new `search` events will be accepted by the router/server while the ongoing searches will be drained to completion or allowed up to the `ZO_WEBSOCKET_SESSION_IDLE_TIMEOUT_SECS` (default is 5 mins) after which the session will be closed by the server.
- [x] track search duration for every `trace_id` and log it