### PR TITLE
fix: add http api search error in the audit stream

### DIFF
--- a/src/handler/http/request/search/error_utils.rs
+++ b/src/handler/http/request/search/error_utils.rs
@@ -16,17 +16,25 @@
 use actix_web::{HttpResponse, http::StatusCode};
 use infra::errors;
 
-use crate::common::meta::http::HttpResponse as MetaHttpResponse;
+use crate::{
+    common::meta::http::HttpResponse as MetaHttpResponse, handler::http::router::ERROR_HEADER,
+};
 
 pub fn map_error_to_http_response(err: errors::Error, trace_id: String) -> HttpResponse {
     match err {
         errors::Error::ErrorCode(code) => match code {
-            errors::ErrorCodes::SearchCancelQuery(_) => HttpResponse::TooManyRequests().json(
-                MetaHttpResponse::error_code_with_trace_id(code, Some(trace_id)),
-            ),
-            errors::ErrorCodes::SearchTimeout(_) => HttpResponse::RequestTimeout().json(
-                MetaHttpResponse::error_code_with_trace_id(code, Some(trace_id)),
-            ),
+            errors::ErrorCodes::SearchCancelQuery(_) => HttpResponse::TooManyRequests()
+                .append_header((ERROR_HEADER, code.to_json()))
+                .json(MetaHttpResponse::error_code_with_trace_id(
+                    code,
+                    Some(trace_id),
+                )),
+            errors::ErrorCodes::SearchTimeout(_) => HttpResponse::RequestTimeout()
+                .append_header((ERROR_HEADER, code.to_json()))
+                .json(MetaHttpResponse::error_code_with_trace_id(
+                    code,
+                    Some(trace_id),
+                )),
             errors::ErrorCodes::InvalidParams(_)
             | errors::ErrorCodes::SearchSQLExecuteError(_)
             | errors::ErrorCodes::SearchFieldHasNoCompatibleDataType(_)
@@ -34,20 +42,26 @@ pub fn map_error_to_http_response(err: errors::Error, trace_id: String) -> HttpR
             | errors::ErrorCodes::FullTextSearchFieldNotFound
             | errors::ErrorCodes::SearchFieldNotFound(_)
             | errors::ErrorCodes::SearchSQLNotValid(_)
-            | errors::ErrorCodes::SearchStreamNotFound(_) => HttpResponse::BadRequest().json(
-                MetaHttpResponse::error_code_with_trace_id(code, Some(trace_id)),
-            ),
+            | errors::ErrorCodes::SearchStreamNotFound(_) => HttpResponse::BadRequest()
+                .append_header((ERROR_HEADER, code.to_json()))
+                .json(MetaHttpResponse::error_code_with_trace_id(
+                    code,
+                    Some(trace_id),
+                )),
 
             errors::ErrorCodes::ServerInternalError(_)
-            | errors::ErrorCodes::SearchParquetFileNotFound => {
-                HttpResponse::InternalServerError().json(
-                    MetaHttpResponse::error_code_with_trace_id(code, Some(trace_id)),
-                )
-            }
+            | errors::ErrorCodes::SearchParquetFileNotFound => HttpResponse::InternalServerError()
+                .append_header((ERROR_HEADER, code.to_json()))
+                .json(MetaHttpResponse::error_code_with_trace_id(
+                    code,
+                    Some(trace_id),
+                )),
         },
-        _ => HttpResponse::InternalServerError().json(MetaHttpResponse::error(
-            StatusCode::INTERNAL_SERVER_ERROR.into(),
-            err.to_string(),
-        )),
+        _ => HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, err.to_string()))
+            .json(MetaHttpResponse::error(
+                StatusCode::INTERNAL_SERVER_ERROR.into(),
+                err.to_string(),
+            )),
     }
 }

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -122,11 +122,8 @@ async fn audit_middleware(
                 String::from_utf8(request_body.to_vec()).unwrap_or_default()
             };
             let error_header = res.response().headers().get(ERROR_HEADER);
-            let error_msg = if let Some(error_header) = error_header {
-                Some(error_header.to_str().unwrap_or_default().to_string())
-            } else {
-                None
-            };
+            let error_msg = error_header
+                .map(|error_header| error_header.to_str().unwrap_or_default().to_string());
             // Remove the error header from the response
             // We can't read the response body at this point, hence need to rely
             // on the error header to get the error message. Since, this is not required


### PR DESCRIPTION
Whenever there is a search error, we put a custom header to use the error message creating the audit message for that event. Also, the custom header is removed while sending the response back to user.