### PR TITLE
fix: alerts owner should be logged in user

### DIFF
--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -1198,14 +1198,10 @@ export default defineComponent({
         if (toBeClonedAlert.value?.id) {
           delete toBeClonedAlert.value?.id;
         }
-        //overriding the owner from the alert payload because the current logged in user will be the owner of the cloned alert
-        if(toBeClonedAlert.value?.owner){
+        //assigning the owner from the alert payload because the current logged in user will be the owner of the cloned alert
           toBeClonedAlert.value.owner = store.state.userInfo.email;
-        }
-        //overriding the last_edited_by from the alert payload because the current logged in user will be the last_edited_by of the cloned alert
-        if(toBeClonedAlert.value?.last_edited_by){
+        //assigning the last_edited_by from the alert payload because the current logged in user will be the last_edited_by of the cloned alert
           toBeClonedAlert.value.last_edited_by = store.state.userInfo.email;
-        }
         //here using the folderIdToBeCloned.value because we need to clone the alert in the folder which is selected by the user
         alertsService
           .create_by_alert_id(

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -1198,6 +1198,14 @@ export default defineComponent({
         if (toBeClonedAlert.value?.id) {
           delete toBeClonedAlert.value?.id;
         }
+        //overriding the owner from the alert payload because the current logged in user will be the owner of the cloned alert
+        if(toBeClonedAlert.value?.owner){
+          toBeClonedAlert.value.owner = store.state.userInfo.email;
+        }
+        //overriding the last_edited_by from the alert payload because the current logged in user will be the last_edited_by of the cloned alert
+        if(toBeClonedAlert.value?.last_edited_by){
+          toBeClonedAlert.value.last_edited_by = store.state.userInfo.email;
+        }
         //here using the folderIdToBeCloned.value because we need to clone the alert in the folder which is selected by the user
         alertsService
           .create_by_alert_id(

--- a/web/src/components/alerts/ImportAlert.vue
+++ b/web/src/components/alerts/ImportAlert.vue
@@ -1048,6 +1048,14 @@ export default defineComponent({
         input.trigger_condition.tolerance_in_secs = null;
       }
       input.folder_id = folderId;
+      //overriding the owner from the alert payload because the current logged in user will be the owner of the alert
+      if(input.owner){
+        input.owner = store.state.userInfo.email;
+      }
+      //overriding the last_edited_by from the alert payload because the current logged in user will be the last_edited_by of the alert
+      if(input.last_edited_by){
+        input.last_edited_by = store.state.userInfo.email;
+      }
       try {
         await alertsService.create_by_alert_id(
           store.state.selectedOrganization.identifier,

--- a/web/src/components/alerts/ImportAlert.vue
+++ b/web/src/components/alerts/ImportAlert.vue
@@ -1048,14 +1048,11 @@ export default defineComponent({
         input.trigger_condition.tolerance_in_secs = null;
       }
       input.folder_id = folderId;
-      //overriding the owner from the alert payload because the current logged in user will be the owner of the alert
-      if(input.owner){
+      //assigning the owner from the alert payload because the current logged in user will be the owner of the alert
         input.owner = store.state.userInfo.email;
-      }
-      //overriding the last_edited_by from the alert payload because the current logged in user will be the last_edited_by of the alert
-      if(input.last_edited_by){
+      //assigning the last_edited_by from the alert payload because the current logged in user will be the last_edited_by of the alert
         input.last_edited_by = store.state.userInfo.email;
-      }
+      
       try {
         await alertsService.create_by_alert_id(
           store.state.selectedOrganization.identifier,


### PR DESCRIPTION
1. This PR makes sure that cloned alert and imported alert owners should be logged in users only