### PR TITLE
fix: when uploading enrichment table with column name only, do not delete the enrichment table

### DIFF
--- a/src/config/src/meta/triggers.rs
+++ b/src/config/src/meta/triggers.rs
@@ -1,3 +1,18 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, sqlx::Type, PartialEq, Serialize, Deserialize, Default)]

--- a/src/handler/http/request/enrichment_table/mod.rs
+++ b/src/handler/http/request/enrichment_table/mod.rs
@@ -81,7 +81,7 @@ pub async fn save_enrichment_table(
                     Some(append_data) => append_data.parse::<bool>().unwrap_or(false),
                     None => false,
                 };
-                let json_record = extract_multipart(payload).await?;
+                let json_record = extract_multipart(payload, append_data).await?;
                 save_enrichment_data(&org_id, &table_name, json_record, append_data).await
             } else {
                 Ok(MetaHttpResponse::bad_request(

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -784,11 +784,11 @@ async fn handle_derived_stream_triggers(
     let columns = trigger.module_key.split('/').collect::<Vec<_>>();
     if columns.len() < 4 {
         log::warn!(
-            "[SCHEDULER trace_id {trace_id}] Invalid module_key format: {}.",
+            "[SCHEDULER trace_id {scheduler_trace_id}] Invalid module_key format: {}.",
             trigger.module_key
         );
         return Err(anyhow::anyhow!(
-            "[SCHEDULER trace_id {trace_id}] Invalid module_key format: {}.",
+            "[SCHEDULER trace_id {scheduler_trace_id}] Invalid module_key format: {}.",
             trigger.module_key
         ));
     }

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -782,11 +782,21 @@ async fn handle_derived_stream_triggers(
 
     // module_key format: stream_type/org_id/pipeline_name/pipeline_id
     let columns = trigger.module_key.split('/').collect::<Vec<_>>();
-    assert_eq!(columns.len(), 4);
+    if columns.len() < 4 {
+        log::warn!(
+            "[SCHEDULER trace_id {trace_id}] Invalid module_key format: {}.",
+            trigger.module_key
+        );
+        return Err(anyhow::anyhow!(
+            "[SCHEDULER trace_id {trace_id}] Invalid module_key format: {}.",
+            trigger.module_key
+        ));
+    }
     let stream_type: StreamType = columns[0].into();
     let org_id = columns[1];
     let pipeline_name = columns[2];
-    let pipeline_id = columns[3];
+    // Handles the case where the pipeline name contains a `/`
+    let pipeline_id = columns[columns.len() - 1];
 
     let mut new_trigger = db::scheduler::Trigger {
         next_run_at: Utc::now().timestamp_micros(),

--- a/src/service/db/schema.rs
+++ b/src/service/db/schema.rs
@@ -130,6 +130,12 @@ pub async fn delete(
 ) -> Result<(), anyhow::Error> {
     let stream_type = stream_type.unwrap_or(StreamType::Logs);
     infra::schema::delete(org_id, stream_type, stream_name, None).await?;
+    if stream_type == StreamType::EnrichmentTables {
+        // Enrichment table size is not deleted by schema delete
+        // Since we are storing the current size of the table in bytes in the meta table,
+        // when we delete enrichment table, we need to delete the size from the db as well.
+        let _ = super::enrichment_table::delete_table_size(org_id, stream_name).await;
+    }
 
     // super cluster
     #[cfg(feature = "enterprise")]

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -122,7 +122,7 @@ pub async fn save_enrichment_data(
         // we will simply use the payload size to check if it exceeds the max size
         0.0
     };
-    let enrichment_table_max_size = cfg.limit.enrichment_table_max_size as f64;
+    let enrichment_table_max_size = cfg.limit.max_enrichment_table_size as f64;
     log::info!(
         "enrichment table [{stream_name}] saving stats: {:?} vs max_table_size {}",
         current_size_in_bytes,

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -33,6 +33,7 @@ use config::{
     SIZE_IN_MB,
 };
 use futures::{StreamExt, TryStreamExt};
+use hashbrown::HashSet;
 use infra::{
     cache::stats,
     schema::{
@@ -94,20 +95,51 @@ pub async fn save_enrichment_data(
         );
     }
 
-    let stats = stats::get_stream_stats(org_id, stream_name, StreamType::EnrichmentTables);
-    let max_enrichment_table_size = cfg.limit.max_enrichment_table_size;
+    // Estimate the size of the payload in json format in bytes
+    let mut bytes_in_payload = 0;
+    for p in payload.iter() {
+        match json::to_value(p) {
+            Ok(v) => bytes_in_payload += json::estimate_json_bytes(&v),
+            Err(_) => {
+                return Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(
+                    http::StatusCode::BAD_REQUEST.into(),
+                    "Invalid JSON payload: Could not convert file data into valid JSON object"
+                        .to_string(),
+                )));
+            }
+        }
+    }
+
+    let current_size_in_bytes = if append_data {
+        let size = enrichment_table::get_table_size(org_id, stream_name).await;
+        if size > 0 {
+            size as f64
+        } else {
+            stats::get_stream_stats(org_id, stream_name, StreamType::EnrichmentTables).storage_size
+        }
+    } else {
+        // If we are not appending data, we do not need to check the current size
+        // we will simply use the payload size to check if it exceeds the max size
+        0.0
+    };
+    let enrichment_table_max_size = cfg.limit.enrichment_table_max_size as f64;
     log::info!(
         "enrichment table [{stream_name}] saving stats: {:?} vs max_table_size {}",
-        stats,
-        max_enrichment_table_size
+        current_size_in_bytes,
+        enrichment_table_max_size
     );
-    if (stats.storage_size / SIZE_IN_MB) > max_enrichment_table_size as f64 {
+    let total_expected_size_in_bytes = current_size_in_bytes + bytes_in_payload as f64;
+    let total_expected_size_in_mb = total_expected_size_in_bytes / SIZE_IN_MB;
+    // if appending data, we need to check if the storage size exceeds the max size
+    // if not, we can append the data
+    // if it does, we need to return an error
+    if append_data && total_expected_size_in_mb > enrichment_table_max_size {
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                 format!(
-                    "enrichment table [{stream_name}] storage size {} exceeds max storage size {}",
-                    stats.storage_size, max_enrichment_table_size
+                    "enrichment table [{stream_name}] total expected storage size {} exceeds max storage size {}",
+                    total_expected_size_in_mb, enrichment_table_max_size
                 ),
             )),
         );
@@ -247,6 +279,15 @@ pub async fn save_enrichment_data(
     )
     .await;
 
+    // The stream_stats table takes some time to update, so we need to update the enrichment table
+    // size in the meta table to avoid exceeding the `ZO_ENRICHMENT_TABLE_LIMIT`.
+    let _ = enrichment_table::update_table_size(
+        org_id,
+        stream_name,
+        total_expected_size_in_bytes as usize,
+    )
+    .await;
+
     Ok(HttpResponse::Ok().json(MetaHttpResponse::error(
         StatusCode::OK.into(),
         "Saved enrichment table".to_string(),
@@ -294,8 +335,10 @@ async fn delete_enrichment_table(org_id: &str, stream_name: &str, stream_type: S
 
 pub async fn extract_multipart(
     mut payload: Multipart,
+    append_data: bool,
 ) -> Result<Vec<json::Map<String, json::Value>>, Error> {
     let mut records = Vec::new();
+    let mut headers_set = HashSet::new();
     while let Ok(Some(mut field)) = payload.try_next().await {
         let Some(content_disposition) = field.content_disposition() else {
             continue;
@@ -317,6 +360,7 @@ pub async fn extract_multipart(
             .map(|x| {
                 let mut x = x.trim().to_string();
                 format_key(&mut x);
+                headers_set.insert(x.clone());
                 x
             })
             .collect::<Vec<_>>()
@@ -337,6 +381,21 @@ pub async fn extract_multipart(
                 records.push(json_record);
             }
         }
+    }
+
+    if records.is_empty() && !headers_set.is_empty() && !append_data {
+        // If the records are empty, that means user has uploaded only headers, not the data
+        // So, we can assume that the user wants to upload an enrichment table with no row data.
+        // The headers are the columns of the enrichment table. Lets push a json
+        // with the headers as the keys and empty strings as the values.
+
+        // This way we will still have the headers in the enrichment table.
+        // And the enrichment table will not be deleted.
+        let mut json_record = json::Map::new();
+        for header in headers_set {
+            json_record.insert(header, json::Value::String("".to_string()));
+        }
+        records.push(json_record);
     }
 
     Ok(records)


### PR DESCRIPTION
When append_data is false (`?append=false`), and user uploads a enrichment file with only headers, we replace the whole enrichment table with a single json record with the headers as keys and empty string as values. When `append=true` we do nothing.

Also, while uploading an enrichment table, it estimates the probable json size and checks if that exceeds the total enrichment table size limit (`ZO_ENRICHMENT_TABLE_LIMIT`) in MB. This pr introduces another key-value pair in meta table to store the current size of an enrichment table so that while uploading we can keep a track how much of enrichment table size is available. This is because, we can't rely on the stream_stats table which is not realtime and takes some time to update.

It also fixes one bug where if the pipeline name contains `/`, the scheduler is not able to extract the pipeline id from the scheduled_jobs module_key.