### PR TITLE
perf: reduce default download thread num

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1911,7 +1911,7 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
 
     if cfg.limit.file_download_thread_num == 0 {
-        cfg.limit.file_download_thread_num = cfg.limit.query_thread_num;
+        cfg.limit.file_download_thread_num = cpu_num;
     }
 
     // HACK for move_file_thread_num equal to CPU core

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1911,7 +1911,7 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
 
     if cfg.limit.file_download_thread_num == 0 {
-        cfg.limit.file_download_thread_num = cpu_num;
+        cfg.limit.file_download_thread_num = std::cmp::max(1, cpu_num / 2);
     }
 
     // HACK for move_file_thread_num equal to CPU core

--- a/src/service/search/super_cluster/leader.rs
+++ b/src/service/search/super_cluster/leader.rs
@@ -20,6 +20,7 @@ use async_recursion::async_recursion;
 use config::{
     get_config,
     meta::{cluster::NodeInfo, search::ScanStats, sql::TableReferenceExt},
+    metrics,
     utils::json,
 };
 use datafusion::{
@@ -84,6 +85,10 @@ pub async fn search(
 
     // 2. get nodes
     let nodes = get_cluster_nodes(trace_id, req_regions, req_clusters).await?;
+
+    metrics::QUERY_RUNNING_NUMS
+        .with_label_values(&[&sql.org_id])
+        .inc();
 
     let (abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
     if super::super::SEARCH_SERVER


### PR DESCRIPTION
Reduce the default value of `ZO_FILE_DOWNLOAD_THREAD_NUM` from `cpu_num * 4` to `cpu_num / 2`, it took too many CPU for downloading.