### PR TITLE
fix: dynamic stream name should be taken for search job

### DIFF
--- a/web/src/plugins/logs/SearchSchedulersList.vue
+++ b/web/src/plugins/logs/SearchSchedulersList.vue
@@ -854,7 +854,7 @@ export default defineComponent({
           ? rawStreamNames.join(",")
           : rawStreamNames[0];
       const queryObject = {
-        stream_type: "logs",
+        stream_type: row.stream_type ?? "logs",
         stream: stream_name,
         from: from,
         to: to,


### PR DESCRIPTION
1. This PR fixes the issue that for search jobs stream type should be taken from the response not static stream type