### PR TITLE
fix: pass trace id from alert manager to queries

### DIFF
--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -826,6 +826,7 @@ pub trait AlertExt: Sync + Send + 'static {
         &self,
         row: Option<&Map<String, Value>>,
         (start_time, end_time): (Option<i64>, i64),
+        trace_id: Option<String>,
     ) -> Result<TriggerEvalResults, anyhow::Error>;
 
     /// Returns a tuple containing a boolean - if all the send notification jobs successfully
@@ -845,6 +846,7 @@ impl AlertExt for Alert {
         &self,
         row: Option<&Map<String, Value>>,
         (start_time, end_time): (Option<i64>, i64),
+        trace_id: Option<String>,
     ) -> Result<TriggerEvalResults, anyhow::Error> {
         if self.is_real_time {
             self.query_condition.evaluate_realtime(row).await
@@ -862,6 +864,7 @@ impl AlertExt for Alert {
                     (start_time, end_time),
                     Some(SearchEventType::Alerts),
                     Some(search_event_ctx),
+                    trace_id,
                 )
                 .await
         }

--- a/src/service/alerts/derived_streams.rs
+++ b/src/service/alerts/derived_streams.rs
@@ -119,7 +119,11 @@ pub async fn save(
                 .num_microseconds()
                 .unwrap();
         if let Err(e) = &derived_stream
-            .evaluate((Some(test_start_time), test_end_time), &trigger_module_key)
+            .evaluate(
+                (Some(test_start_time), test_end_time),
+                &trigger_module_key,
+                None,
+            )
             .await
         {
             return Err(anyhow::anyhow!(
@@ -172,6 +176,7 @@ pub trait DerivedStreamExt: Sync + Send + 'static {
         &self,
         (start_time, end_time): (Option<i64>, i64),
         module_key: &str,
+        trace_id: Option<String>,
     ) -> Result<TriggerEvalResults, anyhow::Error>;
 }
 
@@ -188,6 +193,7 @@ impl DerivedStreamExt for DerivedStream {
         &self,
         (start_time, end_time): (Option<i64>, i64),
         module_key: &str,
+        trace_id: Option<String>,
     ) -> Result<TriggerEvalResults, anyhow::Error> {
         self.query_condition
             .evaluate_scheduled(
@@ -200,6 +206,7 @@ impl DerivedStreamExt for DerivedStream {
                 Some(SearchEventContext::with_derived_stream(Some(
                     module_key.to_string(),
                 ))),
+                trace_id,
             )
             .await
     }

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -181,7 +181,7 @@ impl QueryConditionExt for QueryCondition {
                 };
                 let promql::value::Value::Matrix(value) = resp else {
                     log::warn!(
-                        "Alert evaluate: PromQL query {} returned unexpected response: {:?}",
+                        "Alert evaluate: trace_id: {trace_id}, PromQL query {} returned unexpected response: {:?}",
                         v,
                         resp
                     );
@@ -342,7 +342,7 @@ impl QueryConditionExt for QueryCondition {
                 per_query_response: false, // Will return results in single array
             };
             log::debug!(
-                "evaluate_scheduled begin to call SearchService::search_multi, {:?}",
+                "evaluate_scheduled trace_id: {trace_id}, begin to call SearchService::search_multi, {:?}",
                 req
             );
             SearchService::grpc_search::grpc_search_multi(
@@ -396,7 +396,7 @@ impl QueryConditionExt for QueryCondition {
                 local_mode: None,
             };
             log::debug!(
-                "evaluate_scheduled begin to call SearchService::search, {:?}",
+                "evaluate_scheduled trace_id: {trace_id}, begin to call SearchService::search, {:?}",
                 req
             );
             // SearchService::search(&trace_id, org_id, stream_type, None, &req).await
@@ -460,7 +460,10 @@ impl QueryConditionExt for QueryCondition {
                 _ => {}
             }
         });
-        log::debug!("alert resp hits len:{:#?}", records.len());
+        log::debug!(
+            "alert trace_id: {trace_id}, resp hits len:{:#?}",
+            records.len()
+        );
         eval_results.query_took = Some(resp.took as i64);
         eval_results.data = if self.search_event_type.is_none() {
             let threshold = trigger_condition.threshold as usize;

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -61,6 +61,7 @@ pub trait QueryConditionExt: Sync + Send + 'static {
         (start_time, end_time): (Option<i64>, i64),
         search_type: Option<SearchEventType>,
         search_event_context: Option<SearchEventContext>,
+        trace_id: Option<String>,
     ) -> Result<TriggerEvalResults, anyhow::Error>;
 }
 
@@ -106,12 +107,16 @@ impl QueryConditionExt for QueryCondition {
         (start_time, end_time): (Option<i64>, i64),
         search_type: Option<SearchEventType>,
         search_event_context: Option<SearchEventContext>,
+        trace_id: Option<String>,
     ) -> Result<TriggerEvalResults, anyhow::Error> {
         let mut eval_results = TriggerEvalResults {
             end_time,
             ..Default::default()
         };
-        let trace_id = ider::generate_trace_id();
+        let trace_id = match trace_id {
+            Some(id) => id,
+            None => ider::generate_trace_id(),
+        };
         let sql = match self.query_type {
             QueryType::Custom => {
                 let (Some(stream_name), Some(v)) = (stream_name, self.conditions.as_ref()) else {

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -84,7 +84,8 @@ async fn handle_alert_triggers(
     trace_id: &str,
     trigger: db::scheduler::Trigger,
 ) -> Result<(), anyhow::Error> {
-    let scheduler_trace_id = format!("{}/{}", trace_id, ider::uuid());
+    let query_trace_id = ider::uuid();
+    let scheduler_trace_id = format!("{}/{}", trace_id, query_trace_id);
     let (_, max_retries) = get_scheduler_max_retries();
     log::debug!(
         "[SCHEDULER trace_id {scheduler_trace_id}] Inside handle_alert_triggers: processing trigger: {}",
@@ -293,7 +294,9 @@ async fn handle_alert_triggers(
 
     let evaluation_took = Instant::now();
     // evaluate alert
-    let result = alert.evaluate(None, (start_time, now)).await;
+    let result = alert
+        .evaluate(None, (start_time, now), Some(query_trace_id))
+        .await;
     let evaluation_took = evaluation_took.elapsed().as_secs_f64();
     trigger_data_stream.evaluation_took_in_secs = Some(evaluation_took);
     if result.is_err() {
@@ -734,7 +737,8 @@ async fn handle_derived_stream_triggers(
     trace_id: &str,
     trigger: db::scheduler::Trigger,
 ) -> Result<(), anyhow::Error> {
-    let scheduler_trace_id = format!("{}/{}", trace_id, ider::uuid());
+    let query_trace_id = ider::uuid();
+    let scheduler_trace_id = format!("{}/{}", trace_id, query_trace_id);
     log::debug!(
         "[SCHEDULER trace_id {scheduler_trace_id}] Inside handle_derived_stream_triggers processing trigger: {}",
         trigger.module_key
@@ -993,7 +997,7 @@ async fn handle_derived_stream_triggers(
 
         // evaluate trigger and configure trigger next run time
         match derived_stream
-            .evaluate((start, end), &trigger.module_key)
+            .evaluate((start, end), &trigger.module_key, Some(query_trace_id))
             .await
         {
             Err(e) => {

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -84,7 +84,7 @@ async fn handle_alert_triggers(
     trace_id: &str,
     trigger: db::scheduler::Trigger,
 ) -> Result<(), anyhow::Error> {
-    let query_trace_id = ider::uuid();
+    let query_trace_id = ider::generate_trace_id();
     let scheduler_trace_id = format!("{}/{}", trace_id, query_trace_id);
     let (_, max_retries) = get_scheduler_max_retries();
     log::debug!(
@@ -540,7 +540,7 @@ async fn handle_report_triggers(
     trace_id: &str,
     trigger: db::scheduler::Trigger,
 ) -> Result<(), anyhow::Error> {
-    let scheduler_trace_id = format!("{}/{}", trace_id, ider::uuid());
+    let scheduler_trace_id = format!("{}/{}", trace_id, ider::generate_trace_id());
     let (_, max_retries) = get_scheduler_max_retries();
     log::debug!(
         "[SCHEDULER trace_id {scheduler_trace_id}] Inside handle_report_trigger,org: {}, module_key: {}",
@@ -737,7 +737,7 @@ async fn handle_derived_stream_triggers(
     trace_id: &str,
     trigger: db::scheduler::Trigger,
 ) -> Result<(), anyhow::Error> {
-    let query_trace_id = ider::uuid();
+    let query_trace_id = ider::generate_trace_id();
     let scheduler_trace_id = format!("{}/{}", trace_id, query_trace_id);
     log::debug!(
         "[SCHEDULER trace_id {scheduler_trace_id}] Inside handle_derived_stream_triggers processing trigger: {}",
@@ -997,7 +997,11 @@ async fn handle_derived_stream_triggers(
 
         // evaluate trigger and configure trigger next run time
         match derived_stream
-            .evaluate((start, end), &trigger.module_key, Some(query_trace_id))
+            .evaluate(
+                (start, end),
+                &trigger.module_key,
+                Some(query_trace_id.clone()),
+            )
             .await
         {
             Err(e) => {

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -431,7 +431,10 @@ async fn write_logs(
                     if evaluated_alerts.contains(&key) {
                         continue;
                     }
-                    match alert.evaluate(Some(&record_val), (None, end_time)).await {
+                    match alert
+                        .evaluate(Some(&record_val), (None, end_time), None)
+                        .await
+                    {
                         Ok(trigger_results) if trigger_results.data.is_some() => {
                             triggers.push((alert.clone(), trigger_results.data.unwrap()));
                             evaluated_alerts.insert(key);

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -422,7 +422,10 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
                     let alert_end_time = chrono::Utc::now().timestamp_micros();
                     for alert in alerts {
-                        match alert.evaluate(Some(record), (None, alert_end_time)).await {
+                        match alert
+                            .evaluate(Some(record), (None, alert_end_time), None)
+                            .await
+                        {
                             Ok(res) if res.data.is_some() => {
                                 trigger_alerts.push((alert.clone(), res.data.unwrap()))
                             }

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -517,7 +517,10 @@ pub async fn handle_otlp_request(
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
                     let alert_end_time = chrono::Utc::now().timestamp_micros();
                     for alert in alerts {
-                        match alert.evaluate(Some(val_map), (None, alert_end_time)).await {
+                        match alert
+                            .evaluate(Some(val_map), (None, alert_end_time), None)
+                            .await
+                        {
                             Ok(res) if res.data.is_some() => {
                                 trigger_alerts.push((alert.clone(), res.data.unwrap()))
                             }

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -510,7 +510,10 @@ pub async fn remote_write(
                     let mut trigger_alerts: TriggerAlertData = Vec::new();
                     let alert_end_time = chrono::Utc::now().timestamp_micros();
                     for alert in alerts {
-                        match alert.evaluate(Some(val_map), (None, alert_end_time)).await {
+                        match alert
+                            .evaluate(Some(val_map), (None, alert_end_time), None)
+                            .await
+                        {
                             Ok(res) if res.data.is_some() => {
                                 trigger_alerts.push((alert.clone(), res.data.unwrap()))
                             }

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -919,7 +919,7 @@ async fn write_traces(
                         continue;
                     }
                     match alert
-                        .evaluate(Some(&record_val), (None, alert_end_time))
+                        .evaluate(Some(&record_val), (None, alert_end_time), None)
                         .await
                     {
                         Ok(res) if res.data.is_some() => {


### PR DESCRIPTION
In this pr, the Alert Manager passes the trace id to query requests.