### PR TITLE
feat: add mini search partitions

### DIFF
--- a/src/common/utils/auth_tests.rs
+++ b/src/common/utils/auth_tests.rs
@@ -3248,7 +3248,7 @@ mod tests {
                 inverted_index_skip_threshold: usize::default(),
                 max_query_range_for_sa: i64::default(),
                 db_text_data_type: String::default(),
-                mini_search_partition_duration_secs: u64::default(),
+                search_mini_partition_duration_secs: u64::default(),
             },
             compact: config::Compact {
                 enabled: bool::default(),

--- a/src/common/utils/auth_tests.rs
+++ b/src/common/utils/auth_tests.rs
@@ -3006,6 +3006,8 @@ mod tests {
                 session_max_lifetime_secs: i64::default(),
                 session_gc_interval_secs: i64::default(),
                 ping_interval_secs: i64::default(),
+                max_frame_size: usize::default(),
+                max_continuation_size: usize::default(),
             },
             route: config::Route {
                 timeout: u64::default(),
@@ -3246,6 +3248,7 @@ mod tests {
                 inverted_index_skip_threshold: usize::default(),
                 max_query_range_for_sa: i64::default(),
                 db_text_data_type: String::default(),
+                mini_search_partition_duration_secs: u64::default(),
             },
             compact: config::Compact {
                 enabled: bool::default(),
@@ -3273,6 +3276,7 @@ mod tests {
                 enabled: bool::default(),
                 cache_parquet: bool::default(),
                 cache_index: bool::default(),
+                delete_merge_files: bool::default(),
             },
             memory_cache: config::MemoryCache {
                 enabled: bool::default(),

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1406,12 +1406,6 @@ pub struct Limit {
         help = "Duration of each mini search partition in seconds"
     )]
     pub mini_search_partition_duration_secs: u64,
-    #[env_config(
-        name = "ZO_MINI_SEARCH_PARTITION_COUNT",
-        default = 1,
-        help = "Number of mini search partitions to create"
-    )]
-    pub mini_search_partition_count: usize,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1401,11 +1401,11 @@ pub struct Limit {
     )]
     pub max_dashboard_series: usize,
     #[env_config(
-        name = "ZO_MINI_SEARCH_PARTITION_DURATION_SECS",
+        name = "ZO_SEARCH_MINI_PARTITION_DURATION_SECS",
         default = 60,
         help = "Duration of each mini search partition in seconds"
     )]
-    pub mini_search_partition_duration_secs: u64,
+    pub search_mini_partition_duration_secs: u64,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1400,6 +1400,18 @@ pub struct Limit {
         help = "maximum series to display in charts"
     )]
     pub max_dashboard_series: usize,
+    #[env_config(
+        name = "ZO_MINI_SEARCH_PARTITION_DURATION_SECS",
+        default = 60,
+        help = "Duration of each mini search partition in seconds"
+    )]
+    pub mini_search_partition_duration_secs: u64,
+    #[env_config(
+        name = "ZO_MINI_SEARCH_PARTITION_COUNT",
+        default = 1,
+        help = "Number of mini search partitions to create"
+    )]
+    pub mini_search_partition_count: usize,
 }
 
 #[derive(EnvConfig)]

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -762,7 +762,7 @@ pub async fn search_partition(
         };
     }
 
-    let is_histogram = query.from == -1;
+    let is_histogram = sql.histogram_interval.is_some();
 
     // Create a partition generator
     let generator = partition::PartitionGenerator::new(

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -767,7 +767,7 @@ pub async fn search_partition(
     // Create a partition generator
     let generator = partition::PartitionGenerator::new(
         min_step,
-        cfg.limit.mini_search_partition_duration_secs,
+        cfg.limit.search_mini_partition_duration_secs,
         is_histogram,
     );
 

--- a/src/service/search/partition.rs
+++ b/src/service/search/partition.rs
@@ -46,13 +46,9 @@ impl PartitionGenerator {
     /// Vector of [start, end] time ranges in microseconds, in DESC order
     pub fn generate_partitions(&self, start_time: i64, end_time: i64, step: i64) -> Vec<[i64; 2]> {
         if self.is_histogram {
-            // Use the old partition logic for histogram queries
-            return self
-                .generate_partitions_aligned_with_histogram_interval(start_time, end_time, step);
+            self.generate_partitions_aligned_with_histogram_interval(start_time, end_time, step)
         } else {
-            // For non-histogram queries, generate partitions with mini partition for faster initial
-            // results
-            return self.generate_partitions_with_mini_partition(start_time, end_time, step);
+            self.generate_partitions_with_mini_partition(start_time, end_time, step)
         }
     }
 

--- a/src/service/search/partition.rs
+++ b/src/service/search/partition.rs
@@ -1,3 +1,18 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use std::cmp::max;
 
 /// Generates partitions for search queries

--- a/src/service/search/partition.rs
+++ b/src/service/search/partition.rs
@@ -1,0 +1,227 @@
+use std::cmp::max;
+
+/// Generates partitions for search queries
+pub struct PartitionGenerator {
+    /// Minimum step size in microseconds (usually based on histogram interval)
+    min_step: i64,
+    /// Duration of mini partition in seconds
+    mini_partition_duration_secs: u64,
+    /// Whether the request is for histogram
+    is_histogram: bool,
+}
+
+impl PartitionGenerator {
+    /// Create a new PartitionGenerator
+    pub fn new(min_step: i64, mini_partition_duration_secs: u64, is_histogram: bool) -> Self {
+        Self {
+            min_step,
+            mini_partition_duration_secs,
+            is_histogram,
+        }
+    }
+
+    /// Generate partitions for a time range
+    ///
+    /// # Arguments
+    /// * `start_time` - Start time in microseconds
+    /// * `end_time` - End time in microseconds
+    /// * `step` - Regular partition step size in microseconds
+    ///
+    /// # Returns
+    /// Vector of [start, end] time ranges in microseconds, in DESC order
+    pub fn generate_partitions(&self, start_time: i64, end_time: i64, step: i64) -> Vec<[i64; 2]> {
+        if self.is_histogram {
+            // Use the old partition logic for histogram queries
+            return self
+                .generate_partitions_aligned_with_histogram_interval(start_time, end_time, step);
+        } else {
+            // For non-histogram queries, generate partitions with mini partition for faster initial
+            // results
+            return self.generate_partitions_with_mini_partition(start_time, end_time, step);
+        }
+    }
+
+    /// Generate partitions with a mini partition for faster initial results
+    ///
+    /// # Arguments
+    /// * `start_time` - Start time in microseconds
+    /// * `end_time` - End time in microseconds
+    /// * `step` - Regular partition step size in microseconds
+    ///
+    /// # Returns
+    /// Vector of [start, end] time ranges in microseconds, in DESC order
+    fn generate_partitions_with_mini_partition(
+        &self,
+        start_time: i64,
+        end_time: i64,
+        step: i64,
+    ) -> Vec<[i64; 2]> {
+        // Generate partitions by DESC order
+        let mut partitions = Vec::new();
+        let mut end = end_time;
+
+        // Create a single mini partition for faster initial results
+        let mini_partition_size_microseconds =
+            std::cmp::min(self.mini_partition_duration_secs * 1_000_000, step as u64) as i64;
+
+        // Handle mini partition if it's smaller than the total range
+        if mini_partition_size_microseconds < (end_time - start_time) {
+            let start = std::cmp::max(end - mini_partition_size_microseconds, start_time);
+            partitions.push([start, end]);
+            end = start;
+        }
+
+        // Calculate remaining time range
+        while end > start_time {
+            let start = std::cmp::max(end - step, start_time);
+            partitions.push([start, end]);
+            end = start;
+        }
+
+        // Handle edge case of empty partitions
+        if partitions.is_empty() {
+            partitions.push([start_time, end_time]);
+        }
+
+        partitions
+    }
+
+    /// Generate partitions using the old logic
+    /// This method implements the original partition generation strategy
+    fn generate_partitions_aligned_with_histogram_interval(
+        &self,
+        start_time: i64,
+        end_time: i64,
+        step: i64,
+    ) -> Vec<[i64; 2]> {
+        // Generate partitions by DESC order
+        let mut partitions = Vec::new();
+        let mut end = end_time;
+        let mut last_partition_step = end % self.min_step;
+        let duration = end_time - start_time;
+
+        while end > start_time {
+            let mut start = max(end - step, start_time);
+            if last_partition_step > 0 && duration > self.min_step {
+                // Handle alignment for the first partition
+                partitions.push([end - last_partition_step, end]);
+                start -= last_partition_step;
+                end -= last_partition_step;
+            } else {
+                start = max(start - last_partition_step, start_time);
+            }
+            partitions.push([start, end]);
+            end = start;
+            last_partition_step = 0;
+        }
+
+        // Handle edge case of empty partitions
+        if partitions.is_empty() {
+            partitions.push([start_time, end_time]);
+        }
+
+        partitions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_partition_generator_with_histogram_alignment_without_mini_partition() {
+        // Test case: 10:02 - 10:17 with 5-minute histogram interval
+        let start_time = 1617267720000000; // 10:02
+        let end_time = 1617268620000000; // 10:17
+        let min_step = 300000000; // 5 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            true, // is_histogram = true
+        );
+        let step = 300000000; // 5 minutes
+
+        let partitions = generator.generate_partitions(start_time, end_time, step);
+
+        // Expected partitions:
+        // Partition 1: 10:15 - 10:17
+        // Partition 2: 10:10 - 10:15
+        // Partition 3: 10:05 - 10:10
+        // Partition 4: 10:02 - 10:05
+
+        // Print the actual partitions for debugging
+        println!("HISTOGRAM PARTITIONS:");
+        println!("Number of partitions: {}", partitions.len());
+        for (i, [start, end]) in partitions.iter().enumerate() {
+            // Convert to human-readable time for debugging
+            let start_mins = (start - 1617267600000000) / 60000000; // Minutes since 10:00
+            let end_mins = (end - 1617267600000000) / 60000000;
+            println!(
+                "Partition {}: 10:{:02} - 10:{:02} ({} - {})",
+                i + 1,
+                start_mins,
+                end_mins,
+                start,
+                end
+            );
+        }
+
+        // Verify histogram alignment
+        for [start, end] in &partitions {
+            if *start != start_time && *end != end_time {
+                assert_eq!(
+                    *start % min_step,
+                    0,
+                    "Partition start should align with histogram interval"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_partition_generator_without_histogram_alignment_mini_partition() {
+        // Test case: 10:02 - 10:17 with the same parameters as the histogram test
+        let start_time = 1617267720000000; // 10:02
+        let end_time = 1617268620000000; // 10:17
+        let min_step = 300000000; // 5 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            false, // is_histogram = false
+        );
+        let step = 300000000; // 5 minutes
+
+        let partitions = generator.generate_partitions(start_time, end_time, step);
+
+        // Expected partitions:
+        // 1. 10:16 - 10:17 (mini partition)
+        // 2. 10:11 - 10:16
+        // 3. 10:06 - 10:11
+        // 4. 10:02 - 10:06
+
+        // Print the actual partitions for debugging
+        println!("NON-HISTOGRAM PARTITIONS:");
+        println!("Number of partitions: {}", partitions.len());
+        for (i, [start, end]) in partitions.iter().enumerate() {
+            // Convert to human-readable time for debugging
+            let start_mins = (start - 1617267600000000) / 60000000; // Minutes since 10:00
+            let end_mins = (end - 1617267600000000) / 60000000;
+            println!(
+                "Partition {}: 10:{:02} - 10:{:02} ({} - {})",
+                i + 1,
+                start_mins,
+                end_mins,
+                start,
+                end
+            );
+        }
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.last().unwrap()[0], start_time);
+        assert_eq!(partitions.first().unwrap()[1], end_time);
+    }
+}


### PR DESCRIPTION
# Mini Partitions for Faster Initial Search Results

## Summary of Changes
This PR introduces "mini partitions" to improve user experience for search queries by providing faster initial results, especially for large time range queries.

## Old Partition Logic
- Created partitions of roughly equal size based on time range and data volume
- Optimized for balanced workload distribution across processing nodes
- Users had to wait until a full partition was processed before seeing any results
- For large time ranges (e.g., 7 days), the first result could take long time to appear

## New Partition Logic
- Creates small "mini partitions" at the beginning of the time range
- Followed by regular-sized partitions for the remaining time range
- Preserves all the original constraints and optimizations for regular partitions
- Users see initial results within seconds, even for large time range queries

## New Env
```sh
ZO_MINI_SEARCH_PARTITION_DURATION_SECS: Duration of each mini partition in seconds (default: 60)
```
