### PR TITLE
fix: show total events in distinct query when histogram is on

### DIFF
--- a/web/src/components/alerts/AddAlert.vue
+++ b/web/src/components/alerts/AddAlert.vue
@@ -1551,7 +1551,7 @@ export default defineComponent({
           callAlert
             .then((res: { data: any }) => {
               this.formData = { ...defaultValue };
-              this.$emit("update:list");
+              this.$emit("update:list", this.activeFolderId);
               this.addAlertForm.resetValidation();
               dismiss();
               this.q.notify({

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -243,7 +243,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       round
                       flat
                       :title="t('alerts.edit')"
-                      @click="editAlert(props.row)"
+                      @click.stop="editAlert(props.row)"
                     ></q-btn>
                     <q-btn
                       icon="content_copy"

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1401,7 +1401,7 @@ const useLogs = () => {
             searchObj.meta.showHistogram == true &&
             searchObj.data.stream.selectedStream.length <= 1 &&
             (!searchObj.meta.sqlMode ||
-              (searchObj.meta.sqlMode && !isLimitQuery(parsedSQL)))) ||
+              (searchObj.meta.sqlMode && !isLimitQuery(parsedSQL) && !isDistinctQuery(parsedSQL)))) ||
           (searchObj.loadingHistogram == false &&
             searchObj.meta.showHistogram == true &&
             searchObj.data.stream.selectedStream.length <= 1 &&


### PR DESCRIPTION
1. this PR fixes the issue that is related to when user tries to run distinct query when histogram is on 
eg:
`SELECT DISTINCT body FROM "default"`
currently it will show total events as if 50 records per page it will show 
1 to 50 out of 50 events
