### PR TITLE
fix: read and write locks

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -525,11 +525,15 @@ pub async fn get_cached_nodes(cond: fn(&Node) -> bool) -> Option<Vec<Node>> {
 pub async fn get_cached_node_by_name(name: &str) -> Option<Node> {
     let r = NODES.read().await;
     if r.is_empty() {
+        drop(r);
         return None;
     }
-    r.iter()
+    let node = r
+        .iter()
         .find(|(_uuid, node)| node.name == name)
-        .map(|(_uuid, node)| node.clone())
+        .map(|(_uuid, node)| node.clone());
+    drop(r);
+    node
 }
 
 #[inline(always)]

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -103,4 +103,4 @@ pub static WS_SESSIONS: Lazy<RwAHashMap<String, Arc<TokioRwLock<WsSession>>>> =
 pub static USER_ROLES_CACHE: Lazy<RwAHashMap<String, CachedUserRoles>> =
     Lazy::new(Default::default);
 // Global registry for search requests by `trace_id`
-pub static WS_SEARCH_REGISTRY: Lazy<DashMap<String, SearchState>> = Lazy::new(DashMap::new);
+pub static WS_SEARCH_REGISTRY: Lazy<RwAHashMap<String, SearchState>> = Lazy::new(Default::default);

--- a/src/handler/http/request/ws_v2/session.rs
+++ b/src/handler/http/request/ws_v2/session.rs
@@ -32,14 +32,15 @@ use rand::prelude::SliceRandom;
 use tokio::sync::mpsc;
 
 #[cfg(feature = "enterprise")]
+use crate::common::infra::cluster::get_cached_online_router_nodes;
+#[cfg(feature = "enterprise")]
 use crate::service::{
     self_reporting::audit,
     websocket_events::{handle_cancel, search_registry_utils},
 };
 use crate::{
     common::{
-        infra::{cluster::get_cached_online_router_nodes, config::WS_SEARCH_REGISTRY},
-        utils::websocket::get_ping_interval_secs_with_jitter,
+        infra::config::WS_SEARCH_REGISTRY, utils::websocket::get_ping_interval_secs_with_jitter,
     },
     // router::http::ws_v2::types::StreamMessage,
     service::websocket_events::{

--- a/src/router/http/ws_v2/handler.rs
+++ b/src/router/http/ws_v2/handler.rs
@@ -13,11 +13,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
 };
 
 use actix_http::StatusCode;

--- a/src/router/http/ws_v2/pool.rs
+++ b/src/router/http/ws_v2/pool.rs
@@ -40,19 +40,23 @@ impl QuerierConnectionPool {
         &self,
         querier_name: &QuerierName,
     ) -> WsResult<Arc<QuerierConnection>> {
-        if let Some(conn) = self.connections.read().await.get(querier_name) {
+        let r = self.connections.read().await;
+        if let Some(conn) = r.get(querier_name) {
             log::info!(
                 "[WS::ConnectionPool] returning existing connection to querier {querier_name}"
             );
+            drop(r);
             return Ok(conn.clone());
         }
+        drop(r);
 
         // Create new connection
         let conn = super::connection::create_connection(querier_name).await?;
-        self.connections
-            .write()
-            .await
-            .insert(querier_name.to_string(), conn.clone());
+
+        let w = self.connections.write().await;
+        w.insert(querier_name.to_string(), conn.clone());
+        drop(w);
+
         log::info!("[WS::ConnectionPool] created new connection to querier {querier_name}");
         QuerierConnectionPool::print_all_connections(
             format!("after create new {}", querier_name).as_str(),
@@ -62,10 +66,12 @@ impl QuerierConnectionPool {
     }
 
     pub async fn remove_querier_connection(&self, querier_name: &str) {
-        if let Some(conn) = self.connections.write().await.remove(querier_name) {
+        let w = self.connections.write().await;
+        if let Some(conn) = w.remove(querier_name) {
             log::warn!("[WS::ConnectionPool] removing connection to querier {querier_name}");
             conn.disconnect().await;
         }
+        drop(w);
     }
 
     pub async fn _shutdown(&self) {
@@ -83,7 +89,9 @@ impl QuerierConnectionPool {
         querier_name: &QuerierName,
     ) -> Option<Arc<QuerierConnection>> {
         let read_guard = self.connections.read().await;
-        read_guard.get(querier_name).cloned()
+        let conn = read_guard.get(querier_name).cloned();
+        drop(read_guard);
+        conn
     }
 
     pub async fn clean_up(querier_name: &QuerierName) {
@@ -106,14 +114,10 @@ impl QuerierConnectionPool {
     pub async fn print_all_connections(helper_txt: &str) {
         let ws_handler = get_ws_handler().await;
         let ws_handler_clone = ws_handler.clone();
-        for (querier_name, _) in ws_handler_clone
-            .connection_pool
-            .connections
-            .read()
-            .await
-            .iter()
-        {
+        let r = ws_handler_clone.connection_pool.connections.read().await;
+        for (querier_name, _) in r.iter() {
             log::info!("[WS::ConnectionPool]   {helper_txt}: {querier_name}");
         }
+        drop(r);
     }
 }

--- a/src/router/http/ws_v2/session.rs
+++ b/src/router/http/ws_v2/session.rs
@@ -48,8 +48,10 @@ impl SessionManager {
     ) {
         let r = self.sessions.read().await;
         if r.get(client_id).is_some() {
+            drop(r);
             return;
         }
+        drop(r);
 
         let session_info = SessionInfo {
             querier_mappings: HashMap::default(),

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -554,7 +554,7 @@ async fn process_delta(
 
     for (idx, &[start_time, end_time]) in partitions.iter().enumerate() {
         // Check if the cancellation flag is set
-        if let Some(is_cancelled) = search_registry_utils::is_cancelled(&trace_id) {
+        if let Some(is_cancelled) = search_registry_utils::is_cancelled(&trace_id).await {
             if is_cancelled {
                 // Search is cancelled, stop processing
                 return Ok(());
@@ -725,7 +725,7 @@ async fn send_cached_responses(
     curr_res_size: &mut i64,
     fallback_order_by_col: Option<String>,
 ) -> Result<(), Error> {
-    if let Some(is_cancelled) = search_registry_utils::is_cancelled(trace_id) {
+    if let Some(is_cancelled) = search_registry_utils::is_cancelled(trace_id).await {
         if is_cancelled {
             log::info!(
                 "[WS_SEARCH]: Cancellation detected for trace_id: {}, stopping cached response",
@@ -860,7 +860,7 @@ async fn do_partitioned_search(
 
     for (idx, &[start_time, end_time]) in partitions.iter().enumerate() {
         // Check if the cancellation flag is set
-        if let Some(is_cancelled) = search_registry_utils::is_cancelled(trace_id) {
+        if let Some(is_cancelled) = search_registry_utils::is_cancelled(trace_id).await {
             if is_cancelled {
                 log::info!(
                     "[WS_SEARCH]: Cancellation detected for trace_id: {}, stopping partitioned search",


### PR DESCRIPTION
- [x] ws v2 to use tokio `RwHashMap` instead of `Dashmap` to avoid dead locks
- [x] `trace_id` when retry to be different after the first retry to get a different querier from consistent hash
- [x] `user_id` for enterprise search event when run as single node