### PR TITLE
fix: logs page issues

### DIFF
--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -108,7 +108,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <FolderList
             type="alerts"
             @update:activeFolderId="updateActiveFolderId"
-            :alertsLoading="alertsLoading"
           />
         </template>
         <template #after>
@@ -836,10 +835,6 @@ export default defineComponent({
     const filteredResults: Ref<any[]> = ref([]);
     const selectedAlertToMove: Ref<any> = ref({});
     const folderIdToBeCloned = ref<any>(router.currentRoute.value.query.folder ?? "default");
-    //alertsLoading is used to disable the folderList when the alerts are loading
-    //because if users tries to load the alerts and switch the folder then again switch to other folder due to time taken by the server to fetch the alerts
-    //it may show the old folder alerts in new folders 
-    const alertsLoading = ref(false);
     const getAlertsByFolderId = async (store: any, folderId: any) => {
       try {
         //this is the condition where we are fetching the alerts from the server 
@@ -868,7 +863,6 @@ export default defineComponent({
       //for a moment also so we are not filtering the alerts by the activeTab 
       selectedAlerts.value = [];
       allSelectedAlerts.value = false;
-      alertsLoading.value = true;
       if (query){
         //here we reset the filteredResults before fetching the filtered alerts
         filteredResults.value = [];
@@ -977,9 +971,7 @@ export default defineComponent({
             });
           }
           dismiss();
-          alertsLoading.value = false;
       } catch (error) {
-        alertsLoading.value = false;
           console.error(error);
           dismiss();
           $q.notify({
@@ -1894,7 +1886,6 @@ export default defineComponent({
       refreshImportedAlerts,
       folderIdToBeCloned,
       updateFolderIdToBeCloned,
-      alertsLoading,
     };
   },
 });

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -108,6 +108,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <FolderList
             type="alerts"
             @update:activeFolderId="updateActiveFolderId"
+            :alertsLoading="alertsLoading"
           />
         </template>
         <template #after>
@@ -835,6 +836,10 @@ export default defineComponent({
     const filteredResults: Ref<any[]> = ref([]);
     const selectedAlertToMove: Ref<any> = ref({});
     const folderIdToBeCloned = ref<any>(router.currentRoute.value.query.folder ?? "default");
+    //alertsLoading is used to disable the folderList when the alerts are loading
+    //because if users tries to load the alerts and switch the folder then again switch to other folder due to time taken by the server to fetch the alerts
+    //it may show the old folder alerts in new folders 
+    const alertsLoading = ref(false);
     const getAlertsByFolderId = async (store: any, folderId: any) => {
       try {
         //this is the condition where we are fetching the alerts from the server 
@@ -863,6 +868,7 @@ export default defineComponent({
       //for a moment also so we are not filtering the alerts by the activeTab 
       selectedAlerts.value = [];
       allSelectedAlerts.value = false;
+      alertsLoading.value = true;
       if (query){
         //here we reset the filteredResults before fetching the filtered alerts
         filteredResults.value = [];
@@ -971,8 +977,9 @@ export default defineComponent({
             });
           }
           dismiss();
-        
+          alertsLoading.value = false;
       } catch (error) {
+        alertsLoading.value = false;
           console.error(error);
           dismiss();
           $q.notify({
@@ -1887,6 +1894,7 @@ export default defineComponent({
       refreshImportedAlerts,
       folderIdToBeCloned,
       updateFolderIdToBeCloned,
+      alertsLoading,
     };
   },
 });

--- a/web/src/components/common/sidebar/FolderList.vue
+++ b/web/src/components/common/sidebar/FolderList.vue
@@ -54,7 +54,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         content-class="tab_content full-width"
         class="test-class"
         :data-test="`dashboard-folder-tab-${tab.folderId}`"
-        :disable="alertsLoading"
         >
         <div class="folder-item full-width row justify-between no-wrap">
             <span class="folder-name" :title="tab.name">{{
@@ -214,10 +213,6 @@ export default defineComponent({
       type: {
         type: String,
         default: "alerts",
-      },
-      alertsLoading: {
-        type: Boolean,
-        default: false,
       },
     },
     emits: ['update:folders', 'update:activeFolderId'],

--- a/web/src/components/common/sidebar/FolderList.vue
+++ b/web/src/components/common/sidebar/FolderList.vue
@@ -54,6 +54,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         content-class="tab_content full-width"
         class="test-class"
         :data-test="`dashboard-folder-tab-${tab.folderId}`"
+        :disable="alertsLoading"
         >
         <div class="folder-item full-width row justify-between no-wrap">
             <span class="folder-name" :title="tab.name">{{
@@ -213,6 +214,10 @@ export default defineComponent({
       type: {
         type: String,
         default: "alerts",
+      },
+      alertsLoading: {
+        type: Boolean,
+        default: false,
       },
       emits: ['update:folders', 'update:activeFolderId'],
     },

--- a/web/src/components/common/sidebar/FolderList.vue
+++ b/web/src/components/common/sidebar/FolderList.vue
@@ -237,7 +237,9 @@ export default defineComponent({
       const router = useRouter();
 
       onMounted(async () => {
-        await getFoldersListByType(store, "alerts");
+        if(store.state.organizationData.foldersByType.length == 0) {
+          await getFoldersListByType(store, "alerts");
+        }
         if(router.currentRoute.value.query.folder) {
           activeFolderId.value = router.currentRoute.value.query.folder;
         }

--- a/web/src/components/common/sidebar/FolderList.vue
+++ b/web/src/components/common/sidebar/FolderList.vue
@@ -219,8 +219,8 @@ export default defineComponent({
         type: Boolean,
         default: false,
       },
-      emits: ['update:folders', 'update:activeFolderId'],
     },
+    emits: ['update:folders', 'update:activeFolderId'],
     setup(props, { emit }) {
       const store = useStore();
       const { showPositiveNotification, showErrorNotification } =

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1252,7 +1252,7 @@ export default defineComponent({
           // check is required for union query where both streams interesting fields goes into single array
           // but it should be added if field exist in the strem schema
           searchObj.data.streamResults.list.forEach((stream) => {
-            if (stream.name === parsedSQL.from[0].table) {
+            if (stream.name === parsedSQL?.from?.[0]?.table) {
               stream.schema.forEach((stream_field) => {
                 if (field.name === stream_field.name) {
                   parsedSQL.columns.push({

--- a/web/src/plugins/logs/JsonPreview.vue
+++ b/web/src/plugins/logs/JsonPreview.vue
@@ -199,7 +199,7 @@
                     round
                     class="q-mr-sm pointer"
                   ></q-btn
-                  >{{ t("common.addFieldToTable") }}</q-item-label
+                  >{{addOrRemoveLabel(key)}}</q-item-label
                 >
               </q-item-section>
             </q-item>
@@ -482,6 +482,12 @@ export default {
         return true;
       });
     });
+    const addOrRemoveLabel = (key: string) => {
+      if(searchObj.data.stream.selectedFields.includes(key)) {
+        return t("common.removeFieldFromTable");
+      }
+      return t("common.addFieldToTable");
+    };
 
     return {
       t,
@@ -510,6 +516,7 @@ export default {
       tracesStreams,
       setViewTraceBtn,
       getOriginalData,
+      addOrRemoveLabel,
     };
   },
 };

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -114,7 +114,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           @updated:dataZoom="onChartUpdate"
         />
         
-        <div v-else-if="searchObj.meta.showHistogram && (Object.keys(plotChart)?.length == 0)">
+        <div v-else-if="searchObj.meta.showHistogram && (Object.keys(plotChart)?.length == 0) && searchObj.loadingHistogram == false && searchObj.loading == false">
           <h3
             class="text-center"
             style="margin: 30px 0px"
@@ -124,8 +124,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
         <div
           class="q-pb-lg"
-          style="top: 50px; position: absolute; left: 45%"
-          v-if="searchObj.loadingHistogram == true"
+          style=" left: 45%; margin: 30px 0px"
+          v-if="(searchObj.loadingHistogram == true && searchObj.meta.showHistogram) || (searchObj.loading == true && searchObj.meta.showHistogram) && ( plotChart && Object.keys(plotChart)?.length == 0) "
+          
         >
           <q-spinner-hourglass
             color="primary"

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -125,7 +125,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div
           class="q-pb-lg"
           style=" left: 45%; margin: 30px 0px"
-          v-if="  (searchObj.meta.showHistogram) && (searchObj.loadingHistogram == true ||  searchObj.loading == true) && ( plotChart && Object.keys(plotChart)?.length == 0) "
+          v-if="histogramLoader"
           
         >
           <q-spinner-hourglass
@@ -616,6 +616,10 @@ export default defineComponent({
         return [];
       }
     });
+    //this is used to show the histogram loader when the histogram is loading
+    const histogramLoader = computed(()=>{
+      return (searchObj.meta.showHistogram) && (searchObj.loadingHistogram == true ||  searchObj.loading == true) && ( plotChart.value && Object.keys(plotChart.value)?.length == 0) 
+    })
 
     return {
       t,
@@ -655,6 +659,7 @@ export default defineComponent({
       getPaginations,
       refreshPagination,
       refreshJobPagination,
+      histogramLoader
     };
   },
   computed: {

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -125,7 +125,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div
           class="q-pb-lg"
           style=" left: 45%; margin: 30px 0px"
-          v-if="(searchObj.loadingHistogram == true && searchObj.meta.showHistogram) || (searchObj.loading == true && searchObj.meta.showHistogram) && ( plotChart && Object.keys(plotChart)?.length == 0) "
+          v-if="  (searchObj.meta.showHistogram) && (searchObj.loadingHistogram == true ||  searchObj.loading == true) && ( plotChart && Object.keys(plotChart)?.length == 0) "
           
         >
           <q-spinner-hourglass


### PR DESCRIPTION
this PR fixes
1. histogram loader should while both search and histogram request as well as no data found should only show when there is no actual data not at the time of loading
2. in the detail table when we add a field to the table it again shows add a field to the table instead should show remove from the table
3. when user try to add fields using quick mode with sql mode off there is one console error 