### PR TITLE
fix: schema page tab improvements

### DIFF
--- a/web/src/components/common/AppTabs.vue
+++ b/web/src/components/common/AppTabs.vue
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :class="[
           activeTab === tab.value ? 'active text-primary' : '',
           tab.disabled && 'disabled',
+          tab.hide && 'hidden',
         ]"
         @click="changeTab(tab)"
       >
@@ -47,6 +48,7 @@ interface Tab {
   style?: Record<string, string>;
   disabled?: boolean;
   title?: string;
+  hide?: boolean;
 }
 
 const emit = defineEmits(["update:activeTab"]);
@@ -66,7 +68,7 @@ const props = defineProps({
 });
 
 const changeTab = (tab: Tab) => {
-  if (tab.disabled) return;
+  if (tab.disabled || tab.hide) return;
   emit("update:activeTab", tab.value);
 };
 </script>

--- a/web/src/components/logstream/schema.vue
+++ b/web/src/components/logstream/schema.vue
@@ -260,7 +260,7 @@ class="indexDetailsContainer" style="height: 100vh">
                     <q-tooltip 
                     style="font-size: 14px; width: 250px;"
                     >
-                    Pre-user defined schema fields show only the schema fields that existed before the stream was configured to use a user-defined schema.
+                    Other fields show only the schema fields that existed before the stream was configured to use a user-defined schema.
                     </q-tooltip>
                   </q-icon>
                 </div>
@@ -838,7 +838,7 @@ export default defineComponent({
       if(!hasUserDefinedSchema.value){
         return 'All Fields'
       }
-      return 'Pre-User Defined Schema Fields'
+      return 'Other Fields'
     })
 
     const streamIndexType = [

--- a/web/src/components/logstream/schema.vue
+++ b/web/src/components/logstream/schema.vue
@@ -239,8 +239,9 @@ class="indexDetailsContainer" style="height: 100vh">
                 dense
               />
             </div>
-            <div class="flex justify-between items-center full-width q-mb-md">
-              <div>
+            <div class="q-mb-md">
+              <div class="flex justify-between items-center full-width">
+              <div class="flex items-center">
                 <app-tabs
                   v-if="isSchemaUDSEnabled"
                   class="schema-fields-tabs"
@@ -254,6 +255,15 @@ class="indexDetailsContainer" style="height: 100vh">
                   :active-tab="activeTab"
                   @update:active-tab="updateActiveTab"
                 />
+                <div v-if="hasUserDefinedSchema" class="q-ml-sm">
+                  <q-icon name="info" class="q-mr-xs " size="16px" style="color: #F5A623; cursor: pointer;">
+                    <q-tooltip 
+                    style="font-size: 14px; width: 250px;"
+                    >
+                    Pre-user defined schema fields show only the schema fields that existed before the stream was configured to use a user-defined schema.
+                    </q-tooltip>
+                  </q-icon>
+                </div>
               </div>
 
               <div class="flex items-center tw-gap-4">
@@ -286,6 +296,8 @@ class="indexDetailsContainer" style="height: 100vh">
                 </q-btn>
               </div>
             </div>
+            </div>
+
             <div class="q-mb-md" v-if="isDialogOpen">
               <q-card class="add-fields-card">
                 <!-- Header Section -->
@@ -751,7 +763,6 @@ export default defineComponent({
     const redBtnRows = ref([]);
 
     const newSchemaFields = ref([]);
-    const activeTab = ref("allFields");
     const activeMainTab = ref("schemaSettings");
     let previousSchemaVersion: any = null;
     const approxPartition = ref(false);
@@ -787,18 +798,26 @@ export default defineComponent({
     const allFieldsName = computed(() => {
       return store.state.zoConfig.all_fields_name;
     });
+    //here we are setting the active tab based on the user defined schema
+    //1. if there is UDS then it should be schemaFields
+    //2. if there is no UDS then it should be allFields
+    const activeTab = ref(hasUserDefinedSchema.value ? "schemaFields" : "allFields");
+
 
     const tabs = computed(() => [
-      {
-        value: "allFields",
-        label: `All Fields (${indexData.value.schema.length})`,
-        disabled: false,
-      },
-      {
+    {
         value: "schemaFields",
         label: `User Defined Schema (${indexData.value.defined_schema_fields.length})`,
         disabled: !hasUserDefinedSchema.value,
+        hide: !hasUserDefinedSchema.value,
       },
+      {
+        value: "allFields",
+        label: `${computedSchemaFieldsName.value} (${indexData.value.schema.length})`,
+        disabled: false,
+        hide: false,
+      }
+
     ]);
     const mainTabs = computed(() => [
       {
@@ -812,6 +831,15 @@ export default defineComponent({
         disabled: false,
       },
     ]);
+    //here we are making the schema field name dynamic based on the user defined schema 
+    //1. if there is UDS the it should be other fields 
+    //2. if there is no UDS then it should be all fields
+    const computedSchemaFieldsName = computed(()=>{
+      if(!hasUserDefinedSchema.value){
+        return 'All Fields'
+      }
+      return 'Pre-User Defined Schema Fields'
+    })
 
     const streamIndexType = [
       { label: "Full text search", value: "fullTextSearchKey" },
@@ -833,6 +861,16 @@ export default defineComponent({
       maxQueryRange.value = 0;
       storeOriginalData.value = false;
       approxPartition.value = false;
+    });
+    //here we added a watcher to 
+    //1. if user defined schema is enabled then we need to show the schema fields tab and also need to make sure that it would be the active tab
+    //2. if user defined schema is disabled then we need to show the all fields tab and also need to make sure that it would be the active tab
+    watch(hasUserDefinedSchema, (newVal) => {
+      if(newVal){
+        activeTab.value = "schemaFields";
+      }else{
+        activeTab.value = "allFields";
+      }
     });
 
     const isSchemaUDSEnabled = computed(() => {


### PR DESCRIPTION
1. This PR adds 
**previous approach** 
1. we were showing both All Fields and UDS tabs even user doesnot have UDS enabled 
2. UDS is shown as second tab


**current approach**
1. only show UDS if enabled otherwise show only All fields 
3. if UDS enabled show it as first tab and instead of All Fields(when UDS enabled) renamed it to Other Fields and also added tooltip with some explanatory text after Other Fields with a info icon as
**_

> Other fields show only the schema fields that existed before the stream was configured to use a user-defined schema.

_**
