### PR TITLE
feat: add query parquet cache metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,13 +402,14 @@ dependencies = [
 
 [[package]]
 name = "actix-ws"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535aec173810be3ca6f25dd5b4d431ae7125d62000aa3cbae1ec739921b02cf3"
+checksum = "a3a1fb4f9f2794b0aadaf2ba5f14a6f034c7e86957b458c506a8cb75953f2d99"
 dependencies = [
  "actix-codec",
  "actix-http",
  "actix-web",
+ "bytestring",
  "futures-core",
  "tokio",
 ]

--- a/src/common/utils/auth_tests.rs
+++ b/src/common/utils/auth_tests.rs
@@ -3268,11 +3268,15 @@ mod tests {
                 pending_jobs_metric_interval: u64::default(),
                 max_group_files: usize::default(),
             },
+            cache_latest_files: config::CacheLatestFiles {
+                enabled: bool::default(),
+                cache_parquet: bool::default(),
+                cache_index: bool::default(),
+            },
             memory_cache: config::MemoryCache {
                 enabled: bool::default(),
                 cache_strategy: String::default(),
                 bucket_num: 1,
-                cache_latest_files: bool::default(),
                 max_size: usize::default(),
                 skip_size: usize::default(),
                 release_size: usize::default(),

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1467,6 +1467,8 @@ pub struct CacheLatestFiles {
     // cache index(tantivy) files
     #[env_config(name = "ZO_CACHE_LATEST_FILES_INDEX", default = true)]
     pub cache_index: bool,
+    #[env_config(name = "ZO_CACHE_LATEST_FILES_DELETE_MERGE_FILES", default = false)]
+    pub delete_merge_files: bool,
 }
 
 #[derive(EnvConfig)]
@@ -2376,6 +2378,8 @@ fn check_disk_cache_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     if !cfg.disk_cache.enabled {
         cfg.common.result_cache_enabled = false;
         cfg.common.metrics_cache_enabled = false;
+        cfg.cache_latest_files.enabled = false;
+        cfg.cache_latest_files.delete_merge_files = false;
     }
 
     let disks = sysinfo::disk::get_disk_usage();

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -399,6 +399,7 @@ pub struct Config {
     pub common: Common,
     pub limit: Limit,
     pub compact: Compact,
+    pub cache_latest_files: CacheLatestFiles,
     pub memory_cache: MemoryCache,
     pub disk_cache: DiskCache,
     pub log: Log,
@@ -1457,6 +1458,18 @@ pub struct Compact {
 }
 
 #[derive(EnvConfig)]
+pub struct CacheLatestFiles {
+    #[env_config(name = "ZO_CACHE_LATEST_FILES_ENABLED", default = false)]
+    pub enabled: bool,
+    // cache parquet files
+    #[env_config(name = "ZO_CACHE_LATEST_FILES_PARQUET", default = true)]
+    pub cache_parquet: bool,
+    // cache index(tantivy) files
+    #[env_config(name = "ZO_CACHE_LATEST_FILES_INDEX", default = true)]
+    pub cache_index: bool,
+}
+
+#[derive(EnvConfig)]
 pub struct MemoryCache {
     #[env_config(name = "ZO_MEMORY_CACHE_ENABLED", default = true)]
     pub enabled: bool,
@@ -1466,8 +1479,6 @@ pub struct MemoryCache {
     // Memory data cache bucket num, multiple bucket means multiple locker, default is 0
     #[env_config(name = "ZO_MEMORY_CACHE_BUCKET_NUM", default = 0)]
     pub bucket_num: usize,
-    #[env_config(name = "ZO_MEMORY_CACHE_CACHE_LATEST_FILES", default = false)]
-    pub cache_latest_files: bool,
     // MB, default is 50% of system memory
     #[env_config(name = "ZO_MEMORY_CACHE_MAX_SIZE", default = 0)]
     pub max_size: usize,

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -343,7 +343,33 @@ pub static QUERY_DISK_METRICS_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(||
     .expect("Metric created")
 });
 
-// query metrics cache stats
+// query cache ratio for parquet files
+pub static QUERY_PARQUET_CACHE_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_parquet_cache_requests",
+            "Querier parquet cache requests.".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["organization", "stream_type"],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_PARQUET_CACHE_RATIO: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_parquet_cache_ratio",
+            "Querier parquet cache ratio.".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["organization", "stream_type"],
+    )
+    .expect("Metric created")
+});
+
+// query cache ratio for metrics
 pub static QUERY_METRICS_CACHE_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
@@ -356,11 +382,11 @@ pub static QUERY_METRICS_CACHE_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     )
     .expect("Metric created")
 });
-pub static QUERY_METRICS_CACHE_HITS: Lazy<IntCounterVec> = Lazy::new(|| {
+pub static QUERY_METRICS_CACHE_RATIO: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
-            "query_metrics_cache_hits",
-            "Querier metrics cache hits.".to_owned() + HELP_SUFFIX,
+            "query_metrics_cache_ratio",
+            "Querier metrics cache ratio.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -844,10 +870,16 @@ fn register_metrics(registry: &Registry) {
         .register(Box::new(QUERY_DISK_METRICS_CACHE_USED_BYTES.clone()))
         .expect("Metric registered");
     registry
+        .register(Box::new(QUERY_PARQUET_CACHE_REQUESTS.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_PARQUET_CACHE_RATIO.clone()))
+        .expect("Metric registered");
+    registry
         .register(Box::new(QUERY_METRICS_CACHE_REQUESTS.clone()))
         .expect("Metric registered");
     registry
-        .register(Box::new(QUERY_METRICS_CACHE_HITS.clone()))
+        .register(Box::new(QUERY_METRICS_CACHE_RATIO.clone()))
         .expect("Metric registered");
 
     // query manager

--- a/src/handler/grpc/request/event.rs
+++ b/src/handler/grpc/request/event.rs
@@ -101,7 +101,17 @@ impl Event for Eventer {
 
             // delete merge files
             if cfg.cache_latest_files.delete_merge_files {
-                infra::cache::file_data::delete::add(del_items);
+                if cfg.cache_latest_files.cache_parquet {
+                    infra::cache::file_data::delete::add(del_items.clone());
+                }
+                if cfg.cache_latest_files.cache_index {
+                    infra::cache::file_data::delete::add(
+                        del_items
+                            .into_iter()
+                            .filter_map(|v| convert_parquet_idx_file_name_to_tantivy_file(&v))
+                            .collect(),
+                    );
+                }
             }
         }
 

--- a/src/infra/src/cache/file_data/delete.rs
+++ b/src/infra/src/cache/file_data/delete.rs
@@ -51,5 +51,7 @@ impl Queue {
 }
 
 pub fn add(files: Vec<String>) {
-    PENDING_CHANNEL.add(files)
+    if !files.is_empty() {
+        PENDING_CHANNEL.add(files)
+    }
 }

--- a/src/infra/src/cache/file_data/delete.rs
+++ b/src/infra/src/cache/file_data/delete.rs
@@ -1,0 +1,55 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use once_cell::sync::Lazy;
+use tokio::sync::mpsc;
+
+static PENDING_CHANNEL: Lazy<Queue> = Lazy::new(Queue::new);
+
+struct Queue {
+    tx: mpsc::Sender<Vec<String>>,
+}
+
+impl Queue {
+    fn new() -> Self {
+        let (tx, mut rx) = mpsc::channel::<Vec<String>>(10240);
+        tokio::task::spawn(async move {
+            while let Some(files) = rx.recv().await {
+                for file in files {
+                    if let Err(e) =
+                        super::disk::remove(super::TRACE_ID_FOR_CACHE_LATEST_FILE, &file).await
+                    {
+                        log::error!("[CACHE:FILE_DATA] Failed to delete file: {}", e);
+                    }
+                    tokio::task::consume_budget().await;
+                }
+            }
+        });
+        Self { tx }
+    }
+
+    fn add(&self, files: Vec<String>) {
+        if let Err(e) = self.tx.try_send(files) {
+            log::error!(
+                "[CACHE:FILE_DATA] Failed to send files to pending delete channel: {:?}",
+                e
+            );
+        }
+    }
+}
+
+pub fn add(files: Vec<String>) {
+    PENDING_CHANNEL.add(files)
+}

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -310,10 +310,6 @@ impl FileData {
             return Ok(());
         };
         self.cur_size -= data_size;
-        log::debug!(
-            "[trace_id {trace_id}] File disk cache remove file done, released {} bytes",
-            data_size
-        );
 
         // delete file from local disk
         let file_path = format!(
@@ -324,7 +320,7 @@ impl FileData {
         );
         if let Err(e) = fs::remove_file(&file_path) {
             log::error!(
-                "[trace_id {trace_id}] File disk cache gc remove file: {}, error: {}",
+                "[trace_id {trace_id}] File disk cache remove file: {}, error: {}",
                 file_path,
                 e
             );

--- a/src/infra/src/cache/file_data/memory.rs
+++ b/src/infra/src/cache/file_data/memory.rs
@@ -184,10 +184,6 @@ impl FileData {
             return Ok(());
         };
         self.cur_size -= data_size;
-        log::debug!(
-            "[trace_id {trace_id}] File memory cache remove file done, released {} bytes",
-            data_size
-        );
 
         // remove file from data cache
         let idx = get_bucket_idx(&key);

--- a/src/infra/src/cache/file_data/mod.rs
+++ b/src/infra/src/cache/file_data/mod.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+pub mod delete;
 pub mod disk;
 pub mod memory;
 
@@ -26,6 +27,7 @@ use hashbrown::HashSet;
 use hashlink::lru_cache::LruCache;
 
 const INITIAL_CACHE_SIZE: usize = 128;
+pub const TRACE_ID_FOR_CACHE_LATEST_FILE: &str = "cache_latest_file";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum CacheType {

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -1187,7 +1187,7 @@ async fn write_file_list(org_id: &str, events: &[FileKey]) -> Result<(), anyhow:
             }
         };
         // send broadcast to other nodes
-        if get_config().memory_cache.cache_latest_files {
+        if get_config().cache_latest_files.enabled {
             if let Err(e) = db::file_list::broadcast::send(events, None).await {
                 log::error!("[COMPACTOR] send broadcast for file_list failed: {}", e);
             }

--- a/src/service/db/file_list/mod.rs
+++ b/src/service/db/file_list/mod.rs
@@ -63,7 +63,7 @@ pub async fn set(key: &str, meta: Option<FileMeta>, deleted: bool) -> Result<()>
     let cfg = config::get_config();
 
     // notify other nodes
-    if cfg.memory_cache.cache_latest_files {
+    if cfg.cache_latest_files.enabled {
         let mut q = broadcast::BROADCAST_QUEUE.write().await;
         q.push(file_data);
     }

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -147,9 +147,12 @@ async fn search_in_cluster(
         match cache::get(query, start, end, step).await {
             Ok(Some((new_start, values))) => {
                 let took = start_time.elapsed().as_millis() as i32;
-                config::metrics::QUERY_METRICS_CACHE_HITS
+                config::metrics::QUERY_METRICS_CACHE_RATIO
                     .with_label_values(&[&req.org_id])
-                    .inc();
+                    .inc_by(min(
+                        100,
+                        (new_start - start) as u64 * 100 / (end - start) as u64,
+                    ));
                 log::info!(
                     "[trace_id {trace_id}] promql->search->cache: hit cache, took: {} ms",
                     took

--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -641,7 +641,7 @@ pub async fn partition_filt_list(
     let querier_num = nodes.iter().filter(|node| node.is_querier()).count();
     let mut partition_strategy =
         QueryPartitionStrategy::from(&cfg.common.feature_query_partition_strategy);
-    if cfg.memory_cache.cache_latest_files {
+    if cfg.cache_latest_files.enabled {
         partition_strategy = QueryPartitionStrategy::FileHash;
     }
     let partitions = match partition_strategy {

--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use ::datafusion::arrow::record_batch::RecordBatch;
 use config::{
     meta::{function::VRLResultResolver, search, sql::TableReferenceExt},
+    metrics::{QUERY_PARQUET_CACHE_RATIO, QUERY_PARQUET_CACHE_REQUESTS},
     utils::{
         arrow::record_batches_to_json_rows,
         flatten,
@@ -271,18 +272,26 @@ pub async fn search(
     result.set_file_count(scan_stats.files as usize);
     result.set_scan_size(scan_stats.original_size as usize);
     result.set_scan_records(scan_stats.records as usize);
-    result.set_cached_ratio(
-        (((scan_stats.querier_memory_cached_files + scan_stats.querier_disk_cached_files) * 100)
-            as f64
-            / scan_stats.querier_files as f64) as usize,
-    );
     result.set_idx_scan_size(scan_stats.idx_scan_size as usize);
-
     result.set_idx_took(if idx_took > 0 {
         idx_took
     } else {
         scan_stats.idx_took as usize
     });
+
+    if scan_stats.querier_files > 0 {
+        let parquet_cached_ratio = (((scan_stats.querier_memory_cached_files
+            + scan_stats.querier_disk_cached_files)
+            * 100) as f64
+            / scan_stats.querier_files as f64) as usize;
+        result.set_cached_ratio(parquet_cached_ratio);
+        QUERY_PARQUET_CACHE_RATIO
+            .with_label_values(&[&sql.org_id, &sql.stream_type.to_string()])
+            .inc_by(parquet_cached_ratio as u64);
+        QUERY_PARQUET_CACHE_REQUESTS
+            .with_label_values(&[&sql.org_id, &sql.stream_type.to_string()])
+            .inc();
+    }
 
     if query_type == "table" {
         result.response_type = "table".to_string();


### PR DESCRIPTION
## Add new metrics for parquet cache

- `query_parquet_cache_requests`: how many query requests
- `query_parquet_cache_ratio`: total parquet files cached ratio

For each request on each node, the `requests` will +1, the `ratio` will +%, for example, need query 100 files, cached 71 files on local, `ratio` will +71 (71/100).

Also updated query cache metrics for metrics
- `query_metrics_cache_requests`: how many PromQL metrics query requests
- `query_metrics_cache_ratio`: total metrics result cache ratio for PromQL

For each PromQL request(leader), the `requests` will +1, the `ratio` will +%, for example, query for 1 hour, step is 1min, cached 50 mins, only need query for last 10 mins, `ratio` will +83 (50/60).
## Add new option for cache latest file
deprecated
```
ZO_MEMORY_CACHE_CACHE_LATEST_FILES
```
Start using 4 new env:
```
ZO_CACHE_LATEST_FILES_ENABLED=false
ZO_CACHE_LATEST_FILES_PARQUET=true
ZO_CACHE_LATEST_FILES_INDEX=true
ZO_CACHE_LATEST_FILES_DELETE_MERGE_FILES=false
```