### PR TITLE
feat: add option for index all

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -81,10 +81,11 @@ pub const MINIMUM_DB_CONNECTIONS: u32 = 2;
 pub const REQUIRED_DB_CONNECTIONS: u32 = 4;
 
 // Columns added to ingested records for _INTERNAL_ use only.
-// Used for storing and querying unflattened original data
-pub const ORIGINAL_DATA_COL_NAME: &str = "_original";
-pub const ID_COL_NAME: &str = "_o2_id";
 pub const TIMESTAMP_COL_NAME: &str = "_timestamp";
+// Used for storing and querying unflattened original data
+pub const ID_COL_NAME: &str = "_o2_id";
+pub const ORIGINAL_DATA_COL_NAME: &str = "_original";
+pub const ALL_VALUES_COL_NAME: &str = "_all_values";
 
 const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 7] =
     ["log", "message", "msg", "content", "data", "body", "json"];

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -547,6 +547,10 @@ pub struct UpdateStreamSettings {
     pub approx_partition: Option<bool>,
     #[serde(default)]
     pub extended_retention_days: UpdateSettingsWrapper<TimeRange>,
+    #[serde(default)]
+    pub index_original_data: Option<bool>,
+    #[serde(default)]
+    pub index_all_values: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
@@ -674,6 +678,10 @@ pub struct StreamSettings {
     pub index_updated_at: i64,
     #[serde(default)]
     pub extended_retention_days: Vec<TimeRange>,
+    #[serde(default)]
+    pub index_original_data: bool,
+    #[serde(default)]
+    pub index_all_values: bool,
 }
 
 impl Serialize for StreamSettings {
@@ -701,6 +709,8 @@ impl Serialize for StreamSettings {
         state.serialize_field("approx_partition", &self.approx_partition)?;
         state.serialize_field("index_updated_at", &self.index_updated_at)?;
         state.serialize_field("extended_retention_days", &self.extended_retention_days)?;
+        state.serialize_field("index_original_data", &self.index_original_data)?;
+        state.serialize_field("index_all_values", &self.index_all_values)?;
 
         match self.defined_schema_fields.as_ref() {
             Some(fields) => {
@@ -850,6 +860,16 @@ impl From<&str> for StreamSettings {
             }
         }
 
+        let index_original_data = settings
+            .get("index_original_data")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let index_all_values = settings
+            .get("index_all_values")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
         Self {
             partition_time_level,
             partition_keys,
@@ -865,6 +885,8 @@ impl From<&str> for StreamSettings {
             distinct_value_fields,
             index_updated_at,
             extended_retention_days,
+            index_original_data,
+            index_all_values,
         }
     }
 }

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -18,8 +18,8 @@ use std::{collections::HashMap, sync::Arc};
 use arc_swap::ArcSwap;
 use chrono::Utc;
 use config::{
-    BLOOM_FILTER_DEFAULT_FIELDS, RwAHashMap, RwHashMap, SQL_FULL_TEXT_SEARCH_FIELDS,
-    SQL_SECONDARY_INDEX_SEARCH_FIELDS, get_config,
+    ALL_VALUES_COL_NAME, BLOOM_FILTER_DEFAULT_FIELDS, ORIGINAL_DATA_COL_NAME, RwAHashMap,
+    RwHashMap, SQL_FULL_TEXT_SEARCH_FIELDS, SQL_SECONDARY_INDEX_SEARCH_FIELDS, get_config,
     ider::SnowflakeIdGenerator,
     meta::stream::{PartitionTimeLevel, StreamSettings, StreamType},
     utils::{json, schema_ext::SchemaExt},
@@ -280,6 +280,11 @@ pub fn get_stream_setting_fts_fields(settings: &Option<StreamSettings>) -> Vec<S
         Some(settings) => {
             let mut fields = settings.full_text_search_keys.clone();
             fields.extend(default_fields);
+            if settings.index_original_data {
+                fields.push(ORIGINAL_DATA_COL_NAME.to_string());
+            } else if settings.index_all_values {
+                fields.push(ALL_VALUES_COL_NAME.to_string());
+            }
             fields.sort();
             fields.dedup();
             fields

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -682,19 +682,24 @@ async fn merge_files(
     let bloom_filter_fields = get_stream_setting_bloom_filter_fields(&stream_settings);
     let full_text_search_fields = get_stream_setting_fts_fields(&stream_settings);
     let index_fields = get_stream_setting_index_fields(&stream_settings);
-    let (defined_schema_fields, need_original) = match stream_settings {
-        Some(s) => (
-            s.defined_schema_fields.unwrap_or_default(),
-            s.store_original_data,
-        ),
-        None => (Vec::new(), false),
-    };
+    let (defined_schema_fields, need_original, index_original_data, index_all_values) =
+        match stream_settings {
+            Some(s) => (
+                s.defined_schema_fields.unwrap_or_default(),
+                s.store_original_data,
+                s.index_original_data,
+                s.index_all_values,
+            ),
+            None => (Vec::new(), false, false, false),
+        };
     let latest_schema = if !defined_schema_fields.is_empty() {
         let latest_schema = SchemaCache::new(latest_schema.as_ref().clone());
         let latest_schema = generate_schema_for_defined_schema_fields(
             &latest_schema,
             &defined_schema_fields,
             need_original,
+            index_original_data,
+            index_all_values,
         );
         latest_schema.schema().clone()
     } else {

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -792,19 +792,24 @@ pub async fn merge_files(
     let bloom_filter_fields = get_stream_setting_bloom_filter_fields(&stream_settings);
     let full_text_search_fields = get_stream_setting_fts_fields(&stream_settings);
     let index_fields = get_stream_setting_index_fields(&stream_settings);
-    let (defined_schema_fields, need_original) = match stream_settings {
-        Some(s) => (
-            s.defined_schema_fields.unwrap_or_default(),
-            s.store_original_data,
-        ),
-        None => (Vec::new(), false),
-    };
+    let (defined_schema_fields, need_original, index_original_data, index_all_values) =
+        match stream_settings {
+            Some(s) => (
+                s.defined_schema_fields.unwrap_or_default(),
+                s.store_original_data,
+                s.index_original_data,
+                s.index_all_values,
+            ),
+            None => (Vec::new(), false, false, false),
+        };
     let latest_schema = if !defined_schema_fields.is_empty() {
         let latest_schema = SchemaCache::new(latest_schema);
         let latest_schema = generate_schema_for_defined_schema_fields(
             &latest_schema,
             &defined_schema_fields,
             need_original,
+            index_original_data,
+            index_all_values,
         );
         latest_schema.schema().as_ref().clone()
     } else {

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -514,6 +514,7 @@ pub async fn get_uds_and_original_data_streams(
     streams: &[StreamParams],
     user_defined_schema_map: &mut HashMap<String, Option<HashSet<String>>>,
     streams_need_original: &mut HashMap<String, bool>,
+    streams_need_all_values: &mut HashMap<String, bool>,
 ) {
     for stream in streams {
         if user_defined_schema_map.contains_key(stream.stream_name.as_str()) {
@@ -525,7 +526,11 @@ pub async fn get_uds_and_original_data_streams(
                 .unwrap_or_default();
         streams_need_original.insert(
             stream.stream_name.to_string(),
-            stream_settings.store_original_data,
+            stream_settings.store_original_data || stream_settings.index_original_data,
+        );
+        streams_need_all_values.insert(
+            stream.stream_name.to_string(),
+            stream_settings.index_all_values,
         );
         if let Some(fields) = &stream_settings.defined_schema_fields {
             if !fields.is_empty() {

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -83,6 +83,7 @@ pub async fn ingest(
 
     let mut user_defined_schema_map: HashMap<String, Option<HashSet<String>>> = HashMap::new();
     let mut streams_need_original_map: HashMap<String, bool> = HashMap::new();
+    let mut streams_need_all_values_map: HashMap<String, bool> = HashMap::new();
     let mut store_original_when_pipeline_exists = false;
 
     let mut json_data_by_stream = HashMap::new();
@@ -170,6 +171,7 @@ pub async fn ingest(
                 &streams,
                 &mut user_defined_schema_map,
                 &mut streams_need_original_map,
+                &mut streams_need_all_values_map,
             )
             .await;
 
@@ -380,6 +382,7 @@ pub async fn ingest(
                                 &[stream_params],
                                 &mut user_defined_schema_map,
                                 &mut streams_need_original_map,
+                                &mut streams_need_all_values_map,
                             )
                             .await;
                         }

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -99,10 +99,12 @@ pub async fn ingest(
     // Start get user defined schema
     let mut user_defined_schema_map: HashMap<String, Option<HashSet<String>>> = HashMap::new();
     let mut streams_need_original_map: HashMap<String, bool> = HashMap::new();
+    let mut streams_need_all_values_map: HashMap<String, bool> = HashMap::new();    
     crate::service::ingestion::get_uds_and_original_data_streams(
         &stream_params,
         &mut user_defined_schema_map,
         &mut streams_need_original_map,
+        &mut streams_need_all_values_map,
     )
     .await;
     // with pipeline, we need to store original if any of the destinations requires original
@@ -301,6 +303,7 @@ pub async fn ingest(
                             &[stream_params],
                             &mut user_defined_schema_map,
                             &mut streams_need_original_map,
+                            &mut streams_need_all_values_map,
                         )
                         .await;
                     }

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -22,7 +22,7 @@ use actix_web::http;
 use anyhow::Result;
 use chrono::{Duration, Utc};
 use config::{
-    ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME,
+    ALL_VALUES_COL_NAME, ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME,
     meta::{
         self_reporting::usage::UsageType,
         stream::{StreamParams, StreamType},
@@ -99,7 +99,7 @@ pub async fn ingest(
     // Start get user defined schema
     let mut user_defined_schema_map: HashMap<String, Option<HashSet<String>>> = HashMap::new();
     let mut streams_need_original_map: HashMap<String, bool> = HashMap::new();
-    let mut streams_need_all_values_map: HashMap<String, bool> = HashMap::new();    
+    let mut streams_need_all_values_map: HashMap<String, bool> = HashMap::new();
     crate::service::ingestion::get_uds_and_original_data_streams(
         &stream_params,
         &mut user_defined_schema_map,
@@ -255,6 +255,31 @@ pub async fn ingest(
                 );
             }
 
+            // add `_all_values` if required by StreamSettings
+            if streams_need_all_values_map
+                .get(&stream_name)
+                .is_some_and(|v| *v)
+            {
+                let mut values = Vec::with_capacity(local_val.len());
+                for (k, value) in local_val.iter() {
+                    if [
+                        TIMESTAMP_COL_NAME,
+                        ID_COL_NAME,
+                        ORIGINAL_DATA_COL_NAME,
+                        ALL_VALUES_COL_NAME,
+                    ]
+                    .contains(&k.as_str())
+                    {
+                        continue;
+                    }
+                    values.push(value.to_string());
+                }
+                local_val.insert(
+                    ALL_VALUES_COL_NAME.to_string(),
+                    json::Value::String(values.join(" ")),
+                );
+            }
+
             let (ts_data, fn_num) = json_data_by_stream
                 .entry(stream_name.clone())
                 .or_insert_with(|| (Vec::new(), None));
@@ -360,6 +385,31 @@ pub async fn ingest(
                             );
                         }
 
+                        // add `_all_values` if required by StreamSettings
+                        if streams_need_all_values_map
+                            .get(&destination_stream)
+                            .is_some_and(|v| *v)
+                        {
+                            let mut values = Vec::with_capacity(local_val.len());
+                            for (k, value) in local_val.iter() {
+                                if [
+                                    TIMESTAMP_COL_NAME,
+                                    ID_COL_NAME,
+                                    ORIGINAL_DATA_COL_NAME,
+                                    ALL_VALUES_COL_NAME,
+                                ]
+                                .contains(&k.as_str())
+                                {
+                                    continue;
+                                }
+                                values.push(value.to_string());
+                            }
+                            local_val.insert(
+                                ALL_VALUES_COL_NAME.to_string(),
+                                json::Value::String(values.join(" ")),
+                            );
+                        }
+
                         let (ts_data, fn_num) = json_data_by_stream
                             .entry(destination_stream.clone())
                             .or_insert_with(|| (Vec::new(), None));
@@ -383,6 +433,7 @@ pub async fn ingest(
 
     // drop memory-intensive variables
     drop(streams_need_original_map);
+    drop(streams_need_all_values_map);
     drop(executable_pipeline);
     drop(original_options);
     drop(user_defined_schema_map);

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -94,10 +94,12 @@ pub async fn handle_grpc_request(
     // Start get user defined schema
     let mut user_defined_schema_map: HashMap<String, Option<HashSet<String>>> = HashMap::new();
     let mut streams_need_original_map: HashMap<String, bool> = HashMap::new();
+    let mut streams_need_all_values_map: HashMap<String, bool> = HashMap::new();
     crate::service::ingestion::get_uds_and_original_data_streams(
         &stream_params,
         &mut user_defined_schema_map,
         &mut streams_need_original_map,
+        &mut streams_need_all_values_map,
     )
     .await;
     // with pipeline, we need to store original if any of the destinations requires original
@@ -310,6 +312,7 @@ pub async fn handle_grpc_request(
                             &[stream_params],
                             &mut user_defined_schema_map,
                             &mut streams_need_original_map,
+                            &mut streams_need_all_values_map,
                         )
                         .await;
                     }

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use bytes::BytesMut;
 use chrono::{Duration, Utc};
 use config::{
-    ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME, get_config,
+    ALL_VALUES_COL_NAME, ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME, get_config,
     meta::{
         self_reporting::usage::UsageType,
         stream::{StreamParams, StreamType},
@@ -263,6 +263,31 @@ pub async fn handle_grpc_request(
                         );
                     }
 
+                    // add `_all_values` if required by StreamSettings
+                    if streams_need_all_values_map
+                        .get(&stream_name)
+                        .is_some_and(|v| *v)
+                    {
+                        let mut values = Vec::with_capacity(local_val.len());
+                        for (k, value) in local_val.iter() {
+                            if [
+                                TIMESTAMP_COL_NAME,
+                                ID_COL_NAME,
+                                ORIGINAL_DATA_COL_NAME,
+                                ALL_VALUES_COL_NAME,
+                            ]
+                            .contains(&k.as_str())
+                            {
+                                continue;
+                            }
+                            values.push(value.to_string());
+                        }
+                        local_val.insert(
+                            ALL_VALUES_COL_NAME.to_string(),
+                            json::Value::String(values.join(" ")),
+                        );
+                    }
+
                     let (ts_data, fn_num) = json_data_by_stream
                         .entry(stream_name.clone())
                         .or_insert((Vec::new(), None));
@@ -347,6 +372,31 @@ pub async fn handle_grpc_request(
                             local_val.insert(
                                 ID_COL_NAME.to_string(),
                                 json::Value::String(record_id.to_string()),
+                            );
+                        }
+
+                        // add `_all_values` if required by StreamSettings
+                        if streams_need_all_values_map
+                            .get(&destination_stream)
+                            .is_some_and(|v| *v)
+                        {
+                            let mut values = Vec::with_capacity(local_val.len());
+                            for (k, value) in local_val.iter() {
+                                if [
+                                    TIMESTAMP_COL_NAME,
+                                    ID_COL_NAME,
+                                    ORIGINAL_DATA_COL_NAME,
+                                    ALL_VALUES_COL_NAME,
+                                ]
+                                .contains(&k.as_str())
+                                {
+                                    continue;
+                                }
+                                values.push(value.to_string());
+                            }
+                            local_val.insert(
+                                ALL_VALUES_COL_NAME.to_string(),
+                                json::Value::String(values.join(" ")),
                             );
                         }
 

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use bytes::BytesMut;
 use chrono::{Duration, Utc};
 use config::{
-    ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME, get_config,
+    ALL_VALUES_COL_NAME, ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME, get_config,
     meta::{
         self_reporting::usage::UsageType,
         stream::{StreamParams, StreamType},
@@ -395,6 +395,31 @@ pub async fn logs_json_handler(
                         );
                     }
 
+                    // add `_all_values` if required by StreamSettings
+                    if streams_need_all_values_map
+                        .get(&stream_name)
+                        .is_some_and(|v| *v)
+                    {
+                        let mut values = Vec::with_capacity(local_val.len());
+                        for (k, value) in local_val.iter() {
+                            if [
+                                TIMESTAMP_COL_NAME,
+                                ID_COL_NAME,
+                                ORIGINAL_DATA_COL_NAME,
+                                ALL_VALUES_COL_NAME,
+                            ]
+                            .contains(&k.as_str())
+                            {
+                                continue;
+                            }
+                            values.push(value.to_string());
+                        }
+                        local_val.insert(
+                            ALL_VALUES_COL_NAME.to_string(),
+                            json::Value::String(values.join(" ")),
+                        );
+                    }
+
                     let (ts_data, fn_num) = json_data_by_stream
                         .entry(stream_name.clone())
                         .or_insert((Vec::new(), None));
@@ -479,6 +504,31 @@ pub async fn logs_json_handler(
                             local_val.insert(
                                 ID_COL_NAME.to_string(),
                                 json::Value::String(record_id.to_string()),
+                            );
+                        }
+
+                        // add `_all_values` if required by StreamSettings
+                        if streams_need_all_values_map
+                            .get(&destination_stream)
+                            .is_some_and(|v| *v)
+                        {
+                            let mut values = Vec::with_capacity(local_val.len());
+                            for (k, value) in local_val.iter() {
+                                if [
+                                    TIMESTAMP_COL_NAME,
+                                    ID_COL_NAME,
+                                    ORIGINAL_DATA_COL_NAME,
+                                    ALL_VALUES_COL_NAME,
+                                ]
+                                .contains(&k.as_str())
+                                {
+                                    continue;
+                                }
+                                values.push(value.to_string());
+                            }
+                            local_val.insert(
+                                ALL_VALUES_COL_NAME.to_string(),
+                                json::Value::String(values.join(" ")),
                             );
                         }
 

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -129,10 +129,12 @@ pub async fn logs_json_handler(
     // Start get user defined schema
     let mut user_defined_schema_map: HashMap<String, Option<HashSet<String>>> = HashMap::new();
     let mut streams_need_original_map: HashMap<String, bool> = HashMap::new();
+    let mut streams_need_all_values_map: HashMap<String, bool> = HashMap::new();
     crate::service::ingestion::get_uds_and_original_data_streams(
         &stream_params,
         &mut user_defined_schema_map,
         &mut streams_need_original_map,
+        &mut streams_need_all_values_map,
     )
     .await;
     // with pipeline, we need to store original if any of the destinations requires original
@@ -442,6 +444,7 @@ pub async fn logs_json_handler(
                             &[stream_params],
                             &mut user_defined_schema_map,
                             &mut streams_need_original_map,
+                            &mut streams_need_all_values_map,
                         )
                         .await;
                     }

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -108,10 +108,12 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
     // Start get user defined schema
     let mut user_defined_schema_map: HashMap<String, Option<HashSet<String>>> = HashMap::new();
     let mut streams_need_original_map: HashMap<String, bool> = HashMap::new();
+    let mut streams_need_all_values_map: HashMap<String, bool> = HashMap::new();
     crate::service::ingestion::get_uds_and_original_data_streams(
         &stream_params,
         &mut user_defined_schema_map,
         &mut streams_need_original_map,
+        &mut streams_need_all_values_map,
     )
     .await;
     // with pipeline, we need to store original if any of the destinations requires original
@@ -252,6 +254,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
                             &[stream_params],
                             &mut user_defined_schema_map,
                             &mut streams_need_original_map,
+                            &mut streams_need_all_values_map,
                         )
                         .await;
                     }

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -22,7 +22,7 @@ use actix_web::{HttpResponse, http};
 use anyhow::Result;
 use chrono::{Duration, Utc};
 use config::{
-    ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME, get_config,
+    ALL_VALUES_COL_NAME, ID_COL_NAME, ORIGINAL_DATA_COL_NAME, TIMESTAMP_COL_NAME, get_config,
     meta::{
         self_reporting::usage::UsageType,
         stream::{StreamParams, StreamType},
@@ -208,6 +208,31 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
             );
         }
 
+        // add `_all_values` if required by StreamSettings
+        if streams_need_all_values_map
+            .get(&stream_name)
+            .is_some_and(|v| *v)
+        {
+            let mut values = Vec::with_capacity(local_val.len());
+            for (k, value) in local_val.iter() {
+                if [
+                    TIMESTAMP_COL_NAME,
+                    ID_COL_NAME,
+                    ORIGINAL_DATA_COL_NAME,
+                    ALL_VALUES_COL_NAME,
+                ]
+                .contains(&k.as_str())
+                {
+                    continue;
+                }
+                values.push(value.to_string());
+            }
+            local_val.insert(
+                ALL_VALUES_COL_NAME.to_string(),
+                json::Value::String(values.join(" ")),
+            );
+        }
+
         let (ts_data, fn_num) = json_data_by_stream
             .entry(stream_name.clone())
             .or_insert((Vec::new(), None));
@@ -312,6 +337,31 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
                             local_val.insert(
                                 ID_COL_NAME.to_string(),
                                 json::Value::String(record_id.to_string()),
+                            );
+                        }
+
+                        // add `_all_values` if required by StreamSettings
+                        if streams_need_all_values_map
+                            .get(&destination_stream)
+                            .is_some_and(|v| *v)
+                        {
+                            let mut values = Vec::with_capacity(local_val.len());
+                            for (k, value) in local_val.iter() {
+                                if [
+                                    TIMESTAMP_COL_NAME,
+                                    ID_COL_NAME,
+                                    ORIGINAL_DATA_COL_NAME,
+                                    ALL_VALUES_COL_NAME,
+                                ]
+                                .contains(&k.as_str())
+                                {
+                                    continue;
+                                }
+                                values.push(value.to_string());
+                            }
+                            local_val.insert(
+                                ALL_VALUES_COL_NAME.to_string(),
+                                json::Value::String(values.join(" ")),
                             );
                         }
 

--- a/src/service/metadata/trace_list_index.rs
+++ b/src/service/metadata/trace_list_index.rs
@@ -214,6 +214,8 @@ impl TraceListIndex {
                 distinct_value_fields: vec![],
                 index_updated_at: 0,
                 extended_retention_days: vec![],
+                index_all_values: false,
+                index_original_data: false,
             };
 
             stream::save_stream_settings(org_id, STREAM_NAME, StreamType::Metadata, settings)

--- a/src/service/schema.rs
+++ b/src/service/schema.rs
@@ -17,7 +17,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
 use config::{
-    ID_COL_NAME, ORIGINAL_DATA_COL_NAME, SQL_FULL_TEXT_SEARCH_FIELDS, TIMESTAMP_COL_NAME,
+    ALL_VALUES_COL_NAME, ID_COL_NAME, ORIGINAL_DATA_COL_NAME, SQL_FULL_TEXT_SEARCH_FIELDS,
+    TIMESTAMP_COL_NAME,
     cluster::LOCAL_NODE_ID,
     get_config,
     ider::SnowflakeIdGenerator,
@@ -109,18 +110,23 @@ pub async fn check_for_schema(
         if !is_schema_changed {
             // check defined_schema_fields
             let stream_setting = unwrap_stream_settings(schema.schema());
-            let (defined_schema_fields, need_original) = match stream_setting {
-                Some(s) => (
-                    s.defined_schema_fields.unwrap_or_default(),
-                    s.store_original_data,
-                ),
-                None => (Vec::new(), false),
-            };
+            let (defined_schema_fields, need_original, index_original_data, index_all_values) =
+                match stream_setting {
+                    Some(s) => (
+                        s.defined_schema_fields.unwrap_or_default(),
+                        s.store_original_data,
+                        s.index_original_data,
+                        s.index_all_values,
+                    ),
+                    None => (Vec::new(), false, false, false),
+                };
             if !defined_schema_fields.is_empty() {
                 let schema = generate_schema_for_defined_schema_fields(
                     schema,
                     &defined_schema_fields,
                     need_original,
+                    index_original_data,
+                    index_all_values,
                 );
                 stream_schema_map.insert(stream_name.to_string(), schema);
             }
@@ -411,7 +417,9 @@ async fn handle_diff_schema(
     w.insert(cache_key.clone(), final_schema.clone());
     drop(w);
     let need_original = stream_setting.store_original_data;
-    if need_original {
+    let index_original_data = stream_setting.index_original_data;
+    let index_all_values = stream_setting.index_all_values;
+    if need_original || index_original_data {
         if let dashmap::Entry::Vacant(entry) = STREAM_RECORD_ID_GENERATOR.entry(cache_key.clone()) {
             entry.insert(SnowflakeIdGenerator::new(unsafe { LOCAL_NODE_ID }));
         }
@@ -426,6 +434,8 @@ async fn handle_diff_schema(
         &final_schema,
         &defined_schema_fields,
         need_original,
+        index_original_data,
+        index_all_values,
     );
     stream_schema_map.insert(stream_name.to_string(), final_schema);
 
@@ -450,6 +460,8 @@ pub fn generate_schema_for_defined_schema_fields(
     schema: &SchemaCache,
     fields: &[String],
     need_original: bool,
+    index_original_data: bool,
+    index_all_values: bool,
 ) -> SchemaCache {
     if fields.is_empty() || schema.fields_map().len() < fields.len() + 10 {
         return schema.clone();
@@ -459,6 +471,7 @@ pub fn generate_schema_for_defined_schema_fields(
     let timestamp_col = TIMESTAMP_COL_NAME.to_string();
     let o2_id_col = ID_COL_NAME.to_string();
     let original_col = ORIGINAL_DATA_COL_NAME.to_string();
+    let all_values_col = ALL_VALUES_COL_NAME.to_string();
 
     let mut fields: HashSet<&String> = fields.iter().collect();
     if !fields.contains(&timestamp_col) {
@@ -467,12 +480,17 @@ pub fn generate_schema_for_defined_schema_fields(
     if !fields.contains(&cfg.common.column_all) {
         fields.insert(&cfg.common.column_all);
     }
-    if need_original {
+    if need_original || index_original_data {
         if !fields.contains(&o2_id_col) {
             fields.insert(&o2_id_col);
         }
         if !fields.contains(&original_col) {
             fields.insert(&original_col);
+        }
+    }
+    if index_all_values {
+        if !fields.contains(&all_values_col) {
+            fields.insert(&all_values_col);
         }
     }
 

--- a/src/service/schema.rs
+++ b/src/service/schema.rs
@@ -488,10 +488,8 @@ pub fn generate_schema_for_defined_schema_fields(
             fields.insert(&original_col);
         }
     }
-    if index_all_values {
-        if !fields.contains(&all_values_col) {
-            fields.insert(&all_values_col);
-        }
+    if index_all_values && !fields.contains(&all_values_col) {
+        fields.insert(&all_values_col);
     }
 
     let mut new_fields = Vec::with_capacity(fields.len());

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -1624,7 +1624,8 @@ fn o2_id_is_needed(
     !matches!(search_event_type, Some(SearchEventType::DerivedStream))
         && schemas.values().any(|schema| {
             let stream_setting = unwrap_stream_settings(schema.schema());
-            stream_setting.is_some_and(|setting| setting.store_original_data)
+            stream_setting
+                .is_some_and(|setting| setting.store_original_data || setting.index_original_data)
         })
 }
 


### PR DESCRIPTION
This PR add two new options for stream setting:

```
index_original_data: false
index_all_values: false
```

## index_original_data
Enable it will create Full text index on the original data.
> This is force enable `store_original_data: true`

## index_all_values
Enable it will create Full text index on the field `_all_values` which collect all the fields values.