### PR TITLE
fix: base64 encode should be only in logs page

### DIFF
--- a/web/src/components/alerts/AddAlert.vue
+++ b/web/src/components/alerts/AddAlert.vue
@@ -1217,6 +1217,10 @@ export default defineComponent({
       query.query.start_time = query.query.start_time + 780000000;
 
       query.query.sql = formData.value.query_condition.sql;
+      //removed the encoding as it is not required for the alert queries 
+      if(store.state.zoConfig.sql_base64_enabled && query?.encoding){
+        delete query.encoding;
+      }
 
       if (formData.value.query_condition.vrl_function)
         query.query.query_fn = b64EncodeUnicode(

--- a/web/src/components/pipeline/NodeForm/Query.vue
+++ b/web/src/components/pipeline/NodeForm/Query.vue
@@ -479,6 +479,11 @@ const validateSqlQuery = () => {
 
   query.query.sql = streamRoute.value.query_condition.sql;
 
+  //removed the encoding as it is not required for the pipeline queries 
+  if(store.state.zoConfig.sql_base64_enabled && query?.encoding){
+    delete query.encoding;
+  }
+
   validateSqlQueryPromise.value = new Promise((resolve, reject) => {
     searchService
       .search({

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1099,8 +1099,8 @@ const useLogs = () => {
       if (store.state.zoConfig.sql_base64_enabled) {
         req["encoding"] = "base64";
         req.query.sql = b64EncodeUnicode(req.query.sql);
+        //encode the histogram only if the current page is 1 
         if (
-          !searchObj.meta.sqlMode &&
           searchObj.data.resultGrid.currentPage == 1
         ) {
           req.aggs.histogram = b64EncodeUnicode(req.aggs.histogram);


### PR DESCRIPTION
encoding of sql to base64 from UI when specified only in logs page not in alerts or pipelines page