### PR TITLE
feat: implement `aligntime` for alert manager alerts/pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,6 +2455,7 @@ dependencies = [
  "chromiumoxide",
  "chrono",
  "cityhasher",
+ "cron",
  "dashmap",
  "datafusion",
  "dotenv_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ clap = { version = "4.1", default-features = false, features = [
     "cargo",
 ] }
 cloudevents-sdk = { version = "0.7.0", features = ["actix"] }
-cron = "0.15"
+cron.workspace = true
 csv = "1.3"
 dashmap.workspace = true
 datafusion.workspace = true
@@ -237,6 +237,7 @@ chromiumoxide = { git = "https://github.com/mattsse/chromiumoxide", features = [
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 cityhasher = { version = "0.1", default-features = false }
 collapse = "0.1.2"
+cron = "0.15"
 dashmap = { version = "6.1", features = ["serde"] }
 datafusion = "45.0.0"
 datafusion-proto = "45.0.0"

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -27,6 +27,7 @@ byteorder.workspace = true
 chrono.workspace = true
 cityhasher.workspace = true
 chromiumoxide.workspace = true
+cron.workspace = true
 datafusion.workspace = true
 dashmap.workspace = true
 dotenv_config.workspace = true

--- a/src/config/src/meta/alerts/mod.rs
+++ b/src/config/src/meta/alerts/mod.rs
@@ -508,6 +508,9 @@ mod tests {
 
         // The next trigger should be aligned to the previous 5-minute boundary
         // If current time is 11:03:00, the next trigger should be at 11:05:00
+        let now = Utc::now();
+        let expected = now + Duration::minutes(6);
+        assert!(dt < expected);
         assert_eq!(dt.minute() % 5, 0);
         assert_eq!(dt.second(), 0);
 

--- a/src/config/src/meta/alerts/mod.rs
+++ b/src/config/src/meta/alerts/mod.rs
@@ -392,6 +392,7 @@ mod tests {
         let next_run_at = dt.timestamp_micros();
         let aligned_time = TriggerCondition::align_time(next_run_at, 0, 300); // 5 minutes in seconds
         let aligned_dt = DateTime::from_timestamp_micros(aligned_time).unwrap();
+        assert_eq!(aligned_dt.hour(), 11);
         assert_eq!(aligned_dt.minute(), 0);
         assert_eq!(aligned_dt.second(), 0);
 
@@ -409,6 +410,7 @@ mod tests {
         let next_run_at = dt.timestamp_micros();
         let aligned_time = TriggerCondition::align_time(next_run_at, 0, 60); // 1 minute in seconds
         let aligned_dt = DateTime::from_timestamp_micros(aligned_time).unwrap();
+        assert_eq!(aligned_dt.hour(), 17);
         assert_eq!(aligned_dt.minute(), 19);
         assert_eq!(aligned_dt.second(), 0);
 
@@ -425,6 +427,7 @@ mod tests {
         let timezone = FixedOffset::east_opt(8 * 60 * 60).unwrap(); // UTC+8
         let dt = timezone.with_ymd_and_hms(2025, 1, 1, 17, 19, 30).unwrap();
         let next_run_at = dt.timestamp_micros();
+        // `align_time` expects frequency in minutes, so convert 8 hours to minutes
         let aligned_time = TriggerCondition::align_time(next_run_at, 8 * 60, 3600); // 1 hour in seconds
         let aligned_dt = DateTime::from_timestamp_micros(aligned_time)
             .unwrap()
@@ -447,7 +450,6 @@ mod tests {
         let after_5_minutes = Utc::now() + Duration::minutes(5);
         assert_eq!(dt.minute(), after_5_minutes.minute());
 
-        // Test case 2: Cron expression
         // Test case 2: Cron expression
         let condition = TriggerCondition {
             frequency: 300,
@@ -505,7 +507,7 @@ mod tests {
         let dt = DateTime::from_timestamp_micros(result).unwrap();
 
         // The next trigger should be aligned to the previous 5-minute boundary
-        // If current time is 11:03:00, the next trigger should be at 11:00:00
+        // If current time is 11:03:00, the next trigger should be at 11:05:00
         assert_eq!(dt.minute() % 5, 0);
         assert_eq!(dt.second(), 0);
 

--- a/src/config/src/meta/alerts/mod.rs
+++ b/src/config/src/meta/alerts/mod.rs
@@ -121,7 +121,7 @@ impl TriggerCondition {
     }
 
     // Next trigger time should align with the pipeline timezone time
-    // if the frquency is 5 mins., and it is 11:03:00 now, the next trigger time should be 11:05:00
+    // if the frequency is 5 mins., and it is 11:03:00 now, the next trigger time should be 11:05:00
     fn align_time(next_run_at: i64, timezone_offset: i32, frequency: i64) -> i64 {
         // Convert the timestamp to a DateTime with the specified timezone offset
         let timezone = FixedOffset::east_opt(timezone_offset * 60).unwrap();

--- a/src/config/src/meta/alerts/mod.rs
+++ b/src/config/src/meta/alerts/mod.rs
@@ -13,12 +13,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::str::FromStr;
+
+use chrono::{Duration, FixedOffset, Timelike, Utc};
+use cron::Schedule;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::{
     meta::search::SearchEventType,
-    utils::json::{Map, Value},
+    utils::{
+        json::{Map, Value},
+        rand::get_rand_num_within,
+    },
 };
 
 pub mod alert;
@@ -46,6 +53,137 @@ pub struct TriggerCondition {
     /// (seconds)
     #[serde(default)]
     pub tolerance_in_secs: Option<i64>,
+}
+
+impl TriggerCondition {
+    // TODO: Currently, the frequency for alert is in seconds, but the
+    // frequency for derived stream is in minutes. This needs to be fixed for alert.
+    /// freq_in_secs is true if the frequency is in seconds, false if it is in minutes
+    pub fn get_next_trigger_time(
+        &self,
+        freq_in_secs: bool,
+        timezone_offset: i32,
+        apply_silence: bool,
+    ) -> Result<i64, anyhow::Error> {
+        let frequency = if freq_in_secs {
+            self.frequency
+        } else {
+            self.frequency * 60
+        };
+        let tolerance = match self.tolerance_in_secs {
+            Some(tolerance) if tolerance > 0 => {
+                Duration::seconds(get_rand_num_within(0, tolerance as u64) as i64)
+                    .num_microseconds()
+                    .unwrap()
+            }
+            _ => 0,
+        };
+        let timezone_offset = FixedOffset::east_opt(timezone_offset * 60).unwrap();
+        if self.frequency_type == FrequencyType::Cron {
+            let schedule = Schedule::from_str(&self.cron)?;
+            if apply_silence {
+                let silence = Utc::now() + Duration::try_minutes(self.silence).unwrap();
+                let silence = silence.with_timezone(&timezone_offset);
+                // Check for the cron timestamp after the silence period
+                Ok(schedule.after(&silence).next().unwrap().timestamp_micros() + tolerance)
+            } else {
+                // Check for the cron timestamp in the future
+                Ok(schedule
+                    .upcoming(timezone_offset)
+                    .next()
+                    .unwrap()
+                    .timestamp_micros()
+                    + tolerance)
+            }
+        } else if apply_silence {
+            // silence is in minutes, frequency is in seconds
+            // When the silence period is less than the frequency, the alert runs after the silence
+            // period completely ignoring the frequency. So, if frequency is 60 mins and
+            // silence is 10 mins, the condition is satisfied, in that case, the alert
+            // will run after 10 mins of silence period. To avoid this scenario, we
+            // should use the max of (frequency, silence) as the next_run_at.
+            // Silence period is in minutes, and the frequency is in seconds.
+            let delta = std::cmp::max(frequency, self.silence * 60);
+            Ok(Utc::now().timestamp_micros()
+                + Duration::try_seconds(delta)
+                    .unwrap()
+                    .num_microseconds()
+                    .unwrap()
+                + tolerance)
+        } else {
+            Ok(Utc::now().timestamp_micros()
+                + Duration::try_seconds(frequency)
+                    .unwrap()
+                    .num_microseconds()
+                    .unwrap()
+                + tolerance)
+        }
+    }
+
+    // Next trigger time should align with the pipeline timezone time
+    // if the frquency is 5 mins., and it is 11:03:00 now, the next trigger time should be 11:05:00
+    fn align_time(next_run_at: i64, timezone_offset: i32, frequency: i64) -> i64 {
+        // Convert the timestamp to a DateTime with the specified timezone offset
+        let timezone = FixedOffset::east_opt(timezone_offset * 60).unwrap();
+        let dt = chrono::DateTime::from_timestamp_micros(next_run_at)
+            .unwrap_or_default()
+            .with_timezone(&timezone);
+
+        // Convert frequency from seconds to minutes
+        let frequency_minutes = frequency / 60;
+
+        // Get the minute and second of the next_run_at time
+        let minute = dt.minute() as i64;
+        let second = dt.second() as i64;
+
+        // Calculate how many minutes to subtract to reach the previous interval boundary
+        let minutes_to_subtract = minute % frequency_minutes;
+
+        // If we're exactly at an interval boundary and seconds are 0, don't adjust
+        let minutes_to_subtract = if minutes_to_subtract == 0 && second == 0 {
+            0
+        } else {
+            minutes_to_subtract
+        };
+
+        // Create a new DateTime with the aligned time
+        let aligned_dt = dt
+            .checked_sub_signed(chrono::Duration::minutes(minutes_to_subtract))
+            .unwrap_or(dt)
+            .with_second(0)
+            .unwrap_or(dt)
+            .with_nanosecond(0)
+            .unwrap_or(dt);
+
+        // Convert back to microsecond timestamp
+        aligned_dt.timestamp_micros()
+    }
+
+    /// Get the next trigger time aligned to the previous interval boundary
+    /// `freq_in_secs` is true if the frequency is in seconds, false if it is in minutes
+    /// `timezone_offset` is the timezone offset in minutes
+    /// `apply_silence` is true if the silence period is applied, false otherwise
+    pub fn get_aligned_next_trigger_time(
+        &self,
+        freq_in_secs: bool,
+        timezone_offset: i32,
+        apply_silence: bool,
+    ) -> Result<i64, anyhow::Error> {
+        let next_run_at =
+            self.get_next_trigger_time(freq_in_secs, timezone_offset, apply_silence)?;
+        // Cron frequency is handled by the cron library, so we don't need to align it
+        if self.frequency_type != FrequencyType::Cron {
+            // `align_time` expects frequency in seconds, so convert if necessary
+            let frequency = if freq_in_secs {
+                self.frequency
+            } else {
+                self.frequency * 60
+            };
+            Ok(Self::align_time(next_run_at, timezone_offset, frequency))
+        } else {
+            Ok(next_run_at)
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -237,5 +375,158 @@ impl std::fmt::Display for Operator {
             Operator::Contains => write!(f, "contains"),
             Operator::NotContains => write!(f, "not contains"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, FixedOffset, TimeZone};
+
+    use super::*;
+
+    #[test]
+    fn test_align_time() {
+        // Test case 1: Align to 5-minute intervals
+        let timezone = FixedOffset::east_opt(0).unwrap(); // UTC
+        let dt = timezone.with_ymd_and_hms(2025, 1, 1, 11, 3, 0).unwrap();
+        let next_run_at = dt.timestamp_micros();
+        let aligned_time = TriggerCondition::align_time(next_run_at, 0, 300); // 5 minutes in seconds
+        let aligned_dt = DateTime::from_timestamp_micros(aligned_time).unwrap();
+        assert_eq!(aligned_dt.minute(), 0);
+        assert_eq!(aligned_dt.second(), 0);
+
+        // Test case 2: Align to 1-hour intervals
+        let dt = timezone.with_ymd_and_hms(2025, 1, 1, 17, 19, 30).unwrap();
+        let next_run_at = dt.timestamp_micros();
+        let aligned_time = TriggerCondition::align_time(next_run_at, 0, 3600); // 1 hour in seconds
+        let aligned_dt = DateTime::from_timestamp_micros(aligned_time).unwrap();
+        assert_eq!(aligned_dt.hour(), 17);
+        assert_eq!(aligned_dt.minute(), 0);
+        assert_eq!(aligned_dt.second(), 0);
+
+        // Test case 3: Align to 1-minute intervals
+        let dt = timezone.with_ymd_and_hms(2025, 1, 1, 17, 19, 11).unwrap();
+        let next_run_at = dt.timestamp_micros();
+        let aligned_time = TriggerCondition::align_time(next_run_at, 0, 60); // 1 minute in seconds
+        let aligned_dt = DateTime::from_timestamp_micros(aligned_time).unwrap();
+        assert_eq!(aligned_dt.minute(), 19);
+        assert_eq!(aligned_dt.second(), 0);
+
+        // Test case 4: Already at interval boundary
+        let dt = timezone.with_ymd_and_hms(2025, 1, 1, 17, 0, 0).unwrap();
+        let next_run_at = dt.timestamp_micros();
+        let aligned_time = TriggerCondition::align_time(next_run_at, 0, 3600); // 1 hour in seconds
+        let aligned_dt = DateTime::from_timestamp_micros(aligned_time).unwrap();
+        assert_eq!(aligned_dt.hour(), 17);
+        assert_eq!(aligned_dt.minute(), 0);
+        assert_eq!(aligned_dt.second(), 0);
+
+        // Test case 5: Different timezone (UTC+8)
+        let timezone = FixedOffset::east_opt(8 * 60 * 60).unwrap(); // UTC+8
+        let dt = timezone.with_ymd_and_hms(2025, 1, 1, 17, 19, 30).unwrap();
+        let next_run_at = dt.timestamp_micros();
+        let aligned_time = TriggerCondition::align_time(next_run_at, 8 * 60, 3600); // 1 hour in seconds
+        let aligned_dt = DateTime::from_timestamp_micros(aligned_time)
+            .unwrap()
+            .with_timezone(&timezone);
+        assert_eq!(aligned_dt.hour(), 17);
+        assert_eq!(aligned_dt.minute(), 0);
+        assert_eq!(aligned_dt.second(), 0);
+    }
+
+    #[test]
+    fn test_get_next_trigger_time() {
+        // Test case 1: Regular frequency (5 minutes)
+        let condition = TriggerCondition {
+            frequency: 300, // 5 minutes in seconds
+            frequency_type: FrequencyType::Minutes,
+            ..Default::default()
+        };
+        let result = condition.get_next_trigger_time(true, 0, false).unwrap();
+        let dt = DateTime::from_timestamp_micros(result).unwrap();
+        let after_5_minutes = Utc::now() + Duration::minutes(5);
+        assert_eq!(dt.minute(), after_5_minutes.minute());
+
+        // Test case 2: Cron expression
+        // Test case 2: Cron expression
+        let condition = TriggerCondition {
+            frequency: 300,
+            frequency_type: FrequencyType::Cron,
+            cron: "0 */5 * * * *".to_string(), // Every 5 minutes
+            ..Default::default()
+        };
+        let result = condition.get_next_trigger_time(true, 0, false).unwrap();
+        let dt = DateTime::from_timestamp_micros(result).unwrap();
+        assert_eq!(dt.minute() % 5, 0);
+        assert_eq!(dt.second(), 0);
+
+        // Test case 3: With silence period
+        let condition = TriggerCondition {
+            frequency: 300,
+            silence: 10, // 10 minutes silence
+            ..Default::default()
+        };
+        let result = condition.get_next_trigger_time(true, 0, true).unwrap();
+        let dt = DateTime::from_timestamp_micros(result).unwrap();
+        // The next trigger should be after the silence period
+        let now = Utc::now();
+        let silence_end = now + Duration::minutes(10);
+        assert_eq!(dt.minute(), silence_end.minute());
+
+        // Test case 4: With tolerance
+        let condition = TriggerCondition {
+            frequency: 300,
+            tolerance_in_secs: Some(60), // 1 minute tolerance
+            ..Default::default()
+        };
+        let result = condition.get_next_trigger_time(true, 0, false).unwrap();
+        let dt = DateTime::from_timestamp_micros(result).unwrap();
+        // The next trigger should be within the tolerance range
+        let now = Utc::now();
+        let expected = now + Duration::minutes(5);
+        let min_expected = expected - Duration::minutes(1);
+        let max_expected = expected + Duration::minutes(1);
+        assert!(dt >= min_expected && dt <= max_expected);
+    }
+
+    #[test]
+    fn test_get_aligned_next_trigger_time() {
+        // Test case 1: Regular frequency with alignment
+        let condition = TriggerCondition {
+            frequency: 300, // 5 minutes in seconds
+            frequency_type: FrequencyType::Minutes,
+            ..Default::default()
+        };
+
+        // Mock the current time for testing
+        let result = condition
+            .get_aligned_next_trigger_time(true, 0, false)
+            .unwrap();
+        let dt = DateTime::from_timestamp_micros(result).unwrap();
+
+        // The next trigger should be aligned to the previous 5-minute boundary
+        // If current time is 11:03:00, the next trigger should be at 11:00:00
+        assert_eq!(dt.minute() % 5, 0);
+        assert_eq!(dt.second(), 0);
+
+        // Test case 2: Cron expression (should not be aligned)
+        let condition = TriggerCondition {
+            frequency: 300,
+            frequency_type: FrequencyType::Cron,
+            cron: "0 */5 * * * *".to_string(), // Every 5 minutes at 0th second
+            ..Default::default()
+        };
+
+        // For cron expressions, the time should not be aligned by our function
+        // as it's handled by the cron library
+        let result = condition
+            .get_aligned_next_trigger_time(true, 0, false)
+            .unwrap();
+        let dt = DateTime::from_timestamp_micros(result).unwrap();
+
+        // The next trigger should still be at a 5-minute boundary, but this is
+        // handled by the cron library, not our alignment function
+        assert_eq!(dt.minute() % 5, 0);
+        assert_eq!(dt.second(), 0);
     }
 }

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -20,7 +20,6 @@ use config::{
     cluster::LOCAL_NODE,
     get_config, ider,
     meta::{
-        alerts::FrequencyType,
         dashboards::reports::ReportFrequencyType,
         self_reporting::{
             error::{ErrorData, ErrorSource, PipelineError},
@@ -99,14 +98,14 @@ async fn handle_alert_triggers(
             Ok(Some((_, alert))) => alert,
             Ok(None) => {
                 log::error!(
-                    "[SCHEDULER trace_id {trace_id}] Alert not found for module_key: {}",
+                    "[SCHEDULER trace_id {scheduler_trace_id}] Alert not found for module_key: {}",
                     trigger.module_key
                 );
                 return Err(anyhow::anyhow!("Alert not found"));
             }
             Err(e) => {
                 log::error!(
-                    "[SCHEDULER trace_id {trace_id}] Error getting alert by id: {}",
+                    "[SCHEDULER trace_id {scheduler_trace_id}] Error getting alert by id: {}",
                     e
                 );
                 return Err(anyhow::anyhow!("Error getting alert by id: {}", e));
@@ -114,7 +113,7 @@ async fn handle_alert_triggers(
         }
     } else {
         log::error!(
-            "[SCHEDULER trace_id {trace_id}] Alert id is not a valid ksuid: {}",
+            "[SCHEDULER trace_id {scheduler_trace_id}] Alert id is not a valid ksuid: {}",
             trigger.module_key
         );
         return Err(anyhow::anyhow!(
@@ -184,21 +183,12 @@ async fn handle_alert_triggers(
             &new_trigger.org,
             &new_trigger.module_key
         );
-        if alert.trigger_condition.frequency_type == FrequencyType::Cron {
-            let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;
-            // tz_offset is in minutes
-            let tz_offset = FixedOffset::east_opt(alert.tz_offset * 60).unwrap();
-            new_trigger.next_run_at = schedule
-                .upcoming(tz_offset)
-                .next()
-                .unwrap()
-                .timestamp_micros();
-        } else {
-            new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
-                .unwrap()
-                .num_microseconds()
-                .unwrap();
-        }
+
+        new_trigger.next_run_at =
+            alert
+                .trigger_condition
+                .get_aligned_next_trigger_time(true, alert.tz_offset, false)?;
+
         // Keep the last_satisfied_at field
         trigger_data.reset();
         new_trigger.data = json::to_string(&trigger_data).unwrap();
@@ -335,21 +325,11 @@ async fn handle_alert_triggers(
                 }
             }
             // This didn't work, update the next_run_at to the next expected trigger time
-            if alert.trigger_condition.frequency_type == FrequencyType::Cron {
-                let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;
-                // tz_offset is in minutes
-                let tz_offset = FixedOffset::east_opt(alert.tz_offset * 60).unwrap();
-                new_trigger.next_run_at = schedule
-                    .upcoming(tz_offset)
-                    .next()
-                    .unwrap()
-                    .timestamp_micros();
-            } else {
-                new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
-                    .unwrap()
-                    .num_microseconds()
-                    .unwrap();
-            }
+            new_trigger.next_run_at = alert.trigger_condition.get_aligned_next_trigger_time(
+                true,
+                alert.tz_offset,
+                false,
+            )?;
             trigger_data.reset();
             new_trigger.data = json::to_string(&trigger_data).unwrap();
             trigger_data_stream.next_run_at = new_trigger.next_run_at;
@@ -384,67 +364,29 @@ async fn handle_alert_triggers(
             &new_trigger.module_key
         );
     }
-    let tolerance = match alert.trigger_condition.tolerance_in_secs {
-        Some(tolerance) if tolerance > 0 => {
+    if let Some(tolerance) = alert.trigger_condition.tolerance_in_secs {
+        if tolerance > 0 {
             let tolerance = Duration::seconds(get_rand_num_within(0, tolerance as u64) as i64)
                 .num_microseconds()
                 .unwrap();
             if tolerance > 0 {
                 trigger_data.tolerance = tolerance;
             }
-            tolerance
         }
-        _ => 0,
-    };
+    }
     if trigger_results.data.is_some() && alert.trigger_condition.silence > 0 {
-        if alert.trigger_condition.frequency_type == FrequencyType::Cron {
-            let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;
-            let silence =
-                Utc::now() + Duration::try_minutes(alert.trigger_condition.silence).unwrap();
-            let silence = silence.with_timezone(
-                FixedOffset::east_opt(alert.tz_offset * 60)
-                    .as_ref()
-                    .unwrap(),
-            );
-            // Check for the cron timestamp after the silence period
-            new_trigger.next_run_at =
-                schedule.after(&silence).next().unwrap().timestamp_micros() + tolerance;
-        } else {
-            // When the silence period is less than the frequency, the alert runs after the silence
-            // period completely ignoring the frequency. So, if frequency is 60 mins and
-            // silence is 10 mins, the condition is satisfied, in that case, the alert
-            // will run after 10 mins of silence period. To avoid this scenario, we
-            // should use the max of (frequency, silence) as the next_run_at.
-            // Silence period is in minutes, and the frequency is in seconds.
-            let next_run_in_seconds = std::cmp::max(
-                alert.trigger_condition.silence * 60,
-                alert.trigger_condition.frequency,
-            );
-            new_trigger.next_run_at += Duration::try_seconds(next_run_in_seconds)
-                .unwrap()
-                .num_microseconds()
-                .unwrap()
-                + tolerance;
-        }
+        new_trigger.next_run_at =
+            alert
+                .trigger_condition
+                .get_aligned_next_trigger_time(true, alert.tz_offset, true)?;
         new_trigger.is_silenced = true;
         // For silence period, no need to store last end time
         should_store_last_end_time = false;
-    } else if alert.trigger_condition.frequency_type == FrequencyType::Cron {
-        let schedule = Schedule::from_str(&alert.trigger_condition.cron)?;
-        // tz_offset is in minutes
-        let tz_offset = FixedOffset::east_opt(alert.tz_offset * 60).unwrap();
-        new_trigger.next_run_at = schedule
-            .upcoming(tz_offset)
-            .next()
-            .unwrap()
-            .timestamp_micros()
-            + tolerance;
     } else {
-        new_trigger.next_run_at += Duration::try_seconds(alert.trigger_condition.frequency)
-            .unwrap()
-            .num_microseconds()
-            .unwrap()
-            + tolerance;
+        new_trigger.next_run_at =
+            alert
+                .trigger_condition
+                .get_aligned_next_trigger_time(true, alert.tz_offset, false)?;
     }
     trigger_data_stream.next_run_at = new_trigger.next_run_at;
 
@@ -955,15 +897,44 @@ async fn handle_derived_stream_triggers(
 
     // in case the range [start_time, end_time] is greater than querying period, it needs to
     // evaluate and ingest 1 period at a time.
-    let now = Utc::now().timestamp_micros();
+    let suppossed_to_be_run_at = trigger.next_run_at;
+    let current_time = Utc::now().timestamp_micros();
+    let delay = current_time - suppossed_to_be_run_at; // delay is in microseconds
+    let mut final_end_time = suppossed_to_be_run_at;
+    // let now = Utc::now().timestamp_micros();
     let period_num_microseconds = Duration::try_minutes(derived_stream.trigger_condition.period)
         .unwrap()
         .num_microseconds()
         .unwrap();
+
     let (mut start, mut end) = if let Some(t0) = start_time {
-        (Some(t0), std::cmp::min(now, t0 + period_num_microseconds))
+        // Don't use only the period_num_microseconds, because, the the delay is lets say 10 secs
+        // The following code will make a separate query to cover the delay period of 10 secs which
+        // is unnecessary. Hence, we need to check how big the delay is.
+        // Note: For pipeline, period and frequency both have the same value.
+
+        // If the delay is equal to or greater than the frequency, we need to ingest data one by one
+        // If the delay is less than the frequency, we need to ingest data for the "next run at"
+        // period, For example, if the current time is 5:19pm, frequency is 5 mins, and
+        // delay is 4mins (supposed to be run at 5:15pm), we need to ingest data for the
+        // period from 5:10pm to 5:15pm only. The next run at will be 5:20pm which will
+        // query for the period from 5:15pm to 5:20pm. But, if the suppossed to be run at is
+        // 5:10pm, then we need ingest data for the period from 5:05pm to 5:15pm.
+        // Which is to cover the skipped period from 5:05pm to 5:15pm.
+        if delay >= period_num_microseconds {
+            // final_end_time is the last multiple of given frequency after the "suppossed to be run
+            // at" timestamp
+            let frequency_count = delay / period_num_microseconds;
+            final_end_time = suppossed_to_be_run_at + (frequency_count * period_num_microseconds);
+            (
+                Some(t0),
+                std::cmp::min(suppossed_to_be_run_at, t0 + period_num_microseconds),
+            )
+        } else {
+            (Some(t0), suppossed_to_be_run_at)
+        }
     } else {
-        (None, now)
+        (None, suppossed_to_be_run_at)
     };
 
     // In case the scheduler background job (watch_timeout) updates the trigger retries
@@ -977,34 +948,21 @@ async fn handle_derived_stream_triggers(
             new_trigger.module_key
         );
         // Go to the next nun at, but use the same trigger start time
-        if derived_stream.trigger_condition.frequency_type == FrequencyType::Cron {
-            let schedule = Schedule::from_str(&derived_stream.trigger_condition.cron)?;
-            // tz_offset is in minutes
-            let tz_offset = FixedOffset::east_opt(derived_stream.tz_offset * 60).unwrap();
-            new_trigger.next_run_at = schedule
-                .upcoming(tz_offset)
-                .next()
-                .unwrap()
-                .timestamp_micros();
-        } else {
-            new_trigger.next_run_at +=
-                Duration::try_minutes(derived_stream.trigger_condition.frequency)
-                    .unwrap()
-                    .num_microseconds()
-                    .unwrap();
-        }
+        new_trigger.next_run_at = derived_stream
+            .trigger_condition
+            .get_aligned_next_trigger_time(false, derived_stream.tz_offset, false)?;
         // Start over next time
         new_trigger.retries = 0;
         db::scheduler::update_trigger(new_trigger).await?;
         return Ok(());
     }
 
-    while end <= now {
+    while end <= final_end_time {
         log::debug!(
             "[SCHEDULER trace_id {scheduler_trace_id}] DerivedStream: querying for time range: start_time {}, end_time {}. Final end_time is {}",
             start.unwrap_or_default(),
             end,
-            now
+            final_end_time
         );
 
         let mut trigger_data_stream = TriggerData {
@@ -1072,7 +1030,7 @@ async fn handle_derived_stream_triggers(
                 // incr trigger retry count
                 new_trigger.retries += 1;
                 // set end to now to exit the loop below
-                end = now + 1;
+                end = final_end_time + 1;
             }
             Ok(trigger_results) => {
                 let is_satisfied = trigger_results
@@ -1211,7 +1169,7 @@ async fn handle_derived_stream_triggers(
                         .await;
 
                         // set end to now to exit the loop below but not moving time range forward
-                        end = now + 1;
+                        end = final_end_time + 1;
                     } else {
                         // SUCCESS: move the time range forward by frequency and continue
                         start = Some(trigger_results.end_time);
@@ -1220,10 +1178,10 @@ async fn handle_derived_stream_triggers(
                         // remaining time whichever is smaller
                         let _end = period_num_microseconds + 1;
                         // If the gap is less than or equal to 0, we need to break the loop
-                        end = if now - end <= 0 {
+                        end = if final_end_time - end <= 0 {
                             end + _end
                         } else {
-                            std::cmp::min(end + _end, now)
+                            std::cmp::min(end + _end, final_end_time)
                         };
                         trigger_data_stream.query_took = trigger_results.query_took;
                     }
@@ -1243,17 +1201,17 @@ async fn handle_derived_stream_triggers(
                     // time whichever is smaller
                     let _end = period_num_microseconds + 1;
                     // If the gap is less than or equal to 0, we need to break the loop
-                    end = if now - end <= 0 {
+                    end = if final_end_time - end <= 0 {
                         end + _end
                     } else {
-                        std::cmp::min(end + _end, now)
+                        std::cmp::min(end + _end, final_end_time)
                     };
                 }
             }
         };
 
         // configure next run time before exiting the loop
-        if end > now {
+        if end > final_end_time {
             // Store the last used derived stream period end time
             if let Some(start_time) = start {
                 new_trigger.data = json::to_string(&ScheduledTriggerData {
@@ -1272,22 +1230,9 @@ async fn handle_derived_stream_triggers(
                 && new_trigger.retries < max_retries)
             {
                 // Go to the next nun at, but use the same trigger start time
-                if derived_stream.trigger_condition.frequency_type == FrequencyType::Cron {
-                    let schedule = Schedule::from_str(&derived_stream.trigger_condition.cron)?;
-                    // tz_offset is in minutes
-                    let tz_offset = FixedOffset::east_opt(derived_stream.tz_offset * 60).unwrap();
-                    new_trigger.next_run_at = schedule
-                        .upcoming(tz_offset)
-                        .next()
-                        .unwrap()
-                        .timestamp_micros();
-                } else {
-                    new_trigger.next_run_at +=
-                        Duration::try_minutes(derived_stream.trigger_condition.frequency)
-                            .unwrap()
-                            .num_microseconds()
-                            .unwrap();
-                }
+                new_trigger.next_run_at = derived_stream
+                    .trigger_condition
+                    .get_aligned_next_trigger_time(false, derived_stream.tz_offset, false)?;
 
                 // If the trigger didn't fail, we need to reset the `retries` count.
                 // Only cumulative failures should be used to check with `max_retries`


### PR DESCRIPTION
This pr aligns the next_run_at of the alerts/pipelines according to the timezone of the given alert/pipeline. For example, if the current time is 11:03pm, and the frequency is 5 mins, the next run at should be 11:05pm, then 11:10pm, and so on. In future, we may want to make aligntime an optional feature, by giving a toggle option in the alert/pipeline itself.