### PR TITLE
feat: enforce mandatory _timestamp field selection in scheduled pipeline

### DIFF
--- a/src/config/src/utils/sql.rs
+++ b/src/config/src/utils/sql.rs
@@ -13,13 +13,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ops::ControlFlow;
+use std::{collections::HashSet, ops::ControlFlow};
 
 use sqlparser::{
     ast::{Expr, Function, GroupByExpr, Query, SelectItem, SetExpr, Statement, Visit, Visitor},
     dialect::GenericDialect,
     parser::Parser,
 };
+
+use crate::TIMESTAMP_COL_NAME;
 
 pub const AGGREGATE_UDF_LIST: [&str; 9] = [
     "min",
@@ -63,6 +65,18 @@ pub fn is_simple_aggregate_query(query: &str) -> Result<bool, sqlparser::parser:
             {
                 return Ok(true);
             }
+        }
+    }
+    Ok(false)
+}
+
+/// Checks if _timestamp has been selected
+/// Used for validating scheduled pipeline sql queries
+pub fn is_timestamp_selected(query: &str) -> Result<bool, sqlparser::parser::ParserError> {
+    let ast = Parser::parse_sql(&GenericDialect {}, query)?;
+    for statement in ast.iter() {
+        if has_timestamp(statement) {
+            return Ok(true);
         }
     }
     Ok(false)
@@ -192,5 +206,214 @@ impl Visitor for SubqueryVisitor {
             _ => {}
         }
         ControlFlow::Continue(())
+    }
+}
+
+fn has_timestamp(stat: &Statement) -> bool {
+    let mut visitor = TimestampVisitor::new();
+    stat.visit(&mut visitor);
+    visitor.timestamp_selected
+}
+
+struct TimestampVisitor {
+    pub timestamp_selected: bool,
+}
+
+impl TimestampVisitor {
+    fn new() -> Self {
+        Self {
+            timestamp_selected: false,
+        }
+    }
+}
+
+impl Visitor for TimestampVisitor {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &Query) -> ControlFlow<Self::Break> {
+        if let SetExpr::Select(select) = query.body.as_ref() {
+            for item in &select.projection {
+                match item {
+                    SelectItem::UnnamedExpr(expr) => {
+                        let mut visitor = FieldNameVisitor::new();
+                        expr.visit(&mut visitor);
+                        if visitor.field_names.contains(TIMESTAMP_COL_NAME) {
+                            self.timestamp_selected = true;
+                            break;
+                        }
+                    }
+                    SelectItem::ExprWithAlias { alias, .. } => {
+                        if alias.value == TIMESTAMP_COL_NAME {
+                            self.timestamp_selected = true;
+                            break;
+                        }
+                    }
+                    SelectItem::Wildcard(_) => {
+                        self.timestamp_selected = true;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        ControlFlow::Continue(())
+    }
+}
+
+struct FieldNameVisitor {
+    pub field_names: HashSet<String>,
+}
+
+impl FieldNameVisitor {
+    fn new() -> Self {
+        Self {
+            field_names: HashSet::new(),
+        }
+    }
+}
+
+impl Visitor for FieldNameVisitor {
+    type Break = ();
+
+    fn pre_visit_expr(&mut self, expr: &Expr) -> ControlFlow<Self::Break> {
+        match expr {
+            Expr::Identifier(ident) => {
+                self.field_names.insert(ident.value.clone());
+            }
+            Expr::Case { .. } => {
+                expr.visit(self);
+            }
+            Expr::Subquery(query) => {
+                query.visit(self);
+            }
+            _ => {}
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timestamp_selection() -> Result<(), sqlparser::parser::ParserError> {
+        let test_cases = vec![
+            // Basic selection cases
+            (
+                "SELECT _timestamp FROM table",
+                true,
+                "Direct timestamp selection",
+            ),
+            (
+                "SELECT name, _timestamp FROM table",
+                true,
+                "Timestamp with other columns",
+            ),
+            (
+                "SELECT * FROM table",
+                true,
+                "Wildcard selection includes timestamp",
+            ),
+            ("SELECT name FROM table", false, "No timestamp selected"),
+            // Alias cases
+            (
+                "SELECT _timestamp as ts FROM table",
+                false,
+                "_timestamp has to be the alias",
+            ),
+            (
+                "SELECT name as _timestamp FROM table",
+                false,
+                "Other column aliased as timestamp",
+            ),
+            // Function and expression cases
+            (
+                "SELECT MAX(_timestamp) FROM table",
+                false,
+                "Not aliased as _timestamp",
+            ),
+            (
+                "SELECT histogram(_timestamp, '1m') FROM table",
+                false,
+                "Not aliased as _timestamp",
+            ),
+            (
+                "SELECT date_trunc('hour', _timestamp) FROM table",
+                false,
+                "Not aliased as _timestamp",
+            ),
+            // Group by cases
+            (
+                "SELECT _timestamp, COUNT(*) FROM table GROUP BY _timestamp",
+                true,
+                "Timestamp in GROUP BY",
+            ),
+            (
+                "SELECT date_trunc('hour', _timestamp) as _timestamp, COUNT(*) FROM table GROUP BY _timestamp",
+                true,
+                "Aliased as _timestamp",
+            ),
+            // Complex queries
+            (
+                "SELECT t1._timestamp FROM table t1 JOIN table2 t2 ON t1.id = t2.id",
+                true,
+                "Timestamp in JOIN query",
+            ),
+            (
+                "SELECT * FROM (SELECT _timestamp FROM table) subq",
+                true,
+                "Timestamp in subquery",
+            ),
+            (
+                "SELECT CASE WHEN _timestamp > 0 THEN _timestamp ELSE 0 END FROM table",
+                true,
+                "Timestamp in CASE expression",
+            ),
+            (
+                "SELECT * FROM table WHERE _timestamp > 0",
+                true,
+                "Timestamp only in WHERE clause still counts as selected due to *",
+            ),
+            (
+                "SELECT name FROM table WHERE _timestamp > 0",
+                false,
+                "Timestamp only in WHERE clause doesn't count as selected",
+            ),
+            // Edge cases
+            (
+                "SELECT '_timestamp' as literal FROM table",
+                false,
+                "String literal shouldn't count",
+            ),
+            (
+                "SELECT name as \"_timestamp\" FROM table",
+                true,
+                "Quoted timestamp alias",
+            ),
+            (
+                "WITH t AS (SELECT _timestamp FROM table) SELECT * FROM t",
+                true,
+                "Timestamp in CTE",
+            ),
+        ];
+
+        for (sql, expected, test_name) in test_cases {
+            let result = is_timestamp_selected(sql)?;
+            assert_eq!(
+                result, expected,
+                "Failed test case '{}': expected {}, got {}",
+                test_name, expected, result
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_invalid_sql() {
+        let result = is_timestamp_selected("SELECT * FREM table"); // intentionally malformed SQL
+        assert!(result.is_err(), "Should fail on invalid SQL");
     }
 }

--- a/src/service/alerts/derived_streams.rs
+++ b/src/service/alerts/derived_streams.rs
@@ -49,7 +49,7 @@ pub async fn save(
                 }
 
                 // check if _timestamp is a selected field, or _timestamp as an alias
-                if !is_timestamp_selected(sql)? {
+                if !is_timestamp_selected(sql).map_err(|e| anyhow::anyhow!("Invalid SQL: {}", e))? {
                     return Err(anyhow::anyhow!(
                         "SQL for scheduled pipeline must include _timestamp, or aliased as _timestamp.\n\
                         e.g. SELECT app_name, MAX(_timestamp) AS _timestamp FROM ..."
@@ -95,7 +95,7 @@ pub async fn save(
                 || derived_stream.query_condition.promql_condition.is_none()
             {
                 return Err(anyhow::anyhow!(
-                    "Scheduled pipeline with SQL mode should have a query"
+                    "Scheduled pipeline with PromQL mode should have a query and condition"
                 ));
             }
         }


### PR DESCRIPTION
API layer enforcement: scheduled pipeline queries must generate a `_timestamp` filed in the result, use alias for functions.
recommended:
```sql
SELECT MAX(_timestamp) AS _timestamp, ... FROM ...
```

***This rule is not applied to any existing scheduled pipelines**