### PR TITLE
fix: any responses with function error will not be result cached

### DIFF
--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -455,15 +455,19 @@ pub async fn search(
     // 1. VRL error
     // 2. Super cluster error
     // 3. Range error (max_query_limit)
+
+    // let should_cache_results =
+    //     res.new_start_time.is_some() || res.new_end_time.is_some() ||
+    // res.function_error.is_empty();
+
     // Cache partial results only if there is a range error
+    // if !res.function_error.is_empty() && !range_error.is_empty() {
+    //     res.function_error.retain(|err| !err.contains(&range_error));
+    //     should_cache_results = should_cache_results && res.function_error.is_empty();
+    // }
 
-    let mut should_cache_results =
-        res.new_start_time.is_some() || res.new_end_time.is_some() || res.function_error.is_empty();
-
-    if !res.function_error.is_empty() && !range_error.is_empty() {
-        res.function_error.retain(|err| !err.contains(&range_error));
-        should_cache_results = should_cache_results && res.function_error.is_empty();
-    }
+    // Update: Don't cache any partial results
+    let should_cache_results = res.function_error.is_empty() && !res.hits.is_empty();
 
     // result cache save changes start
     if cfg.common.result_cache_enabled

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -467,7 +467,10 @@ pub async fn search(
     // }
 
     // Update: Don't cache any partial results
-    let should_cache_results = res.function_error.is_empty() && !res.hits.is_empty();
+    let should_cache_results = res.new_start_time.is_none()
+        && res.new_end_time.is_none()
+        && res.function_error.is_empty()
+        && !res.hits.is_empty();
 
     // result cache save changes start
     if cfg.common.result_cache_enabled

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -1031,7 +1031,7 @@ async fn write_results_to_cache(
         }
     }
 
-    let mut merged_response = cache::merge_response(
+    let merged_response = cache::merge_response(
         &c_resp.trace_id,
         &mut cached_responses,
         &mut search_responses,
@@ -1051,15 +1051,19 @@ async fn write_results_to_cache(
     //     || (!merged_response.function_error.is_empty()
     //         && merged_response.function_error.contains("vrl"));
 
-    let mut should_cache_results = merged_response.new_start_time.is_some()
-        || merged_response.new_end_time.is_some()
-        || merged_response.function_error.is_empty();
+    // let mut should_cache_results = merged_response.new_start_time.is_some()
+    //     || merged_response.new_end_time.is_some()
+    //     || merged_response.function_error.is_empty();
 
-    merged_response.function_error.retain(|err| {
-        !err.contains("Query duration is modified due to query range restriction of")
-    });
+    // merged_response.function_error.retain(|err| {
+    //     !err.contains("Query duration is modified due to query range restriction of")
+    // });
 
-    should_cache_results = should_cache_results && merged_response.function_error.is_empty();
+    // should_cache_results = should_cache_results && merged_response.function_error.is_empty();
+
+    // Update: Don't cache any partial results
+    let should_cache_results =
+        merged_response.function_error.is_empty() && !merged_response.hits.is_empty();
 
     if cfg.common.result_cache_enabled && should_cache_results {
         cache::write_results_v2(

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -1062,8 +1062,10 @@ async fn write_results_to_cache(
     // should_cache_results = should_cache_results && merged_response.function_error.is_empty();
 
     // Update: Don't cache any partial results
-    let should_cache_results =
-        merged_response.function_error.is_empty() && !merged_response.hits.is_empty();
+    let should_cache_results = merged_response.new_start_time.is_none()
+        && merged_response.new_end_time.is_none()
+        && merged_response.function_error.is_empty()
+        && !merged_response.hits.is_empty();
 
     if cfg.common.result_cache_enabled && should_cache_results {
         cache::write_results_v2(


### PR DESCRIPTION
- [x] search responses with any error will not be cached (result cache)