### PR TITLE
fix: cache file for alert querier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Run cargo build
         if: contains(matrix.file_name, '-simd')
-        run: RUSTFLAGS='-C target-feature=+aes,+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx512f,+avx512cd,+avx512er,+avx512bw,+avx512dq,+avx512vl' cargo build ${{ matrix.features }} --profile release-prod --target ${{ matrix.arch }}
+        run: RUSTFLAGS='-C target-feature=+aes,+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx512f,+avx512cd,+avx512bw,+avx512dq,+avx512vl' cargo build ${{ matrix.features }} --profile release-prod --target ${{ matrix.arch }}
 
       - name: Calculate checksum and rename binary
         if: contains(matrix.arch, 'windows') == false

--- a/deploy/build/Dockerfile.tag-simd.amd64
+++ b/deploy/build/Dockerfile.tag-simd.amd64
@@ -21,7 +21,7 @@ COPY --from=webBuilder /web/dist web/dist
 RUN mkdir -p /openobserve/target/release/
 
 # RUN cargo build --release
-RUN RUSTFLAGS='-C target-feature=+aes,+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx512f,+avx512cd,+avx512er,+avx512bw,+avx512dq,+avx512vl' cargo build --profile release-prod --features mimalloc --target x86_64-unknown-linux-gnu
+RUN RUSTFLAGS='-C target-feature=+aes,+avx,+avx2,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx512f,+avx512cd,+avx512bw,+avx512dq,+avx512vl' cargo build --profile release-prod --features mimalloc --target x86_64-unknown-linux-gnu
 RUN mv /openobserve/target/x86_64-unknown-linux-gnu/release-prod/openobserve /openobserve/target/release/openobserve
 
 FROM gcr.io/distroless/cc-debian12 AS runtime

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -313,12 +313,9 @@ impl Response {
         });
     }
 
-    pub fn set_local_took(&mut self, val: usize, wait: usize) {
+    pub fn set_local_took(&mut self, val: usize) {
         if self.took_detail.is_some() {
             self.took_detail.as_mut().unwrap().total = val;
-            if wait > 0 {
-                self.took_detail.as_mut().unwrap().wait_queue = wait;
-            }
         }
     }
 

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -344,25 +344,16 @@ pub static QUERY_DISK_METRICS_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(||
 });
 
 // query cache ratio for parquet files
-pub static QUERY_PARQUET_CACHE_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
-    IntCounterVec::new(
-        Opts::new(
-            "query_parquet_cache_requests",
-            "Querier parquet cache requests.".to_owned() + HELP_SUFFIX,
-        )
-        .namespace(NAMESPACE)
-        .const_labels(create_const_labels()),
-        &["organization", "stream_type"],
-    )
-    .expect("Metric created")
-});
-pub static QUERY_PARQUET_CACHE_RATIO: Lazy<IntCounterVec> = Lazy::new(|| {
-    IntCounterVec::new(
-        Opts::new(
+pub static QUERY_PARQUET_CACHE_RATIO: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
             "query_parquet_cache_ratio",
             "Querier parquet cache ratio.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
+        .buckets(vec![
+            0.01, 0.05, 0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 1.0,
+        ])
         .const_labels(create_const_labels()),
         &["organization", "stream_type"],
     )
@@ -370,25 +361,16 @@ pub static QUERY_PARQUET_CACHE_RATIO: Lazy<IntCounterVec> = Lazy::new(|| {
 });
 
 // query cache ratio for metrics
-pub static QUERY_METRICS_CACHE_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
-    IntCounterVec::new(
-        Opts::new(
-            "query_metrics_cache_requests",
-            "Querier metrics cache requests.".to_owned() + HELP_SUFFIX,
-        )
-        .namespace(NAMESPACE)
-        .const_labels(create_const_labels()),
-        &["organization"],
-    )
-    .expect("Metric created")
-});
-pub static QUERY_METRICS_CACHE_RATIO: Lazy<IntCounterVec> = Lazy::new(|| {
-    IntCounterVec::new(
-        Opts::new(
+pub static QUERY_METRICS_CACHE_RATIO: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
             "query_metrics_cache_ratio",
             "Querier metrics cache ratio.".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
+        .buckets(vec![
+            0.01, 0.05, 0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 1.0,
+        ])
         .const_labels(create_const_labels()),
         &["organization"],
     )
@@ -870,13 +852,7 @@ fn register_metrics(registry: &Registry) {
         .register(Box::new(QUERY_DISK_METRICS_CACHE_USED_BYTES.clone()))
         .expect("Metric registered");
     registry
-        .register(Box::new(QUERY_PARQUET_CACHE_REQUESTS.clone()))
-        .expect("Metric registered");
-    registry
         .register(Box::new(QUERY_PARQUET_CACHE_RATIO.clone()))
-        .expect("Metric registered");
-    registry
-        .register(Box::new(QUERY_METRICS_CACHE_REQUESTS.clone()))
         .expect("Metric registered");
     registry
         .register(Box::new(QUERY_METRICS_CACHE_RATIO.clone()))

--- a/src/handler/grpc/request/search/mod.rs
+++ b/src/handler/grpc/request/search/mod.rs
@@ -131,6 +131,7 @@ impl Search for Searcher {
         &self,
         req: Request<SearchRequest>,
     ) -> Result<Response<SearchResponse>, Status> {
+        let start = std::time::Instant::now();
         let req = req.into_inner();
         let request = json::from_slice::<search::Request>(&req.request)
             .map_err(|e| Status::internal(format!("failed to parse search request: {e}")))?;
@@ -146,7 +147,8 @@ impl Search for Searcher {
         .await;
 
         match ret {
-            Ok(ret) => {
+            Ok(mut ret) => {
+                ret.set_took(start.elapsed().as_millis() as usize);
                 let response = json::to_vec(&ret).map_err(|e| {
                     Status::internal(format!("failed to serialize search response: {e}"))
                 })?;

--- a/src/handler/http/request/search/around.rs
+++ b/src/handler/http/request/search/around.rs
@@ -22,7 +22,6 @@ use config::{
         self_reporting::usage::{RequestStats, UsageType},
         stream::StreamType,
     },
-    metrics,
     utils::{base64, json},
 };
 use hashbrown::HashMap;
@@ -119,30 +118,6 @@ pub(crate) async fn around(
             .map(|s| s.to_string())
             .collect::<Vec<_>>()
     });
-
-    metrics::QUERY_PENDING_NUMS
-        .with_label_values(&[org_id])
-        .inc();
-    // get a local search queue lock
-    #[cfg(not(feature = "enterprise"))]
-    let locker = SearchService::QUEUE_LOCKER.clone();
-    #[cfg(not(feature = "enterprise"))]
-    let locker = locker.lock().await;
-    #[cfg(not(feature = "enterprise"))]
-    if !config::get_config().common.feature_query_queue_enabled {
-        drop(locker);
-    }
-    #[cfg(not(feature = "enterprise"))]
-    let took_wait = start.elapsed().as_millis() as usize;
-    #[cfg(feature = "enterprise")]
-    let took_wait = 0;
-    log::info!(
-        "http search around API wait in queue took: {} ms",
-        took_wait
-    );
-    metrics::QUERY_PENDING_NUMS
-        .with_label_values(&[org_id])
-        .dec();
 
     let timeout = query
         .get("timeout")

--- a/src/handler/http/request/search/around.rs
+++ b/src/handler/http/request/search/around.rs
@@ -229,17 +229,9 @@ pub(crate) async fn around(
         max_ts: Some(around_end_time),
         cached_ratio: Some(resp.cached_ratio),
         trace_id: Some(trace_id.to_string()),
-        took_wait_in_queue: match (
-            resp_forward.took_detail.as_ref(),
-            resp_backward.took_detail.as_ref(),
-        ) {
-            (Some(forward_took), Some(backward_took)) => {
-                Some(forward_took.cluster_wait_queue + backward_took.cluster_wait_queue)
-            }
-            (Some(forward_took), None) => Some(forward_took.cluster_wait_queue),
-            (None, Some(backward_took)) => Some(backward_took.cluster_wait_queue),
-            _ => None,
-        },
+        took_wait_in_queue: Some(
+            resp_forward.took_detail.wait_in_queue + resp_backward.took_detail.wait_in_queue,
+        ),
         work_group: get_work_group(vec![
             resp_forward.work_group.clone(),
             resp_backward.work_group.clone(),

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -241,30 +241,6 @@ pub async fn get_latest_traces(
         .get("timeout")
         .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
 
-    metrics::QUERY_PENDING_NUMS
-        .with_label_values(&[&org_id])
-        .inc();
-    // get a local search queue lock
-    #[cfg(not(feature = "enterprise"))]
-    let locker = SearchService::QUEUE_LOCKER.clone();
-    #[cfg(not(feature = "enterprise"))]
-    let locker = locker.lock().await;
-    #[cfg(not(feature = "enterprise"))]
-    if !cfg.common.feature_query_queue_enabled {
-        drop(locker);
-    }
-    #[cfg(not(feature = "enterprise"))]
-    let took_wait = start.elapsed().as_millis() as usize;
-    #[cfg(feature = "enterprise")]
-    let took_wait = 0;
-    log::info!(
-        "http traces latest API wait in queue took: {} ms",
-        took_wait
-    );
-    metrics::QUERY_PENDING_NUMS
-        .with_label_values(&[&org_id])
-        .dec();
-
     // search
     let query_sql = format!(
         "SELECT trace_id, min({}) as zo_sql_timestamp, min(start_time) as trace_start_time, max(end_time) as trace_end_time FROM {stream_name}",

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -282,7 +282,6 @@ use crate::{common::meta, handler::http::request};
             config::meta::search::RequestEncoding,
             config::meta::search::Response,
             config::meta::search::ResponseTook,
-            config::meta::search::ResponseNodeTook,
             config::meta::search::SearchEventType,
             config::meta::search::SearchEventContext,
             config::meta::search::SearchPartitionRequest,

--- a/src/proto/proto/cluster/common.proto
+++ b/src/proto/proto/cluster/common.proto
@@ -36,6 +36,7 @@ message ScanStats {
     int64 querier_disk_cached_files   = 7;
     int64 idx_scan_size               = 8; // unit: MB
     int64 idx_took                    = 9; // unit: ms
+    int64 file_list_took             = 10; // unit: ms
 }
 
 message FileList {

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -67,6 +67,9 @@ pub struct ScanStats {
     /// unit: ms
     #[prost(int64, tag = "9")]
     pub idx_took: i64,
+    /// unit: ms
+    #[prost(int64, tag = "10")]
+    pub file_list_took: i64,
 }
 #[derive(Eq)]
 #[derive(serde::Serialize)]

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -140,19 +140,13 @@ async fn search_in_cluster(
     let (start, cached_values) = if cache_disabled {
         (start, vec![])
     } else {
-        config::metrics::QUERY_METRICS_CACHE_REQUESTS
-            .with_label_values(&[&req.org_id])
-            .inc();
         let start_time = std::time::Instant::now();
         match cache::get(query, start, end, step).await {
             Ok(Some((new_start, values))) => {
                 let took = start_time.elapsed().as_millis() as i32;
                 config::metrics::QUERY_METRICS_CACHE_RATIO
                     .with_label_values(&[&req.org_id])
-                    .inc_by(min(
-                        100,
-                        (new_start - start) as u64 * 100 / (end - start) as u64,
-                    ));
+                    .observe((new_start - start) as f64 / (end - start) as f64);
                 log::info!(
                     "[trace_id {trace_id}] promql->search->cache: hit cache, took: {} ms",
                     took

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -543,6 +543,8 @@ pub fn merge_response(
         res_took.wait_in_queue =
             std::cmp::max(res_took.wait_in_queue, res.took_detail.wait_in_queue);
         res_took.search_took = std::cmp::max(res_took.search_took, res.took_detail.search_took);
+        res_took.file_list_took =
+            std::cmp::max(res_took.file_list_took, res.took_detail.file_list_took);
         if !res.function_error.is_empty() {
             fn_error.extend(res.function_error.clone());
         }

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -175,6 +175,7 @@ pub async fn search(
     let search_role = "cache".to_string();
 
     // Result caching check ends, start search
+    let cache_took = start.elapsed().as_millis() as usize;
     let mut results = Vec::new();
     let mut work_group_set = Vec::new();
     let mut res = if !should_exec_query {
@@ -299,7 +300,7 @@ pub async fn search(
     };
 
     // do search
-    let time = start.elapsed().as_secs_f64();
+    let took_time = start.elapsed().as_secs_f64();
     log::info!(
         "{}",
         search_inspector_fields(
@@ -335,7 +336,8 @@ pub async fn search(
         &search_group,
     );
     res.set_trace_id(trace_id.to_string());
-    res.set_local_took(start.elapsed().as_millis() as usize);
+    res.set_took(took_time as usize);
+    res.set_cache_took(cache_took);
 
     if is_aggregate
         && res.histogram_interval.is_none()
@@ -348,7 +350,7 @@ pub async fn search(
     let num_fn = req.query.query_fn.is_some() as u16;
     let req_stats = RequestStats {
         records: res.hits.len() as i64,
-        response_time: time,
+        response_time: took_time,
         size: res.scan_size as f64,
         request_body: Some(req.query.sql),
         function: req.query.query_fn,
@@ -359,13 +361,7 @@ pub async fn search(
         search_type: req.search_type,
         search_event_context: req.search_event_context.clone(),
         trace_id: Some(trace_id.to_string()),
-        took_wait_in_queue: if res.took_detail.is_some() {
-            let resp_took = res.took_detail.as_ref().unwrap();
-            // Consider only the cluster wait queue duration
-            Some(resp_took.cluster_wait_queue)
-        } else {
-            None
-        },
+        took_wait_in_queue: Some(res.took_detail.wait_in_queue),
         work_group,
         result_cache_ratio: Some(res.result_cache_ratio),
         ..Default::default()
@@ -542,17 +538,11 @@ pub fn merge_response(
         if res.hits.is_empty() {
             continue;
         }
-        // TODO: here we can't plus cluster_total, it is query in parallel
-        // TODO: and, use this value also is wrong, the cluster_total should be the total time of
-        // TODO: the query, here only calculate the time of the delta query
-        if let Some(mut took_details) = res.took_detail {
-            res_took.cluster_total += took_details.cluster_total;
-            res_took.cluster_wait_queue += took_details.cluster_wait_queue;
-            res_took.idx_took += took_details.idx_took;
-            res_took.wait_queue += took_details.wait_queue;
-            res_took.total += took_details.total;
-            res_took.nodes.append(&mut took_details.nodes);
-        }
+        // here the searches in paralles, so we use the max value of the took_detail
+        res_took.idx_took = std::cmp::max(res_took.idx_took, res.took_detail.idx_took);
+        res_took.wait_in_queue =
+            std::cmp::max(res_took.wait_in_queue, res.took_detail.wait_in_queue);
+        res_took.search_took = std::cmp::max(res_took.search_took, res.took_detail.search_took);
         if !res.function_error.is_empty() {
             fn_error.extend(res.function_error.clone());
         }
@@ -577,7 +567,7 @@ pub fn merge_response(
         cache_hits_len,
         result_cache_len
     );
-    cache_response.took_detail = Some(res_took);
+    cache_response.took_detail = res_took;
     cache_response.order_by = search_response.first().and_then(|res| res.order_by);
     cache_response.result_cache_ratio = (((cache_hits_len as f64) * 100_f64)
         / ((result_cache_len + cache_hits_len) as f64))

--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use ::datafusion::arrow::record_batch::RecordBatch;
 use config::{
     meta::{function::VRLResultResolver, search, sql::TableReferenceExt},
-    metrics::{QUERY_PARQUET_CACHE_RATIO, QUERY_PARQUET_CACHE_REQUESTS},
+    metrics::QUERY_PARQUET_CACHE_RATIO,
     utils::{
         arrow::record_batches_to_json_rows,
         flatten,
@@ -280,17 +280,13 @@ pub async fn search(
     });
 
     if scan_stats.querier_files > 0 {
-        let parquet_cached_ratio = (((scan_stats.querier_memory_cached_files
-            + scan_stats.querier_disk_cached_files)
-            * 100) as f64
-            / scan_stats.querier_files as f64) as usize;
-        result.set_cached_ratio(parquet_cached_ratio);
+        let cached_ratio = (scan_stats.querier_memory_cached_files
+            + scan_stats.querier_disk_cached_files) as f64
+            / scan_stats.querier_files as f64;
+        result.set_cached_ratio((cached_ratio * 100.0) as usize);
         QUERY_PARQUET_CACHE_RATIO
             .with_label_values(&[&sql.org_id, &sql.stream_type.to_string()])
-            .inc_by(parquet_cached_ratio as u64);
-        QUERY_PARQUET_CACHE_REQUESTS
-            .with_label_values(&[&sql.org_id, &sql.stream_type.to_string()])
-            .inc();
+            .observe(cached_ratio);
     }
 
     if query_type == "table" {

--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -265,10 +265,14 @@ pub async fn search(
             .unwrap_or_default()
     };
 
+    let took_time = start.elapsed().as_millis() as usize;
+
     result.set_total(total);
     result.set_histogram_interval(sql.histogram_interval);
     result.set_partial(is_partial, partial_err);
-    result.set_cluster_took(start.elapsed().as_millis() as usize, took_wait);
+    result.set_took(took_time);
+    result.set_wait_in_queue(took_wait);
+    result.set_search_took(took_time - took_wait);
     result.set_file_count(scan_stats.files as usize);
     result.set_scan_size(scan_stats.original_size as usize);
     result.set_scan_records(scan_stats.records as usize);

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -15,6 +15,7 @@
 
 use std::{cmp::max, sync::Arc};
 
+use arrow::array::RecordBatch;
 use arrow_schema::{DataType, Field, Schema};
 use cache::cacher::get_ts_col_order_by;
 use chrono::{Duration, Utc};
@@ -85,6 +86,10 @@ pub(crate) mod utils;
 // Checks for #ResultArray#
 pub static RESULT_ARRAY: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^#[ \s]*Result[ \s]*Array[ \s]*#").unwrap());
+
+/// The result of search in cluster
+/// data, scan_stats, wait_in_queue, is_partial, partial_err
+type SearchResult = (Vec<RecordBatch>, search::ScanStats, usize, bool, String);
 
 // search manager
 pub static SEARCH_SERVER: Lazy<Searcher> = Lazy::new(Searcher::new);
@@ -915,6 +920,7 @@ pub async fn query_status() -> Result<search::QueryStatusResponse, Error> {
                 querier_disk_cached_files: scan_stats.querier_disk_cached_files,
                 idx_scan_size: scan_stats.idx_scan_size / 1024 / 1024, // change to MB
                 idx_took: scan_stats.idx_took,
+                file_list_took: scan_stats.file_list_took,
             });
         let query_status = if result.is_queue {
             "waiting"

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -279,13 +279,7 @@ pub async fn search(
                     search_type,
                     search_event_context,
                     trace_id: Some(trace_id),
-                    took_wait_in_queue: if res.took_detail.is_some() {
-                        let resp_took = res.took_detail.as_ref().unwrap();
-                        // Consider only the cluster wait queue duration
-                        Some(resp_took.cluster_wait_queue)
-                    } else {
-                        None
-                    },
+                    took_wait_in_queue: Some(res.took_detail.wait_in_queue),
                     work_group: _work_group,
                     result_cache_ratio: Some(res.result_cache_ratio),
                     ..Default::default()

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -50,8 +50,6 @@ use proto::cluster_rpc::{self, SearchQuery};
 use regex::Regex;
 use sql::Sql;
 use tokio::runtime::Runtime;
-#[cfg(not(feature = "enterprise"))]
-use tokio::sync::Mutex;
 use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 #[cfg(feature = "enterprise")]
@@ -90,10 +88,6 @@ pub static RESULT_ARRAY: Lazy<Regex> =
 
 // search manager
 pub static SEARCH_SERVER: Lazy<Searcher> = Lazy::new(Searcher::new);
-
-#[cfg(not(feature = "enterprise"))]
-pub(crate) static QUEUE_LOCKER: Lazy<Arc<Mutex<bool>>> =
-    Lazy::new(|| Arc::new(Mutex::const_new(false)));
 
 pub static DATAFUSION_RUNTIME: Lazy<Runtime> = Lazy::new(|| {
     tokio::runtime::Builder::new_multi_thread()

--- a/src/service/search/super_cluster/follower.rs
+++ b/src/service/search/super_cluster/follower.rs
@@ -153,6 +153,7 @@ pub async fn search(
     let mut scan_stats = ScanStats {
         files: file_id_list_vec.len() as i64,
         original_size: file_id_list_vec.iter().map(|v| v.original_size).sum(),
+        file_list_took: file_id_list_took as i64,
         ..Default::default()
     };
 

--- a/src/service/search_jobs.rs
+++ b/src/service/search_jobs.rs
@@ -227,7 +227,7 @@ async fn run_partition_job(
     }
     let mut result = res.unwrap();
     let took = start.elapsed().as_millis();
-    result.set_local_took(took as usize);
+    result.set_took(took as usize);
 
     // 4. write the result to s3
     let hits = result.total;
@@ -398,15 +398,7 @@ pub async fn merge_response(
     let mut resp = response.remove(0);
     for r in response {
         resp.took += r.took;
-        resp.took_detail = match (resp.took_detail, r.took_detail.as_ref()) {
-            (Some(mut a), Some(b)) => {
-                a.add(b);
-                Some(a)
-            }
-            (Some(a), None) => Some(a),
-            (None, Some(b)) => Some(b.clone()),
-            (None, None) => None,
-        };
+        resp.took_detail.add(&r.took_detail);
         resp.hits.extend(r.hits);
         resp.total += r.total;
         resp.file_count += r.file_count;

--- a/src/service/search_jobs.rs
+++ b/src/service/search_jobs.rs
@@ -227,7 +227,7 @@ async fn run_partition_job(
     }
     let mut result = res.unwrap();
     let took = start.elapsed().as_millis();
-    result.set_local_took(took as usize, 0);
+    result.set_local_took(took as usize);
 
     // 4. write the result to s3
     let hits = result.total;


### PR DESCRIPTION
We already checked `ConsistentHash` on the source node, so we don't need check again, just cache the file send to the node.