### PR TITLE
feat: support stream delete for object store

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1674,8 +1674,8 @@ pub struct S3 {
     pub feature_http1_only: bool,
     #[env_config(name = "ZO_S3_FEATURE_HTTP2_ONLY", default = false)]
     pub feature_http2_only: bool,
-    #[env_config(name = "ZO_S3_FEATURE_STREAM_DELETE", default = false)]
-    pub feature_stream_delete: bool,
+    #[env_config(name = "ZO_S3_FEATURE_BULK_DELETE", default = false)]
+    pub feature_bulk_delete: bool,
     #[env_config(name = "ZO_S3_ALLOW_INVALID_CERTIFICATES", default = false)]
     pub allow_invalid_certificates: bool,
     #[env_config(name = "ZO_S3_SYNC_TO_CACHE_INTERVAL", default = 600)] // seconds

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1674,6 +1674,8 @@ pub struct S3 {
     pub feature_http1_only: bool,
     #[env_config(name = "ZO_S3_FEATURE_HTTP2_ONLY", default = false)]
     pub feature_http2_only: bool,
+    #[env_config(name = "ZO_S3_FEATURE_STREAM_DELETE", default = false)]
+    pub feature_stream_delete: bool,
     #[env_config(name = "ZO_S3_ALLOW_INVALID_CERTIFICATES", default = false)]
     pub allow_invalid_certificates: bool,
     #[env_config(name = "ZO_S3_SYNC_TO_CACHE_INTERVAL", default = 600)] // seconds

--- a/src/handler/http/request/organization/org.rs
+++ b/src/handler/http/request/organization/org.rs
@@ -452,66 +452,6 @@ async fn node_list(
     Ok(HttpResponse::Ok().json(response))
 }
 
-/// Helper function to collect nodes from the local cluster
-async fn get_local_nodes() -> NodeListResponse {
-    let mut response = NodeListResponse::new();
-
-    // Get all nodes from cache if available
-    if let Some(nodes) = cluster::get_cached_nodes(|_| true).await {
-        for node in nodes {
-            response.add_node(node.clone(), node.get_region(), node.get_cluster_name());
-        }
-    }
-
-    response
-}
-
-#[cfg(feature = "enterprise")]
-/// Helper function to collect nodes from all clusters in a super cluster
-async fn get_super_cluster_nodes(regions: &[String]) -> Result<NodeListResponse, anyhow::Error> {
-    let mut response = NodeListResponse::new();
-
-    // Get all nodes in the super cluster
-    let cluster_nodes = match o2_enterprise::enterprise::super_cluster::search::get_cluster_nodes(
-        "list_nodes",
-        regions.to_vec(),
-        vec![],
-    )
-    .await
-    {
-        Ok(nodes) => nodes,
-        Err(e) => {
-            log::error!("Failed to get super cluster nodes: {:?}", e);
-            return Ok(response); // Return empty response instead of failing
-        }
-    };
-
-    // For each node in the super cluster
-    for node in cluster_nodes {
-        let region = node.get_region();
-        let cluster_name = node.get_cluster_name();
-
-        // Fetch child nodes from this cluster node
-        match crate::service::node::get_node_list(node).await {
-            Ok(cluster_nodes) => {
-                for node in cluster_nodes {
-                    response.add_node(node.clone(), region.clone(), cluster_name.clone());
-                }
-            }
-            Err(e) => {
-                log::error!(
-                    "Failed to get node list from cluster {}: {:?}",
-                    cluster_name,
-                    e
-                );
-                return Err(anyhow::anyhow!("Failed to get node list: {:?}", e));
-            }
-        }
-    }
-
-    Ok(response)
-}
-
 /// GetClusterInfo
 ///
 /// This endpoint returns detailed information about the OpenObserve cluster, organized by
@@ -593,6 +533,67 @@ async fn cluster_info(
     Ok(HttpResponse::Ok().json(cluster_info_response))
 }
 
+/// Helper function to collect nodes from the local cluster
+async fn get_local_nodes() -> NodeListResponse {
+    let mut response = NodeListResponse::new();
+
+    // Get all nodes from cache if available
+    if let Some(nodes) = cluster::get_cached_nodes(|_| true).await {
+        for node in nodes {
+            response.add_node(node.clone(), node.get_region(), node.get_cluster_name());
+        }
+    }
+
+    response
+}
+
+#[cfg(feature = "enterprise")]
+/// Helper function to collect nodes from all clusters in a super cluster
+async fn get_super_cluster_nodes(regions: &[String]) -> Result<NodeListResponse, anyhow::Error> {
+    let mut response = NodeListResponse::new();
+
+    // Get all nodes in the super cluster
+    let cluster_nodes = match o2_enterprise::enterprise::super_cluster::search::get_cluster_nodes(
+        "list_nodes",
+        regions.to_vec(),
+        vec![],
+    )
+    .await
+    {
+        Ok(nodes) => nodes,
+        Err(e) => {
+            log::error!("Failed to get super cluster nodes: {:?}", e);
+            return Ok(response); // Return empty response instead of failing
+        }
+    };
+
+    // For each node in the super cluster
+    let trace_id = config::ider::generate_trace_id();
+    for node in cluster_nodes {
+        let region = node.get_region();
+        let cluster_name = node.get_cluster_name();
+
+        // Fetch child nodes from this cluster node
+        match crate::service::node::get_node_list(&trace_id, node).await {
+            Ok(cluster_nodes) => {
+                for node in cluster_nodes {
+                    response.add_node(node.clone(), region.clone(), cluster_name.clone());
+                }
+            }
+            Err(e) => {
+                log::error!(
+                    "Failed to get node list from cluster {}: {:?}",
+                    cluster_name,
+                    e
+                );
+                return Err(anyhow::anyhow!("Failed to get node list: {:?}", e));
+            }
+        }
+    }
+
+    Ok(response)
+}
+
 /// Helper function to collect cluster info from the local cluster
 async fn get_local_cluster_info() -> Result<ClusterInfoResponse, anyhow::Error> {
     let mut response = ClusterInfoResponse::default();
@@ -636,12 +637,13 @@ async fn get_super_cluster_info(regions: &[String]) -> Result<ClusterInfoRespons
     };
 
     // For each node in the super cluster
+    let trace_id = config::ider::generate_trace_id();
     for node in cluster_nodes {
         let region = node.get_region();
         let cluster_name = node.get_cluster_name();
 
         // Fetch cluster info from this cluster node
-        match crate::service::cluster_info::get_super_cluster_info(node).await {
+        match crate::service::cluster_info::get_super_cluster_info(&trace_id, node).await {
             Ok(cluster_info_obj) => {
                 response.add_cluster_info(cluster_info_obj, cluster_name.clone(), region.clone());
             }

--- a/src/infra/src/storage/mod.rs
+++ b/src/infra/src/storage/mod.rs
@@ -112,7 +112,7 @@ pub async fn del(files: &[&str]) -> object_store::Result<()> {
         .map(|file| file.to_string())
         .collect::<Vec<_>>();
 
-    if !is_local_disk_storage() && get_config().s3.feature_stream_delete {
+    if !is_local_disk_storage() && get_config().s3.feature_bulk_delete {
         let files_stream = futures::stream::iter(files)
             .map(|file| Ok(Path::from(file)))
             .boxed();

--- a/src/infra/src/storage/mod.rs
+++ b/src/infra/src/storage/mod.rs
@@ -111,25 +111,44 @@ pub async fn del(files: &[&str]) -> object_store::Result<()> {
         .iter()
         .map(|file| file.to_string())
         .collect::<Vec<_>>();
-    let files_stream = futures::stream::iter(files);
-    files_stream
-        .for_each_concurrent(get_config().limit.cpu_num, |file| async move {
-            match DEFAULT.delete(&(file.as_str().into())).await {
-                Ok(_) => {
-                    log::debug!("Deleted object: {}", file);
-                }
-                Err(e) => {
-                    // TODO: need a better solution for identifying the error
-                    if file.ends_with(".result.json") {
-                        // ignore search job file deletion error
-                        log::debug!("Failed to delete object: {}, error: {:?}", file, e);
-                    } else if !is_local_disk_storage() {
-                        log::error!("Failed to delete object: {:?}", e);
+
+    if !is_local_disk_storage() && get_config().s3.feature_stream_delete {
+        let files_stream = futures::stream::iter(files)
+            .map(|file| Ok(Path::from(file)))
+            .boxed();
+        match DEFAULT
+            .delete_stream(files_stream)
+            .try_collect::<Vec<Path>>()
+            .await
+        {
+            Ok(files) => {
+                log::debug!("Deleted objects: {:?}", files);
+            }
+            Err(e) => {
+                log::error!("Failed to delete objects: {:?}", e);
+            }
+        }
+    } else {
+        let files_stream = futures::stream::iter(files);
+        files_stream
+            .for_each_concurrent(get_config().limit.cpu_num, |file| async move {
+                match DEFAULT.delete(&(file.as_str().into())).await {
+                    Ok(_) => {
+                        log::debug!("Deleted object: {}", file);
+                    }
+                    Err(e) => {
+                        // TODO: need a better solution for identifying the error
+                        if file.ends_with(".result.json") {
+                            // ignore search job file deletion error
+                            log::debug!("Failed to delete object: {}, error: {:?}", file, e);
+                        } else if !is_local_disk_storage() {
+                            log::error!("Failed to delete object: {:?}", e);
+                        }
                     }
                 }
-            }
-        })
-        .await;
+            })
+            .await;
+    }
 
     if columns[0] == "files" {
         let time = start.elapsed().as_secs_f64();

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -104,7 +104,7 @@ async fn download_file(
     cache_type: file_data::CacheType,
 ) -> Result<usize, anyhow::Error> {
     let cfg = get_config();
-    let ret = match cache_type {
+    match cache_type {
         file_data::CacheType::Memory => {
             let mut disk_exists = false;
             let mem_exists = file_data::memory::exist(file_name).await;
@@ -126,8 +126,7 @@ async fn download_file(
             }
         }
         _ => Ok(0),
-    };
-    Ok(ret?)
+    }
 }
 
 pub async fn queue_background_download(

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -127,12 +127,7 @@ async fn download_file(
         }
         _ => Ok(0),
     };
-    let data_len = ret?;
-    log::debug!(
-        "[trace_id {trace_id}] successfully downloaded file {file_name} into cache {:?}",
-        cache_type
-    );
-    Ok(data_len)
+    Ok(ret?)
 }
 
 pub async fn queue_background_download(

--- a/src/service/cluster_info.rs
+++ b/src/service/cluster_info.rs
@@ -62,10 +62,14 @@ impl proto::cluster_rpc::cluster_info_service_server::ClusterInfoService for Clu
     }
 }
 
-pub async fn get_super_cluster_info(node: Arc<dyn NodeInfo>) -> Result<ClusterInfo, anyhow::Error> {
+pub async fn get_super_cluster_info(
+    trace_id: &str,
+    node: Arc<dyn NodeInfo>,
+) -> Result<ClusterInfo, anyhow::Error> {
     let empty_request = EmptyRequest {};
     let mut request = Request::new(empty_request.clone());
-    let mut client = super::grpc::make_grpc_cluster_info_client(&mut request, &node).await?;
+    let mut client =
+        super::grpc::make_grpc_cluster_info_client(trace_id, &mut request, &node).await?;
     let response = match client.get_cluster_info(Request::new(empty_request)).await {
         Ok(response) => convert_response_to_cluster_info(response.into_inner()),
         Err(err) => {

--- a/src/service/grpc.rs
+++ b/src/service/grpc.rs
@@ -110,6 +110,7 @@ async fn create_channel(grpc_addr: &str) -> Result<Channel, tonic::Status> {
 
 #[tracing::instrument(name = "grpc:search::make_client", skip_all)]
 pub async fn make_grpc_search_client<T>(
+    trace_id: &str,
     request: &mut Request<T>,
     node: &Arc<dyn NodeInfo>,
 ) -> Result<
@@ -136,11 +137,13 @@ pub async fn make_grpc_search_client<T>(
         .await
         .map_err(|err| {
             log::error!(
-                "search->grpc: node: {}, connect err: {:?}",
+                "[trace_id {trace_id}] search->grpc: node: {}, connect err: {:?}",
                 &node.get_grpc_addr(),
                 err
             );
-            Error::ErrorCode(ErrorCodes::ServerInternalError(err.to_string()))
+            let err = ErrorCodes::from_json(err.message())
+                .unwrap_or(ErrorCodes::ServerInternalError(err.to_string()));
+            Error::ErrorCode(err)
         })?;
     let client = cluster_rpc::search_client::SearchClient::with_interceptor(
         channel,
@@ -198,9 +201,9 @@ pub async fn make_grpc_metrics_client<T>(
                 &node.get_grpc_addr(),
                 err
             );
-            Error::ErrorCode(ErrorCodes::ServerInternalError(
-                "connect search node error".to_string(),
-            ))
+            let err = ErrorCodes::from_json(err.message())
+                .unwrap_or(ErrorCodes::ServerInternalError(err.to_string()));
+            Error::ErrorCode(err)
         })?;
     let mut client = cluster_rpc::metrics_client::MetricsClient::with_interceptor(
         channel,
@@ -221,6 +224,7 @@ pub async fn make_grpc_metrics_client<T>(
 
 #[tracing::instrument(name = "grpc:node:make_client", skip_all)]
 pub async fn make_grpc_node_client<T>(
+    trace_id: &str,
     request: &mut Request<T>,
     node: &Arc<dyn NodeInfo>,
 ) -> Result<
@@ -247,11 +251,13 @@ pub async fn make_grpc_node_client<T>(
         .await
         .map_err(|err| {
             log::error!(
-                "node->grpc: node: {}, connect err: {:?}",
+                "[trace_id {trace_id}] node->grpc: node: {}, connect err: {:?}",
                 &node.get_grpc_addr(),
                 err
             );
-            Error::ErrorCode(ErrorCodes::ServerInternalError(err.to_string()))
+            let err = ErrorCodes::from_json(err.message())
+                .unwrap_or(ErrorCodes::ServerInternalError(err.to_string()));
+            Error::ErrorCode(err)
         })?;
     let client = cluster_rpc::node_service_client::NodeServiceClient::with_interceptor(
         channel,
@@ -269,6 +275,7 @@ pub async fn make_grpc_node_client<T>(
 
 #[tracing::instrument(name = "grpc:cluster_info:make_client", skip_all)]
 pub async fn make_grpc_cluster_info_client<T>(
+    trace_id: &str,
     request: &mut Request<T>,
     node: &Arc<dyn NodeInfo>,
 ) -> Result<
@@ -295,11 +302,13 @@ pub async fn make_grpc_cluster_info_client<T>(
         .await
         .map_err(|err| {
             log::error!(
-                "cluster_info->grpc: node: {}, connect err: {:?}",
+                "[trace_id {trace_id}] cluster_info->grpc: node: {}, connect err: {:?}",
                 &node.get_grpc_addr(),
                 err
             );
-            Error::ErrorCode(ErrorCodes::ServerInternalError(err.to_string()))
+            let err = ErrorCodes::from_json(err.message())
+                .unwrap_or(ErrorCodes::ServerInternalError(err.to_string()));
+            Error::ErrorCode(err)
         })?;
     let client =
         cluster_rpc::cluster_info_service_client::ClusterInfoServiceClient::with_interceptor(

--- a/src/service/ingestion/ingestion_service.rs
+++ b/src/service/ingestion/ingestion_service.rs
@@ -47,11 +47,8 @@ pub async fn ingest(
                 "[InternalIngestion] export partial_success node: {addr}, response: {:?}",
                 err
             );
-            if err.code() == tonic::Code::Internal {
-                return Err(err.into());
-            }
             return Err(Error::msg(format!(
-                "Ingest node {addr}, response error: {}",
+                "Ingest node {addr}, response error: {:?}",
                 err
             )));
         }

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -251,11 +251,9 @@ async fn search_in_cluster(
                             &node.get_grpc_addr(),
                             err
                         );
-                        if err.code() == tonic::Code::Internal {
-                            let err = ErrorCodes::from_json(err.message())?;
-                            return Err(Error::ErrorCode(err));
-                        }
-                        return Err(server_internal_error("search node error"));
+                        let err = ErrorCodes::from_json(err.message())
+                            .unwrap_or(ErrorCodes::ServerInternalError(err.to_string()));
+                        return Err(Error::ErrorCode(err));
                     }
                 };
                 let scan_stats = response.scan_stats.as_ref().unwrap();

--- a/src/service/search/cluster/cache_multi.rs
+++ b/src/service/search/cluster/cache_multi.rs
@@ -126,11 +126,8 @@ pub async fn get_cached_results(
                             &node.grpc_addr,
                             err
                         );
-                        if err.code() == tonic::Code::Internal {
-                            let err = ErrorCodes::from_json(err.message())?;
-                            return Err(Error::ErrorCode(err));
-                        }
-                        return Err(super::super::server_internal_error("querier node error"));
+                        let err = ErrorCodes::from_json(err.message())?;
+                        return Err(Error::ErrorCode(err));
                     }
                 };
 

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -126,11 +126,8 @@ pub async fn get_cached_results(
                             &node.grpc_addr,
                             err
                         );
-                        if err.code() == tonic::Code::Internal {
-                            let err = ErrorCodes::from_json(err.message())?;
-                            return Err(Error::ErrorCode(err));
-                        }
-                        return Err(super::super::server_internal_error("querier node error"));
+                        let err = ErrorCodes::from_json(err.message())?;
+                    return Err(Error::ErrorCode(err));
                     }
                 };
 
@@ -338,11 +335,8 @@ pub async fn delete_cached_results(path: String) -> bool {
                             &node.grpc_addr,
                             err
                         );
-                        if err.code() == tonic::Code::Internal {
-                            let err = ErrorCodes::from_json(err.message())?;
-                            return Err(Error::ErrorCode(err));
-                        }
-                        return Err(super::super::server_internal_error("querier node error"));
+                        let err = ErrorCodes::from_json(err.message())?;
+                    return Err(Error::ErrorCode(err));
                     }
                 };
 

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -127,7 +127,7 @@ pub async fn get_cached_results(
                             err
                         );
                         let err = ErrorCodes::from_json(err.message())?;
-                    return Err(Error::ErrorCode(err));
+                        return Err(Error::ErrorCode(err));
                     }
                 };
 
@@ -336,7 +336,7 @@ pub async fn delete_cached_results(path: String) -> bool {
                             err
                         );
                         let err = ErrorCodes::from_json(err.message())?;
-                    return Err(Error::ErrorCode(err));
+                        return Err(Error::ErrorCode(err));
                     }
                 };
 

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -442,21 +442,15 @@ async fn cache_files(
     tokio::spawn(async move {
         let files_num = files.len();
         for (file, size) in files {
-            match job::queue_background_download(&trace_id, &file, size, cache_type).await {
-                Ok(_) => {
-                    log::debug!(
-                        "[trace_id {trace_id}] file {file} successfully queued for download"
-                    );
-                }
-                Err(e) => {
-                    log::error!(
-                        "[trace_id {trace_id}] error in queuing file {file} for background download : {e}"
-                    );
-                }
+            if let Err(e) = job::queue_background_download(&trace_id, &file, size, cache_type).await
+            {
+                log::error!(
+                    "[trace_id {trace_id}] error in queuing file {file} for background download: {e}"
+                );
             }
         }
         log::info!(
-            "[trace_id {}] search->storage: successfully enqueued {} files of {} for background download into {:?} ",
+            "[trace_id {}] search->storage: successfully enqueued {} files of {} for background download into {:?}",
             trace_id,
             files_num,
             file_type,

--- a/src/service/search/grpc_search.rs
+++ b/src/service/search/grpc_search.rs
@@ -74,7 +74,7 @@ pub async fn grpc_search(
                 request: req,
             });
             let node = Arc::new(node) as _;
-            let mut client = make_grpc_search_client(&mut request, &node).await?;
+            let mut client = make_grpc_search_client(&trace_id, &mut request, &node).await?;
             let response = match client.search(request).await {
                 Ok(res) => res.into_inner(),
                 Err(err) => {
@@ -146,7 +146,7 @@ pub async fn grpc_search_multi(
                 request: req,
             });
             let node = Arc::new(node) as _;
-            let mut client = make_grpc_search_client(&mut request, &node).await?;
+            let mut client = make_grpc_search_client(&trace_id, &mut request, &node).await?;
             let response = match client.search_multi(request).await {
                 Ok(res) => res.into_inner(),
                 Err(err) => {
@@ -217,7 +217,7 @@ pub async fn grpc_search_partition(
                 skip_max_query_range,
             });
             let node = Arc::new(node) as _;
-            let mut client = make_grpc_search_client(&mut request, &node).await?;
+            let mut client = make_grpc_search_client(&trace_id, &mut request, &node).await?;
             let response = match client.search_partition(request).await {
                 Ok(res) => res.into_inner(),
                 Err(err) => {

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -841,6 +841,7 @@ pub async fn query_status() -> Result<search::QueryStatusResponse, Error> {
     let nodes = nodes;
 
     // make cluster request
+    let trace_id = config::ider::generate_trace_id();
     let mut tasks = Vec::new();
     for node in nodes.iter().cloned() {
         let node_addr = node.grpc_addr.clone();
@@ -850,24 +851,22 @@ pub async fn query_status() -> Result<search::QueryStatusResponse, Error> {
             node_addr = node_addr.as_str(),
         );
 
+        let trace_id = trace_id.clone();
         let task = tokio::task::spawn(
             async move {
                 let mut request = tonic::Request::new(proto::cluster_rpc::QueryStatusRequest {});
                 let node = Arc::new(node) as _;
-                let mut client = make_grpc_search_client(&mut request, &node).await?;
+                let mut client = make_grpc_search_client(&trace_id, &mut request, &node).await?;
                 let response = match client.query_status(request).await {
                     Ok(res) => res.into_inner(),
                     Err(err) => {
                         log::error!(
-                            "search->grpc: node: {}, search err: {:?}",
+                            "[trace_id {trace_id}] search->grpc: node: {}, search err: {:?}",
                             &node.get_grpc_addr(),
                             err
                         );
-                        if err.code() == tonic::Code::Internal {
-                            let err = ErrorCodes::from_json(err.message())?;
-                            return Err(Error::ErrorCode(err));
-                        }
-                        return Err(server_internal_error("search node error"));
+                        let err = ErrorCodes::from_json(err.message())?;
+                        return Err(Error::ErrorCode(err));
                     }
                 };
                 Ok(response)
@@ -986,26 +985,26 @@ pub async fn cancel_query(
         let trace_id = trace_id.to_string();
         let task = tokio::task::spawn(
             async move {
-                let mut request =
-                    tonic::Request::new(proto::cluster_rpc::CancelQueryRequest { trace_id });
+                let mut request = tonic::Request::new(proto::cluster_rpc::CancelQueryRequest {
+                    trace_id: trace_id.clone(),
+                });
                 let node = Arc::new(node) as _;
-                let mut client = make_grpc_search_client(&mut request, &node).await?;
-                let response: cluster_rpc::CancelQueryResponse =
-                    match client.cancel_query(request).await {
-                        Ok(res) => res.into_inner(),
-                        Err(err) => {
-                            log::error!(
-                                "grpc_cancel_query: node: {}, search err: {:?}",
-                                &node.get_grpc_addr(),
-                                err
-                            );
-                            if err.code() == tonic::Code::Internal {
-                                let err = ErrorCodes::from_json(err.message())?;
-                                return Err(Error::ErrorCode(err));
-                            }
-                            return Err(server_internal_error("search node error"));
-                        }
-                    };
+                let mut client = make_grpc_search_client(&trace_id, &mut request, &node).await?;
+                let response: cluster_rpc::CancelQueryResponse = match client
+                    .cancel_query(request)
+                    .await
+                {
+                    Ok(res) => res.into_inner(),
+                    Err(err) => {
+                        log::error!(
+                            "[trace_id {trace_id}] grpc_cancel_query: node: {}, search err: {:?}",
+                            &node.get_grpc_addr(),
+                            err
+                        );
+                        let err = ErrorCodes::from_json(err.message())?;
+                        return Err(Error::ErrorCode(err));
+                    }
+                };
                 Ok(response)
             }
             .instrument(grpc_span),

--- a/src/service/search_jobs.rs
+++ b/src/service/search_jobs.rs
@@ -440,11 +440,12 @@ pub async fn get_result(
 
     // super cluster
     if get_o2_config().super_cluster.enabled {
+        let trace_id = config::ider::generate_trace_id();
         let node = get_cluster_node_by_name(cluster).await?;
         let path = path.to_string();
         let task = tokio::task::spawn(async move {
             let mut request = tonic::Request::new(proto::cluster_rpc::GetResultRequest { path });
-            let mut client = make_grpc_search_client(&mut request, &node).await?;
+            let mut client = make_grpc_search_client(&trace_id, &mut request, &node).await?;
             let response = match client.get_result(request).await {
                 Ok(res) => res.into_inner(),
                 Err(err) => {
@@ -453,13 +454,8 @@ pub async fn get_result(
                         &node.get_grpc_addr(),
                         err
                     );
-                    if err.code() == tonic::Code::Internal {
-                        let err = ErrorCodes::from_json(err.message())?;
-                        return Err(Error::ErrorCode(err));
-                    }
-                    return Err(Error::ErrorCode(ErrorCodes::ServerInternalError(
-                        "search node error".to_string(),
-                    )));
+                    let err = ErrorCodes::from_json(err.message())?;
+                    return Err(Error::ErrorCode(err));
                 }
             };
             Ok(response)
@@ -484,6 +480,7 @@ pub async fn delete_result(paths: Vec<String>) -> Result<(), anyhow::Error> {
     storage::del(&local_paths).await?;
 
     if get_o2_config().super_cluster.enabled {
+        let trace_id = config::ider::generate_trace_id();
         let nodes = get_cluster_nodes("delete_result", vec![], vec![]).await?;
         // delete result in all cluster,
         // because for retry job, we don't know partition in which cluster
@@ -492,10 +489,11 @@ pub async fn delete_result(paths: Vec<String>) -> Result<(), anyhow::Error> {
                 continue;
             }
             let paths = paths.clone();
+            let trace_id = trace_id.clone();
             let task = tokio::task::spawn(async move {
                 let mut request =
                     tonic::Request::new(proto::cluster_rpc::DeleteResultRequest { paths });
-                let mut client = make_grpc_search_client(&mut request, &node).await?;
+                let mut client = make_grpc_search_client(&trace_id, &mut request, &node).await?;
                 let response = match client.delete_result(request).await {
                     Ok(res) => res.into_inner(),
                     Err(err) => {
@@ -504,13 +502,8 @@ pub async fn delete_result(paths: Vec<String>) -> Result<(), anyhow::Error> {
                             &node.get_grpc_addr(),
                             err
                         );
-                        if err.code() == tonic::Code::Internal {
-                            let err = ErrorCodes::from_json(err.message())?;
-                            return Err(Error::ErrorCode(err));
-                        }
-                        return Err(Error::ErrorCode(ErrorCodes::ServerInternalError(
-                            "search node error".to_string(),
-                        )));
+                        let err = ErrorCodes::from_json(err.message())?;
+                        return Err(Error::ErrorCode(err));
                     }
                 };
                 Ok(response)


### PR DESCRIPTION
- [x] Add feature `ZO_S3_FEATURE_BULK_DELETE`
- [x] Removed trace_id for download files, because there are too many noise
- [x] Keep improve error message for search

## New ENV
```
ZO_S3_FEATURE_BULK_DELETE=false
```
If your object_store support `stream delete` you can enable it, as we know `AWS S3` and `Azure ObjectStore` support it.