### PR TITLE
fix: if `streaming_aggs` allow entire query to be processed

### DIFF
--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -21,8 +21,8 @@ use config::{
     TIMESTAMP_COL_NAME, ider,
     meta::{
         alerts::{
-            AggFunction, Condition, Operator, QueryCondition, QueryType,
-            TriggerCondition, TriggerEvalResults,
+            AggFunction, Condition, Operator, QueryCondition, QueryType, TriggerCondition,
+            TriggerEvalResults,
         },
         cluster::RoleGroup,
         search::{SearchEventContext, SearchEventType, SqlQuery},

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -311,12 +311,12 @@ async fn handle_alert_triggers(
                 time_in_queue_ms: Some(time_in_queue),
             })
             .await;
-            log::info!(
-                "[SCHEDULER trace_id {scheduler_trace_id}] alert {} skipped due to delay: {}",
-                &trigger.module_key,
-                delay
-            );
         }
+        log::info!(
+            "[SCHEDULER trace_id {scheduler_trace_id}] alert {} skipped due to delay: {}",
+            &trigger.module_key,
+            delay
+        );
         (now - final_end_time, true)
     };
 

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -581,6 +581,8 @@ async fn process_delta(
             return Ok(());
         }
 
+        let start = Instant::now();
+
         let mut req = req.clone();
         req.payload.query.start_time = start_time;
         req.payload.query.end_time = end_time;
@@ -606,6 +608,9 @@ async fn process_delta(
             let queried_range =
                 calc_queried_range(start_time, end_time, search_res.result_cache_ratio);
             *remaining_query_range -= queried_range;
+
+            // set took
+            search_res.set_took(start.elapsed().as_millis() as usize);
 
             // when searching with limit queries
             // the limit in sql takes precedence over the requested size
@@ -901,6 +906,8 @@ pub async fn do_partitioned_search(
             return Ok(());
         }
 
+        let start = Instant::now();
+
         let mut req = req.clone();
         req.payload.query.start_time = start_time;
         req.payload.query.end_time = end_time;
@@ -915,6 +922,9 @@ pub async fn do_partitioned_search(
 
         if !search_res.hits.is_empty() {
             search_res = order_search_results(search_res, req.fallback_order_by_col);
+
+            // set took
+            search_res.set_took(start.elapsed().as_millis() as usize);
 
             // check range error
             if !range_error.is_empty() {

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -969,8 +969,8 @@ pub async fn do_partitioned_search(
             send_message(req_id, ws_search_res.to_json()).await?;
         }
 
-        // Stop if reached the requested result size
-        if req_size != -1 && curr_res_size >= req_size {
+        // Stop if reached the requested result size and it is not a streaming aggs query
+        if req_size != -1 && curr_res_size >= req_size && !is_streaming_aggs {
             log::info!(
                 "[WS_SEARCH]: Reached requested result size ({}), stopping search",
                 req_size

--- a/src/service/websocket_events/values.rs
+++ b/src/service/websocket_events/values.rs
@@ -50,6 +50,8 @@ pub async fn handle_values_request(
     req: ValuesEventReq,
     accumulated_results: &mut Vec<SearchResultType>,
 ) -> Result<(), anyhow::Error> {
+    let mut start_timer = std::time::Instant::now();
+
     let cfg = get_config();
     let trace_id = req.trace_id.clone();
     let stream_type = req.stream_type;
@@ -193,6 +195,7 @@ pub async fn handle_values_request(
                     max_query_range,
                     remaining_query_range,
                     &order_by,
+                    &mut start_timer,
                 )
                 .instrument(ws_values_span.clone())
                 .await?;
@@ -233,6 +236,7 @@ pub async fn handle_values_request(
                     user_id,
                     accumulated_results,
                     max_query_range,
+                    &mut start_timer,
                 )
                 .instrument(ws_values_span.clone())
                 .await?;
@@ -288,6 +292,7 @@ pub async fn handle_values_request(
                 user_id,
                 accumulated_results,
                 max_query_range,
+                &mut start_timer,
             )
             .instrument(ws_values_span.clone())
             .await?;


### PR DESCRIPTION
- [x] if `streaming_aggs` is `true`, allow entire partitions to be processed for limit queries
- [x] fix: `took` in ws search responses for `search` &`values` events

fixes: https://github.com/openobserve/openobserve/issues/6610