### PR TITLE
fix: indexing for the nodelist UI should be done in FE

### DIFF
--- a/web/src/components/settings/Nodes.vue
+++ b/web/src/components/settings/Nodes.vue
@@ -693,6 +693,9 @@ export default defineComponent({
             percentageMemoryUsage: { value: 0 },
             cpuUsage: { value: 0 }
         };
+        //gloabal index is used to assign the id to the node
+        //the global index should continue from the last id of the previous node and previous cluster
+        let globalIndex = 1;
 
         for (const region in data) {
             uniqueValues.regions.add(region);
@@ -723,7 +726,9 @@ export default defineComponent({
                     maxValues.percentageMemoryUsage.value = Math.max(maxValues.percentageMemoryUsage.value, percentageMemoryUsage);
                     maxValues.cpuUsage.value = Math.max(maxValues.cpuUsage.value, cpuUsage);
                     //this is done because the id should be 2 digits to maintain consistency with other tables
-                    node.id = node.id < 10 ? `0${node.id}` : node.id;
+                    node.id = globalIndex < 10 ? `0${globalIndex}` : globalIndex;
+                    //increment the global index
+                    globalIndex++;
 
                     result.push({
                         region,


### PR DESCRIPTION
1. This PR fixes the issue that sometimes BE may return id's in non sorting manner which is used in FE so now we are making the indexing in the FE so that it will always be in sorted manner 
2.it was handled in both normal cluster and super cluster as well