### PR TITLE
fix: ui `should_client_retry` & `values` event to search cancel

### DIFF
--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -72,7 +72,7 @@ async fn can_use_distinct_stream(
     stream_name: &str,
     stream_type: StreamType,
     fields: &[String],
-    query_sql: &str,
+    query: &config::meta::search::Query,
     start_time: i64,
 ) -> bool {
     if !matches!(stream_type, StreamType::Logs | StreamType::Traces) {
@@ -102,14 +102,26 @@ async fn can_use_distinct_stream(
 
     // all the fields used in the query sent must be in the distinct stream
     #[allow(deprecated)]
-    let query_fields: Vec<_> = match config::meta::sql::Sql::new(query_sql) {
+    let query_fields: Vec<String> = match crate::service::search::sql::Sql::new(
+        &(query.clone().into()),
+        org,
+        stream_type,
+        None,
+    )
+    .await
+    {
         // if sql is invalid, we let it follow the original search and fail
         Err(_) => return false,
-        Ok(sql) => sql
-            .fields
-            .into_iter()
-            .filter(|f| f != "_timestamp")// _timestamp is hardcoded in queries
-            .collect(),
+        Ok(sql) => {
+            // check if sql contains any filters from which field cannot be inferred.
+            // where clause can contain match_all and a valid field which is in distinct stream
+            // but since there is match_all, we cannot infer the field from the where clause
+            // so we need to return false
+            if sql.match_items.is_some() {
+                return false;
+            }
+            sql.columns.values().flatten().cloned().collect()
+        }
     };
 
     let all_query_fields_distinct = query_fields.iter().all(|f| {
@@ -741,12 +753,21 @@ pub async fn build_search_request_per_field(
         (start_time, end_time)
     };
 
-    let mut uses_fn = false;
+    let mut query = config::meta::search::Query {
+        sql: String::new(), // Will be populated per field in the loop below
+        from: 0,
+        size: config::meta::sql::MAX_LIMIT,
+        start_time,
+        end_time,
+        query_fn: query_fn.clone(),
+        ..Default::default()
+    };
+
     let (sql_where, can_use_distinct_stream) = match req.filter.as_ref() {
         None => {
             if !req.sql.is_empty() {
                 if let Ok(sql) = base64::decode_url(&req.sql) {
-                    uses_fn = functions::get_all_transform_keys(org_id)
+                    query.uses_zo_fn = functions::get_all_transform_keys(org_id)
                         .await
                         .iter()
                         .any(|fn_name| sql.contains(&format!("{}(", fn_name)));
@@ -764,7 +785,7 @@ pub async fn build_search_request_per_field(
                         stream_name,
                         stream_type,
                         &fields,
-                        &sql,
+                        &query,
                         start_time,
                     )
                     .await;
@@ -790,12 +811,14 @@ pub async fn build_search_request_per_field(
                 // Define the default_sql here
                 let default_sql = format!("SELECT {} FROM \"{stream_name}\"", TIMESTAMP_COL_NAME);
 
+                query.sql = format!("{} {}", default_sql, sql_where);
+
                 let can_use_distinct_stream = can_use_distinct_stream(
                     org_id,
                     stream_name,
                     stream_type,
                     &fields,
-                    &format!("{} {}", default_sql, sql_where),
+                    &query,
                     start_time,
                 )
                 .await;
@@ -808,16 +831,7 @@ pub async fn build_search_request_per_field(
     let timeout = req.timeout.unwrap_or(0);
 
     let req = config::meta::search::Request {
-        query: config::meta::search::Query {
-            sql: String::new(), // Will be populated per field in the loop below
-            from: 0,
-            size: config::meta::sql::MAX_LIMIT,
-            start_time,
-            end_time,
-            uses_zo_fn: uses_fn,
-            query_fn: query_fn.clone(),
-            ..Default::default()
-        },
+        query,
         encoding: config::meta::search::RequestEncoding::Empty,
         regions,
         clusters,
@@ -974,17 +988,6 @@ async fn values_v1(
         (start_time, end_time)
     };
 
-    // check if we can use the distinct stream for this query
-    let use_distinct_stream = can_use_distinct_stream(
-        org_id,
-        stream_name,
-        stream_type,
-        &fields,
-        &query_sql,
-        start_time,
-    )
-    .await;
-
     let regions = query.get("regions").map_or(vec![], |regions| {
         regions
             .split(',')
@@ -1004,19 +1007,32 @@ async fn values_v1(
         .get("timeout")
         .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
 
-    // search
     let use_cache = cfg.common.result_cache_enabled && get_use_cache_from_request(query);
+
+    // search
+    let req_query = config::meta::search::Query {
+        sql: query_sql,
+        from: 0,
+        size: config::meta::sql::MAX_LIMIT,
+        start_time,
+        end_time,
+        uses_zo_fn: uses_fn,
+        query_fn: query_fn.clone(),
+        ..Default::default()
+    };
+    // check if we can use the distinct stream for this query
+    let use_distinct_stream = can_use_distinct_stream(
+        org_id,
+        stream_name,
+        stream_type,
+        &fields,
+        &req_query,
+        start_time,
+    )
+    .await;
+
     let req = config::meta::search::Request {
-        query: config::meta::search::Query {
-            sql: query_sql,
-            from: 0,
-            size: config::meta::sql::MAX_LIMIT,
-            start_time,
-            end_time,
-            uses_zo_fn: uses_fn,
-            query_fn: query_fn.clone(),
-            ..Default::default()
-        },
+        query: req_query,
         encoding: config::meta::search::RequestEncoding::Empty,
         regions,
         clusters,

--- a/src/router/http/ws/connection.rs
+++ b/src/router/http/ws/connection.rs
@@ -242,10 +242,9 @@ impl QuerierConnection {
                                     if let Err(e) = self.response_router.route_response(svr_event.clone()).await {
                                         // scenario 2 where the trace_id & sender are not cleaned up -> left for clean job
                                         log::error!(
-                                            "[WS::Router::QuerierConnection] Error routing response from querier back to client, trace_id: {}, socket: {}, message: {}, router: {}, querier: {}",
+                                            "[WS::Router::QuerierConnection] Error routing response from querier back to client, trace_id: {}, socket: {}, router: {}, querier: {}",
                                             svr_event.get_trace_id(),
                                             e,
-                                            svr_event.to_json(),
                                             cfg.common.instance_name,
                                             self.querier_name
                                         );

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -292,7 +292,7 @@ pub async fn handle_search_request(
                         trace_id,
                         e
                     );
-                    Error::Message(e.to_string())
+                    e
                 })?;
         }
     } else {

--- a/src/service/websocket_events/values.rs
+++ b/src/service/websocket_events/values.rs
@@ -47,7 +47,7 @@ pub async fn handle_values_request(
     request_id: &str,
     req: ValuesEventReq,
     accumulated_results: &mut Vec<SearchResultType>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), infra::errors::Error> {
     let mut start_timer = std::time::Instant::now();
 
     let cfg = get_config();
@@ -255,7 +255,7 @@ pub async fn handle_values_request(
                             trace_id,
                             e
                         );
-                        anyhow::anyhow!("Error writing results to cache: {}", e)
+                        e
                     })?;
             }
         } else {

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -5557,7 +5557,7 @@ const useLogs = () => {
     // Any case where below logic may end in recursion
     if (payload.traceId) delete searchPartitionMap[payload.traceId];
 
-    if (searchObj.data.isOperationCancelled) {
+    if (searchObj.data.isOperationCancelled && !response?.content?.should_client_retry) {
       searchObj.loading = false;
       searchObj.loadingHistogram = false;
       searchObj.data.isOperationCancelled = false;
@@ -5597,8 +5597,8 @@ const useLogs = () => {
       processHistogramRequest(payload.queryReq);
     }
 
-    if (payload.type === "search") searchObj.loading = false;
-    if (payload.type === "histogram" || payload.type === "pageCount")
+    if (payload.type === "search" && !response?.content?.should_client_retry) searchObj.loading = false;
+    if ((payload.type === "histogram" || payload.type === "pageCount") && !response?.content?.should_client_retry)
       searchObj.loadingHistogram = false;
 
     searchObj.data.isOperationCancelled = false;

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -5557,7 +5557,7 @@ const useLogs = () => {
     // Any case where below logic may end in recursion
     if (payload.traceId) delete searchPartitionMap[payload.traceId];
 
-    if (searchObj.data.isOperationCancelled && !response?.content?.should_client_retry) {
+    if (searchObj.data.isOperationCancelled) {
       searchObj.loading = false;
       searchObj.loadingHistogram = false;
       searchObj.data.isOperationCancelled = false;

--- a/web/src/composables/useSearchWebSocket.ts
+++ b/web/src/composables/useSearchWebSocket.ts
@@ -123,6 +123,10 @@ const useSearchWebSocket = () => {
               if(canceledTraceIds.has(response.content.trace_id)) {
                 // Don't retry the search
                 // clean up listeners will be called on cancel query response
+                traces[response.content.trace_id]?.close.forEach((handler: any) => handler({
+                  code: response.code,
+                }));
+                cleanUpListeners(response.content.trace_id);
                 return;
               }
               retryActiveTrace(response.content.trace_id, response);

--- a/web/src/composables/useSearchWebSocket.ts
+++ b/web/src/composables/useSearchWebSocket.ts
@@ -93,13 +93,6 @@ const useSearchWebSocket = () => {
       // console.log("shouldRetry", JSON.parse(JSON.stringify(traces)));
       setTimeout(() => {
         Object.keys(traces).forEach((traceId) => {
-          // Skip retrying if this trace ID was explicitly canceled
-          if(canceledTraceIds.has(traceId)) {
-            // Don't retry the search
-            // clean up listeners will be called on cancel query response
-            return;
-          }
-          
           if(((traces[traceId].socketId === _socketId) && traces[traceId].isInitiated) || !traces[traceId].socketId) {
             // Don't send error event when retry is happening
             traces[traceId]?.close.forEach((handler: any) => handler({
@@ -126,7 +119,13 @@ const useSearchWebSocket = () => {
     if(response.type === 'error'){
       if(response.content.should_client_retry && response.content.trace_id){
         setTimeout(() => {
-          retryActiveTrace(response.content.trace_id, response);
+              // Skip retrying if this trace ID was explicitly canceled
+              if(canceledTraceIds.has(response.content.trace_id)) {
+                // Don't retry the search
+                // clean up listeners will be called on cancel query response
+                return;
+              }
+              retryActiveTrace(response.content.trace_id, response);
         }, 300)
 
         return;

--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -73,8 +73,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         data-test="logs-search-no-field-found-text"
         class="text-center col-10 q-mx-none"
       >
-        <q-icon name="info" color="primary" size="xs" /> No field
-        found in selected stream.
+        <q-icon name="info" color="primary" size="xs" /> No field found in
+        selected stream.
       </h3>
     </div>
     <div v-else class="index-table q-mt-xs">
@@ -1347,7 +1347,7 @@ export default defineComponent({
           "Failed to fetch field values";
       }
 
-      removeTraceId(request.queryReq.fields[0], request.content.trace_id);
+      removeTraceId(request.queryReq.fields[0], request.traceId);
     };
 
     const handleSearchResponse = (payload: any, response: any) => {


### PR DESCRIPTION
- [x] honor user cancel in ui (logs, dashboards) if `should_client_retry` is `true, and is looping.
- [x] fix: `values` event to send `cancel` response if search query cancelled
- [x] handle `values` event error in ui