### PR TITLE
fix: enrichment table old data should not be used in vrls (#6639)

### DIFF
--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -1099,6 +1099,13 @@ impl std::fmt::Display for Operator {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct EnrichmentTableMetaStreamStats {
+    pub start_time: i64,
+    pub end_time: i64,
+    pub size: i64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -26,10 +26,7 @@ use config::{
         sql::resolve_stream_names,
         stream::StreamType,
     },
-    utils::{
-        base64, json,
-        time::{BASE_TIME, now_micros},
-    },
+    utils::{base64, json, time::now_micros},
 };
 use hashbrown::HashMap;
 use tracing::{Instrument, Span};
@@ -52,6 +49,7 @@ use crate::{
         },
     },
     service::{
+        db::enrichment_table,
         metadata::distinct_values::DISTINCT_STREAM_PREFIX,
         search as SearchService,
         self_reporting::{http_report_metrics, report_request_usage_stats},
@@ -728,7 +726,7 @@ pub async fn build_search_request_per_field(
     let no_count = req.no_count;
 
     let start_time = if stream_type.eq(&StreamType::EnrichmentTables) {
-        BASE_TIME.timestamp_micros()
+        enrichment_table::get_start_time(org_id, stream_name).await
     } else {
         req.start_time.unwrap_or(0)
     };
@@ -962,7 +960,7 @@ async fn values_v1(
 
     // EnrichmentTable need query without time range
     let start_time = if stream_type.eq(&StreamType::EnrichmentTables) {
-        BASE_TIME.timestamp_micros()
+        enrichment_table::get_start_time(org_id, stream_name).await
     } else {
         query
             .get("start_time")

--- a/src/service/db/schema.rs
+++ b/src/service/db/schema.rs
@@ -134,7 +134,13 @@ pub async fn delete(
         // Enrichment table size is not deleted by schema delete
         // Since we are storing the current size of the table in bytes in the meta table,
         // when we delete enrichment table, we need to delete the size from the db as well.
-        let _ = super::enrichment_table::delete_table_size(org_id, stream_name).await;
+        if let Err(e) = super::enrichment_table::delete_table_size(org_id, stream_name).await {
+            log::error!("Failed to delete table size: {}", e);
+        }
+        if let Err(e) = super::enrichment_table::delete_meta_table_stats(org_id, stream_name).await
+        {
+            log::error!("Failed to delete meta table stats: {}", e);
+        }
     }
 
     // super cluster

--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -29,11 +29,7 @@ use config::{
         stream::{FileKey, QueryPartitionStrategy, StreamType},
     },
     metrics,
-    utils::{
-        inverted_index::split_token,
-        json,
-        time::{BASE_TIME, now_micros},
-    },
+    utils::{inverted_index::split_token, json, time::now_micros},
 };
 use datafusion::{
     common::{TableReference, tree_node::TreeNode},
@@ -54,23 +50,26 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::{
     common::infra::cluster as infra_cluster,
-    service::search::{
-        DATAFUSION_RUNTIME, SearchResult,
-        datafusion::{
-            distributed_plan::{
-                EmptyExecVisitor,
-                remote_scan::RemoteScanExec,
-                rewrite::{RemoteScanRewriter, StreamingAggsRewriter},
+    service::{
+        db::enrichment_table,
+        search::{
+            DATAFUSION_RUNTIME, SearchResult,
+            datafusion::{
+                distributed_plan::{
+                    EmptyExecVisitor,
+                    remote_scan::RemoteScanExec,
+                    rewrite::{RemoteScanRewriter, StreamingAggsRewriter},
+                },
+                exec::{prepare_datafusion_context, register_udf},
+                optimizer::{generate_analyzer_rules, generate_optimizer_rules},
+                table_provider::{catalog::StreamTypeProvider, empty_table::NewEmptyTable},
             },
-            exec::{prepare_datafusion_context, register_udf},
-            optimizer::{generate_analyzer_rules, generate_optimizer_rules},
-            table_provider::{catalog::StreamTypeProvider, empty_table::NewEmptyTable},
+            generate_filter_from_equal_items,
+            inspector::{SearchInspectorFieldsBuilder, search_inspector_fields},
+            request::Request,
+            sql::Sql,
+            utils::{AsyncDefer, ScanStatsVisitor},
         },
-        generate_filter_from_equal_items,
-        inspector::{SearchInspectorFieldsBuilder, search_inspector_fields},
-        request::Request,
-        sql::Sql,
-        utils::{AsyncDefer, ScanStatsVisitor},
     },
 };
 
@@ -886,7 +885,7 @@ pub async fn get_file_id_lists(
         // if stream is enrich, rewrite the time_range
         if let Some(schema) = stream.schema() {
             if schema == "enrich" || schema == "enrichment_tables" {
-                let start = BASE_TIME.timestamp_micros();
+                let start = enrichment_table::get_start_time(org_id, &name).await;
                 let end = now_micros();
                 time_range = Some((start, end));
             }

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -39,6 +39,7 @@ use infra::{
     table::distinct_values::{DistinctFieldRecord, OriginType, check_field_use},
 };
 
+use super::db::enrichment_table;
 use crate::{
     common::meta::{
         authz::Authz,
@@ -62,7 +63,7 @@ pub async fn get_stream(
 
     if schema != Schema::empty() {
         let mut stats = stats::get_stream_stats(org_id, stream_name, stream_type);
-        transform_stats(&mut stats);
+        transform_stats(&mut stats, org_id, stream_name, stream_type).await;
         Some(stream_res(stream_name, stream_type, schema, Some(stats)))
     } else {
         None
@@ -118,7 +119,13 @@ pub async fn get_streams(
                 None,
             ));
         } else {
-            transform_stats(&mut stats);
+            transform_stats(
+                &mut stats,
+                org_id,
+                stream_loc.stream_name.as_str(),
+                stream_loc.stream_type,
+            )
+            .await;
             indices_res.push(stream_res(
                 stream_loc.stream_name.as_str(),
                 stream_loc.stream_type,
@@ -668,10 +675,21 @@ pub async fn delete_stream(
     )))
 }
 
-fn transform_stats(stats: &mut StreamStats) {
+async fn transform_stats(
+    stats: &mut StreamStats,
+    org_id: &str,
+    stream_name: &str,
+    stream_type: StreamType,
+) {
     stats.storage_size /= SIZE_IN_MB;
     stats.compressed_size /= SIZE_IN_MB;
     stats.index_size /= SIZE_IN_MB;
+    if stream_type == StreamType::EnrichmentTables {
+        if let Some(meta) = enrichment_table::get_meta_table_stats(org_id, stream_name).await {
+            stats.doc_time_min = meta.start_time;
+            stats.doc_time_max = meta.end_time;
+        }
+    }
 }
 
 pub fn stream_created(schema: &Schema) -> Option<i64> {


### PR DESCRIPTION
This pr uses the meta table to store the start_time and end_time of enrichment table, instead of relying on the stream_stats table which takes some time to update. When we cache enrichment table for vrls, we use the above start_time and end_time instead of `BASE_TIMESTAMP` (because when enrichment table is overridden, deletion of old data happens in the background and is not realtime, so using `BASE_TIMESTAMP` included old data)

