### PR TITLE
fix: remove cron if frequency changed to minutes (#6676)

### DIFF
--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -279,10 +279,16 @@ async fn prepare_alert(
         alert.trigger_condition.cron = update_cron_expression(&alert.trigger_condition.cron, now);
         // Check the cron expression
         Schedule::from_str(&alert.trigger_condition.cron).map_err(AlertError::ParseCron)?;
-    } else if alert.trigger_condition.frequency == 0 {
-        // default frequency is 60 seconds
-        alert.trigger_condition.frequency =
-            std::cmp::max(60, get_config().limit.alert_schedule_interval);
+    } else {
+        // if cron is not empty, set it to empty string
+        if !alert.trigger_condition.cron.is_empty() {
+            alert.trigger_condition.cron = "".to_string();
+        }
+        if alert.trigger_condition.frequency == 0 {
+            // default frequency is 60 seconds
+            alert.trigger_condition.frequency =
+                std::cmp::max(60, get_config().limit.alert_schedule_interval);
+        }
     }
 
     if alert.name.is_empty() || alert.stream_name.is_empty() {

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -266,7 +266,15 @@ async fn handle_alert_triggers(
 
         let skipped_timestamps_end_timestamp = get_skipped_timestamps(
             trigger.next_run_at,
-            alert.trigger_condition.cron.as_str(),
+            if alert
+                .trigger_condition
+                .frequency_type
+                .eq(&config::meta::alerts::FrequencyType::Cron)
+            {
+                alert.trigger_condition.cron.as_str()
+            } else {
+                ""
+            },
             alert.tz_offset,
             alert.trigger_condition.frequency,
             delay,
@@ -289,7 +297,7 @@ async fn handle_alert_triggers(
             // If delay is greater than the alert frequency, skip them and report the event
             // to the `triggers` usage stream.
             publish_triggers_usage(TriggerData {
-                _timestamp: timestamp,
+                _timestamp: now - 1,
                 org: trigger.org.clone(),
                 module: TriggerDataType::Alert,
                 key: format!("{}/{}", alert.name, trigger.module_key),
@@ -300,7 +308,7 @@ async fn handle_alert_triggers(
                 start_time,
                 end_time: timestamp,
                 retries: trigger.retries,
-                delay_in_secs: Some(Duration::microseconds(now - timestamp).num_seconds()),
+                delay_in_secs: Some(delay),
                 error: None,
                 success_response: None,
                 is_partial: None,

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -111,7 +111,9 @@ pub async fn get_streams(
             stream_loc.stream_name.as_str(),
             stream_loc.stream_type,
         );
-        if stats.eq(&StreamStats::default()) {
+        if stats.eq(&StreamStats::default())
+            && stream_loc.stream_type != StreamType::EnrichmentTables
+        {
             indices_res.push(stream_res(
                 stream_loc.stream_name.as_str(),
                 stream_loc.stream_type,


### PR DESCRIPTION
- When in the alert, frequency is changed from cron to minutes, we don't delete the old cron expression. This pr fixes that.
- Fixes false reporting of skipped alert events
- Enrichment table doc_time_min and doc_time_max should use meta table stats not stream stats in the enrichment table list api.