### PR TITLE
fix: ws `tokio::select`, `health_check` & `router_id` for router-querier conn

### DIFF
--- a/src/handler/http/request/ws/mod.rs
+++ b/src/handler/http/request/ws/mod.rs
@@ -86,7 +86,10 @@ pub async fn websocket(
     );
 
     // Spawn the handler
-    actix_web::rt::spawn(session::run(msg_stream, user_id, router_id, path));
+    actix_web::rt::spawn(session::run(msg_stream, user_id, router_id.clone(), path));
+
+    // Spawn the health check task
+    tokio::spawn(session::health_check(router_id));
 
     Ok(res)
 }

--- a/src/handler/http/request/ws/session.rs
+++ b/src/handler/http/request/ws/session.rs
@@ -141,6 +141,7 @@ pub async fn health_check(req_id: String) {
     let mut ping_interval = tokio::time::interval(Duration::from_secs(
         get_ping_interval_secs_with_jitter() as u64,
     ));
+    ping_interval.tick().await;
     loop {
         ping_interval.tick().await;
         if let Some(session) = sessions_cache_utils::get_session(&req_id).await {

--- a/src/handler/http/request/ws/session.rs
+++ b/src/handler/http/request/ws/session.rs
@@ -145,8 +145,9 @@ pub async fn run(
     );
 
     let mut ping_interval = tokio::time::interval(Duration::from_secs(
-        get_ping_interval_secs_with_jitter() as _,
+        get_ping_interval_secs_with_jitter() as u64,
     ));
+
     let mut close_reason: Option<CloseReason> = None;
 
     loop {

--- a/src/handler/http/request/ws/session.rs
+++ b/src/handler/http/request/ws/session.rs
@@ -296,7 +296,7 @@ pub async fn run(
                 }
             }
         } else {
-            log::info!(
+            log::warn!(
                 "[WS_HANDLER]: No message received for req_id: {}, querier: {}",
                 req_id,
                 cfg.common.instance_name

--- a/src/router/http/ws/connection.rs
+++ b/src/router/http/ws/connection.rs
@@ -132,7 +132,7 @@ pub async fn create_connection(querier_name: &QuerierName) -> WsResult<Arc<Queri
     // Get querier info from cluster
     let node = cluster::get_cached_node_by_name(querier_name)
         .await
-        .ok_or_else(|| WsError::QuerierNotAvailable(querier_name.to_string()))?;
+        .ok_or_else(|| WsError::QuerierWsConnNotAvailable(querier_name.to_string()))?;
 
     let conn = QuerierConnection::connect(&node.name, &node.http_addr).await?;
     Ok(conn)

--- a/src/router/http/ws/connection.rs
+++ b/src/router/http/ws/connection.rs
@@ -321,6 +321,7 @@ impl QuerierConnection {
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(
             get_ping_interval_secs_with_jitter() as _,
         ));
+        interval.tick().await;
 
         loop {
             interval.tick().await;
@@ -426,6 +427,7 @@ impl ResponseRouter {
     /// The only
     async fn spawn_cleanup_task(&self) {
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
+        interval.tick().await;
         loop {
             interval.tick().await;
             let mut write_guard = self.routes.write().await;

--- a/src/router/http/ws/connection.rs
+++ b/src/router/http/ws/connection.rs
@@ -25,10 +25,7 @@ use futures_util::{
 use reqwest::header::{HeaderName, HeaderValue};
 use tokio::{
     net::TcpStream,
-    sync::{
-        RwLock,
-        mpsc::{Sender, channel},
-    },
+    sync::{RwLock, mpsc::Sender},
 };
 use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream, connect_async_with_config,
@@ -62,7 +59,6 @@ pub trait Connection: Send + Sync {
 pub struct QuerierConnection {
     querier_name: QuerierName,
     write: Arc<RwLock<Option<SplitSink<WsStreamType, WsMessage>>>>,
-    shutdown_tx: Sender<()>,
     response_router: Arc<ResponseRouter>,
 }
 
@@ -167,106 +163,153 @@ impl QuerierConnection {
     async fn listen_to_querier_response(
         &self,
         mut read: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
-        mut shutdown_rx: tokio::sync::mpsc::Receiver<()>,
     ) {
         let cfg = get_config();
         let mut querier_conn_error: Option<String> = None;
         loop {
             // Handle incoming messages from querier to router
-            tokio::select! {
-                Some(msg) = read.next() => {
-                    match msg {
-                        Ok(msg) => {
-                            match msg {
-                                tungstenite::protocol::Message::Close(reason) => {
-                                    log::debug!("[WS::Router::QuerierConnection] received close message: {:?}, router: {}, querier: {}", reason, cfg.common.instance_name, self.querier_name);
-                                    break;
+            if let Some(msg) = read.next().await {
+                match msg {
+                    Ok(msg) => {
+                        match msg {
+                            tungstenite::protocol::Message::Close(reason) => {
+                                log::debug!(
+                                    "[WS::Router::QuerierConnection] received close message: {:?}, router: {}, querier: {}",
+                                    reason,
+                                    cfg.common.instance_name,
+                                    self.querier_name
+                                );
+                                break;
+                            }
+                            tungstenite::protocol::Message::Ping(ping) => {
+                                log::debug!(
+                                    "[WS::Router::QuerierConnection] received ping message: {:?}, router: {}, querier: {}",
+                                    ping,
+                                    cfg.common.instance_name,
+                                    self.querier_name
+                                );
+                                let pong = tungstenite::protocol::Message::Pong(ping);
+                                let write_clone = self.write.clone();
+                                let mut write_guard = write_clone.write().await;
+                                if let Some(write) = write_guard.as_mut() {
+                                    let _ = write.send(pong).await;
                                 }
-                                tungstenite::protocol::Message::Ping(ping) => {
-                                    log::debug!("[WS::Router::QuerierConnection] received ping message: {:?}, router: {}, querier: {}", ping, cfg.common.instance_name, self.querier_name);
-                                    let pong = tungstenite::protocol::Message::Pong(ping);
-                                    let write_clone = self.write.clone();
-                                    let mut write_guard = write_clone.write().await;
-                                    if let Some(write) = write_guard.as_mut() {
-                                        let _ = write.send(pong).await;
+                                drop(write_guard);
+                            }
+                            tungstenite::protocol::Message::Pong(pong) => {
+                                log::debug!(
+                                    "[WS::Router::QuerierConnection] received pong message: {:?}, router: {}, querier: {}",
+                                    pong,
+                                    cfg.common.instance_name,
+                                    self.querier_name
+                                );
+                            }
+                            tungstenite::protocol::Message::Binary(binary) => {
+                                log::debug!(
+                                    "[WS::Router::QuerierConnection] received binary message: {:?}, router: {}, querier: {}",
+                                    binary,
+                                    cfg.common.instance_name,
+                                    self.querier_name
+                                );
+                            }
+                            tungstenite::protocol::Message::Frame(frame) => {
+                                log::debug!(
+                                    "[WS::Router::QuerierConnection] received raw frame from querier: {:?}, router: {}, querier: {}",
+                                    frame,
+                                    cfg.common.instance_name,
+                                    self.querier_name
+                                );
+                            }
+                            tungstenite::protocol::Message::Text(text) => {
+                                let svr_event = match json::from_str::<WsServerEvents>(&text) {
+                                    Ok(event) => {
+                                        log::info!(
+                                            "[WS::Router::QuerierConnection] router received message from querier for trace_id: {}, router: {}, querier: {}",
+                                            event.get_trace_id(),
+                                            cfg.common.instance_name,
+                                            self.querier_name
+                                        );
+                                        event
                                     }
-                                    drop(write_guard);
-                                }
-                                tungstenite::protocol::Message::Pong(pong) => {
-                                    log::debug!("[WS::Router::QuerierConnection] received pong message: {:?}, router: {}, querier: {}", pong, cfg.common.instance_name, self.querier_name);
-                                }
-                                tungstenite::protocol::Message::Binary(binary) => {
-                                    log::debug!("[WS::Router::QuerierConnection] received binary message: {:?}, router: {}, querier: {}", binary, cfg.common.instance_name, self.querier_name);
-                                }
-                                tungstenite::protocol::Message::Frame(frame) => {
-                                    log::debug!("[WS::Router::QuerierConnection] received raw frame from querier: {:?}, router: {}, querier: {}", frame, cfg.common.instance_name, self.querier_name);
-                                }
-                                tungstenite::protocol::Message::Text(text) => {
-                                    let svr_event = match json::from_str::<WsServerEvents>(&text) {
-                                        Ok(event) => {
-                                            log::info!("[WS::Router::QuerierConnection] router received message from querier for trace_id: {}, router: {}, querier: {}", event.get_trace_id(), cfg.common.instance_name, self.querier_name);
-                                            event
-                                        },
-                                        Err(e) => {
-                                            log::error!(
-                                                "[WS::Router::QuerierConnection] Error parsing message received from querier: {}, router: {}, querier: {}",
-                                                e,
-                                                cfg.common.instance_name,
-                                                self.querier_name
-                                            );
-                                            match json::from_str::<json::Value>(&text).map(|val| val.get("trace_id").map(ToString::to_string)) {
-                                                Err(e) => {
-                                                    log::error!(
-                                                        "[WS::Router::QuerierConnection] Error parsing trace_id from message received from querier: router: {}, querier: {}, error: {}",
-                                                        cfg.common.instance_name,
-                                                        self.querier_name,
-                                                        e
-                                                    );
-                                                    // scenario 1 where the trace_id & sender are not cleaned up -> left for clean job
-                                                    continue;
-                                                }
-                                                Ok(trace_id) => {
-                                                    WsServerEvents::Error {
-                                                        code: StatusCode::INTERNAL_SERVER_ERROR.into(),
-                                                        message: "Failed to parse event received from querier".to_string(),
-                                                        error_detail: None,
-                                                        trace_id,
-                                                        request_id: None,
-                                                        should_client_retry: true,
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    };
-                                    let remove_trace_id = svr_event.should_clean_trace_id();
-                                    if let Err(e) = self.response_router.route_response(svr_event.clone()).await {
-                                        // scenario 2 where the trace_id & sender are not cleaned up -> left for clean job
+                                    Err(e) => {
                                         log::error!(
-                                            "[WS::Router::QuerierConnection] Error routing response from querier back to client, trace_id: {}, socket: {}, router: {}, querier: {}",
-                                            svr_event.get_trace_id(),
+                                            "[WS::Router::QuerierConnection] Error parsing message received from querier: {}, router: {}, querier: {}",
                                             e,
                                             cfg.common.instance_name,
                                             self.querier_name
                                         );
+                                        match json::from_str::<json::Value>(&text)
+                                            .map(|val| val.get("trace_id").map(ToString::to_string))
+                                        {
+                                            Err(e) => {
+                                                log::error!(
+                                                    "[WS::Router::QuerierConnection] Error parsing trace_id from message received from querier: router: {}, querier: {}, error: {}",
+                                                    cfg.common.instance_name,
+                                                    self.querier_name,
+                                                    e
+                                                );
+                                                // scenario 1 where the trace_id & sender are not
+                                                // cleaned up -> left for clean job
+                                                continue;
+                                            }
+                                            Ok(trace_id) => WsServerEvents::Error {
+                                                code: StatusCode::INTERNAL_SERVER_ERROR.into(),
+                                                message:
+                                                    "Failed to parse event received from querier"
+                                                        .to_string(),
+                                                error_detail: None,
+                                                trace_id,
+                                                request_id: None,
+                                                should_client_retry: true,
+                                            },
+                                        }
                                     }
-                                    if let Some(trace_id) = remove_trace_id {
-                                        log::info!("[WS::Router::QuerierConnection] Unregistering trace_id: {}, svr_event: {:?}, router: {}, querier: {}", trace_id, svr_event, cfg.common.instance_name, self.querier_name);
-                                        self.unregister_request(&trace_id).await;
-                                    }
+                                };
+                                let remove_trace_id = svr_event.should_clean_trace_id();
+                                if let Err(e) =
+                                    self.response_router.route_response(svr_event.clone()).await
+                                {
+                                    // scenario 2 where the trace_id & sender are not cleaned up ->
+                                    // left for clean job
+                                    log::error!(
+                                        "[WS::Router::QuerierConnection] Error routing response from querier back to client, trace_id: {}, socket: {}, router: {}, querier: {}",
+                                        svr_event.get_trace_id(),
+                                        e,
+                                        cfg.common.instance_name,
+                                        self.querier_name
+                                    );
+                                }
+                                if let Some(trace_id) = remove_trace_id {
+                                    log::info!(
+                                        "[WS::Router::QuerierConnection] Unregistering trace_id: {}, svr_event: {:?}, router: {}, querier: {}",
+                                        trace_id,
+                                        svr_event,
+                                        cfg.common.instance_name,
+                                        self.querier_name
+                                    );
+                                    self.unregister_request(&trace_id).await;
                                 }
                             }
                         }
-                        Err(e) => {
-                            log::error!("[WS::Router::QuerierConnection] Read error: {}, Querier: {}, router: {}", e, self.querier_name, cfg.common.instance_name);
-                            querier_conn_error = Some(e.to_string());
-                            break;
-                        }
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "[WS::Router::QuerierConnection] Read error: {}, Querier: {}, router: {}",
+                            e,
+                            self.querier_name,
+                            cfg.common.instance_name
+                        );
+                        querier_conn_error = Some(e.to_string());
+                        break;
                     }
                 }
-                _ = shutdown_rx.recv() => {
-                    log::info!("[WS::Router::QuerierConnection] shutting down. Stop listening from the querier {}, router: {}", self.querier_name, cfg.common.instance_name);
-                    break;
-                }
+            } else {
+                log::error!(
+                    "[WS::Router::QuerierConnection] Read error: could not read message from querier, Querier: {}, router: {}",
+                    self.querier_name,
+                    cfg.common.instance_name
+                );
+                break;
             }
         }
 
@@ -454,23 +497,19 @@ impl Connection for QuerierConnection {
         let (write, read) = ws_stream.split();
         let write = Arc::new(RwLock::new(Some(write)));
 
-        // Signal to shutdown
-        let (shutdown_tx, shutdown_rx) = channel::<()>(1);
-
         // Setting up components needed for the two tasks
         let response_router = ResponseRouter::new();
 
         let conn: Arc<QuerierConnection> = Arc::new(Self {
             querier_name: node_name.to_string(),
             write,
-            shutdown_tx,
             response_router,
         });
 
         // Spawn task to listen to querier responses
         let conn_t1 = conn.clone();
         tokio::spawn(async move {
-            let _ = conn_t1.listen_to_querier_response(read, shutdown_rx).await;
+            let _ = conn_t1.listen_to_querier_response(read).await;
         });
 
         // Spawn health check task
@@ -491,7 +530,6 @@ impl Connection for QuerierConnection {
             *write_guard = None;
         }
         drop(write_guard);
-        _ = self.shutdown_tx.send(()).await;
     }
 
     async fn send_message(&self, message: WsClientEvents) -> WsResult<()> {

--- a/src/router/http/ws/connection.rs
+++ b/src/router/http/ws/connection.rs
@@ -304,12 +304,11 @@ impl QuerierConnection {
                     }
                 }
             } else {
-                log::error!(
+                log::warn!(
                     "[WS::Router::QuerierConnection] Read error: could not read message from querier, Querier: {}, router: {}",
                     self.querier_name,
                     cfg.common.instance_name
                 );
-                break;
             }
         }
 

--- a/src/router/http/ws/connection.rs
+++ b/src/router/http/ws/connection.rs
@@ -604,7 +604,12 @@ fn get_default_querier_request(http_url: &str) -> WsResult<tungstenite::http::Re
     }
 
     let instance_name = get_config().common.instance_name.clone();
-    let parsed_url = parsed_url.to_string() + "api/default/ws/v2/" + &instance_name;
+    let id = format!(
+        "{}-{}",
+        instance_name,
+        chrono::Utc::now().timestamp_micros()
+    );
+    let parsed_url = parsed_url.to_string() + "api/default/ws/v2/" + &id;
 
     let mut ws_req = parsed_url
         .into_client_request()

--- a/src/router/http/ws/connection.rs
+++ b/src/router/http/ws/connection.rs
@@ -534,6 +534,10 @@ impl Connection for QuerierConnection {
     }
 
     async fn send_message(&self, message: WsClientEvents) -> WsResult<()> {
+        log::info!(
+            "[WS::QuerierConnection] send_message -> attempt to send for trace_id: {}",
+            message.get_trace_id()
+        );
         let mut write_guard = self.write.write().await;
         if let Some(write) = write_guard.as_mut() {
             let trace_id = message.get_trace_id();

--- a/src/router/http/ws/connection.rs
+++ b/src/router/http/ws/connection.rs
@@ -305,7 +305,7 @@ impl QuerierConnection {
                 }
             } else {
                 log::warn!(
-                    "[WS::Router::QuerierConnection] Read error: could not read message from querier, Querier: {}, router: {}",
+                    "[WS::Router::QuerierConnection] Read error: received no message from querier, Querier: {}, router: {}",
                     self.querier_name,
                     cfg.common.instance_name
                 );

--- a/src/router/http/ws/error.rs
+++ b/src/router/http/ws/error.rs
@@ -41,8 +41,8 @@ pub enum WsError {
     #[error("Response channel registered for trace_id {0} not found")]
     ResponseChannelClosed(String),
 
-    #[error("Querier not available: {0}")]
-    QuerierNotAvailable(String),
+    #[error("Querier WS connection not available: {0}")]
+    QuerierWsConnNotAvailable(String),
 
     #[error("Querier http url {0} not valid")]
     QuerierUrlInvalid(String),
@@ -63,7 +63,7 @@ impl ResponseError for WsError {
             WsError::SessionNotFound(_) => StatusCode::BAD_REQUEST,
             WsError::QuerierUrlInvalid(_) => StatusCode::INTERNAL_SERVER_ERROR,
             WsError::QuerierWSUrlError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            WsError::QuerierNotAvailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+            WsError::QuerierWsConnNotAvailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             WsError::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
             WsError::ResponseChannelNotFound(_) => StatusCode::INTERNAL_SERVER_ERROR,
             WsError::ResponseChannelClosed(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -122,7 +122,7 @@ impl WsError {
     pub fn should_disconnect(&self) -> bool {
         matches!(
             self,
-            WsError::ProtocolError(_) | WsError::QuerierNotAvailable(_)
+            WsError::ProtocolError(_) | WsError::QuerierWsConnNotAvailable(_)
         )
     }
 

--- a/src/router/http/ws/handler.rs
+++ b/src/router/http/ws/handler.rs
@@ -298,7 +298,7 @@ impl WsHandler {
                                                 }
                                             }
 
-                                            log::info!("[WS::Router::Handler] processed message for client_id: {}, trace_id: {}", client_id, trace_id);
+                                            log::info!("[WS::Router::Handler] processed message to querier: {}, for client_id: {}, trace_id: {}", querier_conn.get_name(), client_id, trace_id);
                                             count += 1;
                                         }
                                     }

--- a/src/router/http/ws/handler.rs
+++ b/src/router/http/ws/handler.rs
@@ -107,7 +107,6 @@ impl WsHandler {
             tokio::sync::mpsc::channel::<Option<DisconnectMessage>>(10);
         let session_manager = self.session_manager.clone();
         let connection_pool = self.connection_pool.clone();
-        // let request_timings = self.request_timings.clone();
 
         // Before spawning the async task, clone the drain state
         let is_session_drain_state = session_manager.is_session_drain_state(&client_id).await;

--- a/src/router/http/ws/handler.rs
+++ b/src/router/http/ws/handler.rs
@@ -630,7 +630,7 @@ pub async fn get_querier_connection(
         tokio::time::sleep(interval).await;
     }
 
-    Err(WsError::QuerierNotAvailable(
+    Err(WsError::QuerierWsConnNotAvailable(
         "Reached maximum retries of 3".to_string(),
     ))
 }
@@ -644,7 +644,7 @@ async fn select_querier(trace_id: &str, role_group: Option<RoleGroup>) -> WsResu
         role_group,
     )
     .await
-    .ok_or_else(|| WsError::QuerierNotAvailable(format!("for trace_id {}", trace_id)))?;
+    .ok_or_else(|| WsError::QuerierWsConnNotAvailable(format!("for trace_id {}", trace_id)))?;
     Ok(node)
 }
 #[cfg(feature = "enterprise")]

--- a/src/router/http/ws/handler.rs
+++ b/src/router/http/ws/handler.rs
@@ -162,7 +162,10 @@ impl WsHandler {
                     .reached_max_idle_time(&client_id_clone)
                     .await
                 {
-                    log::info!("[WS::Router::Handler]: MAX_IDLE_TIME reached. Normal shutdown");
+                    log::info!(
+                        "[WS::Router::Handler]: MAX_IDLE_TIME reached. Normal shutdown client_id: {}",
+                        client_id_clone
+                    );
                     if let Err(e) = disconnect_tx_clone2.send(None).await {
                         log::error!(
                             "[WS::Router::Handler] Error informing handle_outgoing to stop: {e}"

--- a/src/service/db/short_url.rs
+++ b/src/service/db/short_url.rs
@@ -115,6 +115,7 @@ async fn run_gc_task(gc_interval_minutes: i64, retention_period_minutes: i64) {
     let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(
         gc_interval_minutes as u64 * 60,
     ));
+    interval.tick().await;
 
     loop {
         interval.tick().await;

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -863,7 +863,7 @@ async fn send_cached_responses(
         cached.cached_response.result_cache_ratio,
         accumulated_results.len()
     );
-    send_message(req_id, ws_search_res.to_json(), &trace_id).await?;
+    send_message(req_id, ws_search_res.to_json(), trace_id).await?;
 
     // Send progress update
     {
@@ -882,7 +882,7 @@ async fn send_cached_responses(
                 event_type: req.event_type().to_string(),
             }
             .to_json(),
-            &trace_id,
+            trace_id,
         )
         .await?;
     }
@@ -1029,7 +1029,7 @@ pub async fn do_partitioned_search(
                 },
                 streaming_aggs: is_streaming_aggs,
             };
-            send_message(req_id, ws_search_res.to_json(), &trace_id).await?;
+            send_message(req_id, ws_search_res.to_json(), trace_id).await?;
         }
 
         // Send progress update
@@ -1049,7 +1049,7 @@ pub async fn do_partitioned_search(
                     event_type: "search".to_string(),
                 }
                 .to_json(),
-                &trace_id,
+                trace_id,
             )
             .await?;
         }
@@ -1109,7 +1109,7 @@ async fn send_partial_search_resp(
         trace_id
     );
 
-    send_message(req_id, ws_search_res.to_json(), &trace_id).await?;
+    send_message(req_id, ws_search_res.to_json(), trace_id).await?;
 
     Ok(())
 }

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -126,10 +126,10 @@ pub async fn handle_search_request(
             let err_res = WsServerEvents::error_response(
                 &Error::Message(e.to_string()),
                 Some(req_id.to_string()),
-                Some(trace_id),
+                Some(trace_id.clone()),
                 Default::default(),
             );
-            send_message(req_id, err_res.to_json()).await?;
+            send_message(req_id, err_res.to_json(), &trace_id).await?;
             return Ok(());
         }
     };
@@ -143,10 +143,10 @@ pub async fn handle_search_request(
             let err_res = WsServerEvents::error_response(
                 &Error::Message(e),
                 Some(req_id.to_string()),
-                Some(trace_id),
+                Some(trace_id.clone()),
                 Default::default(),
             );
-            send_message(req_id, err_res.to_json()).await?;
+            send_message(req_id, err_res.to_json(), &trace_id).await?;
             return Ok(());
         }
     }
@@ -204,6 +204,7 @@ pub async fn handle_search_request(
             event_type: req.event_type().to_string(),
         }
         .to_json(),
+        &trace_id,
     )
     .await?;
 
@@ -336,7 +337,7 @@ pub async fn handle_search_request(
     let end_res = WsServerEvents::End {
         trace_id: Some(trace_id.clone()),
     };
-    send_message(req_id, end_res.to_json()).await?;
+    send_message(req_id, end_res.to_json(), &trace_id).await?;
 
     Ok(())
 }
@@ -694,7 +695,7 @@ async fn process_delta(
                 result_cache_ratio,
                 accumulated_results.len()
             );
-            send_message(req_id, ws_search_res.to_json()).await?;
+            send_message(req_id, ws_search_res.to_json(), &trace_id).await?;
         }
 
         // Stop if `remaining_query_range` is less than 0
@@ -738,6 +739,7 @@ async fn process_delta(
                     event_type: req.event_type().to_string(),
                 }
                 .to_json(),
+                &trace_id,
             )
             .await?;
         }
@@ -861,7 +863,7 @@ async fn send_cached_responses(
         cached.cached_response.result_cache_ratio,
         accumulated_results.len()
     );
-    send_message(req_id, ws_search_res.to_json()).await?;
+    send_message(req_id, ws_search_res.to_json(), &trace_id).await?;
 
     // Send progress update
     {
@@ -880,6 +882,7 @@ async fn send_cached_responses(
                 event_type: req.event_type().to_string(),
             }
             .to_json(),
+            &trace_id,
         )
         .await?;
     }
@@ -1026,7 +1029,7 @@ pub async fn do_partitioned_search(
                 },
                 streaming_aggs: is_streaming_aggs,
             };
-            send_message(req_id, ws_search_res.to_json()).await?;
+            send_message(req_id, ws_search_res.to_json(), &trace_id).await?;
         }
 
         // Send progress update
@@ -1046,6 +1049,7 @@ pub async fn do_partitioned_search(
                     event_type: "search".to_string(),
                 }
                 .to_json(),
+                &trace_id,
             )
             .await?;
         }
@@ -1105,7 +1109,7 @@ async fn send_partial_search_resp(
         trace_id
     );
 
-    send_message(req_id, ws_search_res.to_json()).await?;
+    send_message(req_id, ws_search_res.to_json(), &trace_id).await?;
 
     Ok(())
 }

--- a/src/service/websocket_events/utils.rs
+++ b/src/service/websocket_events/utils.rs
@@ -114,6 +114,7 @@ pub mod sessions_cache_utils {
 
         let mut interval =
             tokio::time::interval(std::time::Duration::from_secs(interval_secs as u64));
+        interval.tick().await;
 
         tokio::spawn(async move {
             loop {

--- a/src/service/websocket_events/values.rs
+++ b/src/service/websocket_events/values.rs
@@ -84,10 +84,10 @@ pub async fn handle_values_request(
             let err_res = WsServerEvents::error_response(
                 &infra::errors::Error::Message(e),
                 Some(request_id.to_string()),
-                Some(trace_id),
+                Some(trace_id.clone()),
                 Default::default(),
             );
-            send_message(request_id, err_res.to_json()).await?;
+            send_message(request_id, err_res.to_json(), &trace_id).await?;
             return Ok(());
         }
     }
@@ -304,7 +304,7 @@ pub async fn handle_values_request(
     let end_res = WsServerEvents::End {
         trace_id: Some(trace_id.clone()),
     };
-    send_message(request_id, end_res.to_json()).await?;
+    send_message(request_id, end_res.to_json(), &trace_id).await?;
 
     Ok(())
 }

--- a/web/src/composables/useWebSocket.ts
+++ b/web/src/composables/useWebSocket.ts
@@ -66,7 +66,8 @@ const onMessage = (socketId: string, event: MessageEvent) => {
 };
 
 const onClose = (socketId: string, event: CloseEvent) => {
-  console.log("onClose", socketId, event.code, event.reason);
+  const closeTime = new Date().toISOString();
+  console.log("onClose", socketId, event.code, event.reason, closeTime);
   clearInterval(pingIntervals[socketId]);
   delete pingIntervals[socketId];
   delete sockets[socketId];

--- a/web/src/composables/useWebSocket.ts
+++ b/web/src/composables/useWebSocket.ts
@@ -66,7 +66,7 @@ const onMessage = (socketId: string, event: MessageEvent) => {
 };
 
 const onClose = (socketId: string, event: CloseEvent) => {
-  const closeTime = new Date().toISOString();
+  const closeTime = new Date().toLocaleString();
   console.log("onClose", socketId, event.code, event.reason, closeTime);
   clearInterval(pingIntervals[socketId]);
   delete pingIntervals[socketId];


### PR DESCRIPTION
- [x] refactor `tokio::select` spawn tasks instead at router & querier
- [x] fix health check at both router and querier 
- [x] fix router id to use timestamp micros for rotuer-querier conn