### PR TITLE
fix: duplicate usage reporting for alerts

### DIFF
--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -246,6 +246,8 @@ pub async fn search(
                             | search::SearchEventType::Dashboards
                             | search::SearchEventType::Values
                             | search::SearchEventType::Other
+                            // Alerts search now uses grpc cache::search which does report usage
+                            | search::SearchEventType::Alerts
                     ) {
                         (false, None, None)
                     } else {

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -248,6 +248,7 @@ pub async fn search(
                             | search::SearchEventType::Other
                             // Alerts search now uses grpc cache::search which does report usage
                             | search::SearchEventType::Alerts
+                            | search::SearchEventType::DerivedStream
                     ) {
                         (false, None, None)
                     } else {


### PR DESCRIPTION
We recently started using grpc search for alerts inside alert manager. Now, the grpc search uses `cache::search` (and `service::search` when no data in cache). `service::search` already reports usage for alert search event, and also the same is done by `cache::search` as well. Hence, there are duplicate search usage reporting for alerts. In this pr, only the `cache::search` reports usage in case of alerts.