### PR TITLE
fix: scheduler query trace_id should be searchable in traces page

### DIFF
--- a/src/handler/grpc/flight/mod.rs
+++ b/src/handler/grpc/flight/mod.rs
@@ -67,7 +67,7 @@ impl FlightService for FlightServiceImpl {
     type ListActionsStream = BoxStream<'static, Result<ActionType, Status>>;
     type DoExchangeStream = BoxStream<'static, Result<FlightData, Status>>;
 
-    #[tracing::instrument(name = "service:search:flight::do_get", skip_all)]
+    #[tracing::instrument(name = "grpc:search:flight:do_get", skip_all)]
     async fn do_get(
         &self,
         request: Request<Ticket>,

--- a/src/handler/grpc/request/search/mod.rs
+++ b/src/handler/grpc/request/search/mod.rs
@@ -134,7 +134,6 @@ impl Search for Searcher {
     ) -> Result<Response<SearchResponse>, Status> {
         let start = std::time::Instant::now();
         let req = req.into_inner();
-
         let request = json::from_slice::<search::Request>(&req.request)
             .map_err(|e| Status::internal(format!("failed to parse search request: {e}")))?;
         let stream_type = StreamType::from(req.stream_type.as_str());

--- a/src/handler/http/request/ws/session.rs
+++ b/src/handler/http/request/ws/session.rs
@@ -40,9 +40,12 @@ use crate::handler::http::request::search::error_utils::map_error_to_http_respon
 use crate::service::{self_reporting::audit, websocket_events::handle_cancel};
 use crate::{
     common::utils::websocket::get_ping_interval_secs_with_jitter,
-    service::websocket_events::{
-        WsClientEvents, WsServerEvents, handle_search_request, handle_values_request,
-        sessions_cache_utils, setup_tracing_with_trace_id,
+    service::{
+        setup_tracing_with_trace_id,
+        websocket_events::{
+            WsClientEvents, WsServerEvents, handle_search_request, handle_values_request,
+            sessions_cache_utils,
+        },
     },
 };
 
@@ -305,7 +308,6 @@ async fn resolve_enterprise_user_id(
 /// Text message is parsed into `WsClientEvents` and processed accordingly
 /// Depending on each event type, audit must be done
 /// Currently audit is done only for the search event
-#[tracing::instrument(name = "service:search:websocket::handle_text_message", skip_all)]
 pub async fn handle_text_message(user_id: &str, req_id: &str, msg: String, path: String) {
     match serde_json::from_str::<WsClientEvents>(&msg) {
         Ok(client_msg) => {
@@ -331,9 +333,7 @@ pub async fn handle_text_message(user_id: &str, req_id: &str, msg: String, path:
             // Setup tracing
             let ws_span = setup_tracing_with_trace_id(
                 &client_msg.get_trace_id(),
-                tracing::info_span!(
-                    "src::handler::http::request::websocket::ws::session::handle_text_message"
-                ),
+                tracing::info_span!("http:request:ws:session:handle_text_message"),
             )
             .await;
 

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -34,9 +34,13 @@ use config::{
         json::{Map, Value},
     },
 };
+use tracing::Instrument;
 
 use super::promql;
-use crate::service::{search as SearchService, self_reporting::http_report_metrics};
+use crate::service::{
+    search as SearchService, self_reporting::http_report_metrics,
+    websocket_events::setup_tracing_with_trace_id,
+};
 
 pub mod alert;
 pub mod derived_streams;
@@ -109,13 +113,17 @@ impl QueryConditionExt for QueryCondition {
         search_event_context: Option<SearchEventContext>,
         trace_id: Option<String>,
     ) -> Result<TriggerEvalResults, anyhow::Error> {
+        let trace_id = trace_id.unwrap_or_else(|| ider::generate_trace_id());
+        // create context with trace_id
+        let eval_span = setup_tracing_with_trace_id(
+            &trace_id,
+            tracing::info_span!("src::service::alerts::evaluate_scheduled"),
+        )
+        .await;
+
         let mut eval_results = TriggerEvalResults {
             end_time,
             ..Default::default()
-        };
-        let trace_id = match trace_id {
-            Some(id) => id,
-            None => ider::generate_trace_id(),
         };
         let sql = match self.query_type {
             QueryType::Custom => {
@@ -353,6 +361,7 @@ impl QueryConditionExt for QueryCondition {
                 &req,
                 Some(RoleGroup::Background),
             )
+            .instrument(eval_span)
             .await
             // SearchService::search_multi(&trace_id, org_id, stream_type, None, &req).await
         } else {
@@ -408,6 +417,7 @@ impl QueryConditionExt for QueryCondition {
                 &req,
                 Some(RoleGroup::Background),
             )
+            .instrument(eval_span)
             .await
         };
 

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -38,8 +38,7 @@ use tracing::Instrument;
 
 use super::promql;
 use crate::service::{
-    search as SearchService, self_reporting::http_report_metrics,
-    websocket_events::setup_tracing_with_trace_id,
+    search as SearchService, self_reporting::http_report_metrics, setup_tracing_with_trace_id,
 };
 
 pub mod alert;
@@ -117,7 +116,7 @@ impl QueryConditionExt for QueryCondition {
         // create context with trace_id
         let eval_span = setup_tracing_with_trace_id(
             &trace_id,
-            tracing::info_span!("src::service::alerts::evaluate_scheduled"),
+            tracing::info_span!("service:alerts:evaluate_scheduled"),
         )
         .await;
 

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -113,7 +113,7 @@ impl QueryConditionExt for QueryCondition {
         search_event_context: Option<SearchEventContext>,
         trace_id: Option<String>,
     ) -> Result<TriggerEvalResults, anyhow::Error> {
-        let trace_id = trace_id.unwrap_or_else(|| ider::generate_trace_id());
+        let trace_id = trace_id.unwrap_or_else(ider::generate_trace_id);
         // create context with trace_id
         let eval_span = setup_tracing_with_trace_id(
             &trace_id,

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -49,9 +49,8 @@ use crate::{
             self as SearchService, cache, datafusion::distributed_plan::streaming_aggs_exec,
             sql::Sql,
         },
-        websocket_events::{
-            TimeOffset, WsServerEvents, calculate_progress_percentage, setup_tracing_with_trace_id,
-        },
+        setup_tracing_with_trace_id,
+        websocket_events::{TimeOffset, WsServerEvents, calculate_progress_percentage},
     },
 };
 
@@ -84,7 +83,6 @@ pub async fn handle_cancel(trace_id: &str, org_id: &str) -> WsServerEvents {
     }
 }
 
-#[tracing::instrument(name = "service:search:websocket::handle_search_request", skip_all)]
 pub async fn handle_search_request(
     req_id: &str,
     accumulated_results: &mut Vec<SearchResultType>,
@@ -110,7 +108,7 @@ pub async fn handle_search_request(
     // Setup tracing
     let ws_search_span = setup_tracing_with_trace_id(
         &req.trace_id,
-        tracing::info_span!("src::service::websocket_events::search::handle_search_request"),
+        tracing::info_span!("service:websocket_events:search:handle_search_request"),
     )
     .await;
 

--- a/src/service/websocket_events/utils.rs
+++ b/src/service/websocket_events/utils.rs
@@ -14,17 +14,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use actix_web::http::StatusCode;
-use config::{
-    ider,
-    meta::{
-        sql::OrderBy,
-        websocket::{SearchEventReq, ValuesEventReq},
-    },
+use config::meta::{
+    sql::OrderBy,
+    websocket::{SearchEventReq, ValuesEventReq},
 };
 use infra::errors;
 use serde::{Deserialize, Serialize};
 use tokio_tungstenite::tungstenite;
-use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::handler::http::request::search::error_utils::map_error_to_http_response;
 
@@ -234,21 +230,6 @@ pub mod sessions_cache_utils {
         drop(r);
         res
     }
-}
-
-/// Setup tracing with a trace ID
-pub async fn setup_tracing_with_trace_id(trace_id: &str, span: tracing::Span) -> tracing::Span {
-    let mut headers: std::collections::HashMap<String, String> = std::collections::HashMap::new();
-    let traceparent = format!(
-        "00-{}-{}-01", /* 01 to indicate that the span is sampled i.e. needs to be
-                        * recorded/exported */
-        trace_id,
-        ider::generate_span_id()
-    );
-    headers.insert("traceparent".to_string(), traceparent);
-    let parent_ctx = opentelemetry::global::get_text_map_propagator(|prop| prop.extract(&headers));
-    span.set_parent(parent_ctx);
-    span
 }
 
 /// Represents the different types of WebSocket client messages that can be sent.

--- a/src/service/websocket_events/values.rs
+++ b/src/service/websocket_events/values.rs
@@ -30,17 +30,16 @@ use crate::{
     handler::http::request::{search::build_search_request_per_field, ws::session::send_message},
     service::{
         search::{cache, sql::Sql},
+        setup_tracing_with_trace_id,
         websocket_events::{
             WsServerEvents,
             search::{
                 do_partitioned_search, handle_cache_responses_and_deltas, write_results_to_cache,
             },
-            setup_tracing_with_trace_id,
         },
     },
 };
 
-#[tracing::instrument(name = "service:search:websocket::handle_values_request", skip_all)]
 pub async fn handle_values_request(
     org_id: &str,
     user_id: &str,
@@ -62,7 +61,7 @@ pub async fn handle_values_request(
     // Setup tracing
     let ws_values_span = setup_tracing_with_trace_id(
         &trace_id,
-        tracing::info_span!("src::service::websocket_events::values::handle_values_request"),
+        tracing::info_span!("service:websocket_events:values:handle_values_request"),
     )
     .await;
 


### PR DESCRIPTION
Currently, the scheduler trace_ids are not searchable in the traces page, because they are only used in the logs and not in the instrumentation. This pr fixes that - so, the scheduler query trace id (which can be obtained from the `triggers` stream, field name - `scheduler_trace_id`, the trace_id after the `/` is the scheduler query trace_id), can be used as `trace_id` to search the trace in the traces page.

Also, the `grpc::search` and `grpc::search_multi` does not use the trace_id from the grpc "request" for instrumentation. This pr fixes that as well.