### PR TITLE
fix: otlp logs ingestion

### DIFF
--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -63,6 +63,9 @@ use crate::{
 pub mod grpc;
 pub mod ingestion_service;
 
+pub const SERVICE_NAME: &str = "service.name";
+pub const SERVICE: &str = "service";
+
 pub type TriggerAlertData = Vec<(Alert, Vec<Map<String, Value>>)>;
 
 pub fn compile_vrl_function(func: &str, org_id: &str) -> Result<VRLRuntimeConfig, std::io::Error> {

--- a/src/service/logs/otlp.rs
+++ b/src/service/logs/otlp.rs
@@ -268,7 +268,10 @@ pub async fn handle_request(
                         .is_some_and(|v| *v)
                         && original_data.is_some()
                     {
-                        local_val[ORIGINAL_DATA_COL_NAME] = original_data.clone().unwrap().into();
+                        local_val.insert(
+                            ORIGINAL_DATA_COL_NAME.to_string(),
+                            original_data.unwrap().into(),
+                        );
 
                         let record_id = crate::service::ingestion::generate_record_id(
                             org_id,
@@ -276,7 +279,7 @@ pub async fn handle_request(
                             &StreamType::Logs,
                         );
 
-                        local_val[ID_COL_NAME] = json::Value::String(record_id.to_string());
+                        local_val.insert(ID_COL_NAME.to_string(), record_id.to_string().into());
                     }
 
                     // add `_all_values` if required by StreamSettings
@@ -297,7 +300,8 @@ pub async fn handle_request(
                             })
                             .map(|(_, v)| v)
                             .join(" ");
-                        local_val[ALL_VALUES_COL_NAME] = json::Value::String(values);
+                        local_val
+                            .insert(ALL_VALUES_COL_NAME.to_string(), json::Value::String(values));
                     }
 
                     let (ts_data, fn_num) = json_data_by_stream
@@ -372,15 +376,17 @@ pub async fn handle_request(
                             .is_some_and(|v| *v)
                             && original_options[idx].is_some()
                         {
-                            local_val[ORIGINAL_DATA_COL_NAME] =
-                                original_options[idx].clone().unwrap().into();
+                            local_val.insert(
+                                ORIGINAL_DATA_COL_NAME.to_string(),
+                                original_options[idx].clone().unwrap().into(),
+                            );
 
                             let record_id = crate::service::ingestion::generate_record_id(
                                 org_id,
                                 &destination_stream,
                                 &StreamType::Logs,
                             );
-                            local_val[ID_COL_NAME] = record_id.to_string().into();
+                            local_val.insert(ID_COL_NAME.to_string(), record_id.to_string().into());
                         }
 
                         // add `_all_values` if required by StreamSettings
@@ -403,7 +409,7 @@ pub async fn handle_request(
                                 .map(|(_, v)| v)
                                 .join(" ");
 
-                            local_val[ALL_VALUES_COL_NAME] = values.into();
+                            local_val.insert(ALL_VALUES_COL_NAME.to_string(), values.into());
                         }
 
                         let (ts_data, fn_num) = json_data_by_stream

--- a/src/service/logs/otlp.rs
+++ b/src/service/logs/otlp.rs
@@ -43,7 +43,7 @@ use crate::{
     service::{
         format_stream_name,
         ingestion::{
-            check_ingestion_allowed,
+            SERVICE, SERVICE_NAME, check_ingestion_allowed,
             grpc::{get_val, get_val_with_type_retained},
         },
         logs::bulk::TRANSFORM_FAILED,
@@ -59,9 +59,6 @@ pub async fn handle_request(
     user_email: &str,
     req_type: OtlpRequestType,
 ) -> Result<HttpResponse> {
-    const SERVICE_NAME: &str = "service.name";
-    const SERVICE: &str = "service";
-
     let start = std::time::Instant::now();
     let started_at = Utc::now().timestamp_micros();
 
@@ -117,29 +114,23 @@ pub async fn handle_request(
     let mut res = ExportLogsServiceResponse {
         partial_success: None,
     };
-    for resource_log in &request.resource_logs {
+    for resource_log in request.resource_logs {
         if resource_log.scope_logs.is_empty() {
             continue;
         }
 
         let mut service_att_map: json::Map<String, json::Value> = json::Map::new();
-
-        if let Some(attributes) = resource_log
-            .resource
-            .clone()
-            .map(|resource| resource.attributes)
-        {
-            for local_attr in attributes.into_iter() {
-                if local_attr.key == SERVICE_NAME {
-                    let service_name_value = get_val_with_type_retained(&local_attr.value.as_ref());
-
-                    for item in service_name_value.as_object().unwrap().values().cloned() {
-                        service_att_map.insert(SERVICE_NAME.to_string(), item);
+        if let Some(resource) = resource_log.resource {
+            for res_attr in resource.attributes {
+                if res_attr.key.eq(SERVICE_NAME) {
+                    let loc_service_name = get_val(&res_attr.value.as_ref());
+                    if loc_service_name.as_str().is_some() {
+                        service_att_map.insert(SERVICE_NAME.to_string(), loc_service_name);
                     }
                 } else {
                     service_att_map.insert(
-                        format!("{}_{}", SERVICE, local_attr.key),
-                        get_val_with_type_retained(&local_attr.value.as_ref()),
+                        format!("{}_{}", SERVICE, res_attr.key),
+                        get_val(&res_attr.value.as_ref()),
                     );
                 }
             }
@@ -172,22 +163,14 @@ pub async fn handle_request(
                         .inc();
                     log_failed_record(
                         log_ingestion_errors,
-                        &resource_log,
+                        log_record,
                         &stream_status.status.error,
                     );
                     continue;
                 }
 
                 let mut rec = json::json!({});
-
-                // For HttpJson
                 rec.as_object_mut().unwrap().extend(service_att_map.clone());
-
-                if let Some(attributes) = resource_log.resource.as_ref().map(|v| &v.attributes) {
-                    for item in attributes {
-                        rec[item.key.as_str()] = get_val_with_type_retained(&item.value.as_ref());
-                    }
-                }
 
                 if let Some(lib) = &instrumentation_logs.scope {
                     let library_name = lib.name.to_owned();

--- a/src/service/logs/otlp.rs
+++ b/src/service/logs/otlp.rs
@@ -130,7 +130,7 @@ pub async fn handle_request(
                 } else {
                     service_att_map.insert(
                         format!("{}_{}", SERVICE, res_attr.key),
-                        get_val(&res_attr.value.as_ref()),
+                        get_val_with_type_retained(&res_attr.value.as_ref()),
                     );
                 }
             }


### PR DESCRIPTION
fixed #6684

There are two panic:

```
for item in service_name_value.as_object().unwrap().values().cloned() 
```
The service_name is not an object, panicked.

```
local_val[ORIGINAL_DATA_COL_NAME] = original_data.clone().unwrap().into();
```
the local_val can't index by the name, panicked.