### PR TITLE
fix: always create db dir in infra::init

### DIFF
--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -67,6 +67,9 @@ pub async fn db_init() -> Result<(), anyhow::Error> {
 }
 
 pub async fn init() -> Result<(), anyhow::Error> {
+    // if we have skipped db migrations (because version is up-to-date), 
+    // for non-stateful set components this dir will be absent, so we create it anyways
+    std::fs::create_dir_all(&config::get_config().common.data_db_dir)?;
     cache::init().await?;
     file_list::LOCAL_CACHE.create_table().await?;
     file_list::local_cache_gc().await?;


### PR DESCRIPTION
In PR for separating ddl client from normal db client, a new function was created which would do all db initialization. Consequently, fn call to create the local db dir was also moved into that function. However, this function is called only if version key in db is mismatch, so if the version in db matches, this function would not be called, and thus db dir creation will aalso not happen.

This works on stateful set, because most of the time db dir will already be present. However, for non-stateful sets such as router or compactor, this errors because of missing db dir. 

This PR fixes this by always calling create_dir_all in infra::init. They way things are setup, this will get called twice if f db_init also runs, but that is ok. Tested the commit on dev3/dev4 for ~2 hours, container init and restart work fine with this change.