### PR TITLE
fix: update `config::DB_SCHEMA_VERSION` for alert table align time column

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -88,7 +88,7 @@ pub const ORIGINAL_DATA_COL_NAME: &str = "_original";
 pub const ALL_VALUES_COL_NAME: &str = "_all_values";
 
 // for DDL commands and migrations
-pub const DB_SCHEMA_VERSION: u64 = 1;
+pub const DB_SCHEMA_VERSION: u64 = 2;
 pub const DB_SCHEMA_KEY: &str = "/db_schema_version/";
 
 const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 7] =


### PR DESCRIPTION
Recently the `align_time` column was added to `alerts` table, but the `config::DB_SCHEMA_VERSION` version now needs to be upgraded so that the migration can be run.