### PR TITLE
fix: multiple object store for search_job & actions

### DIFF
--- a/src/handler/grpc/request/search/mod.rs
+++ b/src/handler/grpc/request/search/mod.rs
@@ -244,7 +244,7 @@ impl Search for Searcher {
         req: Request<GetResultRequest>,
     ) -> Result<Response<GetResultResponse>, Status> {
         let path = req.into_inner().path;
-        let res = infra::storage::get(&path)
+        let res = infra::storage::get_bytes("", &path)
             .await
             .map_err(|e| Status::internal(format!("failed to get result: {e}")))?;
         Ok(Response::new(GetResultResponse {
@@ -266,8 +266,11 @@ impl Search for Searcher {
         req: Request<DeleteResultRequest>,
     ) -> Result<Response<DeleteResultResponse>, Status> {
         let paths = req.into_inner().paths;
-        let paths = paths.iter().map(|path| path.as_str()).collect::<Vec<_>>();
-        let _ = infra::storage::del(&paths)
+        let paths = paths
+            .iter()
+            .map(|path| ("", path.as_str()))
+            .collect::<Vec<_>>();
+        let _ = infra::storage::del(paths)
             .await
             .map_err(|e| Status::internal(format!("failed to delete result: {e}")))?;
         Ok(Response::new(DeleteResultResponse {}))

--- a/src/super_cluster_queue/action_scripts.rs
+++ b/src/super_cluster_queue/action_scripts.rs
@@ -30,7 +30,7 @@ pub(crate) async fn process(msg: Message) -> Result<()> {
                         == config::get_config().common.web_url
                 {
                     if let Some(zip_path) = &current_cluster_action.zip_file_path {
-                        if let Err(e) = infra::storage::del(&[zip_path]).await {
+                        if let Err(e) = infra::storage::del(vec![("", zip_path)]).await {
                             log::error!(
                                 "failed to delete the zip file from s3 bucket {}: {}",
                                 zip_path,
@@ -52,7 +52,7 @@ pub(crate) async fn process(msg: Message) -> Result<()> {
                 if current_cluster_action.origin_cluster_url == config::get_config().common.web_url
                 {
                     if let Some(zip_path) = &current_cluster_action.zip_file_path {
-                        if let Err(e) = infra::storage::del(&[zip_path]).await {
+                        if let Err(e) = infra::storage::del(vec![("", zip_path)]).await {
                             log::error!(
                                 "failed to delete the zip file from s3 bucket {}: {}",
                                 zip_path,


### PR DESCRIPTION
Always use first (default) object store account for search_job & actions.