### PR TITLE
fix: super cluster scheduler event processing fails for scheduled pipelines

### DIFF
--- a/src/super_cluster_queue/scheduler.rs
+++ b/src/super_cluster_queue/scheduler.rs
@@ -13,7 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::{meta::triggers::Trigger, utils::json};
+use config::{
+    meta::triggers::{Trigger, TriggerModule},
+    utils::json,
+};
 use infra::{
     errors::{Error, Result},
     scheduler,
@@ -130,7 +133,7 @@ async fn delete(msg: Message) -> Result<()> {
 
 async fn trigger_modify_module_key(trigger: &mut Trigger) -> Result<()> {
     // Return if the module_key is in new format (alert_id only)
-    if !trigger.module_key.contains("/") {
+    if !trigger.module_key.contains("/") || trigger.module != TriggerModule::Alert {
         return Ok(());
     }
     let parts = trigger.module_key.split("/").collect::<Vec<&str>>();


### PR DESCRIPTION
There is a bug in the handling of super cluster scheduler event messages for derived streams. The `trigger_modify_module_key` function which was supposed to be executed for alert messages only, also gets applied to scheduled pipeline events containing a different module key format than desired. Hence, it keeps throwing error in the compactor. This pr fixes this issue.