### PR TITLE
fix: remove update compress size to db

### DIFF
--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -60,7 +60,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                             Ok(data_len) => {
                                 if data_len > 0 && data_len != file_size {
                                     log::warn!(
-                                        "[trace_id {trace_id}] search->storage: download file {} found size mismatch, expected: {}, actual: {}, will update it",
+                                        "[trace_id {trace_id}] search->storage: download file {} found size mismatch, expected: {}, actual: {}, will skip it",
                                         file,
                                         file_size,
                                         data_len,

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -66,18 +66,18 @@ pub async fn run() -> Result<(), anyhow::Error> {
                                         data_len,
                                     );
                                     // update database
-                                    if let Err(e) = infra::file_list::update_compressed_size(
-                                        &file,
-                                        data_len as i64,
-                                    )
-                                    .await
-                                    {
-                                        log::error!(
-                                            "[trace_id {trace_id}] search->storage: update file size for file {} err: {}",
-                                            file,
-                                            e,
-                                        );
-                                    }
+                                    // if let Err(e) = infra::file_list::update_compressed_size(
+                                    //     &file,
+                                    //     data_len as i64,
+                                    // )
+                                    // .await
+                                    // {
+                                    //     log::error!(
+                                    //         "[trace_id {trace_id}] search->storage: update file size for file {} err: {}",
+                                    //         file,
+                                    //         e,
+                                    //     );
+                                    // }
                                 }
                             }
                             Err(e) => {

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -1305,7 +1305,7 @@ async fn cache_remote_files(files: &[FileKey]) -> Result<Vec<String>, anyhow::Er
                 Ok(data_len) => {
                     if data_len > 0 && data_len != file_size as usize {
                         log::warn!(
-                            "[COMPACT] download file {} found size mismatch, expected: {}, actual: {}, will update it",
+                            "[COMPACT] download file {} found size mismatch, expected: {}, actual: {}, will skip it",
                             file_name,
                             file_size,
                             data_len,

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -1310,17 +1310,20 @@ async fn cache_remote_files(files: &[FileKey]) -> Result<Vec<String>, anyhow::Er
                             file_size,
                             data_len,
                         );
-                        if let Err(e) =
-                            file_list::update_compressed_size(&file_name, data_len as i64).await
-                        {
-                            log::error!(
-                                "[COMPACT] update file size for file {} err: {}",
-                                file_name,
-                                e
-                            );
-                        }
+                        // update database
+                        // if let Err(e) =
+                        //     file_list::update_compressed_size(&file_name, data_len as i64).await
+                        // {
+                        //     log::error!(
+                        //         "[COMPACT] update file size for file {} err: {}",
+                        //         file_name,
+                        //         e
+                        //     );
+                        // }
+                        Some(file_name)
+                    } else {
+                        None
                     }
-                    None
                 }
                 Err(e) => {
                     if e.to_string().to_lowercase().contains("not found")


### PR DESCRIPTION
Removed the update_compress_size because we found after 3 times we still can download partial parquets.