### PR TITLE
fix: enrichment_table::get returns error when both meta and stream_stats table is empty

### DIFF
--- a/src/service/db/enrichment_table.rs
+++ b/src/service/db/enrichment_table.rs
@@ -17,7 +17,10 @@ use std::sync::Arc;
 
 use config::{
     meta::stream::{EnrichmentTableMetaStreamStats, StreamType},
-    utils::{json, time::now_micros},
+    utils::{
+        json,
+        time::{BASE_TIME, now_micros},
+    },
 };
 use infra::{cache::stats, db as infra_db};
 use vrl::prelude::NotNan;
@@ -32,13 +35,8 @@ pub const ENRICHMENT_TABLE_SIZE_KEY: &str = "/enrichment_table_size";
 pub const ENRICHMENT_TABLE_META_STREAM_STATS_KEY: &str = "/enrichment_table_meta_stream_stats";
 
 pub async fn get(org_id: &str, name: &str) -> Result<Vec<vrl::value::Value>, anyhow::Error> {
-    let (start_time, end_time) = match get_meta_table_stats(org_id, name).await {
-        Some(meta_stats) => (meta_stats.start_time, now_micros()),
-        None => {
-            let stats = stats::get_stream_stats(org_id, name, StreamType::EnrichmentTables);
-            (stats.doc_time_min, now_micros())
-        }
-    };
+    let start_time = get_start_time(org_id, name).await;
+    let end_time = now_micros();
 
     let query = config::meta::search::Query {
         sql: format!("SELECT * FROM \"{name}\""),
@@ -133,7 +131,11 @@ pub async fn get_start_time(org_id: &str, name: &str) -> i64 {
         Some(meta_stats) => meta_stats.start_time,
         None => {
             let stats = stats::get_stream_stats(org_id, name, StreamType::EnrichmentTables);
-            stats.doc_time_min
+            if stats.doc_time_min > 0 {
+                stats.doc_time_min
+            } else {
+                BASE_TIME.timestamp_micros()
+            }
         }
     }
 }

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -289,6 +289,9 @@ pub async fn save_enrichment_data(
     if !append_data {
         enrich_meta_stats.start_time = started_at;
     }
+    if enrich_meta_stats.start_time == 0 {
+        enrich_meta_stats.start_time = enrichment_table::get_start_time(org_id, stream_name).await;
+    }
     enrich_meta_stats.end_time = now_micros();
     enrich_meta_stats.size = total_expected_size_in_bytes as i64;
     // The stream_stats table takes some time to update, so we need to update the enrichment table


### PR DESCRIPTION
For an existing old enrichment table, if the `enrichment_table_meta_stream_stats` key record is not present in the `meta` table  and also there is no record for the enrichment table in the stream_stats table, the `enrichment_table::get` function returns error with `invalid timerange` because, it now uses default value `0`.