### PR TITLE
fix: ZO_DEFAULT_MAX_QUERY_RANGE_DAYS env should be returned by streams list api (#6762)

### DIFF
--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -130,6 +130,7 @@ struct ConfigResponse<'a> {
     query_default_limit: i64,
     max_dashboard_series: usize,
     actions_enabled: bool,
+    max_query_range: i64,
 }
 
 #[derive(Serialize)]
@@ -321,6 +322,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         query_default_limit: cfg.limit.query_default_limit,
         max_dashboard_series: cfg.limit.max_dashboard_series,
         actions_enabled,
+        max_query_range: cfg.limit.default_max_query_range_days * 24,
     }))
 }
 

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -46,7 +46,10 @@ use crate::{
         http::HttpResponse as MetaHttpResponse,
         stream::{Stream, StreamProperty},
     },
-    service::{db, db::distinct_values, metrics::get_prom_metadata_from_schema},
+    service::{
+        db::{self, distinct_values},
+        metrics::get_prom_metadata_from_schema,
+    },
 };
 
 const LOCAL: &str = "disk";

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -3000,17 +3000,17 @@ const useLogs = () => {
               stream.settings = streamData.settings;
               stream.schema = streamSchema;
             }
-
             if (
-              stream.settings.max_query_range > 0 &&
+              (stream.settings.max_query_range > 0 || store.state.zoConfig.max_query_range > 0) &&
               (searchObj.data.datetime.queryRangeRestrictionInHour >
                 stream.settings.max_query_range ||
                 stream.settings.max_query_range == 0 ||
                 searchObj.data.datetime.queryRangeRestrictionInHour == -1) &&
               searchObj.data.datetime.queryRangeRestrictionInHour != 0
             ) {
-              searchObj.data.datetime.queryRangeRestrictionInHour =
-                stream.settings.max_query_range;
+              //if stream has max_query_range, then use that, otherwise use the default max_query_range from the config
+              searchObj.data.datetime.queryRangeRestrictionInHour = stream.settings.max_query_range > 0 ? stream.settings.max_query_range : store.state.zoConfig.max_query_range;
+
               searchObj.data.datetime.queryRangeRestrictionMsg = t(
                 "search.queryRangeRestrictionMsg",
                 {

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -776,7 +776,7 @@ async function extractFields() {
       );
       searchObj.data.datetime.queryRangeRestrictionInHour = -1;
       if (
-        stream.settings.max_query_range > 0 &&
+        (stream.settings.max_query_range > 0 || store.state.zoConfig.max_query_range > 0) &&
         (searchObj.data.datetime.queryRangeRestrictionInHour >
           stream.settings.max_query_range ||
           stream.settings.max_query_range == 0 ||
@@ -784,7 +784,7 @@ async function extractFields() {
         searchObj.data.datetime.queryRangeRestrictionInHour != 0
       ) {
         searchObj.data.datetime.queryRangeRestrictionInHour =
-          stream.settings.max_query_range;
+          stream.settings.max_query_range > 0 ? stream.settings.max_query_range : store.state.zoConfig.max_query_range;
         searchObj.data.datetime.queryRangeRestrictionMsg = t(
           "search.queryRangeRestrictionMsg",
           {


### PR DESCRIPTION
Returns `ZO_DEFAULT_MAX_QUERY_RANGE_DAYS` in the `/config` api so that UI can restrict the maximum query range by default based on the env value given.