### PR TITLE
fix: internal error audit

### DIFF
--- a/src/handler/http/request/search/error_utils.rs
+++ b/src/handler/http/request/search/error_utils.rs
@@ -20,23 +20,17 @@ use crate::{
     common::meta::http::HttpResponse as MetaHttpResponse, handler::http::router::ERROR_HEADER,
 };
 
-pub fn map_error_to_http_response(err: &errors::Error, trace_id: String) -> HttpResponse {
+pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>) -> HttpResponse {
     match err {
         errors::Error::ErrorCode(code) => match code {
             errors::ErrorCodes::SearchCancelQuery(_) | errors::ErrorCodes::RatelimitExceeded(_) => {
                 HttpResponse::TooManyRequests()
                     .append_header((ERROR_HEADER, code.to_json()))
-                    .json(MetaHttpResponse::error_code_with_trace_id(
-                        code,
-                        Some(trace_id),
-                    ))
+                    .json(MetaHttpResponse::error_code_with_trace_id(code, trace_id))
             }
             errors::ErrorCodes::SearchTimeout(_) => HttpResponse::RequestTimeout()
                 .append_header((ERROR_HEADER, code.to_json()))
-                .json(MetaHttpResponse::error_code_with_trace_id(
-                    code,
-                    Some(trace_id),
-                )),
+                .json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
             errors::ErrorCodes::InvalidParams(_)
             | errors::ErrorCodes::SearchSQLExecuteError(_)
             | errors::ErrorCodes::SearchFieldHasNoCompatibleDataType(_)
@@ -46,18 +40,12 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: String) -> Http
             | errors::ErrorCodes::SearchSQLNotValid(_)
             | errors::ErrorCodes::SearchStreamNotFound(_) => HttpResponse::BadRequest()
                 .append_header((ERROR_HEADER, code.to_json()))
-                .json(MetaHttpResponse::error_code_with_trace_id(
-                    code,
-                    Some(trace_id),
-                )),
+                .json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
 
             errors::ErrorCodes::ServerInternalError(_)
             | errors::ErrorCodes::SearchParquetFileNotFound => HttpResponse::InternalServerError()
                 .append_header((ERROR_HEADER, code.to_json()))
-                .json(MetaHttpResponse::error_code_with_trace_id(
-                    code,
-                    Some(trace_id),
-                )),
+                .json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
         },
         _ => HttpResponse::InternalServerError()
             .append_header((ERROR_HEADER, err.to_string()))

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -15,7 +15,7 @@
 
 use std::io::Error;
 
-use actix_web::{HttpRequest, HttpResponse, get, http::StatusCode, post, web};
+use actix_web::{HttpRequest, HttpResponse, get, post, web};
 use chrono::Utc;
 use config::{
     TIMESTAMP_COL_NAME, get_config,
@@ -47,6 +47,7 @@ use crate::{
             stream::get_settings_max_query_range,
         },
     },
+    handler::http::request::search::error_utils::map_error_to_http_response,
     service::{search as SearchService, self_reporting::report_request_usage_stats},
 };
 
@@ -189,12 +190,7 @@ pub async fn search_multi(
         let stream_name = match resolve_stream_names(&req.query.sql) {
             Ok(v) => v[0].clone(),
             Err(e) => {
-                return Ok(HttpResponse::InternalServerError().json(
-                    meta::http::HttpResponse::error(
-                        StatusCode::INTERNAL_SERVER_ERROR.into(),
-                        e.to_string(),
-                    ),
-                ));
+                return Ok(map_error_to_http_response(&(e.into()), Some(trace_id)));
             }
         };
         vrl_stream_name = stream_name.clone();
@@ -265,12 +261,7 @@ pub async fn search_multi(
             let keys_used = match get_cipher_key_names(&req.query.sql) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Ok(HttpResponse::InternalServerError().json(
-                        meta::http::HttpResponse::error(
-                            StatusCode::INTERNAL_SERVER_ERROR.into(),
-                            e.to_string(),
-                        ),
-                    ));
+                    return Ok(map_error_to_http_response(&e, Some(trace_id)));
                 }
             };
             if !keys_used.is_empty() {
@@ -749,15 +740,7 @@ pub async fn _search_partition_multi(
                 ])
                 .inc();
             log::error!("search error: {:?}", err);
-            Ok(match err {
-                errors::Error::ErrorCode(code) => HttpResponse::InternalServerError().json(
-                    meta::http::HttpResponse::error_code_with_trace_id(&code, Some(trace_id)),
-                ),
-                _ => HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
-                    StatusCode::INTERNAL_SERVER_ERROR.into(),
-                    err.to_string(),
-                )),
-            })
+            Ok(map_error_to_http_response(&err, Some(trace_id)))
         }
     }
 }
@@ -896,25 +879,7 @@ pub async fn around_multi(
                     ])
                     .inc();
                 log::error!("multi search around error: {:?}", err);
-                return Ok(match err {
-                    errors::Error::ErrorCode(code) => match code {
-                        errors::ErrorCodes::SearchCancelQuery(_) => HttpResponse::TooManyRequests()
-                            .json(meta::http::HttpResponse::error_code_with_trace_id(
-                                &code,
-                                Some(trace_id),
-                            )),
-                        _ => HttpResponse::InternalServerError().json(
-                            meta::http::HttpResponse::error_code_with_trace_id(
-                                &code,
-                                Some(trace_id),
-                            ),
-                        ),
-                    },
-                    _ => HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
-                        StatusCode::INTERNAL_SERVER_ERROR.into(),
-                        err.to_string(),
-                    )),
-                });
+                return Ok(map_error_to_http_response(&err, Some(trace_id)));
             }
         };
 

--- a/src/handler/http/request/search/search_inspector.rs
+++ b/src/handler/http/request/search/search_inspector.rs
@@ -333,7 +333,10 @@ pub async fn get_search_profile(
                 "",
             );
             log::error!("[trace_id {trace_id}] search error: {}", err);
-            Ok(error_utils::map_error_to_http_response(&err, trace_id))
+            Ok(error_utils::map_error_to_http_response(
+                &err,
+                Some(trace_id),
+            ))
         }
     }
 }

--- a/src/handler/http/request/short_url/mod.rs
+++ b/src/handler/http/request/short_url/mod.rs
@@ -15,15 +15,15 @@
 
 use std::io::Error;
 
-use actix_http::StatusCode;
 use actix_web::{HttpRequest, HttpResponse, get, post, web};
 use config::meta::short_url::ShortenUrlResponse;
 
 use crate::{
     common::{
-        meta::{self, http::HttpResponse as MetaHttpResponse},
+        meta::http::HttpResponse as MetaHttpResponse,
         utils::redirect_response::RedirectResponseBuilder,
     },
+    handler::http::request::search::error_utils::map_error_to_http_response,
     service::short_url,
 };
 
@@ -72,12 +72,7 @@ pub async fn shorten(org_id: web::Path<String>, body: web::Bytes) -> Result<Http
         }
         Err(e) => {
             log::error!("Failed to shorten URL: {:?}", e);
-            Ok(
-                HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
-                    StatusCode::INTERNAL_SERVER_ERROR.into(),
-                    e.to_string(),
-                )),
-            )
+            Ok(map_error_to_http_response(&e.into(), None))
         }
     }
 }

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -17,7 +17,6 @@ use std::{collections::HashMap, io::Error};
 
 use actix_web::{HttpRequest, HttpResponse, get, http, post, web};
 use config::{TIMESTAMP_COL_NAME, get_config, meta::stream::StreamType, metrics, utils::json};
-use infra::errors;
 use serde::Serialize;
 use tracing::{Instrument, Span};
 
@@ -26,7 +25,9 @@ use crate::{
         meta::{self, http::HttpResponse as MetaHttpResponse},
         utils::http::get_or_create_trace_id,
     },
-    handler::http::request::{CONTENT_TYPE_JSON, CONTENT_TYPE_PROTO},
+    handler::http::request::{
+        CONTENT_TYPE_JSON, CONTENT_TYPE_PROTO, search::error_utils::map_error_to_http_response,
+    },
     service::{search as SearchService, traces},
 };
 
@@ -315,18 +316,7 @@ pub async fn get_latest_traces(
                 ])
                 .inc();
             log::error!("get traces latest data error: {:?}", err);
-            return Ok(match err {
-                errors::Error::ErrorCode(code) => match code {
-                    errors::ErrorCodes::SearchCancelQuery(_) => HttpResponse::TooManyRequests()
-                        .json(meta::http::HttpResponse::error_code(code)),
-                    _ => HttpResponse::InternalServerError()
-                        .json(meta::http::HttpResponse::error_code(code)),
-                },
-                _ => HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
-                    http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                    err.to_string(),
-                )),
-            });
+            return Ok(map_error_to_http_response(&err, Some(trace_id)));
         }
     };
     if resp_search.hits.is_empty() {
@@ -408,18 +398,7 @@ pub async fn get_latest_traces(
                     ])
                     .inc();
                 log::error!("get traces latest data error: {:?}", err);
-                return Ok(match err {
-                    errors::Error::ErrorCode(code) => match code {
-                        errors::ErrorCodes::SearchCancelQuery(_) => HttpResponse::TooManyRequests()
-                            .json(meta::http::HttpResponse::error_code(code)),
-                        _ => HttpResponse::InternalServerError()
-                            .json(meta::http::HttpResponse::error_code(code)),
-                    },
-                    _ => HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
-                        http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                        err.to_string(),
-                    )),
-                });
+                return Ok(map_error_to_http_response(&err, Some(trace_id)));
             }
         };
 

--- a/src/handler/http/request/ws/session.rs
+++ b/src/handler/http/request/ws/session.rs
@@ -665,7 +665,7 @@ async fn handle_search_event(
                             let http_response_code: u16;
                             #[cfg(feature = "enterprise")]
                             {
-                                let http_response = map_error_to_http_response(&e, trace_id.to_string());
+                                let http_response = map_error_to_http_response(&e, Some(trace_id.to_string()));
                                 http_response_code = http_response.status().into();
                             }
                             // Add audit before closing
@@ -806,7 +806,7 @@ async fn handle_values_event(
                             let http_response_code: u16;
                             #[cfg(feature = "enterprise")]
                             {
-                                let http_response = map_error_to_http_response(&e, trace_id.to_string());
+                                let http_response = map_error_to_http_response(&e, Some(trace_id.to_string()));
                                 http_response_code = http_response.status().into();
                             }
                             // Add audit before closing

--- a/src/infra/src/errors/mod.rs
+++ b/src/infra/src/errors/mod.rs
@@ -82,6 +82,8 @@ pub enum Error {
     Reqwest(#[from] reqwest::Error),
     #[error("Error# {0}")]
     WalFileError(String),
+    #[error("Error# {0}")]
+    OtherError(#[from] anyhow::Error),
 }
 
 unsafe impl Send for Error {}

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -44,6 +44,7 @@ use infra::{
 
 use crate::{
     common::meta::{http::HttpResponse as MetaHttpResponse, stream::SchemaRecords},
+    handler::http::router::ERROR_HEADER,
     service::{
         compact::retention,
         db::{self, enrichment_table},
@@ -72,12 +73,12 @@ pub async fn save_enrichment_data(
     let stream_name = &format_stream_name(table_name);
 
     if !LOCAL_NODE.is_ingester() {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, "not an ingester".to_string()))
+            .json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                 "not an ingester".to_string(),
-            )),
-        );
+            )));
     }
 
     // check if we are allowed to ingest
@@ -87,12 +88,15 @@ pub async fn save_enrichment_data(
         stream_name,
         None,
     ) {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR.into(),
+        return Ok(HttpResponse::BadRequest()
+            .append_header((
+                ERROR_HEADER,
                 format!("enrichment table [{stream_name}] is being deleted"),
-            )),
-        );
+            ))
+            .json(MetaHttpResponse::error(
+                http::StatusCode::BAD_REQUEST.into(),
+                format!("enrichment table [{stream_name}] is being deleted"),
+            )));
     }
 
     // Estimate the size of the payload in json format in bytes
@@ -245,12 +249,15 @@ pub async fn save_enrichment_data(
         match write_file(&writer, stream_name, buf, !cfg.common.wal_fsync_disabled).await {
             Ok(stats) => stats,
             Err(e) => {
-                return Ok(
-                    HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+                return Ok(HttpResponse::InternalServerError()
+                    .append_header((
+                        ERROR_HEADER,
+                        format!("Error writing enrichment table: {}", e),
+                    ))
+                    .json(MetaHttpResponse::error(
                         http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                         format!("Error writing enrichment table: {}", e),
-                    )),
-                );
+                    )));
             }
         };
 

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -48,6 +48,7 @@ use prost::Message;
 
 use crate::{
     common::meta::{http::HttpResponse as MetaHttpResponse, stream::SchemaRecords},
+    handler::http::router::ERROR_HEADER,
     service::{
         alerts::alert::AlertExt,
         db, format_stream_name,
@@ -120,12 +121,12 @@ pub async fn handle_otlp_request(
     req_type: OtlpRequestType,
 ) -> Result<HttpResponse, anyhow::Error> {
     if !LOCAL_NODE.is_ingester() {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, "not an ingester".to_string()))
+            .json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                 "not an ingester".to_string(),
-            )),
-        );
+            )));
     }
 
     if !db::file_list::BLOCKED_ORGS.is_empty()

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -46,7 +46,11 @@ use crate::{
         http::HttpResponse as MetaHttpResponse,
         stream::{Stream, StreamProperty},
     },
-    service::{db, db::distinct_values, metrics::get_prom_metadata_from_schema},
+    handler::http::router::ERROR_HEADER,
+    service::{
+        db::{self, distinct_values},
+        metrics::get_prom_metadata_from_schema,
+    },
 };
 
 const LOCAL: &str = "disk";
@@ -206,12 +210,15 @@ pub async fn save_stream_settings(
     let cfg = config::get_config();
     // check if we are allowed to ingest
     if db::compact::retention::is_deleting_stream(org_id, stream_type, stream_name, None) {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR.into(),
+        return Ok(HttpResponse::BadRequest()
+            .append_header((
+                ERROR_HEADER,
                 format!("stream [{stream_name}] is being deleted"),
-            )),
-        );
+            ))
+            .json(MetaHttpResponse::error(
+                http::StatusCode::BAD_REQUEST.into(),
+                format!("stream [{stream_name}] is being deleted"),
+            )));
     }
 
     // only allow setting user defined schema for logs stream
@@ -256,12 +263,12 @@ pub async fn save_stream_settings(
     let schema = match infra::schema::get(org_id, stream_name, stream_type).await {
         Ok(schema) => schema,
         Err(e) => {
-            return Ok(
-                HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+            return Ok(HttpResponse::InternalServerError()
+                .append_header((ERROR_HEADER, format!("error in getting schema : {e}")))
+                .json(MetaHttpResponse::error(
                     http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                     format!("error in getting schema : {e}"),
-                )),
-            );
+                )));
         }
     };
     let schema_fields = schema
@@ -479,12 +486,15 @@ pub async fn update_stream_settings(
                         f,
                     );
                     if let Err(e) = distinct_values::add(record).await {
-                        return Ok(HttpResponse::InternalServerError().json(
-                            MetaHttpResponse::error(
+                        return Ok(HttpResponse::InternalServerError()
+                            .append_header((
+                                ERROR_HEADER,
+                                format!("error in updating settings : {e}"),
+                            ))
+                            .json(MetaHttpResponse::error(
                                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                                 format!("error in updating settings : {e}"),
-                            ),
-                        ));
+                            )));
                     }
                     // we cannot allow duplicate entries here
                     let temp = DistinctField {
@@ -503,12 +513,15 @@ pub async fn update_stream_settings(
                         match check_field_use(org_id, stream_name, stream_type.as_str(), f).await {
                             Ok(entry) => entry,
                             Err(e) => {
-                                return Ok(HttpResponse::InternalServerError().json(
-                                    MetaHttpResponse::error(
+                                return Ok(HttpResponse::InternalServerError()
+                                    .append_header((
+                                        ERROR_HEADER,
+                                        format!("error in updating settings : {e}"),
+                                    ))
+                                    .json(MetaHttpResponse::error(
                                         http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                                         format!("error in updating settings : {e}"),
-                                    ),
-                                ));
+                                    )));
                             }
                         };
                     // if there are multiple uses, we cannot allow it to be removed
@@ -599,22 +612,22 @@ pub async fn delete_stream(
     if let Err(e) =
         db::compact::retention::delete_stream(org_id, stream_type, stream_name, None).await
     {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, format!("failed to delete stream: {e}")))
+            .json(MetaHttpResponse::error(
                 StatusCode::INTERNAL_SERVER_ERROR.into(),
                 format!("failed to delete stream: {e}"),
-            )),
-        );
+            )));
     }
 
     // delete stream schema
     if let Err(e) = db::schema::delete(org_id, stream_name, Some(stream_type)).await {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, format!("failed to delete stream schema: {e}")))
+            .json(MetaHttpResponse::error(
                 StatusCode::INTERNAL_SERVER_ERROR.into(),
-                format!("failed to delete stream: {e}"),
-            )),
-        );
+                format!("failed to delete stream schema: {e}"),
+            )));
     }
 
     // delete stream schema cache
@@ -639,12 +652,15 @@ pub async fn delete_stream(
 
     // delete stream compaction offset
     if let Err(e) = db::compact::files::del_offset(org_id, stream_type, stream_name).await {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((
+                ERROR_HEADER,
+                format!("failed to delete stream compact offset: {e}"),
+            ))
+            .json(MetaHttpResponse::error(
                 StatusCode::INTERNAL_SERVER_ERROR.into(),
                 format!("failed to delete stream: {e}"),
-            )),
-        );
+            )));
     };
 
     // delete associated pipelines
@@ -652,15 +668,21 @@ pub async fn delete_stream(
         db::pipeline::get_by_stream(&StreamParams::new(org_id, stream_name, stream_type)).await
     {
         if let Err(e) = db::pipeline::delete(&pipeline.id).await {
-            return Ok(
-                HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+            return Ok(HttpResponse::InternalServerError()
+                .append_header((
+                    ERROR_HEADER,
+                    format!(
+                        "Stream deletion fail: failed to delete the associated pipeline {}: {e}",
+                        pipeline.name
+                    ),
+                ))
+                .json(MetaHttpResponse::error(
                     StatusCode::INTERNAL_SERVER_ERROR.into(),
                     format!(
                         "Stream deletion fail: failed to delete the associated pipeline {}: {e}",
                         pipeline.name
                     ),
-                )),
-            );
+                )));
         }
     }
 

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -49,6 +49,7 @@ use crate::{
         stream::SchemaRecords,
         traces::{Event, Span, SpanLink, SpanLinkContext, SpanRefType},
     },
+    handler::http::router::ERROR_HEADER,
     service::{
         alerts::alert::AlertExt,
         db, format_stream_name,
@@ -154,12 +155,12 @@ pub async fn handle_otlp_request(
     let started_at = Utc::now().timestamp_micros();
 
     if !LOCAL_NODE.is_ingester() {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, "not an ingester".to_string()))
+            .json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                 "not an ingester".to_string(),
-            )),
-        );
+            )));
     }
 
     if !db::file_list::BLOCKED_ORGS.is_empty()
@@ -415,7 +416,9 @@ pub async fn handle_otlp_request(
                                 "[TRACES:OTLP] stream did not receive a valid json object, trace_id: {}",
                                 trace_id
                             );
-                            return Ok(HttpResponse::InternalServerError().json(
+                            return Ok(HttpResponse::InternalServerError()
+                            .append_header((ERROR_HEADER, format!("[trace_id: {trace_id}] stream did not receive a valid json object")))
+                            .json(
                                 MetaHttpResponse::error(
                                     http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                                     "stream did not receive a valid json object".into(),
@@ -500,12 +503,15 @@ pub async fn handle_otlp_request(
                                 log::error!(
                                     "[TRACES:OTLP] stream did not receive a valid json object"
                                 );
-                                return Ok(HttpResponse::InternalServerError().json(
-                                    MetaHttpResponse::error(
+                                return Ok(HttpResponse::InternalServerError()
+                                    .append_header((
+                                        ERROR_HEADER,
+                                        "stream did not receive a valid json object",
+                                    ))
+                                    .json(MetaHttpResponse::error(
                                         http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                                         "stream did not receive a valid json object".into(),
-                                    ),
-                                ));
+                                    )));
                             }
                         };
 
@@ -543,12 +549,12 @@ pub async fn handle_otlp_request(
     if let Err(e) = write_traces_by_stream(org_id, (started_at, &start), json_data_by_stream).await
     {
         log::error!("Error while writing traces: {}", e);
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, format!("error while writing trace data: {e}")))
+            .json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                format!("error while writing trace data: {e}",),
-            )),
-        );
+                format!("error while writing trace data: {e}"),
+            )));
     }
 
     let time = start.elapsed().as_secs_f64();
@@ -590,12 +596,12 @@ pub async fn ingest_json(
     let started_at = Utc::now().timestamp_micros();
 
     if !LOCAL_NODE.is_ingester() {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, "not an ingester".to_string()))
+            .json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                 "not an ingester".to_string(),
-            )),
-        );
+            )));
     }
 
     if !db::file_list::BLOCKED_ORGS.is_empty()
@@ -667,12 +673,17 @@ pub async fn ingest_json(
                     "[TRACES:JSON] stream did not receive a valid json object, trace_id: {}",
                     &trace_id
                 );
-                return Ok(
-                    HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+                return Ok(HttpResponse::InternalServerError()
+                    .append_header((
+                        ERROR_HEADER,
+                        format!(
+                            "[trace_id: {trace_id}] stream did not receive a valid json object"
+                        ),
+                    ))
+                    .json(MetaHttpResponse::error(
                         http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                         "stream did not receive a valid json object".into(),
-                    )),
-                );
+                    )));
             }
         };
 
@@ -695,12 +706,12 @@ pub async fn ingest_json(
     if let Err(e) = write_traces_by_stream(org_id, (started_at, &start), json_data_by_stream).await
     {
         log::error!("Error while writing traces: {}", e);
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, format!("error while writing trace data: {e}")))
+            .json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                format!("error while writing trace data: {e}",),
-            )),
-        );
+                format!("error while writing trace data: {e}"),
+            )));
     }
 
     let time = start.elapsed().as_secs_f64();

--- a/src/service/websocket_events/utils.rs
+++ b/src/service/websocket_events/utils.rs
@@ -385,7 +385,7 @@ impl WsServerEvents {
                 let message = code.get_message();
                 let error_detail = code.get_error_detail();
                 let http_response =
-                    map_error_to_http_response(err, trace_id.clone().unwrap_or_default());
+                    map_error_to_http_response(err, Some(trace_id.clone().unwrap_or_default()));
                 WsServerEvents::Error {
                     code: http_response.status().into(),
                     message,

--- a/src/service/websocket_events/utils.rs
+++ b/src/service/websocket_events/utils.rs
@@ -384,8 +384,7 @@ impl WsServerEvents {
             errors::Error::ErrorCode(code) => {
                 let message = code.get_message();
                 let error_detail = code.get_error_detail();
-                let http_response =
-                    map_error_to_http_response(err, Some(trace_id.clone().unwrap_or_default()));
+                let http_response = map_error_to_http_response(err, trace_id.clone());
                 WsServerEvents::Error {
                     code: http_response.status().into(),
                     message,


### PR DESCRIPTION
This adds the error header to all cases of internal server error so they show up properly in audit. This is done by one of two approaches -
1. preferably using the `map_error_to_http_response` function , so that everything goes via the same function
2. directly adding the header where the above function cannot be used because is is not an error per say like trying to ingest at non-ingester.
