### PR TITLE
fix: fixed page-count api for streaming aggs query

### DIFF
--- a/web/src/components/QueryEditor.vue
+++ b/web/src/components/QueryEditor.vue
@@ -219,7 +219,27 @@ export default defineComponent({
       });
 
       editorObj.onDidBlurEditorWidget(() => {
-        setValue(editorObj.getValue()?.trim());
+        const model = editorObj.getModel();
+        const value = model.getValue();
+        const trimmedValue = value.trim();
+        
+        // Only apply trim if there are actually tailing and leading spaces to trim
+        if (value !== trimmedValue) {
+          const lastLine = model.getLineCount();
+          const lastLineLength = model.getLineLength(lastLine);
+          
+          // Create an edit operation that replaces the entire content
+          // This preserves undo history becuase it treats this as a single edit operation
+          //and it will be in the undo stack as one operation 
+          model.pushEditOperations(
+            [],
+            [{
+              range: new monaco.Range(1, 1, lastLine, lastLineLength + 1),
+              text: trimmedValue
+            }],
+            () => null
+          );
+        }
         emit("blur");
       });
 

--- a/web/src/components/dashboards/QueryEditor.vue
+++ b/web/src/components/dashboards/QueryEditor.vue
@@ -329,7 +329,27 @@ export default defineComponent({
       });
 
       editorObj.onDidBlurEditorWidget(() => {
-        setValue(editorObj.getValue()?.trim());
+        const model = editorObj.getModel();
+        const value = model.getValue();
+        const trimmedValue = value.trim();
+        
+        // Only apply trim if there are actually tailing and leading spaces to trim
+        if (value !== trimmedValue) {
+          const lastLine = model.getLineCount();
+          const lastLineLength = model.getLineLength(lastLine);
+          
+          // Create an edit operation that replaces the entire content
+          // This preserves undo history becuase it treats this as a single edit operation
+          //and it will be in the undo stack as one operation 
+          model.pushEditOperations(
+            [],
+            [{
+              range: new monaco.Range(1, 1, lastLine, lastLineLength + 1),
+              text: trimmedValue
+            }],
+            () => null
+          );
+        }
       });
 
       editorObj.createContextKey("ctrlenter", true);

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1627,7 +1627,7 @@ const useLogs = () => {
       //reset the plot chart when the query is run 
       //this is to avoid the issue of chart not updating when histogram is disabled and enabled and clicking the run query button
       //only reset the plot chart when the query is not run for pagination
-      if(!isPagination) searchObj.meta.resetPlotChart = true;
+      if(!isPagination && searchObj.meta.refreshInterval == 0) searchObj.meta.resetPlotChart = true;
 
       if (queryReq != null) {
         // in case of live refresh, reset from to 0

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1627,7 +1627,7 @@ const useLogs = () => {
       //reset the plot chart when the query is run 
       //this is to avoid the issue of chart not updating when histogram is disabled and enabled and clicking the run query button
       //only reset the plot chart when the query is not run for pagination
-      if(!isPagination && searchObj.meta.refreshInterval == 0) searchObj.meta.resetPlotChart = true;
+      // if(!isPagination && searchObj.meta.refreshInterval == 0) searchObj.meta.resetPlotChart = true;
 
       if (queryReq != null) {
         // in case of live refresh, reset from to 0
@@ -1746,6 +1746,7 @@ const useLogs = () => {
         // based on pagination request, get the data
         searchObjDebug["paginatedDatawithAPIStartTime"] = performance.now();
         await getPaginatedData(queryReq);
+        if(!isPagination && searchObj.meta.refreshInterval == 0) searchObj.meta.resetPlotChart = true;
         searchObjDebug["paginatedDatawithAPIEndTime"] = performance.now();
         const parsedSQL: any = fnParsedSQL();
 

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1388,7 +1388,7 @@ const useLogs = () => {
     }
   };
 
-  const refreshPartitionPagination = (regenrateFlag: boolean = false) => {
+  const refreshPartitionPagination = (regenrateFlag: boolean = false, isStreamingOutput: boolean = false) => {
     if (searchObj.meta.jobId != "") {
       return;
     }
@@ -1434,12 +1434,17 @@ const useLogs = () => {
           ) {
           }
         } else {
-          searchObj.data.queryResults.total =
+          if(isStreamingOutput) {
+            if(partitionDetail.partitionTotal[partitionDetail.partitionTotal.length - 1] > -1)
+              searchObj.data.queryResults.total = partitionDetail.partitionTotal[partitionDetail.partitionTotal.length - 1];
+          } else {
+            searchObj.data.queryResults.total =
             partitionDetail.partitionTotal.reduce(
               (accumulator: number, currentValue: number) =>
                 accumulator + Math.max(currentValue, 0),
               0,
             );
+          }
         }
         // partitionDetail.partitions.forEach((item: any, index: number) => {
         for (const [index, item] of partitionDetail.partitions.entries()) {
@@ -2154,12 +2159,15 @@ const useLogs = () => {
   const getPageCount = async (queryReq: any) => {
     return new Promise((resolve, reject) => {
       try {
+        const isStreamingOutput = !!queryReq.query.streaming_output;
         searchObj.loadingCounter = true;
         searchObj.data.countErrorMsg = "";
         queryReq.query.size = 0;
         delete queryReq.query.from;
         delete queryReq.query.quick_mode;
         if(queryReq.query.action_id) delete queryReq.query.action_id;
+        if(queryReq.query.hasOwnProperty("streaming_output")) delete queryReq.query.streaming_output;
+        if(queryReq.query.hasOwnProperty("streaming_id")) delete queryReq.query.streaming_id;
 
         queryReq.query["sql_mode"] = "full";
 
@@ -2184,6 +2192,8 @@ const useLogs = () => {
             //   (item: any, index: number) => {
             searchObj.data.queryResults.scan_size += res.data.scan_size;
             searchObj.data.queryResults.took += res.data.took;
+            
+            // Update total for the last partition
             if (searchObj.meta.jobId == "") {
               for (const [
                 index,
@@ -2205,13 +2215,17 @@ const useLogs = () => {
               }
             }
 
+            if (isStreamingOutput) {
+              searchObj.data.queryResults.total = res.data.total;
+            }
+
             let regeratePaginationFlag = false;
             if (res.data.hits.length != searchObj.meta.resultGrid.rowsPerPage) {
               regeratePaginationFlag = true;
             }
             // if total records in partition is greater than recordsPerPage then we need to update pagination
             // setting up forceFlag to true to update pagination as we have check for pagination already created more than currentPage + 3 pages.
-            refreshPartitionPagination(regeratePaginationFlag);
+            refreshPartitionPagination(regeratePaginationFlag, isStreamingOutput);
 
             searchObj.data.histogram.chartParams.title = getHistogramTitle();
             searchObj.loadingCounter = false;

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1746,7 +1746,7 @@ const useLogs = () => {
         // based on pagination request, get the data
         searchObjDebug["paginatedDatawithAPIStartTime"] = performance.now();
         await getPaginatedData(queryReq);
-        if(!isPagination && searchObj.meta.refreshInterval == 0) searchObj.meta.resetPlotChart = true;
+        if(!isPagination && searchObj.meta.refreshInterval == 0 && searchObj.data.queryResults.hits.length > 0) searchObj.meta.resetPlotChart = true;
         searchObjDebug["paginatedDatawithAPIEndTime"] = performance.now();
         const parsedSQL: any = fnParsedSQL();
 

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1434,10 +1434,12 @@ const useLogs = () => {
           ) {
           }
         } else {
+          // if streaming output is enabled, then we need to update the total as the last partition total, as the last partition total is the total of all the records in case of streaming output
           if(isStreamingOutput) {
-            if(partitionDetail.partitionTotal[partitionDetail.partitionTotal.length - 1] > -1)
+            if(partitionDetail.partitionTotal[partitionDetail.partitionTotal?.length - 1] > -1)
               searchObj.data.queryResults.total = partitionDetail.partitionTotal[partitionDetail.partitionTotal.length - 1];
           } else {
+            // if streaming output is disabled, then we need to update the total as the sum of all partition totals
             searchObj.data.queryResults.total =
             partitionDetail.partitionTotal.reduce(
               (accumulator: number, currentValue: number) =>

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2132,6 +2132,7 @@ const useLogs = () => {
     }
   };
 
+  // TODO OK : Replace backticks with double quotes, as stream name from sqlify is coming with backticks
   const fnUnparsedSQL = (parsedObj: any) => {
     try {
       return parser.sqlify(parsedObj);
@@ -4700,6 +4701,24 @@ const useLogs = () => {
     }
   };
 
+  /**
+   * Extract value query
+   * - Extract the query from the query string
+   * - Replace the INDEX_NAME with the stream name
+   * - Return the query
+   * 
+   * JOIN Queries
+   * - Parse the query and make where null
+   * - Replace the INDEX_NAME with the stream name
+   * - Return the query
+   * 
+   * UNION Queries
+   * - Parse the query and add where clause to each query
+   * - Replace the INDEX_NAME with the stream name
+   * - Return the query
+   * 
+   * @returns 
+   */
   const extractValueQuery = () => {
     try {
       if (searchObj.meta.sqlMode == false || searchObj.data.query == "") {
@@ -4722,7 +4741,7 @@ const useLogs = () => {
       ) {
         newParsedSQL.where = parsedSQL.where;
 
-        query = parser.sqlify(newParsedSQL);
+        query = parser.sqlify(newParsedSQL).replace(/`/g, '"');
         outputQueries[parsedSQL.from[0].table] = query.replace(
           "INDEX_NAME",
           "[INDEX_NAME]",
@@ -4731,11 +4750,11 @@ const useLogs = () => {
         // parse join queries & union queries
         if (Object.hasOwn(parsedSQL, "from") && parsedSQL.from.length > 1) {
           parsedSQL.where = cleanBinaryExpression(parsedSQL.where);
-          // parse join queries
+          // parse join queries and make where null
           searchObj.data.stream.selectedStream.forEach((stream: string) => {
             newParsedSQL.where = null;
 
-            query = parser.sqlify(newParsedSQL);
+            query = parser.sqlify(newParsedSQL).replace(/`/g, '"');
             outputQueries[stream] = query.replace("INDEX_NAME", "[INDEX_NAME]");
           });
         } else if (parsedSQL._next != null) {
@@ -4746,7 +4765,7 @@ const useLogs = () => {
 
             newParsedSQL.where = parsedSQL.where;
 
-            query = parser.sqlify(newParsedSQL);
+            query = parser.sqlify(newParsedSQL).replace(/`/g, '"');
             outputQueries[parsedSQL.from[0].table] = query.replace(
               "INDEX_NAME",
               "[INDEX_NAME]",
@@ -4759,12 +4778,12 @@ const useLogs = () => {
           while (nextTable && depth++ < MAX_DEPTH) {
             // Map through each "from" array in the _next object, as it can contain multiple tables
             if (nextTable.from) {
-              let query = `select * from INDEX_NAME`;
+              let query = "select * from INDEX_NAME";
               const newParsedSQL = parser.astify(query);
 
               newParsedSQL.where = nextTable.where;
 
-              query = parser.sqlify(newParsedSQL);
+              query = parser.sqlify(newParsedSQL).replace(/`/g, '"');
               outputQueries[nextTable.from[0].table] = query.replace(
                 "INDEX_NAME",
                 "[INDEX_NAME]",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -937,7 +937,8 @@
     "SearchFunctionNotDefined": "Error: Search function not defined.",
     "SearchParquetFileNotFound": "Error: Search parquet file not found.",
     "SearchFieldHasNoCompatibleDataType": "Error: Search file has no compatible data type.",
-    "SearchSQLExecuteError": "Error: Search SQL execute error."
+    "SearchSQLExecuteError": "Error: Search SQL execute error.",
+    "SearchSQLCancelled": "Error: Search SQL was cancelled."
   },
   "alerts": {
     "header": "Alerts",

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1662,7 +1662,11 @@ export default defineComponent({
         ? this.searchObj.config.lastSplitterPosition
         : 0;
     },
-    async showHistogram() {
+    async showHistogram(newVal, oldVal) {
+      if(newVal == true && oldVal == false && this.searchObj.meta.histogramDirtyFlag == true){
+        this.searchObj.meta.resetPlotChart = true;
+        this.searchObj.data.queryResults.aggs = [];
+      }
       let parsedSQL = null;
 
       if (this.searchObj.meta.sqlMode) parsedSQL = this.fnParsedSQL();

--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -1016,9 +1016,14 @@ export default defineComponent({
           if (streams.length > 1) {
             query_context = "select * from [INDEX_NAME]";
           }
-          if (searchObj.data.stream.selectedStream.length > 1) {
+          if (
+            searchObj.data.stream.selectedStream.length > 1 &&
+            searchObj.meta.sqlMode &&
+            queries[selectedStream]
+          ) {
             query_context = queries[selectedStream];
           }
+
           if (query_context !== "") {
             query_context = query_context == undefined ? "" : query_context;
 

--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -849,6 +849,17 @@ export default defineComponent({
       filterHitsColumns();
     }
 
+    /**
+     * Single Stream
+     * - Consider filter in sql and non sql mode, create sql query and fetch values
+     *
+     * Multiple Stream
+     * - Dont consider filter in both mode, create sql query for each stream and fetch values
+     *
+     * @param event
+     * @param param1
+     */
+
     const openFilterCreator = async (
       event: any,
       { name, ftsKey, isSchemaField, streams }: any,
@@ -999,6 +1010,7 @@ export default defineComponent({
             );
           }
         }
+
         let countTotal = streams.length;
         for (const selectedStream of streams) {
           if (streams.length > 1) {
@@ -1033,21 +1045,30 @@ export default defineComponent({
               continue;
             }
 
-            //TODO : add comments for this in future 
+            //TODO : add comments for this in future
             //for future reference
             //values api using partition based api
-            let queryToBeSent = searchObj.meta.sqlMode ? searchObj.data.query : query_context.replace("[INDEX_NAME]", selectedStream);
-            const response = await getValuesPartition(startISOTimestamp,endISOTimestamp,name,queryToBeSent);
+            let queryToBeSent = query_context.replace(
+              "[INDEX_NAME]",
+              selectedStream,
+            );
+
+            const response = await getValuesPartition(
+              startISOTimestamp,
+              endISOTimestamp,
+              name,
+              queryToBeSent,
+            );
             const partitions: any = response?.data.partitions || [];
-          
 
             for (const partition of partitions) {
               try {
-                //check if the field is opened because sometimes 
+                //check if the field is opened because sometimes
                 // user might close the field before all the subsequent requests are completed
-                if(!openedFilterFields.value.includes(name)){
+                if (!openedFilterFields.value.includes(name)) {
                   return;
                 }
+
                 const res: any = await streamService.fieldValues({
                   org_identifier: store.state.selectedOrganization.identifier,
                   stream_name: selectedStream,
@@ -1055,10 +1076,7 @@ export default defineComponent({
                   end_time: partition[1],
                   fields: [name],
                   size: 10,
-                  query_context:
-                    b64EncodeUnicode(
-                      query_context.replace("[INDEX_NAME]", selectedStream),
-                    ) || "",
+                  query_context: b64EncodeUnicode(queryToBeSent) || "",
                   query_fn: query_fn,
                   action_id,
                   type: searchObj.data.stream.streamType,
@@ -1076,7 +1094,8 @@ export default defineComponent({
                         (value: any) => value.key === subItem.zo_sql_key,
                       );
                       if (index !== -1) {
-                        fieldValues.value[name]["values"][index].count += parseInt(subItem.zo_sql_num);
+                        fieldValues.value[name]["values"][index].count +=
+                          parseInt(subItem.zo_sql_num);
                       } else {
                         fieldValues.value[name]["values"].push({
                           key: subItem.zo_sql_key,
@@ -1087,8 +1106,12 @@ export default defineComponent({
                   });
 
                   if (fieldValues.value[name]["values"].length > 10) {
-                    fieldValues.value[name]["values"].sort((a, b) => b.count - a.count);
-                    fieldValues.value[name]["values"] = fieldValues.value[name]["values"].slice(0, 10);
+                    fieldValues.value[name]["values"].sort(
+                      (a, b) => b.count - a.count,
+                    );
+                    fieldValues.value[name]["values"] = fieldValues.value[name][
+                      "values"
+                    ].slice(0, 10);
                   }
                 }
               } catch (err) {
@@ -1101,13 +1124,17 @@ export default defineComponent({
                 }
               }
             }
-            openedFilterFields.value = openedFilterFields.value.filter((field:string)=>field !== name);
-
           }
         }
+
+        openedFilterFields.value = openedFilterFields.value.filter(
+          (field: string) => field !== name,
+        );
       } catch (err) {
         fieldValues.value[name]["isLoading"] = false;
-        openedFilterFields.value = openedFilterFields.value.filter((field:string)=>field !== name);
+        openedFilterFields.value = openedFilterFields.value.filter(
+          (field: string) => field !== name,
+        );
         console.log(err);
         $q.notify({
           type: "negative",
@@ -1347,7 +1374,7 @@ export default defineComponent({
     };
 
     const handleSearchError = (request: any, err: any) => {
-      if (fieldValues.value[request.queryReq.fields[0]]) {
+      if (fieldValues.value[request.queryReq?.fields[0]]) {
         fieldValues.value[request.queryReq.fields[0]].isLoading = false;
         fieldValues.value[request.queryReq.fields[0]].errMsg =
           "Failed to fetch field values";
@@ -1357,78 +1384,91 @@ export default defineComponent({
     };
 
     const handleSearchResponse = (payload: any, response: any) => {
-      if (response.type === "cancel_response") {
-        removeTraceId(payload.queryReq.fields[0], response.content.trace_id);
-        return;
-      }
+      const fieldName = payload?.queryReq?.fields[0];
+      const streamName = payload?.queryReq?.stream_name;
 
-      const fieldName = payload.queryReq.fields[0];
-      const streamName = payload.queryReq.stream_name;
+      try {
+        // We don't need to handle search_response_metadata
+        if (response.type === "cancel_response") {
+          removeTraceId(payload.queryReq.fields[0], response.content.trace_id);
+          return;
+        }
 
-      // Initialize if not exists
-      if (!fieldValues.value[fieldName]) {
-        fieldValues.value[fieldName] = {
+        if (response.type !== "search_response_hits") {
+          return;
+        }
+
+        // Initialize if not exists
+        if (!fieldValues.value[fieldName]) {
+          fieldValues.value[fieldName] = {
+            values: [],
+            isLoading: false,
+            errMsg: "",
+          };
+        }
+
+        // Initialize stream-specific values if not exists
+        if (!streamFieldValues.value[fieldName]) {
+          streamFieldValues.value[fieldName] = {};
+        }
+
+        streamFieldValues.value[fieldName][streamName] = {
           values: [],
-          isLoading: false,
-          errMsg: "",
         };
-      }
 
-      // Initialize stream-specific values if not exists
-      if (!streamFieldValues.value[fieldName]) {
-        streamFieldValues.value[fieldName] = {};
-      }
+        // Process the results
+        if (response.content.results.hits.length) {
+          // Store stream-specific values
+          const streamValues: { key: string; count: number }[] = [];
 
-      streamFieldValues.value[fieldName][streamName] = {
-        values: [],
-      };
-
-      // Process the results
-      if (response.content.results.hits.length) {
-        // Store stream-specific values
-        const streamValues: { key: string; count: number }[] = [];
-
-        response.content.results.hits.forEach((item: any) => {
-          item.values.forEach((subItem: any) => {
-            streamValues.push({
-              key: subItem.zo_sql_key,
-              count: parseInt(subItem.zo_sql_num),
+          response.content.results.hits.forEach((item: any) => {
+            item.values.forEach((subItem: any) => {
+              streamValues.push({
+                key: subItem.zo_sql_key,
+                count: parseInt(subItem.zo_sql_num),
+              });
             });
           });
-        });
 
-        // Update stream-specific values
-        streamFieldValues.value[fieldName][streamName].values = streamValues;
+          // Update stream-specific values
+          streamFieldValues.value[fieldName][streamName].values = streamValues;
 
-        // Aggregate values across all streams
-        const aggregatedValues: { [key: string]: number } = {};
+          // Aggregate values across all streams
+          const aggregatedValues: { [key: string]: number } = {};
 
-        // Collect all values from all streams
-        Object.keys(streamFieldValues.value[fieldName]).forEach((stream) => {
-          streamFieldValues.value[fieldName][stream].values.forEach((value) => {
-            if (aggregatedValues[value.key]) {
-              aggregatedValues[value.key] += value.count;
-            } else {
-              aggregatedValues[value.key] = value.count;
-            }
+          // Collect all values from all streams
+          Object.keys(streamFieldValues.value[fieldName]).forEach((stream) => {
+            streamFieldValues.value[fieldName][stream].values.forEach(
+              (value) => {
+                if (aggregatedValues[value.key]) {
+                  aggregatedValues[value.key] += value.count;
+                } else {
+                  aggregatedValues[value.key] = value.count;
+                }
+              },
+            );
           });
-        });
 
-        // Convert aggregated values to array and sort
-        const aggregatedArray = Object.keys(aggregatedValues).map((key) => ({
-          key,
-          count: aggregatedValues[key],
-        }));
+          // Convert aggregated values to array and sort
+          const aggregatedArray = Object.keys(aggregatedValues).map((key) => ({
+            key,
+            count: aggregatedValues[key],
+          }));
 
-        // Sort by count in descending order
-        aggregatedArray.sort((a, b) => b.count - a.count);
+          // Sort by count in descending order
+          aggregatedArray.sort((a, b) => b.count - a.count);
 
-        // Take top 10
-        fieldValues.value[fieldName].values = aggregatedArray.slice(0, 10);
+          // Take top 10
+          fieldValues.value[fieldName].values = aggregatedArray.slice(0, 10);
+        }
+
+        // Mark as not loading
+        fieldValues.value[fieldName].isLoading = false;
+      } catch (error) {
+        console.error("Failed to fetch field values:", error);
+        fieldValues.value[fieldName].errMsg = "Failed to fetch field values";
+        fieldValues.value[fieldName].isLoading = false;
       }
-
-      // Mark as not loading
-      fieldValues.value[fieldName].isLoading = false;
     };
 
     const handleSearchReset = (data: any) => {
@@ -1465,17 +1505,15 @@ export default defineComponent({
       }
     };
 
-
     const cancelFilterCreator = (row: any) => {
       //if it is websocker based then cancel the trace id
       //else cancel the further value api calls using the openedFilterFields
-      if(isWebSocketEnabled()){
+      if (isWebSocketEnabled()) {
         cancelTraceId(row.name);
-      }
-      else{
+      } else {
         cancelValueApi(row.name);
       }
-    }
+    };
 
     const cancelTraceId = (field: string) => {
       const traceIds = traceIdMapper.value[field];
@@ -1490,30 +1528,36 @@ export default defineComponent({
     };
     const cancelValueApi = (value: string) => {
       //remove the field from the openedFilterFields
-      openedFilterFields.value = openedFilterFields.value.filter((field:string)=>field !== value);
-    }
-    const getValuesPartition = async (start: number, end: number,name:string,queryToBeSent:string) => {
-      try{
-          const queryReq = {
-            sql: queryToBeSent,
-            start_time: start,
-            end_time: end,
-            sql_mode: "context",
-            // streaming_output: true,
-          }
-          const res = await searchService.partition({
-            org_identifier: store.state.selectedOrganization.identifier,
-            query: queryReq,
-            page_type: searchObj.data.stream.streamType,
-            traceparent: generateTraceContext().traceId,
-          });
-        
-          return res;
+      openedFilterFields.value = openedFilterFields.value.filter(
+        (field: string) => field !== value,
+      );
+    };
+    const getValuesPartition = async (
+      start: number,
+      end: number,
+      name: string,
+      queryToBeSent: string,
+    ) => {
+      try {
+        const queryReq = {
+          sql: queryToBeSent,
+          start_time: start,
+          end_time: end,
+          sql_mode: "context",
+          // streaming_output: true,
+        };
+        const res = await searchService.partition({
+          org_identifier: store.state.selectedOrganization.identifier,
+          query: queryReq,
+          page_type: searchObj.data.stream.streamType,
+          traceparent: generateTraceContext().traceId,
+        });
+
+        return res;
       } catch (err) {
         console.error("Failed to fetch field values:", err);
         fieldValues.value[name].errMsg = "Failed to fetch field values";
       }
-
     };
 
     return {
@@ -1587,7 +1631,7 @@ export default defineComponent({
       sortedStreamFields,
       placeHolderText,
       cancelTraceId,
-      cancelFilterCreator
+      cancelFilterCreator,
     };
   },
 });

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -716,9 +716,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               v-model:query="searchObj.data.query"
               :keywords="autoCompleteKeywords"
               :suggestions="autoCompleteSuggestions"
-              @keydown.ctrl.enter="handleRunQueryFn"
               @update:query="updateQueryValue"
               @run-query="handleRunQueryFn"
+              @keydown="handleKeyDown"
               :class="
                 searchObj.data.editorValue == '' &&
                 searchObj.meta.queryEditorPlaceholderFlag
@@ -748,7 +748,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       ? 'empty-function'
                       : ''
                   "
-                  @keydown.ctrl.enter="handleRunQueryFn"
+                  @keydown="handleKeyDown"
                   language="vrl"
                   @focus="searchObj.meta.functionEditorPlaceholderFlag = false"
                   @blur="searchObj.meta.functionEditorPlaceholderFlag = true"
@@ -1354,6 +1354,11 @@ export default defineComponent({
           });
         });
     },
+    handleKeyDown(e) {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+          this.handleRunQueryFn();
+      }
+    }
   },
   props: {
     fieldValues: {

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     >
       <div   class="row tw-min-h-[44px]">
         <div
-          class="col-6 text-left q-pl-lg q-mt-xs bg-warning text-white rounded-borders"
+          class="col-7 text-left q-pl-lg q-mt-xs bg-warning text-white rounded-borders"
           v-if="searchObj.data.countErrorMsg != ''"
         >
           <SanitizedHtmlRenderer
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :htmlContent="searchObj.data.countErrorMsg"
           />
         </div>
-        <div v-else class="col-6 text-left q-pl-lg q-mt-xs warning flex items-center">
+        <div v-else class="col-7 text-left q-pl-lg q-mt-xs warning flex items-center">
           {{ noOfRecordsTitle }}
           <span v-if="searchObj.loadingCounter" class="q-ml-md">
             <q-spinner-hourglass
@@ -65,7 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </div>
         </div>
 
-        <div class="col-6 text-right q-pr-md q-gutter-xs pagination-block">
+        <div class="col-5 text-right q-pr-md q-gutter-xs pagination-block">
           
           <q-pagination
             v-if="searchObj.meta.resultGrid.showPagination"

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -170,11 +170,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             >{{ t("search.histogramErrorBtnLabel") }}</q-btn
           ><br />
           <span v-if="disableMoreErrorDetails">
-            {{ searchObj.data.histogram?.errorMsg }}
+            <SanitizedHtmlRenderer
+              data-test="logs-search-histogram-error-message"
+              :htmlContent="
+                searchObj.data?.histogram?.errorMsg
+              "
+            />
           </span>
         </h6>
         <h6 class="text-center" v-else-if="searchObj.data.histogram.errorCode != -1">
-          {{ searchObj.data.histogram?.errorMsg }}
+          <SanitizedHtmlRenderer
+              data-test="logs-search-histogram-error-message"
+              :htmlContent="
+                searchObj.data?.histogram?.errorMsg
+              "
+            />
         </h6>
       </div>
       <tenstack-table

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -116,7 +116,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           ></q-select>
         </div>
       </div>
-      <div style="height: 100px;" v-if="searchObj.data?.histogram?.errorMsg == '' && searchObj.data.histogram.errorCode != -1">
+      <div :style="{
+        height: searchObj.meta.showHistogram ? '100px' : '0px'}" v-if="searchObj.data?.histogram?.errorMsg == '' && searchObj.data.histogram.errorCode != -1">
         <ChartRenderer
           v-if="searchObj.meta.showHistogram   && (searchObj.data?.queryResults?.aggs?.length > 0 || ( plotChart && Object.keys(plotChart)?.length > 0))"
           data-test="logs-search-result-bar-chart"

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -116,30 +116,35 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           ></q-select>
         </div>
       </div>
-      <div v-if="searchObj.data?.histogram?.errorMsg == '' && searchObj.data.histogram.errorCode != -1">
+      <div style="height: 100px;" v-if="searchObj.data?.histogram?.errorMsg == '' && searchObj.data.histogram.errorCode != -1">
         <ChartRenderer
-          v-if="searchObj.meta.showHistogram && (searchObj.data?.queryResults?.aggs?.length > 0 || ( plotChart && Object.keys(plotChart)?.length > 0))"
+          v-if="searchObj.meta.showHistogram   && (searchObj.data?.queryResults?.aggs?.length > 0 || ( plotChart && Object.keys(plotChart)?.length > 0))"
           data-test="logs-search-result-bar-chart"
           :data="plotChart"
-          style="max-height: 100px"
+          style="max-height: 100px;"
           @updated:dataZoom="onChartUpdate"
         />
         
-        <div v-else-if="searchObj.meta.showHistogram && (Object.keys(plotChart)?.length == 0) && searchObj.loadingHistogram == false && searchObj.loading == false">
+        <div style="height: 100px;" v-else-if="searchObj.meta.showHistogram && (Object.keys(plotChart)?.length == 0) && (searchObj.loadingHistogram == false && searchObj.loading == false)">
           <h3
             class="text-center"
-            style="margin: 30px 0px"
           >
-            <q-icon name="warning" color="warning" size="xs"></q-icon> No data found for histogram.
+           <span style="min-height: 50px;"> <q-icon name="warning" color="warning" size="xs"></q-icon> No data found for histogram.</span>
           </h3>
         </div>
 
-
+        <div style="height: 100px;" v-else-if="searchObj.meta.showHistogram && ((Object.keys(plotChart)?.length == 0))  ">
+            <h3
+              class="text-center"
+            >
+              <span style="min-height: 50px; color: transparent;">.</span>
+            </h3>
+        </div>
 
         <div
           class="q-pb-lg"
-          style=" left: 45%; margin: 25px 0px;"
-          v-else-if="histogramLoader"
+          style="top: 50px; position: absolute; left: 50%"
+          v-if="histogramLoader"
           
         >
           <q-spinner-hourglass
@@ -643,7 +648,7 @@ export default defineComponent({
     });
     //this is used to show the histogram loader when the histogram is loading
     const histogramLoader = computed(()=>{
-      return (searchObj.meta.showHistogram) && (searchObj.loadingHistogram == true ||  searchObj.loading == true) && ( plotChart.value && Object.keys(plotChart.value)?.length == 0) 
+      return (searchObj.meta.showHistogram) && (searchObj.loadingHistogram == true ||  searchObj.loading == true);
     })
 
     return {

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -649,7 +649,7 @@ export default defineComponent({
     });
     //this is used to show the histogram loader when the histogram is loading
     const histogramLoader = computed(()=>{
-      return (searchObj.meta.showHistogram) && (searchObj.loadingHistogram == true ||  searchObj.loading == true);
+      return (searchObj.meta.showHistogram) && searchObj.loadingHistogram == true;
     })
 
     return {

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       ref="searchListContainer"
       style="width: 100%"
     >
-      <div class="row">
+      <div   class="row tw-min-h-[44px]">
         <div
           class="col-6 text-left q-pl-lg q-mt-xs bg-warning text-white rounded-borders"
           v-if="searchObj.data.countErrorMsg != ''"

--- a/web/src/utils/common.ts
+++ b/web/src/utils/common.ts
@@ -102,6 +102,7 @@ export const logsErrorMessage = (code: number) => {
     20006: "SearchParquetFileNotFound",
     20007: "SearchFieldHasNoCompatibleDataType",
     20008: "SearchSQLExecuteError",
+    20009: "SearchSQLCancelled",
   };
 
   if (messages[code] != undefined) {


### PR DESCRIPTION
#6771 
1. When we get streaming aggs response, streaming_output key was getting added to page-count api payload, causing the api to fail.
2. Histogram loader is not visible when loading histogram is in progress.
3. Remove histogram refresh in live mode
4. Get `undefined` when histogram query is cancelled
5. query editor undo redo functionality even after user looses focus and focus again
6. Cmd enter fix on logs page
