### PR TITLE
fix: s3 ListBucket error

### DIFF
--- a/src/infra/src/storage/remote.rs
+++ b/src/infra/src/storage/remote.rs
@@ -398,7 +398,7 @@ pub async fn test_config() -> Result<(), anyhow::Error> {
         Err(e) => match e {
             object_store::Error::NotFound { .. } => {}
             object_store::Error::PermissionDenied { path: _, source }
-                if !source.to_string().contains("ListBucket") => {}
+                if source.to_string().contains("ListBucket") => {}
             _ => {
                 return Err(anyhow::anyhow!("S3 download test failed: {:?}", e));
             }


### PR DESCRIPTION
If the file not found S3 will check `ListBucket` permission, it is tricky, but it works like that. 

This PR will skip that error, that is not a real problem. we should skip that.