### PR TITLE
feat: download manager improvements

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1157,6 +1157,8 @@ pub struct Limit {
     pub file_download_priority_queue_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_WINDOW_SECS", default = 3600)]
     pub file_download_priority_queue_window_secs: u64,
+    #[env_config(name = "ZO_FILE_DOWNLOAD_ENABLE_PRIORITY_QUEUE", default = true)]
+    pub file_download_enable_priority_queue: bool,
     #[env_config(name = "ZO_QUERY_TIMEOUT", default = 600)]
     pub query_timeout: u64,
     #[env_config(name = "ZO_QUERY_INGESTER_TIMEOUT", default = 0)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1153,6 +1153,10 @@ pub struct Limit {
     pub query_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_THREAD_NUM", default = 0)]
     pub file_download_thread_num: usize,
+    #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_THREAD_NUM", default = 0)]
+    pub file_download_priority_queue_thread_num: usize,
+    #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_WINDOW_SECS", default = 3600)]
+    pub file_download_priority_queue_window_secs: u64,
     #[env_config(name = "ZO_QUERY_TIMEOUT", default = 600)]
     pub query_timeout: u64,
     #[env_config(name = "ZO_QUERY_INGESTER_TIMEOUT", default = 0)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1933,6 +1933,10 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         cfg.limit.file_download_thread_num = std::cmp::max(1, cpu_num / 2);
     }
 
+    if cfg.limit.file_download_priority_queue_thread_num == 0 {
+        cfg.limit.file_download_priority_queue_thread_num = std::cmp::max(1, cpu_num / 2);
+    }
+
     // HACK for move_file_thread_num equal to CPU core
     if cfg.limit.file_move_thread_num == 0 {
         if cfg.common.local_mode {

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -790,11 +790,11 @@ pub static NODE_TCP_CONNECTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 // query disk cache metrics
-pub static QUERY_DISK_CACHE_COUNT: Lazy<CounterVec> = Lazy::new(|| {
+pub static QUERY_DISK_CACHE_UTILIZATION_COUNT: Lazy<CounterVec> = Lazy::new(|| {
     CounterVec::new(
         Opts::new(
-            "query_disk_cache_count",
-            "query disk cache count".to_owned() + HELP_SUFFIX,
+            "query_disk_cache_utilization_count",
+            "query disk cache utilization count".to_owned() + HELP_SUFFIX,
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
@@ -1033,7 +1033,7 @@ fn register_metrics(registry: &Registry) {
 
     // query disk cache metrics
     registry
-        .register(Box::new(QUERY_DISK_CACHE_COUNT.clone()))
+        .register(Box::new(QUERY_DISK_CACHE_UTILIZATION_COUNT.clone()))
         .expect("Metric registered");
     // file downloader metrics
     registry

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -17,8 +17,8 @@ use std::collections::HashMap;
 
 use once_cell::sync::Lazy;
 use prometheus::{
-    CounterVec, Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry,
-    TextEncoder,
+    CounterVec, Encoder, GaugeVec, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts,
+    Registry, TextEncoder,
 };
 
 pub const NAMESPACE: &str = "zo";
@@ -816,6 +816,16 @@ pub static FILE_DOWNLOADER_CACHE_MISS_COUNT: Lazy<CounterVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+pub static FILE_DOWNLOADER_QUEUE_SIZE: Lazy<GaugeVec> = Lazy::new(|| {
+    GaugeVec::new(
+        Opts::new("file_downloader_queue_size", "file downloader queue size")
+            .namespace(NAMESPACE)
+            .const_labels(create_const_labels()),
+        &["queue_type"],
+    )
+    .expect("Metric created")
+});
+
 fn register_metrics(registry: &Registry) {
     // http latency
     registry
@@ -1027,12 +1037,15 @@ fn register_metrics(registry: &Registry) {
         .register(Box::new(NODE_TCP_CONNECTIONS.clone()))
         .expect("Metric registered");
 
-    // file downloader cache metrics
+    // file downloader metrics
     registry
         .register(Box::new(FILE_DOWNLOADER_CACHE_HIT_COUNT.clone()))
         .expect("Metric registered");
     registry
         .register(Box::new(FILE_DOWNLOADER_CACHE_MISS_COUNT.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(FILE_DOWNLOADER_QUEUE_SIZE.clone()))
         .expect("Metric registered");
 }
 

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -798,7 +798,13 @@ pub static QUERY_DISK_CACHE_COUNT: Lazy<CounterVec> = Lazy::new(|| {
         )
         .namespace(NAMESPACE)
         .const_labels(create_const_labels()),
-        &["organization", "stream_type", "storage_type", "count_type"],
+        &[
+            "organization",
+            "stream_type",
+            "storage_type",
+            "count_type",
+            "file_type",
+        ],
     )
     .expect("Metric created")
 });

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -790,8 +790,8 @@ pub static NODE_TCP_CONNECTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 // query disk cache metrics
-pub static QUERY_DISK_CACHE_UTILIZATION_COUNT: Lazy<CounterVec> = Lazy::new(|| {
-    CounterVec::new(
+pub static QUERY_DISK_CACHE_UTILIZATION_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
         Opts::new(
             "query_disk_cache_utilization_count",
             "query disk cache utilization count".to_owned() + HELP_SUFFIX,

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -789,33 +789,21 @@ pub static NODE_TCP_CONNECTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+// query disk cache metrics
+pub static QUERY_DISK_CACHE_COUNT: Lazy<CounterVec> = Lazy::new(|| {
+    CounterVec::new(
+        Opts::new(
+            "query_disk_cache_count",
+            "query disk cache count".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["organization", "stream_type", "storage_type", "count_type"],
+    )
+    .expect("Metric created")
+});
+
 // file downloader metrics
-pub static FILE_DOWNLOADER_CACHE_HIT_COUNT: Lazy<CounterVec> = Lazy::new(|| {
-    CounterVec::new(
-        Opts::new(
-            "file_downloader_cache_hit_count",
-            "file downloader cache hit count".to_owned() + HELP_SUFFIX,
-        )
-        .namespace(NAMESPACE)
-        .const_labels(create_const_labels()),
-        &["organization", "stream_type", "storage_type"],
-    )
-    .expect("Metric created")
-});
-
-pub static FILE_DOWNLOADER_CACHE_MISS_COUNT: Lazy<CounterVec> = Lazy::new(|| {
-    CounterVec::new(
-        Opts::new(
-            "file_downloader_cache_miss_count",
-            "file downloader cache miss count".to_owned() + HELP_SUFFIX,
-        )
-        .namespace(NAMESPACE)
-        .const_labels(create_const_labels()),
-        &["organization", "stream_type", "storage_type"],
-    )
-    .expect("Metric created")
-});
-
 pub static FILE_DOWNLOADER_QUEUE_SIZE: Lazy<GaugeVec> = Lazy::new(|| {
     GaugeVec::new(
         Opts::new("file_downloader_queue_size", "file downloader queue size")
@@ -1037,13 +1025,11 @@ fn register_metrics(registry: &Registry) {
         .register(Box::new(NODE_TCP_CONNECTIONS.clone()))
         .expect("Metric registered");
 
+    // query disk cache metrics
+    registry
+        .register(Box::new(QUERY_DISK_CACHE_COUNT.clone()))
+        .expect("Metric registered");
     // file downloader metrics
-    registry
-        .register(Box::new(FILE_DOWNLOADER_CACHE_HIT_COUNT.clone()))
-        .expect("Metric registered");
-    registry
-        .register(Box::new(FILE_DOWNLOADER_CACHE_MISS_COUNT.clone()))
-        .expect("Metric registered");
     registry
         .register(Box::new(FILE_DOWNLOADER_QUEUE_SIZE.clone()))
         .expect("Metric registered");

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -789,6 +789,33 @@ pub static NODE_TCP_CONNECTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+// file downloader metrics
+pub static FILE_DOWNLOADER_CACHE_HIT_COUNT: Lazy<CounterVec> = Lazy::new(|| {
+    CounterVec::new(
+        Opts::new(
+            "file_downloader_cache_hit_count",
+            "file downloader cache hit count".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["organization", "stream_type", "storage_type"],
+    )
+    .expect("Metric created")
+});
+
+pub static FILE_DOWNLOADER_CACHE_MISS_COUNT: Lazy<CounterVec> = Lazy::new(|| {
+    CounterVec::new(
+        Opts::new(
+            "file_downloader_cache_miss_count",
+            "file downloader cache miss count".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["organization", "stream_type", "storage_type"],
+    )
+    .expect("Metric created")
+});
+
 fn register_metrics(registry: &Registry) {
     // http latency
     registry
@@ -998,6 +1025,14 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(NODE_TCP_CONNECTIONS.clone()))
+        .expect("Metric registered");
+
+    // file downloader cache metrics
+    registry
+        .register(Box::new(FILE_DOWNLOADER_CACHE_HIT_COUNT.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(FILE_DOWNLOADER_CACHE_MISS_COUNT.clone()))
         .expect("Metric registered");
 }
 

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -218,7 +218,7 @@ pub async fn queue_background_download(
     Ok(())
 }
 
-pub fn should_priorotize_file(file_meta: &FileMeta) -> bool {
+pub fn should_prioritize_file(file_meta: &FileMeta) -> bool {
     let cfg = get_config();
     let window_micros = (cfg.limit.file_download_priority_queue_window_secs * 1_000_000) as i64;
     let now = chrono::Utc::now().timestamp_micros();

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -25,9 +25,6 @@ use tokio::sync::{
 
 type FileInfo = (String, String, usize, file_data::CacheType);
 
-const NORMAL_QUEUE: &str = "normal";
-const PRIORITY_QUEUE: &str = "priority";
-
 struct DownloadQueue {
     sender: Sender<FileInfo>,
     receiver: Arc<Mutex<Receiver<FileInfo>>>,
@@ -125,8 +122,8 @@ pub async fn run() -> Result<(), anyhow::Error> {
                         }
 
                         // update metrics
-                        metrics::FILE_DOWNLOADER_QUEUE_SIZE
-                            .with_label_values(&[NORMAL_QUEUE])
+                        metrics::FILE_DOWNLOADER_NORMAL_QUEUE_SIZE
+                            .with_label_values(&[])
                             .dec();
                     }
                 }
@@ -201,8 +198,8 @@ pub async fn run() -> Result<(), anyhow::Error> {
                         }
 
                         // update metrics
-                        metrics::FILE_DOWNLOADER_QUEUE_SIZE
-                            .with_label_values(&[PRIORITY_QUEUE])
+                        metrics::FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE
+                            .with_label_values(&[])
                             .dec();
                     }
                     None => {
@@ -266,8 +263,8 @@ pub async fn queue_background_download(
             .await?;
 
         // update metrics
-        metrics::FILE_DOWNLOADER_QUEUE_SIZE
-            .with_label_values(&[NORMAL_QUEUE])
+        metrics::FILE_DOWNLOADER_NORMAL_QUEUE_SIZE
+            .with_label_values(&[])
             .inc();
     } else {
         PRIORITY_FILE_DOWNLOAD_CHANNEL
@@ -281,8 +278,8 @@ pub async fn queue_background_download(
             .await?;
 
         // update metrics
-        metrics::FILE_DOWNLOADER_QUEUE_SIZE
-            .with_label_values(&[PRIORITY_QUEUE])
+        metrics::FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE
+            .with_label_values(&[])
             .inc();
     }
     Ok(())

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -251,7 +251,7 @@ pub async fn queue_background_download(
     cache_type: file_data::CacheType,
     to_priority_queue: bool,
 ) -> Result<(), anyhow::Error> {
-    if !to_priority_queue {
+    if !to_priority_queue || !get_config().limit.file_download_enable_priority_queue {
         FILE_DOWNLOAD_CHANNEL
             .sender
             .send((

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -25,6 +25,9 @@ use tokio::sync::{
 
 type FileInfo = (String, String, usize, file_data::CacheType);
 
+const NORMAL_QUEUE: &str = "normal";
+const PRIORITY_QUEUE: &str = "priority";
+
 struct DownloadQueue {
     sender: Sender<FileInfo>,
     receiver: Arc<Mutex<Receiver<FileInfo>>>,
@@ -123,7 +126,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
                         // update metrics
                         metrics::FILE_DOWNLOADER_QUEUE_SIZE
-                            .with_label_values(&["normal"])
+                            .with_label_values(&[NORMAL_QUEUE])
                             .dec();
                     }
                 }
@@ -184,7 +187,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
                         // update metrics
                         metrics::FILE_DOWNLOADER_QUEUE_SIZE
-                            .with_label_values(&["priority"])
+                            .with_label_values(&[PRIORITY_QUEUE])
                             .dec();
                     }
                     None => {
@@ -249,7 +252,7 @@ pub async fn queue_background_download(
 
         // update metrics
         metrics::FILE_DOWNLOADER_QUEUE_SIZE
-            .with_label_values(&["normal"])
+            .with_label_values(&[NORMAL_QUEUE])
             .inc();
     } else {
         PRIORITY_FILE_DOWNLOAD_CHANNEL
@@ -264,7 +267,7 @@ pub async fn queue_background_download(
 
         // update metrics
         metrics::FILE_DOWNLOADER_QUEUE_SIZE
-            .with_label_values(&["priority"])
+            .with_label_values(&[PRIORITY_QUEUE])
             .inc();
     }
     Ok(())

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -42,7 +42,7 @@ mod stats;
 pub(crate) mod syslog_server;
 mod telemetry;
 
-pub use file_downloader::queue_background_download;
+pub use file_downloader::{queue_background_download, should_priorotize_file};
 pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 
 pub async fn init() -> Result<(), anyhow::Error> {

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -42,7 +42,7 @@ mod stats;
 pub(crate) mod syslog_server;
 mod telemetry;
 
-pub use file_downloader::{queue_background_download, should_priorotize_file};
+pub use file_downloader::{queue_background_download, should_prioritize_file};
 pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 
 pub async fn init() -> Result<(), anyhow::Error> {

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -244,23 +244,11 @@ pub(crate) async fn create_context(
     .await?;
 
     // report cache hit and miss metrics
-    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
-        .with_label_values(&[
-            &query.org_id,
-            &query.stream_type.to_string(),
-            "local",
-            "cache_hit",
-            "parquet",
-        ])
+    metrics::QUERY_DISK_CACHE_HIT_COUNT
+        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "parquet"])
         .inc_by(cache_hits);
-    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
-        .with_label_values(&[
-            &query.org_id,
-            &query.stream_type.to_string(),
-            "remote",
-            "cache_miss",
-            "parquet",
-        ])
+    metrics::QUERY_DISK_CACHE_MISS_COUNT
+        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "parquet"])
         .inc_by(cache_misses);
 
     Ok(Some((ctx, schema, scan_stats)))

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -250,6 +250,7 @@ pub(crate) async fn create_context(
             &query.stream_type.to_string(),
             "local",
             "cache_hit",
+            "parquet",
         ])
         .inc_by(cache_hits as f64);
     metrics::QUERY_DISK_CACHE_COUNT
@@ -258,6 +259,7 @@ pub(crate) async fn create_context(
             &query.stream_type.to_string(),
             "remote",
             "cache_miss",
+            "parquet",
         ])
         .inc_by(cache_misses as f64);
 

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -252,7 +252,7 @@ pub(crate) async fn create_context(
             "cache_hit",
             "parquet",
         ])
-        .inc_by(cache_hits as f64);
+        .inc_by(cache_hits);
     metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
         .with_label_values(&[
             &query.org_id,
@@ -261,7 +261,7 @@ pub(crate) async fn create_context(
             "cache_miss",
             "parquet",
         ])
-        .inc_by(cache_misses as f64);
+        .inc_by(cache_misses);
 
     Ok(Some((ctx, schema, scan_stats)))
 }

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -244,11 +244,21 @@ pub(crate) async fn create_context(
     .await?;
 
     // report cache hit and miss metrics
-    metrics::FILE_DOWNLOADER_CACHE_HIT_COUNT
-        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "local"])
+    metrics::QUERY_DISK_CACHE_COUNT
+        .with_label_values(&[
+            &query.org_id,
+            &query.stream_type.to_string(),
+            "local",
+            "cache_hit",
+        ])
         .inc_by(cache_hits as f64);
-    metrics::FILE_DOWNLOADER_CACHE_MISS_COUNT
-        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "remote"])
+    metrics::QUERY_DISK_CACHE_COUNT
+        .with_label_values(&[
+            &query.org_id,
+            &query.stream_type.to_string(),
+            "remote",
+            "cache_miss",
+        ])
         .inc_by(cache_misses as f64);
 
     Ok(Some((ctx, schema, scan_stats)))

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -244,7 +244,7 @@ pub(crate) async fn create_context(
     .await?;
 
     // report cache hit and miss metrics
-    metrics::QUERY_DISK_CACHE_COUNT
+    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
         .with_label_values(&[
             &query.org_id,
             &query.stream_type.to_string(),
@@ -253,7 +253,7 @@ pub(crate) async fn create_context(
             "parquet",
         ])
         .inc_by(cache_hits as f64);
-    metrics::QUERY_DISK_CACHE_COUNT
+    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
         .with_label_values(&[
             &query.org_id,
             &query.stream_type.to_string(),

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -275,7 +275,7 @@ pub async fn search(
     .await?;
 
     // report cache hit and miss metrics
-    metrics::QUERY_DISK_CACHE_COUNT
+    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
         .with_label_values(&[
             &query.org_id,
             &query.stream_type.to_string(),
@@ -284,7 +284,7 @@ pub async fn search(
             "parquet",
         ])
         .inc_by(cache_hits as f64);
-    metrics::QUERY_DISK_CACHE_COUNT
+    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
         .with_label_values(&[
             &query.org_id,
             &query.stream_type.to_string(),
@@ -567,7 +567,7 @@ pub async fn filter_file_list_by_tantivy_index(
     .await?;
 
     // report cache hit and miss metrics
-    metrics::QUERY_DISK_CACHE_COUNT
+    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
         .with_label_values(&[
             &query.org_id,
             &query.stream_type.to_string(),
@@ -576,7 +576,7 @@ pub async fn filter_file_list_by_tantivy_index(
             "index",
         ])
         .inc_by(cache_hits as f64);
-    metrics::QUERY_DISK_CACHE_COUNT
+    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
         .with_label_values(&[
             &query.org_id,
             &query.stream_type.to_string(),

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -400,11 +400,21 @@ pub async fn search(
     );
 
     // report cache hit and miss metrics
-    metrics::FILE_DOWNLOADER_CACHE_HIT_COUNT
-        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "local"])
+    metrics::QUERY_DISK_CACHE_COUNT
+        .with_label_values(&[
+            &query.org_id,
+            &query.stream_type.to_string(),
+            "local",
+            "cache_hit",
+        ])
         .inc_by(cache_hits as f64);
-    metrics::FILE_DOWNLOADER_CACHE_MISS_COUNT
-        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "remote"])
+    metrics::QUERY_DISK_CACHE_COUNT
+        .with_label_values(&[
+            &query.org_id,
+            &query.stream_type.to_string(),
+            "remote",
+            "cache_miss",
+        ])
         .inc_by(cache_misses as f64);
 
     Ok((tables, scan_stats))
@@ -556,11 +566,16 @@ pub async fn filter_file_list_by_tantivy_index(
     .await?;
 
     // report cache hit and miss metrics
-    metrics::FILE_DOWNLOADER_CACHE_HIT_COUNT
+    metrics::QUERY_DISK_CACHE_COUNT
         .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "local"])
         .inc_by(cache_hits as f64);
-    metrics::FILE_DOWNLOADER_CACHE_MISS_COUNT
-        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "remote"])
+    metrics::QUERY_DISK_CACHE_COUNT
+        .with_label_values(&[
+            &query.org_id,
+            &query.stream_type.to_string(),
+            "remote",
+            "cache_miss",
+        ])
         .inc_by(cache_misses as f64);
 
     let cached_ratio = (scan_stats.querier_memory_cached_files

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -275,23 +275,11 @@ pub async fn search(
     .await?;
 
     // report cache hit and miss metrics
-    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
-        .with_label_values(&[
-            &query.org_id,
-            &query.stream_type.to_string(),
-            "local",
-            "cache_hit",
-            "parquet",
-        ])
+    metrics::QUERY_DISK_CACHE_HIT_COUNT
+        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "parquet"])
         .inc_by(cache_hits);
-    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
-        .with_label_values(&[
-            &query.org_id,
-            &query.stream_type.to_string(),
-            "remote",
-            "cache_miss",
-            "parquet",
-        ])
+    metrics::QUERY_DISK_CACHE_MISS_COUNT
+        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "parquet"])
         .inc_by(cache_misses);
 
     scan_stats.idx_took = idx_took as i64;
@@ -567,23 +555,11 @@ pub async fn filter_file_list_by_tantivy_index(
     .await?;
 
     // report cache hit and miss metrics
-    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
-        .with_label_values(&[
-            &query.org_id,
-            &query.stream_type.to_string(),
-            "local",
-            "cache_hit",
-            "index",
-        ])
+    metrics::QUERY_DISK_CACHE_HIT_COUNT
+        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "index"])
         .inc_by(cache_hits);
-    metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
-        .with_label_values(&[
-            &query.org_id,
-            &query.stream_type.to_string(),
-            "remote",
-            "cache_miss",
-            "index",
-        ])
+    metrics::QUERY_DISK_CACHE_MISS_COUNT
+        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "index"])
         .inc_by(cache_misses);
 
     let cached_ratio = (scan_stats.querier_memory_cached_files

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -283,7 +283,7 @@ pub async fn search(
             "cache_hit",
             "parquet",
         ])
-        .inc_by(cache_hits as f64);
+        .inc_by(cache_hits);
     metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
         .with_label_values(&[
             &query.org_id,
@@ -292,7 +292,7 @@ pub async fn search(
             "cache_miss",
             "parquet",
         ])
-        .inc_by(cache_misses as f64);
+        .inc_by(cache_misses);
 
     scan_stats.idx_took = idx_took as i64;
     scan_stats.querier_files = scan_stats.files;
@@ -427,7 +427,7 @@ pub async fn cache_files(
     files: &[(&str, i64, bool)],
     scan_stats: &mut ScanStats,
     file_type: &str,
-) -> Result<(file_data::CacheType, i64, i64), Error> {
+) -> Result<(file_data::CacheType, u64, u64), Error> {
     // check how many files already cached
     let mut cached_files = HashSet::with_capacity(files.len());
     let (mut cache_hits, mut cache_misses) = (0, 0);
@@ -575,7 +575,7 @@ pub async fn filter_file_list_by_tantivy_index(
             "cache_hit",
             "index",
         ])
-        .inc_by(cache_hits as f64);
+        .inc_by(cache_hits);
     metrics::QUERY_DISK_CACHE_UTILIZATION_COUNT
         .with_label_values(&[
             &query.org_id,
@@ -584,7 +584,7 @@ pub async fn filter_file_list_by_tantivy_index(
             "cache_miss",
             "index",
         ])
-        .inc_by(cache_misses as f64);
+        .inc_by(cache_misses);
 
     let cached_ratio = (scan_stats.querier_memory_cached_files
         + scan_stats.querier_disk_cached_files) as f64


### PR DESCRIPTION
Closes: https://github.com/openobserve/openobserve/issues/6786

New Env: 
```
ZO_FILE_DOWNLOAD_ENABLE_PRIORITY_QUEUE # default true
ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_THREAD_NUM # default 0
ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_WINDOW_SECS # default 3600
```

New Metrics:
```
zo_query_disk_cache_hit_count
zo_query_disk_cache_miss_count
zo_file_downloader_normal_queue_size
zo_file_downloader_priority_queue_size
```

Todo:
- [x] add priority queue and logic to determine of a file `is_priority` 
- [x] add env for priority queue threads, time window
- [x] add metrics for `cache_hits`, `cache_miss`, `queue_length` (both normal & priority queue)