### PR TITLE
fix: internal error audit (#6768)

### DIFF
--- a/src/handler/http/request/search/error_utils.rs
+++ b/src/handler/http/request/search/error_utils.rs
@@ -25,10 +25,7 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>)
         errors::Error::ErrorCode(code) => match code {
             errors::ErrorCodes::RatelimitExceeded(_) => HttpResponse::TooManyRequests()
                 .append_header((ERROR_HEADER, code.to_json()))
-                .json(MetaHttpResponse::error_code_with_trace_id(
-                    code,
-                    Some(trace_id),
-                )),
+                .json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
             errors::ErrorCodes::SearchTimeout(_) => HttpResponse::RequestTimeout()
                 .append_header((ERROR_HEADER, code.to_json()))
                 .json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),

--- a/src/handler/http/request/search/error_utils.rs
+++ b/src/handler/http/request/search/error_utils.rs
@@ -20,7 +20,7 @@ use crate::{
     common::meta::http::HttpResponse as MetaHttpResponse, handler::http::router::ERROR_HEADER,
 };
 
-pub fn map_error_to_http_response(err: &errors::Error, trace_id: String) -> HttpResponse {
+pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>) -> HttpResponse {
     match err {
         errors::Error::ErrorCode(code) => match code {
             errors::ErrorCodes::RatelimitExceeded(_) => HttpResponse::TooManyRequests()
@@ -31,10 +31,7 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: String) -> Http
                 )),
             errors::ErrorCodes::SearchTimeout(_) => HttpResponse::RequestTimeout()
                 .append_header((ERROR_HEADER, code.to_json()))
-                .json(MetaHttpResponse::error_code_with_trace_id(
-                    code,
-                    Some(trace_id),
-                )),
+                .json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
             errors::ErrorCodes::InvalidParams(_)
             | errors::ErrorCodes::SearchSQLExecuteError(_)
             | errors::ErrorCodes::SearchFieldHasNoCompatibleDataType(_)
@@ -45,18 +42,12 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: String) -> Http
             | errors::ErrorCodes::SearchStreamNotFound(_)
             | errors::ErrorCodes::SearchCancelQuery(_) => HttpResponse::BadRequest()
                 .append_header((ERROR_HEADER, code.to_json()))
-                .json(MetaHttpResponse::error_code_with_trace_id(
-                    code,
-                    Some(trace_id),
-                )),
+                .json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
 
             errors::ErrorCodes::ServerInternalError(_)
             | errors::ErrorCodes::SearchParquetFileNotFound => HttpResponse::InternalServerError()
                 .append_header((ERROR_HEADER, code.to_json()))
-                .json(MetaHttpResponse::error_code_with_trace_id(
-                    code,
-                    Some(trace_id),
-                )),
+                .json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
         },
         _ => HttpResponse::InternalServerError()
             .append_header((ERROR_HEADER, err.to_string()))

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -15,7 +15,7 @@
 
 use std::io::Error;
 
-use actix_web::{HttpRequest, HttpResponse, get, http::StatusCode, post, web};
+use actix_web::{HttpRequest, HttpResponse, get, post, web};
 use chrono::Utc;
 use config::{
     TIMESTAMP_COL_NAME, get_config,
@@ -47,6 +47,7 @@ use crate::{
             stream::get_settings_max_query_range,
         },
     },
+    handler::http::request::search::error_utils::map_error_to_http_response,
     service::{search as SearchService, self_reporting::report_request_usage_stats},
 };
 
@@ -189,12 +190,7 @@ pub async fn search_multi(
         let stream_name = match resolve_stream_names(&req.query.sql) {
             Ok(v) => v[0].clone(),
             Err(e) => {
-                return Ok(HttpResponse::InternalServerError().json(
-                    meta::http::HttpResponse::error(
-                        StatusCode::INTERNAL_SERVER_ERROR.into(),
-                        e.to_string(),
-                    ),
-                ));
+                return Ok(map_error_to_http_response(&(e.into()), Some(trace_id)));
             }
         };
         vrl_stream_name = stream_name.clone();
@@ -265,12 +261,7 @@ pub async fn search_multi(
             let keys_used = match get_cipher_key_names(&req.query.sql) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Ok(HttpResponse::InternalServerError().json(
-                        meta::http::HttpResponse::error(
-                            StatusCode::INTERNAL_SERVER_ERROR.into(),
-                            e.to_string(),
-                        ),
-                    ));
+                    return Ok(map_error_to_http_response(&e, Some(trace_id)));
                 }
             };
             if !keys_used.is_empty() {
@@ -749,15 +740,7 @@ pub async fn _search_partition_multi(
                 ])
                 .inc();
             log::error!("search error: {:?}", err);
-            Ok(match err {
-                errors::Error::ErrorCode(code) => HttpResponse::InternalServerError().json(
-                    meta::http::HttpResponse::error_code_with_trace_id(&code, Some(trace_id)),
-                ),
-                _ => HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
-                    StatusCode::INTERNAL_SERVER_ERROR.into(),
-                    err.to_string(),
-                )),
-            })
+            Ok(map_error_to_http_response(&err, Some(trace_id)))
         }
     }
 }
@@ -896,25 +879,7 @@ pub async fn around_multi(
                     ])
                     .inc();
                 log::error!("multi search around error: {:?}", err);
-                return Ok(match err {
-                    errors::Error::ErrorCode(code) => match code {
-                        errors::ErrorCodes::SearchCancelQuery(_) => HttpResponse::TooManyRequests()
-                            .json(meta::http::HttpResponse::error_code_with_trace_id(
-                                &code,
-                                Some(trace_id),
-                            )),
-                        _ => HttpResponse::InternalServerError().json(
-                            meta::http::HttpResponse::error_code_with_trace_id(
-                                &code,
-                                Some(trace_id),
-                            ),
-                        ),
-                    },
-                    _ => HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
-                        StatusCode::INTERNAL_SERVER_ERROR.into(),
-                        err.to_string(),
-                    )),
-                });
+                return Ok(map_error_to_http_response(&err, Some(trace_id)));
             }
         };
 

--- a/src/handler/http/request/search/search_inspector.rs
+++ b/src/handler/http/request/search/search_inspector.rs
@@ -331,7 +331,10 @@ pub async fn get_search_profile(
                 "",
             );
             log::error!("[trace_id {trace_id}] search error: {}", err);
-            Ok(error_utils::map_error_to_http_response(&err, trace_id))
+            Ok(error_utils::map_error_to_http_response(
+                &err,
+                Some(trace_id),
+            ))
         }
     }
 }

--- a/src/handler/http/request/short_url/mod.rs
+++ b/src/handler/http/request/short_url/mod.rs
@@ -15,15 +15,15 @@
 
 use std::io::Error;
 
-use actix_http::StatusCode;
 use actix_web::{HttpRequest, HttpResponse, get, post, web};
 use config::meta::short_url::ShortenUrlResponse;
 
 use crate::{
     common::{
-        meta::{self, http::HttpResponse as MetaHttpResponse},
+        meta::http::HttpResponse as MetaHttpResponse,
         utils::redirect_response::RedirectResponseBuilder,
     },
+    handler::http::request::search::error_utils::map_error_to_http_response,
     service::short_url,
 };
 
@@ -72,12 +72,7 @@ pub async fn shorten(org_id: web::Path<String>, body: web::Bytes) -> Result<Http
         }
         Err(e) => {
             log::error!("Failed to shorten URL: {:?}", e);
-            Ok(
-                HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
-                    StatusCode::INTERNAL_SERVER_ERROR.into(),
-                    e.to_string(),
-                )),
-            )
+            Ok(map_error_to_http_response(&e.into(), None))
         }
     }
 }

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -17,7 +17,6 @@ use std::{collections::HashMap, io::Error};
 
 use actix_web::{HttpRequest, HttpResponse, get, http, post, web};
 use config::{TIMESTAMP_COL_NAME, get_config, meta::stream::StreamType, metrics, utils::json};
-use infra::errors;
 use serde::Serialize;
 use tracing::{Instrument, Span};
 
@@ -26,7 +25,9 @@ use crate::{
         meta::{self, http::HttpResponse as MetaHttpResponse},
         utils::http::get_or_create_trace_id,
     },
-    handler::http::request::{CONTENT_TYPE_JSON, CONTENT_TYPE_PROTO},
+    handler::http::request::{
+        CONTENT_TYPE_JSON, CONTENT_TYPE_PROTO, search::error_utils::map_error_to_http_response,
+    },
     service::{search as SearchService, traces},
 };
 
@@ -315,18 +316,7 @@ pub async fn get_latest_traces(
                 ])
                 .inc();
             log::error!("get traces latest data error: {:?}", err);
-            return Ok(match err {
-                errors::Error::ErrorCode(code) => match code {
-                    errors::ErrorCodes::SearchCancelQuery(_) => HttpResponse::TooManyRequests()
-                        .json(meta::http::HttpResponse::error_code(code)),
-                    _ => HttpResponse::InternalServerError()
-                        .json(meta::http::HttpResponse::error_code(code)),
-                },
-                _ => HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
-                    http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                    err.to_string(),
-                )),
-            });
+            return Ok(map_error_to_http_response(&err, Some(trace_id)));
         }
     };
     if resp_search.hits.is_empty() {
@@ -408,18 +398,7 @@ pub async fn get_latest_traces(
                     ])
                     .inc();
                 log::error!("get traces latest data error: {:?}", err);
-                return Ok(match err {
-                    errors::Error::ErrorCode(code) => match code {
-                        errors::ErrorCodes::SearchCancelQuery(_) => HttpResponse::TooManyRequests()
-                            .json(meta::http::HttpResponse::error_code(code)),
-                        _ => HttpResponse::InternalServerError()
-                            .json(meta::http::HttpResponse::error_code(code)),
-                    },
-                    _ => HttpResponse::InternalServerError().json(meta::http::HttpResponse::error(
-                        http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                        err.to_string(),
-                    )),
-                });
+                return Ok(map_error_to_http_response(&err, Some(trace_id)));
             }
         };
 

--- a/src/handler/http/request/ws/session.rs
+++ b/src/handler/http/request/ws/session.rs
@@ -454,7 +454,8 @@ async fn handle_search_event(
                     let http_response_code: u16;
                     #[cfg(feature = "enterprise")]
                     {
-                        let http_response = map_error_to_http_response(&e, trace_id.to_string());
+                        let http_response =
+                            map_error_to_http_response(&e, Some(trace_id.to_string()));
                         http_response_code = http_response.status().into();
                     }
                     // Add audit before closing
@@ -607,7 +608,8 @@ async fn handle_values_event(
                     let http_response_code: u16;
                     #[cfg(feature = "enterprise")]
                     {
-                        let http_response = map_error_to_http_response(&e, trace_id.to_string());
+                        let http_response =
+                            map_error_to_http_response(&e, Some(trace_id.to_string()));
                         http_response_code = http_response.status().into();
                     }
                     // Add audit before closing

--- a/src/infra/src/errors/mod.rs
+++ b/src/infra/src/errors/mod.rs
@@ -82,6 +82,8 @@ pub enum Error {
     Reqwest(#[from] reqwest::Error),
     #[error("Error# {0}")]
     WalFileError(String),
+    #[error("Error# {0}")]
+    OtherError(#[from] anyhow::Error),
 }
 
 unsafe impl Send for Error {}

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -44,6 +44,7 @@ use infra::{
 
 use crate::{
     common::meta::{http::HttpResponse as MetaHttpResponse, stream::SchemaRecords},
+    handler::http::router::ERROR_HEADER,
     service::{
         compact::retention,
         db::{self, enrichment_table},
@@ -72,12 +73,12 @@ pub async fn save_enrichment_data(
     let stream_name = &format_stream_name(table_name);
 
     if !LOCAL_NODE.is_ingester() {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, "not an ingester".to_string()))
+            .json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                 "not an ingester".to_string(),
-            )),
-        );
+            )));
     }
 
     // check if we are allowed to ingest
@@ -87,12 +88,15 @@ pub async fn save_enrichment_data(
         stream_name,
         None,
     ) {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR.into(),
+        return Ok(HttpResponse::BadRequest()
+            .append_header((
+                ERROR_HEADER,
                 format!("enrichment table [{stream_name}] is being deleted"),
-            )),
-        );
+            ))
+            .json(MetaHttpResponse::error(
+                http::StatusCode::BAD_REQUEST.into(),
+                format!("enrichment table [{stream_name}] is being deleted"),
+            )));
     }
 
     // Estimate the size of the payload in json format in bytes
@@ -245,12 +249,15 @@ pub async fn save_enrichment_data(
         match write_file(&writer, stream_name, buf, !cfg.common.wal_fsync_disabled).await {
             Ok(stats) => stats,
             Err(e) => {
-                return Ok(
-                    HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+                return Ok(HttpResponse::InternalServerError()
+                    .append_header((
+                        ERROR_HEADER,
+                        format!("Error writing enrichment table: {}", e),
+                    ))
+                    .json(MetaHttpResponse::error(
                         http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                         format!("Error writing enrichment table: {}", e),
-                    )),
-                );
+                    )));
             }
         };
 

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -48,6 +48,7 @@ use prost::Message;
 
 use crate::{
     common::meta::{http::HttpResponse as MetaHttpResponse, stream::SchemaRecords},
+    handler::http::router::ERROR_HEADER,
     service::{
         alerts::alert::AlertExt,
         db, format_stream_name,
@@ -120,12 +121,12 @@ pub async fn handle_otlp_request(
     req_type: OtlpRequestType,
 ) -> Result<HttpResponse, anyhow::Error> {
     if !LOCAL_NODE.is_ingester() {
-        return Ok(
-            HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, "not an ingester".to_string()))
+            .json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
                 "not an ingester".to_string(),
-            )),
-        );
+            )));
     }
 
     if !db::file_list::BLOCKED_ORGS.is_empty()

--- a/src/service/websocket_events/utils.rs
+++ b/src/service/websocket_events/utils.rs
@@ -243,8 +243,7 @@ impl WsServerEvents {
             errors::Error::ErrorCode(code) => {
                 let message = code.get_message();
                 let error_detail = code.get_error_detail();
-                let http_response =
-                    map_error_to_http_response(err, trace_id.clone().unwrap_or_default());
+                let http_response = map_error_to_http_response(err, trace_id.clone());
                 WsServerEvents::Error {
                     code: http_response.status().into(),
                     message,


### PR DESCRIPTION
This adds the error header to all cases of internal server error so they show up properly in audit. This is done by one of two approaches -
1. preferably using the `map_error_to_http_response` function , so that everything goes via the same function
2. directly adding the header where the above function cannot be used because is is not an error per say like trying to ingest at non-ingester.

cherry pick of https://github.com/openobserve/openobserve/pull/6768