### PR TITLE
fix: Logs UI Issues

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1381,7 +1381,7 @@ const useLogs = () => {
     }
   };
 
-  const refreshPartitionPagination = (regenrateFlag: boolean = false) => {
+  const refreshPartitionPagination = (regenrateFlag: boolean = false, isStreamingOutput: boolean = false) => {
     if (searchObj.meta.jobId != "") {
       return;
     }
@@ -1427,12 +1427,17 @@ const useLogs = () => {
           ) {
           }
         } else {
-          searchObj.data.queryResults.total =
+          if(isStreamingOutput) {
+            if(partitionDetail.partitionTotal[partitionDetail.partitionTotal.length - 1] > -1)
+              searchObj.data.queryResults.total = partitionDetail.partitionTotal[partitionDetail.partitionTotal.length - 1];
+          } else {
+            searchObj.data.queryResults.total =
             partitionDetail.partitionTotal.reduce(
               (accumulator: number, currentValue: number) =>
                 accumulator + Math.max(currentValue, 0),
               0,
             );
+          }
         }
         // partitionDetail.partitions.forEach((item: any, index: number) => {
         for (const [index, item] of partitionDetail.partitions.entries()) {
@@ -2141,12 +2146,15 @@ const useLogs = () => {
   const getPageCount = async (queryReq: any) => {
     return new Promise((resolve, reject) => {
       try {
+        const isStreamingOutput = !!queryReq.query.streaming_output;
         searchObj.loadingCounter = true;
         searchObj.data.countErrorMsg = "";
         queryReq.query.size = 0;
         delete queryReq.query.from;
         delete queryReq.query.quick_mode;
         if(queryReq.query.action_id) delete queryReq.query.action_id;
+        if(queryReq.query.hasOwnProperty("streaming_output")) delete queryReq.query.streaming_output;
+        if(queryReq.query.hasOwnProperty("streaming_id")) delete queryReq.query.streaming_id;
 
         queryReq.query["sql_mode"] = "full";
 
@@ -2171,6 +2179,8 @@ const useLogs = () => {
             //   (item: any, index: number) => {
             searchObj.data.queryResults.scan_size += res.data.scan_size;
             searchObj.data.queryResults.took += res.data.took;
+            
+            // Update total for the last partition
             if (searchObj.meta.jobId == "") {
               for (const [
                 index,
@@ -2192,13 +2202,17 @@ const useLogs = () => {
               }
             }
 
+            if (isStreamingOutput) {
+              searchObj.data.queryResults.total = res.data.total;
+            }
+
             let regeratePaginationFlag = false;
             if (res.data.hits.length != searchObj.meta.resultGrid.rowsPerPage) {
               regeratePaginationFlag = true;
             }
             // if total records in partition is greater than recordsPerPage then we need to update pagination
             // setting up forceFlag to true to update pagination as we have check for pagination already created more than currentPage + 3 pages.
-            refreshPartitionPagination(regeratePaginationFlag);
+            refreshPartitionPagination(regeratePaginationFlag, isStreamingOutput);
 
             searchObj.data.histogram.chartParams.title = getHistogramTitle();
             searchObj.loadingCounter = false;

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1427,10 +1427,12 @@ const useLogs = () => {
           ) {
           }
         } else {
+          // if streaming output is enabled, then we need to update the total as the last partition total, as the last partition total is the total of all the records in case of streaming output
           if(isStreamingOutput) {
-            if(partitionDetail.partitionTotal[partitionDetail.partitionTotal.length - 1] > -1)
+            if(partitionDetail.partitionTotal[partitionDetail.partitionTotal?.length - 1] > -1)
               searchObj.data.queryResults.total = partitionDetail.partitionTotal[partitionDetail.partitionTotal.length - 1];
           } else {
+            // if streaming output is disabled, then we need to update the total as the sum of all partition totals
             searchObj.data.queryResults.total =
             partitionDetail.partitionTotal.reduce(
               (accumulator: number, currentValue: number) =>

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -33,34 +33,43 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :htmlContent="searchObj.data.countErrorMsg"
           />
         </div>
-        <div v-else class="col-9 text-left q-pl-lg q-mt-xs warning flex items-center">
+        <div
+          v-else
+          class="col-9 text-left q-pl-lg q-mt-xs warning flex items-center"
+        >
           {{ noOfRecordsTitle }}
           <span v-if="searchObj.loadingCounter" class="q-ml-md">
             <q-spinner-hourglass
-            color="primary"
-            size="25px"
-            style="margin: 0 auto; display: block"
-          />
-          <q-tooltip
+              color="primary"
+              size="25px"
+              style="margin: 0 auto; display: block"
+            />
+            <q-tooltip
               anchor="center right"
               self="center left"
               max-width="300px"
             >
-              <span style="font-size: 14px"
-                >Fetching the search events</span
-              >
+              <span style="font-size: 14px">Fetching the search events</span>
             </q-tooltip>
-
           </span>
-          <span v-else-if="searchObj.data.histogram.errorCode == -1 && !searchObj.loadingCounter && searchObj.meta.showHistogram" class="q-ml-md " 
-          :class="store.state.theme == 'dark' ? 'histogram-unavailable-text' : 'histogram-unavailable-text-light'"
+          <span
+            v-else-if="
+              searchObj.data.histogram.errorCode == -1 &&
+              !searchObj.loadingCounter &&
+              searchObj.meta.showHistogram
+            "
+            class="q-ml-md"
+            :class="
+              store.state.theme == 'dark'
+                ? 'histogram-unavailable-text'
+                : 'histogram-unavailable-text-light'
+            "
           >
             {{ searchObj.data.histogram.errorMsg }}
           </span>
         </div>
 
         <div class="col-3 text-right q-pr-md q-gutter-xs pagination-block">
-          
           <q-pagination
             v-if="searchObj.meta.resultGrid.showPagination"
             :disable="searchObj.loading == true"
@@ -110,28 +119,41 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           ></q-select>
         </div>
       </div>
-      <div v-if="searchObj.data?.histogram?.errorMsg == '' && searchObj.data.histogram.errorCode != -1">
+      <div
+        v-if="
+          searchObj.data?.histogram?.errorMsg == '' &&
+          searchObj.data.histogram.errorCode != -1
+        "
+      >
         <ChartRenderer
-          v-if="searchObj.meta.showHistogram && (searchObj.data?.queryResults?.aggs?.length > 0 || ( plotChart && Object.keys(plotChart)?.length > 0))"
+          v-if="
+            searchObj.meta.showHistogram &&
+            (searchObj.data?.queryResults?.aggs?.length > 0 ||
+              (plotChart && Object.keys(plotChart)?.length > 0))
+          "
           data-test="logs-search-result-bar-chart"
           :data="plotChart"
           style="max-height: 100px"
           @updated:dataZoom="onChartUpdate"
         />
-        
-        <div v-else-if="searchObj.meta.showHistogram && (Object.keys(plotChart)?.length == 0) && searchObj.loadingHistogram == false && searchObj.loading == false">
-          <h3
-            class="text-center"
-            style="margin: 30px 0px"
-          >
-            <q-icon name="warning" color="warning" size="xs"></q-icon> No data found for histogram.
+
+        <div
+          v-else-if="
+            searchObj.meta.showHistogram &&
+            Object.keys(plotChart)?.length == 0 &&
+            searchObj.loadingHistogram == false &&
+            searchObj.loading == false
+          "
+        >
+          <h3 class="text-center" style="margin: 30px 0px">
+            <q-icon name="warning" color="warning" size="xs"></q-icon> No data
+            found for histogram.
           </h3>
         </div>
         <div
           class="q-pb-lg"
-          style=" left: 45%; margin: 30px 0px"
+          style="left: 45%; margin: 30px 0px"
           v-if="histogramLoader"
-          
         >
           <q-spinner-hourglass
             color="primary"
@@ -143,17 +165,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div
         v-else-if="
           searchObj.data.histogram?.errorMsg != '' &&
-          searchObj.meta.showHistogram
-          && searchObj.data.histogram.errorCode != -1
+          searchObj.meta.showHistogram &&
+          searchObj.data.histogram.errorCode != -1
         "
       >
         <h6
           class="text-center"
           style="margin: 30px 0px"
-          v-if="searchObj.data.histogram.errorCode != 0 && searchObj.data.histogram.errorCode != -1"
+          v-if="
+            searchObj.data.histogram.errorCode != 0 &&
+            searchObj.data.histogram.errorCode != -1
+          "
         >
-          <q-icon name="warning" color="warning" size="xs"></q-icon> Error
-          while fetching histogram data.
+          <q-icon name="warning" color="warning" size="xs"></q-icon> Error while
+          fetching histogram data.
           <q-btn
             @click="toggleErrorDetails"
             size="sm"
@@ -163,18 +188,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <span v-if="disableMoreErrorDetails">
             <SanitizedHtmlRenderer
               data-test="logs-search-histogram-error-message"
-              :htmlContent="
-                searchObj.data?.histogram?.errorMsg
-              "
+              :htmlContent="searchObj.data?.histogram?.errorMsg"
             />
           </span>
         </h6>
-        <h6 class="text-center" v-else-if="searchObj.data.histogram.errorCode != -1">
+        <h6
+          class="text-center"
+          v-else-if="searchObj.data.histogram.errorCode != -1"
+        >
           <SanitizedHtmlRenderer
             data-test="logs-search-histogram-error-message"
-            :htmlContent="
-              searchObj.data?.histogram?.errorMsg
-            "
+            :htmlContent="searchObj.data?.histogram?.errorMsg"
           />
         </h6>
       </div>
@@ -189,13 +213,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :functionErrorMsg="searchObj?.data?.functionError"
         :expandedRows="expandedLogs"
         :highlight-timestamp="searchObj.data?.searchAround?.indexTimestamp"
-        :highlight-query="searchObj.meta.sqlMode ? searchObj.data.query.toLowerCase().split('where')[1] : searchObj.data.query.toLowerCase()"
+        :highlight-query="
+          searchObj.meta.sqlMode
+            ? searchObj.data.query.toLowerCase().split('where')[1]
+            : searchObj.data.query.toLowerCase()
+        "
         :default-columns="!searchObj.data.stream.selectedFields.length"
         class="col-12"
         :style="{
-          height: !searchObj.meta.showHistogram || (searchObj.meta.showHistogram && searchObj.data.histogram.errorCode == -1)
-            ? 'calc(100% - 40px)'
-            : 'calc(100% - 140px)',
+          height:
+            !searchObj.meta.showHistogram ||
+            (searchObj.meta.showHistogram &&
+              searchObj.data.histogram.errorCode == -1)
+              ? 'calc(100% - 40px)'
+              : 'calc(100% - 140px)',
         }"
         @update:columnSizes="handleColumnSizesUpdate"
         @update:columnOrder="handleColumnOrderUpdate"
@@ -206,7 +237,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         @click:data-row="openLogDetails"
         @expand-row="expandLog"
         @view-trace="redirectToTraces"
-
       />
 
       <q-dialog
@@ -359,23 +389,26 @@ export default defineComponent({
         this.searchObj.data.resultGrid.currentPage = 1;
         this.pageNumberInput = this.searchObj.data.resultGrid.currentPage;
         if (this.searchObj.communicationMethod === "ws") {
-            if (this.searchObj.meta.jobId == "") {
-              this.refreshPagination();
-            } else {
-              this.refreshJobPagination();
-            }
+          if (this.searchObj.meta.jobId == "") {
+            this.refreshPagination();
           } else {
-            if (this.searchObj.meta.jobId !== "") {
-              this.refreshJobPagination();
-            } else {
-              this.refreshPartitionPagination(true);
-            }
+            this.refreshJobPagination();
           }
+        } else {
+          if (this.searchObj.meta.jobId !== "") {
+            this.refreshJobPagination();
+          } else {
+            this.refreshPartitionPagination(true);
+          }
+        }
         this.$emit("update:recordsPerPage");
         this.scrollTableToTop(0);
       } else if (actionType == "pageChange") {
-      //here at first the queryResults is undefined so we are checking if it is undefined then we are setting it to empty array
-        if(this.searchObj.meta.jobId != "" && this.searchObj.data.queryResults.paginations == undefined){
+        //here at first the queryResults is undefined so we are checking if it is undefined then we are setting it to empty array
+        if (
+          this.searchObj.meta.jobId != "" &&
+          this.searchObj.data.queryResults.paginations == undefined
+        ) {
           this.searchObj.data.queryResults.pagination = [];
         }
         const maxPages =
@@ -384,7 +417,10 @@ export default defineComponent({
             ? this.searchObj.data.queryResults.pagination.length
             : this.searchObj.data.queryResults?.partitionDetail?.paginations
                 .length;
-        if (this.pageNumberInput > Math.ceil(maxPages) && this.searchObj.meta.jobId == "") {
+        if (
+          this.pageNumberInput > Math.ceil(maxPages) &&
+          this.searchObj.meta.jobId == ""
+        ) {
           this.$q.notify({
             type: "negative",
             message:
@@ -635,9 +671,14 @@ export default defineComponent({
       }
     });
     //this is used to show the histogram loader when the histogram is loading
-    const histogramLoader = computed(()=>{
-      return (searchObj.meta.showHistogram) && (searchObj.loadingHistogram == true ||  searchObj.loading == true) && ( plotChart.value && Object.keys(plotChart.value)?.length == 0) 
-    })
+    const histogramLoader = computed(() => {
+      return (
+        searchObj.meta.showHistogram &&
+        (searchObj.loadingHistogram == true || searchObj.loading == true) &&
+        plotChart.value &&
+        Object.keys(plotChart.value)?.length == 0
+      );
+    });
 
     return {
       t,
@@ -677,7 +718,7 @@ export default defineComponent({
       getPaginations,
       refreshPagination,
       refreshJobPagination,
-      histogramLoader
+      histogramLoader,
     };
   },
   computed: {
@@ -708,7 +749,7 @@ export default defineComponent({
       this.noOfRecordsTitle = this.searchObj.data.histogram.chartParams.title;
     },
     resetPlotChart(newVal: boolean) {
-      if(newVal) {
+      if (newVal) {
         this.plotChart = {};
         this.searchObj.meta.resetPlotChart = false;
       }
@@ -968,10 +1009,10 @@ export default defineComponent({
     height: 30px;
   }
 }
-.histogram-unavailable-text{
-  color: #F5A623;
+.histogram-unavailable-text {
+  color: #f5a623;
 }
-.histogram-unavailable-text-light{
+.histogram-unavailable-text-light {
   color: #ff8800;
 }
 </style>


### PR DESCRIPTION
1. Distinct Query page-count api streaming aggs response, streaming_output key was getting added to page-count api payload, causing the api to fail.
2. Histogram loader is not visible when loading histogram is in progress.
3. Remove histogram refresh in live mode
4. Get undefined when histogram query is cancelled
5. query editor undo redo functionality even after user looses focus and focus again
6. Cmd enter fix on logs page