### PR TITLE
fix: consider actual records size per page for search job

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2320,9 +2320,9 @@ const useLogs = () => {
         showCancelSearchNotification();
         return;
       }
-      if (searchObj.meta.jobId != "") {
-        searchObj.meta.resultGrid.rowsPerPage = queryReq.query.size;
-      }
+      // if (searchObj.meta.jobId != "") {
+      //   searchObj.meta.resultGrid.rowsPerPage = queryReq.query.size;
+      // }
       const parsedSQL: any = fnParsedSQL();
       searchObj.meta.resultGrid.showPagination = true;
       if (searchObj.meta.sqlMode == true && parsedSQL != undefined) {
@@ -2546,7 +2546,7 @@ const useLogs = () => {
             await getPaginatedData(queryReq, true);
           }
           if (searchObj.meta.jobId != "") {
-            searchObj.meta.resultGrid.rowsPerPage = queryReq.query.size;
+            // searchObj.meta.resultGrid.rowsPerPage = queryReq.query.size;
             searchObj.data.queryResults.pagination = [];
             refreshJobPagination(true);
           }


### PR DESCRIPTION
consider only actual per page records size while searching schedule job because when it is histogram the size is -1 then it becomes -1 per page records , so we can consider actual per page records.