### PR TITLE
fix: pipeline list show cron expression if enabled

### DIFF
--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -513,9 +513,9 @@ const getPipelines = async () => {
             pipeline.stream_type = pipeline.source.stream_type;
           } else {
             pipeline.stream_type = pipeline.source.stream_type;
-            pipeline.frequency = pipeline.source.trigger_condition.frequency + " Mins";
+            pipeline.frequency = pipeline.source.trigger_condition.frequency_type == 'minutes' ? pipeline.source.trigger_condition.frequency + " Mins" : pipeline.source.trigger_condition.cron
             pipeline.period = pipeline.source.trigger_condition.period + " Mins";
-            pipeline.cron = pipeline.cron && pipeline.cron !== "" ? pipeline.source.trigger_condition.cron : 'False';
+            pipeline.cron = pipeline.source.trigger_condition.frequency_type == 'minutes' ? 'False' : 'True';
             pipeline.sql_query = pipeline.source.query_condition.sql;
           }
 


### PR DESCRIPTION
if cron is enabled for scheduled pipeline then it should it be shown in the listing page 
and it should show cron column as true 
This PR fixes #6809 