### PR TITLE
fix: Update enrichment table cache with correct start time after meta table update and pipeline delayed timerange fix

### DIFF
--- a/src/config/src/meta/triggers.rs
+++ b/src/config/src/meta/triggers.rs
@@ -15,6 +15,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::utils::json;
+
 #[derive(Debug, Clone, sqlx::Type, PartialEq, Serialize, Deserialize, Default)]
 #[repr(i32)]
 pub enum TriggerStatus {
@@ -87,5 +89,13 @@ impl ScheduledTriggerData {
     pub fn reset(&mut self) {
         self.period_end_time = None;
         self.tolerance = 0;
+    }
+
+    pub fn to_string(&self) -> String {
+        json::to_string(self).unwrap()
+    }
+
+    pub fn from_str(s: &str) -> Result<Self, serde_json::Error> {
+        json::from_str(s)
     }
 }

--- a/src/config/src/meta/triggers.rs
+++ b/src/config/src/meta/triggers.rs
@@ -91,11 +91,11 @@ impl ScheduledTriggerData {
         self.tolerance = 0;
     }
 
-    pub fn to_string(&self) -> String {
+    pub fn to_json_string(&self) -> String {
         json::to_string(self).unwrap()
     }
 
-    pub fn from_str(s: &str) -> Result<Self, serde_json::Error> {
+    pub fn from_json_string(s: &str) -> Result<Self, serde_json::Error> {
         json::from_str(s)
     }
 }

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -849,7 +849,7 @@ async fn handle_derived_stream_triggers(
     let mut new_trigger_data = if trigger.data.is_empty() {
         ScheduledTriggerData::default()
     } else {
-        ScheduledTriggerData::from_str(&trigger.data).unwrap()
+        ScheduledTriggerData::from_json_string(&trigger.data).unwrap()
     };
     let Ok(pipeline) = db::pipeline::get_by_id(pipeline_id).await else {
         let err_msg = format!(
@@ -886,7 +886,7 @@ async fn handle_derived_stream_triggers(
 
         log::error!("[SCHEDULER trace_id {scheduler_trace_id}] {}", err_msg);
         new_trigger_data.reset();
-        new_trigger.data = new_trigger_data.to_string();
+        new_trigger.data = new_trigger_data.to_json_string();
         db::scheduler::update_trigger(new_trigger).await?;
         publish_triggers_usage(trigger_data_stream).await;
         return Err(anyhow::anyhow!(
@@ -929,7 +929,7 @@ async fn handle_derived_stream_triggers(
         };
         log::info!("[SCHEDULER trace_id {scheduler_trace_id}] {}", msg);
         new_trigger_data.reset();
-        new_trigger.data = new_trigger_data.to_string();
+        new_trigger.data = new_trigger_data.to_json_string();
         db::scheduler::update_trigger(new_trigger).await?;
         publish_triggers_usage(trigger_data_stream).await;
         return Ok(());
@@ -968,7 +968,7 @@ async fn handle_derived_stream_triggers(
         };
         log::error!("[SCHEDULER trace_id {scheduler_trace_id}] {}", err_msg);
         new_trigger_data.reset();
-        new_trigger.data = new_trigger_data.to_string();
+        new_trigger.data = new_trigger_data.to_json_string();
         db::scheduler::update_trigger(new_trigger).await?;
         publish_triggers_usage(trigger_data_stream).await;
         return Err(anyhow::anyhow!(

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -846,7 +846,11 @@ async fn handle_derived_stream_triggers(
         status: db::scheduler::TriggerStatus::Waiting,
         ..trigger.clone()
     };
-
+    let mut new_trigger_data = if trigger.data.is_empty() {
+        ScheduledTriggerData::default()
+    } else {
+        ScheduledTriggerData::from_str(&trigger.data).unwrap()
+    };
     let Ok(pipeline) = db::pipeline::get_by_id(pipeline_id).await else {
         let err_msg = format!(
             "Pipeline associated with trigger not found: {}/{}/{}/{}. Checking after 5 mins.",
@@ -881,6 +885,8 @@ async fn handle_derived_stream_triggers(
         };
 
         log::error!("[SCHEDULER trace_id {scheduler_trace_id}] {}", err_msg);
+        new_trigger_data.reset();
+        new_trigger.data = new_trigger_data.to_string();
         db::scheduler::update_trigger(new_trigger).await?;
         publish_triggers_usage(trigger_data_stream).await;
         return Err(anyhow::anyhow!(
@@ -922,6 +928,8 @@ async fn handle_derived_stream_triggers(
             time_in_queue_ms: Some(time_in_queue),
         };
         log::info!("[SCHEDULER trace_id {scheduler_trace_id}] {}", msg);
+        new_trigger_data.reset();
+        new_trigger.data = new_trigger_data.to_string();
         db::scheduler::update_trigger(new_trigger).await?;
         publish_triggers_usage(trigger_data_stream).await;
         return Ok(());
@@ -959,6 +967,8 @@ async fn handle_derived_stream_triggers(
             time_in_queue_ms: Some(time_in_queue),
         };
         log::error!("[SCHEDULER trace_id {scheduler_trace_id}] {}", err_msg);
+        new_trigger_data.reset();
+        new_trigger.data = new_trigger_data.to_string();
         db::scheduler::update_trigger(new_trigger).await?;
         publish_triggers_usage(trigger_data_stream).await;
         return Err(anyhow::anyhow!(
@@ -966,23 +976,13 @@ async fn handle_derived_stream_triggers(
             err_msg
         ));
     };
-    let start_time = if trigger.data.is_empty() {
-        None
-    } else {
-        let trigger_data: Option<ScheduledTriggerData> = json::from_str(&new_trigger.data).ok();
-        if let Some(trigger_data) = trigger_data {
-            trigger_data
-                .period_end_time
-                .map(|period_end_time| period_end_time + 1)
-        } else {
-            None
-        }
-    };
+    let start_time = new_trigger_data
+        .period_end_time
+        .map(|period_end_time| period_end_time + 1);
 
     // in case the range [start_time, end_time] is greater than querying period, it needs to
     // evaluate and ingest 1 period at a time.
     let suppossed_to_be_run_at = trigger.next_run_at;
-    let delay = current_time - suppossed_to_be_run_at; // delay is in microseconds
     let mut final_end_time = suppossed_to_be_run_at;
     // let now = Utc::now().timestamp_micros();
     let period_num_microseconds = Duration::try_minutes(derived_stream.trigger_condition.period)
@@ -996,26 +996,26 @@ async fn handle_derived_stream_triggers(
         // is unnecessary. Hence, we need to check how big the delay is.
         // Note: For pipeline, period and frequency both have the same value.
 
-        // If the delay is equal to or greater than the frequency, we need to ingest data one by one
-        // If the delay is less than the frequency, we need to ingest data for the "next run at"
-        // period, For example, if the current time is 5:19pm, frequency is 5 mins, and
-        // delay is 4mins (supposed to be run at 5:15pm), we need to ingest data for the
-        // period from 5:10pm to 5:15pm only. The next run at will be 5:20pm which will
-        // query for the period from 5:15pm to 5:20pm. But, if the suppossed to be run at is
-        // 5:10pm, then we need ingest data for the period from 5:05pm to 5:15pm.
-        // Which is to cover the skipped period from 5:05pm to 5:15pm.
-        if delay >= period_num_microseconds {
-            // final_end_time is the last multiple of given frequency after the "suppossed to be run
-            // at" timestamp
-            let frequency_count = delay / period_num_microseconds;
-            final_end_time = suppossed_to_be_run_at + (frequency_count * period_num_microseconds);
-            (
-                Some(t0),
-                std::cmp::min(suppossed_to_be_run_at, t0 + period_num_microseconds),
-            )
-        } else {
-            (Some(t0), suppossed_to_be_run_at)
-        }
+        // For derived stream, period is in minutes, so we need to convert it to seconds for
+        // align_time
+        final_end_time = TriggerCondition::align_time(
+            current_time,
+            derived_stream.tz_offset,
+            derived_stream.trigger_condition.period * 60,
+        );
+        // If the delay is equal to or greater than the frequency, we need to ingest data one by
+        // one If the delay is less than the frequency, we need to ingest data for
+        // the "next run at" period, For example, if the current time is 5:19pm,
+        // frequency is 5 mins, and delay is 4mins (supposed to be run at 5:15pm),
+        // we need to ingest data for the period from 5:10pm to 5:15pm only. The
+        // next run at will be 5:20pm which will query for the period from 5:15pm to
+        // 5:20pm. But, if the suppossed to be run at is 5:10pm, then we need ingest
+        // data for the period from 5:05pm to 5:15pm. Which is to cover the skipped
+        // period from 5:05pm to 5:15pm.
+        (
+            Some(t0),
+            std::cmp::min(suppossed_to_be_run_at, t0 + period_num_microseconds),
+        )
     } else {
         (None, suppossed_to_be_run_at)
     };

--- a/src/service/db/enrichment_table.rs
+++ b/src/service/db/enrichment_table.rs
@@ -42,6 +42,7 @@ pub async fn get(org_id: &str, name: &str) -> Result<Vec<vrl::value::Value>, any
         sql: format!("SELECT * FROM \"{name}\""),
         start_time,
         end_time,
+        size: -1, // -1 means no limit, enrichment table should not be limited
         ..Default::default()
     };
 
@@ -56,6 +57,11 @@ pub async fn get(org_id: &str, name: &str) -> Result<Vec<vrl::value::Value>, any
         use_cache: None,
         local_mode: Some(true),
     };
+    log::debug!(
+        "get enrichment table {} data req start time: {}",
+        name,
+        start_time
+    );
     // do search
     match SearchService::search("", org_id, StreamType::EnrichmentTables, None, &req).await {
         Ok(res) => {
@@ -231,6 +237,11 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                 let data = super::enrichment_table::get(org_id, stream_name)
                     .await
                     .unwrap();
+                log::debug!(
+                    "enrichment table: {} cache data length: {}",
+                    item_key,
+                    data.len()
+                );
                 ENRICHMENT_TABLES.insert(
                     item_key.to_owned(),
                     StreamTable {

--- a/src/service/db/enrichment_table.rs
+++ b/src/service/db/enrichment_table.rs
@@ -17,7 +17,10 @@ use std::sync::Arc;
 
 use config::{
     meta::stream::{EnrichmentTableMetaStreamStats, StreamType},
-    utils::{json, time::now_micros},
+    utils::{
+        json,
+        time::{BASE_TIME, now_micros},
+    },
 };
 use infra::{cache::stats, db as infra_db};
 use vrl::prelude::NotNan;
@@ -32,13 +35,8 @@ pub const ENRICHMENT_TABLE_SIZE_KEY: &str = "/enrichment_table_size";
 pub const ENRICHMENT_TABLE_META_STREAM_STATS_KEY: &str = "/enrichment_table_meta_stream_stats";
 
 pub async fn get(org_id: &str, name: &str) -> Result<Vec<vrl::value::Value>, anyhow::Error> {
-    let (start_time, end_time) = match get_meta_table_stats(org_id, name).await {
-        Some(meta_stats) => (meta_stats.start_time, now_micros()),
-        None => {
-            let stats = stats::get_stream_stats(org_id, name, StreamType::EnrichmentTables);
-            (stats.doc_time_min, now_micros())
-        }
-    };
+    let start_time = get_start_time(org_id, name).await;
+    let end_time = now_micros();
 
     let query = config::meta::search::Query {
         sql: format!("SELECT * FROM \"{name}\""),
@@ -133,7 +131,11 @@ pub async fn get_start_time(org_id: &str, name: &str) -> i64 {
         Some(meta_stats) => meta_stats.start_time,
         None => {
             let stats = stats::get_stream_stats(org_id, name, StreamType::EnrichmentTables);
-            stats.doc_time_min
+            if stats.doc_time_min > 0 {
+                stats.doc_time_min
+            } else {
+                BASE_TIME.timestamp_micros()
+            }
         }
     }
 }

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -122,15 +122,11 @@ pub async fn save_enrichment_data(
         0.0
     };
     let enrichment_table_max_size = cfg.limit.enrichment_table_max_size as f64;
-    log::info!(
-        "enrichment table [{stream_name}] saving stats: {:?} vs max_table_size {}",
-        current_size_in_bytes,
-        enrichment_table_max_size
-    );
     let total_expected_size_in_bytes = current_size_in_bytes + bytes_in_payload as f64;
     let total_expected_size_in_mb = total_expected_size_in_bytes / SIZE_IN_MB;
-    log::debug!(
-        "enrichment table [{stream_name}] total expected storage size in mb: {} and max storage size in mb: {}",
+    log::info!(
+        "enrichment table [{stream_name}] current stats in bytes: {:?} vs total expected size in mb: {} vs max_table_size in mb: {}",
+        current_size_in_bytes,
         total_expected_size_in_mb,
         enrichment_table_max_size
     );
@@ -261,6 +257,22 @@ pub async fn save_enrichment_data(
             }
         };
 
+    let mut enrich_meta_stats = enrichment_table::get_meta_table_stats(org_id, stream_name)
+        .await
+        .unwrap_or_default();
+
+    if !append_data {
+        enrich_meta_stats.start_time = started_at;
+    }
+    if enrich_meta_stats.start_time == 0 {
+        enrich_meta_stats.start_time = enrichment_table::get_start_time(org_id, stream_name).await;
+    }
+    enrich_meta_stats.end_time = now_micros();
+    enrich_meta_stats.size = total_expected_size_in_bytes as i64;
+    // The stream_stats table takes some time to update, so we need to update the enrichment table
+    // size in the meta table to avoid exceeding the `ZO_ENRICHMENT_TABLE_LIMIT`.
+    let _ = enrichment_table::update_meta_table_stats(org_id, stream_name, enrich_meta_stats).await;
+
     // notify update
     if !schema.fields().is_empty() {
         if let Err(e) = super::db::enrichment_table::notify_update(org_id, stream_name).await {
@@ -288,22 +300,6 @@ pub async fn save_enrichment_data(
         started_at,
     )
     .await;
-
-    let mut enrich_meta_stats = enrichment_table::get_meta_table_stats(org_id, stream_name)
-        .await
-        .unwrap_or_default();
-
-    if !append_data {
-        enrich_meta_stats.start_time = started_at;
-    }
-    if enrich_meta_stats.start_time == 0 {
-        enrich_meta_stats.start_time = enrichment_table::get_start_time(org_id, stream_name).await;
-    }
-    enrich_meta_stats.end_time = now_micros();
-    enrich_meta_stats.size = total_expected_size_in_bytes as i64;
-    // The stream_stats table takes some time to update, so we need to update the enrichment table
-    // size in the meta table to avoid exceeding the `ZO_ENRICHMENT_TABLE_LIMIT`.
-    let _ = enrichment_table::update_meta_table_stats(org_id, stream_name, enrich_meta_stats).await;
 
     Ok(HttpResponse::Ok().json(MetaHttpResponse::error(
         StatusCode::OK.into(),

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -296,6 +296,9 @@ pub async fn save_enrichment_data(
     if !append_data {
         enrich_meta_stats.start_time = started_at;
     }
+    if enrich_meta_stats.start_time == 0 {
+        enrich_meta_stats.start_time = enrichment_table::get_start_time(org_id, stream_name).await;
+    }
     enrich_meta_stats.end_time = now_micros();
     enrich_meta_stats.size = total_expected_size_in_bytes as i64;
     // The stream_stats table takes some time to update, so we need to update the enrichment table

--- a/src/super_cluster_queue/meta.rs
+++ b/src/super_cluster_queue/meta.rs
@@ -16,12 +16,26 @@
 use infra::errors::{Error, Result};
 use o2_enterprise::enterprise::super_cluster::queue::{Message, MessageType};
 
+use crate::service::db::enrichment_table::{ENRICHMENT_TABLE_META_STREAM_STATS_KEY, notify_update};
+
 pub(crate) async fn process(msg: Message) -> Result<()> {
     let db = infra::db::get_db().await;
     match msg.message_type {
         MessageType::Put => {
             db.put(&msg.key, msg.value.unwrap(), msg.need_watch, None)
                 .await?;
+            // hack: notify the nodes to update the meta table stats
+            if msg.key.starts_with(ENRICHMENT_TABLE_META_STREAM_STATS_KEY) {
+                let key_parts = msg.key.split('/').collect::<Vec<&str>>();
+                let org_id = key_parts[1];
+                let name = key_parts[2];
+                if let Err(e) = notify_update(org_id, name).await {
+                    log::error!(
+                        "super cluster meta queue enrichment table notify_update error: {:?}",
+                        e
+                    );
+                }
+            }
         }
         MessageType::Delete(with_prefix) => {
             db.delete(&msg.key, with_prefix, msg.need_watch, None)


### PR DESCRIPTION
- when creating an enrichment table, the `notify_update` is called before the enrichment table stats is stored in the meta table.
- When pipeline reaches max retries and gets triggered again in the next run, it uses one single time window for the whole delayed timerange.