### PR TITLE
feat: Add HTTP2 Streaming support (#6721)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
 dependencies = [
  "actix-utils",
  "actix-web",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-util",
  "log",
  "once_cell",
@@ -76,7 +76,7 @@ dependencies = [
  "brotli 6.0.0",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 0.99.18",
  "encoding_rs",
  "flate2",
  "futures-core",
@@ -118,7 +118,7 @@ dependencies = [
  "actix-multipart-derive",
  "actix-utils",
  "actix-web",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-core",
  "futures-util",
  "httparse",
@@ -191,12 +191,11 @@ dependencies = [
 
 [[package]]
 name = "actix-service"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
 dependencies = [
  "futures-core",
- "paste",
  "pin-project-lite",
 ]
 
@@ -254,7 +253,7 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 0.99.18",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -338,7 +337,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "csv",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-core",
  "futures-util",
  "http 0.2.12",
@@ -1162,7 +1161,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-core",
  "futures-util",
  "h2 0.3.26",
@@ -1848,7 +1847,7 @@ checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 4.0.1",
 ]
 
 [[package]]
@@ -1859,7 +1858,18 @@ checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 4.0.1",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 5.0.0",
 ]
 
 [[package]]
@@ -1867,6 +1877,16 @@ name = "brotli-decompressor"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -3473,6 +3493,28 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case 0.7.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -6137,7 +6179,9 @@ dependencies = [
  "actix-cors",
  "actix-http",
  "actix-multipart",
+ "actix-service",
  "actix-tls",
+ "actix-utils",
  "actix-web",
  "actix-web-actors",
  "actix-web-httpauth",
@@ -6160,6 +6204,7 @@ dependencies = [
  "bitflags 2.9.0",
  "bitvec",
  "blake3",
+ "brotli 8.0.1",
  "byteorder",
  "bytes",
  "chromiumoxide",
@@ -6175,6 +6220,7 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-json",
  "datafusion-proto",
+ "derive_more 2.0.1",
  "enrichment",
  "env_logger 0.10.2",
  "etcd-client",
@@ -6183,6 +6229,7 @@ dependencies = [
  "flate2",
  "float-cmp",
  "futures",
+ "futures-core",
  "futures-util",
  "getrandom 0.2.15",
  "hashbrown 0.15.2",
@@ -6198,6 +6245,7 @@ dependencies = [
  "maxminddb",
  "memchr",
  "mimalloc",
+ "mime",
  "object_store",
  "once_cell",
  "opentelemetry 0.26.0",
@@ -6206,6 +6254,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "parquet",
+ "pin-project-lite",
  "pprof",
  "prettytable-rs",
  "prometheus",
@@ -6240,6 +6289,7 @@ dependencies = [
  "tikv-jemallocator",
  "time",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tonic 0.12.3",
@@ -6766,9 +6816,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -10053,7 +10103,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "lazy_static",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,14 @@ pprof = { version = "0.14", features = [
     "flamegraph",
     "prost-codec",
 ], optional = true }
+tokio-stream.workspace = true
+mime = "0.3.17"
+pin-project-lite = "0.2.16"
+futures-core = "0.3.31"
+actix-service = "2.0.3"
+actix-utils = "3.0.1"
+derive_more = {version = "2.0.1", features = ["full"]}
+brotli = "8.0.1"
 
 [dev-dependencies]
 async-walkdir.workspace = true

--- a/src/common/meta/organization.rs
+++ b/src/common/meta/organization.rs
@@ -137,6 +137,10 @@ fn default_enable_websocket_search() -> bool {
     false
 }
 
+fn default_enable_streaming_search() -> bool {
+    false
+}
+
 #[derive(Serialize, ToSchema, Deserialize, Debug, Clone)]
 pub struct OrganizationSettingPayload {
     /// Ideally this should be the same as prometheus-scrape-interval (in
@@ -151,6 +155,8 @@ pub struct OrganizationSettingPayload {
     pub toggle_ingestion_logs: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_websocket_search: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_streaming_search: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_auto_refresh_interval: Option<u32>,
 }
@@ -169,6 +175,8 @@ pub struct OrganizationSetting {
     pub toggle_ingestion_logs: bool,
     #[serde(default = "default_enable_websocket_search")]
     pub enable_websocket_search: bool,
+    #[serde(default = "default_enable_streaming_search")]
+    pub enable_streaming_search: bool,
     #[serde(default = "default_auto_refresh_interval")]
     pub min_auto_refresh_interval: u32,
 }
@@ -181,6 +189,7 @@ impl Default for OrganizationSetting {
             span_id_field_name: default_span_id_field_name(),
             toggle_ingestion_logs: default_toggle_ingestion_logs(),
             enable_websocket_search: default_enable_websocket_search(),
+            enable_streaming_search: default_enable_streaming_search(),
             min_auto_refresh_interval: default_auto_refresh_interval(),
         }
     }

--- a/src/common/utils/http.rs
+++ b/src/common/utils/http.rs
@@ -38,6 +38,13 @@ pub(crate) fn get_stream_type_from_request(
 }
 
 #[inline(always)]
+pub(crate) fn get_fallback_order_by_col_from_request(
+    query: &Query<HashMap<String, String>>,
+) -> Option<String> {
+    query.get("fallback_order_by_col").map(|s| s.to_string())
+}
+
+#[inline(always)]
 pub(crate) fn get_search_type_from_request(
     query: &Query<HashMap<String, String>>,
 ) -> Result<Option<SearchEventType>, Error> {

--- a/src/common/utils/websocket.rs
+++ b/src/common/utils/websocket.rs
@@ -71,7 +71,8 @@ pub(crate) fn calc_queried_range(start_time: i64, end_time: i64, result_cache_ra
 }
 
 /// Updates the `HISTOGRAM` function in a SQL query to include or modify the interval.
-pub(crate) fn update_histogram_interval_in_query(
+// TODO: should be a utils function in sql crate
+pub fn update_histogram_interval_in_query(
     sql: &str,
     histogram_interval: i64,
 ) -> Result<String, Error> {

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -448,6 +448,24 @@ pub struct WebSocket {
         help = "Maximum allowed continuation size in MB"
     )]
     pub max_continuation_size: usize,
+    #[env_config(
+        name = "ZO_WEBSOCKET_CHANNEL_BUFFER_SIZE",
+        default = 100,
+        help = "Maximum allowed number of messages in buffer"
+    )]
+    pub max_channel_buffer_size: usize,
+    #[env_config(
+        name = "ZO_STREAMING_RESPONSE_CHUNK_SIZE_MB",
+        default = 1,
+        help = "Size in MB for each chunk when streaming search responses"
+    )]
+    pub streaming_response_chunk_size: usize,
+    #[env_config(
+        name = "ZO_STREAMING_ENABLED",
+        default = false,
+        help = "Enable streaming"
+    )]
+    pub streaming_enabled: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -13,17 +13,28 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::VecDeque;
+
+use bytes::Bytes as BytesImpl;
 use proto::cluster_rpc;
 use serde::{Deserialize, Deserializer, Serialize};
 use utoipa::ToSchema;
 
 use crate::{
+    config::get_config,
     meta::{sql::OrderBy, stream::StreamType},
     utils::{base64, json},
 };
 
 pub const PARTIAL_ERROR_RESPONSE_MESSAGE: &str =
     "Please be aware that the response is based on partial data";
+
+/// To represent the query start and end time based of partition or cache
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TimeOffset {
+    pub start_time: i64,
+    pub end_time: i64,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StorageType {
@@ -215,6 +226,114 @@ pub struct Response {
     pub work_group: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order_by: Option<OrderBy>,
+}
+
+/// Iterator for Streaming response of search `Response`
+///
+/// This is used to split the search response to smaller chunks based on
+/// env variable
+/// The format of the iterator is as follows:
+/// - Chunk 1: Response Metadata
+/// - Chunk 2: Hits (1MB)
+/// - Chunk 3: Hits (1MB)
+pub struct ResponseChunkIterator {
+    // Original response (will be split into chunks)
+    response: Response,
+    // Target size for each chunk in bytes
+    chunk_size: usize,
+    // Hits waiting to be processed
+    remaining_hits: VecDeque<crate::utils::json::Value>,
+    // Whether metadata has been sent
+    metadata_sent: bool,
+    // Current position in the iteration
+    position: usize,
+}
+
+impl ResponseChunkIterator {
+    /// Create a new response chunk iterator
+    pub fn new(mut response: Response, chunk_size: Option<usize>) -> Self {
+        // Get the configured chunk size or use the provided one or default
+        let chunk_size = chunk_size.unwrap_or_else(|| {
+            // Get from config, convert from MB to bytes
+            let mb = 1024 * 1024;
+            crate::get_config().websocket.streaming_response_chunk_size * mb
+        });
+
+        let hits = response.hits.drain(..).collect::<Vec<_>>();
+
+        Self {
+            response,
+            chunk_size,
+            remaining_hits: VecDeque::from(hits),
+            metadata_sent: false,
+            position: 0,
+        }
+    }
+}
+
+// Define the possible chunk types
+#[derive(Debug, Clone)]
+pub enum ResponseChunk {
+    Metadata {
+        response: Box<Response>,
+    },
+    Hits {
+        hits: Vec<crate::utils::json::Value>,
+    },
+}
+
+impl Iterator for ResponseChunkIterator {
+    type Item = ResponseChunk;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // First send metadata
+        if !self.metadata_sent {
+            self.metadata_sent = true;
+            self.position += 1;
+
+            // Clone response but remove hits
+            let mut metadata_response = self.response.clone();
+            metadata_response.hits = vec![];
+
+            return Some(ResponseChunk::Metadata {
+                response: Box::new(metadata_response),
+            });
+        }
+
+        // If we have no hits left, we're done
+        if self.remaining_hits.is_empty() {
+            return None;
+        }
+
+        // Create the next chunk of hits
+        let mut current_chunk: Vec<crate::utils::json::Value> = Vec::new();
+        let mut current_chunk_size: usize = 0;
+
+        // Keep adding hits until we reach the target chunk size
+        while !self.remaining_hits.is_empty() {
+            // Peek at the front hit
+            let hit = &self.remaining_hits[0];
+            let hit_size = crate::utils::json::estimate_json_bytes(hit);
+
+            // If adding this hit would exceed target size, break
+            if !current_chunk.is_empty() && current_chunk_size + hit_size > self.chunk_size {
+                break;
+            }
+
+            // Add hit to current chunk - using pop_front() for O(1) complexity
+            if let Some(hit) = self.remaining_hits.pop_front() {
+                current_chunk.push(hit);
+                current_chunk_size += hit_size;
+            }
+        }
+
+        self.position += 1;
+
+        // Return the hits chunk
+        Some(ResponseChunk::Hits {
+            hits: current_chunk,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, ToSchema)]
@@ -1312,6 +1431,180 @@ mod search_history_utils {
             AND user_email = 'user123@gmail.com'";
 
             assert_eq!(query, expected_query);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum StreamResponses {
+    // Original variant - to be deprecated but kept for backward compatibility
+    SearchResponse {
+        results: Response,
+        streaming_aggs: bool,
+        time_offset: TimeOffset,
+    },
+    // New focused variants
+    SearchResponseMetadata {
+        results: Response,
+        streaming_aggs: bool,
+        time_offset: TimeOffset,
+    },
+    SearchResponseHits {
+        hits: Vec<json::Value>,
+    },
+    Progress {
+        percent: usize,
+    },
+    Error {
+        code: u16,
+        message: String,
+        error_detail: Option<String>,
+    },
+    Done,
+    Cancelled,
+}
+
+/// An iterator that yields formatted chunks from a StreamResponse
+pub struct StreamResponseChunks {
+    /// The inner iterator for search responses with multiple chunks
+    chunks_iter: Option<Box<dyn Iterator<Item = Result<BytesImpl, std::io::Error>> + Send>>,
+    /// Single chunk for simple responses
+    single_chunk: Option<Result<BytesImpl, std::io::Error>>,
+}
+
+impl Iterator for StreamResponseChunks {
+    type Item = Result<BytesImpl, std::io::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(iter) = &mut self.chunks_iter {
+            iter.next()
+        } else {
+            self.single_chunk.take()
+        }
+    }
+}
+
+impl StreamResponses {
+    /// Convert a response to an iterator of formatted chunks
+    /// For SearchResponse, this will apply the ResponseChunkIterator to break it into multiple
+    /// chunks For other response types, this will return an iterator with a single chunk
+    pub fn to_chunks(&self) -> StreamResponseChunks {
+        // Helper function to format event data
+        let format_event = |event_type: &str, data: &str| -> BytesImpl {
+            let formatted = format!("event: {}\ndata: {}\n\n", event_type, data);
+            BytesImpl::from(formatted.into_bytes())
+        };
+
+        match self {
+            // Handle search responses with chunking
+            StreamResponses::SearchResponse {
+                results,
+                streaming_aggs,
+                time_offset,
+            } => {
+                log::info!(
+                    "[HTTP2_STREAM] Chunking search response with {} hits using ResponseChunkIterator",
+                    results.hits.len()
+                );
+
+                // Create the iterator
+                let iterator = ResponseChunkIterator::new(
+                    results.clone(),
+                    None, // Use configured chunk size from environment
+                );
+
+                // Add a log message to show the chunk size being used
+                log::info!(
+                    "[HTTP2_STREAM] Using chunk size of {}MB from configuration",
+                    get_config().websocket.streaming_response_chunk_size
+                );
+
+                // Capture needed values for the closure
+                let streaming_aggs = *streaming_aggs;
+                let time_offset = time_offset.clone();
+
+                // Create an iterator that maps each chunk to a formatted BytesImpl
+                let chunks_iter = iterator.map(move |chunk| {
+                    let (event_type, data) = match chunk {
+                        ResponseChunk::Metadata { response } => {
+                            // Add streaming_aggs and time_offset from the original response
+                            let metadata = StreamResponses::SearchResponseMetadata {
+                                results: *response,
+                                streaming_aggs,
+                                time_offset: time_offset.clone(),
+                            };
+                            (
+                                "search_response_metadata",
+                                serde_json::to_string(&metadata).unwrap_or_default(),
+                            )
+                        }
+                        ResponseChunk::Hits { hits } => {
+                            let hits_chunk = StreamResponses::SearchResponseHits { hits };
+                            (
+                                "search_response_hits",
+                                serde_json::to_string(&hits_chunk).unwrap_or_default(),
+                            )
+                        }
+                    };
+
+                    // Format and encode the chunk
+                    Ok(format_event(event_type, &data))
+                });
+
+                StreamResponseChunks {
+                    chunks_iter: Some(Box::new(chunks_iter)),
+                    single_chunk: None,
+                }
+            }
+
+            // Handle other response types with a single chunk
+            StreamResponses::SearchResponseMetadata { .. } => {
+                let data = serde_json::to_string(self).unwrap_or_default();
+                let bytes = format_event("search_response_metadata", &data);
+                StreamResponseChunks {
+                    chunks_iter: None,
+                    single_chunk: Some(Ok(bytes)),
+                }
+            }
+            StreamResponses::SearchResponseHits { .. } => {
+                let data = serde_json::to_string(self).unwrap_or_default();
+                let bytes = format_event("search_response_hits", &data);
+                StreamResponseChunks {
+                    chunks_iter: None,
+                    single_chunk: Some(Ok(bytes)),
+                }
+            }
+            StreamResponses::Progress { .. } => {
+                let data = serde_json::to_string(self).unwrap_or_default();
+                let bytes = format_event("progress", &data);
+                StreamResponseChunks {
+                    chunks_iter: None,
+                    single_chunk: Some(Ok(bytes)),
+                }
+            }
+            StreamResponses::Error { .. } => {
+                let data = serde_json::to_string(self).unwrap_or_default();
+                let bytes = format_event("error", &data);
+                StreamResponseChunks {
+                    chunks_iter: None,
+                    single_chunk: Some(Ok(bytes)),
+                }
+            }
+            StreamResponses::Done => {
+                let bytes = BytesImpl::from("data: [[DONE]]\n\n");
+                StreamResponseChunks {
+                    chunks_iter: None,
+                    single_chunk: Some(Ok(bytes)),
+                }
+            }
+            StreamResponses::Cancelled => {
+                let bytes = BytesImpl::from("data: [[CANCELLED]]\n\n");
+                StreamResponseChunks {
+                    chunks_iter: None,
+                    single_chunk: Some(Ok(bytes)),
+                }
+            }
         }
     }
 }

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -315,6 +315,12 @@ impl Iterator for ResponseChunkIterator {
             let hit = &self.remaining_hits[0];
             let hit_size = crate::utils::json::estimate_json_bytes(hit);
 
+            if hit_size > self.chunk_size {
+                return Some(ResponseChunk::Hits {
+                    hits: vec![hit.to_owned()],
+                });
+            }
+
             // If adding this hit would exceed target size, break
             if !current_chunk.is_empty() && current_chunk_size + hit_size > self.chunk_size {
                 break;
@@ -1534,16 +1540,23 @@ impl StreamResponses {
                                 streaming_aggs,
                                 time_offset: time_offset.clone(),
                             };
+                            let data = serde_json::to_string(&metadata).unwrap_or_else(|_| {
+                                log::error!("Failed to serialize metadata: {:?}", metadata);
+                                String::new()
+                            });
                             (
                                 "search_response_metadata",
-                                serde_json::to_string(&metadata).unwrap_or_default(),
+                                data,
                             )
                         }
                         ResponseChunk::Hits { hits } => {
-                            let hits_chunk = StreamResponses::SearchResponseHits { hits };
+                            let data = serde_json::to_string(&StreamResponses::SearchResponseHits { hits }).unwrap_or_else(|e| {
+                                log::error!("Failed to serialize hits: {:?}", e);
+                                String::new()
+                            });
                             (
                                 "search_response_hits",
-                                serde_json::to_string(&hits_chunk).unwrap_or_default(),
+                                data,
                             )
                         }
                     };

--- a/src/config/src/router.rs
+++ b/src/config/src/router.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /// usize indicates the number of parts to skip based on their actual paths.
-const QUERIER_ROUTES: [(&str, usize); 21] = [
+const QUERIER_ROUTES: [(&str, usize); 23] = [
     ("config", 0),                            // /config
     ("summary", 2),                           // /api/{org_id}/summary
     ("organizations", 1),                     // /api/organizations
@@ -26,6 +26,8 @@ const QUERIER_ROUTES: [(&str, usize); 21] = [
     ("query_manager", 2),                     // /api/{org_id}/query_manager/...
     ("ws", 2),                                // /api/{org_id}/ws
     ("_search", 2),                           // /api/{org_id}/_search
+    ("_search_stream", 2),                    // /api/{org_id}/_search_stream
+    ("_values_stream", 2),                    // /api/{org_id}/_values_stream
     ("_around", 3),                           // /api/{org_id}/{stream_name}/_around
     ("_values", 3),                           // /api/{org_id}/{stream_name}/_values
     ("functions?page_num=", 2),               // /api/{org_id}/functions
@@ -39,7 +41,11 @@ const QUERIER_ROUTES: [(&str, usize); 21] = [
                                                * {label_name}/
                                                * values */
 ];
-const QUERIER_ROUTES_BY_BODY: [&str; 2] = [
+const QUERIER_ROUTES_BY_BODY: [&str; 6] = [
+    "/_search",
+    "/_search_partition",
+    "/_search_stream",
+    "/_values_stream",
     "/prometheus/api/v1/query_range",
     "/prometheus/api/v1/query_exemplars",
 ];

--- a/src/handler/http/request/organization/settings.rs
+++ b/src/handler/http/request/organization/settings.rs
@@ -103,6 +103,11 @@ async fn create(
         }
     }
 
+    if let Some(enable_streaming_search) = settings.enable_streaming_search {
+        field_found = true;
+        data.enable_streaming_search = enable_streaming_search;
+    }
+
     if !field_found {
         return Ok(MetaHttpResponse::bad_request("No valid field found"));
     }

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -64,6 +64,7 @@ pub mod query_manager;
 pub mod saved_view;
 pub mod search_inspector;
 pub mod search_job;
+pub mod search_stream;
 pub(crate) mod utils;
 
 async fn can_use_distinct_stream(
@@ -872,6 +873,8 @@ pub async fn build_search_request_per_field(
     let mut requests = Vec::new();
     for field in fields {
         let sql = if no_count {
+            // we use min(0) as a hack to do streaming aggregation but actually return 0,
+            // essentially we are not counting the values
             format!(
                 "SELECT \"{field}\" AS zo_sql_key, min(0) AS zo_sql_num FROM \"{distinct_prefix}{stream_name}\" {sql_where} GROUP BY zo_sql_key"
             )

--- a/src/handler/http/request/search/search_stream.rs
+++ b/src/handler/http/request/search/search_stream.rs
@@ -1,0 +1,712 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use actix_web::{HttpRequest, HttpResponse, post, web};
+use config::{
+    get_config,
+    meta::{
+        search::{SearchEventType, StreamResponses, ValuesEventContext},
+        sql::{OrderBy, resolve_stream_names},
+    },
+    utils::json,
+};
+use futures::stream::StreamExt;
+use hashbrown::HashMap;
+use log;
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::common::{
+    auditor::{AuditMessage, Protocol, ResponseMeta},
+    infra::config::get_config as get_o2_config,
+};
+use tokio::sync::mpsc;
+use tracing::Span;
+
+use crate::{
+    common::{
+        meta::http::HttpResponse as MetaHttpResponse,
+        utils::{
+            http::{
+                get_fallback_order_by_col_from_request, get_or_create_trace_id,
+                get_search_event_context_from_request, get_search_type_from_request,
+                get_stream_type_from_request, get_use_cache_from_request,
+            },
+            websocket::update_histogram_interval_in_query,
+        },
+    },
+    handler::http::request::search::{
+        build_search_request_per_field, error_utils::map_error_to_http_response,
+    },
+    service::{search::search_stream::process_search_stream_request, setup_tracing_with_trace_id},
+};
+#[cfg(feature = "enterprise")]
+use crate::{
+    handler::http::request::search::utils::check_stream_permissions, service::self_reporting::audit,
+    service::search::search_stream::AuditContext,
+};
+/// Search HTTP2 streaming endpoint
+///
+/// #{"ratelimit_module":"Search", "ratelimit_module_operation":"get"}#
+#[utoipa::path(
+    context_path = "/api",
+    tag = "Search",
+    operation_id = "SearchStreamHttp2",
+    security(
+        ("Authorization"= [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+    ),
+    request_body(content = String, description = "Search query", content_type = "application/json", example = json!({
+        "sql": "select * from logs LIMIT 10",
+        "start_time": 1675182660872049i64,
+        "end_time": 1675185660872049i64
+    })),
+    responses(
+        (status = 200, description = "Success", content_type = "text/event-stream"),
+        (status = 400, description = "Failure", content_type = "application/json", body = HttpResponse),
+    )
+)]
+#[post("/{org_id}/_search_stream")]
+pub async fn search_http2_stream(
+    org_id: web::Path<String>,
+    in_req: HttpRequest,
+    body: web::Bytes,
+) -> HttpResponse {
+    let cfg = get_config();
+    let org_id = org_id.into_inner();
+
+    // Create a tracing span
+    let http_span = if cfg.common.tracing_search_enabled {
+        tracing::info_span!("/api/{org_id}/_search_stream", org_id = org_id.clone())
+    } else {
+        Span::none()
+    };
+    let trace_id = get_or_create_trace_id(in_req.headers(), &http_span);
+
+    let user_id = in_req
+        .headers()
+        .get("user_id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    // Log the request
+    log::info!(
+        "[trace_id: {}] Received HTTP/2 stream request at handler for org_id: {}",
+        trace_id,
+        org_id
+    );
+
+    // Get query params
+    let query = web::Query::<HashMap<String, String>>::from_query(in_req.query_string()).unwrap();
+    let stream_type = get_stream_type_from_request(&query).unwrap_or_default();
+
+    #[cfg(feature = "enterprise")]
+    let body_bytes = String::from_utf8_lossy(&body).to_string();
+
+    // Parse the search request
+    let mut req: config::meta::search::Request = match json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            #[cfg(feature = "enterprise")]
+            let error_message = e.to_string();
+            
+            let http_response = map_error_to_http_response(&(e.into()), Some(trace_id.clone()));
+            
+            // Add audit before closing
+            #[cfg(feature = "enterprise")]
+            {
+                report_to_audit(
+                    user_id,
+                    org_id,
+                    trace_id,
+                    http_response.status().into(),
+                    Some(error_message),
+                    &in_req,
+                    body_bytes,
+                )
+                .await;
+            }
+            return http_response;
+        }
+    };
+
+    if let Err(e) = req.decode() {
+        #[cfg(feature = "enterprise")]
+        let error_message = e.to_string();
+        
+        let http_response = map_error_to_http_response(&(e.into()), Some(trace_id.clone()));
+        
+        // Add audit before closing
+        #[cfg(feature = "enterprise")]
+        {
+            report_to_audit(
+                user_id,
+                org_id,
+                trace_id,
+                http_response.status().into(),
+                Some(error_message),
+                &in_req,
+                body_bytes,
+            )
+            .await;
+        }
+        return http_response;
+    }
+
+    // Set use_cache from query params
+    let use_cache = cfg.common.result_cache_enabled && get_use_cache_from_request(&query);
+    req.use_cache = Some(use_cache);
+
+    // Set search type if not set
+    if req.search_type.is_none() {
+        req.search_type = match get_search_type_from_request(&query) {
+            Ok(v) => v,
+            Err(e) => {
+                #[cfg(feature = "enterprise")]
+                let error_message = e.to_string();
+                
+                let http_response = map_error_to_http_response(&(e.into()), Some(trace_id.clone()));
+                
+                // Add audit before closing
+                #[cfg(feature = "enterprise")]
+                {
+                    report_to_audit(
+                        user_id,
+                        org_id,
+                        trace_id,
+                        http_response.status().into(),
+                        Some(error_message),
+                        &in_req,
+                        body_bytes,
+                    )
+                    .await;
+                }
+                return http_response;
+            }
+        };
+    }
+
+    let fallback_order_by_col = get_fallback_order_by_col_from_request(&query);
+
+    // Set search event context if not set
+    if req.search_event_context.is_none() {
+        req.search_event_context = req
+            .search_type
+            .as_ref()
+            .and_then(|event_type| get_search_event_context_from_request(event_type, &query));
+    }
+
+    // get stream name
+    let stream_names = match resolve_stream_names(&req.query.sql) {
+        Ok(v) => v.clone(),
+        Err(e) => {
+            #[cfg(feature = "enterprise")]
+            let error_message = e.to_string();
+            
+            let http_response = map_error_to_http_response(&(e.into()), Some(trace_id.clone()));
+            
+            // Add audit before closing
+            #[cfg(feature = "enterprise")]
+            {
+                report_to_audit(
+                    user_id,
+                    org_id,
+                    trace_id,
+                    http_response.status().into(),
+                    Some(error_message),
+                    &in_req,
+                    body_bytes,
+                )
+                .await;
+            }
+            return http_response;
+        }
+    };
+
+    // Check permissions for each stream
+    #[cfg(feature = "enterprise")]
+    for stream_name in stream_names.iter() {
+        if let Some(res) =
+            check_stream_permissions(stream_name, &org_id, &user_id, &stream_type).await
+        {
+            // Add audit before closing
+            #[cfg(feature = "enterprise")]
+            {
+                report_to_audit(
+                    user_id,
+                    org_id,
+                    trace_id,
+                    res.status().into(),
+                    Some("Unauthorized Access".to_string()),
+                    &in_req,
+                    body_bytes,
+                )
+                .await;
+            }
+            return res;
+        }
+    }
+
+    // create new sql query with histogram interval
+    let sql = match crate::service::search::sql::Sql::new(
+        &req.query.clone().into(),
+        &org_id,
+        stream_type,
+        req.search_type,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!("[trace_id: {}] Error parsing sql: {:?}", trace_id, e);
+            
+            #[cfg(feature = "enterprise")]
+            let error_message = e.to_string();
+            
+            let http_response = map_error_to_http_response(&e, Some(trace_id.clone()));
+            
+            // Add audit before closing
+            #[cfg(feature = "enterprise")]
+            {
+                report_to_audit(
+                    user_id,
+                    org_id,
+                    trace_id,
+                    http_response.status().into(),
+                    Some(error_message),
+                    &in_req,
+                    body_bytes,
+                )
+                .await;
+            }
+            return http_response;
+        }
+    };
+
+    if let Some(interval) = sql.histogram_interval {
+        // modify the sql query statement to include the histogram interval
+        if let Ok(updated_query) = update_histogram_interval_in_query(&req.query.sql, interval) {
+            req.query.sql = updated_query;
+        } else {
+            log::error!(
+                "[HTTP2_STREAM] [trace_id: {}] Failed to update query with histogram interval: {}",
+                trace_id,
+                interval
+            );
+
+            // Add audit before closing
+            #[cfg(feature = "enterprise")]
+            {
+                report_to_audit(
+                    user_id,
+                    org_id,
+                    trace_id,
+                    400,
+                    Some("Failed to update query with histogram interval".to_string()),
+                    &in_req,
+                    body_bytes,
+                )
+                .await;
+            }
+
+            return MetaHttpResponse::bad_request("Failed to update query with histogram interval");
+        }
+        log::info!(
+            "[HTTP2_STREAM] [trace_id: {}] Updated query {}; with histogram interval: {}",
+            trace_id,
+            req.query.sql,
+            interval
+        );
+    }
+    let req_order_by = sql.order_by.first().map(|v| v.1).unwrap_or_default();
+
+    let search_span = setup_tracing_with_trace_id(
+        &trace_id,
+        tracing::info_span!("service::search::search_stream_h2"),
+    )
+    .await;
+
+    if req.search_type.is_none() {
+        req.search_type = Some(SearchEventType::Other);
+    }
+
+    // Create a channel for streaming results
+    let (tx, rx) = mpsc::channel::<Result<StreamResponses, infra::errors::Error>>(100);
+
+    #[cfg(feature = "enterprise")]
+    let audit_ctx = Some(AuditContext {
+        method: in_req.method().to_string(),
+        path: in_req.path().to_string(),
+        query_params: in_req.query_string().to_string(),
+        body: body_bytes,
+    });
+    #[cfg(not(feature = "enterprise"))]
+    let audit_ctx = None;
+
+    // Spawn the search task in a separate task
+    actix_web::rt::spawn(process_search_stream_request(
+        org_id.clone(),
+        user_id,
+        trace_id.clone(),
+        req,
+        stream_type,
+        stream_names,
+        req_order_by,
+        search_span.clone(),
+        tx,
+        None,
+        fallback_order_by_col,
+        audit_ctx,
+    ));
+
+    // Return streaming response
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx).flat_map(move |result| {
+        let chunks_iter = match result {
+            Ok(v) => v.to_chunks(),
+            Err(err) => {
+                log::error!(
+                    "[HTTP2_STREAM] trace_id: {} Error in stream: {}",
+                    trace_id,
+                    err
+                );
+                let err_res = match err {
+                    infra::errors::Error::ErrorCode(ref code) => {
+                        // if err code is cancelled return cancelled response
+                        match code {
+                            infra::errors::ErrorCodes::SearchCancelQuery(_) => {
+                                StreamResponses::Cancelled
+                            }
+                            _ => {
+                                let message = code.get_message();
+                                let error_detail = code.get_error_detail();
+                                let http_response = map_error_to_http_response(&err, None);
+
+                                StreamResponses::Error {
+                                    code: http_response.status().into(),
+                                    message,
+                                    error_detail: Some(error_detail),
+                                }
+                            }
+                        }
+                    }
+                    _ => StreamResponses::Error {
+                        code: 500,
+                        message: err.to_string(),
+                        error_detail: None,
+                    },
+                };
+                err_res.to_chunks()
+            }
+        };
+
+        // Convert the iterator to a stream only once
+        futures::stream::iter(chunks_iter)
+    });
+
+    HttpResponse::Ok()
+        .content_type("text/event-stream")
+        .streaming(stream)
+}
+
+#[cfg(feature = "enterprise")]
+async fn report_to_audit(
+    user_id: String,
+    org_id: String,
+    trace_id: String,
+    code: u16,
+    error_message: Option<String>,
+    req: &HttpRequest,
+    req_body: String,
+) {
+    let is_audit_enabled = get_o2_config().common.audit_enabled;
+    if is_audit_enabled {
+        // Using spawn to handle the async call
+        audit(AuditMessage {
+            user_email: user_id,
+            org_id,
+            _timestamp: chrono::Utc::now().timestamp(),
+            protocol: Protocol::Http,
+            response_meta: ResponseMeta {
+                http_method: req.method().to_string(),
+                http_path: req.path().to_string(),
+                http_query_params: req.query_string().to_string(),
+                http_body: req_body,
+                http_response_code: code,
+                error_msg: error_message,
+                trace_id: Some(trace_id.to_string()),
+            },
+        })
+        .await;
+    }
+}
+
+/// Values  HTTP2 streaming endpoint
+///
+/// #{"ratelimit_module":"Search", "ratelimit_module_operation":"get"}#
+#[utoipa::path(
+    context_path = "/api",
+    tag = "Search",
+    operation_id = "ValuesStreamHttp2",
+    security(
+        ("Authorization"= [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+    ),
+    request_body(content = String, description = "Values query", content_type = "application/json", example = json!({
+        "sql": "select * from logs LIMIT 10",
+        "start_time": 1675182660872049i64,
+        "end_time": 1675185660872049i64
+    })),
+    responses(
+        (status = 200, description = "Success", content_type = "text/event-stream"),
+        (status = 400, description = "Failure", content_type = "application/json", body = HttpResponse),
+    )
+)]
+#[post("/{org_id}/_values_stream")]
+pub async fn values_http2_stream(
+    org_id: web::Path<String>,
+    in_req: HttpRequest,
+    body: web::Bytes,
+) -> HttpResponse {
+    let cfg = get_config();
+    let org_id = org_id.into_inner();
+
+    // Create a tracing span
+    let http_span = if cfg.common.tracing_search_enabled {
+        tracing::info_span!("/api/{org_id}/_values_stream", org_id = org_id.clone())
+    } else {
+        Span::none()
+    };
+    let trace_id = get_or_create_trace_id(in_req.headers(), &http_span);
+
+    let user_id = in_req
+        .headers()
+        .get("user_id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    // Log the request
+    log::info!(
+        "[trace_id: {}] Received values HTTP/2 stream request for org_id: {}",
+        trace_id,
+        org_id
+    );
+
+    // Get query params
+    let query = web::Query::<HashMap<String, String>>::from_query(in_req.query_string()).unwrap();
+    let stream_type = get_stream_type_from_request(&query).unwrap_or_default();
+
+    #[cfg(feature = "enterprise")]
+    let body_bytes = String::from_utf8_lossy(&body).to_string();
+
+    // Parse the values request
+    let mut values_req: config::meta::search::ValuesRequest = match json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            #[cfg(feature = "enterprise")]
+            let error_message = e.to_string();
+            
+            let http_response = map_error_to_http_response(&(e.into()), Some(trace_id.clone()));
+            
+            // Add audit before closing
+            #[cfg(feature = "enterprise")]
+            {
+                report_to_audit(
+                    user_id,
+                    org_id,
+                    trace_id,
+                    http_response.status().into(),
+                    Some(error_message),
+                    &in_req,
+                    body_bytes,
+                )
+                .await;
+            }
+            return http_response;
+        }
+    };
+    let no_count = values_req.no_count;
+    let top_k = values_req.size;
+
+    // Get use_cache from query params
+    values_req.use_cache = cfg.common.result_cache_enabled && get_use_cache_from_request(&query);
+
+    // Build search requests per field and use only the first one
+    let reqs = match build_search_request_per_field(
+        &values_req,
+        &org_id,
+        stream_type,
+        &values_req.stream_name,
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            #[cfg(feature = "enterprise")]
+            let error_message = e.to_string();
+            
+            let http_response = map_error_to_http_response(&(e.into()), Some(trace_id.clone()));
+            
+            // Add audit before closing
+            #[cfg(feature = "enterprise")]
+            {
+                report_to_audit(
+                    user_id,
+                    org_id,
+                    trace_id,
+                    http_response.status().into(),
+                    Some(error_message),
+                    &in_req,
+                    body_bytes.clone(),
+                )
+                .await;
+            }
+            return http_response;
+        }
+    };
+    if reqs.is_empty() {
+        let http_response = MetaHttpResponse::bad_request("No valid fields to process");
+        // Add audit before closing
+        #[cfg(feature = "enterprise")]
+        {
+            report_to_audit(
+                user_id,
+                org_id,
+                trace_id,
+                http_response.status().into(),
+                Some("No valid fields to process".to_string()),
+                &in_req,
+                body_bytes.clone(),
+            )
+            .await;
+        }
+        return http_response;
+    }
+
+    // Take only the first request
+    let (req, stream_type, field_name) = reqs.into_iter().next().unwrap();
+
+    // Get stream name directly from the values request
+    let stream_names = vec![values_req.stream_name.clone()];
+
+    // Check permissions for each stream
+    #[cfg(feature = "enterprise")]
+    for stream_name in stream_names.iter() {
+        if let Some(res) =
+            check_stream_permissions(stream_name, &org_id, &user_id, &stream_type).await
+        {
+            // Add audit before closing
+            #[cfg(feature = "enterprise")]
+            {
+                report_to_audit(
+                    user_id,
+                    org_id,
+                    trace_id,
+                    res.status().into(),
+                    Some("Unauthorized Access".to_string()),
+                    &in_req,
+                    body_bytes.clone(),
+                )
+                .await;
+            }
+            return res;
+        }
+    }
+
+    let search_span = setup_tracing_with_trace_id(
+        &trace_id,
+        tracing::info_span!("service::search::values_stream_h2"),
+    )
+    .await;
+
+    // Create a channel for streaming results
+    let (tx, rx) =
+        mpsc::channel::<Result<config::meta::search::StreamResponses, infra::errors::Error>>(100);
+
+    let values_event_context = ValuesEventContext {
+        field: field_name,
+        top_k,
+        no_count,
+    };
+
+    #[cfg(feature = "enterprise")]
+    let audit_ctx = Some(AuditContext {
+        method: in_req.method().to_string(),
+        path: in_req.path().to_string(),
+        query_params: in_req.query_string().to_string(),
+        body: body_bytes,
+    });
+    #[cfg(not(feature = "enterprise"))]
+    let audit_ctx = None;
+
+    // Spawn the search task to process the request
+    actix_web::rt::spawn(process_search_stream_request(
+        org_id.clone(),
+        user_id,
+        trace_id.clone(),
+        req,
+        stream_type,
+        stream_names,
+        OrderBy::default(),
+        search_span.clone(),
+        tx,
+        Some(values_event_context),
+        None,
+        audit_ctx,
+    ));
+
+    // Return streaming response
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx).flat_map(move |result| {
+        let chunks_iter = match result {
+            Ok(v) => v.to_chunks(),
+            Err(err) => {
+                log::error!(
+                    "[HTTP2_STREAM] trace_id: {} Error in stream: {}",
+                    trace_id,
+                    err
+                );
+                let err_res = match err {
+                    infra::errors::Error::ErrorCode(ref code) => {
+                        let message = code.get_message();
+                        let error_detail = code.get_error_detail();
+                        let http_response = map_error_to_http_response(&err, None);
+
+                        config::meta::search::StreamResponses::Error {
+                            code: http_response.status().into(),
+                            message,
+                            error_detail: Some(error_detail),
+                        }
+                    }
+                    _ => config::meta::search::StreamResponses::Error {
+                        code: 500,
+                        message: err.to_string(),
+                        error_detail: None,
+                    },
+                };
+                err_res.to_chunks()
+            }
+        };
+
+        // Convert the iterator to a stream only once
+        futures::stream::iter(chunks_iter)
+    });
+
+    HttpResponse::Ok()
+        .content_type("text/event-stream")
+        .streaming(stream)
+}

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -127,6 +127,7 @@ struct ConfigResponse<'a> {
     query_default_limit: i64,
     max_dashboard_series: usize,
     actions_enabled: bool,
+    streaming_enabled: bool,
     histogram_enabled: bool,
     max_query_range: i64,
 }
@@ -320,6 +321,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         query_default_limit: cfg.limit.query_default_limit,
         max_dashboard_series: cfg.limit.max_dashboard_series,
         actions_enabled,
+        streaming_enabled: cfg.websocket.streaming_enabled,
         histogram_enabled: cfg.limit.histogram_enabled,
         max_query_range: cfg.limit.default_max_query_range_days * 24,
     }))

--- a/src/handler/http/router/middlewares/compress/mod.rs
+++ b/src/handler/http/router/middlewares/compress/mod.rs
@@ -1,0 +1,241 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use actix_service::{Service, Transform};
+use actix_utils::future::{Either, Ready, ok};
+use actix_web::{
+    Error, HttpMessage, HttpResponse,
+    body::{EitherBody, MessageBody},
+    dev::{ServiceRequest, ServiceResponse},
+    http::{
+        StatusCode,
+        header::{self, AcceptEncoding, ContentEncoding, Encoding, HeaderValue},
+    },
+};
+use futures_core::ready;
+use mime::Mime;
+use once_cell::sync::Lazy;
+use pin_project_lite::pin_project;
+
+use super::encoding::Encoder;
+
+/// Middleware for compressing response payloads.
+///
+/// # Encoding Negotiation
+/// `Compress` will read the `Accept-Encoding` header to negotiate which compression codec to use.
+/// Payloads are not compressed if the header is not sent. The `compress-*` [feature flags] are also
+/// considered in this selection process.
+///
+/// # Pre-compressed Payload
+/// If you are serving some data that is already using a compressed representation (e.g., a gzip
+/// compressed HTML file from disk) you can signal this to `Compress` by setting an appropriate
+/// `Content-Encoding` header. In addition to preventing double compressing the payload, this header
+/// is required by the spec when using compressed representations and will inform the client that
+/// the content should be uncompressed.
+///
+/// However, it is not advised to unconditionally serve encoded representations of content because
+/// the client may not support it. The [`AcceptEncoding`] typed header has some utilities to help
+/// perform manual encoding negotiation, if required. When negotiating content encoding, it is also
+/// required by the spec to send a `Vary: Accept-Encoding` header.
+///
+/// A (naïve) example serving an pre-compressed Gzip file is included below.
+///
+/// # Examples
+/// To enable automatic payload compression just include `Compress` as a top-level middleware:
+/// ```
+/// use actix_web::{App, HttpResponse, middleware, web};
+///
+/// let app = App::new()
+///     .wrap(middleware::Compress::default())
+///     .default_service(web::to(|| async { HttpResponse::Ok().body("hello world") }));
+/// ```
+///
+/// Pre-compressed Gzip file being served from disk with correct headers added to bypass middleware:
+/// ```no_run
+/// use actix_web::{App, HttpResponse, Responder, http::header, middleware, web};
+///
+/// async fn index_handler() -> actix_web::Result<impl Responder> {
+///     Ok(actix_files::NamedFile::open_async("./assets/index.html.gz")
+///         .await?
+///         .customize()
+///         .insert_header(header::ContentEncoding::Gzip))
+/// }
+///
+/// let app = App::new()
+///     .wrap(middleware::Compress::default())
+///     .default_service(web::to(index_handler));
+/// ```
+///
+/// [feature flags]: ../index.html#crate-features
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct Compress;
+
+impl<S, B> Transform<S, ServiceRequest> for Compress
+where
+    B: MessageBody,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+{
+    type Response = ServiceResponse<EitherBody<Encoder<B>>>;
+    type Error = Error;
+    type Transform = CompressMiddleware<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ok(CompressMiddleware { service })
+    }
+}
+
+pub struct CompressMiddleware<S> {
+    service: S,
+}
+
+impl<S, B> Service<ServiceRequest> for CompressMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    B: MessageBody,
+{
+    type Response = ServiceResponse<EitherBody<Encoder<B>>>;
+    type Error = Error;
+    #[allow(clippy::type_complexity)]
+    type Future = Either<CompressResponse<S, B>, Ready<Result<Self::Response, Self::Error>>>;
+
+    actix_service::forward_ready!(service);
+
+    #[allow(clippy::borrow_interior_mutable_const)]
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        // negotiate content-encoding
+        let accept_encoding = req.get_header::<AcceptEncoding>();
+
+        let accept_encoding = match accept_encoding {
+            // missing header; fallback to identity
+            None => {
+                return Either::left(CompressResponse {
+                    encoding: Encoding::identity(),
+                    fut: self.service.call(req),
+                    _phantom: PhantomData,
+                });
+            }
+
+            // valid accept-encoding header
+            Some(accept_encoding) => accept_encoding,
+        };
+
+        match accept_encoding.negotiate(SUPPORTED_ENCODINGS.iter()) {
+            None => {
+                let mut res = HttpResponse::with_body(
+                    StatusCode::NOT_ACCEPTABLE,
+                    SUPPORTED_ENCODINGS_STRING.as_str(),
+                );
+
+                res.headers_mut()
+                    .insert(header::VARY, HeaderValue::from_static("Accept-Encoding"));
+
+                Either::right(ok(req
+                    .into_response(res)
+                    .map_into_boxed_body()
+                    .map_into_right_body()))
+            }
+
+            Some(encoding) => Either::left(CompressResponse {
+                fut: self.service.call(req),
+                encoding,
+                _phantom: PhantomData,
+            }),
+        }
+    }
+}
+
+pin_project! {
+    pub struct CompressResponse<S, B>
+    where
+        S: Service<ServiceRequest>,
+    {
+        #[pin]
+        fut: S::Future,
+        encoding: Encoding,
+        _phantom: PhantomData<B>,
+    }
+}
+
+impl<S, B> Future for CompressResponse<S, B>
+where
+    B: MessageBody,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+{
+    type Output = Result<ServiceResponse<EitherBody<Encoder<B>>>, Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_mut().project();
+
+        match ready!(this.fut.poll(cx)) {
+            Ok(resp) => {
+                let enc = match this.encoding {
+                    Encoding::Known(enc) => *enc,
+                    Encoding::Unknown(enc) => {
+                        unimplemented!("encoding '{enc}' should not be here");
+                    }
+                };
+
+                Poll::Ready(Ok(resp.map_body(move |head, body| {
+                    let content_type = head.headers.get(header::CONTENT_TYPE);
+
+                    fn default_compress_predicate(content_type: Option<&HeaderValue>) -> bool {
+                        match content_type {
+                            None => true,
+                            Some(hdr) => {
+                                match hdr.to_str().ok().and_then(|hdr| hdr.parse::<Mime>().ok()) {
+                                    Some(mime) if mime.type_().as_str() == "image" => false,
+                                    Some(mime) if mime.type_().as_str() == "video" => false,
+                                    _ => true,
+                                }
+                            }
+                        }
+                    }
+
+                    let enc = if default_compress_predicate(content_type) {
+                        enc
+                    } else {
+                        ContentEncoding::Identity
+                    };
+
+                    // For SSE responses, we'll use the default encoder which handles streaming
+                    EitherBody::left(Encoder::response(enc, head, body))
+                })))
+            }
+
+            Err(err) => Poll::Ready(Err(err)),
+        }
+    }
+}
+
+static SUPPORTED_ENCODINGS_STRING: Lazy<String> =
+    Lazy::new(|| "br, gzip, deflate, zstd".to_string());
+
+static SUPPORTED_ENCODINGS: &[Encoding] = &[
+    Encoding::identity(),
+    Encoding::brotli(),
+    Encoding::gzip(),
+    Encoding::deflate(),
+    Encoding::zstd(),
+];

--- a/src/handler/http/router/middlewares/encoding/encoder.rs
+++ b/src/handler/http/router/middlewares/encoding/encoder.rs
@@ -292,7 +292,7 @@ enum ContentEncoder {
     Deflate(ZlibEncoder<Writer>),
     Gzip(GzEncoder<Writer>),
     Brotli(Box<brotli::CompressorWriter<Writer>>),
-    // Wwe need explicit 'static lifetime here because ZstdEncoder needs a lifetime argument and
+    // We need explicit 'static lifetime here because ZstdEncoder needs a lifetime argument and
     // we use `spawn_blocking` in `Encoder::poll_next` that requires `FnOnce() -> R + Send +
     // 'static`.
     Zstd(ZstdEncoder<'static, Writer>),

--- a/src/handler/http/router/middlewares/encoding/encoder.rs
+++ b/src/handler/http/router/middlewares/encoding/encoder.rs
@@ -1,0 +1,442 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    error::Error as StdError,
+    future::Future,
+    io::{self, Write as _},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use actix_http::{
+    ResponseHead, StatusCode,
+    body::{self, BodySize, MessageBody},
+    header::{self, CONTENT_ENCODING, ContentEncoding, HeaderValue},
+};
+use actix_web::rt::task::{JoinHandle, spawn_blocking};
+use bytes::Bytes;
+use derive_more::Display;
+use flate2::write::{GzEncoder, ZlibEncoder};
+use futures_core::ready;
+use pin_project_lite::pin_project;
+use tracing::trace;
+use zstd::stream::write::Encoder as ZstdEncoder;
+
+use super::Writer;
+
+const MAX_CHUNK_SIZE_ENCODE_IN_PLACE: usize = 1024;
+
+pin_project! {
+    pub struct Encoder<B> {
+        #[pin]
+        body: EncoderBody<B>,
+        encoder: Option<ContentEncoder>,
+        fut: Option<JoinHandle<Result<ContentEncoder, io::Error>>>,
+        eof: bool,
+    }
+}
+
+impl<B: MessageBody> Encoder<B> {
+    fn none() -> Self {
+        Encoder {
+            body: EncoderBody::None {
+                body: body::None::new(),
+            },
+            encoder: None,
+            fut: None,
+            eof: true,
+        }
+    }
+
+    fn empty() -> Self {
+        Encoder {
+            body: EncoderBody::Full { body: Bytes::new() },
+            encoder: None,
+            fut: None,
+            eof: true,
+        }
+    }
+
+    pub fn response(encoding: ContentEncoding, head: &mut ResponseHead, body: B) -> Self {
+        // no need to compress empty bodies
+        match body.size() {
+            BodySize::None => return Self::none(),
+            BodySize::Sized(0) => return Self::empty(),
+            _ => {}
+        }
+
+        let should_encode = !(head.headers().contains_key(&CONTENT_ENCODING)
+            || head.status == StatusCode::SWITCHING_PROTOCOLS
+            || head.status == StatusCode::NO_CONTENT
+            || encoding == ContentEncoding::Identity);
+
+        let body = match body.try_into_bytes() {
+            Ok(body) => EncoderBody::Full { body },
+            Err(body) => EncoderBody::Stream { body },
+        };
+
+        if should_encode {
+            // wrap body only if encoder is feature-enabled
+            if let Some(enc) = ContentEncoder::select(encoding) {
+                update_head(encoding, head);
+
+                return Encoder {
+                    body,
+                    encoder: Some(enc),
+                    fut: None,
+                    eof: false,
+                };
+            }
+        }
+
+        Encoder {
+            body,
+            encoder: None,
+            fut: None,
+            eof: false,
+        }
+    }
+}
+
+pin_project! {
+    #[project = EncoderBodyProj]
+    enum EncoderBody<B> {
+        None { body: body::None },
+        Full { body: Bytes },
+        Stream { #[pin] body: B },
+    }
+}
+
+impl<B> MessageBody for EncoderBody<B>
+where
+    B: MessageBody,
+{
+    type Error = EncoderError;
+
+    #[inline]
+    fn size(&self) -> BodySize {
+        match self {
+            EncoderBody::None { body } => body.size(),
+            EncoderBody::Full { body } => body.size(),
+            EncoderBody::Stream { body } => body.size(),
+        }
+    }
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Bytes, Self::Error>>> {
+        match self.project() {
+            EncoderBodyProj::None { body } => {
+                Pin::new(body).poll_next(cx).map_err(|err| match err {})
+            }
+            EncoderBodyProj::Full { body } => {
+                Pin::new(body).poll_next(cx).map_err(|err| match err {})
+            }
+            EncoderBodyProj::Stream { body } => body
+                .poll_next(cx)
+                .map_err(|err| EncoderError::Body(err.into())),
+        }
+    }
+
+    #[inline]
+    fn try_into_bytes(self) -> Result<Bytes, Self>
+    where
+        Self: Sized,
+    {
+        match self {
+            EncoderBody::None { body } => Ok(body.try_into_bytes().unwrap()),
+            EncoderBody::Full { body } => Ok(body.try_into_bytes().unwrap()),
+            _ => Err(self),
+        }
+    }
+}
+
+impl<B> MessageBody for Encoder<B>
+where
+    B: MessageBody,
+{
+    type Error = EncoderError;
+
+    #[inline]
+    fn size(&self) -> BodySize {
+        if self.encoder.is_some() {
+            BodySize::Stream
+        } else {
+            self.body.size()
+        }
+    }
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Bytes, Self::Error>>> {
+        let mut this = self.project();
+
+        loop {
+            if *this.eof {
+                return Poll::Ready(None);
+            }
+
+            if let Some(fut) = this.fut {
+                let mut encoder = ready!(Pin::new(fut).poll(cx))
+                    .map_err(|_| {
+                        EncoderError::Io(io::Error::new(
+                            io::ErrorKind::Other,
+                            "Blocking task was cancelled unexpectedly",
+                        ))
+                    })?
+                    .map_err(EncoderError::Io)?;
+
+                let chunk = encoder.take();
+                *this.encoder = Some(encoder);
+                this.fut.take();
+
+                if !chunk.is_empty() {
+                    return Poll::Ready(Some(Ok(chunk)));
+                }
+            }
+
+            let result = ready!(this.body.as_mut().poll_next(cx));
+
+            match result {
+                Some(Err(err)) => return Poll::Ready(Some(Err(err))),
+
+                Some(Ok(chunk)) => {
+                    // log::debug!(
+                    //     "chunk: {:?}, {}",
+                    //     chunk.len(),
+                    //     String::from_utf8_lossy(&chunk)
+                    // );
+                    if let Some(mut encoder) = this.encoder.take() {
+                        if chunk.len() < MAX_CHUNK_SIZE_ENCODE_IN_PLACE {
+                            encoder.write(&chunk).map_err(EncoderError::Io)?;
+                            let chunk = encoder.flush().map_err(EncoderError::Io)?;
+                            let _ = encoder.take();
+                            *this.encoder = Some(encoder);
+
+                            if !chunk.is_empty() {
+                                return Poll::Ready(Some(Ok(chunk)));
+                            }
+                        } else {
+                            *this.fut = Some(spawn_blocking(move || {
+                                encoder.write(&chunk)?;
+                                Ok(encoder)
+                            }));
+                        }
+                    } else {
+                        return Poll::Ready(Some(Ok(chunk)));
+                    }
+                }
+
+                None => {
+                    if let Some(encoder) = this.encoder.take() {
+                        let chunk = encoder.finish().map_err(EncoderError::Io)?;
+
+                        if chunk.is_empty() {
+                            return Poll::Ready(None);
+                        } else {
+                            *this.eof = true;
+                            return Poll::Ready(Some(Ok(chunk)));
+                        }
+                    } else {
+                        return Poll::Ready(None);
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn try_into_bytes(mut self) -> Result<Bytes, Self>
+    where
+        Self: Sized,
+    {
+        if self.encoder.is_some() {
+            Err(self)
+        } else {
+            match self.body.try_into_bytes() {
+                Ok(body) => Ok(body),
+                Err(body) => {
+                    self.body = body;
+                    Err(self)
+                }
+            }
+        }
+    }
+}
+
+fn update_head(encoding: ContentEncoding, head: &mut ResponseHead) {
+    head.headers_mut()
+        .insert(header::CONTENT_ENCODING, encoding.to_header_value());
+    head.headers_mut()
+        .append(header::VARY, HeaderValue::from_static("accept-encoding"));
+
+    head.no_chunking(false);
+}
+
+enum ContentEncoder {
+    Deflate(ZlibEncoder<Writer>),
+    Gzip(GzEncoder<Writer>),
+    Brotli(Box<brotli::CompressorWriter<Writer>>),
+    // Wwe need explicit 'static lifetime here because ZstdEncoder needs a lifetime argument and
+    // we use `spawn_blocking` in `Encoder::poll_next` that requires `FnOnce() -> R + Send +
+    // 'static`.
+    Zstd(ZstdEncoder<'static, Writer>),
+}
+
+impl ContentEncoder {
+    fn select(encoding: ContentEncoding) -> Option<Self> {
+        match encoding {
+            ContentEncoding::Deflate => Some(ContentEncoder::Deflate(ZlibEncoder::new(
+                Writer::new(),
+                flate2::Compression::fast(),
+            ))),
+            ContentEncoding::Gzip => Some(ContentEncoder::Gzip(GzEncoder::new(
+                Writer::new(),
+                flate2::Compression::fast(),
+            ))),
+            ContentEncoding::Brotli => Some(ContentEncoder::Brotli(new_brotli_compressor())),
+            ContentEncoding::Zstd => {
+                let encoder = ZstdEncoder::new(Writer::new(), 3).ok()?;
+                Some(ContentEncoder::Zstd(encoder))
+            }
+
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn take(&mut self) -> Bytes {
+        match *self {
+            ContentEncoder::Brotli(ref mut encoder) => encoder.get_mut().take(),
+            ContentEncoder::Deflate(ref mut encoder) => encoder.get_mut().take(),
+            ContentEncoder::Gzip(ref mut encoder) => encoder.get_mut().take(),
+            ContentEncoder::Zstd(ref mut encoder) => encoder.get_mut().take(),
+        }
+    }
+
+    fn flush(&mut self) -> Result<Bytes, io::Error> {
+        match self {
+            ContentEncoder::Brotli(encoder) => match encoder.flush() {
+                Ok(()) => Ok(encoder.get_mut().take()),
+                Err(err) => Err(err),
+            },
+            ContentEncoder::Gzip(encoder) => match encoder.flush() {
+                Ok(()) => Ok(encoder.get_mut().take()),
+                Err(err) => Err(err),
+            },
+            ContentEncoder::Deflate(encoder) => match encoder.flush() {
+                Ok(()) => Ok(encoder.get_mut().take()),
+                Err(err) => Err(err),
+            },
+            ContentEncoder::Zstd(encoder) => match encoder.flush() {
+                Ok(()) => Ok(encoder.get_mut().take()),
+                Err(err) => Err(err),
+            },
+        }
+    }
+
+    fn finish(self) -> Result<Bytes, io::Error> {
+        match self {
+            ContentEncoder::Brotli(mut encoder) => match encoder.flush() {
+                Ok(()) => Ok(encoder.into_inner().buf.freeze()),
+                Err(err) => Err(err),
+            },
+            ContentEncoder::Gzip(encoder) => match encoder.finish() {
+                Ok(writer) => Ok(writer.buf.freeze()),
+                Err(err) => Err(err),
+            },
+            ContentEncoder::Deflate(encoder) => match encoder.finish() {
+                Ok(writer) => Ok(writer.buf.freeze()),
+                Err(err) => Err(err),
+            },
+            ContentEncoder::Zstd(encoder) => match encoder.finish() {
+                Ok(writer) => Ok(writer.buf.freeze()),
+                Err(err) => Err(err),
+            },
+        }
+    }
+
+    fn write(&mut self, data: &[u8]) -> Result<(), io::Error> {
+        match *self {
+            ContentEncoder::Brotli(ref mut encoder) => match encoder.write_all(data) {
+                Ok(_) => Ok(()),
+                Err(err) => {
+                    trace!("Error decoding br encoding: {}", err);
+                    Err(err)
+                }
+            },
+            ContentEncoder::Gzip(ref mut encoder) => match encoder.write_all(data) {
+                Ok(_) => Ok(()),
+                Err(err) => {
+                    trace!("Error decoding gzip encoding: {}", err);
+                    Err(err)
+                }
+            },
+            ContentEncoder::Deflate(ref mut encoder) => match encoder.write_all(data) {
+                Ok(_) => Ok(()),
+                Err(err) => {
+                    trace!("Error decoding deflate encoding: {}", err);
+                    Err(err)
+                }
+            },
+            ContentEncoder::Zstd(ref mut encoder) => match encoder.write_all(data) {
+                Ok(_) => Ok(()),
+                Err(err) => {
+                    trace!("Error decoding ztsd encoding: {}", err);
+                    Err(err)
+                }
+            },
+        }
+    }
+}
+
+fn new_brotli_compressor() -> Box<brotli::CompressorWriter<Writer>> {
+    Box::new(brotli::CompressorWriter::new(
+        Writer::new(),
+        32 * 1024, // 32 KiB buffer
+        3,         // BROTLI_PARAM_QUALITY
+        22,        // BROTLI_PARAM_LGWIN
+    ))
+}
+
+#[derive(Debug, Display)]
+#[non_exhaustive]
+pub enum EncoderError {
+    /// Wrapped body stream error.
+    #[display("body")]
+    Body(Box<dyn StdError>),
+
+    /// Generic I/O error.
+    #[display("io")]
+    Io(io::Error),
+}
+
+impl StdError for EncoderError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            EncoderError::Body(err) => Some(&**err),
+            EncoderError::Io(err) => Some(err),
+        }
+    }
+}
+
+impl From<EncoderError> for actix_web::Error {
+    fn from(err: EncoderError) -> Self {
+        actix_web::error::ErrorInternalServerError(err)
+    }
+}

--- a/src/handler/http/router/middlewares/encoding/mod.rs
+++ b/src/handler/http/router/middlewares/encoding/mod.rs
@@ -13,11 +13,40 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-mod check_keep_alive;
-mod compress;
-mod encoding;
-mod slow_log;
+use std::io;
 
-pub use check_keep_alive::check_keep_alive;
-pub use compress::Compress;
-pub use slow_log::SlowLog;
+use bytes::{Bytes, BytesMut};
+
+mod encoder;
+
+pub use self::encoder::Encoder;
+
+/// Special-purpose writer for streaming (de-)compression.
+///
+/// Pre-allocates 8KiB of capacity.
+struct Writer {
+    buf: BytesMut,
+}
+
+impl Writer {
+    fn new() -> Writer {
+        Writer {
+            buf: BytesMut::with_capacity(8192),
+        }
+    }
+
+    fn take(&mut self) -> Bytes {
+        self.buf.split().freeze()
+    }
+}
+
+impl io::Write for Writer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -84,8 +84,9 @@ async fn audit_middleware(
     let path_columns = path.split('/').collect::<Vec<&str>>();
     let path_len = path_columns.len();
     if get_o2_config().common.audit_enabled
-        && !path_columns.get(1).unwrap_or(&"").to_string().eq("ws")
-        && !(method.eq("POST") && INGESTION_EP.contains(&path_columns[path_len - 1]))
+        && !(path_columns.get(1).unwrap_or(&"").to_string().eq("ws")
+        || path_columns.get(1).unwrap_or(&"").to_string().ends_with("_stream") // skip for http2 streams
+        || (method.eq("POST") && INGESTION_EP.contains(&path_columns[path_len - 1])))
     {
         let query_params = req.query_string().to_string();
         let org_id = {
@@ -438,6 +439,8 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(search::saved_view::get_view)
         .service(search::saved_view::get_views)
         .service(search::saved_view::delete_view)
+        .service(search::search_stream::search_http2_stream)
+        .service(search::search_stream::values_http2_stream)
         .service(functions::save_function)
         .service(functions::list_functions)
         .service(functions::test_function)

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -190,6 +190,8 @@ use crate::{common::meta, handler::http::request};
         request::search::search_job::get_job_result,
         request::search::search_job::delete_job,
         request::search::search_job::retry_job,
+        request::search::search_stream::search_http2_stream,
+        request::search::search_stream::values_http2_stream,
     ),
     components(
         schemas(

--- a/src/main.rs
+++ b/src/main.rs
@@ -721,7 +721,7 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
         app.app_data(web::JsonConfig::default().limit(cfg.limit.req_json_limit))
             .app_data(web::PayloadConfig::new(cfg.limit.req_payload_limit)) // size is in bytes
             .app_data(web::Data::new(local_id))
-            .wrap(middleware::Compress::default())
+            .wrap(middlewares::Compress::default())
             .wrap(middleware::Logger::new(
                 r#"%a "%r" %s %b "%{Content-Length}i" "%{Referer}i" "%{User-Agent}i" %T"#,
             ))
@@ -841,7 +841,7 @@ async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
         app.app_data(web::JsonConfig::default().limit(cfg.limit.req_json_limit))
             .app_data(web::PayloadConfig::new(cfg.limit.req_payload_limit)) // size is in bytes
             .app_data(web::Data::new(local_id))
-            .wrap(middleware::Compress::default())
+            .wrap(middlewares::Compress::default())
             .wrap(middleware::Logger::new(
                 r#"%a "%r" %s %b "%{Content-Length}i" "%{Referer}i" "%{User-Agent}i" %T"#,
             ))
@@ -1088,7 +1088,7 @@ async fn init_script_server() -> Result<(), anyhow::Error> {
         app.app_data(web::JsonConfig::default().limit(cfg.limit.req_json_limit))
             .app_data(web::PayloadConfig::new(cfg.limit.req_payload_limit)) // size is in bytes
             .app_data(web::Data::new(local_id))
-            .wrap(middleware::Compress::default())
+            .wrap(middlewares::Compress::default())
             .wrap(middleware::Logger::new(
                 r#"%a "%r" %s %b "%{Content-Length}i" "%{Referer}i" "%{User-Agent}i" %T"#,
             ))

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -18,13 +18,14 @@ use ::config::{
     meta::{
         cluster::{Role, RoleGroup},
         promql::RequestRangeQuery,
+        search::{Request as SearchRequest, SearchPartitionRequest, ValuesRequest},
     },
     router::{INGESTER_ROUTES, is_fixed_querier_route, is_querier_route, is_querier_route_by_body},
-    utils::rand::get_rand_element,
+    utils::{json, rand::get_rand_element},
 };
 use actix_web::{
-    FromRequest, HttpRequest, HttpResponse,
-    http::{Error, Method},
+    FromRequest, HttpMessage, HttpRequest, HttpResponse,
+    http::{Error, Method, header},
     route, web,
 };
 use hashbrown::HashMap;
@@ -229,6 +230,8 @@ async fn default_proxy(
     new_url: URLDetails,
     start: std::time::Instant,
 ) -> actix_web::Result<HttpResponse, Error> {
+    let p = new_url.path.find("?").unwrap_or(new_url.path.len());
+    let query_str = &new_url.path[..p];
     // send query
     let req = create_proxy_request(client, req, &new_url).await?;
     let mut resp = match req.send_stream(payload).await {
@@ -257,27 +260,47 @@ async fn default_proxy(
         }
     }
 
-    // set body
-    let body = match resp
-        .body()
-        .limit(get_config().limit.req_payload_limit)
-        .await
-    {
-        Ok(b) => b,
-        Err(e) => {
-            log::error!(
-                "dispatch: {} to {}, proxy response error: {:?}, took: {} ms",
-                new_url.path,
-                new_url.node_addr,
-                e,
-                start.elapsed().as_millis()
-            );
-            return Ok(HttpResponse::ServiceUnavailable()
-                .force_close()
-                .body(e.to_string()));
-        }
-    };
-    Ok(new_resp.body(body))
+    let http_response =
+        if query_str.ends_with("/_search_stream") || query_str.ends_with("/_values_stream") {
+            // Add headers to disable response buffering
+            new_resp
+                .insert_header((header::CACHE_CONTROL, "no-cache"))
+                .insert_header((
+                    header::CONNECTION,
+                    header::HeaderValue::from_static("keep-alive"),
+                ))
+                .streaming(resp.take_payload())
+        } else {
+            let body = match resp
+                .body()
+                .limit(get_config().limit.req_payload_limit)
+                .await
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    log::error!(
+                        "dispatch: {} to {}, proxy response error: {:?}, took: {} ms",
+                        new_url.path,
+                        new_url.node_addr,
+                        e,
+                        start.elapsed().as_millis()
+                    );
+                    return Ok(HttpResponse::ServiceUnavailable()
+                        .force_close()
+                        .body(e.to_string()));
+                }
+            };
+            new_resp.body(body)
+        };
+    Ok(http_response)
+}
+
+enum ProxyPayload {
+    None,
+    PromQLQuery(web::Form<RequestRangeQuery>),
+    SearchRequest(Box<web::Json<SearchRequest>>),
+    SearchPartitionRequest(Box<web::Json<SearchPartitionRequest>>),
+    ValuesRequest(Box<web::Json<ValuesRequest>>),
 }
 
 async fn proxy_querier_by_body(
@@ -287,24 +310,85 @@ async fn proxy_querier_by_body(
     mut new_url: URLDetails,
     start: std::time::Instant,
 ) -> actix_web::Result<HttpResponse, Error> {
-    let (key, payload) = if new_url.path.contains("/prometheus/api/v1/query_range")
-        || new_url.path.contains("/prometheus/api/v1/query_exemplars")
-    {
-        if req.method() == Method::GET {
-            let Ok(query) = web::Query::<RequestRangeQuery>::from_query(req.query_string()) else {
-                return Ok(HttpResponse::BadRequest().body("Failed to parse query string"));
-            };
-            (query.query.clone().unwrap_or_default(), None)
-        } else {
-            let Ok(query) =
-                web::Form::<RequestRangeQuery>::from_request(&req, &mut payload.into_inner()).await
-            else {
-                return Ok(HttpResponse::BadRequest().body("Failed to parse form data"));
-            };
-            (query.query.clone().unwrap_or_default(), Some(query))
+    let p = new_url.path.find("?").unwrap_or(new_url.path.len());
+    let query_str = &new_url.path[..p];
+    log::debug!("proxy_querier_by_body checking query_str: {}", query_str);
+    let (key, payload) = match query_str {
+        s if s.ends_with("/prometheus/api/v1/query_range")
+            || s.ends_with("/prometheus/api/v1/query_exemplars") =>
+        {
+            if req.method() == Method::GET {
+                let Ok(query) = web::Query::<RequestRangeQuery>::from_query(req.query_string())
+                else {
+                    return Ok(HttpResponse::BadRequest().body("Failed to parse query string"));
+                };
+                (query.query.clone().unwrap_or_default(), ProxyPayload::None)
+            } else {
+                let Ok(query) =
+                    web::Form::<RequestRangeQuery>::from_request(&req, &mut payload.into_inner())
+                        .await
+                else {
+                    return Ok(HttpResponse::BadRequest().body("Failed to parse form data"));
+                };
+                (
+                    query.query.clone().unwrap_or_default(),
+                    ProxyPayload::PromQLQuery(query),
+                )
+            }
         }
-    } else {
-        return default_proxy(req, payload, client, new_url, start).await;
+        s if s.ends_with("/_values_stream") => {
+            let body = payload.to_bytes().await.map_err(|e| {
+                log::error!("Failed to parse values stream request data: {:?}", e);
+                Error::from(actix_http::error::PayloadError::Io(std::io::Error::other(
+                    "Failed to parse values stream request data",
+                )))
+            })?;
+            let Ok(query) = json::from_slice::<ValuesRequest>(&body) else {
+                return Ok(HttpResponse::BadRequest().body("Failed to parse values stream request"));
+            };
+            (
+                query.sql.to_string(),
+                ProxyPayload::ValuesRequest(Box::new(web::Json(query))),
+            )
+        }
+        s if s.ends_with("/_search") || s.ends_with("/_search_stream") => {
+            let is_stream = s.ends_with("/_stream");
+            let request_type = if is_stream { "stream" } else { "search" };
+
+            let body = payload.to_bytes().await.map_err(|e| {
+                log::error!("Failed to parse {} request data: {:?}", request_type, e);
+                Error::from(actix_http::error::PayloadError::Io(std::io::Error::other(
+                    format!("Failed to parse {} request data", request_type).as_str(),
+                )))
+            })?;
+            let Ok(query) = json::from_slice::<SearchRequest>(&body) else {
+                return if is_stream {
+                    Ok(HttpResponse::BadRequest().body("Failed to parse search stream request"))
+                } else {
+                    Ok(HttpResponse::BadRequest().body("Failed to parse search request"))
+                };
+            };
+            (
+                query.query.sql.to_string(),
+                ProxyPayload::SearchRequest(Box::new(web::Json(query))),
+            )
+        }
+        s if s.ends_with("/_search_partition") => {
+            let body = payload.to_bytes().await.map_err(|e| {
+                log::error!("Failed to parse search partition request data: {:?}", e);
+                Error::from(actix_http::error::PayloadError::Io(std::io::Error::other(
+                    "Failed to parse search partition request data",
+                )))
+            })?;
+            let Ok(query) = json::from_slice::<SearchPartitionRequest>(&body) else {
+                return Ok(HttpResponse::BadRequest().body("Failed to parse search request"));
+            };
+            (
+                query.sql.to_string(),
+                ProxyPayload::SearchPartitionRequest(Box::new(web::Json(query))),
+            )
+        }
+        _ => return default_proxy(req, payload, client, new_url, start).await,
     };
 
     // get node name by consistent hash
@@ -329,10 +413,12 @@ async fn proxy_querier_by_body(
 
     // send query
     let req = create_proxy_request(client, req, &new_url).await?;
-    let resp = if let Some(payload) = payload {
-        req.send_form(&payload).await
-    } else {
-        req.send().await
+    let resp = match payload {
+        ProxyPayload::None => req.send().await,
+        ProxyPayload::PromQLQuery(payload) => req.send_form(&payload).await,
+        ProxyPayload::SearchRequest(payload) => req.send_json(&payload).await,
+        ProxyPayload::SearchPartitionRequest(payload) => req.send_json(&payload).await,
+        ProxyPayload::ValuesRequest(payload) => req.send_json(&payload).await,
     };
     let mut resp = match resp {
         Ok(resp) => resp,
@@ -360,27 +446,39 @@ async fn proxy_querier_by_body(
         }
     }
 
-    // set body
-    let body = match resp
-        .body()
-        .limit(get_config().limit.req_payload_limit)
-        .await
-    {
-        Ok(b) => b,
-        Err(e) => {
-            log::error!(
-                "dispatch: {} to {}, proxy response error: {:?}, took: {} ms",
-                new_url.path,
-                new_url.node_addr,
-                e,
-                start.elapsed().as_millis()
-            );
-            return Ok(HttpResponse::ServiceUnavailable()
-                .force_close()
-                .body(e.to_string()));
-        }
-    };
-    Ok(new_resp.body(body))
+    let http_response =
+        if query_str.ends_with("/_search_stream") || query_str.ends_with("/_values_stream") {
+            // Add headers to disable response buffering
+            new_resp
+                .insert_header((header::CACHE_CONTROL, "no-cache"))
+                .insert_header((
+                    header::CONNECTION,
+                    header::HeaderValue::from_static("keep-alive"),
+                ))
+                .streaming(resp.take_payload())
+        } else {
+            let body = match resp
+                .body()
+                .limit(get_config().limit.req_payload_limit)
+                .await
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    log::error!(
+                        "dispatch: {} to {}, proxy response error: {:?}, took: {} ms",
+                        new_url.path,
+                        new_url.node_addr,
+                        e,
+                        start.elapsed().as_millis()
+                    );
+                    return Ok(HttpResponse::ServiceUnavailable()
+                        .force_close()
+                        .body(e.to_string()));
+                }
+            };
+            new_resp.body(body)
+        };
+    Ok(http_response)
 }
 
 async fn proxy_ws(

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -77,6 +77,7 @@ pub(crate) mod index;
 pub(crate) mod inspector;
 pub(crate) mod partition;
 pub(crate) mod request;
+pub(crate) mod search_stream;
 pub(crate) mod sql;
 #[cfg(feature = "enterprise")]
 pub(crate) mod super_cluster;

--- a/src/service/search/search_stream.rs
+++ b/src/service/search/search_stream.rs
@@ -1,0 +1,1389 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{cmp::Reverse, collections::BinaryHeap, time::Instant};
+
+use config::{
+    meta::{
+        search::{
+            PARTIAL_ERROR_RESPONSE_MESSAGE, Response, SearchEventType, SearchPartitionRequest,
+            SearchPartitionResponse, StreamResponses, TimeOffset, ValuesEventContext,
+        },
+        sql::OrderBy,
+        stream::StreamType,
+        websocket::SearchResultType,
+    },
+    utils::json::{Value, get_string_value},
+};
+use log;
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::common::{
+    auditor::{AuditMessage, Protocol, ResponseMeta},
+    infra::config::get_config as get_o2_config,
+};
+use serde_json::Map;
+use tokio::sync::mpsc;
+use tracing::Instrument;
+
+use crate::{
+    common::{
+        meta::search::{CachedQueryResponse, QueryDelta},
+        utils::{stream::get_max_query_range, websocket::calc_queried_range},
+    },
+    service::{
+        search::{self as SearchService, cache, datafusion::distributed_plan::streaming_aggs_exec},
+        websocket_events::{
+            search::write_results_to_cache, sort::order_search_results,
+            utils::calculate_progress_percentage,
+        },
+    },
+};
+#[cfg(feature = "enterprise")]
+use crate::{
+    handler::http::request::search::error_utils::map_error_to_http_response,
+    service::self_reporting::audit,
+};
+
+// #[derive(Debug, Clone)]
+// pub struct SearchStreamerBuilder {
+//     pub org_id: String,
+//     pub user_id: String,
+//     pub trace_id: String,
+//     pub req: config::meta::search::Request,
+//     pub stream_type: StreamType,
+//     pub stream_names: Vec<String>,
+//     pub req_order_by: OrderBy,
+//     pub search_span: tracing::Span,
+//     pub sender: mpsc::Sender<Result<config::meta::search::StreamResponses, infra::errors::Error>>,
+//     pub values_ctx: Option<ValuesEventContext>,
+//     pub fallback_order_by_col: Option<String>,
+//     pub _audit_ctx: Option<AuditContext>,
+// }
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct AuditContext {
+    pub method: String,
+    pub path: String,
+    pub query_params: String,
+    pub body: String,
+}
+
+// New function to encapsulate search task logic
+#[allow(clippy::too_many_arguments)]
+pub async fn process_search_stream_request(
+    org_id: String,
+    user_id: String,
+    trace_id: String,
+    mut req: config::meta::search::Request,
+    stream_type: StreamType,
+    stream_names: Vec<String>,
+    req_order_by: OrderBy,
+    search_span: tracing::Span,
+    sender: mpsc::Sender<Result<config::meta::search::StreamResponses, infra::errors::Error>>,
+    values_ctx: Option<ValuesEventContext>,
+    fallback_order_by_col: Option<String>,
+    _audit_ctx: Option<AuditContext>,
+) {
+    log::info!(
+        "[HTTP2_STREAM] trace_id: {} Received test HTTP/2 stream request for org_id: {}",
+        trace_id,
+        org_id
+    );
+
+    // Send a progress: 0 event as an indiciator of search initiation
+    if let Err(e) = sender
+        .send(Ok(StreamResponses::Progress { percent: 0 }))
+        .await
+    {
+        log::error!("[HTTP2_STREAM] Error sending progress event: {}", e);
+    }
+
+    let mut start = Instant::now();
+    let mut accumulated_results: Vec<SearchResultType> = Vec::new();
+    let use_cache = req.use_cache.unwrap_or(false);
+    let start_time = req.query.start_time;
+    let end_time = req.query.end_time;
+
+    let max_query_range = get_max_query_range(&stream_names, &org_id, &user_id, stream_type).await; // hours
+
+    if req.query.from == 0 && !req.query.track_total_hits {
+        let c_resp = match cache::check_cache_v2(&trace_id, &org_id, stream_type, &req, use_cache)
+            .instrument(search_span.clone())
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!(
+                    "[HTTP2_STREAM] trace_id: {}; Failed to check cache: {}",
+                    trace_id,
+                    e.to_string()
+                );
+
+                // send audit response first
+                #[cfg(feature = "enterprise")]
+                {
+                    let resp = map_error_to_http_response(&e, None).status().into();
+                    if get_o2_config().common.audit_enabled {
+                        // Using spawn to handle the async call
+                        audit(AuditMessage {
+                            user_email: user_id,
+                            org_id,
+                            _timestamp: chrono::Utc::now().timestamp(),
+                            protocol: Protocol::Http,
+                            response_meta: ResponseMeta {
+                                http_method: _audit_ctx.as_ref().unwrap().method.to_string(),
+                                http_path: _audit_ctx.as_ref().unwrap().path.to_string(),
+                                http_query_params: _audit_ctx
+                                    .as_ref()
+                                    .unwrap()
+                                    .query_params
+                                    .to_string(),
+                                http_body: _audit_ctx.as_ref().unwrap().body.to_string(),
+                                http_response_code: resp,
+                                error_msg: Some(e.to_string()),
+                                trace_id: Some(trace_id.to_string()),
+                            },
+                        })
+                        .await;
+                    }
+                }
+
+                // send error message to client
+                if let Err(e) = sender.send(Err(e)).await {
+                    log::error!(
+                        "[HTTP2_STREAM] Error sending error message to client: {}",
+                        e
+                    );
+                }
+                return;
+            }
+        };
+        let local_c_resp = c_resp.clone();
+        let cached_resp = local_c_resp.cached_response;
+        let mut deltas = local_c_resp.deltas;
+        deltas.sort();
+        deltas.dedup();
+
+        let cached_hits = cached_resp
+            .iter()
+            .fold(0, |acc, c| acc + c.cached_response.hits.len());
+
+        let c_start_time = cached_resp
+            .first()
+            .map(|c| c.response_start_time)
+            .unwrap_or_default();
+
+        let c_end_time = cached_resp
+            .last()
+            .map(|c| c.response_end_time)
+            .unwrap_or_default();
+
+        log::info!(
+            "[HTTP2_STREAM] trace_id: {}, found cache responses len:{}, with hits: {},
+        cache_start_time: {:#?}, cache_end_time: {:#?}",
+            trace_id,
+            cached_resp.len(),
+            cached_hits,
+            c_start_time,
+            c_end_time
+        );
+
+        // handle cache responses and deltas
+        if !cached_resp.is_empty() && cached_hits > 0 {
+            // `max_query_range` is used initialize `remaining_query_range`
+            // set max_query_range to i64::MAX if it is 0, to ensure unlimited query range
+            // for cache only search
+            let remaining_query_range = if max_query_range == 0 {
+                i64::MAX
+            } else {
+                max_query_range
+            }; // hours
+
+            let size = req.query.size;
+            // Step 1(a): handle cache responses & query the deltas
+            if let Err(e) = handle_cache_responses_and_deltas(
+                &mut req,
+                size,
+                &trace_id,
+                &org_id,
+                stream_type,
+                cached_resp,
+                deltas,
+                &mut accumulated_results,
+                &user_id,
+                max_query_range,
+                remaining_query_range,
+                &req_order_by,
+                fallback_order_by_col,
+                &mut start,
+                sender.clone(),
+                values_ctx,
+            )
+            .instrument(search_span.clone())
+            .await
+            {
+                // send audit response first
+                #[cfg(feature = "enterprise")]
+                {
+                    let resp = map_error_to_http_response(&e, None).status().into();
+                    if get_o2_config().common.audit_enabled {
+                        // Using spawn to handle the async call
+                        audit(AuditMessage {
+                            user_email: user_id,
+                            org_id,
+                            _timestamp: chrono::Utc::now().timestamp(),
+                            protocol: Protocol::Http,
+                            response_meta: ResponseMeta {
+                                http_method: _audit_ctx.as_ref().unwrap().method.to_string(),
+                                http_path: _audit_ctx.as_ref().unwrap().path.to_string(),
+                                http_query_params: _audit_ctx
+                                    .as_ref()
+                                    .unwrap()
+                                    .query_params
+                                    .to_string(),
+                                http_body: _audit_ctx.as_ref().unwrap().body.to_string(),
+                                http_response_code: resp,
+                                error_msg: Some(e.to_string()),
+                                trace_id: Some(trace_id.to_string()),
+                            },
+                        })
+                        .await;
+                    }
+                }
+
+                if let Err(e) = sender.send(Err(e)).await {
+                    log::error!(
+                        "[HTTP2_STREAM] Error sending error message to client: {}",
+                        e
+                    );
+                }
+                return;
+            }
+        } else {
+            // Step 2: Search without cache
+            // no caches found process req directly
+            log::info!(
+                "[HTTP2_STREAM] trace_id: {} No cache found, processing search request",
+                trace_id
+            );
+
+            let size = req.query.size;
+            if let Err(e) = do_partitioned_search(
+                &mut req,
+                &trace_id,
+                &org_id,
+                stream_type,
+                size,
+                &user_id,
+                &mut accumulated_results,
+                max_query_range,
+                &mut start,
+                &req_order_by,
+                sender.clone(),
+                values_ctx,
+                fallback_order_by_col,
+            )
+            .instrument(search_span.clone())
+            .await
+            {
+                // send audit response first
+                #[cfg(feature = "enterprise")]
+                {
+                    let resp = map_error_to_http_response(&e, None).status().into();
+                    if get_o2_config().common.audit_enabled {
+                        // Using spawn to handle the async call
+                        audit(AuditMessage {
+                            user_email: user_id,
+                            org_id,
+                            _timestamp: chrono::Utc::now().timestamp(),
+                            protocol: Protocol::Http,
+                            response_meta: ResponseMeta {
+                                http_method: _audit_ctx.as_ref().unwrap().method.to_string(),
+                                http_path: _audit_ctx.as_ref().unwrap().path.to_string(),
+                                http_query_params: _audit_ctx
+                                    .as_ref()
+                                    .unwrap()
+                                    .query_params
+                                    .to_string(),
+                                http_body: _audit_ctx.as_ref().unwrap().body.to_string(),
+                                http_response_code: resp,
+                                error_msg: Some(e.to_string()),
+                                trace_id: Some(trace_id.to_string()),
+                            },
+                        })
+                        .await;
+                    }
+                }
+
+                if let Err(e) = sender.send(Err(e)).await {
+                    log::error!(
+                        "[HTTP2_STREAM] Error sending error message to client: {}",
+                        e
+                    );
+                }
+                return;
+            }
+        }
+        // Step 3: Write to results cache
+        // cache only if from is 0 and is not an aggregate_query
+        if req.query.from == 0 {
+            if let Err(e) =
+                write_results_to_cache(c_resp, start_time, end_time, &mut accumulated_results)
+                    .instrument(search_span.clone())
+                    .await
+                    .map_err(|e| {
+                        log::error!(
+                            "[HTTP2_STREAM] trace_id: {}, Error writing results to cache: {:?}",
+                            trace_id,
+                            e
+                        );
+                        e
+                    })
+            {
+                // send audit response first
+                #[cfg(feature = "enterprise")]
+                {
+                    let resp = map_error_to_http_response(&e, None).status().into();
+                    if get_o2_config().common.audit_enabled {
+                        // Using spawn to handle the async call
+                        audit(AuditMessage {
+                            user_email: user_id,
+                            org_id,
+                            _timestamp: chrono::Utc::now().timestamp(),
+                            protocol: Protocol::Http,
+                            response_meta: ResponseMeta {
+                                http_method: _audit_ctx.as_ref().unwrap().method.to_string(),
+                                http_path: _audit_ctx.as_ref().unwrap().path.to_string(),
+                                http_query_params: _audit_ctx
+                                    .as_ref()
+                                    .unwrap()
+                                    .query_params
+                                    .to_string(),
+                                http_body: _audit_ctx.as_ref().unwrap().body.to_string(),
+                                http_response_code: resp,
+                                error_msg: Some(e.to_string()),
+                                trace_id: Some(trace_id.to_string()),
+                            },
+                        })
+                        .await;
+                    }
+                }
+
+                if let Err(e) = sender.send(Err(e)).await {
+                    log::error!(
+                        "[HTTP2_STREAM] Error sending error message to client: {}",
+                        e
+                    );
+                }
+                return;
+            }
+        }
+    } else {
+        // Step 4: Search without cache for req with from > 0
+        let size = req.query.size;
+        if let Err(e) = do_partitioned_search(
+            &mut req,
+            &trace_id,
+            &org_id,
+            stream_type,
+            size,
+            &user_id,
+            &mut accumulated_results,
+            max_query_range,
+            &mut start,
+            &req_order_by,
+            sender.clone(),
+            values_ctx,
+            fallback_order_by_col,
+        )
+        .instrument(search_span.clone())
+        .await
+        {
+            // send audit response first
+            #[cfg(feature = "enterprise")]
+            {
+                let resp = map_error_to_http_response(&e, None).status().into();
+                if get_o2_config().common.audit_enabled {
+                    // Using spawn to handle the async call
+                    audit(AuditMessage {
+                        user_email: user_id,
+                        org_id,
+                        _timestamp: chrono::Utc::now().timestamp(),
+                        protocol: Protocol::Http,
+                        response_meta: ResponseMeta {
+                            http_method: _audit_ctx.as_ref().unwrap().method.to_string(),
+                            http_path: _audit_ctx.as_ref().unwrap().path.to_string(),
+                            http_query_params: _audit_ctx
+                                .as_ref()
+                                .unwrap()
+                                .query_params
+                                .to_string(),
+                            http_body: _audit_ctx.as_ref().unwrap().body.to_string(),
+                            http_response_code: resp,
+                            error_msg: Some(e.to_string()),
+                            trace_id: Some(trace_id.to_string()),
+                        },
+                    })
+                    .await;
+                }
+            }
+
+            if let Err(e) = sender.send(Err(e)).await {
+                log::error!(
+                    "[HTTP2_STREAM] Error sending error message to client: {}",
+                    e
+                );
+            }
+            return;
+        }
+    }
+
+    // Once all searches are complete, write the accumulated results to a file
+    log::info!(
+        "[HTTP2_STREAM] trace_id {} stream took {:?}",
+        trace_id,
+        start.elapsed()
+    );
+
+    #[cfg(feature = "enterprise")]
+    {
+        if get_o2_config().common.audit_enabled {
+            // Using spawn to handle the async call
+            audit(AuditMessage {
+                user_email: user_id,
+                org_id,
+                _timestamp: chrono::Utc::now().timestamp(),
+                protocol: Protocol::Http,
+                response_meta: ResponseMeta {
+                    http_method: _audit_ctx.as_ref().unwrap().method.to_string(),
+                    http_path: _audit_ctx.as_ref().unwrap().path.to_string(),
+                    http_query_params: _audit_ctx.as_ref().unwrap().query_params.to_string(),
+                    http_body: _audit_ctx.as_ref().unwrap().body.to_string(),
+                    http_response_code: 200,
+                    error_msg: None,
+                    trace_id: Some(trace_id.to_string()),
+                },
+            })
+            .await;
+        }
+    }
+
+    // Send a completion signal
+    if let Err(e) = sender
+        .send(Ok(config::meta::search::StreamResponses::Done))
+        .await
+    {
+        log::error!(
+            "[HTTP2_STREAM] Error sending completion message to client: {}",
+            e
+        );
+    }
+}
+
+// Do partitioned search without cache
+#[tracing::instrument(name = "service:search::http::do_partitioned_search", skip_all)]
+#[allow(clippy::too_many_arguments)]
+pub async fn do_partitioned_search(
+    req: &mut config::meta::search::Request,
+    trace_id: &str,
+    org_id: &str,
+    stream_type: StreamType,
+    req_size: i64,
+    user_id: &str,
+    accumulated_results: &mut Vec<SearchResultType>,
+    max_query_range: i64, // hours
+    start_timer: &mut Instant,
+    req_order_by: &OrderBy,
+    sender: mpsc::Sender<Result<StreamResponses, infra::errors::Error>>,
+    values_ctx: Option<ValuesEventContext>,
+    fallback_order_by_col: Option<String>,
+) -> Result<(), infra::errors::Error> {
+    // limit the search by max_query_range
+    let mut range_error = String::new();
+    if max_query_range > 0
+        && (req.query.end_time - req.query.start_time) > max_query_range * 3600 * 1_000_000
+    {
+        req.query.start_time = req.query.end_time - max_query_range * 3600 * 1_000_000;
+        log::info!(
+            "[HTTP2_STREAM] Query duration is modified due to query range restriction of {} hours, new start_time: {}",
+            max_query_range,
+            req.query.start_time
+        );
+        range_error = format!(
+            "Query duration is modified due to query range restriction of {} hours",
+            max_query_range
+        );
+    }
+    // for new_start_time & new_end_time
+    let modified_start_time = req.query.start_time;
+    let modified_end_time = req.query.end_time;
+
+    let partition_resp = get_partitions(trace_id, org_id, stream_type, req, user_id).await?;
+
+    let mut partitions = partition_resp.partitions;
+
+    if partitions.is_empty() {
+        return Ok(());
+    }
+
+    // check if `streaming_aggs` is supported
+    let is_streaming_aggs = partition_resp.streaming_aggs;
+    if is_streaming_aggs {
+        req.query.streaming_output = true;
+        req.query.streaming_id = partition_resp.streaming_id.clone();
+    }
+
+    // The order by for the partitions is the same as the order by in the query
+    // unless the query is a dashboard or histogram
+    let mut partition_order_by = req_order_by;
+    // sort partitions in desc by _timestamp for dashboards & histograms
+    if req.search_type.expect("populate search_type") == SearchEventType::Dashboards
+        || req.query.size == -1
+    {
+        partitions.sort_by(|a, b| b[0].cmp(&a[0]));
+        partition_order_by = &OrderBy::Desc;
+    }
+
+    let mut curr_res_size = 0;
+
+    log::info!(
+        "[HTTP2_STREAM] Found {} partitions for trace_id: {}, partitions: {:?}",
+        partitions.len(),
+        trace_id,
+        &partitions
+    );
+
+    for (idx, &[start_time, end_time]) in partitions.iter().enumerate() {
+        let mut req = req.clone();
+        req.query.start_time = start_time;
+        req.query.end_time = end_time;
+
+        if req_size != -1 && !is_streaming_aggs {
+            req.query.size -= curr_res_size;
+        }
+
+        // do not use cache for partitioned search without cache
+        let mut search_res = do_search(trace_id, org_id, stream_type, &req, user_id, false).await?;
+
+        curr_res_size += search_res.hits.len() as i64;
+
+        if !search_res.hits.is_empty() {
+            search_res = order_search_results(search_res, fallback_order_by_col.clone());
+
+            // set took
+            search_res.set_took(start_timer.elapsed().as_millis() as usize);
+            // reset start time
+            *start_timer = Instant::now();
+
+            // check range error
+            if !range_error.is_empty() {
+                search_res.is_partial = true;
+                search_res.function_error = if search_res.function_error.is_empty() {
+                    vec![range_error.clone()]
+                } else {
+                    search_res.function_error.push(range_error.clone());
+                    search_res.function_error
+                };
+                search_res.new_start_time = Some(modified_start_time);
+                search_res.new_end_time = Some(modified_end_time);
+            }
+
+            // Accumulate the result
+            if is_streaming_aggs {
+                // Only accumulate the results of the last partition
+                if idx == partitions.len() - 1 {
+                    accumulated_results.push(SearchResultType::Search(search_res.clone()));
+                }
+            } else {
+                accumulated_results.push(SearchResultType::Search(search_res.clone()));
+            }
+
+            // add top k values for values search
+            if req.search_type == Some(SearchEventType::Values) && values_ctx.is_some() {
+                let search_stream_span = tracing::info_span!(
+                    "src::handler::http::request::search::process_stream::do_partitioned_search::get_top_k_values",
+                    org_id = %org_id,
+                );
+                let instant = Instant::now();
+                let field = values_ctx.as_ref().unwrap().field.clone();
+                let top_k = values_ctx.as_ref().unwrap().top_k.unwrap_or(10);
+                let no_count = values_ctx.as_ref().unwrap().no_count;
+                let top_k_values = tokio::task::spawn_blocking(move || {
+                    get_top_k_values(&search_res.hits, &field, top_k, no_count)
+                })
+                .instrument(search_stream_span.clone())
+                .await
+                .unwrap();
+                search_res.hits = top_k_values?;
+                let duration = instant.elapsed();
+                log::debug!("Top k values for partition {idx} took {:?}", duration);
+            }
+
+            // Send the cached response
+            let response = StreamResponses::SearchResponse {
+                results: search_res.clone(),
+                streaming_aggs: is_streaming_aggs,
+                time_offset: TimeOffset {
+                    start_time,
+                    end_time,
+                },
+            };
+
+            if let Err(e) = sender.send(Ok(response)).await {
+                log::error!("Error sending response: {}", e);
+                return Err(infra::errors::Error::Message(
+                    "Error sending response".to_string(),
+                ));
+            }
+        }
+
+        // Send progress update
+        {
+            let percent = calculate_progress_percentage(
+                start_time,
+                end_time,
+                modified_start_time,
+                modified_end_time,
+                partition_order_by,
+            );
+            if let Err(e) = sender.send(Ok(StreamResponses::Progress { percent })).await {
+                log::error!("Error sending progress: {}", e);
+                return Err(infra::errors::Error::Message(
+                    "Error sending progress".to_string(),
+                ));
+            }
+        }
+        // Stop if reached the requested result size and it is not a streaming aggs query
+        if req_size != -1 && req_size != 0 && curr_res_size >= req_size && !is_streaming_aggs {
+            log::info!(
+                "[HTTP2_STREAM]: Reached requested result size ({}), stopping search",
+                req_size
+            );
+            break;
+        }
+    }
+
+    // Remove the streaming_aggs cache
+    if is_streaming_aggs && partition_resp.streaming_id.is_some() {
+        streaming_aggs_exec::remove_cache(&partition_resp.streaming_id.unwrap())
+    }
+    Ok(())
+}
+
+async fn get_partitions(
+    trace_id: &str,
+    org_id: &str,
+    stream_type: StreamType,
+    req: &config::meta::search::Request,
+    user_id: &str,
+) -> Result<SearchPartitionResponse, infra::errors::Error> {
+    let search_partition_req = SearchPartitionRequest {
+        sql: req.query.sql.clone(),
+        start_time: req.query.start_time,
+        end_time: req.query.end_time,
+        encoding: req.encoding,
+        regions: req.regions.clone(),
+        clusters: req.clusters.clone(),
+        // vrl is not required for _search_partition
+        query_fn: Default::default(),
+        streaming_output: true,
+    };
+
+    let res = SearchService::search_partition(
+        trace_id,
+        org_id,
+        Some(user_id),
+        stream_type,
+        &search_partition_req,
+        false,
+    )
+    .instrument(tracing::info_span!(
+        "src::handler::http::request::search::test_stream::get_partitions"
+    ))
+    .await?;
+
+    Ok(res)
+}
+
+#[tracing::instrument(name = "service:search:http::do_search", skip_all)]
+async fn do_search(
+    trace_id: &str,
+    org_id: &str,
+    stream_type: StreamType,
+    req: &config::meta::search::Request,
+    user_id: &str,
+    use_cache: bool,
+) -> Result<Response, infra::errors::Error> {
+    let mut req = req.clone();
+
+    req.use_cache = Some(use_cache);
+    let res = SearchService::cache::search(
+        trace_id,
+        org_id,
+        stream_type,
+        Some(user_id.to_string()),
+        &req,
+        "".to_string(),
+    )
+    .await;
+
+    res.map(handle_partial_response)
+}
+
+fn handle_partial_response(mut res: Response) -> Response {
+    if res.is_partial {
+        res.function_error = if res.function_error.is_empty() {
+            vec![PARTIAL_ERROR_RESPONSE_MESSAGE.to_string()]
+        } else {
+            res.function_error
+                .push(PARTIAL_ERROR_RESPONSE_MESSAGE.to_string());
+            res.function_error
+        };
+    }
+    res
+}
+
+#[tracing::instrument(
+    name = "service:search:http::handle_cache_responses_and_deltas",
+    skip_all
+)]
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_cache_responses_and_deltas(
+    req: &mut config::meta::search::Request,
+    req_size: i64,
+    trace_id: &str,
+    org_id: &str,
+    stream_type: StreamType,
+    mut cached_resp: Vec<CachedQueryResponse>,
+    mut deltas: Vec<QueryDelta>,
+    accumulated_results: &mut Vec<SearchResultType>,
+    user_id: &str,
+    max_query_range: i64,
+    remaining_query_range: i64,
+    req_order_by: &OrderBy,
+    fallback_order_by_col: Option<String>,
+    start_timer: &mut Instant,
+    sender: mpsc::Sender<Result<StreamResponses, infra::errors::Error>>,
+    values_ctx: Option<ValuesEventContext>,
+) -> Result<(), infra::errors::Error> {
+    // Force set order_by to desc for dashboards & histogram
+    // so that deltas are processed in the reverse order
+    let cache_order_by = if req.search_type.expect("search_type is required")
+        == SearchEventType::Dashboards
+        || req.query.size == -1
+    {
+        &OrderBy::Desc
+    } else {
+        req_order_by
+    };
+
+    // sort both deltas and cache by order_by
+    match cache_order_by {
+        OrderBy::Desc => {
+            deltas.sort_by(|a, b| b.delta_start_time.cmp(&a.delta_start_time));
+            cached_resp.sort_by(|a, b| b.response_start_time.cmp(&a.response_start_time));
+        }
+        OrderBy::Asc => {
+            deltas.sort_by(|a, b| a.delta_start_time.cmp(&b.delta_start_time));
+            cached_resp.sort_by(|a, b| a.response_start_time.cmp(&b.response_start_time));
+        }
+    }
+
+    // Initialize iterators for deltas and cached responses
+    let mut delta_iter = deltas.iter().peekable();
+    let mut cached_resp_iter = cached_resp.iter().peekable();
+    let mut curr_res_size = 0; // number of records
+
+    let mut remaining_query_range = remaining_query_range as f64; // hours
+    let cache_start_time = cached_resp
+        .first()
+        .map(|c| c.response_start_time)
+        .unwrap_or_default();
+    let cache_end_time = cached_resp
+        .last()
+        .map(|c| c.response_end_time)
+        .unwrap_or_default();
+    let cache_duration = cache_end_time - cache_start_time; // microseconds
+    let cached_search_duration = cache_duration + (max_query_range * 3600 * 1_000_000); // microseconds
+
+    log::info!(
+        "[HTTP2_STREAM] trace_id: {}, Handling cache response and deltas, curr_res_size: {}, cached_search_duration: {}, remaining_query_duration: {}, deltas_len: {}, cache_start_time: {}, cache_end_time: {}",
+        trace_id,
+        curr_res_size,
+        cached_search_duration,
+        remaining_query_range,
+        deltas.len(),
+        cache_start_time,
+        cache_end_time,
+    );
+
+    // Process cached responses and deltas in sorted order
+    while cached_resp_iter.peek().is_some() || delta_iter.peek().is_some() {
+        if let (Some(&delta), Some(cached)) = (delta_iter.peek(), cached_resp_iter.peek()) {
+            // If the delta is before the current cached response time, fetch partitions
+            log::info!(
+                "[HTTP2_STREAM] checking delta: {:?} with cached start_time: {:?}, end_time:{}",
+                delta,
+                cached.response_start_time,
+                cached.response_end_time,
+            );
+            // Compare delta and cached response based on the order
+            let process_delta_first = match cache_order_by {
+                OrderBy::Asc => delta.delta_end_time <= cached.response_start_time,
+                OrderBy::Desc => delta.delta_start_time >= cached.response_end_time,
+            };
+
+            if process_delta_first {
+                log::info!(
+                    "[HTTP2_STREAM] trace_id: {} Processing delta before cached response, order_by: {:#?}",
+                    trace_id,
+                    cache_order_by
+                );
+                process_delta(
+                    req,
+                    trace_id,
+                    org_id,
+                    stream_type,
+                    delta,
+                    req_size,
+                    accumulated_results,
+                    &mut curr_res_size,
+                    user_id,
+                    &mut remaining_query_range,
+                    cached_search_duration,
+                    start_timer,
+                    cache_order_by,
+                    sender.clone(),
+                    values_ctx.clone(),
+                )
+                .await?;
+                delta_iter.next(); // Move to the next delta after processing
+            } else {
+                // Send cached response
+                send_cached_responses(
+                    req,
+                    trace_id,
+                    req_size,
+                    cached,
+                    &mut curr_res_size,
+                    accumulated_results,
+                    fallback_order_by_col.clone(),
+                    cache_order_by,
+                    start_timer,
+                    sender.clone(),
+                )
+                .await?;
+                cached_resp_iter.next();
+            }
+        } else if let Some(&delta) = delta_iter.peek() {
+            // Process remaining deltas
+            log::info!(
+                "[HTTP2_STREAM] trace_id: {} Processing remaining delta",
+                trace_id
+            );
+            process_delta(
+                req,
+                trace_id,
+                org_id,
+                stream_type,
+                delta,
+                req_size,
+                accumulated_results,
+                &mut curr_res_size,
+                user_id,
+                &mut remaining_query_range,
+                cached_search_duration,
+                start_timer,
+                cache_order_by,
+                sender.clone(),
+                values_ctx.clone(),
+            )
+            .await?;
+            delta_iter.next(); // Move to the next delta after processing
+        } else if let Some(cached) = cached_resp_iter.next() {
+            // Process remaining cached responses
+            send_cached_responses(
+                req,
+                trace_id,
+                req_size,
+                cached,
+                &mut curr_res_size,
+                accumulated_results,
+                fallback_order_by_col.clone(),
+                cache_order_by,
+                start_timer,
+                sender.clone(),
+            )
+            .await?;
+        }
+
+        // Stop if reached the requested result size
+        if req_size != -1 && curr_res_size >= req_size {
+            log::info!(
+                "[HTTP2_STREAM] trace_id: {} Reached requested result size: {}, stopping search",
+                trace_id,
+                req_size
+            );
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+// Process a single delta (time range not covered by cache)
+#[allow(clippy::too_many_arguments)]
+async fn process_delta(
+    req: &mut config::meta::search::Request,
+    trace_id: &str,
+    org_id: &str,
+    stream_type: StreamType,
+    delta: &QueryDelta,
+    req_size: i64,
+    accumulated_results: &mut Vec<SearchResultType>,
+    curr_res_size: &mut i64,
+    user_id: &str,
+    remaining_query_range: &mut f64,
+    cache_req_duration: i64,
+    start_timer: &mut Instant,
+    cache_order_by: &OrderBy,
+    sender: mpsc::Sender<Result<StreamResponses, infra::errors::Error>>,
+    values_ctx: Option<ValuesEventContext>,
+) -> Result<(), infra::errors::Error> {
+    log::info!(
+        "[HTTP2_STREAM]: Processing delta for trace_id: {}, delta: {:?}",
+        trace_id,
+        delta
+    );
+    let mut req = req.clone();
+    let original_req_start_time = req.query.start_time;
+    let original_req_end_time = req.query.end_time;
+    req.query.start_time = delta.delta_start_time;
+    req.query.end_time = delta.delta_end_time;
+
+    let partition_resp = get_partitions(trace_id, org_id, stream_type, &req, user_id).await?;
+    let mut partitions = partition_resp.partitions;
+
+    if partitions.is_empty() {
+        return Ok(());
+    }
+
+    // check if `streaming_aggs` is supported
+    let is_streaming_aggs = partition_resp.streaming_aggs;
+    if is_streaming_aggs {
+        req.query.streaming_output = true;
+        req.query.streaming_id = partition_resp.streaming_id.clone();
+    }
+
+    log::info!(
+        "[HTTP2_STREAM] Found {} partitions for trace_id: {}",
+        partitions.len(),
+        trace_id
+    );
+
+    // for dashboards & histograms
+    if req.search_type.expect("search_type is required") == SearchEventType::Dashboards
+        || req.query.size == -1
+    {
+        // sort partitions by timestamp in desc
+        partitions.sort_by(|a, b| b[0].cmp(&a[0]));
+    }
+
+    for (idx, &[start_time, end_time]) in partitions.iter().enumerate() {
+        let mut req = req.clone();
+        req.query.start_time = start_time;
+        req.query.end_time = end_time;
+
+        if req_size != -1 {
+            req.query.size -= *curr_res_size;
+        }
+
+        // use cache for delta search
+        let mut search_res = do_search(trace_id, org_id, stream_type, &req, user_id, true).await?;
+        *curr_res_size += search_res.hits.len() as i64;
+
+        log::info!(
+            "[HTTP2_STREAM]: Found {} hits, for trace_id: {}",
+            search_res.hits.len(),
+            trace_id
+        );
+
+        if !search_res.hits.is_empty() {
+            // search_res = order_search_results(search_res, req.fallback_order_by_col.clone());
+            // for every partition, compute the queried range omitting the result cache ratio
+            let queried_range =
+                calc_queried_range(start_time, end_time, search_res.result_cache_ratio);
+            *remaining_query_range -= queried_range;
+
+            // set took
+            search_res.set_took(start_timer.elapsed().as_millis() as usize);
+            // reset start timer
+            *start_timer = Instant::now();
+
+            // when searching with limit queries
+            // the limit in sql takes precedence over the requested size
+            // hence, the search result needs to be trimmed when the req limit is reached
+            if *curr_res_size > req_size {
+                let excess_hits = *curr_res_size - req_size;
+                let total_hits = search_res.hits.len() as i64;
+                if total_hits > excess_hits {
+                    let cache_hits: usize = (total_hits - excess_hits) as usize;
+                    search_res.hits.truncate(cache_hits);
+                    search_res.total = cache_hits;
+                }
+            }
+
+            // Accumulate the result
+            if is_streaming_aggs {
+                // Only accumulate the results of the last partition
+                if idx == partitions.len() - 1 {
+                    accumulated_results.push(SearchResultType::Search(search_res.clone()));
+                }
+            } else {
+                accumulated_results.push(SearchResultType::Search(search_res.clone()));
+            }
+
+            // `result_cache_ratio` will be 0 for delta search
+            let result_cache_ratio = search_res.result_cache_ratio;
+
+            if req.search_type == Some(SearchEventType::Values) && values_ctx.is_some() {
+                let search_stream_span = tracing::info_span!(
+                    "src::handler::http::request::search::process_stream::process_delta::get_top_k_values",
+                    org_id = %org_id,
+                );
+
+                log::debug!("Getting top k values for partition {idx}");
+                let field = values_ctx.as_ref().unwrap().field.clone();
+                let top_k = values_ctx.as_ref().unwrap().top_k.unwrap_or(10);
+                let no_count = values_ctx.as_ref().unwrap().no_count;
+                let top_k_values = tokio::task::spawn_blocking(move || {
+                    get_top_k_values(&search_res.hits, &field, top_k, no_count)
+                })
+                .instrument(search_stream_span.clone())
+                .await
+                .unwrap();
+                search_res.hits = top_k_values?;
+            }
+
+            let response = StreamResponses::SearchResponse {
+                results: search_res.clone(),
+                streaming_aggs: is_streaming_aggs,
+                time_offset: TimeOffset {
+                    start_time,
+                    end_time,
+                },
+            };
+            log::info!(
+                "[HTTP2_STREAM]: Processing deltas for trace_id: {}, hits: {:?}",
+                trace_id,
+                search_res.hits
+            );
+            log::debug!(
+                "[HTTP2_STREAM]: Sending search response for trace_id: {}, delta: {:?}, hits len: {}, result_cache_ratio: {}",
+                trace_id,
+                delta,
+                search_res.hits.len(),
+                result_cache_ratio,
+            );
+            if let Err(e) = sender.send(Ok(response)).await {
+                log::error!("Error sending search response: {}", e);
+                return Err(infra::errors::Error::Message(
+                    "Failed to send search response".to_string(),
+                ));
+            }
+        }
+
+        // Stop if `remaining_query_range` is less than 0
+        if *remaining_query_range <= 0.00 {
+            log::info!(
+                "[HTTP2_STREAM]: trace_id: {} Remaining query range is less than 0, stopping search",
+                trace_id
+            );
+            let (new_start_time, new_end_time) = (
+                original_req_end_time - cache_req_duration,
+                original_req_end_time,
+            );
+            // passs original start_time and end_time partition end time
+            let _ = send_partial_search_resp(
+                trace_id,
+                "reached max query range limit",
+                new_start_time,
+                new_end_time,
+                search_res.order_by,
+                is_streaming_aggs,
+                sender,
+            )
+            .await;
+            break;
+        }
+
+        // Send progress update
+        {
+            let percent = calculate_progress_percentage(
+                start_time,
+                end_time,
+                original_req_start_time,
+                original_req_end_time,
+                cache_order_by,
+            );
+            if let Err(e) = sender.send(Ok(StreamResponses::Progress { percent })).await {
+                log::error!("Error sending progress update: {}", e);
+                return Err(infra::errors::Error::Message(
+                    "Failed to send progress update".to_string(),
+                ));
+            }
+        }
+
+        // Stop if reached the request result size
+        if req_size != -1 && *curr_res_size >= req_size {
+            log::info!(
+                "[HTTP2_STREAM]: Reached requested result size ({}), stopping search",
+                req_size
+            );
+            break;
+        }
+    }
+
+    // Remove the streaming_aggs cache
+    if is_streaming_aggs && partition_resp.streaming_id.is_some() {
+        streaming_aggs_exec::remove_cache(&partition_resp.streaming_id.unwrap())
+    }
+
+    Ok(())
+}
+
+async fn send_partial_search_resp(
+    trace_id: &str,
+    error: &str,
+    new_start_time: i64,
+    new_end_time: i64,
+    order_by: Option<OrderBy>,
+    is_streaming_aggs: bool,
+    sender: mpsc::Sender<Result<StreamResponses, infra::errors::Error>>,
+) -> Result<(), infra::errors::Error> {
+    let error = if error.is_empty() {
+        PARTIAL_ERROR_RESPONSE_MESSAGE.to_string()
+    } else {
+        format!("{} \n {}", PARTIAL_ERROR_RESPONSE_MESSAGE, error)
+    };
+    let s_resp = Response {
+        is_partial: true,
+        function_error: vec![error],
+        new_start_time: Some(new_start_time),
+        new_end_time: Some(new_end_time),
+        order_by,
+        trace_id: trace_id.to_string(),
+        ..Default::default()
+    };
+
+    let response = StreamResponses::SearchResponse {
+        results: s_resp,
+        streaming_aggs: is_streaming_aggs,
+        time_offset: TimeOffset {
+            start_time: new_start_time,
+            end_time: new_end_time,
+        },
+    };
+    log::info!(
+        "[HTTP2_STREAM]: trace_id: {} Sending partial search response",
+        trace_id
+    );
+
+    if let Err(e) = sender.send(Ok(response)).await {
+        log::error!("Error sending partial search response: {}", e);
+        return Err(infra::errors::Error::Message(
+            "Error sending partial search response".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn send_cached_responses(
+    req: &mut config::meta::search::Request,
+    trace_id: &str,
+    req_size: i64,
+    cached: &CachedQueryResponse,
+    curr_res_size: &mut i64,
+    accumulated_results: &mut Vec<SearchResultType>,
+    fallback_order_by_col: Option<String>,
+    cache_order_by: &OrderBy,
+    start_timer: &mut Instant,
+    sender: mpsc::Sender<Result<StreamResponses, infra::errors::Error>>,
+) -> Result<(), infra::errors::Error> {
+    log::info!(
+        "[HTTP2_STREAM]: Processing cached response for trace_id: {}",
+        trace_id
+    );
+
+    let mut cached = cached.clone();
+
+    // add cache hits to `curr_res_size`
+    *curr_res_size += cached.cached_response.hits.len() as i64;
+
+    // truncate hits if `curr_res_size` is greater than `req_size`
+    if req_size != -1 && *curr_res_size > req_size {
+        let excess_hits = *curr_res_size - req_size;
+        let total_hits = cached.cached_response.hits.len() as i64;
+        if total_hits > excess_hits {
+            let cache_hits: usize = (total_hits - excess_hits) as usize;
+            cached.cached_response.hits.truncate(cache_hits);
+            cached.cached_response.total = cache_hits;
+        }
+    }
+
+    cached.cached_response = order_search_results(cached.cached_response, fallback_order_by_col);
+
+    accumulated_results.push(SearchResultType::Cached(cached.cached_response.clone()));
+
+    // `result_cache_ratio` for cached response is 100
+    cached.cached_response.result_cache_ratio = 100;
+    // `scan_size` is 0, as it is not used for cached responses
+    cached.cached_response.scan_size = 0;
+
+    // set took
+    cached
+        .cached_response
+        .set_took(start_timer.elapsed().as_millis() as usize);
+    // reset start timer
+    *start_timer = Instant::now();
+
+    log::info!(
+        "[HTTP2_STREAM]: Sending cached search response for trace_id: {}, hits: {}, result_cache_ratio: {}",
+        trace_id,
+        cached.cached_response.hits.len(),
+        cached.cached_response.result_cache_ratio,
+    );
+    let response = StreamResponses::SearchResponse {
+        results: cached.cached_response,
+        streaming_aggs: false,
+        time_offset: TimeOffset {
+            start_time: cached.response_start_time,
+            end_time: cached.response_end_time,
+        },
+    };
+    if let Err(e) = sender.send(Ok(response)).await {
+        log::error!("Error sending cached search response: {}", e);
+        return Err(infra::errors::Error::Message(
+            "Error sending cached search response".to_string(),
+        ));
+    }
+
+    {
+        let percent = calculate_progress_percentage(
+            cached.response_start_time,
+            cached.response_end_time,
+            req.query.start_time,
+            req.query.end_time,
+            cache_order_by,
+        );
+        sender
+            .send(Ok(StreamResponses::Progress { percent }))
+            .await
+            .unwrap();
+    }
+
+    Ok(())
+}
+
+/// This function will compute top k values for values request
+#[tracing::instrument(name = "service:search:http::get_top_k_values", skip_all)]
+pub fn get_top_k_values(
+    hits: &Vec<Value>,
+    field: &str,
+    top_k: i64,
+    no_count: bool,
+) -> Result<Vec<Value>, infra::errors::Error> {
+    let mut top_k_values: Vec<Value> = Vec::new();
+
+    if field.is_empty() {
+        log::error!("Field is empty for values search");
+        return Err(infra::errors::Error::Message("field is empty".to_string()));
+    }
+
+    let k_limit = top_k;
+
+    let mut search_result_hits = Vec::new();
+    for hit in hits {
+        let key: String = hit
+            .get("zo_sql_key")
+            .map(get_string_value)
+            .unwrap_or_default();
+        let num = hit
+            .get("zo_sql_num")
+            .and_then(|v| v.as_i64())
+            .unwrap_or_default();
+        search_result_hits.push((key, num));
+    }
+
+    if no_count {
+        // For alphabetical sorting, collect all entries first
+        let mut all_entries: Vec<_> = search_result_hits;
+        all_entries.sort_by(|a, b| a.0.cmp(&b.0));
+        all_entries.truncate(k_limit as usize);
+
+        let top_hits = all_entries
+            .into_iter()
+            .map(|(k, v)| {
+                let mut item = Map::new();
+                item.insert("zo_sql_key".to_string(), Value::String(k));
+                item.insert("zo_sql_num".to_string(), Value::Number(v.into()));
+                Value::Object(item)
+            })
+            .collect::<Vec<_>>();
+
+        let mut field_value: Map<String, Value> = Map::new();
+        field_value.insert("field".to_string(), Value::String(field.to_string()));
+        field_value.insert("values".to_string(), Value::Array(top_hits));
+        top_k_values.push(Value::Object(field_value));
+    } else {
+        // For value-based sorting, use a min heap to get top k elements
+        let mut min_heap: BinaryHeap<Reverse<(i64, String)>> =
+            BinaryHeap::with_capacity(k_limit as usize);
+        for (k, v) in search_result_hits {
+            if min_heap.len() < k_limit as usize {
+                // If heap not full, just add
+                min_heap.push(Reverse((v, k)));
+            } else if !min_heap.is_empty() && v > min_heap.peek().unwrap().0.0 {
+                // If current value is larger than smallest in heap, replace it
+                min_heap.pop();
+                min_heap.push(Reverse((v, k)));
+            }
+        }
+
+        // Convert heap to vector and sort in descending order
+        let mut top_elements: Vec<_> = min_heap.into_iter().map(|Reverse((v, k))| (k, v)).collect();
+        top_elements.sort_by(|a, b| b.1.cmp(&a.1));
+
+        let top_hits = top_elements
+            .into_iter()
+            .map(|(k, v)| {
+                let mut item = Map::new();
+                item.insert("zo_sql_key".to_string(), Value::String(k));
+                item.insert("zo_sql_num".to_string(), Value::Number(v.into()));
+                Value::Object(item)
+            })
+            .collect::<Vec<_>>();
+
+        let mut field_value: Map<String, Value> = Map::new();
+        field_value.insert("field".to_string(), Value::String(field.to_string()));
+        field_value.insert("values".to_string(), Value::Array(top_hits));
+        top_k_values.push(Value::Object(field_value));
+    }
+
+    Ok(top_k_values)
+}

--- a/src/service/search/search_stream.rs
+++ b/src/service/search/search_stream.rs
@@ -1116,7 +1116,7 @@ async fn process_delta(
                 original_req_end_time - cache_req_duration,
                 original_req_end_time,
             );
-            // passs original start_time and end_time partition end time
+            // pass original start_time and end_time partition end time
             let _ = send_partial_search_resp(
                 trace_id,
                 "reached max query range limit",
@@ -1291,10 +1291,15 @@ async fn send_cached_responses(
             req.query.end_time,
             cache_order_by,
         );
-        sender
+        if let Err(e) = sender
             .send(Ok(StreamResponses::Progress { percent }))
             .await
-            .unwrap();
+        {
+            log::error!("Error sending progress update: {}", e);
+            return Err(infra::errors::Error::Message(
+                "Error sending progress update".to_string(),
+            ));
+        }
     }
 
     Ok(())

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -20,7 +20,7 @@ use config::{
     meta::{
         search::{
             PARTIAL_ERROR_RESPONSE_MESSAGE, Response, SearchEventType, SearchPartitionRequest,
-            SearchPartitionResponse, ValuesEventContext,
+            SearchPartitionResponse, TimeOffset, ValuesEventContext,
         },
         sql::{OrderBy, resolve_stream_names},
         websocket::{MAX_QUERY_RANGE_LIMIT_ERROR_MESSAGE, SearchEventReq, SearchResultType},
@@ -50,7 +50,7 @@ use crate::{
             sql::Sql,
         },
         setup_tracing_with_trace_id,
-        websocket_events::{TimeOffset, WsServerEvents, calculate_progress_percentage},
+        websocket_events::{WsServerEvents, calculate_progress_percentage},
     },
 };
 
@@ -1061,7 +1061,7 @@ pub async fn do_partitioned_search(
         }
 
         // Stop if reached the requested result size and it is not a streaming aggs query
-        if req_size != -1 && curr_res_size >= req_size && !is_streaming_aggs {
+        if req_size != -1 && req_size != 0 && curr_res_size >= req_size && !is_streaming_aggs {
             log::info!(
                 "[WS_SEARCH]: Reached requested result size ({}), stopping search",
                 req_size

--- a/src/service/websocket_events/utils.rs
+++ b/src/service/websocket_events/utils.rs
@@ -15,6 +15,7 @@
 
 use actix_web::http::StatusCode;
 use config::meta::{
+    search::TimeOffset,
     sql::OrderBy,
     websocket::{SearchEventReq, ValuesEventReq},
 };
@@ -322,13 +323,6 @@ impl WsClientEvents {
             _ => {}
         }
     }
-}
-
-/// To represent the query start and end time based of partition or cache
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct TimeOffset {
-    pub start_time: i64,
-    pub end_time: i64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/web/src/components/settings/General.vue
+++ b/web/src/components/settings/General.vue
@@ -46,8 +46,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           v-model="enableWebsocketSearch"
           :label="t('settings.enableWebsocketSearch')"
           data-test="general-settings-enable-websocket"
-          class="q-py-md showLabelOnTop"
+          class="q-pt-md q-pb-md showLabelOnTop"
         />
+
+        <q-toggle
+          v-if="store.state.zoConfig.streaming_enabled"
+          v-model="enableStreamingSearch"
+          :label="t('settings.enableStreamingSearch')"
+          data-test="general-settings-enable-streaming"
+          class="q-pb-lg showLabelOnTop"
+        />
+
         <span>&nbsp;</span>
 
         <div class="flex justify-start">
@@ -256,6 +265,11 @@ export default defineComponent({
         ?.enable_websocket_search ?? false,
     );
 
+    const enableStreamingSearch = ref(
+      store.state?.organizationData?.organizationSettings
+        ?.enable_streaming_search ?? false,
+    );
+
     const loadingState = ref(false);
     const customText = ref("");
     const editingText = ref(false);
@@ -271,6 +285,10 @@ export default defineComponent({
       enableWebsocketSearch.value =
         store.state?.organizationData?.organizationSettings
           ?.enable_websocket_search ?? false;
+
+      enableStreamingSearch.value =
+        store.state?.organizationData?.organizationSettings
+          ?.enable_streaming_search ?? false;
     });
 
     watch(
@@ -290,6 +308,7 @@ export default defineComponent({
           ...store.state?.organizationData?.organizationSettings,
           scrape_interval: scrapeIntereval.value,
           enable_websocket_search: enableWebsocketSearch.value,
+          enable_streaming_search: enableStreamingSearch.value,
         });
 
         //update settings in backend
@@ -514,6 +533,7 @@ export default defineComponent({
       updateCustomText,
       confirmDeleteImage: ref(false),
       sanitizeInput,
+      enableStreamingSearch,
     };
   },
 });

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -39,12 +39,14 @@ import {
   b64EncodeUnicode,
   generateTraceContext,
   isWebSocketEnabled,
+  isStreamingEnabled,
 } from "@/utils/zincutils";
 import { usePanelCache } from "./usePanelCache";
 import { isEqual, omit } from "lodash-es";
 import { convertOffsetToSeconds } from "@/utils/dashboard/convertDataIntoUnitValue";
 import useSearchWebSocket from "@/composables/useSearchWebSocket";
 import { useAnnotations } from "./useAnnotations";
+import useHttpStreamingSearch from "../useStreamingSearch";
 
 /**
  * debounce time in milliseconds for panel data loader
@@ -84,6 +86,14 @@ export const usePanelDataLoader = (
     cancelSearchQueryBasedOnRequestId,
     cleanUpListeners,
   } = useSearchWebSocket();
+
+  const {
+    fetchQueryDataWithHttpStream,
+    cancelStreamQueryBasedOnRequestId,
+    closeStreamWithError,
+    closeStream,
+    resetAuthToken,
+  } = useHttpStreamingSearch();
 
   const { refreshAnnotations } = useAnnotations(
     store.state.selectedOrganization.identifier,
@@ -635,32 +645,90 @@ export const usePanelDataLoader = (
 
     // if streaming aggs, replace the state data
     if (streaming_aggs) {
-      state.data[payload?.queryReq?.currentQueryIndex] = [
+      state.data[payload?.meta?.currentQueryIndex] = [
         ...(searchRes?.content?.results?.hits ?? {}),
       ];
     }
     // if order by is desc, append new partition response at end
     else if (searchRes?.content?.results?.order_by?.toLowerCase() === "asc") {
       // else append new partition response at start
-      state.data[payload?.queryReq?.currentQueryIndex] = [
+      state.data[payload?.meta?.currentQueryIndex] = [
         ...(searchRes?.content?.results?.hits ?? {}),
-        ...(state.data[payload?.queryReq?.currentQueryIndex] ?? []),
+        ...(state.data[payload?.meta?.currentQueryIndex] ?? []),
       ];
     } else {
-      state.data[payload?.queryReq?.currentQueryIndex] = [
-        ...(state.data[payload?.queryReq?.currentQueryIndex] ?? []),
+      state.data[payload?.meta?.currentQueryIndex] = [
+        ...(state.data[payload?.meta?.currentQueryIndex] ?? []),
         ...(searchRes?.content?.results?.hits ?? {}),
       ];
     }
 
     // update result metadata
-    state.resultMetaData[payload?.queryReq?.currentQueryIndex] =
+    state.resultMetaData[payload?.meta?.currentQueryIndex] =
       searchRes?.content?.results ?? {};
+  };
+
+  const handleStreamingHistogramMetadata = (payload: any, searchRes: any) => {
+    // update result metadata
+    state.resultMetaData[payload?.meta?.currentQueryIndex] = {
+      ...(searchRes?.content ?? {}),
+      ...(searchRes?.content?.results ?? {}),
+    };
+  };
+
+  const handleStreamingHistogramHits = (payload: any, searchRes: any) => {
+    // remove past error detail
+    state.errorDetail = {
+      message: "",
+      code: "",
+    };
+
+    // is streaming aggs
+    const streaming_aggs =
+      state?.resultMetaData?.[payload?.meta?.currentQueryIndex]
+        ?.streaming_aggs ?? false;
+
+    // if streaming aggs, replace the state data
+    if (streaming_aggs) {
+      state.data[payload?.meta?.currentQueryIndex] = [
+        ...(searchRes?.content?.results?.hits ?? {}),
+      ];
+    }
+    // if order by is desc, append new partition response at end
+    else if (
+      state?.resultMetaData?.[payload?.meta?.currentQueryIndex]?.order_by
+        ?.toLowerCase() === "asc"
+    ) {
+      // else append new partition response at start
+      state.data[payload?.meta?.currentQueryIndex] = [
+        ...(searchRes?.content?.results?.hits ?? {}),
+        ...(state.data[payload?.meta?.currentQueryIndex] ?? []),
+      ];
+    } else {
+      state.data[payload?.meta?.currentQueryIndex] = [
+        ...(state.data[payload?.meta?.currentQueryIndex] ?? []),
+        ...(searchRes?.content?.results?.hits ?? {}),
+      ];
+    }
+
+    // update result metadata
+    state.resultMetaData[payload?.meta?.currentQueryIndex].hits =
+      searchRes?.content?.results?.hits ?? {};
   };
 
   // Limit, aggregation, vrl function, pagination, function error and query error
   const handleSearchResponse = (payload: any, response: any) => {
     try {
+      console.log("panel data loader response", payload.traceId, response);
+
+      if (response.type === "search_response_metadata") {
+        handleStreamingHistogramMetadata(payload, response);
+      }
+
+      if (response.type === "search_response_hits") {
+        handleStreamingHistogramHits(payload, response);
+      }
+
       if (response.type === "search_response") {
         handleHistogramResponse(payload, response);
       }
@@ -807,6 +875,7 @@ export const usePanelDataLoader = (
         traceId: string;
         org_id: string;
         pageType: string;
+        meta: any;
       } = {
         queryReq: {
           query,
@@ -825,6 +894,9 @@ export const usePanelDataLoader = (
         traceId,
         org_id: store?.state?.selectedOrganization?.identifier,
         pageType,
+        meta: {
+          currentQueryIndex,
+        },
       };
 
       fetchQueryDataWithWebSocket(payload, {
@@ -832,6 +904,95 @@ export const usePanelDataLoader = (
         close: handleSearchClose,
         error: handleSearchError,
         message: handleSearchResponse,
+        reset: handleSearchReset,
+      });
+
+      addTraceId(traceId);
+    } catch (e: any) {
+      state.errorDetail = {
+        message: e?.message || e,
+        code: e?.code ?? "",
+      };
+      state.loading = false;
+      state.isOperationCancelled = false;
+    }
+  };
+
+  const getDataThroughStreaming = async (
+    query: string,
+    it: any,
+    startISOTimestamp: string,
+    endISOTimestamp: string,
+    pageType: string,
+    currentQueryIndex: number,
+    abortControllerRef: any,
+  ) => {
+    try {
+      const { traceId } = generateTraceContext();
+
+      const payload: {
+        queryReq: any;
+        type: "search" | "histogram" | "pageCount";
+        isPagination: boolean;
+        traceId: string;
+        org_id: string;
+        pageType: string;
+        searchType: string;
+        meta: any;
+      } = {
+        queryReq: {
+          query: await getHistogramSearchRequest(
+            query,
+            it,
+            startISOTimestamp,
+            endISOTimestamp,
+            null,
+          ),
+        },
+        type: "histogram",
+        isPagination: false,
+        traceId,
+        org_id: store?.state?.selectedOrganization?.identifier,
+        pageType,
+        searchType: searchType.value ?? "dashboards",
+        meta: {
+          currentQueryIndex,
+          dashboard_id: dashboardId?.value,
+          folder_id: folderId?.value,
+          fallback_order_by_col: getFallbackOrderByCol(),
+        },
+      };
+
+      // type: "search",
+      // content: {
+      //   trace_id: payload.traceId,
+      //   payload: {
+      //     query: await getHistogramSearchRequest(
+      //       payload.queryReq.query,
+      //       payload.queryReq.it,
+      //       payload.queryReq.startISOTimestamp,
+      //       payload.queryReq.endISOTimestamp,
+      //       null,
+      //     ),
+      //   },
+      //   stream_type: payload.pageType,
+      //   search_type: searchType.value ?? "dashboards",
+      //   org_id: store?.state?.selectedOrganization?.identifier,
+      //   use_cache: (window as any).use_cache ?? true,
+      //   dashboard_id: dashboardId?.value,
+      //   folder_id: folderId?.value,
+      //   fallback_order_by_col: getFallbackOrderByCol(),
+      // },
+
+      // if aborted, return
+      if (abortControllerRef?.signal?.aborted) {
+        return;
+      }
+
+      fetchQueryDataWithHttpStream(payload, {
+        data: handleSearchResponse,
+        error: handleSearchError,
+        complete: handleSearchClose,
         reset: handleSearchReset,
       });
 
@@ -1266,7 +1427,18 @@ export const usePanelDataLoader = (
                   )
                 : [];
               state.annotations = annotations;
-              if (isWebSocketEnabled()) {
+
+              if (isStreamingEnabled()) {
+                await getDataThroughStreaming(
+                  query,
+                  it,
+                  startISOTimestamp,
+                  endISOTimestamp,
+                  pageType,
+                  panelQueryIndex,
+                  abortControllerRef,
+                );
+              } else if (isWebSocketEnabled()) {
                 await getDataThroughWebSocket(
                   query,
                   it,
@@ -1561,12 +1733,13 @@ export const usePanelDataLoader = (
             ? errorDetailValue.slice(0, 300) + " ..."
             : errorDetailValue;
 
-        const errorCode = isWebSocketEnabled()
-          ? error?.response?.data?.code || error?.code || ""
-          : error?.response?.status ||
-            error?.status ||
-            error?.response?.data?.code ||
-            "";
+        const errorCode =
+          isWebSocketEnabled() || isStreamingEnabled()
+            ? error?.response?.data?.code || error?.code || error?.status || ""
+            : error?.response?.status ||
+              error?.status ||
+              error?.response?.data?.code ||
+              "";
 
         state.errorDetail = {
           message: trimmedErrorMessage,

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -53,6 +53,7 @@ import {
   generateTraceContext,
   arraysMatch,
   isWebSocketEnabled,
+  isStreamingEnabled
 } from "@/utils/zincutils";
 import {
   convertDateToTimestamp,
@@ -77,6 +78,7 @@ import savedviewsService from "@/services/saved_views";
 import config from "@/aws-exports";
 import useSearchWebSocket from "./useSearchWebSocket";
 import useActions from "./useActions";
+import useStreamingSearch from "./useStreamingSearch";
 
 const defaultObject = {
   organizationIdentifier: "",
@@ -243,7 +245,7 @@ const defaultObject = {
     customDownloadQueryObj: <any>{},
     functionError: "",
     searchRequestTraceIds: <string[]>[],
-    searchWebSocketRequestIdsAndTraceIds: <{ traceId: string }[]>[],
+    searchWebSocketTraceIds: <string[]>[],
     isOperationCancelled: false,
     searchRetriesCount: <{ [key: string]: number }>{},
     actionId: null,
@@ -307,6 +309,14 @@ const {
   cancelSearchQueryBasedOnRequestId,
   closeSocketBasedOnRequestId,
 } = useSearchWebSocket();
+
+const {
+  fetchQueryDataWithHttpStream,
+  cancelStreamQueryBasedOnRequestId,
+  closeStreamWithError,
+  closeStream,
+  resetAuthToken,
+} = useStreamingSearch();
 
 const searchPartitionMap = reactive<{ [key: string]: number }>({});
 
@@ -1553,7 +1563,7 @@ const useLogs = () => {
       // Reset cancel query on new search request initation
       searchObj.data.isOperationCancelled = false;
       searchObj.data.searchRequestTraceIds = [];
-      searchObj.data.searchWebSocketRequestIdsAndTraceIds = [];
+      searchObj.data.searchWebSocketTraceIds = [];
 
       // get websocket enable config from store
       // window will have more priority
@@ -1561,17 +1571,19 @@ const useLogs = () => {
       // else use organization settings
       searchObj.meta.jobId = "";
       const shouldUseWebSocket = isWebSocketEnabled();
+      const shouldUseStreaming = isStreamingEnabled();
 
       const isMultiStreamSearch =
         searchObj.data.stream.selectedStream.length > 1 &&
         !searchObj.meta.sqlMode;
 
-      searchObj.communicationMethod =
-        shouldUseWebSocket && !isMultiStreamSearch ? "ws" : "http";
-
-      if (searchObj.communicationMethod === "ws") {
-        getDataThroughWebSocket(isPagination);
-        return;
+      // Determine communication method based on available options and constraints
+      if (shouldUseStreaming) {
+        searchObj.communicationMethod = "streaming";
+      } else if (shouldUseWebSocket && !isMultiStreamSearch) {
+        searchObj.communicationMethod = "ws";
+      } else {
+        searchObj.communicationMethod = "http";
       }
 
       // searchObj.data.histogram.chartParams.title = "";
@@ -1595,6 +1607,13 @@ const useLogs = () => {
           (router.currentRoute.value?.query?.period as string) || "15m",
         );
       }
+
+      // Use the appropriate method to fetch data
+      if (searchObj.communicationMethod === "ws" || searchObj.communicationMethod === "streaming") {
+        getDataThroughStream(isPagination);
+        return;
+      }
+    
 
       searchObjDebug["buildSearchStartTime"] = performance.now();
       const queryReq: any = buildSearch();
@@ -3566,7 +3585,7 @@ const useLogs = () => {
         endCount = searchObj.meta.resultGrid.rowsPerPage * (currentPage + 1);
         if (
           currentPage >=
-          (searchObj.communicationMethod === "ws" || searchObj.meta.jobId != ""
+          (searchObj.communicationMethod === "ws" || searchObj.communicationMethod === "streaming" || searchObj.meta.jobId != ""
             ? searchObj.data.queryResults?.pagination?.length
             : searchObj.data.queryResults.partitionDetail?.paginations
                 ?.length || 0) -
@@ -3602,7 +3621,7 @@ const useLogs = () => {
       }
 
       if (
-        searchObj.communicationMethod === "ws" &&
+        (searchObj.communicationMethod === "ws" || searchObj.communicationMethod === "streaming") &&
         endCount < totalCount &&
         !searchObj.meta.showHistogram
       ) {
@@ -4387,37 +4406,39 @@ const useLogs = () => {
   };
 
   const addTraceId = (traceId: string) => {
-    if (searchObj.data.searchRequestTraceIds.includes(traceId)) {
-      return;
-    }
+    if (searchObj.communicationMethod !== "ws") {
+      if (searchObj.data.searchRequestTraceIds.includes(traceId)) {
+        return;
+      }
 
-    searchObj.data.searchRequestTraceIds.push(traceId);
+      searchObj.data.searchRequestTraceIds.push(traceId);
+    } else {
+      if (searchObj.data.searchWebSocketTraceIds.includes(traceId)) {
+        return;
+      }
+
+      searchObj.data.searchWebSocketTraceIds.push(traceId);
+    }
   };
 
   const removeTraceId = (traceId: string) => {
-    searchObj.data.searchRequestTraceIds =
-      searchObj.data.searchRequestTraceIds.filter(
-        (id: string) => id !== traceId,
-      );
-  };
-
-  const addRequestId = (traceId: string) => {
-    searchObj.data.searchWebSocketRequestIdsAndTraceIds.push({
-      traceId,
-    });
-  };
-
-  const removeRequestId = (traceId: string) => {
-    searchObj.data.searchWebSocketRequestIdsAndTraceIds =
-      searchObj.data.searchWebSocketRequestIdsAndTraceIds.filter(
-        (id) => id.traceId !== traceId,
-      );
+    if (searchObj.communicationMethod !== "ws") {
+      searchObj.data.searchRequestTraceIds =
+        searchObj.data.searchRequestTraceIds.filter(
+          (id: string) => id !== traceId,
+        );
+    } else {
+      searchObj.data.searchWebSocketTraceIds =
+        searchObj.data.searchWebSocketTraceIds.filter(
+          (_traceId) => _traceId !== traceId,
+        );
+    }
   };
 
   const cancelQuery = () => {
     if (searchObj.communicationMethod === "ws") {
       sendCancelSearchMessage([
-        ...searchObj.data.searchWebSocketRequestIdsAndTraceIds,
+        ...searchObj.data.searchWebSocketTraceIds,
       ]);
       return;
     }
@@ -4797,11 +4818,10 @@ const useLogs = () => {
     return node && node.type === "column_ref";
   }
 
-  const getDataThroughWebSocket = (isPagination: boolean) => {
-    try {
-      if (!isPagination) {
-        resetQueryData();
-        searchObj.data.queryResults = {};
+  const getQueryReq = (isPagination: boolean) => {
+    if (!isPagination) {
+      resetQueryData();
+      searchObj.data.queryResults = {};
       }
 
       // reset searchAggData
@@ -4924,16 +4944,45 @@ const useLogs = () => {
         }
       }
 
-      const payload = buildWebSocketPayload(queryReq, isPagination, "search");
-      const requestId = initializeWebSocketConnection(payload);
+      return queryReq;
+  };
 
-      if (!requestId) {
-        throw new Error("Failed to initialize WebSocket connection");
+  const getDataThroughStream = (isPagination: boolean) => {
+    try {
+      const queryReq = getQueryReq(isPagination) as SearchRequestPayload;
+
+      if(!queryReq) return;
+      
+      if(!isPagination) {
+        resetQueryData();
+        histogramResults = [];
+        searchObj.data.queryResults.hits = [];
+        searchObj.data.histogram = {
+          xData: [],
+          yData: [],
+          chartParams: {
+            title: "",
+            unparsed_x_data: [],
+            timezone: "",
+          },
+          errorCode: 0,
+          errorMsg: "",
+          errorDetail: "",
+        };
+
+        if(searchObj.meta.refreshInterval == 0) searchObj.meta.resetPlotChart = true;
       }
 
-      addRequestId(payload.traceId);
+      const payload = buildWebSocketPayload(queryReq, isPagination, "search");
+      const requestId = initializeSearchConnection(payload);
+
+      if (!requestId) {
+        throw new Error(`Failed to initialize ${searchObj.communicationMethod} connection`);
+      }
+
+      addTraceId(payload.traceId);
     } catch (e: any) {
-      console.error("Error while getting data through web socket", e);
+      console.error(`Error while getting data through ${searchObj.communicationMethod}`, e);
       searchObj.loading = false;
       showErrorNotification(
         notificationMsg.value || "Error occurred during the search operation.",
@@ -4970,16 +5019,38 @@ const useLogs = () => {
     return payload;
   };
 
-  const initializeWebSocketConnection = (payload: any): string => {
-    return fetchQueryDataWithWebSocket(payload, {
-      open: sendSearchMessage,
-      close: handleSearchClose,
-      error: handleSearchError,
-      message: handleSearchResponse,
-      reset: handleSearchReset,
-    }) as string;
+  const initializeSearchConnection = (payload: any): string | Promise<void>  | null=> {
+    // Use the appropriate method to fetch data
+    if (searchObj.communicationMethod === "ws") {
+      return fetchQueryDataWithWebSocket(payload, {
+        open: sendSearchMessage,
+        close: handleSearchClose,
+        error: handleSearchError,
+        message: handleSearchResponse,
+        reset: handleSearchReset,
+      }) as string;
+    } else if (searchObj.communicationMethod === "streaming") {
+      payload.searchType = "ui";
+      payload.pageType = searchObj.data.stream.streamType;
+      return fetchQueryDataWithHttpStream(payload, {
+        data: handleSearchResponse,
+        error: handleSearchError,
+        complete: handleSearchClose,
+        reset: handleSearchReset,
+      }) as Promise<void>;
+    }
+
+    return null;
   };
 
+  const initializeStreamingConnection = (payload: any): Promise<void> => {
+    return fetchQueryDataWithHttpStream(payload, {
+      data: handleSearchResponse,
+      error: handleSearchError,
+      complete: handleSearchClose,
+      reset: handleSearchReset,
+    }) as Promise<void>;
+  };
 
   const handleSearchReset = async (data: any, traceId?: string) => {
     // reset query data
@@ -5018,8 +5089,8 @@ const useLogs = () => {
 
         const payload = buildWebSocketPayload(data.queryReq, data.isPagination, "search");
 
-        initializeWebSocketConnection(payload);
-        addRequestId(payload.traceId);
+        initializeSearchConnection(payload);
+        addTraceId(payload.traceId);
       }
 
       if(data.type === "histogram" || data.type === "pageCount") {
@@ -5051,9 +5122,9 @@ const useLogs = () => {
           data.type,
         );
 
-        initializeWebSocketConnection(payload);
+        initializeSearchConnection(payload);
 
-        addRequestId(payload.traceId);
+        addTraceId(payload.traceId);
       }
     } catch(e: any){
       console.error("Error while resetting search", e);
@@ -5110,13 +5181,298 @@ const useLogs = () => {
     searchObj.data.datetime.endTime = extractedDate.to;
   };
 
+
+  // Get metadata
+  // Update metadata
+  // Update results
+
+  const handleStreamingHits = (payload: WebSocketSearchPayload, response: WebSocketSearchResponse, isPagination: boolean, appendResult: boolean = false) => {
+    if (
+      searchObj.meta.refreshInterval > 0 &&
+      router.currentRoute.value.name == "logs"
+    ) {
+      searchObj.data.queryResults.hits = response.content.results.hits;
+    }
+
+    if (!searchObj.meta.refreshInterval) {
+      // Scan-size and took time in histogram title
+      // For the initial request, we get histogram and logs data. So, we need to sum the scan_size and took time of both the requests.
+      // For the pagination request, we only get logs data. So, we need to consider scan_size and took time of only logs request.
+      if (appendResult) {
+        searchObj.data.queryResults.hits.push(
+          ...response.content.results.hits,
+        );
+      } else {
+        searchObj.data.queryResults.hits = response.content.results.hits;
+      }
+    }
+
+    //       // We are storing time_offset for the context of pagecount, to get the partial pagecount
+    // if (searchObj.data.queryResults) {
+    //   searchObj.data.queryResults.time_offset = response.content?.time_offset;
+    // }
+
+    processPostPaginationData();
+  }
+
+  const handleStreamingMetadata = (payload: WebSocketSearchPayload, response: WebSocketSearchResponse, isPagination: boolean, appendResult: boolean = false) => {
+    ////// Handle function error ///////
+    handleFunctionError(payload.queryReq, response);
+      
+    ////// Handle aggregation ///////
+    handleAggregation(payload.queryReq, response);
+    
+    ////// Handle reset field values ///////
+    resetFieldValues();
+
+    if (
+      searchObj.meta.refreshInterval > 0 &&
+      router.currentRoute.value.name == "logs"
+    ) {
+      searchObj.data.queryResults.from = response.content.results.from;
+      searchObj.data.queryResults.scan_size =
+        response.content.results.scan_size;
+      searchObj.data.queryResults.took = response.content.results.took;
+      searchObj.data.queryResults.aggs = response.content.results.aggs;
+    }
+
+    if (!searchObj.meta.refreshInterval) {
+      // In page count we set track_total_hits
+      if (!payload.queryReq.query.hasOwnProperty("track_total_hits")) {
+        delete response.content.total;
+      }
+
+      // Scan-size and took time in histogram title
+      // For the initial request, we get histogram and logs data. So, we need to sum the scan_size and took time of both the requests.
+      // For the pagination request, we only get logs data. So, we need to consider scan_size and took time of only logs request.
+      if (appendResult) {
+        searchObj.data.queryResults.total += response.content.results.total;
+        searchObj.data.queryResults.took += response.content.results.took;
+        searchObj.data.queryResults.scan_size +=
+          response.content.results.scan_size;
+      } else {
+        if (isPagination && response.content?.streaming_aggs) {
+          searchObj.data.queryResults.from = response.content.results.from;
+          searchObj.data.queryResults.scan_size =
+            response.content.results.scan_size;
+          searchObj.data.queryResults.took = response.content.results.took;
+        } else if (response.content?.streaming_aggs) {
+          searchObj.data.queryResults = {
+            ...response.content.results,
+            took: (searchObj.data?.queryResults?.took || 0) + response.content.results.took,
+            scan_size: (searchObj.data?.queryResults?.scan_size || 0) + response.content.results.scan_size,
+            hits: searchObj.data?.queryResults?.hits || [],
+            streaming_aggs: response.content?.streaming_aggs,
+          }
+        } else if (isPagination) {
+          searchObj.data.queryResults.from = response.content.results.from;
+          searchObj.data.queryResults.scan_size =
+            response.content.results.scan_size;
+          searchObj.data.queryResults.took = response.content.results.took;
+          searchObj.data.queryResults.total = response.content.results.total;
+        } else {
+          searchObj.data.queryResults = response.content.results;
+        }
+      }
+    }
+
+          // We are storing time_offset for the context of pagecount, to get the partial pagecount
+    if (searchObj.data.queryResults) {
+      searchObj.data.queryResults.time_offset = response.content?.time_offset;
+    }
+
+          // If its a pagination request, then append
+    if (!isPagination) {
+      searchObj.data.queryResults.pagination = [];
+    }
+    
+    if (isPagination) refreshPagination(true);
+  }
+
+  const handleHistogramStreamingHits = (payload: WebSocketSearchPayload, response: WebSocketSearchResponse, isPagination: boolean, appendResult: boolean = false) => {
+    
+    searchObj.loading = false;
+
+    if (!searchObj.data.queryResults.aggs) {
+      searchObj.data.queryResults.aggs = [];
+    }
+
+    if (
+      searchObj.data.queryResults.aggs.length == 0 &&
+      response.content.results.hits.length > 0
+    ) {
+      let date = new Date();
+
+      const startDateTime =
+        searchObj.data.customDownloadQueryObj.query.start_time / 1000;
+
+      const endDateTime =
+        searchObj.data.customDownloadQueryObj.query.end_time / 1000;
+
+      const nowString = response.content.results.hits[0].zo_sql_key;
+      const now = new Date(nowString);
+
+      const day = String(now.getDate()).padStart(2, "0");
+      const month = String(now.getMonth() + 1).padStart(2, "0");
+      const year = now.getFullYear();
+
+      const dateToBePassed = `${day}-${month}-${year}`;
+      const hours = String(now.getHours()).padStart(2, "0");
+      let minutes = String(now.getMinutes()).padStart(2, "0");
+      if (searchObj.data.histogramInterval / 1000 <= 9999) {
+        minutes = String(now.getMinutes() + 1).padStart(2, "0");
+      }
+
+      const time = `${hours}:${minutes}`;
+
+      const currentTimeToBePassed = convertDateToTimestamp(
+        dateToBePassed,
+        time,
+        "UTC",
+      );
+      for (
+        let currentTime: any = currentTimeToBePassed.timestamp / 1000;
+        currentTime < endDateTime;
+        currentTime += searchObj.data.histogramInterval / 1000
+      ) {
+        date = new Date(currentTime);
+        histogramResults.push({
+          zo_sql_key: date.toISOString().slice(0, 19),
+          zo_sql_num: 0,
+        });
+      }
+      for (
+        let currentTime: any = currentTimeToBePassed.timestamp / 1000;
+        currentTime > startDateTime;
+        currentTime -= searchObj.data.histogramInterval / 1000
+      ) {
+        date = new Date(currentTime);
+        histogramResults.push({
+          zo_sql_key: date.toISOString().slice(0, 19),
+          zo_sql_num: 0,
+        });
+      }
+    }
+    
+    searchObj.data.queryResults.aggs.push(...response.content.results.hits);
+
+    (async () => {
+      try {
+        generateHistogramData();
+        if (!payload.meta?.isHistogramOnly) refreshPagination(true);
+      } catch (error) {
+        console.error("Error processing histogram data:", error);
+
+        searchObj.loadingHistogram = false;
+      }
+    })();
+
+    // queryReq.query.start_time =
+    //   searchObj.data.queryResults.partitionDetail.paginations[
+    //     searchObj.data.resultGrid.currentPage - 1
+    //   ][0].startTime;
+    // queryReq.query.end_time =
+    //   searchObj.data.queryResults.partitionDetail.paginations[
+    //     searchObj.data.resultGrid.currentPage - 1
+    //   ][0].endTime;
+
+    // if (hasAggregationFlag) {
+    //   searchObj.data.queryResults.total = res.data.total;
+    // }
+
+    if (!payload.meta?.isHistogramOnly)
+      searchObj.data.histogram.chartParams.title = getHistogramTitle();
+
+    searchObjDebug["histogramProcessingEndTime"] = performance.now();
+    searchObjDebug["histogramEndTime"] = performance.now();
+  }
+
+  const handleHistogramStreamingMetadata = (payload: WebSocketSearchPayload, response: WebSocketSearchResponse, isPagination: boolean, appendResult: boolean = false) => {
+    searchObjDebug["histogramProcessingStartTime"] = performance.now();
+
+    searchObj.data.queryResults.scan_size += response.content.results.scan_size;
+    searchObj.data.queryResults.took += response.content.results.took;
+    searchObj.data.queryResults.result_cache_ratio +=
+      response.content.results.result_cache_ratio;
+  }
+
+  const handlePageCountStreamingHits = (payload: WebSocketSearchPayload, response: WebSocketSearchResponse, isPagination: boolean, appendResult: boolean = false) => {
+    let regeratePaginationFlag = false;
+    if (
+      response.content.results.hits.length !=
+      searchObj.meta.resultGrid.rowsPerPage
+    ) {
+      regeratePaginationFlag = true;
+    }
+  
+    if(response.content?.streaming_aggs || searchObj.data.queryResults.streaming_aggs) {
+      searchObj.data.queryResults.aggs = response.content.results.hits;
+    } else {
+      searchObj.data.queryResults.aggs.push(...response.content.results.hits);
+    }
+
+
+    // if total records in partition is greater than recordsPerPage then we need to update pagination
+    // setting up forceFlag to true to update pagination as we have check for pagination already created more than currentPage + 3 pages.
+    refreshPagination(regeratePaginationFlag);
+
+    searchObj.data.histogram.chartParams.title = getHistogramTitle();
+  }
+
+  const handlePageCountStreamingMetadata = (payload: WebSocketSearchPayload, response: WebSocketSearchResponse, isPagination: boolean, appendResult: boolean = false) => {
+    removeTraceId(response.content.traceId);
+
+    if (searchObj.data.queryResults.aggs == null) {
+      searchObj.data.queryResults.aggs = [];
+    }
+
+    searchObj.data.queryResults.streaming_aggs = response?.content?.streaming_aggs;
+
+    searchObj.data.queryResults.scan_size += response.content.results.scan_size;
+    searchObj.data.queryResults.took += response.content.results.took;
+  }
+
   // Limit, aggregation, vrl function, pagination, function error and query error
   const handleSearchResponse = (
     payload: WebSocketSearchPayload,
-    response: WebSocketSearchResponse | WebSocketErrorResponse,
+    response: WebSocketSearchResponse,
   ) => {
+    if(payload.type === "search" && response?.type === "search_response_hits") {
+      handleStreamingHits(payload, response, payload.isPagination, !(response.content?.streaming_aggs || searchObj.data.queryResults.streaming_aggs) && searchPartitionMap[payload.traceId] > 1);
+      return;
+    }
+
+    if(payload.type === "search" && response?.type === "search_response_metadata") {
+      searchPartitionMap[payload.traceId] = searchPartitionMap[payload.traceId]
+      ? searchPartitionMap[payload.traceId]
+      : 0;
+      searchPartitionMap[payload.traceId]++;
+      handleStreamingMetadata(payload, response, payload.isPagination, !response.content?.streaming_aggs && searchPartitionMap[payload.traceId] > 1);
+      return;
+    }
+
+    if(payload.type === "histogram" && response?.type === "search_response_hits") {
+      handleHistogramStreamingHits(payload, response, payload.isPagination);
+      return;
+    }
+
+    if(payload.type === "histogram" && response?.type === "search_response_metadata") {
+      handleHistogramStreamingMetadata(payload, response, payload.isPagination);
+      return;
+    }
+
+
+    if(payload.type === "pageCount" && response?.type === "search_response_hits") {
+      handlePageCountStreamingHits(payload, response, payload.isPagination);
+      return;
+    }
+
+    if(payload.type === "pageCount" && response?.type === "search_response_metadata") {
+      handlePageCountStreamingMetadata(payload, response, payload.isPagination);
+      return;
+    }
+    
     if (response.type === "search_response") {
-      
       searchPartitionMap[payload.traceId] = searchPartitionMap[payload.traceId]
       ? searchPartitionMap[payload.traceId]
       : 0;
@@ -5147,9 +5503,9 @@ const useLogs = () => {
       }
     }
 
-    if (response.type === "error") {
-      handleSearchError(payload.traceId, response);
-    }
+    // if (response.type === "error") {
+    //   handleSearchError(payload.traceId, response);
+    // }
 
     if (response.type === "cancel_response") {
       searchObj.loading = false;
@@ -5161,6 +5517,114 @@ const useLogs = () => {
     }
   };
 
+  const handleFunctionError = (queryReq: SearchRequestPayload, response: any) => {
+    if (
+      response.content.results.hasOwnProperty("function_error") &&
+      response.content.results.function_error != ""
+    ) {
+      searchObj.data.functionError = response.content.results.function_error;
+    }
+
+    if (
+      response.content.results.hasOwnProperty("function_error") &&
+      response.content.results.function_error != "" &&
+      response.content.results.hasOwnProperty("new_start_time") &&
+      response.content.results.hasOwnProperty("new_end_time")
+    ) {
+      response.content.results.function_error = getFunctionErrorMessage(
+        response.content.results.function_error,
+        response.content.results.new_start_time,
+        response.content.results.new_end_time,
+        store.state.timezone,
+      );
+      searchObj.data.datetime.startTime =
+        response.content.results.new_start_time;
+      searchObj.data.datetime.endTime = response.content.results.new_end_time;
+      searchObj.data.datetime.type = "absolute";
+      queryReq.query.start_time = response.content.results.new_start_time;
+      queryReq.query.end_time = response.content.results.new_end_time;
+      searchObj.data.histogramQuery.query.start_time =
+        response.content.results.new_start_time;
+      searchObj.data.histogramQuery.query.end_time =
+        response.content.results.new_end_time;
+
+      updateUrlQueryParams();
+    }
+  }
+
+  const handleAggregation = (queryReq: SearchRequestPayload, response: any) => {
+    const parsedSQL = fnParsedSQL();
+
+    if (searchObj.meta.sqlMode) {
+      if (hasAggregation(parsedSQL?.columns) || parsedSQL.groupby != null) {
+        searchAggData.hasAggregation = true;
+        searchObj.meta.resultGrid.showPagination = false;
+
+        if (response.content?.streaming_aggs) {
+          searchAggData.total = response.content?.results?.total;
+        } else {
+          searchAggData.total =
+            searchAggData.total + response.content?.results?.total;
+        }
+      }
+    }
+  }
+
+  const updateResult = async (queryReq: SearchRequestPayload, response: any, isPagination: boolean, appendResult: boolean = false) => {
+    if (
+      searchObj.meta.refreshInterval > 0 &&
+      router.currentRoute.value.name == "logs"
+    ) {
+      searchObj.data.queryResults.from = response.content.results.from;
+      searchObj.data.queryResults.scan_size =
+        response.content.results.scan_size;
+      searchObj.data.queryResults.took = response.content.results.took;
+      searchObj.data.queryResults.aggs = response.content.results.aggs;
+      searchObj.data.queryResults.hits = response.content.results.hits;
+    }
+
+    if (!searchObj.meta.refreshInterval) {
+      // In page count we set track_total_hits
+      if (!queryReq.query.hasOwnProperty("track_total_hits")) {
+        delete response.content.total;
+      }
+
+        // Scan-size and took time in histogram title
+        // For the initial request, we get histogram and logs data. So, we need to sum the scan_size and took time of both the requests.
+        // For the pagination request, we only get logs data. So, we need to consider scan_size and took time of only logs request.
+        if (appendResult) {
+          await chunkedAppend(searchObj.data.queryResults.hits, response.content.results.hits);
+
+        searchObj.data.queryResults.total += response.content.results.total;
+        searchObj.data.queryResults.took += response.content.results.took;
+        searchObj.data.queryResults.scan_size +=
+          response.content.results.scan_size;
+      } else {
+        if (response.content?.streaming_aggs) {
+          searchObj.data.queryResults = {
+            ...response.content.results,
+            took: (searchObj.data?.queryResults?.took || 0) + response.content.results.took,
+            scan_size: (searchObj.data?.queryResults?.scan_size || 0) + response.content.results.scan_size,
+          }
+        } else if (isPagination) {
+          searchObj.data.queryResults.hits = response.content.results.hits;
+          searchObj.data.queryResults.from = response.content.results.from;
+          searchObj.data.queryResults.scan_size =
+            response.content.results.scan_size;
+          searchObj.data.queryResults.took = response.content.results.took;
+          searchObj.data.queryResults.total = response.content.results.total;
+        } else {
+          searchObj.data.queryResults = response.content.results;
+        }
+      }
+    }
+
+          // We are storing time_offset for the context of pagecount, to get the partial pagecount
+    if (searchObj.data.queryResults) {
+      searchObj.data.queryResults.time_offset = response.content?.time_offset;
+    }
+  }
+
   const handleLogsResponse = async (
     queryReq: SearchRequestPayload,
     isPagination: boolean,
@@ -5169,109 +5633,18 @@ const useLogs = () => {
     appendResult: boolean = false,
   ) => {
     try {
-      const parsedSQL = fnParsedSQL();
+      ////// Handle function error ///////
+      handleFunctionError(queryReq, response);
+      
+      ////// Handle aggregation ///////
+      handleAggregation(queryReq, response);
 
-      if (
-        response.content.results.hasOwnProperty("function_error") &&
-        response.content.results.function_error != ""
-      ) {
-        searchObj.data.functionError = response.content.results.function_error;
-      }
-
-      if (
-        response.content.results.hasOwnProperty("function_error") &&
-        response.content.results.function_error != "" &&
-        response.content.results.hasOwnProperty("new_start_time") &&
-        response.content.results.hasOwnProperty("new_end_time")
-      ) {
-        response.content.results.function_error = getFunctionErrorMessage(
-          response.content.results.function_error,
-          response.content.results.new_start_time,
-          response.content.results.new_end_time,
-          store.state.timezone,
-        );
-        searchObj.data.datetime.startTime =
-          response.content.results.new_start_time;
-        searchObj.data.datetime.endTime = response.content.results.new_end_time;
-        searchObj.data.datetime.type = "absolute";
-        queryReq.query.start_time = response.content.results.new_start_time;
-        queryReq.query.end_time = response.content.results.new_end_time;
-        searchObj.data.histogramQuery.query.start_time =
-          response.content.results.new_start_time;
-        searchObj.data.histogramQuery.query.end_time =
-          response.content.results.new_end_time;
-
-        updateUrlQueryParams();
-      }
-
-      if (searchObj.meta.sqlMode) {
-        if (hasAggregation(parsedSQL?.columns) || parsedSQL.groupby != null) {
-          searchAggData.hasAggregation = true;
-          searchObj.meta.resultGrid.showPagination = false;
-
-          if (response.content?.streaming_aggs) {
-            searchAggData.total = response.content?.results?.total;
-          } else {
-            searchAggData.total =
-              searchAggData.total + response.content?.results?.total;
-          }
-        }
-      }
-
+      ////// Handle reset field values ///////
       resetFieldValues();
 
-      if (
-        searchObj.meta.refreshInterval > 0 &&
-        router.currentRoute.value.name == "logs"
-      ) {
-        searchObj.data.queryResults.from = response.content.results.from;
-        searchObj.data.queryResults.scan_size =
-          response.content.results.scan_size;
-        searchObj.data.queryResults.took = response.content.results.took;
-        searchObj.data.queryResults.aggs = response.content.results.aggs;
-        searchObj.data.queryResults.hits = response.content.results.hits;
-      }
-
-      if (!searchObj.meta.refreshInterval) {
-        // In page count we set track_total_hits
-        if (!queryReq.query.hasOwnProperty("track_total_hits")) {
-          delete response.content.total;
-        }
-
-        // Scan-size and took time in histogram title
-        // For the initial request, we get histogram and logs data. So, we need to sum the scan_size and took time of both the requests.
-        // For the pagination request, we only get logs data. So, we need to consider scan_size and took time of only logs request.
-        if (appendResult) {
-          await chunkedAppend(searchObj.data.queryResults.hits, response.content.results.hits);
-
-          searchObj.data.queryResults.total += response.content.results.total;
-          searchObj.data.queryResults.took += response.content.results.took;
-          searchObj.data.queryResults.scan_size +=
-            response.content.results.scan_size;
-        } else {
-          if (response.content?.streaming_aggs) {
-            searchObj.data.queryResults = {
-              ...response.content.results,
-              took: (searchObj.data?.queryResults?.took || 0) + response.content.results.took,
-              scan_size: (searchObj.data?.queryResults?.scan_size || 0) + response.content.results.scan_size,
-            }
-          } else if (isPagination) {
-            searchObj.data.queryResults.hits = response.content.results.hits;
-            searchObj.data.queryResults.from = response.content.results.from;
-            searchObj.data.queryResults.scan_size =
-              response.content.results.scan_size;
-            searchObj.data.queryResults.took = response.content.results.took;
-            searchObj.data.queryResults.total = response.content.results.total;
-          } else {
-            searchObj.data.queryResults = response.content.results;
-          }
-        }
-      }
-
-      // We are storing time_offset for the context of pagecount, to get the partial pagecount
-      if (searchObj.data.queryResults) {
-        searchObj.data.queryResults.time_offset = response.content?.time_offset;
-      }
+      ////// Update results ///////
+      updateResult(queryReq, response, isPagination, appendResult);
+    
 
       // If its a pagination request, then append
       if (!isPagination) {
@@ -5413,6 +5786,7 @@ const useLogs = () => {
         if (!meta?.isHistogramOnly) refreshPagination(true);
       } catch (error) {
         console.error("Error processing histogram data:", error);
+
         searchObj.loadingHistogram = false;
       }
     })();
@@ -5465,6 +5839,7 @@ const useLogs = () => {
       return;
     }
 
+
     searchObj.data.queryResults.aggs = [];
     if (shouldShowHistogram) {
       searchObj.meta.refreshHistogram = false;
@@ -5483,9 +5858,14 @@ const useLogs = () => {
           false,
           "histogram",
         );
-        const requestId = initializeWebSocketConnection(payload);
 
-        addRequestId(payload.traceId);
+        payload.meta = {
+          isHistogramOnly: searchObj.meta.histogramDirtyFlag,
+        }
+
+        const requestId = initializeSearchConnection(payload);
+
+        addTraceId(payload.traceId);
       }
     } else if (searchObj.meta.sqlMode && isLimitQuery(parsedSQL)) {
       resetHistogramWithError("Histogram unavailable for CTEs, DISTINCT and LIMIT queries.", -1);
@@ -5563,7 +5943,7 @@ const useLogs = () => {
   }
 
   const handleSearchClose = (payload: any, response: any) => {
-    if (payload.traceId) removeRequestId(payload.traceId);
+    if (payload.traceId) removeTraceId(payload.traceId);
 
     // Any case where below logic may end in recursion
     if (payload.traceId) delete searchPartitionMap[payload.traceId];
@@ -5600,6 +5980,10 @@ const useLogs = () => {
 
     if (payload.traceId) removeTraceId(payload.traceId);
 
+    if(!searchObj.data.queryResults.hasOwnProperty('hits')){
+      searchObj.data.queryResults.hits = [];
+    }
+
     if (
       payload.type === "search" &&
       !payload.isPagination &&
@@ -5609,8 +5993,11 @@ const useLogs = () => {
     }
 
     if (payload.type === "search" && !response?.content?.should_client_retry) searchObj.loading = false;
-    if ((payload.type === "histogram" || payload.type === "pageCount") && !response?.content?.should_client_retry)
+    if ((payload.type === "histogram" || payload.type === "pageCount") && !response?.content?.should_client_retry){
       searchObj.loadingHistogram = false;
+    }
+
+
 
     searchObj.data.isOperationCancelled = false;
   };
@@ -5619,7 +6006,7 @@ const useLogs = () => {
     searchObj.loading = false;
     searchObj.loadingHistogram = false;
 
-    const { message, trace_id, code, error_detail } = err.content;
+    const { message, trace_id, code, error_detail, error } = err.content;
 
     // 20009 is the code for query cancelled
     if (code === 20009) {
@@ -5629,12 +6016,16 @@ const useLogs = () => {
 
     if (trace_id) removeTraceId(trace_id);
 
-    const errorMsg = constructErrorMessage({
+    let errorMsg = constructErrorMessage({
       message,
       code,
       trace_id,
       defaultMessage: "Error while processing request",
     });
+
+    if(error === "rate_limit_exceeded") {
+      errorMsg = message;
+    }
 
     searchObj.data.errorDetail = error_detail || "";
     searchObj.data.errorMsg = errorMsg;
@@ -5709,6 +6100,7 @@ const useLogs = () => {
       return false;
     }
   };
+  
   const refreshJobPagination = (regenrateFlag: boolean = false) => {
     try {
       const { rowsPerPage } = searchObj.meta.resultGrid;
@@ -5773,9 +6165,9 @@ const useLogs = () => {
 
     searchObj.loadingHistogram = true;
 
-    const requestId = initializeWebSocketConnection(payload);
+    const requestId = initializeSearchConnection(payload);
 
-    addRequestId(payload.traceId);
+    addTraceId(payload.traceId);
   };
 
   const sendCancelSearchMessage = (searchRequests: any[]) => {
@@ -5788,7 +6180,7 @@ const useLogs = () => {
       searchObj.data.isOperationCancelled = true;
 
       // loop on all requestIds
-      searchRequests.forEach(({ traceId }) => {
+      searchRequests.forEach((traceId) => {
         cancelSearchQueryBasedOnRequestId({
           trace_id: traceId,
           org_id: store?.state?.selectedOrganization?.identifier,
@@ -5863,7 +6255,7 @@ const useLogs = () => {
   const isActionsEnabled = computed(() => {
     return (config.isEnterprise == "true" || config.isCloud == "true") && store.state.zoConfig.actions_enabled;
   });
-
+  
   return {
     searchObj,
     searchAggData,
@@ -5915,8 +6307,8 @@ const useLogs = () => {
     refreshJobPagination,
     enableRefreshInterval,
     buildWebSocketPayload,
-    initializeWebSocketConnection,
-    addRequestId,
+    initializeSearchConnection,
+    addTraceId,
     routeToSearchSchedule,
     isActionsEnabled,
     sendCancelSearchMessage,

--- a/web/src/composables/useSearchWebSocket.ts
+++ b/web/src/composables/useSearchWebSocket.ts
@@ -206,6 +206,7 @@ const useSearchWebSocket = () => {
       isPagination: boolean;
       traceId: string;
       org_id: string;
+      meta: any;
     },
     handlers: {
       open: (data: any, response: any) => void;
@@ -254,6 +255,7 @@ const useSearchWebSocket = () => {
     isPagination: boolean;
     traceId: string;
     org_id: string;
+    meta: any;
   }, handlers: {
     open: (data: any, response: any) => void;
     message: (data: any, response: any) => void;

--- a/web/src/composables/useStreamingSearch.ts
+++ b/web/src/composables/useStreamingSearch.ts
@@ -1,0 +1,421 @@
+// Copyright 2023 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { ref } from "vue";
+import type { SearchRequestPayload } from "@/ts/interfaces";
+import authService from "@/services/auth";
+import store from "@/stores";
+import { getUUID } from "@/utils/zincutils";
+
+// Create and manage stream workers
+let streamWorker: Worker | null = null;
+const createStreamWorker = () => {
+  if (!streamWorker && window.Worker) {
+    streamWorker = new Worker(new URL('../workers/streamWorker.js', import.meta.url), { type: 'module' });
+  }
+  return streamWorker;
+};
+
+// Type definitions similar to WebSocket but for HTTP/2 streaming
+type StreamHandler = (data: any, traceId: string) => void;
+type ErrorHandler = (error: any, traceId: string) => void;
+type CompleteHandler = (traceId: string) => void;
+type ResetHandler = (data: any, traceId: string) => void;
+
+type TraceRecord = {
+  data: StreamHandler[];
+  error: ErrorHandler[];
+  complete: CompleteHandler[];
+  reset: ResetHandler[];
+  isInitiated: boolean;
+  streamId: string | null;
+  abortController: AbortController | null;
+  requestData: any;
+};
+
+const traceMap = ref<Record<string, TraceRecord>>({});
+const activeStreamId = ref<string | null>(null);
+const streamConnections = ref<Record<string, ReadableStreamDefaultReader<Uint8Array>>>({});
+const abortControllers = ref<Record<string, AbortController>>({});
+const errorOccurred = ref(false);
+
+type StreamResponseType = 'search_response_metadata' | 'search_response_hits' | 'progress' | 'error' | 'end';
+
+const useHttpStreaming = () => {
+  const onData = (traceId: string, type: StreamResponseType | 'end', response: any) => {
+    if (!traceMap.value[traceId]) return;
+
+    if (response === 'end' || response === '[[DONE]]') {
+      for (const handler of traceMap.value[traceId].complete) {
+        handler(traceId);
+      }
+      cleanUpListeners(traceId);
+      return
+    }
+
+    if (typeof response === 'string') {
+      response = JSON.parse(response);
+    }
+
+    const wsResponse = wsMapper[type as StreamResponseType](traceId, response, type);
+
+
+    for (const handler of traceMap.value[traceId].data) {
+      handler(wsResponse, traceId);
+    }
+  };
+
+  const onComplete = (traceId: string) => {
+    if (!traceMap.value[traceId]) return;
+
+    for (const handler of traceMap.value[traceId].complete) {
+      handler(traceId);
+    }
+  };
+
+  const onError = async (traceId: string, error: any) => {
+    if (!traceMap.value[traceId]) return;
+
+    errorOccurred.value = true;
+    
+    const response = convertToWsError(traceId, error);
+
+    for (const handler of traceMap.value[traceId].error) {
+      handler(response, traceId);
+    }
+
+    cleanUpListeners(traceId);
+
+  };
+
+  const onReset = (data: any, traceId: string) => {
+    if (!traceMap.value[traceId]) return;
+
+    for (const handler of traceMap.value[traceId].reset) {
+      handler(data, traceId);
+    }
+  };
+
+  const fetchQueryDataWithHttpStream = async (
+    data: {
+      queryReq: SearchRequestPayload;
+      type: "search" | "histogram" | "pageCount" | "values";
+      traceId: string;
+      org_id: string;
+      pageType: string;
+      searchType: string;
+      meta: any;
+    },
+    handlers: {
+      data: (data: any, response: any) => void;
+      error: (data: any, response: any) => void;
+      complete: (data: any, response: any) => void;
+      reset: (data: any, response: any) => void;
+    }
+  ) => {
+    const { traceId, org_id } = data;
+
+    if (!traceMap.value[traceId]) {
+      traceMap.value[traceId] = {
+        data: [],
+        error: [],
+        complete: [],
+        reset: [],
+        isInitiated: false,
+        streamId: null,
+        abortController: null,
+        requestData: { ...data }
+      };
+    }
+
+    // Register handlers for this trace ID
+    traceMap.value[traceId].data.push((res) => handlers.data(data, res));
+    traceMap.value[traceId].error.push((err) => handlers.error(data, err));
+    traceMap.value[traceId].complete.push((_) => handlers.complete(data, _));
+    traceMap.value[traceId].reset.push((res) => handlers.reset(data, res));
+
+    // If the stream connection is already initiated for this trace, exit early
+    if (traceMap.value[traceId].isInitiated) {
+      return;
+    }
+
+    // Mark this trace as initiated
+    traceMap.value[traceId].isInitiated = true;
+
+    // Initiate the HTTP/2 stream connection
+    initiateStreamConnection(data, handlers);
+  };
+
+  const initiateStreamConnection = async (
+    data: {
+      queryReq: SearchRequestPayload;
+      type: "search" | "histogram" | "pageCount" | "values";
+      traceId: string;
+      org_id: string;
+      pageType: string;
+      searchType: string;
+      meta: any;
+    },
+    handlers: {
+      data: (data: any, response: any) => void;
+      error: (data: any, response: any) => void;
+      complete: (data: any, response: any) => void;
+      reset: (data: any, response: any) => void;
+    }
+  ) => {
+    const { traceId, org_id, type, queryReq, searchType, pageType, meta } = data;
+    const abortController = new AbortController();
+
+    // Store the abort controller for this trace
+    abortControllers.value[traceId] = abortController;
+    traceMap.value[traceId].abortController = abortController;
+
+    // Construct URL based on search type
+    let url = '';
+    const use_cache = (window as any).use_cache !== undefined
+      ? (window as any).use_cache
+      : true;
+
+      //TODO OK: Create method to get the url based on the type
+      if(type === "search" || type === "histogram" || type === "pageCount") {
+        url = `/_search_stream?type=${pageType}&search_type=${searchType}&use_cache=${use_cache}`;
+        if (meta?.dashboard_id) url += `&dashboard_id=${meta?.dashboard_id}`;
+        if (meta?.folder_id) url += `&folder_id=${meta?.folder_id}`;
+        if (meta?.fallback_order_by_col) url += `&fallback_order_by_col=${meta?.fallback_order_by_col}`;
+        if (typeof queryReq.query.sql != "string") {
+          url = `/_search_multi_stream?type=${pageType}&search_type=${searchType}&use_cache=${use_cache}`;
+        }
+      } else if(type === "values") {
+        const fieldsString = meta?.fields.join(",");
+        url = `/_values_stream`
+      }
+
+    url = `${store.state.API_ENDPOINT}/api/${org_id}` + url;
+
+    try {
+      const spanId = getUUID().replace(/-/g, "").slice(0, 16);
+      const traceparent = `00-${traceId}-${spanId}-01`;
+      // Make the HTTP/2 streaming request
+      const response = await fetch(url, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'traceparent': traceparent,
+        },
+        body: JSON.stringify(queryReq),
+        signal: abortController.signal,
+      });
+
+      if (!response.ok) {
+        onError(traceId, {
+          status: response.status,
+          ...(await response.json()),
+        });
+        return;
+      }
+
+      // Set up worker for stream processing
+      const worker = createStreamWorker();
+      
+      if(worker) {
+      // Set up worker message handling
+        worker.onmessage = (event) => {
+          const { type, traceId: eventTraceId, data } = event.data;
+          switch (type) {
+            case 'search_response_metadata':
+              onData(eventTraceId, 'search_response_metadata', data);
+              break;
+            case 'search_response_hits':
+              onData(eventTraceId, 'search_response_hits', data);
+              break;
+            case 'progress':
+              onData(eventTraceId, 'progress', data);
+              break;
+            case 'error':
+              onError(eventTraceId, data);
+              break;
+            case 'end':
+              onData(eventTraceId, 'end', 'end');
+              break;
+          }
+        };
+      } else {
+        throw new Error('Worker is not supported');
+      }
+
+
+      // Get the ReadableStream
+      const readableStream = response.body;
+      if (!readableStream) {
+        throw new Error('Response body is null');
+      }
+      
+      // Start the stream in the worker
+      if(worker) {
+        worker.postMessage({
+          action: 'startStream',
+          traceId,
+          readableStream
+        }, [readableStream as any]);
+      } else {
+        throw new Error('Worker is not supported');
+      }
+      
+      // Store reference to abort controller for cancellation
+      activeStreamId.value = traceId;
+      
+    } catch (error) {
+      if ((error as any).name === 'AbortError') {
+        console.error('Stream was canceled');
+      } else {
+        onError(traceId, error);
+      }
+    }
+  };
+
+  const cancelStreamQueryBasedOnRequestId = (payload: {
+    trace_id: string;
+    org_id: string;
+  }) => {
+    const { trace_id } = payload;
+
+    if (abortControllers.value[trace_id]) {
+      abortControllers.value[trace_id].abort();
+      delete abortControllers.value[trace_id];
+    }
+
+    // Also cancel in worker
+    if (streamWorker) {
+      streamWorker.postMessage({
+        action: 'cancelStream',
+        traceId: trace_id
+      });
+    }
+
+    cleanUpListeners(trace_id);
+  };
+
+  const cleanUpListeners = (traceId: string) => {
+    if (traceMap.value[traceId]) {
+      delete traceMap.value[traceId];
+    }
+  };
+
+  const closeStreamWithError = () => {
+    Object.keys(abortControllers.value).forEach((traceId) => {
+      abortControllers.value[traceId].abort();
+      delete abortControllers.value[traceId];
+    });
+
+    // Close all streams in worker
+    if (streamWorker) {
+      streamWorker.postMessage({
+        action: 'closeAll'
+      });
+    }
+
+    Object.keys(traceMap.value).forEach((traceId) => {
+      delete traceMap.value[traceId];
+    });
+
+    activeStreamId.value = null;
+  };
+
+  const closeStream = () => {
+    Object.keys(abortControllers.value).forEach((traceId) => {
+      abortControllers.value[traceId].abort();
+      delete abortControllers.value[traceId];
+    });
+
+    // Close all streams in worker
+    if (streamWorker) {
+      streamWorker.postMessage({
+        action: 'closeAll'
+      });
+    }
+
+    Object.keys(traceMap.value).forEach((traceId) => {
+      delete traceMap.value[traceId];
+    });
+
+    activeStreamId.value = null;
+  };
+
+  const resetAuthToken = async () => {
+    await authService.refresh_token();
+  };
+
+
+  const convertToWsResponse = (traceId: string, response: any, type: StreamResponseType) => {
+
+    let resp = {
+      content: {
+        results: response.results || response,
+        streaming_aggs: response.streaming_aggs,
+        time_offset: response?.time_offset || {},
+        trace_id: traceId,
+      },
+      type: type,
+    };
+    return resp;
+  }
+
+  const convertToWsError = (traceId: string, response: any) => {
+    return {
+      content: {
+        ...response,
+        trace_id: traceId,
+      },
+      type: "error",
+    }
+  }
+
+  const convertToWsEventProgress = (traceId: string, response: any, type: StreamResponseType) => {
+    return {
+      content: {
+        percent: response?.percent,
+      },
+      type: "event_progress",
+    }
+  }
+
+  const convertToWsEnd = (traceId: string, response: any, type: StreamResponseType) => {
+    return {
+      content: {
+        end: true,
+      },
+      type: "end",
+    }
+  }
+
+  const wsMapper = {
+    'search_response_metadata': convertToWsResponse,
+    'search_response_hits': convertToWsResponse,
+    'progress': convertToWsEventProgress,
+    'error': convertToWsError,
+    'end': convertToWsEnd,
+  }
+
+  return {
+    fetchQueryDataWithHttpStream,
+    cancelStreamQueryBasedOnRequestId,
+    closeStreamWithError,
+    closeStream,
+    resetAuthToken,
+  };
+};
+
+export default useHttpStreaming; 

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -1142,6 +1142,8 @@ export default defineComponent({
             orgSettings?.data?.data?.toggle_ingestion_logs ?? false,
           enable_websocket_search:
             orgSettings?.data?.data?.enable_websocket_search ?? false,
+          enable_streaming_search:
+            orgSettings?.data?.data?.enable_streaming_search ?? false,
         });
       } catch (error) {
         console.error("Error in getOrganizationSettings:", error);

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -1093,7 +1093,8 @@
     "spanIdFieldName": "Span ID Field Name",
     "toggleIngestionLogsLabel": "Toggle Ingestion Logs",
     "cipherKeys": "Cipher Keys",
-    "nodes": "Nodes"
+    "nodes": "Nodes",
+    "enableStreamingSearch": "Enable Streaming Search"
   },
   "reports": {
     "header": "Reports",

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -387,7 +387,7 @@ import SearchBar from "@/plugins/logs/SearchBar.vue";
 import SearchHistory from "@/plugins/logs/SearchHistory.vue";
 import SearchSchedulersList from "@/plugins/logs/SearchSchedulersList.vue";
 import { type ActivationState, PageType } from "@/ts/interfaces/logs.ts";
-import { isWebSocketEnabled } from "@/utils/zincutils";
+import { isWebSocketEnabled, isStreamingEnabled } from "@/utils/zincutils";
 
 export default defineComponent({
   name: "PageSearch",
@@ -565,8 +565,8 @@ export default defineComponent({
       isLimitQuery,
       enableRefreshInterval,
       buildWebSocketPayload,
-      initializeWebSocketConnection,
-      addRequestId,
+      initializeSearchConnection,
+      addTraceId,
       sendCancelSearchMessage,
       isDistinctQuery,
       isWithQuery,
@@ -1542,9 +1542,7 @@ export default defineComponent({
     // [END] cancel running queries
 
     const cancelOnGoingSearchQueries = () => {
-      sendCancelSearchMessage(
-        searchObj.data.searchWebSocketRequestIdsAndTraceIds,
-      );
+      sendCancelSearchMessage(searchObj.data.searchWebSocketTraceIds);
     };
 
     return {
@@ -1595,14 +1593,15 @@ export default defineComponent({
       fnParsedSQL,
       isLimitQuery,
       buildWebSocketPayload,
-      initializeWebSocketConnection,
-      addRequestId,
+      initializeSearchConnection,
+      addTraceId,
       isWebSocketEnabled,
       showJobScheduler,
       showSearchScheduler,
       closeSearchSchedulerFn,
       isDistinctQuery,
       isWithQuery,
+      isStreamingEnabled,
     };
   },
   computed: {
@@ -1681,14 +1680,17 @@ export default defineComponent({
 
         if (this.searchObj.meta.sqlMode && this.isLimitQuery(parsedSQL)) {
           this.resetHistogramWithError(
-            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",-1
+            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
+            -1,
           );
           this.searchObj.meta.histogramDirtyFlag = false;
-        } 
-        else if (this.searchObj.meta.sqlMode && (this.isDistinctQuery(parsedSQL) || this.isWithQuery(parsedSQL))) {
+        } else if (
+          this.searchObj.meta.sqlMode &&
+          (this.isDistinctQuery(parsedSQL) || this.isWithQuery(parsedSQL))
+        ) {
           this.resetHistogramWithError(
             "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
-            -1
+            -1,
           );
           this.searchObj.meta.histogramDirtyFlag = false;
         } else if (this.searchObj.data.stream.selectedStream.length > 1) {
@@ -1705,11 +1707,11 @@ export default defineComponent({
           this.searchObj.loadingHistogram = true;
 
           const shouldUseWebSocket = this.isWebSocketEnabled();
-
+          const shouldUseStreaming = this.isStreamingEnabled();
           // Generate histogram skeleton before making request
           await this.generateHistogramSkeleton();
 
-          if (shouldUseWebSocket) {
+          if (shouldUseWebSocket || shouldUseStreaming) {
             // Use WebSocket for histogram data
             const payload = this.buildWebSocketPayload(
               this.searchObj.data.histogramQuery,
@@ -1719,10 +1721,10 @@ export default defineComponent({
                 isHistogramOnly: this.searchObj.meta.histogramDirtyFlag,
               },
             );
-            const requestId = this.initializeWebSocketConnection(payload);
+            const requestId = this.initializeSearchConnection(payload);
 
             if (requestId) {
-              this.addRequestId(requestId, payload.traceId);
+              this.addTraceId(payload.traceId);
             }
 
             return;
@@ -1787,8 +1789,12 @@ export default defineComponent({
     async fullSQLMode(newVal) {
       if (newVal) {
         await nextTick();
-        this.setQuery(newVal);
-        this.updateUrlQueryParams();
+        if (this.searchObj.meta.sqlModeManualTrigger) {
+          this.searchObj.meta.sqlModeManualTrigger = false;
+        } else {
+          this.setQuery(newVal);
+          this.updateUrlQueryParams();
+        }
       } else {
         this.searchObj.meta.sqlMode = false;
         this.searchObj.data.query = "";

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -658,7 +658,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <q-btn
                 v-if="
                   config.isEnterprise == 'true' &&
-                  !!searchObj.data.searchRequestTraceIds.length &&
+                  (!!searchObj.data.searchRequestTraceIds.length ||
+                    !!searchObj.data.searchWebSocketTraceIds.length) &&
                   (searchObj.loading == true ||
                     searchObj.loadingHistogram == true)
                 "
@@ -1721,6 +1722,14 @@ export default defineComponent({
           }
         }
       }
+      if (
+        searchObj.meta.sqlMode === false &&
+        value.toLowerCase().includes("select") &&
+        value.toLowerCase().includes("from")
+      ) {
+        searchObj.meta.sqlMode = true;
+        searchObj.meta.sqlModeManualTrigger = true;
+      }
 
       if (value != "" && searchObj.meta.sqlMode === true) {
         const parsedSQL = fnParsedSQL();
@@ -1738,9 +1747,12 @@ export default defineComponent({
         if (searchObj.meta.sqlMode === true) {
           searchObj.data.parsedQuery = parser.astify(value);
           if (searchObj.data.parsedQuery?.from?.length > 0) {
-            //this condition is to handle the with queries so for WITH queries the table name is not present in the from array it will be there in the with array 
+            //this condition is to handle the with queries so for WITH queries the table name is not present in the from array it will be there in the with array
             //the table which is there in from array is the temporary array
-            const tableName: string = !searchObj.data.parsedQuery.with ? searchObj.data.parsedQuery.from[0].table || searchObj.data.parsedQuery.from[0].expr?.ast?.from?.[0]?.table : "";
+            const tableName: string = !searchObj.data.parsedQuery.with
+              ? searchObj.data.parsedQuery.from[0].table ||
+                searchObj.data.parsedQuery.from[0].expr?.ast?.from?.[0]?.table
+              : "";
             if (
               !searchObj.data.stream.selectedStream.includes(tableName) &&
               tableName !== streamName

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       ref="searchListContainer"
       style="width: 100%"
     >
-      <div class="row">
+      <div class="row tw-min-h-[44px]">
         <div
           class="col-6 text-left q-pl-lg q-mt-xs bg-warning text-white rounded-borders"
           v-if="searchObj.data.countErrorMsg != ''"
@@ -33,34 +33,47 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :htmlContent="searchObj.data.countErrorMsg"
           />
         </div>
-        <div v-else class="col-9 text-left q-pl-lg q-mt-xs warning flex items-center">
+        <div
+          v-else
+          class="col-7 text-left q-pl-lg q-mt-xs warning flex items-center"
+        >
           {{ noOfRecordsTitle }}
           <span v-if="searchObj.loadingCounter" class="q-ml-md">
             <q-spinner-hourglass
-            color="primary"
-            size="25px"
-            style="margin: 0 auto; display: block"
-          />
-          <q-tooltip
+              color="primary"
+              size="25px"
+              style="margin: 0 auto; display: block"
+            />
+            <q-tooltip
               anchor="center right"
               self="center left"
               max-width="300px"
             >
-              <span style="font-size: 14px"
-                >Fetching the search events</span
-              >
+              <span style="font-size: 14px">Fetching the search events</span>
             </q-tooltip>
-
           </span>
-          <span v-else-if="searchObj.data.histogram.errorCode == -1 && !searchObj.loadingCounter && searchObj.meta.showHistogram" class="q-ml-md " 
-          :class="store.state.theme == 'dark' ? 'histogram-unavailable-text' : 'histogram-unavailable-text-light'"
+          <div
+            v-else-if="
+              searchObj.data.histogram.errorCode == -1 &&
+              !searchObj.loadingCounter &&
+              searchObj.meta.showHistogram
+            "
+            class="q-ml-md tw-cursor-pointer"
+            :class="
+              store.state.theme == 'dark'
+                ? 'histogram-unavailable-text'
+                : 'histogram-unavailable-text-light'
+            "
           >
-            {{ searchObj.data.histogram.errorMsg }}
-          </span>
+            <!-- {{ searchObj.data.histogram.errorMsg }} -->
+            <q-icon name="info" color="warning" size="sm"> </q-icon>
+            <q-tooltip position="top" class="tw-text-sm tw-font-semi-bold">
+              {{ searchObj.data.histogram.errorMsg }}
+            </q-tooltip>
+          </div>
         </div>
 
-        <div class="col-3 text-right q-pr-md q-gutter-xs pagination-block">
-          
+        <div class="col-5 text-right q-pr-md q-gutter-xs pagination-block">
           <q-pagination
             v-if="searchObj.meta.resultGrid.showPagination"
             :disable="searchObj.loading == true"
@@ -74,6 +87,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               Math.max(
                 1,
                 (searchObj.communicationMethod === 'ws' ||
+                searchObj.communicationMethod === 'streaming' ||
                 searchObj.meta.jobId != ''
                   ? searchObj.data.queryResults?.pagination?.length
                   : searchObj.data.queryResults?.partitionDetail?.paginations
@@ -110,28 +124,59 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           ></q-select>
         </div>
       </div>
-      <div v-if="searchObj.data?.histogram?.errorMsg == '' && searchObj.data.histogram.errorCode != -1">
+      <div
+        :style="{
+          height: searchObj.meta.showHistogram ? '100px' : '0px',
+        }"
+        v-if="
+          searchObj.data?.histogram?.errorMsg == '' &&
+          searchObj.data.histogram.errorCode != -1
+        "
+      >
         <ChartRenderer
-          v-if="searchObj.meta.showHistogram && (searchObj.data?.queryResults?.aggs?.length > 0 || ( plotChart && Object.keys(plotChart)?.length > 0))"
+          v-if="
+            searchObj.meta.showHistogram &&
+            (searchObj.data?.queryResults?.aggs?.length > 0 ||
+              (plotChart && Object.keys(plotChart)?.length > 0))
+          "
           data-test="logs-search-result-bar-chart"
           :data="plotChart"
           style="max-height: 100px"
           @updated:dataZoom="onChartUpdate"
         />
-        
-        <div v-else-if="searchObj.meta.showHistogram && (Object.keys(plotChart)?.length == 0) && searchObj.loadingHistogram == false && searchObj.loading == false">
-          <h3
-            class="text-center"
-            style="margin: 30px 0px"
-          >
-            <q-icon name="warning" color="warning" size="xs"></q-icon> No data found for histogram.
+
+        <div
+          style="height: 100px"
+          v-else-if="
+            searchObj.meta.showHistogram &&
+            Object.keys(plotChart)?.length == 0 &&
+            searchObj.loadingHistogram == false &&
+            searchObj.loading == false
+          "
+        >
+          <h3 class="text-center">
+            <span style="min-height: 50px">
+              <q-icon name="warning" color="warning" size="xs"></q-icon> No data
+              found for histogram.</span
+            >
           </h3>
         </div>
+
+        <div
+          style="height: 100px"
+          v-else-if="
+            searchObj.meta.showHistogram && Object.keys(plotChart)?.length == 0
+          "
+        >
+          <h3 class="text-center">
+            <span style="min-height: 50px; color: transparent">.</span>
+          </h3>
+        </div>
+
         <div
           class="q-pb-lg"
           style=" left: 45%; margin: 30px 0px"
           v-if="histogramLoader"
-          
         >
           <q-spinner-hourglass
             color="primary"
@@ -143,17 +188,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div
         v-else-if="
           searchObj.data.histogram?.errorMsg != '' &&
-          searchObj.meta.showHistogram
-          && searchObj.data.histogram.errorCode != -1
+          searchObj.meta.showHistogram &&
+          searchObj.data.histogram.errorCode != -1
         "
       >
         <h6
           class="text-center"
           style="margin: 30px 0px"
-          v-if="searchObj.data.histogram.errorCode != 0 && searchObj.data.histogram.errorCode != -1"
+          v-if="
+            searchObj.data.histogram.errorCode != 0 &&
+            searchObj.data.histogram.errorCode != -1
+          "
         >
-          <q-icon name="warning" color="warning" size="xs"></q-icon> Error
-          while fetching histogram data.
+          <q-icon name="warning" color="warning" size="xs"></q-icon> Error while
+          fetching histogram data.
           <q-btn
             @click="toggleErrorDetails"
             size="sm"
@@ -163,18 +211,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <span v-if="disableMoreErrorDetails">
             <SanitizedHtmlRenderer
               data-test="logs-search-histogram-error-message"
-              :htmlContent="
-                searchObj.data?.histogram?.errorMsg
-              "
+              :htmlContent="searchObj.data?.histogram?.errorMsg"
             />
           </span>
         </h6>
-        <h6 class="text-center" v-else-if="searchObj.data.histogram.errorCode != -1">
+        <h6
+          class="text-center"
+          v-else-if="searchObj.data.histogram.errorCode != -1"
+        >
           <SanitizedHtmlRenderer
             data-test="logs-search-histogram-error-message"
-            :htmlContent="
-              searchObj.data?.histogram?.errorMsg
-            "
+            :htmlContent="searchObj.data?.histogram?.errorMsg"
           />
         </h6>
       </div>
@@ -193,9 +240,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :default-columns="!searchObj.data.stream.selectedFields.length"
         class="col-12"
         :style="{
-          height: !searchObj.meta.showHistogram || (searchObj.meta.showHistogram && searchObj.data.histogram.errorCode == -1)
-            ? 'calc(100% - 40px)'
-            : 'calc(100% - 140px)',
+          height:
+            !searchObj.meta.showHistogram ||
+            (searchObj.meta.showHistogram &&
+              searchObj.data.histogram.errorCode == -1)
+              ? 'calc(100% - 40px)'
+              : 'calc(100% - 140px)',
         }"
         @update:columnSizes="handleColumnSizesUpdate"
         @update:columnOrder="handleColumnOrderUpdate"
@@ -358,33 +408,43 @@ export default defineComponent({
       } else if (actionType == "recordsPerPage") {
         this.searchObj.data.resultGrid.currentPage = 1;
         this.pageNumberInput = this.searchObj.data.resultGrid.currentPage;
-        if (this.searchObj.communicationMethod === "ws") {
-            if (this.searchObj.meta.jobId == "") {
-              this.refreshPagination();
-            } else {
-              this.refreshJobPagination();
-            }
+        if (
+          this.searchObj.communicationMethod === "ws" ||
+          this.searchObj.communicationMethod === "streaming"
+        ) {
+          if (this.searchObj.meta.jobId == "") {
+            this.refreshPagination();
           } else {
-            if (this.searchObj.meta.jobId !== "") {
-              this.refreshJobPagination();
-            } else {
-              this.refreshPartitionPagination(true);
-            }
+            this.refreshJobPagination();
           }
+        } else {
+          if (this.searchObj.meta.jobId !== "") {
+            this.refreshJobPagination();
+          } else {
+            this.refreshPartitionPagination(true);
+          }
+        }
         this.$emit("update:recordsPerPage");
         this.scrollTableToTop(0);
       } else if (actionType == "pageChange") {
-      //here at first the queryResults is undefined so we are checking if it is undefined then we are setting it to empty array
-        if(this.searchObj.meta.jobId != "" && this.searchObj.data.queryResults.paginations == undefined){
+        //here at first the queryResults is undefined so we are checking if it is undefined then we are setting it to empty array
+        if (
+          this.searchObj.meta.jobId != "" &&
+          this.searchObj.data.queryResults.paginations == undefined
+        ) {
           this.searchObj.data.queryResults.pagination = [];
         }
         const maxPages =
           this.searchObj.communicationMethod === "ws" ||
+          this.searchObj.communicationMethod === "streaming" ||
           this.searchObj.meta.jobId != ""
             ? this.searchObj.data.queryResults.pagination.length
             : this.searchObj.data.queryResults?.partitionDetail?.paginations
                 .length;
-        if (this.pageNumberInput > Math.ceil(maxPages) && this.searchObj.meta.jobId == "") {
+        if (
+          this.pageNumberInput > Math.ceil(maxPages) &&
+          this.searchObj.meta.jobId == ""
+        ) {
           this.$q.notify({
             type: "negative",
             message:
@@ -635,9 +695,9 @@ export default defineComponent({
       }
     });
     //this is used to show the histogram loader when the histogram is loading
-    const histogramLoader = computed(()=>{
-      return (searchObj.meta.showHistogram) && (searchObj.loadingHistogram == true ||  searchObj.loading == true) && ( plotChart.value && Object.keys(plotChart.value)?.length == 0) 
-    })
+    const histogramLoader = computed(() => {
+      return searchObj.meta.showHistogram && searchObj.loadingHistogram == true;
+    });
 
     return {
       t,
@@ -677,7 +737,7 @@ export default defineComponent({
       getPaginations,
       refreshPagination,
       refreshJobPagination,
-      histogramLoader
+      histogramLoader,
     };
   },
   computed: {
@@ -708,7 +768,7 @@ export default defineComponent({
       this.noOfRecordsTitle = this.searchObj.data.histogram.chartParams.title;
     },
     resetPlotChart(newVal: boolean) {
-      if(newVal) {
+      if (newVal) {
         this.plotChart = {};
         this.searchObj.meta.resetPlotChart = false;
       }
@@ -968,10 +1028,10 @@ export default defineComponent({
     height: 30px;
   }
 }
-.histogram-unavailable-text{
-  color: #F5A623;
+.histogram-unavailable-text {
+  color: #f5a623;
 }
-.histogram-unavailable-text-light{
+.histogram-unavailable-text-light {
   color: #ff8800;
 }
 </style>

--- a/web/src/services/streaming_search.ts
+++ b/web/src/services/streaming_search.ts
@@ -1,0 +1,230 @@
+import { generateTraceContext } from "@/utils/zincutils";
+import http from "./http";
+
+const stream = {
+  // HTTP/2 streaming search endpoint with SSE
+  searchStreamUrl: (
+    {
+      org_identifier,
+      page_type = "logs",
+      search_type = "ui",
+      traceId,
+    }: {
+      org_identifier: string;
+      page_type: string;
+      search_type?: string;
+      traceId: string;
+    }
+  ) => {
+    const use_cache: boolean =
+      (window as any).use_cache !== undefined
+        ? (window as any).use_cache
+        : true;
+    
+    return `/api/${org_identifier}/_search_stream?type=${page_type}&search_type=${search_type}&use_cache=${use_cache}&trace_id=${traceId}`;
+  },
+  
+  // HTTP/2 streaming histogram endpoint with SSE
+  histogramStreamUrl: (
+    {
+      org_identifier,
+      page_type = "logs",
+      search_type = "ui",
+      traceId,
+    }: {
+      org_identifier: string;
+      page_type: string;
+      search_type?: string;
+      traceId: string;
+    }
+  ) => {
+    const use_cache: boolean =
+      (window as any).use_cache !== undefined
+        ? (window as any).use_cache
+        : true;
+        
+    return `/api/${org_identifier}/_search_histogram_stream?type=${page_type}&search_type=${search_type}&use_cache=${use_cache}&trace_id=${traceId}`;
+  },
+  
+  // HTTP/2 streaming page count endpoint with SSE
+  pageCountStreamUrl: (
+    {
+      org_identifier,
+      page_type = "logs",
+      search_type = "ui",
+      traceId,
+    }: {
+      org_identifier: string;
+      page_type: string;
+      search_type?: string;
+      traceId: string;
+    }
+  ) => {
+    const use_cache: boolean =
+      (window as any).use_cache !== undefined
+        ? (window as any).use_cache
+        : true;
+        
+    return `/api/${org_identifier}/_search_pagecount_stream?type=${page_type}&search_type=${search_type}&use_cache=${use_cache}&trace_id=${traceId}`;
+  },
+  
+  // HTTP/2 streaming values endpoint with SSE for field value lookups
+  fieldValuesStreamUrl: (
+    {
+      org_identifier,
+      fields,
+      stream_name,
+      page_type = "logs",
+      traceId,
+    }: {
+      org_identifier: string;
+      fields: string[];
+      stream_name: string;
+      page_type: string;
+      traceId: string;
+    }
+  ) => {
+    const fieldsString = fields.join(',');
+    const use_cache: boolean =
+      (window as any).use_cache !== undefined
+        ? (window as any).use_cache
+        : true;
+        
+    return `/api/${org_identifier}/${stream_name}/_values_stream?fields=${fieldsString}&type=${page_type}&use_cache=${use_cache}&trace_id=${traceId}`;
+  },
+  
+  // Start a streaming search request
+  search: (
+    {
+      org_identifier,
+      query,
+      page_type = "logs",
+      search_type = "ui",
+      traceId,
+    }: {
+      org_identifier: string;
+      query: any;
+      page_type: string;
+      search_type?: string;
+      traceId?: string;
+    }
+  ) => {
+    if (!traceId) {
+      traceId = generateTraceContext()?.traceId;
+    }
+    
+    const use_cache: boolean =
+      (window as any).use_cache !== undefined
+        ? (window as any).use_cache
+        : true;
+        
+    const url = `/api/${org_identifier}/_search_stream?type=${page_type}&search_type=${search_type}&use_cache=${use_cache}&trace_id=${traceId}`;
+    return http().post(url, query);
+  },
+  
+  // Start a streaming histogram request
+  histogram: (
+    {
+      org_identifier,
+      query,
+      page_type = "logs",
+      search_type = "ui",
+      traceId,
+    }: {
+      org_identifier: string;
+      query: any;
+      page_type: string;
+      search_type?: string;
+      traceId?: string;
+    }
+  ) => {
+    if (!traceId) {
+      traceId = generateTraceContext()?.traceId;
+    }
+    
+    const use_cache: boolean =
+      (window as any).use_cache !== undefined
+        ? (window as any).use_cache
+        : true;
+        
+    const url = `/api/${org_identifier}/_search_histogram_stream?type=${page_type}&search_type=${search_type}&use_cache=${use_cache}&trace_id=${traceId}`;
+    return http().post(url, query);
+  },
+  
+  // Start a streaming page count request
+  pageCount: (
+    {
+      org_identifier,
+      query,
+      page_type = "logs",
+      search_type = "ui",
+      traceId,
+    }: {
+      org_identifier: string;
+      query: any;
+      page_type: string;
+      search_type?: string;
+      traceId?: string;
+    }
+  ) => {
+    if (!traceId) {
+      traceId = generateTraceContext()?.traceId;
+    }
+    
+    const use_cache: boolean =
+      (window as any).use_cache !== undefined
+        ? (window as any).use_cache
+        : true;
+        
+    const url = `/api/${org_identifier}/_search_pagecount_stream?type=${page_type}&search_type=${search_type}&use_cache=${use_cache}&trace_id=${traceId}`;
+    return http().post(url, query);
+  },
+  
+  // Fetch field values using streaming
+  fieldValues: (
+    {
+      org_identifier,
+      stream_name,
+      fields,
+      query,
+      page_type = "logs",
+      traceId,
+    }: {
+      org_identifier: string;
+      stream_name: string;
+      fields: string[];
+      query: any;
+      page_type: string;
+      traceId?: string;
+    }
+  ) => {
+    if (!traceId) {
+      traceId = generateTraceContext()?.traceId;
+    }
+    
+    const fieldsString = fields.join(',');
+    const use_cache: boolean =
+      (window as any).use_cache !== undefined
+        ? (window as any).use_cache
+        : true;
+        
+    const url = `/api/${org_identifier}/${stream_name}/_values_stream?fields=${fieldsString}&type=${page_type}&use_cache=${use_cache}&trace_id=${traceId}`;
+    return http().post(url, query);
+  },
+  
+  // Cancel an ongoing HTTP/2 stream
+  cancelStream: async (
+    {
+      org_identifier,
+      traceId,
+    }: {
+      org_identifier: string;
+      traceId: string;
+    }
+  ) => {
+    const url = `/api/${org_identifier}/query_manager/cancel`;
+    return http().put(url, [traceId]);
+  }
+};
+
+export default stream; 

--- a/web/src/ts/interfaces/query.ts
+++ b/web/src/ts/interfaces/query.ts
@@ -43,7 +43,7 @@ export interface HistogramQueryPayload {
 }
 
 export interface WebSocketSearchResponse {
-  type: "search_response" | "cancel_response";
+  type: "search_response" | "cancel_response" | "error" | "end" | "progress" | "search_response_metadata" | "search_response_hits";
   content: {
     results: {
       hits: any[];
@@ -53,8 +53,15 @@ export interface WebSocketSearchResponse {
       new_start_time?: number;
       new_end_time?: number;
       scan_size?: number;
+      from?: number;
+      aggs?: any;
+      result_cache_ratio?: number;
     };
     streaming_aggs?: boolean;
+    total?: number;
+    time_offset?: string;
+    traceId: string;
+    type?: string;
   };
 }
 
@@ -80,9 +87,50 @@ export interface ErrorContent {
   trace_id?: string;
   code?: number;
   error_detail?: string;
+  error?: string;
 }
 
 export interface WebSocketErrorResponse {
   content: ErrorContent;
   type: "error";
+}
+
+// HTTP2 Streaming interfaces
+export interface StreamingSource {
+  [traceId: string]: EventSource;
+}
+
+export interface StreamingSearchResponse {
+  hits: any[];
+  total: number;
+  took: number;
+  function_error?: string;
+  new_start_time?: number;
+  new_end_time?: number;
+  scan_size?: number;
+  time_offset?: string;
+  cached_ratio?: number;
+  streaming_aggs?: boolean;
+}
+
+export interface StreamingSearchEvent {
+  data: string; // JSON string of StreamingSearchResponse
+  type: "message" | "error" | "open" | "end";
+  lastEventId?: string;
+}
+
+export interface StreamingSearchPayload {
+  queryReq: SearchRequestPayload;
+  type: "search" | "histogram" | "pageCount" | "values";
+  isPagination: boolean;
+  traceId: string;
+  org_id: string;
+  meta?: any;
+}
+
+export interface StreamingErrorResponse {
+  message: string;
+  trace_id?: string;
+  code?: number;
+  error_detail?: string;
 }

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -349,7 +349,9 @@ export const convertSQLData = async (
 
   const missingValue = () => {
     // Get the interval in minutes
-    const interval = resultMetaData?.map((it: any) => it?.histogram_interval)?.[0];
+    const interval = resultMetaData?.map(
+      (it: any) => it?.histogram_interval,
+    )?.[0];
 
     if (
       !interval ||

--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -994,6 +994,20 @@ export const isWebSocketEnabled = () => {
     return (window as any).use_web_socket;
   }
 };
+
+export const isStreamingEnabled = () => {
+  if (!store.state.zoConfig?.streaming_enabled) {
+    return false;
+  }
+
+  if ((window as any).use_streaming === undefined) {
+    return store?.state?.organizationData?.organizationSettings
+      ?.enable_streaming_search;
+  } else {
+    return (window as any).use_streaming;
+  }
+};
+
 export const maxLengthCharValidation = (
   val: string = "",
   char_length: number = 50,

--- a/web/src/workers/streamWorker.js
+++ b/web/src/workers/streamWorker.js
@@ -1,0 +1,144 @@
+// Worker to handle stream processing
+// This offloads decoding and parsing from the main thread
+
+let activeStreams = {};
+let activeBuffers = {};
+// Handle messages from main thread
+self.onmessage = async (event) => {
+  const { action, traceId, readableStream, chunk } = event.data;
+
+  switch (action) {
+    case 'startStream':
+      // Convert transferable stream back to a reader
+      const reader = readableStream.getReader();
+      activeStreams[traceId] = reader;
+      activeBuffers[traceId] = '';
+      processStream(traceId, reader);
+      break;
+
+    case 'cancelStream':
+      if (activeStreams[traceId]) {
+        activeStreams[traceId].cancel();
+        delete activeStreams[traceId];
+        delete activeBuffers[traceId];
+      }
+      break;
+
+    case 'closeAll':
+      Object.keys(activeStreams).forEach(id => {
+        if (activeStreams[id]) {
+          activeStreams[id].cancel();
+        }
+      });
+      activeStreams = {};
+      activeBuffers = {};
+      break;
+  }
+};
+
+// Process the stream for a given traceId
+async function processStream(traceId, reader) {
+  const decoder = new TextDecoder();
+  let buffer = activeBuffers[traceId] || '';
+
+  try {
+    while (activeStreams[traceId]) {
+      const { done, value, cancelled } = await reader.read();
+
+      if (done) {
+        // Stream ended, send end notification
+        self.postMessage({
+          type: 'end',
+          traceId,
+        });
+        
+        delete activeStreams[traceId];
+        delete activeBuffers[traceId];
+        break;
+      }
+      
+      // Decode chunk and add to buffer
+      const chunk = decoder.decode(value, { stream: true });
+      buffer += chunk;
+      
+      // Process complete messages
+      const messages = buffer.split('\n\n');
+      // Keep the last potentially incomplete message in buffer
+      buffer = messages.pop() || '';
+      activeBuffers[traceId] = buffer;
+      
+      const lines = messages.filter(line => line.trim());
+      
+      // Process each complete line
+      for (let i = 0; i < lines.length; i++) {
+        try {
+          const msgLines = lines[i].split('\n');          
+          // Check if this is an event line
+
+          if(msgLines.length > 1){
+            const eventType = msgLines[0].startsWith('event:') ? msgLines[0].slice(7).trim() : msgLines[0].slice(6).trim();
+
+            if (msgLines[1]?.startsWith('data:') || msgLines[1]?.startsWith('data: ')) {
+              const data = msgLines[1]?.startsWith('data:') ? msgLines[1]?.slice(6) : msgLines[1]?.slice(5);
+
+              try {
+                // Try to parse as JSON
+                const json = JSON.parse(data);
+                                // Send message based on event type
+                self.postMessage({
+                  type: eventType,
+                  traceId,
+                  data: json,
+                });
+              } catch (parseErr) {
+                // If JSON parsing fails, send raw data
+                self.postMessage({
+                  type: 'error',
+                  traceId,
+                  data: { message: 'Error parsing data', error: parseErr.toString() },
+                });
+              }
+            }
+          }
+
+          if (msgLines[0]?.startsWith('data:') || msgLines[0]?.startsWith('data: ')) {
+            const data = msgLines[0]?.startsWith('data:') ? msgLines[0]?.slice(6) : msgLines[0]?.slice(5);
+            try {
+              // Try to parse as JSON
+              const json = JSON.parse(data);
+                              // Send message based on event type
+              self.postMessage({
+                type: 'data',
+                traceId,
+                data: json,
+              });
+            } catch (parseErr) {
+              // If JSON parsing fails, send raw data
+              self.postMessage({
+                type: 'data',
+                traceId,
+                data: data,
+              });
+            }
+          }
+        } catch (e) {
+          self.postMessage({
+            type: 'error',
+            traceId,
+            data: { message: 'Error processing message', error: e.toString() },
+          });
+        }
+      }
+    }
+  } catch (error) {
+    // Send error to main thread
+    self.postMessage({
+      type: 'error',
+      traceId,
+      data: { message: 'Stream processing error', error },
+    });
+    
+    delete activeStreams[traceId];
+    delete activeBuffers[traceId];
+  }
+} 


### PR DESCRIPTION
- [x] Stream compressed chunks
- [x] Split partitioned responses to chunks
- [x] Values API Logs page support
- [x] ~~Values API Dashboards page support~~ ( To be added later )
- [x] Mapping errors to HTTP code
- [x] Add Event types
  - `Error` event addition (`event: error\ndata: {}\n\n"`)
  - `Done` event ('data: [[DONE]]`)
- Add event header to responses (`event: search_response_hits` & `event: search_response_metadata`)
- [x] Audit Stream verification.
- [x] FE Cancel API fix
- [x] Dashboard fallback column for order by
- [x] Toggle streaming
- [x] rate limit `/_search_stream`
- [ ] ~~FE manual retry at connection err~~ ( Can be added as per requirement )

Testing:
- [x] ~~reproduce`ERR_INCOMPLETE_CHUNKED_ENCODING` fix~~ ( Not reproducible after streaming fixed )
- [x] load testing with Navigating dashboards

---------