### PR TITLE
fix: skip download if partial downalod after all retries

### DIFF
--- a/src/infra/src/cache/file_data/mod.rs
+++ b/src/infra/src/cache/file_data/mod.rs
@@ -264,12 +264,15 @@ async fn download_from_storage(
             tokio::time::sleep(tokio::time::Duration::from_secs(retry_time)).await;
             retry_time *= 2;
             continue;
+        } else {
+            // size matches
+            break;
         }
     }
     // if even after retries, the download size does not match, we skip it
     // no point in validating or setting the value
     if data_len != expected_blob_size {
-        Err(anyhow::anyhow!(
+        return Err(anyhow::anyhow!(
             "file {file} could not be downloaded completely: expected {expected_blob_size}, got {data_len} skipping"
         ));
     }

--- a/src/infra/src/cache/file_data/mod.rs
+++ b/src/infra/src/cache/file_data/mod.rs
@@ -266,6 +266,13 @@ async fn download_from_storage(
             continue;
         }
     }
+    // if even after retries, the download size does not match, we skip it
+    // no point in validating or setting the value
+    if data_len != expected_blob_size {
+        Err(anyhow::anyhow!(
+            "file {file} could not be downloaded completely: expected {expected_blob_size}, got {data_len} skipping"
+        ));
+    }
 
     // now the size we downloaded matches what blob store has or tried the max attempts, we check
     // if it matches with what we have in db or not. Also because the size matches blob store/we


### PR DESCRIPTION
Previously we did a footer check even when after all retries the blob download was partial. Now we skip and return error, as no sense in checking footer when we know the blob size is incomplete.