### PR TITLE
feat: download manager improvements

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1995,6 +1995,10 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         cfg.limit.file_download_thread_num = std::cmp::max(1, cpu_num / 2);
     }
 
+    if cfg.limit.file_download_priority_queue_thread_num == 0 {
+        cfg.limit.file_download_priority_queue_thread_num = std::cmp::max(1, cpu_num / 2);
+    }
+
     // HACK for move_file_thread_num equal to CPU core
     if cfg.limit.file_move_thread_num == 0 {
         if cfg.common.local_mode {

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1191,6 +1191,12 @@ pub struct Limit {
     pub query_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_THREAD_NUM", default = 0)]
     pub file_download_thread_num: usize,
+    #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_THREAD_NUM", default = 0)]
+    pub file_download_priority_queue_thread_num: usize,
+    #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_WINDOW_SECS", default = 3600)]
+    pub file_download_priority_queue_window_secs: u64,
+    #[env_config(name = "ZO_FILE_DOWNLOAD_ENABLE_PRIORITY_QUEUE", default = true)]
+    pub file_download_enable_priority_queue: bool,
     #[env_config(name = "ZO_QUERY_TIMEOUT", default = 600)]
     pub query_timeout: u64,
     #[env_config(name = "ZO_QUERY_INGESTER_TIMEOUT", default = 0)]

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -789,6 +789,59 @@ pub static NODE_TCP_CONNECTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+// query disk cache metrics
+pub static QUERY_DISK_CACHE_HIT_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_disk_cache_hit_count",
+            "query disk cache hit count".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["organization", "stream_type", "file_type"],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_DISK_CACHE_MISS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_disk_cache_miss_count",
+            "query disk cache miss count".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["organization", "stream_type", "file_type"],
+    )
+    .expect("Metric created")
+});
+
+// file downloader metrics
+pub static FILE_DOWNLOADER_NORMAL_QUEUE_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "file_downloader_normal_queue_size",
+            "file downloader normal queue size",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
+pub static FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "file_downloader_priority_queue_size",
+            "file downloader priority queue size",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
 fn register_metrics(registry: &Registry) {
     // http latency
     registry
@@ -998,6 +1051,21 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(NODE_TCP_CONNECTIONS.clone()))
+        .expect("Metric registered");
+
+    // query disk cache metrics
+    registry
+        .register(Box::new(QUERY_DISK_CACHE_HIT_COUNT.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_DISK_CACHE_MISS_COUNT.clone()))
+        .expect("Metric registered");
+    // file downloader metrics
+    registry
+        .register(Box::new(FILE_DOWNLOADER_NORMAL_QUEUE_SIZE.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE.clone()))
         .expect("Metric registered");
 }
 

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -13,9 +13,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::{collections::VecDeque, sync::Arc};
 
-use config::get_config;
+use config::{get_config, meta::stream::FileMeta, metrics};
 use infra::cache::file_data;
 use once_cell::sync::Lazy;
 use tokio::sync::{
@@ -37,14 +37,44 @@ impl DownloadQueue {
     }
 }
 
+struct PriorityDownloadQueue {
+    sender: Sender<FileInfo>,
+    receiver: Arc<Mutex<Receiver<FileInfo>>>,
+    stack: Arc<Mutex<VecDeque<FileInfo>>>,
+}
+
+impl PriorityDownloadQueue {
+    fn new(sender: Sender<FileInfo>, receiver: Arc<Mutex<Receiver<FileInfo>>>) -> Self {
+        Self {
+            sender,
+            receiver,
+            stack: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+
+    async fn push(&self, file_info: FileInfo) {
+        self.stack.lock().await.push_back(file_info);
+    }
+
+    async fn pop(&self) -> Option<FileInfo> {
+        self.stack.lock().await.pop_front()
+    }
+}
+
 const FILE_DOWNLOAD_QUEUE_SIZE: usize = 10000;
 static FILE_DOWNLOAD_CHANNEL: Lazy<DownloadQueue> = Lazy::new(|| {
     let (tx, rx) = tokio::sync::mpsc::channel::<FileInfo>(FILE_DOWNLOAD_QUEUE_SIZE);
     DownloadQueue::new(tx, Arc::new(Mutex::new(rx)))
 });
 
+static PRIORITY_FILE_DOWNLOAD_CHANNEL: Lazy<PriorityDownloadQueue> = Lazy::new(|| {
+    let (tx, rx) = tokio::sync::mpsc::channel::<FileInfo>(FILE_DOWNLOAD_QUEUE_SIZE);
+    PriorityDownloadQueue::new(tx, Arc::new(Mutex::new(rx)))
+});
+
 pub async fn run() -> Result<(), anyhow::Error> {
     let cfg = get_config();
+    // handle normal queue download
     // move files
     for _ in 0..cfg.limit.file_download_thread_num {
         let rx = FILE_DOWNLOAD_CHANNEL.receiver.clone();
@@ -87,12 +117,98 @@ pub async fn run() -> Result<(), anyhow::Error> {
                                 );
                             }
                         }
+
+                        // update metrics
+                        metrics::FILE_DOWNLOADER_NORMAL_QUEUE_SIZE
+                            .with_label_values(&[])
+                            .dec();
                     }
                 }
             }
         });
     }
 
+    // main task: add files to priority queue
+    let rx = PRIORITY_FILE_DOWNLOAD_CHANNEL.receiver.clone();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    tokio::spawn(async move {
+        loop {
+            let ret = rx.lock().await.recv().await;
+            match ret {
+                None => {
+                    log::debug!(
+                        "[FILE_CACHE_DOWNLOAD:PRIORITY_QUEUE:JOB] Receiving channel is closed"
+                    );
+                    if shutdown_tx.send(true).is_err() {
+                        log::error!(
+                            "[FILE_CACHE_DOWNLOAD:PRIORITY_QUEUE:JOB] Failed to send disconnect signal"
+                        );
+                    }
+                    break;
+                }
+                Some((trace_id, file, file_size, cache)) => {
+                    PRIORITY_FILE_DOWNLOAD_CHANNEL
+                        .push((trace_id, file, file_size, cache))
+                        .await;
+                }
+            }
+        }
+    });
+
+    // worker tasks: handle priority queue download
+    for _ in 0..cfg.limit.file_download_priority_queue_thread_num {
+        let mut shutdown_rx = shutdown_rx.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => {
+                        log::warn!(
+                            "[FILE_CACHE_DOWNLOAD:PRIORITY_QUEUE:JOB] Received shutdown signal, exiting"
+                        );
+                        break;
+                    }
+                    _ = async {
+                        let file_info = PRIORITY_FILE_DOWNLOAD_CHANNEL.pop().await;
+                        match file_info {
+                            Some((trace_id, file, file_size, cache)) => {
+                                match download_file(&trace_id, &file, file_size, cache).await {
+                                    Ok(data_len) => {
+                                        if data_len > 0 && data_len != file_size {
+                                            log::warn!(
+                                                "[trace_id {}] priority queue download file {} found size mismatch, expected: {}, actual: {}, will skip it",
+                                                trace_id,
+                                                file,
+                                                file_size,
+                                                data_len
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        log::error!(
+                                            "[trace_id {}] priority queue download file {} to cache {:?} err: {}",
+                                            trace_id,
+                                            file,
+                                            cache,
+                                            e
+                                        );
+                                    }
+                                }
+
+                                // update metrics
+                                metrics::FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE
+                                    .with_label_values(&[])
+                                    .dec();
+                            }
+                            None => {
+                                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                            }
+                        }
+                    } => {}
+                }
+            }
+        });
+    }
     Ok(())
 }
 
@@ -132,10 +248,38 @@ pub async fn queue_download(
     file: String,
     size: i64,
     cache_type: file_data::CacheType,
+    to_priority_queue: bool,
 ) -> Result<(), anyhow::Error> {
-    FILE_DOWNLOAD_CHANNEL
-        .sender
-        .send((account, file, size as usize, cache_type))
-        .await?;
+    if !to_priority_queue || !get_config().limit.file_download_enable_priority_queue {
+        FILE_DOWNLOAD_CHANNEL
+            .sender
+            .send((account, file.to_owned(), size as usize, cache_type))
+            .await?;
+
+        // update metrics
+        metrics::FILE_DOWNLOADER_NORMAL_QUEUE_SIZE
+            .with_label_values(&[])
+            .inc();
+    } else {
+        PRIORITY_FILE_DOWNLOAD_CHANNEL
+            .sender
+            .send((account, file.to_owned(), size as usize, cache_type))
+            .await?;
+
+        // update metrics
+        metrics::FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE
+            .with_label_values(&[])
+            .inc();
+    }
     Ok(())
+}
+
+pub fn should_prioritize_file(file_meta: &FileMeta) -> bool {
+    let cfg = get_config();
+    let window_micros = (cfg.limit.file_download_priority_queue_window_secs * 1_000_000) as i64;
+    let now = chrono::Utc::now().timestamp_micros();
+    // Check if the file's timestamp range overlaps with the current time window.
+    // A file is prioritized if its data is "fresh" - containing events from the recent past
+    // through the near future relative to current time, within the configured window.
+    file_meta.min_ts > now - window_micros && file_meta.max_ts < now + window_micros
 }

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -43,7 +43,7 @@ mod stats;
 pub(crate) mod syslog_server;
 mod telemetry;
 
-pub use file_downloader::queue_download;
+pub use file_downloader::{queue_download, should_prioritize_file};
 pub use file_list_dump::FILE_LIST_SCHEMA;
 pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -27,7 +27,7 @@ use config::{
         search::{ScanStats, StorageType},
         stream::{FileKey, StreamType},
     },
-    metrics::QUERY_PARQUET_CACHE_RATIO_NODE,
+    metrics::{self, QUERY_PARQUET_CACHE_RATIO_NODE},
     utils::{
         file::is_exists,
         inverted_index::convert_parquet_idx_file_name_to_tantivy_file,
@@ -49,7 +49,7 @@ use tokio::sync::Semaphore;
 use tracing::Instrument;
 
 use crate::{
-    job,
+    job::{self, should_prioritize_file},
     service::{
         db, file_list,
         search::{
@@ -256,17 +256,32 @@ pub async fn search(
 
     // load files to local cache
     let cache_start = std::time::Instant::now();
-    let cache_type = cache_files(
+    let (cache_type, cache_hits, cache_misses) = cache_files(
         &query.trace_id,
         &files
             .iter()
-            .map(|f| (&f.account, &f.key, f.meta.compressed_size))
+            .map(|f| {
+                (
+                    &f.account,
+                    &f.key,
+                    f.meta.compressed_size,
+                    should_prioritize_file(&f.meta),
+                )
+            })
             .collect_vec(),
         &mut scan_stats,
         "parquet",
     )
     .instrument(enter_span.clone())
     .await?;
+
+    // report cache hit and miss metrics
+    metrics::QUERY_DISK_CACHE_HIT_COUNT
+        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "parquet"])
+        .inc_by(cache_hits);
+    metrics::QUERY_DISK_CACHE_MISS_COUNT
+        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "parquet"])
+        .inc_by(cache_misses);
 
     scan_stats.idx_took = idx_took as i64;
     scan_stats.querier_files = scan_stats.files;
@@ -399,25 +414,30 @@ pub async fn search(
 #[tracing::instrument(name = "service:search:grpc:storage:cache_files", skip_all)]
 pub async fn cache_files(
     trace_id: &str,
-    files: &[(&String, &String, i64)],
+    files: &[(&String, &String, i64, bool)],
     scan_stats: &mut ScanStats,
     file_type: &str,
-) -> Result<file_data::CacheType, Error> {
+) -> Result<(file_data::CacheType, u64, u64), Error> {
     // check how many files already cached
     let mut cached_files = HashSet::with_capacity(files.len());
-    for (_account, file, _size) in files.iter() {
+    let (mut cache_hits, mut cache_misses) = (0, 0);
+    for (_account, file, _size, _to_priority_queue) in files.iter() {
         if file_data::memory::exist(file).await {
             scan_stats.querier_memory_cached_files += 1;
             cached_files.insert(file);
+            cache_hits += 1;
         } else if file_data::disk::exist(file).await {
             scan_stats.querier_disk_cached_files += 1;
             cached_files.insert(file);
+            cache_hits += 1;
+        } else {
+            cache_misses += 1;
         }
     }
     let files_num = files.len() as i64;
     if files_num == scan_stats.querier_memory_cached_files + scan_stats.querier_disk_cached_files {
         // all files are cached
-        return Ok(file_data::CacheType::None);
+        return Ok((file_data::CacheType::None, cache_hits, cache_misses));
     }
 
     // check cache size
@@ -435,25 +455,33 @@ pub async fn cache_files(
         file_data::CacheType::Disk
     } else {
         // no cache, the files are too big than cache size
-        return Ok(file_data::CacheType::None);
+        return Ok((file_data::CacheType::None, cache_hits, cache_misses));
     };
 
     let trace_id = trace_id.to_string();
     let files = files
         .iter()
-        .filter_map(|(account, file, size)| {
+        .filter_map(|(account, file, size, to_priority_queue)| {
             if cached_files.contains(&file) {
                 None
             } else {
-                Some((account.to_string(), file.to_string(), *size))
+                Some((
+                    account.to_string(),
+                    file.to_string(),
+                    *size,
+                    *to_priority_queue,
+                ))
             }
         })
         .collect_vec();
     let file_type = file_type.to_string();
     tokio::spawn(async move {
         let files_num = files.len();
-        for (account, file, size) in files {
-            if let Err(e) = job::queue_download(account, file.clone(), size, cache_type).await {
+        for (account, file, size, to_priority_queue) in files {
+            if let Err(e) =
+                job::queue_download(account, file.clone(), size, cache_type, to_priority_queue)
+                    .await
+            {
                 log::error!(
                     "[trace_id {trace_id}] error in queuing file {file} for background download: {e}"
                 );
@@ -471,9 +499,9 @@ pub async fn cache_files(
     // if cached file less than 50% of the total files, return None
     if scan_stats.querier_memory_cached_files + scan_stats.querier_disk_cached_files < files_num / 2
     {
-        Ok(file_data::CacheType::None)
+        Ok((file_data::CacheType::None, cache_hits, cache_misses))
     } else {
-        Ok(cache_type)
+        Ok((cache_type, cache_hits, cache_misses))
     }
 }
 
@@ -511,16 +539,31 @@ pub async fn filter_file_list_by_tantivy_index(
         })
         .collect_vec();
     scan_stats.querier_files = index_file_names.len() as i64;
-    let cache_type = cache_files(
+    let (cache_type, cache_hits, cache_misses) = cache_files(
         &query.trace_id,
         &index_file_names
             .iter()
-            .map(|(ttv_file, f)| (&f.account, ttv_file, f.meta.index_size))
+            .map(|(ttv_file, f)| {
+                (
+                    &f.account,
+                    ttv_file,
+                    f.meta.index_size,
+                    should_prioritize_file(&f.meta),
+                )
+            })
             .collect_vec(),
         &mut scan_stats,
         "index",
     )
     .await?;
+
+    // report cache hit and miss metrics
+    metrics::QUERY_DISK_CACHE_HIT_COUNT
+        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "index"])
+        .inc_by(cache_hits);
+    metrics::QUERY_DISK_CACHE_MISS_COUNT
+        .with_label_values(&[&query.org_id, &query.stream_type.to_string(), "index"])
+        .inc_by(cache_misses);
 
     let cached_ratio = (scan_stats.querier_memory_cached_files
         + scan_stats.querier_disk_cached_files) as f64


### PR DESCRIPTION
Closes: https://github.com/openobserve/openobserve/issues/6786
Ref: https://github.com/openobserve/openobserve/pull/6792

New Env: 
```
ZO_FILE_DOWNLOAD_ENABLE_PRIORITY_QUEUE # default true
ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_THREAD_NUM # default 0
ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_WINDOW_SECS # default 3600
```

New Metrics:
```
zo_query_disk_cache_hit_count
zo_query_disk_cache_miss_count
zo_file_downloader_normal_queue_size
zo_file_downloader_priority_queue_size
```

Todo:
- [x] add priority queue and logic to determine of a file `is_priority` 
- [x] add env for priority queue threads, time window
- [x] add metrics for `cache_hits`, `cache_miss`, `queue_length` (both normal & priority queue)