### PR TITLE
fix: chery-pick fixes 

### DIFF
--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -619,6 +619,7 @@ impl FromRequest for AuthExtractor {
                 || path.contains("query_manager")
                 || path.contains("/short")
                 || path.contains("/ws")
+                || path.contains("/_values_stream")
             {
                 return ready(Ok(AuthExtractor {
                     auth: auth_str.to_owned(),

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1107,6 +1107,12 @@ pub struct Common {
     pub file_list_dump_min_hour: usize,
     #[env_config(name = "ZO_FILE_LIST_DUMP_DEBUG_CHECK", default = true)]
     pub file_list_dump_debug_check: bool,
+    #[env_config(
+        name = "ZO_USE_STREAM_SETTINGS_FOR_PARTITIONS_ENABLED",
+        default = false,
+        help = "Enable to use stream settings for partitions. This will apply for all streams"
+    )]
+    pub use_stream_settings_for_partitions_enabled: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/utils/sql.rs
+++ b/src/config/src/utils/sql.rs
@@ -75,7 +75,12 @@ pub fn is_simple_distinct_query(query: &str) -> Result<bool, sqlparser::parser::
     let ast = Parser::parse_sql(&GenericDialect {}, query)?;
     for statement in ast.iter() {
         if let Statement::Query(query) = statement {
-            if has_distinct(query) && !has_group_by(query) {
+            if has_distinct(query)
+                && !has_group_by(query)
+                && !has_join(query)
+                && !has_subquery(statement)
+                && !has_union(query)
+            {
                 return Ok(true);
             }
         }

--- a/src/config/src/utils/sql.rs
+++ b/src/config/src/utils/sql.rs
@@ -70,6 +70,19 @@ pub fn is_simple_aggregate_query(query: &str) -> Result<bool, sqlparser::parser:
     Ok(false)
 }
 
+/// distinct with no group by
+pub fn is_simple_distinct_query(query: &str) -> Result<bool, sqlparser::parser::ParserError> {
+    let ast = Parser::parse_sql(&GenericDialect {}, query)?;
+    for statement in ast.iter() {
+        if let Statement::Query(query) = statement {
+            if has_distinct(query) && !has_group_by(query) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
 /// Checks if _timestamp has been selected
 /// Used for validating scheduled pipeline sql queries
 pub fn is_timestamp_selected(query: &str) -> Result<bool, sqlparser::parser::ParserError> {
@@ -145,6 +158,15 @@ fn has_group_by(query: &Query) -> bool {
             GroupByExpr::All(v) => !v.is_empty(),
             GroupByExpr::Expressions(v, _) => !v.is_empty(),
         }
+    } else {
+        false
+    }
+}
+
+// Check if has distinct
+fn has_distinct(query: &Query) -> bool {
+    if let SetExpr::Select(ref select) = *query.body {
+        select.distinct.is_some()
     } else {
         false
     }

--- a/src/handler/grpc/request/search/mod.rs
+++ b/src/handler/grpc/request/search/mod.rs
@@ -231,6 +231,7 @@ impl Search for Searcher {
             stream_type,
             &request,
             req.skip_max_query_range,
+            true,
         )
         .await;
 

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -1334,6 +1334,7 @@ pub async fn search_partition(
         stream_type,
         &req,
         false,
+        true,
     )
     .instrument(http_span)
     .await;

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -646,7 +646,8 @@ pub async fn search_partition(
         let stream_type = stream.get_stream_type(stream_type);
         let stream_name = stream.stream_name();
         let stream_settings = unwrap_stream_settings(schema.schema()).unwrap_or_default();
-        let use_stream_stats_for_partition = stream_settings.approx_partition;
+        let use_stream_stats_for_partition = cfg.common.use_stream_settings_for_partitions_enabled
+            || stream_settings.approx_partition;
 
         if !skip_get_file_list && !use_stream_stats_for_partition {
             let stream_files = crate::service::file_list::query_ids(

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -34,7 +34,7 @@ use config::{
     utils::{
         base64, json,
         schema::filter_source_by_partition_key,
-        sql::{is_aggregate_query, is_simple_aggregate_query},
+        sql::{is_aggregate_query, is_simple_aggregate_query, is_simple_distinct_query},
         time::now_micros,
     },
 };
@@ -578,6 +578,7 @@ pub async fn search_partition(
     stream_type: StreamType,
     req: &search::SearchPartitionRequest,
     skip_max_query_range: bool,
+    is_http_req: bool,
 ) -> Result<search::SearchPartitionResponse, Error> {
     let start = std::time::Instant::now();
     let cfg = get_config();
@@ -611,10 +612,17 @@ pub async fn search_partition(
         && is_simple_aggregate_query(&req.sql).unwrap_or(false)
         && cfg.common.feature_query_streaming_aggs;
     let mut skip_get_file_list = ts_column.is_none() || apply_over_hits;
+    let is_simple_distinct = is_simple_distinct_query(&req.sql).unwrap_or(false);
+    let is_http_distinct = is_simple_distinct && is_http_req;
 
     // if need streaming output and is simple query, we shouldn't skip file list
     if skip_get_file_list && req.streaming_output && is_streaming_aggregate {
         skip_get_file_list = false;
+    }
+
+    // if http distinct, we should skip file list
+    if is_http_distinct {
+        skip_get_file_list = true;
     }
 
     // check if we need to use streaming_output
@@ -1176,6 +1184,7 @@ pub async fn search_partition_multi(
                 streaming_output: req.streaming_output,
             },
             false,
+            true,
         )
         .await
         {

--- a/src/service/search/search_stream.rs
+++ b/src/service/search/search_stream.rs
@@ -710,6 +710,7 @@ async fn get_partitions(
         stream_type,
         &search_partition_req,
         false,
+        false,
     )
     .instrument(tracing::info_span!(
         "src::handler::http::request::search::test_stream::get_partitions"

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -794,6 +794,7 @@ async fn get_partitions(
         req.stream_type,
         &search_partition_req,
         false,
+        false,
     )
     .instrument(tracing::info_span!(
         "src::handler::http::request::websocket::search::get_partitions"


### PR DESCRIPTION
- fix: auth for _values_stream (#6849)
- fix: simple distinct sql for http api (#6836)
- feat: add env to enable use_stream_setting for partitions (#6866)

# closes
- https://github.com/openobserve/openobserve/issues/6863

New Env
```
ZO_USE_STREAM_SETTINGS_FOR_PARTITIONS_ENABLED # default false
```