### PR TITLE
fix: Fixed http partition pagination issue for less events in partitions

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -3679,7 +3679,8 @@ const useLogs = () => {
 
       let plusSign: string = "";
       if (
-        searchObj.data.queryResults?.partitionDetail?.partitions?.length > 1 &&
+        searchObj.data.queryResults?.partitionDetail?.partitions?.length > 1 && 
+        endCount < totalCount &&
         searchObj.meta.showHistogram == false
       ) {
         plusSign = "+";

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1504,12 +1504,14 @@ const useLogs = () => {
                 partitionDetail.paginations[pageNumber] = [];
               }
 
-              partitionDetail.paginations[pageNumber].push({
-                startTime: item[0],
-                endTime: item[1],
-                from,
-                size: Math.abs(Math.min(recordSize, rowsPerPage)),
-              });
+              if(recordSize > 0) {
+                partitionDetail.paginations[pageNumber].push({
+                  startTime: item[0],
+                  endTime: item[1],
+                  from,
+                  size: Math.abs(Math.min(recordSize, rowsPerPage)),
+                });
+              }
 
               partitionFrom += recordSize;
 
@@ -1546,12 +1548,18 @@ const useLogs = () => {
               recordSize = 0;
             }
 
-            partitionDetail.paginations[pageNumber].push({
-              startTime: item[0],
-              endTime: item[1],
-              from,
-              size: Math.abs(recordSize),
-            });
+            if (total < recordSize) {
+              recordSize = total;
+            }
+
+            if(recordSize > 0) {
+              partitionDetail.paginations[pageNumber].push({
+                startTime: item[0],
+                endTime: item[1],
+                from,
+                size: Math.abs(recordSize),
+              });
+            }
 
             if (partitionDetail.paginations[pageNumber].size > 0) {
               pageNumber++;

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1473,7 +1473,9 @@ const useLogs = () => {
 
               // if (i === 0 && partitionDetail.paginations.length > 0) {
               lastPartitionSize = 0;
-              if (pageNumber > 0) {
+
+              // if the pagination array is not empty, then we need to get the last page and add the size of the last page to the last partition size
+              if (partitionDetail.paginations[pageNumber]?.length) {
                 lastPage = partitionDetail.paginations.length - 1;
 
                 // partitionDetail.paginations[lastPage].forEach((item: any) => {

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -5291,11 +5291,11 @@ const useLogs = () => {
       
 
 
-      updatePageCountTotal(payload.queryReq, searchObj.data.queryResults.hits.length);
+      updatePageCountTotal(payload.queryReq, response.content.results.hits.length, searchObj.data.queryResults.hits.length);
       trimPageCountExtraHit(payload.queryReq, searchObj.data.queryResults.hits.length);
     }
 
-    if (isPagination) refreshPagination(true);
+    refreshPagination(true);
 
     processPostPaginationData();
   }
@@ -5374,12 +5374,12 @@ const useLogs = () => {
     if (isPagination) refreshPagination(true);
   }
 
-  const updatePageCountTotal = (queryReq: SearchRequestPayload, total: any) => {
+  const updatePageCountTotal = (queryReq: SearchRequestPayload, currentHits: number, total: any) => {
     try {
       if(shouldGetPageCount(queryReq, fnParsedSQL()) && (total === queryReq.query.size)) {
         searchObj.data.queryResults.pageCountTotal = (searchObj.meta.resultGrid.rowsPerPage * searchObj.data.resultGrid.currentPage) + 1;
-      } else if(shouldGetPageCount(queryReq, fnParsedSQL()) && (searchObj.data.queryResults.hits != queryReq.query.size)){
-        searchObj.data.queryResults.pageCountTotal = ((searchObj.meta.resultGrid.rowsPerPage) * Math.max(searchObj.data.resultGrid.currentPage-1,0)) + queryResults.total;
+      } else if(shouldGetPageCount(queryReq, fnParsedSQL()) && (total !== queryReq.query.size)){
+        searchObj.data.queryResults.pageCountTotal = ((searchObj.meta.resultGrid.rowsPerPage) * Math.max(searchObj.data.resultGrid.currentPage-1,0)) + currentHits;
       }
     } catch(e: any) {
       console.error("Error while updating page count total", e);
@@ -5387,14 +5387,23 @@ const useLogs = () => {
   }
 
   const trimPageCountExtraHit = (queryReq: SearchRequestPayload, total: any) => {
-    if(shouldGetPageCount(queryReq, fnParsedSQL()) && (total === queryReq.query.size)) {
-      searchObj.data.queryResults.hits = searchObj.data.queryResults.hits.slice(0, searchObj.data.queryResults.hits.length- 1);
+    try{
+      if(shouldGetPageCount(queryReq, fnParsedSQL()) && (total === queryReq.query.size)) {
+        searchObj.data.queryResults.hits = searchObj.data.queryResults.hits.slice(0, searchObj.data.queryResults.hits.length- 1);
+      }
+    } catch(e: any) {
+      console.error("Error while trimming page count extra hit", e);
     }
   }
 
   const updatePageCountSearchSize = (queryReq: SearchRequestPayload) => {
-    if(shouldGetPageCount(queryReq, fnParsedSQL())) {
-      queryReq.query.size = queryReq.query.size + 1;
+    try{
+      if(shouldGetPageCount(queryReq, fnParsedSQL())) {
+        queryReq.query.size = queryReq.query.size + 1;
+      }
+    } catch(e: any) {
+      console.error("Error while updating page count search size", e);
+      return queryReq.query.size;
     }
   }
 

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1457,10 +1457,13 @@ const useLogs = () => {
         // partitionDetail.partitions.forEach((item: any, index: number) => {
         for (const [index, item] of partitionDetail.partitions.entries()) {
           total = partitionDetail.partitionTotal[index];
-          totalPages = Math.ceil(total / rowsPerPage);
+          
           if (!partitionDetail.paginations[pageNumber]) {
             partitionDetail.paginations[pageNumber] = [];
           }
+
+          totalPages = getPartitionTotalPages(total);
+          
           if (totalPages > 0) {
             partitionFrom = 0;
             for (let i = 0; i < totalPages; i++) {
@@ -1565,6 +1568,29 @@ const useLogs = () => {
       return false;
     }
   };
+
+  /**
+   * This function is used to get the total pages for the single partition 
+   * This method handles the case where previous partition is not fully loaded and we are loading the next partition
+   * In this case, we need to add the size of the previous partition to the total size of the current partition for accurate total pages
+   * @param total - The total number of records in the partition
+   * @returns The total number of pages for the partition
+   */
+  const getPartitionTotalPages = (total: number) => {
+    const lastPage = searchObj.data.queryResults.partitionDetail.paginations?.length - 1;
+
+    let lastPartitionSize = 0;
+    let partitionTotal = 0;
+    for (const item of searchObj.data.queryResults.partitionDetail.paginations[lastPage]) {
+      lastPartitionSize += item.size;
+    }
+
+    if (lastPartitionSize < searchObj.meta.resultGrid.rowsPerPage) {
+        partitionTotal = total + lastPartitionSize;
+    }
+
+    return Math.ceil(partitionTotal / searchObj.meta.resultGrid.rowsPerPage);
+  }
 
   const getQueryData = async (isPagination = false) => {
     try {

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1954,6 +1954,7 @@ const useLogs = () => {
       }
       searchObjDebug["queryDataEndTime"] = performance.now();
     } catch (e: any) {
+      console.error(`${notificationMsg.value || "Error occurred during the search operation."}`, e);
       searchObj.loading = false;
       showErrorNotification(
         notificationMsg.value || "Error occurred during the search operation.",
@@ -5059,9 +5060,7 @@ const useLogs = () => {
 
       const payload = buildWebSocketPayload(queryReq, isPagination, "search");
       
-      if(shouldGetPageCount(queryReq, fnParsedSQL())) {
-        queryReq.query.size = queryReq.query.size + 1;
-      }
+      updatePageCountSearchSize(queryReq);
 
       const requestId = initializeSearchConnection(payload);
 
@@ -5291,10 +5290,12 @@ const useLogs = () => {
       }
       
 
-      if(shouldGetPageCount(payload.queryReq, fnParsedSQL()) && (searchObj.data.queryResults.hits.length === payload.queryReq.query.size)) {
-        searchObj.data.queryResults.hits = searchObj.data.queryResults.hits.slice(0, payload.queryReq.query.size - 1);
-      }
+
+      updatePageCountTotal(payload.queryReq, searchObj.data.queryResults.hits.length);
+      trimPageCountExtraHit(payload.queryReq, searchObj.data.queryResults.hits.length);
     }
+
+    if (isPagination) refreshPagination(true);
 
     processPostPaginationData();
   }
@@ -5358,12 +5359,6 @@ const useLogs = () => {
           searchObj.data.queryResults = response.content.results;
         }
       }
-
-      if(shouldGetPageCount(payload.queryReq, fnParsedSQL()) && (response.content.results.total === payload.queryReq.query.size)) {
-        searchObj.data.queryResults.pageCountTotal = payload.queryReq.query.size * searchObj.data.resultGrid.currentPage;
-      } else if(shouldGetPageCount(payload.queryReq, fnParsedSQL()) && (response.content.results.total != payload.queryReq.query.size)){
-        searchObj.data.queryResults.pageCountTotal = (payload.queryReq.query.size * Math.max(searchObj.data.resultGrid.currentPage-1,0)) + response.content.results.total;
-      }
     }
 
           // We are storing time_offset for the context of pagecount, to get the partial pagecount
@@ -5377,6 +5372,30 @@ const useLogs = () => {
     }
     
     if (isPagination) refreshPagination(true);
+  }
+
+  const updatePageCountTotal = (queryReq: SearchRequestPayload, total: any) => {
+    try {
+      if(shouldGetPageCount(queryReq, fnParsedSQL()) && (total === queryReq.query.size)) {
+        searchObj.data.queryResults.pageCountTotal = (searchObj.meta.resultGrid.rowsPerPage * searchObj.data.resultGrid.currentPage) + 1;
+      } else if(shouldGetPageCount(queryReq, fnParsedSQL()) && (searchObj.data.queryResults.hits != queryReq.query.size)){
+        searchObj.data.queryResults.pageCountTotal = ((searchObj.meta.resultGrid.rowsPerPage) * Math.max(searchObj.data.resultGrid.currentPage-1,0)) + queryResults.total;
+      }
+    } catch(e: any) {
+      console.error("Error while updating page count total", e);
+    }
+  }
+
+  const trimPageCountExtraHit = (queryReq: SearchRequestPayload, total: any) => {
+    if(shouldGetPageCount(queryReq, fnParsedSQL()) && (total === queryReq.query.size)) {
+      searchObj.data.queryResults.hits = searchObj.data.queryResults.hits.slice(0, searchObj.data.queryResults.hits.length- 1);
+    }
+  }
+
+  const updatePageCountSearchSize = (queryReq: SearchRequestPayload) => {
+    if(shouldGetPageCount(queryReq, fnParsedSQL())) {
+      queryReq.query.size = queryReq.query.size + 1;
+    }
   }
 
   const handleHistogramStreamingHits = (payload: WebSocketSearchPayload, response: WebSocketSearchResponse, isPagination: boolean, appendResult: boolean = false) => {
@@ -6011,7 +6030,7 @@ const useLogs = () => {
   }
 
   function isHistogramDataMissing(searchObj: any) {
-    return searchObj.data.queryResults.aggs === undefined || searchObj.data.queryResults.aggs.length === 0;
+    return !searchObj.data.queryResults?.aggs?.length;
   }
 
   const handleSearchClose = (payload: any, response: any) => {

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1474,6 +1474,11 @@ const useLogs = () => {
                   : rowsPerPage;
               from = partitionFrom;
 
+
+              if (total < recordSize) {
+                recordSize = total;
+              }
+
               // if (i === 0 && partitionDetail.paginations.length > 0) {
               lastPartitionSize = 0;
 
@@ -1489,7 +1494,12 @@ const useLogs = () => {
                 if (lastPartitionSize != rowsPerPage) {
                   recordSize = rowsPerPage - lastPartitionSize;
                 }
+
+                if (total < recordSize) {
+                  recordSize = total;
+                }
               }
+
               if (!partitionDetail.paginations[pageNumber]) {
                 partitionDetail.paginations[pageNumber] = [];
               }


### PR DESCRIPTION
Issues

1. http - Fixed partition logic for multiple partitions in single page. Example partition: [14, 144]
2.  http - Fixed partition logic for partition with 0 events. Example partition: [14, 0, 144]
4. http - Last page was not visible for specific partitions.  Example partition: [14, 144]
5. http - + was shown for the last page total-count
6. http2 streaming - Incremental ( size + 1 ) was not working with multiple partitions