### PR TITLE
feat: add env to enable use_stream_setting for partitions

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1088,11 +1088,11 @@ pub struct Common {
     #[env_config(name = "ZO_ADDITIONAL_REPORTING_ORGS", default = "")]
     pub additional_reporting_orgs: String,
     #[env_config(
-        name = "ZO_ENABLE_USE_STREAM_SETTINGS_FOR_PARTITIONS",
+        name = "ZO_USE_STREAM_SETTINGS_FOR_PARTITIONS_ENABLED",
         default = false,
         help = "Enable to use stream settings for partitions. This will apply for all streams"
     )]
-    pub enable_use_stream_settings_for_partitions: bool,
+    pub use_stream_settings_for_partitions_enabled: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1087,6 +1087,12 @@ pub struct Common {
     pub min_auto_refresh_interval: u32,
     #[env_config(name = "ZO_ADDITIONAL_REPORTING_ORGS", default = "")]
     pub additional_reporting_orgs: String,
+    #[env_config(
+        name = "ZO_ENABLE_USE_STREAM_SETTINGS_FOR_PARTITIONS",
+        default = false,
+        help = "Enable to use stream settings for partitions. This will apply for all streams"
+    )]
+    pub enable_use_stream_settings_for_partitions: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -647,7 +647,8 @@ pub async fn search_partition(
         let stream_type = stream.get_stream_type(stream_type);
         let stream_name = stream.stream_name();
         let stream_settings = unwrap_stream_settings(schema.schema()).unwrap_or_default();
-        let use_stream_stats_for_partition = cfg.common.enable_use_stream_settings_for_partitions || stream_settings.approx_partition;
+        let use_stream_stats_for_partition = cfg.common.use_stream_settings_for_partitions_enabled
+            || stream_settings.approx_partition;
 
         if !skip_get_file_list && !use_stream_stats_for_partition {
             let stream_files = crate::service::file_list::query_ids(

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -647,7 +647,7 @@ pub async fn search_partition(
         let stream_type = stream.get_stream_type(stream_type);
         let stream_name = stream.stream_name();
         let stream_settings = unwrap_stream_settings(schema.schema()).unwrap_or_default();
-        let use_stream_stats_for_partition = stream_settings.approx_partition;
+        let use_stream_stats_for_partition = cfg.common.enable_use_stream_settings_for_partitions || stream_settings.approx_partition;
 
         if !skip_get_file_list && !use_stream_stats_for_partition {
             let stream_files = crate::service::file_list::query_ids(


### PR DESCRIPTION
closes: https://github.com/openobserve/openobserve/issues/6863

New Env
```
ZO_USE_STREAM_SETTINGS_FOR_PARTITIONS_ENABLED # default false
```