### PR TITLE
fix: Partition stream stats handle case when end time is 0

### DIFF
--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -681,7 +681,14 @@ pub async fn search_partition(
             // data duration in seconds
             let query_duration = (req.end_time - req.start_time) / 1000 / 1000;
             let stats = stats::get_stream_stats(org_id, &stream_name, stream_type);
-            let data_end_time = std::cmp::min(Utc::now().timestamp_micros(), stats.doc_time_max);
+
+            // if stats.doc_time_max is 0, handle the case by using current time
+            let data_end_time = if stats.doc_time_max == 0 {
+                Utc::now().timestamp_micros()
+            } else {
+                std::cmp::min(Utc::now().timestamp_micros(), stats.doc_time_max)
+            };
+
             let data_retention_based_on_stats = (data_end_time - stats.doc_time_min) / 1000 / 1000;
             if data_retention_based_on_stats > 0 {
                 data_retention = std::cmp::min(data_retention, data_retention_based_on_stats);


### PR DESCRIPTION
Handle the case when stream stats end time is set to unix epoch