### PR TITLE
fix: cache miss after NATs restarts (#6726)

### DIFF
--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -33,6 +33,7 @@ use hashbrown::HashMap;
 use infra::table::short_urls::ShortUrlRecord;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
+use tokio::sync::{RwLock as TokioRwLock, mpsc};
 use vector_enrichment::TableRegistry;
 
 use crate::{
@@ -95,3 +96,46 @@ pub static USER_SESSIONS: Lazy<RwHashMap<String, String>> = Lazy::new(Default::d
 pub static SHORT_URLS: Lazy<RwHashMap<String, ShortUrlRecord>> = Lazy::new(DashMap::default);
 pub static USER_ROLES_CACHE: Lazy<RwAHashMap<String, CachedUserRoles>> =
     Lazy::new(Default::default);
+
+/// Refreshes in-memory cache in the event of NATs restart.
+///
+/// We should add all in-memory caches listed above that a CacheMiss is not followed by
+/// reading from db, e.g. UserSession, Pipeline
+pub(crate) async fn update_cache(mut nats_event_rx: mpsc::Receiver<infra::db::nats::NatsEvent>) {
+    let mut first_conenction = true;
+    while let Some(event) = nats_event_rx.recv().await {
+        if let infra::db::nats::NatsEvent::Connected = event {
+            // Skip refreshing if it's the first time connecting to the client
+            if first_conenction {
+                first_conenction = false;
+                continue;
+            }
+            log::info!(
+                "[infra::config] received NATs event: {event}, refreshing in-memory cache for Alerts, Pipelines, RealtimeTriggers, Schema, Users, and UserSessions"
+            );
+            if let Err(e) = crate::service::db::alerts::alert::cache().await {
+                log::error!("Error refreshing in-memory cache \"Alerts\": {}", e);
+            }
+            if let Err(e) = crate::service::db::pipeline::cache().await {
+                log::error!("Error refreshing in-memory cache \"Pipelines\": {}", e);
+            }
+            if let Err(e) = crate::service::db::alerts::realtime_triggers::cache().await {
+                log::error!(
+                    "Error refreshing in-memory cache \"RealtimeTriggers\": {}",
+                    e
+                );
+            }
+            if let Err(e) = crate::service::db::schema::cache().await {
+                log::error!("Error refreshing in-memory cache \"Schema\": {}", e);
+            }
+            if let Err(e) = crate::service::db::session::cache().await {
+                log::error!("Error refreshing in-memory cache \"UserSessions\": {}", e);
+            }
+            if let Err(e) = crate::service::db::user::cache().await {
+                log::error!("Error refreshing in-memory cache \"Users\": {}", e);
+            }
+        }
+    }
+
+    log::info!("[infra::config] stops to listen to NATs event to refresh in-memory caches");
+}

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -33,7 +33,7 @@ use hashbrown::HashMap;
 use infra::table::short_urls::ShortUrlRecord;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use tokio::sync::{RwLock as TokioRwLock, mpsc};
+use tokio::sync::mpsc;
 use vector_enrichment::TableRegistry;
 
 use crate::{

--- a/src/infra/src/queue/nats.rs
+++ b/src/infra/src/queue/nats.rs
@@ -68,7 +68,7 @@ impl Default for NatsQueue {
 impl super::Queue for NatsQueue {
     async fn create(&self, topic: &str) -> Result<()> {
         let cfg = config::get_config();
-        let client = get_nats_client().await.clone();
+        let client = get_nats_client().await?;
         let jetstream = jetstream::new(client);
         let topic_name = format!("{}{}", self.prefix, topic);
         let config = jetstream::stream::Config {
@@ -85,7 +85,7 @@ impl super::Queue for NatsQueue {
 
     /// you can pub message with the topic or topic.* to match the topic
     async fn publish(&self, topic: &str, value: Bytes) -> Result<()> {
-        let client = get_nats_client().await.clone();
+        let client = get_nats_client().await?;
         let jetstream = jetstream::new(client);
         // Publish a message to the stream
         let topic_name = format!("{}{}", self.prefix, topic);
@@ -100,7 +100,7 @@ impl super::Queue for NatsQueue {
         let consumer_name = self.consumer_name.clone();
         let is_durable = self.is_durable;
         let _task: JoinHandle<Result<()>> = tokio::task::spawn(async move {
-            let client = get_nats_client().await.clone();
+            let client = get_nats_client().await?;
             let jetstream = jetstream::new(client);
             let stream = jetstream.get_stream(&stream_name).await.map_err(|e| {
                 log::error!("Failed to get nats stream {}: {}", stream_name, e);


### PR DESCRIPTION
Refreshing in-memory cache in such NATs event trigger by NATs client's callback closure.

---------