### PR TITLE
fix: log page download count issue , service account description field added

### DIFF
--- a/web/src/components/iam/serviceAccounts/AddServiceAccount.vue
+++ b/web/src/components/iam/serviceAccounts/AddServiceAccount.vue
@@ -65,22 +65,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           <q-input
             v-model="firstName"
-            :label="t('user.firstName')"
+            :label="t('user.description')"
             color="input-border"
             bg-color="input-bg"
             class="q-py-md showLabelOnTop q-mt-sm"
-            stack-label
-            outlined
-            filled
-            dense
-          />
-
-          <q-input
-            v-model="lastName"
-            :label="t('user.lastName')"
-            color="input-border"
-            bg-color="input-bg"
-            class="q-py-md showLabelOnTop"
             stack-label
             outlined
             filled
@@ -133,7 +121,6 @@ const defaultValue: any = () => {
     org_member_id: "",
     role: "admin",
     first_name: "",
-    last_name: "",
     email: "",
     organization: "",
   };
@@ -166,7 +153,6 @@ export default defineComponent({
     const logout_confirm = ref(false);
 
     const firstName = ref(formData.value.first_name);
-    const lastName = ref("");
 
     onActivated(() => {
       formData.value.organization = store.state.selectedOrganization.identifier;
@@ -187,7 +173,6 @@ export default defineComponent({
       loadingOrganizations,
       logout_confirm,
       firstName,
-      lastName,
     };
   },
   created() {
@@ -202,7 +187,6 @@ export default defineComponent({
       this.beingUpdated = true;
       this.formData = {...this.modelValue};
       this.firstName = this.modelValue?.first_name;
-      this.lastName = this.modelValue?.last_name;
     }
   },
   methods: {
@@ -219,7 +203,6 @@ export default defineComponent({
         selectedOrg = encodeURIComponent(this.formData.other_organization);
       }
       this.formData.first_name = this.firstName;
-      this.formData.last_name = this.lastName;
       if (this.beingUpdated) {
         const userEmail = this.formData.email;
         delete this.formData.email;

--- a/web/src/components/iam/serviceAccounts/ServiceAccountsList.vue
+++ b/web/src/components/iam/serviceAccounts/ServiceAccountsList.vue
@@ -378,14 +378,7 @@ export default defineComponent({
       {
         name: "first_name",
         field: "first_name",
-        label: t("user.firstName"),
-        align: "left",
-        sortable: true,
-      },
-      {
-        name: "last_name",
-        field: "last_name",
-        label: t("user.lastName"),
+        label: t("user.description"),
         align: "left",
         sortable: true,
       },

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -304,7 +304,8 @@
     "apiKeyNotFound": "User API Key Not Found.",
     "allowedOrg": "Allowed Organization",
     "roles": "Roles",
-    "groups": "Groups"
+    "groups": "Groups",
+    "description": "Description"
   },
   "serviceAccounts": {
     "header": "Service Accounts",

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -1321,7 +1321,8 @@ export default defineComponent({
         return;
       }
       // const queryReq = this.buildSearch();
-      this.searchObj.data.customDownloadQueryObj.query.from = initNumber;
+      this.searchObj.data.customDownloadQueryObj.query.from =
+        initNumber == 0 ? 0 : initNumber - 1;
       this.searchObj.data.customDownloadQueryObj.query.size =
         this.downloadCustomRange;
       searchService


### PR DESCRIPTION
1. This PR fixes the log page download count mismatch issue so when user tries to get 1 to 100 records we are actually sending from as 1 which is incorrect because BE expects from 0 so modified we now send -1 from user input eg: user enters 1 we send it as 0 , user sends 50 send 49 this will make sure that actual records are being downloaded 
2. This PR also fixes the service account issue so we dont need first name and last name for the service account so we removed that and added description in place of that , removed them in the service account list as well |
#6887
#6837 