### PR TITLE
fix: tantivy timestamp update time

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -100,6 +100,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
         .await
         .expect("db version set failed");
 
+    // check tantivy _timestamp update time
+    _ = db::metas::tantivy_index::get_ttv_timestamp_updated_at().await;
+
     // Auth auditing should be done by router also
     #[cfg(feature = "enterprise")]
     tokio::task::spawn(async move { self_reporting::run_audit_publish().await });


### PR DESCRIPTION
There is one issue the `tantivy::TIMESTAMP_UPDATED_AT` never create before call search, but maybe we already created a lot of index files. 

So we need to init this time when the app start.