### PR TITLE
fix: demote log level to debug when local cache insert fails

### DIFF
--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -87,7 +87,7 @@ pub async fn query_by_ids(trace_id: &str, ids: &[i64]) -> Result<Vec<FileKey>> {
         let cached_files = match file_list::LOCAL_CACHE.query_by_ids(ids).await {
             Ok(files) => files,
             Err(e) => {
-                log::error!(
+                log::debug!(
                     "[trace_id {trace_id}] file_list query cache failed: {:?}",
                     e
                 );


### PR DESCRIPTION
demotes the log level to debug for when local cache insert fails. This can happen when multiple queries on same stream for same range are fired, and after getting file meta from pg, all of them try to insert in local cache, and after one of them succeeds others will fail with sqlite error of unique constraint violation. This will simply log it on debug level instead of error, because even if insert fails in local cache, not a big problem.