### PR TITLE
fix: demote log level to debug when local cache insert fails

### DIFF
--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -1384,6 +1384,7 @@ INSERT INTO {table} (id, account, org, stream, date, file, deleted, min_ts, max_
                         .push_bind(item.meta.index_size)
                         .push_bind(item.meta.flattened);
                 });
+                query_builder.push(" ON CONFLICT(id) DO NOTHING");
                 if let Err(e) = query_builder.build().execute(&mut *tx).await {
                     if let Err(e) = tx.rollback().await {
                         log::error!(

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -151,7 +151,7 @@ pub async fn query_by_ids(
         let cached_files = match file_list::LOCAL_CACHE.query_by_ids(ids).await {
             Ok(files) => files,
             Err(e) => {
-                log::error!(
+                log::debug!(
                     "[trace_id {trace_id}] file_list query cache failed: {:?}",
                     e
                 );

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -151,7 +151,7 @@ pub async fn query_by_ids(
         let cached_files = match file_list::LOCAL_CACHE.query_by_ids(ids).await {
             Ok(files) => files,
             Err(e) => {
-                log::debug!(
+                log::error!(
                     "[trace_id {trace_id}] file_list query cache failed: {:?}",
                     e
                 );


### PR DESCRIPTION
demotes the log level to debug for when local cache insert fails. This can happen when multiple queries on same stream for same range are fired, and after getting file meta from pg, all of them try to insert in local cache, and after one of them succeeds others will fail with sqlite error of unique constraint violation. This will simply log it on debug level instead of error, because even if insert fails in local cache, not a big problem.