### PR TITLE
fix: update `DB_SCHEMA_VERSION`

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -46,7 +46,7 @@ pub type RwAHashSet<K> = tokio::sync::RwLock<HashSet<K>>;
 pub type RwBTreeMap<K, V> = tokio::sync::RwLock<BTreeMap<K, V>>;
 
 // for DDL commands and migrations
-pub const DB_SCHEMA_VERSION: u64 = 3;
+pub const DB_SCHEMA_VERSION: u64 = 4;
 pub const DB_SCHEMA_KEY: &str = "/db_schema_version/";
 
 // global version variables


### PR DESCRIPTION
Since the organization revamp is merged, all the migrations for organization revamp needs to run. So, the `DB_SCHEMA_VERSION` needs to be upgraded.