### PR TITLE
fix: stream stats for super cluster

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -295,7 +295,9 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                 }
                 "stream-stats" => {
                     // init nats client
-                    if !cfg.common.local_mode && cfg.common.meta_store.to_lowercase() == "nats" {
+                    if !cfg.common.local_mode
+                        && cfg.common.cluster_coordinator.to_lowercase() == "nats"
+                    {
                         let (tx, _rx) = tokio::sync::mpsc::channel::<infra::db::nats::NatsEvent>(1);
                         infra::db::nats::init_nats_client(tx).await?;
                     }

--- a/src/handler/grpc/request/stream.rs
+++ b/src/handler/grpc/request/stream.rs
@@ -101,11 +101,20 @@ impl Streams for StreamServiceImpl {
 
         let entries = Self::process_orgs_batch(&orgs, stream_type, stream_name).await;
         log::debug!(
-            "orgs:{:?}, stream_type:{:?}, stream_name:{:?}",
+            "[grpc:stream_stats] orgs: {:?}, stream_type: {:?}, stream_name: {:?}",
             orgs,
             stream_type,
             stream_name,
         );
+        for entry in entries.iter() {
+            if entry.stream.contains("default8") {
+                log::info!(
+                    "[grpc:stream_stats] stream: {}, records: {}",
+                    entry.stream,
+                    entry.stats.as_ref().unwrap().doc_num
+                );
+            }
+        }
         Ok(Response::new(StreamStatsResponse { entries }))
     }
 }

--- a/src/handler/grpc/request/stream.rs
+++ b/src/handler/grpc/request/stream.rs
@@ -106,15 +106,6 @@ impl Streams for StreamServiceImpl {
             stream_type,
             stream_name,
         );
-        for entry in entries.iter() {
-            if entry.stream.contains("default8") {
-                log::info!(
-                    "[grpc:stream_stats] stream: {}, records: {}",
-                    entry.stream,
-                    entry.stats.as_ref().unwrap().doc_num
-                );
-            }
-        }
         Ok(Response::new(StreamStatsResponse { entries }))
     }
 }


### PR DESCRIPTION
The issue is when we get cluster list we didn't filter the alert querier cluster then the stats duplicated. The fix in o2 enterprise. this pr only update some logs.