### PR TITLE
fix: stream stats for super cluster

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -313,6 +313,13 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                     db::functions::reset().await?;
                 }
                 "stream-stats" => {
+                    // init nats client
+                    let (tx, _rx) = tokio::sync::mpsc::channel::<infra::db::nats::NatsEvent>(1);
+                    if !cfg.common.local_mode
+                        && cfg.common.cluster_coordinator.to_lowercase() == "nats"
+                    {
+                        infra::db::nats::init_nats_client(tx).await?;
+                    }
                     // reset stream stats update offset
                     db::compact::stats::set_offset(0, None).await?;
                     // reset stream stats table data

--- a/src/handler/grpc/request/stream.rs
+++ b/src/handler/grpc/request/stream.rs
@@ -101,7 +101,7 @@ impl Streams for StreamServiceImpl {
 
         let entries = Self::process_orgs_batch(&orgs, stream_type, stream_name).await;
         log::debug!(
-            "orgs:{:?}, stream_type:{:?}, stream_name:{:?}",
+            "[grpc:stream_stats] orgs: {:?}, stream_type: {:?}, stream_name: {:?}",
             orgs,
             stream_type,
             stream_name,


### PR DESCRIPTION
The issue is when we get cluster list we didn't filter the alert querier cluster then the stats duplicated. The fix in o2 enterprise. this pr only update some logs.