### PR TITLE
fix: pipeline should be able to use resultarray vrl functions

### DIFF
--- a/src/config/src/meta/function.rs
+++ b/src/config/src/meta/function.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use once_cell::sync::Lazy;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use vrl::{
@@ -21,6 +23,10 @@ use vrl::{
 };
 
 use crate::{meta::stream::StreamType, utils::json};
+
+// Checks for #ResultArray#
+pub static RESULT_ARRAY: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^#[ \s]*Result[ \s]*Array[ \s]*#").unwrap());
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -37,6 +43,15 @@ pub struct Transform {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub streams: Option<Vec<StreamOrder>>,
+}
+
+impl Transform {
+    pub fn is_vrl(&self) -> bool {
+        self.trans_type.is_some() && self.trans_type.unwrap() == 0
+    }
+    pub fn is_result_array_vrl(&self) -> bool {
+        self.is_vrl() && RESULT_ARRAY.is_match(&self.function)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -20,7 +20,7 @@ use chrono::Utc;
 use config::{
     TIMESTAMP_COL_NAME, get_config,
     meta::{
-        function::VRLResultResolver,
+        function::{RESULT_ARRAY, VRLResultResolver},
         search::{self, PARTIAL_ERROR_RESPONSE_MESSAGE},
         self_reporting::usage::{RequestStats, UsageType},
         sql::resolve_stream_names,
@@ -464,11 +464,9 @@ pub async fn search_multi(
         // compile vrl function & apply the same before returning the response
         let mut input_fn = query_fn.unwrap().trim().to_string();
 
-        let apply_over_hits = SearchService::RESULT_ARRAY.is_match(&input_fn);
+        let apply_over_hits = RESULT_ARRAY.is_match(&input_fn);
         if apply_over_hits {
-            input_fn = SearchService::RESULT_ARRAY
-                .replace(&input_fn, "")
-                .to_string();
+            input_fn = RESULT_ARRAY.replace(&input_fn, "").to_string();
         }
         let mut runtime = crate::common::utils::functions::init_vrl_runtime();
         let program = match crate::service::ingestion::compile_vrl_function(&input_fn, &org_id) {

--- a/src/service/functions.rs
+++ b/src/service/functions.rs
@@ -21,7 +21,9 @@ use actix_web::{
 };
 use config::{
     meta::{
-        function::{FunctionList, TestVRLResponse, Transform, VRLResult, VRLResultResolver},
+        function::{
+            FunctionList, RESULT_ARRAY, TestVRLResponse, Transform, VRLResult, VRLResultResolver,
+        },
         pipeline::{PipelineDependencyItem, PipelineDependencyResponse},
     },
     utils::json,
@@ -36,7 +38,7 @@ use crate::{
     handler::http::{
         request::search::error_utils::map_error_to_http_response, router::ERROR_HEADER,
     },
-    service::{db, ingestion::compile_vrl_function, search::RESULT_ARRAY},
+    service::{db, ingestion::compile_vrl_function},
 };
 
 const FN_SUCCESS: &str = "Function saved successfully";

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -27,7 +27,7 @@ use config::{
     },
     utils::{
         flatten,
-        json::{Value, get_string_value},
+        json::{self, Value, get_string_value},
     },
 };
 use futures::future::try_join_all;
@@ -51,12 +51,12 @@ static DYNAMIC_STREAM_NAME_PATTERN: Lazy<regex::Regex> =
 pub trait PipelineExt: Sync + Send + 'static {
     /// Registers the function of all the FunctionNode of this pipeline once for execution.
     /// Returns a map of node_id -> VRLResultResolver for quick lookup
-    async fn register_functions(&self) -> Result<HashMap<String, VRLResultResolver>>;
+    async fn register_functions(&self) -> Result<HashMap<String, (VRLResultResolver, bool)>>;
 }
 
 #[async_trait]
 impl PipelineExt for Pipeline {
-    async fn register_functions(&self) -> Result<HashMap<String, VRLResultResolver>> {
+    async fn register_functions(&self) -> Result<HashMap<String, (VRLResultResolver, bool)>> {
         let mut vrl_map = HashMap::new();
         for node in &self.nodes {
             if let NodeData::Function(func_params) = &node.data {
@@ -69,10 +69,13 @@ impl PipelineExt for Pipeline {
                 registry.finish_load();
                 vrl_map.insert(
                     node.get_node_id(),
-                    VRLResultResolver {
-                        program: vrl_runtime_config.program,
-                        fields: vrl_runtime_config.fields,
-                    },
+                    (
+                        VRLResultResolver {
+                            program: vrl_runtime_config.program,
+                            fields: vrl_runtime_config.fields,
+                        },
+                        transform.is_result_array_vrl(),
+                    ),
                 );
             }
         }
@@ -86,7 +89,7 @@ pub struct ExecutablePipeline {
     name: String,
     source_node_id: String,
     sorted_nodes: Vec<String>,
-    vrl_map: HashMap<String, VRLResultResolver>,
+    vrl_map: HashMap<String, (VRLResultResolver, bool)>,
     node_map: HashMap<String, ExecutableNode>,
 }
 
@@ -492,7 +495,7 @@ async fn process_node(
     node: ExecutableNode,
     mut receiver: Receiver<(usize, Value, bool)>,
     mut child_senders: Vec<Sender<(usize, Value, bool)>>,
-    vrl_runtime: Option<VRLResultResolver>,
+    vrl_runtime: Option<(VRLResultResolver, bool)>,
     result_sender: Option<Sender<(usize, StreamParams, Value)>>,
     error_sender: Sender<(String, String, String)>,
     pipeline_name: String,
@@ -643,8 +646,9 @@ async fn process_node(
             log::debug!("[Pipeline]: func node {node_idx} starts processing");
             let mut runtime = crate::service::ingestion::init_functions_runtime();
             let stream_name = stream_name.unwrap_or("pipeline".to_string());
+            let mut result_array_records = Vec::new();
             while let Some((idx, mut record, mut flattened)) = receiver.recv().await {
-                if let Some(vrl_runtime) = &vrl_runtime {
+                if let Some((vrl_runtime, is_result_array_vrl)) = &vrl_runtime {
                     if func_params.after_flatten && !flattened {
                         record = match flatten::flatten_with_level(
                             record,
@@ -667,10 +671,54 @@ async fn process_node(
                             }
                         };
                     }
-                    record = match apply_vrl_fn(
+                    if !is_result_array_vrl {
+                        record = match apply_vrl_fn(
+                            &mut runtime,
+                            vrl_runtime,
+                            record,
+                            &org_id,
+                            &[stream_name.clone()],
+                        ) {
+                            (res, None) => res,
+                            (res, Some(error)) => {
+                                let err_msg = format!("FunctionNode error: {}", error);
+                                if let Err(send_err) = error_sender
+                                    .send((node.id.to_string(), node.node_type(), err_msg))
+                                    .await
+                                {
+                                    log::error!(
+                                        "[Pipeline] {} : FunctionNode failed sending errors for collection caused by: {send_err}",
+                                        pipeline_name
+                                    );
+                                    break;
+                                }
+                                res
+                            }
+                        };
+                        flattened = false; // since apply_vrl_fn can produce unflattened data
+                        send_to_children(
+                            &mut child_senders,
+                            (idx, record, flattened),
+                            "FunctionNode",
+                        )
+                        .await;
+                    } else {
+                        result_array_records.push((idx, record, flattened));
+                    }
+                }
+                count += 1;
+            }
+            if !result_array_records.is_empty() {
+                if let Some((vrl_runtime, true)) = &vrl_runtime {
+                    let result = match apply_vrl_fn(
                         &mut runtime,
                         vrl_runtime,
-                        record,
+                        json::Value::Array(
+                            result_array_records
+                                .into_iter()
+                                .map(|(_, record, _)| record)
+                                .collect(),
+                        ),
                         &org_id,
                         &[stream_name.clone()],
                     ) {
@@ -685,16 +733,21 @@ async fn process_node(
                                     "[Pipeline] {} : FunctionNode failed sending errors for collection caused by: {send_err}",
                                     pipeline_name
                                 );
-                                break;
+                                return Ok(());
                             }
                             res
                         }
                     };
-                    flattened = false; // since apply_vrl_fn can produce unflattened data
+                    // since apply_vrl_fn can produce unflattened data
+                    for (idx, record) in result.as_array().unwrap().iter().enumerate() {
+                        send_to_children(
+                            &mut child_senders,
+                            (idx, record.clone(), false),
+                            "FunctionNode",
+                        )
+                        .await;
+                    }
                 }
-                send_to_children(&mut child_senders, (idx, record, flattened), "FunctionNode")
-                    .await;
-                count += 1;
             }
             log::debug!("[Pipeline]: func node {node_idx} done processing {count} records");
         }

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -25,6 +25,7 @@ use config::{
     get_config, ider,
     meta::{
         cluster::RoleGroup,
+        function::RESULT_ARRAY,
         search,
         self_reporting::usage::{RequestStats, UsageType},
         sql::{OrderBy, SqlOperator, TableReferenceExt, resolve_stream_names},
@@ -48,7 +49,6 @@ use infra::{
 use once_cell::sync::Lazy;
 use opentelemetry::trace::TraceContextExt;
 use proto::cluster_rpc::{self, SearchQuery};
-use regex::Regex;
 use sql::Sql;
 use tokio::runtime::Runtime;
 use tracing::Instrument;
@@ -83,10 +83,6 @@ pub(crate) mod sql;
 pub(crate) mod super_cluster;
 pub(crate) mod tantivy;
 pub(crate) mod utils;
-
-// Checks for #ResultArray#
-pub static RESULT_ARRAY: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^#[ \s]*Result[ \s]*Array[ \s]*#").unwrap());
 
 /// The result of search in cluster
 /// data, scan_stats, wait_in_queue, is_partial, partial_err


### PR DESCRIPTION
Currently pipelines (both realtime/scheduled) don't work with ResultArray vrl functions. This pr fixes this bug - when the vrl function is "resultarray" the function node waits until all the records are received and then it processes the received records with the vrl function.