### PR TITLE
fix: return original query if not able to parse via parser

### DIFF
--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -684,53 +684,57 @@ export const changeHistogramInterval = async (
   query: any,
   histogramInterval: any,
 ) => {
-  // if histogramInterval is null or query is null or query is empty, return query
-  if (query === null || query === "") {
-    return query;
-  }
+  try {
+    // if histogramInterval is null or query is null or query is empty, return query
+    if (query === null || query === "") {
+      return query;
+    }
 
-  await importSqlParser();
-  const ast: any = parser.astify(query);
+    await importSqlParser();
+    const ast: any = parser.astify(query);
 
-  // Iterate over the columns to check if the column is histogram
-  ast?.columns?.forEach((column: any) => {
-    // check if the column is histogram
-    if (
-      column.expr.type === "function" &&
-      column?.expr?.name?.name?.[0]?.value === "histogram" &&
-      histogramInterval !== null
-    ) {
-      const histogramExpr = column.expr;
-      if (histogramExpr.args && histogramExpr.args.type === "expr_list") {
-        // if selected histogramInterval is null then remove interval argument
-        if (!histogramInterval) {
-          histogramExpr.args.value = histogramExpr.args.value.slice(0, 1);
-        }
-        // else update interval argument
-        else {
-          // check if there is existing interval value
-          // if have then do not do anything
-          // else insert new arg with given histogramInterval
-          if (histogramExpr.args.value[1]) {
-            // Update existing interval value
-            // histogramExpr.args.value[1] = {
-            //   type: "single_quote_string",
-            //   value: `${histogramInterval}`,
-            // };
-          } else {
-            // create new arg for interval
-            histogramExpr.args.value.push({
-              type: "single_quote_string",
-              value: `${histogramInterval}`,
-            });
+    // Iterate over the columns to check if the column is histogram
+    ast?.columns?.forEach((column: any) => {
+      // check if the column is histogram
+      if (
+        column.expr.type === "function" &&
+        column?.expr?.name?.name?.[0]?.value === "histogram" &&
+        histogramInterval !== null
+      ) {
+        const histogramExpr = column.expr;
+        if (histogramExpr.args && histogramExpr.args.type === "expr_list") {
+          // if selected histogramInterval is null then remove interval argument
+          if (!histogramInterval) {
+            histogramExpr.args.value = histogramExpr.args.value.slice(0, 1);
+          }
+          // else update interval argument
+          else {
+            // check if there is existing interval value
+            // if have then do not do anything
+            // else insert new arg with given histogramInterval
+            if (histogramExpr.args.value[1]) {
+              // Update existing interval value
+              // histogramExpr.args.value[1] = {
+              //   type: "single_quote_string",
+              //   value: `${histogramInterval}`,
+              // };
+            } else {
+              // create new arg for interval
+              histogramExpr.args.value.push({
+                type: "single_quote_string",
+                value: `${histogramInterval}`,
+              });
+            }
           }
         }
       }
-    }
-  });
+    });
 
-  const sql = parser.sqlify(ast);
-  return sql.replace(/`/g, '"');
+    const sql = parser.sqlify(ast);
+    return sql.replace(/`/g, '"');
+  } catch (error) {
+    return query;
+  }
 };
 
 export const convertQueryIntoSingleLine = async (query: any) => {


### PR DESCRIPTION
- Parser fails to parse Data fusion functions which throws error.
- Pass original user written query if not able to parse. 