### PR TITLE
perf: optimize stream stats calculate with limit

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1271,6 +1271,8 @@ pub struct Limit {
     pub job_runtime_shutdown_timeout: u64,
     #[env_config(name = "ZO_CALCULATE_STATS_INTERVAL", default = 60)] // seconds
     pub calculate_stats_interval: u64,
+    #[env_config(name = "ZO_CALCULATE_STATS_STEP_LIMIT", default = 10000)] // records
+    pub calculate_stats_step_limit: i64,
     #[env_config(name = "ZO_ACTIX_REQ_TIMEOUT", default = 5)] // seconds
     pub http_request_timeout: u64,
     #[env_config(name = "ZO_ACTIX_KEEP_ALIVE", default = 5)] // seconds
@@ -2066,11 +2068,11 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
 
     if cfg.limit.consistent_hash_vnodes == 0 {
-        cfg.limit.consistent_hash_vnodes = 100;
+        cfg.limit.consistent_hash_vnodes = 1000;
     }
 
     // reset to default if given zero
-    if cfg.limit.max_dashboard_series == 0 {
+    if cfg.limit.max_dashboard_series < 1 {
         cfg.limit.max_dashboard_series = 100;
     }
 
@@ -2078,6 +2080,11 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     #[allow(deprecated)]
     if cfg.limit.udschema_max_fields > 0 {
         cfg.limit.schema_max_fields_to_enable_uds = cfg.limit.udschema_max_fields;
+    }
+
+    // check for calculate stats
+    if cfg.limit.calculate_stats_step_limit < 1 {
+        cfg.limit.calculate_stats_step_limit = 10000;
     }
 
     Ok(())

--- a/src/service/compact/stats.rs
+++ b/src/service/compact/stats.rs
@@ -38,8 +38,10 @@ pub async fn update_stats_from_file_list() -> Result<Option<(i64, i64)>, anyhow:
         }
     }
 
-    // get latest offset
+    // get latest offset and apply step limit
+    let step_limit = config::get_config().limit.calculate_stats_step_limit;
     let latest_pk = infra_file_list::get_max_pk_value().await?;
+    let latest_pk = std::cmp::min(offset + step_limit, latest_pk);
     let pk_value = if offset == 0 && latest_pk == 0 {
         None
     } else {
@@ -49,15 +51,9 @@ pub async fn update_stats_from_file_list() -> Result<Option<(i64, i64)>, anyhow:
     // get stats from file_list
     let orgs = db::schema::list_organizations_from_cache().await;
     for org_id in orgs {
-        let add_stream_stats = infra_file_list::stats(&org_id, None, None, pk_value, false)
-            .await
-            .unwrap_or_default();
-        let dumped_add_stats = file_list_dump::stats(&org_id, None, None, pk_value)
-            .await
-            .unwrap_or_default();
-        let del_stream_stats = infra_file_list::stats(&org_id, None, None, pk_value, true)
-            .await
-            .unwrap_or_default();
+        let add_stream_stats = infra_file_list::stats(&org_id, None, None, pk_value, false).await?;
+        let dumped_add_stats = file_list_dump::stats(&org_id, None, None, pk_value).await?;
+        let del_stream_stats = infra_file_list::stats(&org_id, None, None, pk_value, true).await?;
         // dump never store deleted files, so we do not have to consider deleted here
         let mut stream_stats = HashMap::new();
         for (stream, stats) in add_stream_stats {


### PR DESCRIPTION
This PR fixed the issue when compactor not working for a long time, it will have millions files need to be update stream stats. it will take a long time or time out.