### PR TITLE
feat: add file query time metrics

### DIFF
--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -851,6 +851,21 @@ pub static FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE: Lazy<IntGaugeVec> = Lazy::new(||
     .expect("Metric created")
 });
 
+// File access time bucket histogram
+pub static FILE_ACCESS_TIME: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
+            "file_access_time",
+            "Histogram showing query counts within time windows from 1h to 1week (1h, 2h, 3h, 6h, 12h, 24h, 48h, 96h, 168h)"
+        )
+        .namespace(NAMESPACE)
+        .buckets(vec![1.0, 2.0, 3.0, 6.0, 12.0, 24.0, 48.0, 96.0, 168.0])
+        .const_labels(create_const_labels()),
+        &["stream_type"],
+    )
+    .expect("Metric created")
+});
+
 fn register_metrics(registry: &Registry) {
     // http latency
     registry
@@ -1078,6 +1093,9 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(FILE_ACCESS_TIME.clone()))
         .expect("Metric registered");
 }
 


### PR DESCRIPTION
This histogram metric should allow understanding the age of files handled by querier.
Example queries
`histogram_quantile(0.95,
rate(zo_file_access_time_bucket{stream_type='logs'}[5m]))`

---------