### PR TITLE
fix: deserialize from `member` to `admin`

### DIFF
--- a/src/infra/src/table/migration/m20241227_000400_populate_users_table.rs
+++ b/src/infra/src/table/migration/m20241227_000400_populate_users_table.rs
@@ -175,7 +175,7 @@ mod meta {
     pub enum UserRole {
         #[serde(rename = "root")]
         Root = 0,
-        #[serde(rename = "admin")]
+        #[serde(rename = "admin", alias = "member")]
         Admin = 1,
         #[serde(rename = "editor")]
         Editor = 2,


### PR DESCRIPTION
`member` role should also be deserialized to the `admin` role.