### PR TITLE
feat: reset scheduled pipeline

### DIFF
--- a/src/handler/http/request/pipeline.rs
+++ b/src/handler/http/request/pipeline.rs
@@ -269,3 +269,35 @@ pub async fn enable_pipeline(
         Err(e) => Ok(e.into()),
     }
 }
+
+/// ResetScheduledPipeline
+///
+/// #{"ratelimit_module":"Pipeline", "ratelimit_module_operation":"update"}#
+#[utoipa::path(
+    context_path = "/api",
+    tag = "Pipelines",
+    operation_id = "resetScheduledPipeline",
+    security(
+        ("Authorization"= [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+        ("pipeline_id" = String, Path, description = "Pipeline ID"),
+    ),
+    responses(
+        (status = 200, description = "Success",  content_type = "application/json", body = HttpResponse),
+        (status = 404, description = "NotFound", content_type = "application/json", body = HttpResponse),
+        (status = 500, description = "Failure",  content_type = "application/json", body = HttpResponse),
+    )
+)]
+#[put("/{org_id}/pipelines/{pipeline_id}/reset")]
+pub async fn reset_pipeline(path: web::Path<(String, String)>) -> Result<HttpResponse, Error> {
+    let (org_id, pipeline_id) = path.into_inner();
+    let resp_msg = "Pipeline reset successfully ".to_string();
+    match pipeline::reset_pipeline(&org_id, &pipeline_id).await {
+        Ok(()) => {
+            Ok(HttpResponse::Ok().json(MetaHttpResponse::message(http::StatusCode::OK, resp_msg)))
+        }
+        Err(e) => Ok(e.into()),
+    }
+}

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -555,6 +555,7 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(pipeline::list_streams_with_pipeline)
         .service(pipeline::delete_pipeline)
         .service(pipeline::enable_pipeline)
+        .service(pipeline::reset_pipeline)
         .service(search::multi_streams::search_multi)
         .service(search::multi_streams::_search_partition_multi)
         .service(search::multi_streams::around_multi)

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -156,6 +156,7 @@ use crate::{common::meta, handler::http::request};
         request::pipeline::delete_pipeline,
         request::pipeline::update_pipeline,
         request::pipeline::enable_pipeline,
+        request::pipeline::reset_pipeline,
         request::dashboards::reports::create_report,
         request::dashboards::reports::update_report,
         request::dashboards::reports::list_reports,

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -927,7 +927,7 @@ async fn handle_derived_stream_triggers(
             "Pipeline associated with trigger not enabled: {}/{}/{}/{}. Checking after 5 mins.",
             org_id, stream_type, pipeline_name, pipeline_id
         );
-        new_trigger.next_run_at += Duration::try_minutes(5)
+        new_trigger.next_run_at += Duration::try_minutes(1)
             .unwrap()
             .num_microseconds()
             .unwrap();
@@ -939,9 +939,9 @@ async fn handle_derived_stream_triggers(
             next_run_at: new_trigger.next_run_at,
             is_realtime: new_trigger.is_realtime,
             is_silenced: new_trigger.is_silenced,
-            status: TriggerDataStatus::Failed,
-            start_time: 0,
-            end_time: 0,
+            status: TriggerDataStatus::Skipped,
+            start_time: new_trigger.start_time.unwrap_or_default(),
+            end_time: new_trigger.end_time.unwrap_or_default(),
             retries: new_trigger.retries,
             error: Some(msg.clone()),
             success_response: None,
@@ -954,8 +954,6 @@ async fn handle_derived_stream_triggers(
             time_in_queue_ms: Some(time_in_queue),
         };
         log::info!("[SCHEDULER trace_id {scheduler_trace_id}] {}", msg);
-        new_trigger_data.reset();
-        new_trigger.data = new_trigger_data.to_json_string();
         db::scheduler::update_trigger(new_trigger).await?;
         publish_triggers_usage(trigger_data_stream).await;
         return Ok(());

--- a/src/service/db/pipeline.rs
+++ b/src/service/db/pipeline.rs
@@ -49,6 +49,8 @@ pub enum PipelineError {
     InvalidPipeline(String),
     #[error("Invalid DerivedStream config: {0}")]
     InvalidDerivedStream(String),
+    #[error("Reset only applied to scheduled pipelines")]
+    PipelineDoesNotApply,
     #[error("Error deleting previous DerivedStream: {0}")]
     DeleteDerivedStream(String),
 }


### PR DESCRIPTION
new endpoint: 

```
PUT /{org_id}/pipelines/{pipeline_id}/reset
```

**Reset**
- disregard a scheduled pipeline's previous trigger status and immediately sets `next_run_at` to now and starts fresh
- only applied to scheduled pipelines
- Pending UI update @nikhilsaikethe 

**Pause**
- Keeps scheduled pipeline's trigger status intact, and starts again from previous `end_time` when unpaused
- applied to realtime pipelines as well, same effect as before