### PR TITLE
fix: saved views for long queries

### DIFF
--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -1356,10 +1356,10 @@ export default defineComponent({
         });
     },
     handleKeyDown(e) {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-          this.handleRunQueryFn();
+      if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+        this.handleRunQueryFn();
       }
-    }
+    },
   },
   props: {
     fieldValues: {
@@ -2668,6 +2668,8 @@ export default defineComponent({
 
         savedSearchObj.data.timezone = store.state.timezone;
         delete savedSearchObj.value;
+
+        delete savedSearchObj.data.parsedQuery;
 
         return savedSearchObj;
         // return b64EncodeUnicode(JSON.stringify(savedSearchObj));


### PR DESCRIPTION
Parsed SQL query object was getting saved with saved-view payload.
When we have very long search query, size of parsedSQL increases which causes error while saving in BE