### PR TITLE
fix: change stream name label to o2_stream_name

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1559,7 +1559,7 @@ pub struct CacheLatestFiles {
 
 #[derive(EnvConfig)]
 pub struct MemoryCache {
-    #[env_config(name = "ZO_MEMORY_CACHE_ENABLED", default = false)]
+    #[env_config(name = "ZO_MEMORY_CACHE_ENABLED", default = true)]
     pub enabled: bool,
     // Memory data cache strategy, default is lru, other value is fifo, time_lru
     #[env_config(name = "ZO_MEMORY_CACHE_STRATEGY", default = "lru")]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -91,6 +91,8 @@ pub const ID_COL_NAME: &str = "_o2_id";
 pub const ORIGINAL_DATA_COL_NAME: &str = "_original";
 pub const ALL_VALUES_COL_NAME: &str = "_all_values";
 pub const MESSAGE_COL_NAME: &str = "message";
+pub const STREAM_NAME_LABEL: &str = "o2_stream_name";
+pub const DEFAULT_STREAM_NAME: &str = "default";
 
 const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 7] =
     ["log", "message", "msg", "content", "data", "body", "json"];
@@ -462,7 +464,7 @@ pub struct WebSocket {
     pub streaming_response_chunk_size: usize,
     #[env_config(
         name = "ZO_STREAMING_ENABLED",
-        default = false,
+        default = true,
         help = "Enable streaming"
     )]
     pub streaming_enabled: bool,
@@ -802,7 +804,7 @@ pub struct Common {
         help = "Comma separated list of fields to use for search around"
     )]
     pub search_around_default_fields: String,
-    #[env_config(name = "ZO_WAL_FSYNC_DISABLED", default = false)]
+    #[env_config(name = "ZO_WAL_FSYNC_DISABLED", default = true)]
     pub wal_fsync_disabled: bool,
     #[env_config(
         name = "ZO_WAL_WRITE_QUEUE_ENABLED",
@@ -1148,10 +1150,10 @@ pub struct Limit {
     #[env_config(name = "ZO_MAX_FILE_RETENTION_TIME", default = 600)] // seconds
     pub max_file_retention_time: u64,
     // MB, per log file size limit on disk
-    #[env_config(name = "ZO_MAX_FILE_SIZE_ON_DISK", default = 128)]
+    #[env_config(name = "ZO_MAX_FILE_SIZE_ON_DISK", default = 256)]
     pub max_file_size_on_disk: usize,
     // MB, per data file size limit in memory
-    #[env_config(name = "ZO_MAX_FILE_SIZE_IN_MEMORY", default = 128)]
+    #[env_config(name = "ZO_MAX_FILE_SIZE_IN_MEMORY", default = 256)]
     pub max_file_size_in_memory: usize,
     #[deprecated(
         since = "0.14.1",
@@ -1184,7 +1186,7 @@ pub struct Limit {
         help = "MemTable bucket num, default is 1"
     )] // default is 1
     pub mem_table_bucket_num: usize,
-    #[env_config(name = "ZO_MEM_PERSIST_INTERVAL", default = 5)] // seconds
+    #[env_config(name = "ZO_MEM_PERSIST_INTERVAL", default = 2)] // seconds
     pub mem_persist_interval: u64,
     #[env_config(name = "ZO_WAL_WRITE_BUFFER_SIZE", default = 16384)] // 16 KB
     pub wal_write_buffer_size: usize,
@@ -1484,7 +1486,7 @@ pub struct Limit {
 pub struct Compact {
     #[env_config(name = "ZO_COMPACT_ENABLED", default = true)]
     pub enabled: bool,
-    #[env_config(name = "ZO_COMPACT_INTERVAL", default = 60)] // seconds
+    #[env_config(name = "ZO_COMPACT_INTERVAL", default = 10)] // seconds
     pub interval: u64,
     #[env_config(name = "ZO_COMPACT_OLD_DATA_INTERVAL", default = 3600)] // seconds
     pub old_data_interval: u64,
@@ -1557,7 +1559,7 @@ pub struct CacheLatestFiles {
 
 #[derive(EnvConfig)]
 pub struct MemoryCache {
-    #[env_config(name = "ZO_MEMORY_CACHE_ENABLED", default = true)]
+    #[env_config(name = "ZO_MEMORY_CACHE_ENABLED", default = false)]
     pub enabled: bool,
     // Memory data cache strategy, default is lru, other value is fifo, time_lru
     #[env_config(name = "ZO_MEMORY_CACHE_STRATEGY", default = "lru")]

--- a/src/service/logs/loki.rs
+++ b/src/service/logs/loki.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use config::{
-    MESSAGE_COL_NAME, TIMESTAMP_COL_NAME,
+    DEFAULT_STREAM_NAME, MESSAGE_COL_NAME, STREAM_NAME_LABEL, TIMESTAMP_COL_NAME,
     utils::{json, schema::format_stream_name},
 };
 use promql_parser::{
@@ -33,8 +33,6 @@ use crate::{
     },
     service::logs,
 };
-
-const STREAM_NAME_LABEL: &str = "stream_name";
 
 pub enum LokiRequest {
     Json(LokiPushRequest),
@@ -281,7 +279,7 @@ fn determine_service_stream_name(labels: &HashMap<String, String>) -> String {
         .get(STREAM_NAME_LABEL)
         .map(|name| format_stream_name(name))
         .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| "default".to_string())
+        .unwrap_or_else(|| DEFAULT_STREAM_NAME.to_string())
 }
 
 #[cfg(test)]
@@ -321,7 +319,7 @@ mod tests {
         // Test empty stream_name falls back to default
         let mut labels = HashMap::new();
         labels.insert(STREAM_NAME_LABEL.to_string(), "".to_string());
-        assert_eq!(determine_service_stream_name(&labels), "default");
+        assert_eq!(determine_service_stream_name(&labels), DEFAULT_STREAM_NAME);
     }
 
     #[test]

--- a/src/service/logs/loki.rs
+++ b/src/service/logs/loki.rs
@@ -449,7 +449,7 @@ mod tests {
         let proto_request = loki_rpc::PushRequest {
             streams: vec![
                 loki_rpc::StreamAdapter {
-                    labels: r#"{"stream_name":"auth"}"#.to_string(),
+                    labels: r#"{"o2_stream_name":"auth"}"#.to_string(),
                     entries: vec![loki_rpc::EntryAdapter {
                         timestamp: Some(Timestamp {
                             seconds: 1702834800,
@@ -461,7 +461,7 @@ mod tests {
                     hash: 1,
                 },
                 loki_rpc::StreamAdapter {
-                    labels: r#"{"stream_name":"payment"}"#.to_string(),
+                    labels: r#"{"o2_stream_name":"payment"}"#.to_string(),
                     entries: vec![loki_rpc::EntryAdapter {
                         timestamp: Some(Timestamp {
                             seconds: 1702834801,

--- a/src/service/promql/search/grpc/wal.rs
+++ b/src/service/promql/search/grpc/wal.rs
@@ -177,7 +177,7 @@ async fn get_wal_batches(
             idx_file_list: vec![], // not needed for wal
             start_time: time_range.0,
             end_time: time_range.1,
-            timeout: cfg.limit.query_timeout as u64,
+            timeout: cfg.limit.query_timeout,
         },
         index_info: IndexInfo::default(), // not needed for wal
         super_cluster_info: cluster_rpc::SuperClusterInfo::default(), // current not needed for wal


### PR DESCRIPTION
### **User description**
For `Loki` API we use `o2_stream_name` label to decide the stream name. if we can't get this label value, we will use `default` as stream name.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor Loki stream label constant

- Update default config env values

- Increase file size limits defaults

- Reduce persistence and compaction intervals


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Update configuration defaults and constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<li>Added <code>STREAM_NAME_LABEL</code> and <code>DEFAULT_STREAM_NAME</code><br> <li> Enabled streaming, disabled WAL fsync, disabled memory cache<br> <li> Increased default file size limits<br> <li> Reduced persistence and compaction intervals


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7092/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loki.rs</strong><dd><code>Use constants for Loki stream names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/logs/loki.rs

<li>Import <code>STREAM_NAME_LABEL</code> and <code>DEFAULT_STREAM_NAME</code><br> <li> Remove hardcoded <code>stream_name</code> constant<br> <li> Use constants in stream name function<br> <li> Update tests with <code>DEFAULT_STREAM_NAME</code>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7092/files#diff-a970c8c4785d4e4d878218615b17eec0cf4b4976121766b002c2b2f76371bfe6">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wal.rs</strong><dd><code>Remove redundant timeout cast</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/promql/search/grpc/wal.rs

- Removed redundant `as u64` timeout cast


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7092/files#diff-f47892ffc5d3076d37a66f49f55db4e83cb6f42df517da68c001a42c04adac72">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>