### PR TITLE
fix: `NOT IN` filter parsing issue for visualization

### DIFF
--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -525,7 +525,11 @@ function parseCondition(condition: any) {
       ];
 
       // function without field name and with value
-      const conditionsWithoutFieldName = ["match_all"];
+      const conditionsWithoutFieldName = [
+        "match_all",
+        "match_all_raw",
+        "match_all_raw_ignore_case",
+      ];
 
       if (conditionsWithFieldName.includes(conditionName)) {
         return {


### PR DESCRIPTION
- #6967 
- `NOT IN`, `Starts With` and `Ends With` filters support for visualization.