### PR TITLE
fix: pipeline dynamic stream fix

### DIFF
--- a/web/src/components/pipeline/NodeForm/Stream.vue
+++ b/web/src/components/pipeline/NodeForm/Stream.vue
@@ -241,7 +241,7 @@ watch(
         position: "bottom",
         timeout: 2000,
       });
-      return;
+      return "";
     }
     const regex = /\{[^{}]+\}/g;
     const parts: string[] = [];


### PR DESCRIPTION
This PR fixes 
now we have increased the stream name to 100 chars before it was 60 chars
this PR should allow user to add this type of stream name
someprefix{stream_name}somesuffix
along with that
example_stream_name
{dynamic_stream_name_output}