### PR TITLE
fix: improve streaming output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6199,7 +6199,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openobserve"
-version = "0.14.8"
+version = "0.15.0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -6259,6 +6259,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.15",
  "hashbrown 0.15.2",
+ "hashlink",
  "hex",
  "http-auth-basic",
  "infra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = [
 license = "AGPL-3.0-only"
 name = "openobserve"
 repository = "https://github.com/openobserve/openobserve/"
-version = "0.14.8"
+version = "0.15.0"
 publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -102,8 +102,9 @@ etcd-client.workspace = true
 faststr.workspace = true
 flate2.workspace = true
 futures.workspace = true
-hex.workspace = true
+hashlink.workspace = true
 hashbrown.workspace = true
+hex.workspace = true
 http-auth-basic = "0.3"
 ipnetwork.workspace = true
 itertools.workspace = true

--- a/src/service/search/datafusion/distributed_plan/rewrite.rs
+++ b/src/service/search/datafusion/distributed_plan/rewrite.rs
@@ -216,7 +216,7 @@ impl TreeNodeRewriter for StreamingAggsRewriter {
             && node.children().first().unwrap().name() == "AggregateExec"
             && config::get_config().common.feature_query_streaming_aggs
         {
-            if !streaming_aggs_exec::GLOBAL_ID_CACHE.exists(&self.id) {
+            if !streaming_aggs_exec::GLOBAL_CACHE.exists(&self.id) {
                 return Err(DataFusionError::Plan(format!(
                     "streaming aggregation cache not found with id: {}",
                     self.id

--- a/src/service/search/datafusion/distributed_plan/streaming_aggs_exec.rs
+++ b/src/service/search/datafusion/distributed_plan/streaming_aggs_exec.rs
@@ -501,12 +501,14 @@ mod tests {
         cache.insert("key3".to_string(), 1, 2);
         cache.insert("key4".to_string(), 1, 2);
         cache.insert("key5".to_string(), 1, 2);
+        // trigger the key as last recently used
+        cache.insert("key1".to_string(), 1, 2);
         assert_eq!(cache.data.read().len(), 5);
         let gc_keys = cache.gc(2);
-        assert_eq!(gc_keys, vec!["key1", "key2"]);
+        assert_eq!(gc_keys, vec!["key2", "key3"]);
         assert_eq!(cache.data.read().len(), 3);
-        assert!(cache.exists("key3"));
         assert!(cache.exists("key4"));
         assert!(cache.exists("key5"));
+        assert!(cache.exists("key1"));
     }
 }

--- a/src/service/search/datafusion/distributed_plan/streaming_aggs_exec.rs
+++ b/src/service/search/datafusion/distributed_plan/streaming_aggs_exec.rs
@@ -492,4 +492,21 @@ mod tests {
         let cacher_len = cache.data.len();
         assert_eq!(cacher_len, 3);
     }
+
+    #[test]
+    fn test_streaming_id_cache_gc() {
+        let cache = StreamingIdCache::new(10);
+        cache.insert("key1".to_string(), 1, 2);
+        cache.insert("key2".to_string(), 1, 2);
+        cache.insert("key3".to_string(), 1, 2);
+        cache.insert("key4".to_string(), 1, 2);
+        cache.insert("key5".to_string(), 1, 2);
+        assert_eq!(cache.data.read().len(), 5);
+        let gc_keys = cache.gc(2);
+        assert_eq!(gc_keys, vec!["key1", "key2"]);
+        assert_eq!(cache.data.read().len(), 3);
+        assert!(cache.exists("key3"));
+        assert!(cache.exists("key4"));
+        assert!(cache.exists("key5"));
+    }
 }


### PR DESCRIPTION
### **User description**
This PR use `LRU` replace `VecDeque` to evict the oldest (no longer) used streaming id


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace `VecDeque` with `LruCache` eviction

- Evict 1% oldest streaming entries on insert

- Refactor `StreamingIdCache` concurrency and eviction

- Update dependency, tests, bump version


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>streaming_aggs_exec.rs</strong><dd><code>Use LruCache for streaming cache eviction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/datafusion/distributed_plan/streaming_aggs_exec.rs

• Swapped out <code>VecDeque</code> for <code>LruCache</code> from <code>hashlink</code>  <br> • Evict oldest 1% entries via new <code>gc</code> method  <br> • Refactored <code>StreamingIdCache</code> to use <code>RwLock<LruCache></code>  <br> • Updated insert, exists, remove, check_time logic and logs


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7106/files#diff-1c0c32a6e29645ada6b2d29147cca3ebc9251e144a998bdf43d74bb94b5dabe6">+44/-24</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump version and add hashlink dep</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

• Bumped package version to <code>0.15.0</code>  <br> • Added <code>hashlink</code> workspace dependency


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7106/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>