### PR TITLE
fix: http2 streaming in Safari browser

### DIFF
--- a/web/src/composables/useStreamingSearch.ts
+++ b/web/src/composables/useStreamingSearch.ts
@@ -256,17 +256,49 @@ const useHttpStreaming = () => {
 
       // Get the ReadableStream
       const readableStream = response.body;
+
       if (!readableStream) {
         throw new Error('Response body is null');
       }
       
       // Start the stream in the worker
-      if(worker) {
+      if (worker) {        
+        // Initialize the stream in the worker
         worker.postMessage({
           action: 'startStream',
-          traceId,
-          readableStream
-        }, [readableStream as any]);
+          traceId
+        });
+        
+        // For Safari compatibility: manually read the stream and send chunks to worker
+        const reader = readableStream.getReader();
+        const decoder = new TextDecoder();
+        
+        (async () => {
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              
+              if (done) {
+                worker.postMessage({
+                  action: 'endStream',
+                  traceId
+                });
+                break;
+              }
+              
+              // Decode and send chunks to the worker
+              const chunk = decoder.decode(value, { stream: true });
+              worker.postMessage({
+                action: 'processChunk',
+                traceId,
+                chunk
+              });
+            }
+          } catch (error) {
+            console.error('Error reading stream:', error);
+            onError(traceId, error);
+          }
+        })();
       } else {
         throw new Error('Worker is not supported');
       }

--- a/web/src/composables/useStreamingSearch.ts
+++ b/web/src/composables/useStreamingSearch.ts
@@ -296,6 +296,7 @@ const useHttpStreaming = () => {
             }
           } catch (error) {
             console.error('Error reading stream:', error);
+            reader.releaseLock();
             onError(traceId, error);
           }
         })();

--- a/web/src/workers/streamWorker.js
+++ b/web/src/workers/streamWorker.js
@@ -1,7 +1,5 @@
 // Worker to handle stream processing
 // This offloads decoding and parsing from the main thread
-
-let activeStreams = {};
 let activeBuffers = {};
 // Handle messages from main thread
 self.onmessage = async (event) => {
@@ -27,17 +25,14 @@ self.onmessage = async (event) => {
         traceId,
       });
       
-      delete activeStreams[traceId];
       delete activeBuffers[traceId];
       break;
 
     case 'cancelStream':
-      delete activeStreams[traceId];
       delete activeBuffers[traceId];
       break;
 
     case 'closeAll':
-      activeStreams = {};
       activeBuffers = {};
       break;
   }


### PR DESCRIPTION
1. TransferableStream: Safari has limited support for transferring ReadableStreams to workers.
2. TextDecoder : Safari has incomplete support for decoder.decode() in workers

Moved ReadableStreams and TextDecoder logic to streaming composable