### PR TITLE
fix: http partition pagination for less number of partition counts

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1503,7 +1503,11 @@ const useLogs = () => {
                   recordSize = rowsPerPage - lastPartitionSize;
                 }
 
-                if (total < recordSize) {
+                if (total == 0) {
+                  recordSize = 0;
+                }
+      
+                if (total !== -1 && total < recordSize) {
                   recordSize = total;
                 }
               }

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -6207,7 +6207,6 @@ const useLogs = () => {
       total = getAggsTotal();
 
 
-      console.log("total ----", searchObj.data.queryResults.pageCountTotal, total);
 
       if((searchObj.data.queryResults.pageCountTotal || -1) > total) {
         total = searchObj.data.queryResults.pageCountTotal;


### PR DESCRIPTION
http - Fixed partition logic for multiple partitions in single page. Example partition: [14, 144]
http - Fixed partition logic for partition with 0 events. Example partition: [14, 0, 144]
http - Last page was not visible for specific partitions. Example partition: [14, 144]
http - + was shown for the last page total-count
http2 streaming - Incremental ( size + 1 ) was not working with multiple partitions