### PR TITLE
fix: call CryptoProvider::install_default() before this point

### DIFF
--- a/src/job/syslog_server.rs
+++ b/src/job/syslog_server.rs
@@ -49,7 +49,7 @@ pub async fn run(start_srv: bool, is_init: bool) -> Result<(), anyhow::Error> {
     let udp_addr: SocketAddr = format!("{bind_addr}:{}", cfg.tcp.udp_port).parse()?;
     let tcp_tls_enabled = cfg.tcp.tcp_tls_enabled;
     if (!server_running || is_init) && start_srv {
-        log::info!("Starting TCP UDP server");
+        log::info!("Starting TCP UDP server on {tcp_addr}");
         let tcp_listener: TcpListener = TcpListener::bind(tcp_addr).await?;
         let udp_socket = UdpSocket::bind(udp_addr).await?;
         let tls_server_config = if tcp_tls_enabled {


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Include TCP address in logs  

- Fully qualify rustls types  

- Remove CryptoProvider install_default  

- Simplify itertools import


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>syslog_server.rs</strong><dd><code>Include TCP address in syslog logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/job/syslog_server.rs

<li>Log now includes <code>{tcp_addr}</code> address  <br> <li> Updated log message with formatted address


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7125/files#diff-cb7610142582b44885f673583ab16262c3b9ca6de1f59a9def65e503360665a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Modernize rustls imports and configs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/tls/mod.rs

<li>Fully qualify <code>rustls::ServerConfig</code> and <code>ClientConfig</code>  <br> <li> Update function return types to <code>rustls</code> qualifiers  <br> <li> Remove <code>CryptoProvider::install_default</code> call  <br> <li> Simplify <code>itertools</code> import usage


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7125/files#diff-5061e662a8899b7e00e5744bd72f808b28ac479a8921ac519f7409bffdc4438a">+10/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>