### PR TITLE
fix: fix size reported in usage

### DIFF
--- a/src/config/src/meta/self_reporting/usage.rs
+++ b/src/config/src/meta/self_reporting/usage.rs
@@ -239,6 +239,7 @@ impl UsageType {
             self,
             UsageType::Bulk
                 | UsageType::Json
+                | UsageType::Hec
                 | UsageType::Multi
                 | UsageType::KinesisFirehose
                 | UsageType::GCPSubscription

--- a/src/config/src/utils/json.rs
+++ b/src/config/src/utils/json.rs
@@ -133,8 +133,13 @@ pub fn estimate_json_bytes(val: &Value) -> usize {
             }
         }
         Value::String(s) => {
+            // count the " character in string, as it will be escaped in the input json
+            // also we use bytes() here as sometimes compiler can optimize it faster with sse
+            // see https://users.rust-lang.org/t/count-number-of-z-in-a-string/49763/5
+            let quote_count = s.bytes().filter(|b| *b == b'"').count();
+            let slash_count = s.bytes().filter(|b| *b == b'\\').count();
             // "?"=>2
-            size += s.len() + 2;
+            size += s.len() + 2 + quote_count + slash_count;
         }
         Value::Number(n) => {
             size += n.to_string().len();

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -28,7 +28,11 @@ use config::{
         stream::{StreamParams, StreamType},
     },
     metrics,
-    utils::{flatten, json, time::parse_timestamp_micro_from_value},
+    utils::{
+        flatten,
+        json::{self, estimate_json_bytes},
+        time::parse_timestamp_micro_from_value,
+    },
 };
 use flate2::read::GzDecoder;
 use opentelemetry_proto::tonic::{
@@ -171,6 +175,7 @@ pub async fn ingest(
 
     let mut stream_status = StreamStatus::new(&stream_name);
     let mut json_data_by_stream = HashMap::new();
+    let mut size_by_stream = HashMap::new();
     for ret in data.iter() {
         let mut item = match ret {
             Ok(item) => item,
@@ -211,6 +216,9 @@ pub async fn ingest(
             pipeline_inputs.push(item);
             original_options.push(original_data);
         } else {
+            let _size = size_by_stream.entry(stream_name.clone()).or_insert(0);
+            *_size += estimate_json_bytes(&item);
+
             // JSON Flattening
             let mut res = flatten::flatten_with_level(item, cfg.limit.ingest_flatten_level)?;
 
@@ -362,6 +370,9 @@ pub async fn ingest(
                             }
                         };
 
+                        // we calculate the size BEFORE applying uds
+                        let original_size = estimate_json_bytes(&res);
+
                         // get json object
                         let mut local_val = match res.take() {
                             json::Value::Object(val) => val,
@@ -428,6 +439,11 @@ pub async fn ingest(
                         ts_data.push((timestamp, local_val));
                         *fn_num = need_usage_report.then_some(function_no);
 
+                        let _size = size_by_stream
+                            .entry(destination_stream.clone())
+                            .or_insert(0);
+                        *_size += original_size;
+
                         tokio::task::coop::consume_budget().await;
                     }
                 }
@@ -460,6 +476,7 @@ pub async fn ingest(
             usage_type,
             &mut status,
             json_data_by_stream,
+            size_by_stream,
         )
         .await;
         stream_status.status = match status {

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -24,7 +24,7 @@ use anyhow::Result;
 use arrow_schema::{DataType, Field};
 use bulk::SCHEMA_CONFORMANCE_FAILED;
 use config::{
-    DISTINCT_FIELDS, get_config,
+    DISTINCT_FIELDS, SIZE_IN_MB, get_config,
     meta::{
         alerts::alert::Alert,
         self_reporting::usage::{RequestStats, UsageType},
@@ -205,6 +205,7 @@ async fn write_logs_by_stream(
     usage_type: UsageType,
     status: &mut IngestionStatus,
     json_data_by_stream: HashMap<String, O2IngestJsonData>,
+    byte_size_by_stream: HashMap<String, usize>,
 ) -> Result<()> {
     for (stream_name, (json_data, fn_num)) in json_data_by_stream {
         // check if we are allowed to ingest
@@ -244,6 +245,14 @@ async fn write_logs_by_stream(
         };
 
         if let Some(fns_length) = fn_num {
+            // the issue here is req_stats.size calculates size after flattening and
+            // adding _timestamp col etc ; which inflates the size compared to the actual
+            // data sent by user. So when reporting we check if the calling function has provided us
+            // an "actual" size of the input, and is so use that instead of the req_stats
+            if let Some(size) = byte_size_by_stream.get(&stream_name) {
+                // req_stats already divides the size in mb
+                req_stats.size = *size as f64 / SIZE_IN_MB;
+            }
             report_request_usage_stats(
                 req_stats,
                 org_id,


### PR DESCRIPTION
This fixes the size reported in usage stream. We used to calculate size after flattening the data and adding _timestamp col etc, because of which the size that is actually sent for ingestion and size reported in usage stream differed. This fixes that issue.

Also we didn't cover all the cases when calculating size of string, fixed some of them.