### PR TITLE
fix: escape quote for variable values

### DIFF
--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -489,6 +489,8 @@ pub struct VariableList {
     pub select_all_value_for_multi_select: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_multi_select_value: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub escape_single_quotes: Option<bool>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]

--- a/tests/ui-testing/playwright-tests/dashboards/dashboard-variables-setting.spec.js
+++ b/tests/ui-testing/playwright-tests/dashboards/dashboard-variables-setting.spec.js
@@ -579,7 +579,6 @@ test.describe("dashboard variables setting", () => {
     await page
       .locator('[data-test="dashboard-variable-label"]')
       .fill("custom-variable");
-    // await page.getByRole("button", { name: "Add Option" }).click();
     await page
       .locator('[data-test="dashboard-custom-variable-0-label"]')
       .click();
@@ -642,7 +641,6 @@ test.describe("dashboard variables setting", () => {
     await page
       .locator('[data-test="dashboard-variable-label"]')
       .fill("custom-variable");
-    // await page.getByRole("button", { name: "Add Option" }).click();
     await page
       .locator('[data-test="dashboard-custom-variable-0-label"]')
       .click();
@@ -712,7 +710,6 @@ test.describe("dashboard variables setting", () => {
     await page
       .locator('[data-test="dashboard-variable-label"]')
       .fill("custom-variable");
-    // await page.getByRole("button", { name: "Add Option" }).click();
     await page
       .locator('[data-test="dashboard-custom-variable-0-label"]')
       .click();

--- a/tests/ui-testing/playwright-tests/dashboards/dashboard-variables-setting.spec.js
+++ b/tests/ui-testing/playwright-tests/dashboards/dashboard-variables-setting.spec.js
@@ -579,7 +579,7 @@ test.describe("dashboard variables setting", () => {
     await page
       .locator('[data-test="dashboard-variable-label"]')
       .fill("custom-variable");
-    await page.getByRole("button", { name: "Add Option" }).click();
+    // await page.getByRole("button", { name: "Add Option" }).click();
     await page
       .locator('[data-test="dashboard-custom-variable-0-label"]')
       .click();
@@ -642,7 +642,7 @@ test.describe("dashboard variables setting", () => {
     await page
       .locator('[data-test="dashboard-variable-label"]')
       .fill("custom-variable");
-    await page.getByRole("button", { name: "Add Option" }).click();
+    // await page.getByRole("button", { name: "Add Option" }).click();
     await page
       .locator('[data-test="dashboard-custom-variable-0-label"]')
       .click();
@@ -712,7 +712,7 @@ test.describe("dashboard variables setting", () => {
     await page
       .locator('[data-test="dashboard-variable-label"]')
       .fill("custom-variable");
-    await page.getByRole("button", { name: "Add Option" }).click();
+    // await page.getByRole("button", { name: "Add Option" }).click();
     await page
       .locator('[data-test="dashboard-custom-variable-0-label"]')
       .click();

--- a/web/src/components/dashboards/settings/AddSettingVariable.vue
+++ b/web/src/components/dashboards/settings/AddSettingVariable.vue
@@ -561,6 +561,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               data-test="dashboard-variable-hide_on_dashboard"
             />
           </div>
+
+          <!-- escape single quotes toggle -->
+          <div>
+            <div class="row items-center all-pointer-events">
+              <q-toggle
+                v-model="variableData.escapeSingleQuotes"
+                :label="t('dashboard.escapeSingleQuotes')"
+              />
+              <div>
+                <q-icon
+                  class="q-ml-xs"
+                  size="20px"
+                  name="info"
+                  data-test="dashboard-config-limit-info"
+                />
+                <q-tooltip
+                  class="bg-grey-8"
+                  anchor="top middle"
+                  self="bottom middle"
+                >
+                  If enabled, single quotes will be escaped in the query. For
+                  example, a value like `O'Reilly` will be replaced as
+                  `O''Reilly`.
+                </q-tooltip>
+              </div>
+            </div>
+          </div>
           <div class="flex justify-center q-mt-lg">
             <q-btn
               class="q-mb-md text-bold"
@@ -685,6 +712,7 @@ export default defineComponent({
       hideOnDashboard: false,
       selectAllValueForMultiSelect: "first",
       customMultiSelectValue: [],
+      escapeSingleQuotes: false,
     });
 
     const filterCycleError: any = ref("");
@@ -724,6 +752,11 @@ export default defineComponent({
     // by default, use selectAllValueForMultiSelect as 'first'
     if (!variableData.selectAllValueForMultiSelect) {
       variableData.selectAllValueForMultiSelect = "first";
+    }
+
+    // by default, use escapeSingleQuotes as false
+    if (!variableData.escapeSingleQuotes) {
+      variableData.escapeSingleQuotes = false;
     }
 
     const filterUpdated = (index: number, filter: any) => {

--- a/web/src/components/dashboards/settings/AddSettingVariable.vue
+++ b/web/src/components/dashboards/settings/AddSettingVariable.vue
@@ -404,6 +404,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <q-btn
                   flat
                   round
+                  :disable="variableData.options.length === 1"
                   @click="removeField(index)"
                   :data-test="`dashboard-custom-variable-${index}-remove`"
                   icon="cancel"
@@ -707,7 +708,13 @@ export default defineComponent({
         filter: [],
       },
       value: "",
-      options: [],
+      options: [
+        {
+          label: "",
+          value: "",
+          selected: true,
+        },
+      ],
       multiSelect: false,
       hideOnDashboard: false,
       selectAllValueForMultiSelect: "first",
@@ -907,6 +914,9 @@ export default defineComponent({
     };
 
     const removeField = (index: any) => {
+      if (variableData.options.length === 1) {
+        return;
+      }
       variableData.options.splice(index, 1);
 
       // if all values are selected, then check customSelectAllModel = true
@@ -1050,6 +1060,15 @@ export default defineComponent({
         // check if filter has cycle
         if (await isFilterHasCycle()) {
           // filter has cycle, so show error and return
+          return false;
+        }
+
+        // for custom, check at least one option is selected as default value
+        if (
+          variableData.type === "custom" &&
+          variableData.options.every((option: any) => !option.selected)
+        ) {
+          showErrorNotification("Select at least one default option");
           return false;
         }
 

--- a/web/src/components/dashboards/settings/AddSettingVariable.vue
+++ b/web/src/components/dashboards/settings/AddSettingVariable.vue
@@ -404,7 +404,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <q-btn
                   flat
                   round
-                  :disable="variableData.options.length === 1"
+                  :disable="variableData?.options?.length === 1"
                   @click="removeField(index)"
                   :data-test="`dashboard-custom-variable-${index}-remove`"
                   icon="cancel"
@@ -914,7 +914,7 @@ export default defineComponent({
     };
 
     const removeField = (index: any) => {
-      if (variableData.options.length === 1) {
+      if (variableData?.options?.length === 1) {
         return;
       }
       variableData.options.splice(index, 1);

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -1647,8 +1647,8 @@ export const usePanelDataLoader = (
             variable.value === null
               ? ""
               : variable.escapeSingleQuotes
-                ? `'${escapeSingleQuotes(variable.value)}'`
-                : `'${variable.value}'`;
+                ? `${escapeSingleQuotes(variable.value)}`
+                : `${variable.value}`;
           if (query.includes(variableName)) {
             metadata.push({
               type: "variable",

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -41,6 +41,7 @@ import {
   generateTraceContext,
   isWebSocketEnabled,
   isStreamingEnabled,
+  escapeSingleQuotes,
 } from "@/utils/zincutils";
 import { usePanelCache } from "./usePanelCache";
 import { isEqual, omit } from "lodash-es";
@@ -1592,7 +1593,13 @@ export const usePanelDataLoader = (
         let variableValue = "";
         if (Array.isArray(variable.value)) {
           const value =
-            variable.value.map((value: any) => `'${value}'`).join(",") || "''";
+            variable.value
+              .map((value: any) =>
+                variable.escapeSingleQuotes
+                  ? `'${escapeSingleQuotes(value)}'`
+                  : `'${value}'`,
+              )
+              .join(",") || "''";
           const possibleVariablesPlaceHolderTypes = [
             {
               placeHolder: `\${${variable.name}:csv}`,
@@ -1636,7 +1643,12 @@ export const usePanelDataLoader = (
             );
           });
         } else {
-          variableValue = variable.value === null ? "" : variable.value;
+          variableValue =
+            variable.value === null
+              ? ""
+              : variable.escapeSingleQuotes
+                ? `'${escapeSingleQuotes(variable.value)}'`
+                : `'${variable.value}'`;
           if (query.includes(variableName)) {
             metadata.push({
               type: "variable",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -689,6 +689,7 @@
     "DefaultSize": "Default max record size (optional)",
     "multiSelect": "Allow multiple selection",
     "hideOnDashboard": "Hide On Dashboard",
+    "escapeSingleQuotes": "Escape Single Quotes",
     "maxRecordSize": "Default max record size is 10. You can update this value as required",
     "newFolderBtnLabel": "New Folder",
     "folderLabel": "Folders",


### PR DESCRIPTION
### **User description**
- Config to enable escape quotes. 
![image](https://github.com/user-attachments/assets/ad8fb954-a50a-447c-9ee2-f0938c3dcd16)

- Needs to enable it if variable value contains single quote.
For example variable value is `EFhoAf&fugy=P'fG;LR;Hr=jTe3fr).p%"`
then will require to escape single quote from value.
![image](https://github.com/user-attachments/assets/a05d983e-940a-4e3c-83c2-f7fd5206c4af)

- For custom typed variables, added some validations:
1. At least one option must there.
2. At lease one option should be selected as default value.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add `escapeSingleQuotes` flag to variable config

- Provide UI toggle with explanatory tooltip

- Update query loader to escape quotes conditionally

- Prevent removing last option and enforce default selection


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add escape_single_quotes field to config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/dashboards/v5/mod.rs

<li>Introduce <code>escape_single_quotes</code> boolean field<br> <li> Mark field as optional in <code>VariableList</code> struct


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7134/files#diff-da49585bbcb02bf0f737bb68739ebc248edd15c7ad9427c0e68f7728bb4a8c17">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AddSettingVariable.vue</strong><dd><code>Enhance variable settings UI for quote escaping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/settings/AddSettingVariable.vue

<li>Add <code>escapeSingleQuotes</code> toggle with tooltip<br> <li> Initialize default <code>escapeSingleQuotes</code> value to false<br> <li> Disable remove button when only one option remains<br> <li> Validate at least one default selection for custom variables


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7134/files#diff-e622f54c1f7629ee67d29ed2fc87008d07eb9246767a05435cc42c3c17ce459a">+53/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>usePanelDataLoader.ts</strong><dd><code>Implement conditional quote escaping in loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/dashboard/usePanelDataLoader.ts

<li>Import <code>escapeSingleQuotes</code> utility<br> <li> Conditionally escape single quotes in variable values<br> <li> Apply escaping for both array and scalar values


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7134/files#diff-5a42e9493a7bcd722b88e61fd38883c4f61001bc9cafa399f65f8eafda3aace9">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add translation for escapeSingleQuotes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/locales/languages/en.json

- Add `"escapeSingleQuotes": "Escape Single Quotes"` entry


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7134/files#diff-892aa3d75ab6e129ef9116aa21bec1b9a15ba69ce5366d2a19128078c690d824">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>