### PR TITLE
fix: Modified pagination logic to continue partitions when hits exceed rowsPerPage limit

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2520,8 +2520,8 @@ const useLogs = () => {
           if(queryReq.query?.streaming_output) {
             searchObj.data.queryResults.total = searchObj.data.queryResults.hits.length;
             searchObj.data.queryResults.from = res.data.from;
-            searchObj.data.queryResults.scan_size += res.data.scan_size;
-            searchObj.data.queryResults.took += res.data.took;
+            searchObj.data.queryResults.scan_size = (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
+            searchObj.data.queryResults.took = (searchObj.data.queryResults.took || 0) + res.data.took;
             searchObj.data.queryResults.hits = res.data.hits;
 
             if (

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2394,7 +2394,7 @@ const useLogs = () => {
       //   searchObj.meta.resultGrid.rowsPerPage = queryReq.query.size;
       // }
       const parsedSQL: any = fnParsedSQL();
-      searchObj.meta.resultGrid.showPagination = true;
+
       if (searchObj.meta.sqlMode == true && parsedSQL != undefined) {
         // if query has aggregation or groupby then we need to set size to -1 to get all records
         // issue #5432
@@ -2494,13 +2494,18 @@ const useLogs = () => {
 
           searchAggData.total = 0;
           searchAggData.hasAggregation = false;
+          searchObj.meta.resultGrid.showPagination = true;
+
           if (searchObj.meta.sqlMode == true && parsedSQL != undefined) {
             if (
               hasAggregation(parsedSQL?.columns) ||
               parsedSQL.groupby != null
             ) {
-              searchAggData.total = res.data.total;
-              searchAggData.hasAggregation = true;
+              if(queryReq.query?.streaming_output) {
+                searchAggData.total = res.data.total;
+                searchAggData.hasAggregation = true;
+              }
+
               searchObj.meta.resultGrid.showPagination = false;
             }
           }
@@ -2566,8 +2571,6 @@ const useLogs = () => {
                 searchObj.data.queryResults.took = res.data.took;
                 searchObj.data.queryResults.hits = res.data.hits;
               }
-              
-              
             }
           } else {
             resetFieldValues();

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2448,12 +2448,12 @@ const useLogs = () => {
 
       const isAggregation = searchObj.meta.sqlMode && parsedSQL != undefined && (hasAggregation(parsedSQL?.columns) || parsedSQL.groupby != null);
 
-      console.log("searchObj.data.queryResults.histogram_interval", searchObj.data.queryResults.histogram_interval);
       if(isAggregation && !queryReq.query?.streaming_output && searchObj.data.queryResults.histogram_interval) {
         const interval = searchObj.data.queryResults.histogram_interval ? searchObj.data.queryResults.histogram_interval + ' seconds' : null;
         let query = await changeHistogramInterval(queryReq.query.sql, interval);
-        console.log("query", query);
-        queryReq.query.sql = query;
+        if(query) {
+          queryReq.query.sql = query;
+        }
       }
 
       const { traceparent, traceId } = generateTraceContext();

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -79,6 +79,7 @@ import config from "@/aws-exports";
 import useSearchWebSocket from "./useSearchWebSocket";
 import useActions from "./useActions";
 import useStreamingSearch from "./useStreamingSearch";
+import { changeHistogramInterval } from "@/utils/query/sqlUtils";
 
 const defaultObject = {
   organizationIdentifier: "",
@@ -1252,6 +1253,8 @@ const useLogs = () => {
                 paginations: [],
               };
 
+              searchObj.data.queryResults.histogram_interval = res.data?.histogram_interval;
+
               if (typeof partitionQueryReq.sql != "string") {
                 const partitionSize = 0;
                 let partitions = [];
@@ -2365,11 +2368,36 @@ const useLogs = () => {
     searchObj.data.histogram.chartParams.title = getHistogramTitle();
   };
 
+
+  const fetchAllParitions = async(queryReq: any) => {
+    if (
+      searchObj.data.queryResults.partitionDetail.partitions[
+        searchObj.data.queryResults.subpage
+      ]?.length
+    ) {
+      queryReq.query.start_time =
+        searchObj.data.queryResults.partitionDetail.partitions[
+          searchObj.data.queryResults.subpage
+        ][0];
+      queryReq.query.end_time =
+        searchObj.data.queryResults.partitionDetail.partitions[
+          searchObj.data.queryResults.subpage
+        ][1];
+      queryReq.query.from = 0;
+      queryReq.query.size = -1;
+      searchObj.data.queryResults.subpage++;
+      setTimeout(async () => {
+        processPostPaginationData();
+      }, 0);
+      await getPaginatedData(queryReq, true);
+    }
+  }
+
   const getPaginatedData = async (
     queryReq: any,
     appendResult: boolean = false,
   ) => {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       // // set track_total_hits true for first request of partition to get total records in partition
       // // it will be used to send pagination request
       // if (queryReq.query.from == 0) {
@@ -2416,6 +2444,16 @@ const useLogs = () => {
         if (isDistinctQuery(parsedSQL) || isWithQuery(parsedSQL)) {
           delete queryReq.query.track_total_hits;
         }
+      }
+
+      const isAggregation = searchObj.meta.sqlMode && parsedSQL != undefined && (hasAggregation(parsedSQL?.columns) || parsedSQL.groupby != null);
+
+      console.log("searchObj.data.queryResults.histogram_interval", searchObj.data.queryResults.histogram_interval);
+      if(isAggregation && !queryReq.query?.streaming_output && searchObj.data.queryResults.histogram_interval) {
+        const interval = searchObj.data.queryResults.histogram_interval ? searchObj.data.queryResults.histogram_interval + ' seconds' : null;
+        let query = await changeHistogramInterval(queryReq.query.sql, interval);
+        console.log("query", query);
+        queryReq.query.sql = query;
       }
 
       const { traceparent, traceId } = generateTraceContext();
@@ -2496,18 +2534,13 @@ const useLogs = () => {
           searchAggData.hasAggregation = false;
           searchObj.meta.resultGrid.showPagination = true;
 
-          if (searchObj.meta.sqlMode == true && parsedSQL != undefined) {
-            if (
-              hasAggregation(parsedSQL?.columns) ||
-              parsedSQL.groupby != null
-            ) {
-              if(queryReq.query?.streaming_output) {
-                searchAggData.total = res.data.total;
-                searchAggData.hasAggregation = true;
-              }
 
-              searchObj.meta.resultGrid.showPagination = false;
+          if (isAggregation) {
+            if(queryReq.query?.streaming_output) {
+              searchAggData.total = res.data.total;
+              searchAggData.hasAggregation = true;
             }
+            searchObj.meta.resultGrid.showPagination = false;
           }
 
           let regeratePaginationFlag = false;
@@ -2516,42 +2549,33 @@ const useLogs = () => {
           }
           // if total records in partition is greater than recordsPerPage then we need to update pagination
           // setting up forceFlag to true to update pagination as we have check for pagination already created more than currentPage + 3 pages.
-          if (searchObj.meta.jobId == "" && !queryReq.query?.streaming_output) {
+          if (searchObj.meta.jobId == "" && !(queryReq.query?.streaming_output || isAggregation)) {
             refreshPartitionPagination(regeratePaginationFlag);
           }
           // Scan-size and took time in histogram title
           // For the initial request, we get histogram and logs data. So, we need to sum the scan_size and took time of both the requests.
           // For the pagination request, we only get logs data. So, we need to consider scan_size and took time of only logs request.
+
+          // Aggregation
+
+          // Streaming Outout
+
+          // Normal 
+
           if(queryReq.query?.streaming_output) {
             searchObj.data.queryResults.total = searchObj.data.queryResults.hits.length;
             searchObj.data.queryResults.from = res.data.from;
             searchObj.data.queryResults.scan_size = (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
             searchObj.data.queryResults.took = (searchObj.data.queryResults.took || 0) + res.data.took;
             searchObj.data.queryResults.hits = res.data.hits;
-
-            if (
-              searchObj.data.queryResults.partitionDetail.partitions[
-                searchObj.data.queryResults.subpage
-              ]?.length
-            ) {
-              queryReq.query.start_time =
-                searchObj.data.queryResults.partitionDetail.partitions[
-                  searchObj.data.queryResults.subpage
-                ][0];
-              queryReq.query.end_time =
-                searchObj.data.queryResults.partitionDetail.partitions[
-                  searchObj.data.queryResults.subpage
-                ][1];
-              queryReq.query.from = 0;
-              queryReq.query.size = -1;
-  
-              searchObj.data.queryResults.subpage++;
-  
-              setTimeout(async () => {
-                processPostPaginationData();
-              }, 0);
-              await getPaginatedData(queryReq, true);
-            }
+            fetchAllParitions(queryReq);
+          } else if(isAggregation) {
+            searchObj.data.queryResults.from = res.data.from;
+            searchObj.data.queryResults.total = (searchObj.data.queryResults.total || 0) + res.data.total;
+            searchObj.data.queryResults.scan_size = (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
+            searchObj.data.queryResults.took = (searchObj.data.queryResults.took || 0) + res.data.took;
+            searchObj.data.queryResults.hits.push(...res.data.hits);
+            fetchAllParitions(queryReq);
           } else if (res.data.from > 0 || searchObj.data.queryResults.subpage > 1) {
             if (appendResult && !queryReq.query?.streaming_output) {
               searchObj.data.queryResults.from += res.data.from;
@@ -2559,6 +2583,7 @@ const useLogs = () => {
               searchObj.data.queryResults.took += res.data.took;
               searchObj.data.queryResults.hits.push(...res.data.hits);
             } else {
+              // Replace result
               if(queryReq.query?.streaming_output) {
                 searchObj.data.queryResults.total = searchObj.data.queryResults.hits.length;
                 searchObj.data.queryResults.from = res.data.from;
@@ -2566,6 +2591,7 @@ const useLogs = () => {
                 searchObj.data.queryResults.took += res.data.took;
                 searchObj.data.queryResults.hits = res.data.hits;
               } else {
+                // Replace result
                 searchObj.data.queryResults.from = res.data.from;
                 searchObj.data.queryResults.scan_size = res.data.scan_size;
                 searchObj.data.queryResults.took = res.data.took;
@@ -2607,6 +2633,7 @@ const useLogs = () => {
           // check for pagination request for the partition and check for subpage if we have to pull data from multiple partitions
           // it will check for subpage and if subpage is present then it will send pagination request for next partition
           if (
+            !(isAggregation  && queryReq.query?.streaming_output) &&
             searchObj.meta.jobId == "" &&
             searchObj.data.queryResults.partitionDetail.paginations[
               searchObj.data.resultGrid.currentPage - 1
@@ -3010,6 +3037,10 @@ const useLogs = () => {
         for (const key of Object.keys(item)) {
           if (excludedFields.includes(key)) {
             return;
+          }
+
+          if(fieldValues.value === undefined) {
+            fieldValues.value = {}
           }
 
           if (fieldValues.value[key] == undefined) {
@@ -5353,13 +5384,13 @@ const useLogs = () => {
     // Scan-size and took time in histogram title
     // For the initial request, we get histogram and logs data. So, we need to sum the scan_size and took time of both the requests.
     // For the pagination request, we only get logs data. So, we need to consider scan_size and took time of only logs request.
-    if (appendResult) {
+    if(isPagination || !appendResult){
+      searchObj.data.queryResults.hits = response.content.results.hits;
+    } else if (appendResult) {
       searchObj.data.queryResults.hits.push(
         ...response.content.results.hits,
       );
-    } else {
-      searchObj.data.queryResults.hits = response.content.results.hits;
-    }
+    } 
     
     if (searchObj.meta.refreshInterval === 0) {
       updatePageCountTotal(payload.queryReq, response.content.results.hits.length, searchObj.data.queryResults.hits.length);


### PR DESCRIPTION
#7161 
Modified pagination logic to continue partitions when hits exceed rowsPerPage limit
Changed pagination logic for streaming-output partitions