### PR TITLE
fix: add memory circuit breaker for ingester

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -902,7 +902,7 @@ pub struct Common {
     pub default_scrape_interval: u32,
     #[env_config(name = "ZO_CIRCUIT_BREAKER_ENABLE", default = false)]
     pub memory_circuit_breaker_enable: bool,
-    #[env_config(name = "ZO_CIRCUIT_BREAKER_RATIO", default = 100)]
+    #[env_config(name = "ZO_CIRCUIT_BREAKER_RATIO", default = 90)]
     pub memory_circuit_breaker_ratio: usize,
     #[env_config(
         name = "ZO_RESTRICTED_ROUTES_ON_EMPTY_DATA",

--- a/src/infra/src/errors/mod.rs
+++ b/src/infra/src/errors/mod.rs
@@ -81,6 +81,8 @@ pub enum Error {
     #[error("Error# {0}")]
     Reqwest(#[from] reqwest::Error),
     #[error("Error# {0}")]
+    IngestionError(String),
+    #[error("Error# {0}")]
     WalFileError(String),
     #[error("Error# {0}")]
     OtherError(#[from] anyhow::Error),

--- a/src/ingester/src/errors.rs
+++ b/src/ingester/src/errors.rs
@@ -114,6 +114,7 @@ pub enum Error {
         )>,
     },
     MemoryTableOverflowError {},
+    MemoryCircuitBreakerError {},
     ExternalError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },

--- a/src/ingester/src/lib.rs
+++ b/src/ingester/src/lib.rs
@@ -32,7 +32,10 @@ pub use immutable::read_from_immutable;
 use once_cell::sync::Lazy;
 use snafu::ResultExt;
 use tokio::sync::{Mutex, mpsc};
-pub use writer::{Writer, check_memtable_size, flush_all, get_writer, read_from_memtable};
+pub use writer::{
+    Writer, check_memory_circuit_breaker, check_memtable_size, flush_all, get_writer,
+    read_from_memtable,
+};
 
 use crate::errors::OpenDirSnafu;
 

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -64,11 +64,25 @@ pub struct Writer {
 
 // check total memory size
 pub fn check_memtable_size() -> Result<()> {
-    let total_mem_size = metrics::INGEST_MEMTABLE_ARROW_BYTES
+    let cur_mem = metrics::INGEST_MEMTABLE_ARROW_BYTES
         .with_label_values(&[])
         .get();
-    if total_mem_size >= get_config().limit.mem_table_max_size as i64 {
+    if cur_mem >= get_config().limit.mem_table_max_size as i64 {
         Err(Error::MemoryTableOverflowError {})
+    } else {
+        Ok(())
+    }
+}
+
+// check total memory size
+pub fn check_memory_circuit_breaker() -> Result<()> {
+    let cfg = get_config();
+    if !cfg.common.memory_circuit_breaker_enable || cfg.common.memory_circuit_breaker_ratio == 0 {
+        return Ok(());
+    }
+    let cur_mem = metrics::NODE_MEMORY_USAGE.with_label_values(&[]).get() as usize;
+    if cur_mem > cfg.limit.mem_total / 100 * cfg.common.memory_circuit_breaker_ratio {
+        Err(Error::MemoryCircuitBreakerError {})
     } else {
         Ok(())
     }

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -62,7 +62,7 @@ pub struct Writer {
     write_queue: Arc<mpsc::Sender<(WriterSignal, Vec<Entry>, bool)>>,
 }
 
-// check total memory size
+// check total memtable size
 pub fn check_memtable_size() -> Result<()> {
     let cur_mem = metrics::INGEST_MEMTABLE_ARROW_BYTES
         .with_label_values(&[])

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -62,7 +62,7 @@ pub async fn ingest(
     let started_at = Utc::now().timestamp_micros();
 
     // check system resource
-    check_ingestion_allowed(org_id, None)?;
+    check_ingestion_allowed(org_id, StreamType::Logs, None)?;
 
     // let mut errors = false;
     let mut bulk_res = BulkResponse {

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -79,7 +79,7 @@ pub async fn ingest(
     } else {
         format_stream_name(in_stream_name)
     };
-    check_ingestion_allowed(org_id, Some(&stream_name))?;
+    check_ingestion_allowed(org_id, StreamType::Logs, Some(&stream_name))?;
 
     let min_ts = (Utc::now() - Duration::try_hours(cfg.limit.ingest_allowed_upto).unwrap())
         .timestamp_micros();

--- a/src/service/logs/otlp_grpc.rs
+++ b/src/service/logs/otlp_grpc.rs
@@ -68,7 +68,7 @@ pub async fn handle_grpc_request(
         Some(name) => format_stream_name(name),
         None => "default".to_owned(),
     };
-    check_ingestion_allowed(org_id, Some(&stream_name))?;
+    check_ingestion_allowed(org_id, StreamType::Logs, Some(&stream_name))?;
 
     let cfg = get_config();
     let min_ts = (Utc::now() - Duration::try_hours(cfg.limit.ingest_allowed_upto).unwrap())

--- a/src/service/logs/otlp_http.rs
+++ b/src/service/logs/otlp_http.rs
@@ -105,7 +105,7 @@ pub async fn logs_json_handler(
         Some(name) => format_stream_name(name),
         None => "default".to_owned(),
     };
-    check_ingestion_allowed(org_id, Some(&stream_name))?;
+    check_ingestion_allowed(org_id, StreamType::Logs, Some(&stream_name))?;
 
     let min_ts = (Utc::now() - Duration::try_hours(cfg.limit.ingest_allowed_upto).unwrap())
         .timestamp_micros();

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -84,6 +84,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
     // check stream
     let stream_name = format_stream_name(in_stream_name);
     if let Err(e) = check_ingestion_allowed(org_id, StreamType::Logs, Some(&stream_name)) {
+        log::error!("Syslogs ingestion error: {:?}", e);
         return Ok(map_error_to_http_response(&e.into(), None));
     };
 

--- a/src/service/logs/syslog.rs
+++ b/src/service/logs/syslog.rs
@@ -83,7 +83,7 @@ pub async fn ingest(msg: &str, addr: SocketAddr) -> Result<HttpResponse> {
 
     // check stream
     let stream_name = format_stream_name(in_stream_name);
-    if let Err(e) = check_ingestion_allowed(org_id, Some(&stream_name)) {
+    if let Err(e) = check_ingestion_allowed(org_id, StreamType::Logs, Some(&stream_name)) {
         return Ok(map_error_to_http_response(&e.into(), None));
     };
 

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -19,7 +19,6 @@ use actix_web::{http, web};
 use anyhow::{Result, anyhow};
 use config::{
     TIMESTAMP_COL_NAME,
-    cluster::LOCAL_NODE,
     meta::{
         alerts::alert::Alert,
         promql::{HASH_LABEL, METADATA_LABEL, Metadata, NAME_LABEL, TYPE_LABEL, VALUE_LABEL},
@@ -47,7 +46,10 @@ use crate::{
     service::{
         alerts::alert::AlertExt,
         db, format_stream_name,
-        ingestion::{TriggerAlertData, evaluate_trigger, get_write_partition_key, write_file},
+        ingestion::{
+            TriggerAlertData, check_ingestion_allowed, evaluate_trigger, get_write_partition_key,
+            write_file,
+        },
         pipeline::batch_execution::ExecutablePipeline,
         schema::check_for_schema,
         self_reporting::report_request_usage_stats,
@@ -55,30 +57,17 @@ use crate::{
 };
 
 pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse> {
-    let start = std::time::Instant::now();
-    let started_at = now_micros();
-
-    if !LOCAL_NODE.is_ingester() {
-        return Err(anyhow::anyhow!("not an ingester"));
-    }
-
-    if !db::file_list::BLOCKED_ORGS.is_empty()
-        && db::file_list::BLOCKED_ORGS.contains(&org_id.to_string())
-    {
-        return Err(anyhow::anyhow!(
-            "Quota exceeded for this organization [{}]",
-            org_id
-        ));
-    }
-
-    // check memtable
-    if let Err(e) = ingester::check_memtable_size() {
+    // check system resource
+    if let Err(e) = check_ingestion_allowed(org_id, StreamType::Metrics, None) {
         return Ok(IngestionResponse {
             code: http::StatusCode::SERVICE_UNAVAILABLE.into(),
             status: vec![],
             error: Some(e.to_string()),
         });
     }
+
+    let start = std::time::Instant::now();
+    let started_at = now_micros();
 
     let mut stream_schema_map: HashMap<String, SchemaCache> = HashMap::new();
     let mut stream_status_map: HashMap<String, StreamStatus> = HashMap::new();

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -59,6 +59,7 @@ use crate::{
 pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse> {
     // check system resource
     if let Err(e) = check_ingestion_allowed(org_id, StreamType::Metrics, None) {
+        log::error!("Metrics ingestion error: {:?}", e);
         return Ok(IngestionResponse {
             code: http::StatusCode::SERVICE_UNAVAILABLE.into(),
             status: vec![],

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -120,6 +120,7 @@ pub async fn handle_otlp_request(
 ) -> Result<HttpResponse, anyhow::Error> {
     // check system resource
     if let Err(e) = check_ingestion_allowed(org_id, StreamType::Metrics, None) {
+        log::error!("Metrics ingestion error: {:?}", e);
         return Ok(
             HttpResponse::ServiceUnavailable().json(MetaHttpResponse::error(
                 http::StatusCode::SERVICE_UNAVAILABLE.into(),

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -24,7 +24,6 @@ use bytes::BytesMut;
 use chrono::Utc;
 use config::{
     TIMESTAMP_COL_NAME,
-    cluster::LOCAL_NODE,
     meta::{
         alerts::alert,
         otlp::OtlpRequestType,
@@ -48,12 +47,11 @@ use prost::Message;
 
 use crate::{
     common::meta::{http::HttpResponse as MetaHttpResponse, stream::SchemaRecords},
-    handler::http::router::ERROR_HEADER,
     service::{
         alerts::alert::AlertExt,
         db, format_stream_name,
         ingestion::{
-            TriggerAlertData, evaluate_trigger,
+            TriggerAlertData, check_ingestion_allowed, evaluate_trigger,
             grpc::{get_exemplar_val, get_metric_val, get_val},
             write_file,
         },
@@ -120,26 +118,8 @@ pub async fn handle_otlp_request(
     request: ExportMetricsServiceRequest,
     req_type: OtlpRequestType,
 ) -> Result<HttpResponse, anyhow::Error> {
-    if !LOCAL_NODE.is_ingester() {
-        return Ok(HttpResponse::InternalServerError()
-            .append_header((ERROR_HEADER, "not an ingester".to_string()))
-            .json(MetaHttpResponse::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                "not an ingester".to_string(),
-            )));
-    }
-
-    if !db::file_list::BLOCKED_ORGS.is_empty()
-        && db::file_list::BLOCKED_ORGS.contains(&org_id.to_string())
-    {
-        return Ok(HttpResponse::Forbidden().json(MetaHttpResponse::error(
-            http::StatusCode::FORBIDDEN.into(),
-            format!("Quota exceeded for this organization [{}]", org_id),
-        )));
-    }
-
-    // check memtable
-    if let Err(e) = ingester::check_memtable_size() {
+    // check system resource
+    if let Err(e) = check_ingestion_allowed(org_id, StreamType::Metrics, None) {
         return Ok(
             HttpResponse::ServiceUnavailable().json(MetaHttpResponse::error(
                 http::StatusCode::SERVICE_UNAVAILABLE.into(),

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -53,7 +53,7 @@ use crate::{
     service::{
         alerts::alert::AlertExt,
         db, format_stream_name,
-        ingestion::{TriggerAlertData, evaluate_trigger, write_file},
+        ingestion::{TriggerAlertData, check_ingestion_allowed, evaluate_trigger, write_file},
         metrics::format_label_name,
         pipeline::batch_execution::ExecutablePipeline,
         schema::{check_for_schema, stream_schema_exists},
@@ -66,25 +66,11 @@ pub async fn remote_write(
     org_id: &str,
     body: web::Bytes,
 ) -> std::result::Result<(), anyhow::Error> {
+    // check system resource
+    check_ingestion_allowed(org_id, StreamType::Metrics, None)?;
+
     let start = std::time::Instant::now();
     let started_at = Utc::now().timestamp_micros();
-    if !LOCAL_NODE.is_ingester() {
-        return Err(anyhow::anyhow!("not an ingester"));
-    }
-
-    if !db::file_list::BLOCKED_ORGS.is_empty()
-        && db::file_list::BLOCKED_ORGS.contains(&org_id.to_string())
-    {
-        return Err(anyhow::anyhow!(
-            "Quota exceeded for this organization [{}]",
-            org_id
-        ));
-    }
-
-    // check memtable
-    if let Err(e) = ingester::check_memtable_size() {
-        return Err(anyhow::Error::msg(e.to_string()));
-    }
 
     let cfg = get_config();
     let dedup_enabled = cfg.common.metrics_dedup_enabled;

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -41,6 +41,10 @@ pub struct QueryParams {
 
 fn check_memory_circuit_breaker(trace_id: &str, scan_stats: &ScanStats) -> Result<()> {
     let cfg = get_config();
+    if !cfg.common.memory_circuit_breaker_enable || cfg.common.memory_circuit_breaker_ratio == 0 {
+        return Ok(());
+    }
+
     let scan_size = if scan_stats.compressed_size > 0 {
         scan_stats.compressed_size
     } else {
@@ -64,7 +68,7 @@ fn check_memory_circuit_breaker(trace_id: &str, scan_stats: &ScanStats) -> Resul
                     / 100
             );
             log::warn!("[circuit_breaker {trace_id}] {}", err);
-            return Err(Error::Message(err.to_string()));
+            return Err(Error::IngestionError(err.to_string()));
         }
     }
     Ok(())

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -247,9 +247,8 @@ pub async fn search(
         scan_stats.compressed_size
     );
 
-    if cfg.common.memory_circuit_breaker_enable {
-        super::check_memory_circuit_breaker(&query.trace_id, &scan_stats)?;
-    }
+    // check memory circuit breaker
+    super::check_memory_circuit_breaker(&query.trace_id, &scan_stats)?;
 
     // load files to local cache
     let cache_start = std::time::Instant::now();

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -252,12 +252,11 @@ pub async fn search_parquet(
         )
     );
 
-    if cfg.common.memory_circuit_breaker_enable {
-        if let Err(e) = super::check_memory_circuit_breaker(&query.trace_id, &scan_stats) {
-            // release all files
-            wal::release_files(&lock_files);
-            return Err(e);
-        }
+    // check memory circuit breaker
+    if let Err(e) = super::check_memory_circuit_breaker(&query.trace_id, &scan_stats) {
+        // release all files
+        wal::release_files(&lock_files);
+        return Err(e);
     }
 
     // construct latest schema map

--- a/src/service/search/search_stream.rs
+++ b/src/service/search/search_stream.rs
@@ -120,10 +120,12 @@ pub async fn process_search_stream_request(
 
     let max_query_range = get_max_query_range(&stream_names, &org_id, &user_id, stream_type).await; // hours
 
-    // HACK: always search from the first partition, this is becuase to support pagination in http2 streaming
-    // we need context of no of hits per partition, which currently is not available. Hence we start from the first partition
-    // everytime and skip the hits. The following is a global variable to keep track of how many hits to skip across all partitions.
-    // This is a temporary hack and will be removed once we have the context of no of hits per partition.
+    // HACK: always search from the first partition, this is becuase to support pagination in http2
+    // streaming we need context of no of hits per partition, which currently is not available.
+    // Hence we start from the first partition everytime and skip the hits. The following is a
+    // global variable to keep track of how many hits to skip across all partitions.
+    // This is a temporary hack and will be removed once we have the context of no of hits per
+    // partition.
     let mut hits_to_skip = req.query.from;
 
     if req.query.from == 0 && !req.query.track_total_hits {
@@ -586,8 +588,9 @@ pub async fn do_partitioned_search(
             req.query.size -= curr_res_size;
         }
 
-        // here we increase the size of the query to fetch requested hits in addition to the hits_to_skip
-        // we set the from to 0 to fetch the hits from the the beginning of the partition
+        // here we increase the size of the query to fetch requested hits in addition to the
+        // hits_to_skip we set the from to 0 to fetch the hits from the the beginning of the
+        // partition
         req.query.size += *hits_to_skip;
         req.query.from = 0;
         let mut search_res = do_search(trace_id, org_id, stream_type, &req, user_id, false).await?;

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -172,6 +172,20 @@ pub async fn handle_otlp_request(
         )));
     }
 
+    // check memory circuit breaker
+    if let Err(e) = ingester::check_memory_circuit_breaker() {
+        log::error!(
+            "[TRACES:OTLP] ingestion error while checking memory circuit breaker: {}",
+            e
+        );
+        return Ok(
+            HttpResponse::ServiceUnavailable().json(MetaHttpResponse::error(
+                http::StatusCode::SERVICE_UNAVAILABLE.into(),
+                e.to_string(),
+            )),
+        );
+    }
+
     // check memtable
     if let Err(e) = ingester::check_memtable_size() {
         log::error!(
@@ -597,6 +611,20 @@ pub async fn ingest_json(
             http::StatusCode::FORBIDDEN.into(),
             format!("Quota exceeded for this organization [{}]", org_id),
         )));
+    }
+
+    // check memory circuit breaker
+    if let Err(e) = ingester::check_memory_circuit_breaker() {
+        log::error!(
+            "ingestion error while checking memory circuit breaker: {}",
+            e
+        );
+        return Ok(
+            HttpResponse::ServiceUnavailable().json(MetaHttpResponse::error(
+                http::StatusCode::SERVICE_UNAVAILABLE.into(),
+                e.to_string(),
+            )),
+        );
     }
 
     // check memtable


### PR DESCRIPTION

This PR add circuit breaker for ingester to protect OOM.  To enable this feature we need to config:

```
ZO_CIRCUIT_BREAKER_ENABLE=true
ZO_CIRCUIT_BREAKER_RATIO=90
```

If the system memory usage over `90%` , we will return `503` with error `MemoryCircuitBreakerError`.

Default is `false`, disabled.