### PR TITLE
fix: histogram interval update subquery for HTTP2 (#7170)

### DIFF
--- a/src/service/search/search_stream.rs
+++ b/src/service/search/search_stream.rs
@@ -120,10 +120,12 @@ pub async fn process_search_stream_request(
 
     let max_query_range = get_max_query_range(&stream_names, &org_id, &user_id, stream_type).await; // hours
 
-    // HACK: always search from the first partition, this is becuase to support pagination in http2 streaming
-    // we need context of no of hits per partition, which currently is not available. Hence we start from the first partition
-    // everytime and skip the hits. The following is a global variable to keep track of how many hits to skip across all partitions.
-    // This is a temporary hack and will be removed once we have the context of no of hits per partition.
+    // HACK: always search from the first partition, this is becuase to support pagination in http2
+    // streaming we need context of no of hits per partition, which currently is not available.
+    // Hence we start from the first partition everytime and skip the hits. The following is a
+    // global variable to keep track of how many hits to skip across all partitions.
+    // This is a temporary hack and will be removed once we have the context of no of hits per
+    // partition.
     let mut hits_to_skip = req.query.from;
 
     if req.query.from == 0 && !req.query.track_total_hits {
@@ -586,8 +588,9 @@ pub async fn do_partitioned_search(
             req.query.size -= curr_res_size;
         }
 
-        // here we increase the size of the query to fetch requested hits in addition to the hits_to_skip
-        // we set the from to 0 to fetch the hits from the the beginning of the partition
+        // here we increase the size of the query to fetch requested hits in addition to the
+        // hits_to_skip we set the from to 0 to fetch the hits from the the beginning of the
+        // partition
         req.query.size += *hits_to_skip;
         req.query.from = 0;
         let mut search_res = do_search(trace_id, org_id, stream_type, &req, user_id, false).await?;


### PR DESCRIPTION
### **User description**
fixes #7169 for HTTP2 streaming

cherry-picked from: https://github.com/openobserve/openobserve/pull/7170


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace manual AST walk with VisitorMut for histogram

- Inject missing interval arg into `histogram` calls

- Remove deprecated `visit_statements_mut` logic

- Reflow comments in search_stream.rs


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>websocket.rs</strong><dd><code>Use VisitorMut for histogram interval update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/common/utils/websocket.rs

<li>Introduce <code>HistogramIntervalVisitorMut</code> struct<br> <li> Implement <code>VisitorMut</code> to append missing interval args<br> <li> Update <code>update_histogram_interval_in_query</code> to use visitor<br> <li> Remove old <code>visit_statements_mut</code> & helper function


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7174/files#diff-6ff41099eded8eca4a0e579142d7af4429efb83350917780e0d3ae7dac13847a">+39/-44</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>search_stream.rs</strong><dd><code>Reflow comments in partitioned search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/search_stream.rs

<li>Reflow and wrap multi-line comments<br> <li> Adjust comment formatting around skip logic


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7174/files#diff-b952a89375f2745a0daa273f1bdefc80c22997759a9b17a8fccbc70ae294e8e4">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>