### PR TITLE
fix: check 2nd arg for approx percentile fn on visualization page

### DIFF
--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -296,6 +296,28 @@ export function extractFields(parsedAst: any, timeField: string) {
         column?.expr?.args?.value[0]?.column?.expr?.value ?? timeField;
       field.aggregationFunction =
         column?.expr?.name?.name[0]?.value?.toLowerCase() ?? "histogram";
+
+      if (field.aggregationFunction === "approx_percentile_cont") {
+        // check 2nd argument of function
+        if (
+          column?.expr?.args?.value[1]?.value === "0.5" ||
+          column?.expr?.args?.value[1]?.value === "0.50"
+        ) {
+          field.aggregationFunction = "p50";
+        } else if (
+          column?.expr?.args?.value[1]?.value === "0.9" ||
+          column?.expr?.args?.value[1]?.value === "0.90"
+        ) {
+          field.aggregationFunction = "p90";
+        } else if (column?.expr?.args?.value[1]?.value === "0.95") {
+          field.aggregationFunction = "p95";
+        } else if (column?.expr?.args?.value[1]?.value === "0.99") {
+          field.aggregationFunction = "p99";
+        } else {
+          // default to p50
+          field.aggregationFunction = "p50";
+        }
+      }
     }
 
     field.alias = column?.as ?? field?.column ?? timeField;

--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -314,8 +314,7 @@ export function extractFields(parsedAst: any, timeField: string) {
         } else if (column?.expr?.args?.value[1]?.value === "0.99") {
           field.aggregationFunction = "p99";
         } else {
-          // default to p50
-          field.aggregationFunction = "p50";
+          throw new Error("Unsupported percentile value");
         }
       }
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Check `approx_percentile_cont` second argument

- Map 0.5/0.50 to `p50` percentile

- Support `p90`, `p95`, and `p99` mappings

- Default fallback to `p50` percentile


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sqlUtils.ts</strong><dd><code>Implement percentile mapping for approx_percentile_cont</code>&nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/query/sqlUtils.ts

<li>Added check for <code>approx_percentile_cont</code> argument<br> <li> Mapped second argument to p50, p90, p95, and p99<br> <li> Defaulted unrecognized percentiles to <code>p50</code>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7189/files#diff-dde40e8fcb5c37b06c011ede08922c44a3c025682fbc341aee97ba046b73a0e3">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>