### PR TITLE
fix: check 2nd arg for approx percentile fn on visualization page (#7189)

### DIFF
--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -283,7 +283,7 @@ export const isGivenFieldInOrderBy = async (
 // Function to extract field names, aliases, and aggregation functions
 export function extractFields(parsedAst: any, timeField: string) {
   let fields = parsedAst.columns.map((column: any) => {
-    const field = {
+    const field: any = {
       column: "",
       alias: "",
       aggregationFunction: null,


### PR DESCRIPTION

- https://github.com/openobserve/openobserve/issues/7191

### **PR Type**
Bug fix


___

### **Description**
- Check `approx_percentile_cont` second argument

- Map 0.5/0.50 to `p50` percentile

- Support `p90`, `p95`, and `p99` mappings

- Default fallback to `p50` percentile


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>sqlUtils.ts</strong><dd><code>Implement percentile mapping for approx_percentile_cont</code>&nbsp; &nbsp; </dd></summary> <hr>

web/src/utils/query/sqlUtils.ts

<li>Added check for <code>approx_percentile_cont</code> argument<br> <li> Mapped second argument to p50, p90, p95, and p99<br> <li> Defaulted unrecognized percentiles to <code>p50</code>


</details>


  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/7189/files#diff-dde40e8fcb5c37b06c011ede08922c44a3c025682fbc341aee97ba046b73a0e3">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>