### PR TITLE
fix: dashboard variables search 

### DIFF
--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -412,6 +412,8 @@ export default defineComponent({
           (response.type === "search_response" ||
             response.type === "search_response_hits")
         ) {
+          // variableObject.isVariablePartialLoaded = true;
+
           const hits = response.content.results.hits;
 
           const fieldHit = hits.find(

--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -448,55 +448,20 @@ export default defineComponent({
                     ? value.zo_sql_key.toString()
                     : "<blank>",
                 value: value.zo_sql_key.toString(),
-              }));
-
-            // For first response, completely replace options instead of merging
-            if (isFirstResponse) {
-              variableObject.options = newOptions;
-              variableObject.options.sort((a: any, b: any) =>
-                a.label.localeCompare(b.label),
-              );
-
-              // Filter out values that are not in new options
-              if (
-                variableObject.multiSelect &&
-                Array.isArray(variableObject.value)
-              ) {
-                const validValues = variableObject.value.filter((val: string) =>
-                  newOptions.some(
-                    (opt: any) => opt.value === val || val === SELECT_ALL_VALUE,
+              }))
+              // remove duplicates from previous options
+              .filter(
+                (option: any) =>
+                  !variableObject.options.some(
+                    (existingOption: any) =>
+                      existingOption.value === option.value,
                   ),
-                );
-                if (validValues.length !== variableObject.value.length) {
-                  variableObject.value = validValues;
-                }
-              } else if (
-                !variableObject.multiSelect &&
-                variableObject.value !== null
-              ) {
-                const valueExists = newOptions.some(
-                  (opt: any) => opt.value === variableObject.value,
-                );
-                if (!valueExists) {
-                  variableObject.value =
-                    newOptions.length > 0 ? newOptions[0].value : null;
-                }
-              }
-            } else {
-              // For subsequent responses, merge with existing options
-              variableObject.options = [
-                ...newOptions,
-                ...variableObject.options,
-              ];
-              // Remove duplicates
-              variableObject.options = variableObject.options.filter(
-                (option: any, index: number, self: any[]) =>
-                  index === self.findIndex((o) => o.value === option.value),
               );
-              variableObject.options.sort((a: any, b: any) =>
-                a.label.localeCompare(b.label),
-              );
-            }
+
+            variableObject.options = [...newOptions, ...variableObject.options];
+            variableObject.options.sort((a: any, b: any) =>
+              a.label.localeCompare(b.label),
+            );
 
             variableLog(
               variableObject.name,
@@ -829,7 +794,7 @@ export default defineComponent({
     onUnmounted(() => {
       // Clean up any in-flight promises to prevent memory leaks
       rejectAllPromises();
-      Object.keys(currentlyExecutingPromises).forEach((key) => {
+      Object.keys(currentlyExecutingPromises).forEach(key => {
         currentlyExecutingPromises[key] = null;
       });
     });

--- a/web/src/components/dashboards/settings/VariableQueryValueSelector.vue
+++ b/web/src/components/dashboards/settings/VariableQueryValueSelector.vue
@@ -69,9 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             />
           </q-item-section>
           <q-item-section @click.stop="toggleSelectAll" style="cursor: pointer">
-            <q-item-label>{{
-              variableItem.multiSelect ? "Select All" : "All"
-            }}</q-item-label>
+            <q-item-label>{{ variableItem.multiSelect ? 'Select All' : 'All' }}</q-item-label>
           </q-item-section>
         </q-item>
         <q-separator />
@@ -118,6 +116,7 @@ export default defineComponent({
         opt.label.toLowerCase().includes(searchText),
       );
     });
+
     const filterOptions = (val: string, update: Function) => {
       filterText.value = val;
       update();
@@ -125,37 +124,27 @@ export default defineComponent({
 
     const isAllSelected = computed(() => {
       if (props.variableItem.multiSelect) {
-        return (
-          Array.isArray(selectedValue.value) &&
-          selectedValue.value?.[0] === SELECT_ALL_VALUE
-        );
+        return Array.isArray(selectedValue.value) && selectedValue.value?.[0] === SELECT_ALL_VALUE;
       }
       return selectedValue.value === SELECT_ALL_VALUE;
-    });
-    const toggleSelectAll = () => {
+    });    const toggleSelectAll = () => {
       const newValue = props.variableItem.multiSelect
-        ? isAllSelected.value
-          ? []
-          : [SELECT_ALL_VALUE]
+        ? isAllSelected.value ? [] : [SELECT_ALL_VALUE]
         : SELECT_ALL_VALUE;
-
+      
       selectedValue.value = newValue;
       emit("update:modelValue", newValue);
     };
 
     const onUpdateValue = (val: any) => {
       // If multiselect and user selects any regular value after SELECT_ALL, remove SELECT_ALL
-      if (
-        props.variableItem.multiSelect &&
-        Array.isArray(val) &&
-        val.length > 0
-      ) {
+      if (props.variableItem.multiSelect && Array.isArray(val) && val.length > 0) {
         if (val.includes(SELECT_ALL_VALUE) && val.length > 1) {
-          val = val.filter((v) => v !== SELECT_ALL_VALUE);
+          val = val.filter(v => v !== SELECT_ALL_VALUE);
         }
       }
       selectedValue.value = val;
-      if (!props.variableItem.multiSelect) {
+      if(!props.variableItem.multiSelect) {
         emit("update:modelValue", val);
       }
     };
@@ -184,12 +173,9 @@ export default defineComponent({
               .join(", ");
             const remainingCount = selectedValue.value.length - 2;
             return `${firstTwoValues} ...+${remainingCount} more`;
-          } else if (
-            props.variableItem.options.length === 0 &&
-            selectedValue.value.length === 0
-          ) {
+          } else if (props.variableItem.options.length === 0 && selectedValue.value.length === 0) {
             return "(No Data Found)";
-          } else {
+          } else {            
             return selectedValue.value
               .map((it: any) => {
                 if (it === "") return "<blank>";

--- a/web/src/components/dashboards/settings/VariableQueryValueSelector.vue
+++ b/web/src/components/dashboards/settings/VariableQueryValueSelector.vue
@@ -69,7 +69,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             />
           </q-item-section>
           <q-item-section @click.stop="toggleSelectAll" style="cursor: pointer">
-            <q-item-label>{{ variableItem.multiSelect ? 'Select All' : 'All' }}</q-item-label>
+            <q-item-label>{{
+              variableItem.multiSelect ? "Select All" : "All"
+            }}</q-item-label>
           </q-item-section>
         </q-item>
         <q-separator />
@@ -116,7 +118,6 @@ export default defineComponent({
         opt.label.toLowerCase().includes(searchText),
       );
     });
-
     const filterOptions = (val: string, update: Function) => {
       filterText.value = val;
       update();
@@ -124,27 +125,37 @@ export default defineComponent({
 
     const isAllSelected = computed(() => {
       if (props.variableItem.multiSelect) {
-        return Array.isArray(selectedValue.value) && selectedValue.value?.[0] === SELECT_ALL_VALUE;
+        return (
+          Array.isArray(selectedValue.value) &&
+          selectedValue.value?.[0] === SELECT_ALL_VALUE
+        );
       }
       return selectedValue.value === SELECT_ALL_VALUE;
-    });    const toggleSelectAll = () => {
+    });
+    const toggleSelectAll = () => {
       const newValue = props.variableItem.multiSelect
-        ? isAllSelected.value ? [] : [SELECT_ALL_VALUE]
+        ? isAllSelected.value
+          ? []
+          : [SELECT_ALL_VALUE]
         : SELECT_ALL_VALUE;
-      
+
       selectedValue.value = newValue;
       emit("update:modelValue", newValue);
     };
 
     const onUpdateValue = (val: any) => {
       // If multiselect and user selects any regular value after SELECT_ALL, remove SELECT_ALL
-      if (props.variableItem.multiSelect && Array.isArray(val) && val.length > 0) {
+      if (
+        props.variableItem.multiSelect &&
+        Array.isArray(val) &&
+        val.length > 0
+      ) {
         if (val.includes(SELECT_ALL_VALUE) && val.length > 1) {
-          val = val.filter(v => v !== SELECT_ALL_VALUE);
+          val = val.filter((v) => v !== SELECT_ALL_VALUE);
         }
       }
       selectedValue.value = val;
-      if(!props.variableItem.multiSelect) {
+      if (!props.variableItem.multiSelect) {
         emit("update:modelValue", val);
       }
     };
@@ -173,9 +184,12 @@ export default defineComponent({
               .join(", ");
             const remainingCount = selectedValue.value.length - 2;
             return `${firstTwoValues} ...+${remainingCount} more`;
-          } else if (props.variableItem.options.length === 0 && selectedValue.value.length === 0) {
+          } else if (
+            props.variableItem.options.length === 0 &&
+            selectedValue.value.length === 0
+          ) {
             return "(No Data Found)";
-          } else {            
+          } else {
             return selectedValue.value
               .map((it: any) => {
                 if (it === "") return "<blank>";
@@ -204,7 +218,11 @@ export default defineComponent({
         if (isOpen.value && selectRef.value) {
           nextTick(() => {
             if (selectRef.value) {
-              (selectRef.value as any).updateInputValue();
+              if (!filterText.value) {
+                (selectRef.value as any).updateInputValue();
+              } else {
+                filterOptions(filterText.value, () => {});
+              }
             }
           });
         }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
Preserve dropdown input when `filterText.value` exists
Call `filterOptions` for non-empty `filterText.value`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VariableQueryValueSelector.vue</strong><dd><code>Conditional input update or filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/settings/VariableQueryValueSelector.vue

<li>Add <code>filterText.value</code> check before updating input<br> <li> Update input only if <code>filterText.value</code> empty<br> <li> Invoke <code>filterOptions</code> when <code>filterText.value</code> exists


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7195/files#diff-2cca760c14e835bd1845485fb5517a60f71a6dc23626a6381c8559b82476f5f4">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>