### PR TITLE
fix: logs page chart render issue on another page switch (#7207)

### DIFF
--- a/web/src/components/dashboards/panels/ChartRenderer.vue
+++ b/web/src/components/dashboards/panels/ChartRenderer.vue
@@ -219,22 +219,22 @@ export default defineComponent({
     const store = useStore();
 
     const cleanupChart = () => {
+      // Remove all event listeners from chart
+      chart?.off("mousemove");
+      chart?.off("mouseout");
+      chart?.off("globalout");
+      chart?.off("legendselectchanged");
+      chart?.off("highlight");
+      chart?.off("dataZoom");
+      chart?.off("click");
+      chart?.off("mouseover");
+
       //dispose
       if (chart) {
         chart.dispose();
       }
-      // Remove all event listeners from chart
-      chart?.off('mousemove');
-      chart?.off('mouseout');
-      chart?.off('globalout');
-      chart?.off('legendselectchanged');
-      chart?.off('highlight');
-      chart?.off('dataZoom');
-      chart?.off('click');
-      chart?.off('mouseover');
 
       chart = null;
-      chartRef.value = null;
     };
 
     const windowResizeEventCallback = async () => {
@@ -541,6 +541,7 @@ export default defineComponent({
         await nextTick();
         const theme = store.state.theme === "dark" ? "dark" : "light";
         if (chartRef.value) {
+          cleanupChart();
           chart = echarts.init(chartRef.value, theme, {
             renderer: props.renderType,
           });
@@ -617,15 +618,38 @@ export default defineComponent({
     });
 
     //need to resize chart on activated
-    onActivated(() => {
-      windowResizeEventCallback();
+    onActivated(async () => {
+      try {
+        await nextTick();
+        await nextTick();
+        await nextTick();
+        await nextTick();
+        await nextTick();
+        await nextTick();
+        await nextTick();
+        const theme = store.state.theme === "dark" ? "dark" : "light";
+        if (chartRef.value) {
+          cleanupChart();
+          chart = echarts.init(chartRef.value, theme, {
+            renderer: props.renderType,
+          });
+        }
+        chart?.setOption(props?.data?.options || {}, true);
+        chartInitialSetUp();
+        windowResizeEventCallback();
 
-      // we need that toolbox datazoom button initially selected
-      chart?.dispatchAction({
-        type: "takeGlobalCursor",
-        key: "dataZoomSelect",
-        dataZoomSelectActive: true,
-      });
+        // we need that toolbox datazoom button initially selected
+        chart?.dispatchAction({
+          type: "takeGlobalCursor",
+          key: "dataZoomSelect",
+          dataZoomSelectActive: true,
+        });
+      } catch (e: any) {
+        emit("error", {
+          message: e,
+          code: "",
+        });
+      }
     });
 
     // Clean up on deactivate


### PR DESCRIPTION
### **User description**
- Move away from the logs page and come back, histogram chart doesn't
load.

- on theme change, charts render issue on dashboard


___

### **PR Type**
Bug fix


___

### **Description**
- detach event listeners before chart disposal

- add repeated nextTick delays on activation

- reinitialize chart with correct theme and renderer

- wrap activation logic in error handler


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>ChartRenderer.vue</strong><dd><code>Enhance chart
cleanup and reinitialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

web/src/components/dashboards/panels/ChartRenderer.vue

<li>added off calls before <code>chart.dispose</code><br> <li> removed
<code>chartRef.value</code> clearing<br> <li> enhanced
<code>onActivated</code> with nextTick loops and chart init<br> <li>
wrapped activation logic in try/catch emitting error event


</details>


  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/7207/files#diff-353fab39cd76197438814db862c4a506636ea7e15633ee92d9269adbd97fe67c">+40/-18</a>&nbsp;
</td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>