### PR TITLE
fix: use a single queue for all org-user related info

### DIFF
--- a/src/super_cluster_queue/mod.rs
+++ b/src/super_cluster_queue/mod.rs
@@ -36,8 +36,8 @@ mod user;
 use config::cluster::{LOCAL_NODE, is_offline};
 use o2_enterprise::enterprise::super_cluster::queue::{
     ActionScriptsQueue, AlertsQueue, DashboardsQueue, DestinationsQueue, FoldersQueue, MetaQueue,
-    OrgUsersQueue, OrganizationsQueue, PipelinesQueue, SchedulerQueue, SchemasQueue,
-    SearchJobsQueue, SuperClusterQueueTrait, TemplatesQueue, UsersQueue,
+    OrgUsersQueue, PipelinesQueue, SchedulerQueue, SchemasQueue, SearchJobsQueue,
+    SuperClusterQueueTrait, TemplatesQueue,
 };
 
 /// Creates a super cluster queue for each super cluster topic and begins
@@ -88,15 +88,11 @@ pub async fn init() -> Result<(), anyhow::Error> {
     let action_scripts_queue = ActionScriptsQueue {
         on_action_script_msg: action_scripts::process,
     };
-    let orgs_queue = OrganizationsQueue {
-        on_meta_msg: meta::process,
-        on_orgs_msg: organization::process,
-    };
-    let users_queue = UsersQueue {
-        on_user_msg: user::process,
-    };
     let org_users_queue = OrgUsersQueue {
         on_org_users_msg: org_user::process,
+        on_user_msg: user::process,
+        on_meta_msg: meta::process,
+        on_orgs_msg: organization::process,
     };
 
     let queues: Vec<Box<dyn SuperClusterQueueTrait + Sync + Send>> = vec![
@@ -111,8 +107,6 @@ pub async fn init() -> Result<(), anyhow::Error> {
         Box::new(destinations_queue),
         Box::new(action_scripts_queue),
         Box::new(scheduler_queue),
-        Box::new(orgs_queue),
-        Box::new(users_queue),
         Box::new(org_users_queue),
     ];
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Consolidate org and user queues into one

- Remove separate orgs and users queue code

- Add meta, orgs, user handlers in OrgUsersQueue

- Update queue list to use only OrgUsersQueue


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Merge orgs and user queues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/super_cluster_queue/mod.rs

<li>Removed separate <code>OrganizationsQueue</code> and <code>UsersQueue</code> declarations.<br> <li> Updated imports to drop those queue modules.<br> <li> Incorporated handlers into <code>OrgUsersQueue</code> struct.<br> <li> Cleaned up queue vector to remove redundant queues.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7211/files#diff-6ed0f1dd36b7216fffde573232a49869f247330ecb03b50f94b2ddd723742e46">+5/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>