### PR TITLE
fix: string inside quotes of (sql) [query editor]  should have different colour in dark mode

### DIFF
--- a/web/src/components/QueryEditor.vue
+++ b/web/src/components/QueryEditor.vue
@@ -140,6 +140,16 @@ export default defineComponent({
           "editor.border": "#000000",
         },
       });
+      monaco.editor.defineTheme("myDarkTheme", {
+        base: "vs-dark",
+        inherit: true,
+        rules: [
+            { token: 'string.content.sql', foreground: 'FF6255' },
+            { token: 'string.sql', foreground: 'FF6255' }
+          ],
+
+        colors: {}
+      });
 
       // Dispose the provider if it already exists before registering a new one
       provider.value?.dispose();
@@ -166,7 +176,7 @@ export default defineComponent({
       editorObj = monaco.editor.create(editorElement as HTMLElement, {
         value: props.query?.trim(),
         language: props.language,
-        theme: store.state.theme == "dark" ? "vs-dark" : "myCustomTheme",
+        theme: store.state.theme == "dark" ? "myDarkTheme" : "myCustomTheme",
         showFoldingControls: enableCodeFolding.value ? "always" : "never",
         folding: enableCodeFolding.value,
         wordWrap: "on",
@@ -270,6 +280,14 @@ export default defineComponent({
         await import(
           "monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js"
         );
+        monaco.languages.setMonarchTokensProvider("sql", {
+          tokenizer: {
+            root: [
+              [/'[^']+?'/, 'string.content'],
+              [/"[^"]+?"/, 'string.content']
+            ]
+          }
+        });
       }
 
       if (props.language === "json") {
@@ -338,7 +356,7 @@ export default defineComponent({
       () => store.state.theme,
       () => {
         monaco.editor.setTheme(
-          store.state.theme == "dark" ? "vs-dark" : "myCustomTheme",
+          store.state.theme == "dark" ? "myDarkTheme" : "myCustomTheme",
         );
       },
     );

--- a/web/src/components/QueryEditor.vue
+++ b/web/src/components/QueryEditor.vue
@@ -280,14 +280,6 @@ export default defineComponent({
         await import(
           "monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js"
         );
-        monaco.languages.setMonarchTokensProvider("sql", {
-          tokenizer: {
-            root: [
-              [/'[^']+?'/, 'string.content'],
-              [/"[^"]+?"/, 'string.content']
-            ]
-          }
-        });
       }
 
       if (props.language === "json") {


### PR DESCRIPTION
### **User description**
1.This PR fixes the red color displaying for string inside quotes of sql query in monaco editor in dark mode this will have now 
#FF6255


___

### **PR Type**
Enhancement


___

### **Description**
- Added `myDarkTheme` with SQL string color rules

- Switched to `myDarkTheme` in dark mode initialization

- Configured Monarch tokens for SQL string content

- Updated theme watcher to apply custom dark theme


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QueryEditor.vue</strong><dd><code>QueryEditor.vue: introduce custom dark theme</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/QueryEditor.vue

<li>Defined new <code>myDarkTheme</code> with red for SQL strings<br> <li> Replaced <code>vs-dark</code> with <code>myDarkTheme</code> when dark<br> <li> Set Monarch tokens provider for SQL string content<br> <li> Updated theme switch watcher to use <code>myDarkTheme</code>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7229/files#diff-b949ab08f913cc89fb6db9d9929dab88b1ea6d671537ed95401b721b95d1a43c">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>