### PR TITLE
fix: panel load issue on panel visible

### DIFF
--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -1144,6 +1144,20 @@ export const usePanelDataLoader = (
 
       state.lastTriggeredAt = new Date().getTime();
 
+      if (runCount == 0) {
+        log("loadData: panelcache: run count is 0");
+        // restore from the cache and return
+        const isRestoredFromCache = await restoreFromCache();
+        log("loadData: panelcache: isRestoredFromCache", isRestoredFromCache);
+        if (isRestoredFromCache) {
+          state.loading = false;
+          state.isOperationCancelled = false;
+          log("loadData: panelcache: restored from cache");
+          runCount++;
+          return;
+        }
+      }
+
       // Wait for isVisible to become true
       await waitForThePanelToBecomeVisible(abortController.signal);
 
@@ -1169,20 +1183,6 @@ export const usePanelDataLoader = (
         endISOTimestamp = new Date(timestamps.end_time.toISOString()).getTime();
       } else {
         return;
-      }
-
-      if (runCount == 0) {
-        log("loadData: panelcache: run count is 0");
-        // restore from the cache and return
-        const isRestoredFromCache = await restoreFromCache();
-        log("loadData: panelcache: isRestoredFromCache", isRestoredFromCache);
-        if (isRestoredFromCache) {
-          state.loading = false;
-          state.isOperationCancelled = false;
-          log("loadData: panelcache: restored from cache");
-          runCount++;
-          return;
-        }
       }
 
       log(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Introduce early cache restore before visibility wait

- Prevent unnecessary waiting on initial load

- Ensure state reset and early return on cache hit

- Remove redundant cache check block later


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usePanelDataLoader.ts</strong><dd><code>Early cache restore before panel visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/dashboard/usePanelDataLoader.ts

<li>Added runCount==0 check before panel visibility wait<br> <li> Invoked restoreFromCache and early return on hit<br> <li> Removed duplicate cache-restore block later<br> <li> Updated log messages around cache restoration


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7232/files#diff-5a42e9493a7bcd722b88e61fd38883c4f61001bc9cafa399f65f8eafda3aace9">+14/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>