### PR TITLE
fix: make `ZO_CREATE_ORG_THROUGH_INGESTION` true by default

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1107,8 +1107,8 @@ pub struct Common {
     pub es_version: String,
     #[env_config(
         name = "ZO_CREATE_ORG_THROUGH_INGESTION",
-        default = false,
-        help = "If true (default false), new org can be automatically created through ingestion for root user. This can be changed in the runtime."
+        default = true,
+        help = "If true (default true), new org can be automatically created through ingestion for root user. This can be changed in the runtime."
     )]
     pub create_org_through_ingestion: bool,
     #[env_config(


### PR DESCRIPTION
### **User description**
Fixes #7243 . 

This pr changes the default behaviour of organization creation through ingestion. Because the default value of `ZO_CREATE_ORG_THROUGH_INGESTION` is now `true`, the root user will be able to create organization through the ingestion api. However, this behaviour can be turned off by make the env variable value `false`.


___

### **PR Type**
Bug fix


___

### **Description**
- Default ingestion-based org creation enabled

- `ZO_CREATE_ORG_THROUGH_INGESTION` default set true

- Updated help text reflecting new default


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Enable ingestion org creation by default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<li>Changed <code>ZO_CREATE_ORG_THROUGH_INGESTION</code> default to true<br> <li> Updated help description to mention default true


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7245/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>