### PR TITLE
fix: improve node status monitor

### DIFF
--- a/src/common/infra/cluster/etcd.rs
+++ b/src/common/infra/cluster/etcd.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{cmp::min, sync::atomic::Ordering};
+use std::sync::atomic::Ordering;
 
 use config::{
     cluster::*,
@@ -45,7 +45,7 @@ pub(crate) async fn register_and_keep_alive() -> Result<()> {
             }
         }
         // after the node is online, keep alive
-        let ttl_keep_alive = min(5, (get_config().limit.node_heartbeat_ttl / 2) as u64);
+        let ttl_keep_alive = std::cmp::max(1, (get_config().limit.node_heartbeat_ttl / 4) as u64);
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(ttl_keep_alive)).await;
             loop {

--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -14,7 +14,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
-    cmp::min,
     collections::HashMap,
     ops::Bound,
     sync::{Arc, atomic::Ordering},
@@ -203,12 +202,11 @@ pub async fn register_and_keep_alive() -> Result<()> {
 
     // check node heatbeat
     tokio::task::spawn(async move {
-        let cfg = get_config();
         let client = reqwest::ClientBuilder::new()
             .danger_accept_invalid_certs(true)
             .build()
             .unwrap();
-        let ttl_keep_alive = min(10, (cfg.limit.node_heartbeat_ttl / 2) as u64);
+        let ttl_keep_alive = std::cmp::max(1, (get_config().limit.node_heartbeat_ttl / 2) as u64);
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(ttl_keep_alive)).await;
             if let Err(e) = check_nodes_status(&client).await {

--- a/src/common/infra/cluster/nats.rs
+++ b/src/common/infra/cluster/nats.rs
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use core::cmp::min;
 use std::sync::atomic::Ordering;
 
 use config::{
@@ -57,7 +56,7 @@ pub(crate) async fn register_and_keep_alive() -> Result<()> {
             }
         }
         // after the node is online, keep alive
-        let ttl_keep_alive = min(5, (get_config().limit.node_heartbeat_ttl / 2) as u64);
+        let ttl_keep_alive = std::cmp::max(1, (get_config().limit.node_heartbeat_ttl / 4) as u64);
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(ttl_keep_alive)).await;
             loop {

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1885,6 +1885,7 @@ pub struct Encryption {
     #[env_config(name = "ZO_MASTER_ENCRYPTION_KEY", default = "")]
     pub master_key: String,
 }
+
 #[derive(EnvConfig)]
 pub struct HealthCheck {
     #[env_config(name = "ZO_HEALTH_CHECK_ENABLED", default = true)]

--- a/src/job/stats.rs
+++ b/src/job/stats.rs
@@ -19,7 +19,7 @@ use tokio::time;
 use crate::service::{compact::stats::update_stats_from_file_list, db};
 
 pub async fn run() -> Result<(), anyhow::Error> {
-    // tokio::task::spawn(async move { usage_report_stats().await });
+    tokio::task::spawn(async move { update_node_memory_usage().await });
     tokio::task::spawn(async move { file_list_update_stats().await });
     tokio::task::spawn(async move { cache_stream_stats().await });
     Ok(())
@@ -86,5 +86,16 @@ async fn cache_stream_stats() -> Result<(), anyhow::Error> {
         } else {
             log::debug!("[STATS] run cached stream stats success");
         }
+    }
+}
+
+// update node memory usage metrics every second
+async fn update_node_memory_usage() -> Result<(), anyhow::Error> {
+    loop {
+        let mem_usage = config::utils::sysinfo::get_memory_usage();
+        config::metrics::NODE_MEMORY_USAGE
+            .with_label_values(&[])
+            .set(mem_usage as i64);
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
     }
 }


### PR DESCRIPTION
### **User description**
Add a separate task to update memory status every second.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Use `std::cmp::max(1, …)` for node heartbeat TTL

- Remove unused `min` imports from cluster modules

- Spawn per-second node memory usage metric task

- Minor formatting in `config.rs`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>etcd.rs</strong><dd><code>Use max for etcd heartbeat TTL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/common/infra/cluster/etcd.rs

<li>Remove unused <code>cmp::min</code> import<br> <li> Replace TTL calculation with <code>std::cmp::max(1, ttl/4)</code>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7276/files#diff-37c2c2803d1c12ebb4ef9299bc79c9e6740fc5f19f7f4d84e7cfbb610b9561a9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update cluster mod heartbeat TTL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/common/infra/cluster/mod.rs

<li>Drop unused <code>min</code> import<br> <li> Compute TTL with <code>std::cmp::max(1, ttl/2)</code><br> <li> Simplify config retrieval in heartbeat task


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7276/files#diff-d15434a27e2b8406811f5a707b605203b603dad4a262c0642326be860bd2b568">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats.rs</strong><dd><code>Adjust NATS heartbeat TTL logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/common/infra/cluster/nats.rs

<li>Remove <code>core::cmp::min</code> import<br> <li> Switch TTL logic to <code>std::cmp::max(1, ttl/4)</code>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7276/files#diff-901773980aa255942e7865b977fe63811f31511ac40bc512d6bbb14dbb54bece">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Improve spacing in config definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

- Add blank line before `HealthCheck` definition


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7276/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stats.rs</strong><dd><code>Add node memory usage metrics task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/job/stats.rs

<li>Spawn <code>update_node_memory_usage</code> in <code>run()</code><br> <li> Add <code>update_node_memory_usage</code> loop for metrics


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7276/files#diff-f3ca67d9d2c68beeafd6e5de947dbc9a648ac2d2699c5dc87458c369887d09b9">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>