### PR TITLE
feat: dashboard type ahead for variables (#7277)

### DIFF
--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -32,6 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :variableItem="item"
           @update:model-value="onVariablesValueUpdated(index)"
           :loadOptions="loadVariableOptions"
+          @search="onVariableSearch(index, $event)"
         />
       </div>
       <div v-else-if="item.type == 'constant'">
@@ -300,6 +301,12 @@ export default defineComponent({
       Object.keys(traceIdMapper.value).forEach((field) => {
         cancelTraceId(field);
       });
+
+      // Clean up any in-flight promises to prevent memory leaks
+      rejectAllPromises();
+      Object.keys(currentlyExecutingPromises).forEach((key) => {
+        currentlyExecutingPromises[key] = null;
+      });
     });
 
     const sendSearchMessage = (queryReq: any) => {
@@ -385,6 +392,12 @@ export default defineComponent({
       variableLog(variableObject.name, `Received response...`);
 
       if (!variableObject) {
+        return;
+      }
+
+      // Check if this operation was cancelled before processing
+      if (currentlyExecutingPromises[variableObject.name] === null) {
+        removeTraceId(variableObject.name, payload.traceId);
         return;
       }
 
@@ -624,6 +637,12 @@ export default defineComponent({
         // console.error("Invalid time range");
         return;
       }
+
+      // Check if this operation was cancelled before proceeding
+      if (currentlyExecutingPromises[variableObject.name] === null) {
+        return;
+      }
+
       // Set loading state before initiating WebSocket
       variableObject.isLoading = true;
       variableObject.isVariableLoadingPending = true;
@@ -1174,6 +1193,7 @@ export default defineComponent({
     const loadSingleVariableDataByName = async (
       variableObject: any,
       isInitialLoad: boolean = false,
+      searchText?: string,
     ) => {
       return new Promise(async (resolve, reject) => {
         const { name } = variableObject;
@@ -1184,11 +1204,17 @@ export default defineComponent({
           return;
         }
 
-        // If the variable is already being processed, cancel the previous request
-        if (currentlyExecutingPromises[name]) {
-          variableLog(name, "Canceling previous request");
-          currentlyExecutingPromises[name](false);
+        // For search operations, use comprehensive cancellation
+        if (searchText) {
+          cancelAllVariableOperations(name);
+        } else {
+          // If the variable is already being processed, cancel the previous request
+          if (currentlyExecutingPromises[name]) {
+            variableLog(name, "Canceling previous request");
+            currentlyExecutingPromises[name](false);
+          }
         }
+
         currentlyExecutingPromises[name] = reject;
 
         // Check if this variable has any dependencies
@@ -1277,6 +1303,7 @@ export default defineComponent({
           const success = await handleVariableType(
             variableObject,
             isInitialLoad,
+            searchText,
           );
           // await finalizeVariableLoading(variableObject, success);
           resolve(success);
@@ -1296,6 +1323,7 @@ export default defineComponent({
     const handleVariableType = async (
       variableObject: any,
       isInitialLoad: boolean = false,
+      searchText?: string,
     ) => {
       variableLog(
         variableObject.name,
@@ -1305,7 +1333,7 @@ export default defineComponent({
         case "query_values": {
           // for initial loading check if the value is already available,
           // do not load the values
-          if (isInitialLoad) {
+          if (isInitialLoad && !searchText) {
             variableLog(
               variableObject.name,
               `Initial load check for variable: ${variableObject.name}, value: ${JSON.stringify(variableObject)}`,
@@ -1318,7 +1346,11 @@ export default defineComponent({
               (!Array.isArray(variableObject.value) ||
                 variableObject.value.length > 0)
             ) {
-              finalizePartialVariableLoading(variableObject, true, isInitialLoad);
+              finalizePartialVariableLoading(
+                variableObject,
+                true,
+                isInitialLoad,
+              );
               finalizeVariableLoading(variableObject, true);
               emitVariablesData();
               return true;
@@ -1326,7 +1358,10 @@ export default defineComponent({
           }
 
           try {
-            const queryContext: any = await buildQueryContext(variableObject);
+            const queryContext: any = await buildQueryContext(
+              variableObject,
+              searchText,
+            );
 
             if (isWebSocketEnabled() || isStreamingEnabled()) {
               // For WebSocket, we don't need to wait for the response here
@@ -1340,6 +1375,7 @@ export default defineComponent({
                   variableObject,
                   queryContext,
                 );
+
                 if (response?.data?.hits) {
                   const originalValue = JSON.parse(
                     JSON.stringify(variableObject.value),
@@ -1402,18 +1438,31 @@ export default defineComponent({
      * @param variableObject The variable object containing the query data.
      * @returns The query context as a string.
      */
-    const buildQueryContext = async (variableObject: any) => {
+    const buildQueryContext = async (
+      variableObject: any,
+      searchText?: string,
+    ) => {
       variableLog(
         variableObject.name,
-        `Building query context for variable: ${variableObject.name}`,
+        `Building query context for variable: ${variableObject.name}${searchText ? ` with search: ${searchText}` : ""}`,
       );
 
       const timestamp_column =
         store.state.zoConfig.timestamp_column || "_timestamp";
       let dummyQuery = `SELECT ${timestamp_column} FROM '${variableObject.query_data.stream}'`;
 
+      const filters = JSON.parse(JSON.stringify(variableObject.query_data.filter)) || [];
+
+      if(searchText) {
+        filters.push({
+          name: variableObject.query_data.field,
+          operator: "LIKE",
+          value: `%${escapeSingleQuotes(searchText.trim())}%`,
+        });
+      }
+
       // Construct the filter from the query data
-      const constructedFilter = (variableObject.query_data.filter || []).map(
+      const constructedFilter = filters.map(
         (condition: any) => ({
           name: condition.name,
           operator: condition.operator,
@@ -1959,12 +2008,59 @@ export default defineComponent({
       }
     };
 
+    /**
+     * Comprehensive cancellation function that cancels all ongoing operations for a variable
+     * @param {string} variableName - The name of the variable to cancel operations for
+     */
+    const cancelAllVariableOperations = (variableName: string) => {
+      // 1. Cancel any ongoing promise-based operations
+      if (currentlyExecutingPromises[variableName]) {
+        variableLog(variableName, "Canceling currently executing promise");
+        currentlyExecutingPromises[variableName](false);
+        currentlyExecutingPromises[variableName] = null;
+      }
+
+      // 2. Cancel any ongoing WebSocket/Streaming operations
+      cancelTraceId(variableName);      
+
+      // 3. Reset loading states for the variable only if not in search mode
+      const variableObject = variablesData.values.find(
+        (v: any) => v.name === variableName,
+      );
+
+      if (variableObject) {
+        variableObject.isLoading = false;        
+        variableObject.isVariableLoadingPending = false;
+      }
+    };
+
+    const onVariableSearch = async (
+      index: number,
+      { variableItem, filterText }: any,
+    ) => {
+      if (
+        typeof index !== "number" ||
+        !variableItem ||
+        variableItem.type !== "query_values"
+      )
+        return;
+
+      const variableName = variableItem.name;
+
+      // Cancel any previous API calls for this variable immediately
+      cancelAllVariableOperations(variableName);
+
+      await loadSingleVariableDataByName(variableItem, false, filterText);
+    };
+
     return {
       props,
       variablesData,
       changeInitialVariableValues,
       onVariablesValueUpdated,
       loadVariableOptions,
+      onVariableSearch,
+      cancelAllVariableOperations,
     };
   },
 });

--- a/web/src/components/dashboards/settings/VariableQueryValueSelector.vue
+++ b/web/src/components/dashboards/settings/VariableQueryValueSelector.vue
@@ -121,12 +121,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <script lang="ts">
 import { SELECT_ALL_VALUE } from "@/utils/dashboard/constants";
-import { defineComponent, ref, watch, computed, nextTick } from "vue";
+import { debounce } from "lodash-es";
+import { defineComponent, ref, watch, computed, nextTick, onUnmounted } from "vue";
 
 export default defineComponent({
   name: "VariableQueryValueSelector",
   props: ["modelValue", "variableItem", "loadOptions"],
-  emits: ["update:modelValue"],
+  emits: ["update:modelValue", "search"],
   setup(props: any, { emit }) {
     const selectedValue = ref(props.variableItem?.value);
     const filterText = ref("");
@@ -136,17 +137,57 @@ export default defineComponent({
 
     const availableOptions = computed(() => props.variableItem?.options || []);
 
+    // Show searchResults if filterText is active, else normal options
     const filteredOptions = computed(() => {
       if (!filterText.value) return availableOptions.value;
-      const searchText = filterText.value.toLowerCase();
       return availableOptions.value.filter((opt: any) =>
-        opt.label.toLowerCase().includes(searchText),
+        opt.label.toLowerCase().includes(filterText.value.toLowerCase()),
       );
     });
     const filterOptions = (val: string, update: Function) => {
       filterText.value = val;
       update();
     };
+
+    // set debouced filterText value that can trigger search
+    const searchText = ref("");
+    const updateSearch = debounce((val: string) => {
+        searchText.value = val;
+    }, 500);
+
+    // --- Typeahead debounce and emit search event ---
+    watch(
+      () => filterText.value,
+      (newVal) => {
+        // set search text
+        updateSearch(newVal);
+      },
+    );
+
+    // emit when searchText changes
+    watch(
+      () => searchText.value,
+      (newVal) => {
+        if(newVal == null || newVal == undefined) {
+          return
+        }
+
+        // no need to update results if the menu is hidden
+        if (!isOpen.value) {
+          return;
+        }
+
+        emit("search", {
+          variableItem: props.variableItem,
+          filterText: newVal,
+        });
+      }
+    )
+
+    // Cleanup debounce timeout when component is unmounted
+    onUnmounted(() => {
+      updateSearch.cancel();
+    });
 
     const isAllSelected = computed(() => {
       if (props.variableItem.multiSelect) {
@@ -200,6 +241,7 @@ export default defineComponent({
 
     const onPopupHide = () => {
       isOpen.value = false;
+      
       filterText.value = "";
       if (props.variableItem.multiSelect) {
         emit("update:modelValue", selectedValue.value);
@@ -279,7 +321,7 @@ export default defineComponent({
       },
       { immediate: true },
     );
-    const handleCustomValue = (value: string) => {
+    const handleCustomValue = async (value: string) => {
       if (!value?.trim() || props.variableItem.multiSelect) return;
 
       const newValue = value.trim();


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add debounced typeahead search in variable selectors

- Implement unified cancellation to avoid race conditions

- Extend loader functions to accept `searchText` parameter

- Clean up controllers, timeouts and promises on unmount


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>VariablesValueSelector.vue</strong><dd><code>Add search and cancellation support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

web/src/components/dashboards/VariablesValueSelector.vue

<li>Pass <code>searchResults</code> and <code>onVariableSearch</code> to child selector<br> <li> Clean up search controllers, debounce timeouts, and promises on <br>unmount<br> <li> Check cancellation before processing responses and loading<br> <li> Extend
<code>loadSingleVariableDataByName</code> and
<code>handleVariableType</code> to handle <br><code>searchText</code>


</details>


  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/7277/files#diff-5c6e3bcb87cb64f25bf8157a541604b7a4904c1282acf662cab5d76a5be6bd56">+238/-10</a></td>

</tr>

<tr>
  <td>
    <details>

<summary><strong>VariableQueryValueSelector.vue</strong><dd><code>Implement debounced search in selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/settings/VariableQueryValueSelector.vue

<li>Add <code>searchResults</code> prop and emit <code>search</code> event<br> <li> Debounce <code>filterText</code> watch for 1000ms before search emit<br> <li> Show <code>searchResults</code> during filter and track <code>searching</code> state<br> <li> Reset results and loading on clear and popup hide


</details>


  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/7277/files#diff-2cca760c14e835bd1845485fb5517a60f71a6dc23626a6381c8559b82476f5f4">+61/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>ViewDashboard.vue</strong><dd><code>Remove debug logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/Dashboards/ViewDashboard.vue

- Remove `console.log` debugging on time update


</details>


  </td> <td><a
href="https://github.com/openobserve/openobserve/pull/7277/files#diff-052badb6758aff09ceaf1645869b9ba96125e6a0ea21abb01a8ee0a40d6467f3">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

---------