### PR TITLE
feat: add typeahead query builder for variable selection

### DIFF
--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -1439,6 +1439,62 @@ export default defineComponent({
       }
     };
 
+    let parser: any;
+
+    const importSqlParser = async () => {
+      const useSqlParser: any = await import("@/composables/useParser");
+      const { sqlParser }: any = useSqlParser.default();
+      parser = await sqlParser();
+    };
+
+    /**
+     * Builds a typeahead query for the given variable object and search text.
+     * This function constructs a SQL query to search for the given text
+     * within a specified field of a data stream.
+     *
+     * @param variableObject The variable object containing query data.
+     * @param searchText The text to search for within the field.
+     * @returns A base64 encoded SQL query string or null if input is invalid.
+     */
+    const buildVariablesTypeAheadQuery = async (
+      variableObject: any,
+      searchText: string,
+    ) => {
+      // Return null if search text or field is not provided
+      if (!searchText || !variableObject?.query_data?.field) return null;
+
+      // Dynamically import the SQL parser
+      await importSqlParser();
+
+      // Get the timestamp column from the store or use a default value
+      const timestamp_column =
+        store.state.zoConfig.timestamp_column || "_timestamp";
+
+      // Build the base query string for typeahead search
+      let baseQuery = `SELECT ${timestamp_column} FROM '${variableObject.query_data.stream}' WHERE CAST(${variableObject.query_data.field} AS TEXT) LIKE '%${escapeSingleQuotes(searchText.trim())}%'`;
+
+      // Add any existing filters to the query
+      const filters = variableObject.query_data?.filter || [];
+      if (filters.length > 0) {
+        const filterConditions = filters
+          .map(
+            (filter: any) =>
+              `${filter.name} ${filter.operator} '${escapeSingleQuotes(filter.value)}'`,
+          )
+          .join(" AND ");
+        baseQuery += ` AND ${filterConditions}`;
+      }
+
+      // Parse the SQL query into an abstract syntax tree (AST)
+      const ast = parser.astify(baseQuery);
+
+      // Convert the AST back into a SQL string, replacing backticks with double quotes
+      let queryContext = parser.sqlify(ast).replace(/`/g, '"');
+
+      // Encode the query string in base64
+      return b64EncodeUnicode(queryContext);
+    };
+
     /**
      * Builds the query context for the given variable object.
      * @param variableObject The variable object containing the query data.
@@ -1453,19 +1509,18 @@ export default defineComponent({
         `Building query context for variable: ${variableObject.name}${searchText ? ` with search: ${searchText}` : ""}`,
       );
 
+      // If searchText is provided, use the typeahead query builder
+      if (searchText) {
+        return await buildVariablesTypeAheadQuery(variableObject, searchText);
+      }
+
       const timestamp_column =
         store.state.zoConfig.timestamp_column || "_timestamp";
       let dummyQuery = `SELECT ${timestamp_column} FROM '${variableObject.query_data.stream}'`;
 
-      const filters = JSON.parse(JSON.stringify(variableObject.query_data?.filter || []));
-
-      if(searchText) {
-        filters.push({
-          name: variableObject.query_data.field,
-          operator: "LIKE",
-          value: `%${escapeSingleQuotes(searchText.trim())}%`,
-        });
-      }
+      const filters = JSON.parse(
+        JSON.stringify(variableObject.query_data?.filter || []),
+      );
 
       // Construct the filter from the query data
       const constructedFilter = filters.map(

--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -1464,12 +1464,8 @@ export default defineComponent({
         dummyQuery = `SELECT ${timestamp_column} FROM '${variableObject.query_data.stream}'`;
       }
 
-      const filters = JSON.parse(
-        JSON.stringify(variableObject.query_data?.filter || []),
-      );
-
       // Construct the filter from the query data
-      const constructedFilter = filters.map(
+      const constructedFilter = (variableObject.query_data?.filter || []).map(
         (condition: any) => ({
           name: condition.name,
           operator: condition.operator,
@@ -1477,14 +1473,11 @@ export default defineComponent({
         }),
       );
 
-      if (!constructedFilter || constructedFilter.length === 0) {
-        return b64EncodeUnicode(dummyQuery);
-      }
       // Add labels to the dummy query
-      let queryContext = await addLabelsToSQlQuery(
+      let queryContext = constructedFilter.length ? await addLabelsToSQlQuery(
         dummyQuery,
         constructedFilter,
-      );
+      ) : dummyQuery;
 
       // Replace variable placeholders with actual values
       for (const variable of variablesData.values) {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add dynamic SQL parser import for variable typeahead

- Implement buildVariablesTypeAheadQuery with base64 SQL

- Update query context builder to use typeahead

- Remove redundant inline LIKE filter logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VariablesValueSelector.vue</strong><dd><code>Implement variable typeahead SQL builder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/VariablesValueSelector.vue

<li>Import and initialize <code>sqlParser</code> dynamically<br> <li> Add <code>buildVariablesTypeAheadQuery</code> for typeahead SQL<br> <li> Encode generated queries in base64 format<br> <li> Adjust query context builder to use new function


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7306/files#diff-5c6e3bcb87cb64f25bf8157a541604b7a4904c1282acf662cab5d76a5be6bd56">+64/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>