### PR TITLE
fix: stream_types for join (#7319)

### DIFF
--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -55,8 +55,11 @@ pub async fn search(
     let sql = Arc::new(meta);
 
     for s in sql.stream_names.iter() {
-        let schema =
-            infra::schema::get_cache(&sql.org_id, &s.stream_name(), sql.stream_type).await?;
+        // Get the schem from `TableReference` for join queries
+        // Since it resolves queries where stream_name is prefixed with the stream_type
+        // e.g. `logs.my_stream`, `enrich.my_stream`
+        let stream_type = config::meta::stream::StreamType::from(s.stream_type());
+        let schema = infra::schema::get_cache(&sql.org_id, &s.stream_name(), stream_type).await?;
         if schema.schema().fields().is_empty() {
             let mut result = search::Response::new(sql.offset, sql.limit);
             result.function_error = vec![format!("Stream not found {}", &s.stream_name())];

--- a/src/service/search/cluster/http.rs
+++ b/src/service/search/cluster/http.rs
@@ -55,7 +55,7 @@ pub async fn search(
     let sql = Arc::new(meta);
 
     for s in sql.stream_names.iter() {
-        // Get the schem from `TableReference` for join queries
+        // Get the schema from `TableReference` for join queries
         // Since it resolves queries where stream_name is prefixed with the stream_type
         // e.g. `logs.my_stream`, `enrich.my_stream`
         let stream_type = config::meta::stream::StreamType::from(s.stream_type());


### PR DESCRIPTION
### **User description**
fix #7319


___

### **PR Type**
Bug fix


___

### **Description**
- Use TableReference stream_type in schema cache

- Support join queries with prefixed stream names

- Convert s.stream_type() to StreamType

- Remove direct sql.stream_type usage


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http.rs</strong><dd><code>Update schema cache retrieval for join queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cluster/http.rs

<li>Added comment explaining TableReference stream type<br> <li> Converted s.stream_type() to StreamType enum<br> <li> Replaced sql.stream_type with new stream_type value<br> <li> Removed old schema retrieval parameter


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7320/files#diff-fe0a1bbec7ef6418120544b589a531e5144b28cd2650f99135ed8a70ac17ac03">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>