### PR TITLE
fix: cache delta start_time (#7367)

### DIFF
--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -762,7 +762,7 @@ fn calculate_deltas_multi(
         // fetches the data after the last cache result timestamp, thereby avoiding duplicates
         let mut expected_delta_start_time = current_end_time + histogram_interval.abs();
         if expected_delta_start_time > end_time {
-            expected_delta_start_time = start_time;
+            expected_delta_start_time = current_end_time;
         }
         deltas.push(QueryDelta {
             delta_start_time: expected_delta_start_time,
@@ -853,5 +853,14 @@ mod tests {
                 delta
             );
         }
+
+        let expected_deltas = vec![
+            QueryDelta {
+                delta_start_time: 1747659555000000,
+                delta_end_time: 1747659600000000,
+                delta_removed_hits: false,
+            },
+        ];
+        assert_eq!(deltas, expected_deltas);
     }
 }


### PR DESCRIPTION
### **User description**
fix #7365
previous ref: #5872


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Avoid duplicate end-gap query entries

- Reset delta_start when exceeding end_time

- Add unit test for delta intervals

- Mark TODO in `check_cache`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cacher.rs</strong><dd><code>Fix end-gap delta start calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/cacher.rs

<li>Wrap end-gap delta start computation<br> <li> Cap <code>expected_delta_start_time</code> to query start<br> <li> Add tests verifying delta interval validity<br> <li> Insert TODO in <code>check_cache</code>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7366/files#diff-8c387b22b2c0a282600ee41ca702b3db60f5a284d507c0feb7418608ff062c6c">+84/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>