### PR TITLE
fix: scheduled pipeline should catch up when there is failures for a timerange

### DIFF
--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -1029,7 +1029,7 @@ async fn handle_derived_stream_triggers(
         // 5:20pm. But, if the suppossed to be run at is 5:10pm, then we need ingest
         // data for the period from 5:05pm to 5:15pm. Which is to cover the skipped
         // period from 5:05pm to 5:15pm.
-        log::warn!(
+        log::debug!(
             "supposed_to_be_run_at: {}, t0 + supposed_to_be_run_at: {}, supposed_to_be_run_smaller: {}",
             chrono::DateTime::from_timestamp_micros(supposed_to_be_run_at)
                 .unwrap()
@@ -1045,7 +1045,15 @@ async fn handle_derived_stream_triggers(
                 // For cron frequency, don't believe the period, the period can be dynamic for cron.
                 // For example, if cron expression evaluates to "run every weekend 12am", the period
                 // is dynamic here.
-                supposed_to_be_run_at
+                std::cmp::min(
+                    supposed_to_be_run_at,
+                    derived_stream.trigger_condition.get_next_trigger_time(
+                        false,
+                        derived_stream.tz_offset,
+                        false,
+                        Some(t0),
+                    )?,
+                )
             } else {
                 std::cmp::min(supposed_to_be_run_at, t0 + period_num_microseconds)
             },
@@ -1352,18 +1360,29 @@ async fn handle_derived_stream_triggers(
     if !(trigger_data_stream.status == TriggerDataStatus::Failed
         && new_trigger.retries < max_retries)
     {
-        // Go to the next nun at, but use the same trigger start time
-        new_trigger.next_run_at = derived_stream.trigger_condition.get_next_trigger_time(
-            false,
-            derived_stream.tz_offset,
-            false,
-            Some(trigger.next_run_at),
-        )?;
-
+        let need_to_catch_up = end < supposed_to_be_run_at;
         // If the trigger didn't fail, we need to reset the `retries` count.
         // Only cumulative failures should be used to check with `max_retries`
         if trigger_data_stream.status != TriggerDataStatus::Failed {
             new_trigger.retries = 0;
+        }
+
+        if trigger_data_stream.status != TriggerDataStatus::Failed && need_to_catch_up {
+            // Go to the next nun at, but use the same trigger start time
+            new_trigger.next_run_at = derived_stream.trigger_condition.get_next_trigger_time(
+                false,
+                derived_stream.tz_offset,
+                false,
+                Some(end),
+            )?;
+        } else {
+            // Go to the next nun at, but use the same trigger start time
+            new_trigger.next_run_at = derived_stream.trigger_condition.get_next_trigger_time(
+                false,
+                derived_stream.tz_offset,
+                false,
+                Some(trigger.next_run_at),
+            )?;
         }
     }
     trigger_data_stream.next_run_at = new_trigger.next_run_at;


### PR DESCRIPTION
For a scheduled pipeline, we have a logic to catch up the delay whenever there is a delay. For example, say, at 10:00am, there are some errors while triggering scheduled pipeline, it will retry 3 times and then retry again after the given frequency (say 2 mins). Now when the error is resolved at 11:02am, the scheduled pipeline will again try to run the timerange of 10:00am - 10:02am first. But since there is a bug in the current code, this 1 hour delay will always be there. At, 11:04am it will run for 10:02-10:04, at 11:06, 10:04-10:06am etc.

This pr fixes this bug. So, after the delay due to failures, the next time it runs successfully, it will be able to catch up the timerange by immediately retriggering the pipelines until it is in sync with the current time.