### PR TITLE
fix: single node schedulable

### DIFF
--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -186,7 +186,9 @@ pub async fn register_and_keep_alive() -> Result<()> {
             panic!("Local mode only support NODE_ROLE=all");
         }
         // cache local node
-        let node = load_local_node();
+        let mut node = load_local_node();
+        node.status = NodeStatus::Online;
+        node.scheduled = true;
         add_node_to_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Interactive)).await;
         add_node_to_consistent_hash(&node, &Role::Querier, Some(RoleGroup::Background)).await;
         add_node_to_consistent_hash(&node, &Role::Compactor, None).await;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Make local node mutable for status update

- Set `node.status` to Online

- Enable scheduling by setting `node.scheduled`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Enable local node scheduling and online status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/common/infra/cluster/mod.rs

<li>Changed <code>load_local_node()</code> to return a mutable node<br> <li> Assigned <code>NodeStatus::Online</code> to <code>node.status</code><br> <li> Enabled scheduling by setting <code>node.scheduled = true</code>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7376/files#diff-d15434a27e2b8406811f5a707b605203b603dad4a262c0642326be860bd2b568">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>