### PR TITLE
fix: ensure minimum loading progress percentage is 5

### DIFF
--- a/web/src/components/common/LoadingProgress.vue
+++ b/web/src/components/common/LoadingProgress.vue
@@ -125,6 +125,9 @@ export default defineComponent({
       if (!props.loading) {
         return internalPercentage.value;
       }
+      if (props.loadingProgressPercentage < 5) {
+        return 5;
+      }
       return props.loadingProgressPercentage;
     });
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Enforce minimum loading progress percentage at 5%

- Update displayPercentage computed property


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LoadingProgress.vue</strong><dd><code>Clamp minimum loading progress to 5%</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/common/LoadingProgress.vue

<li>Introduce clamp for minimum progress of 5%<br> <li> Return 5% when loadingProgressPercentage < 5


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7385/files#diff-0e124527ca2b1d19c4f098616e1cdeb8c405d4f89b68bf119a09b9a518eba23a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>