### PR TITLE
fix: delete result cache to also delete aggregation cache

### DIFF
--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -669,19 +669,16 @@ pub async fn delete_cache(path: &str) -> std::io::Result<bool> {
     let mut aggs_remove_files: Vec<String> = vec![];
     #[cfg(feature = "enterprise")]
     {
-        let aggs_pattern = format!("{}/{}/{}", root_dir, STREAMING_AGGS_CACHE_DIR, path);
+        let aggs_pattern = format!("{root_dir}/{STREAMING_AGGS_CACHE_DIR}/{path}");
         let aggs_files = scan_files(&aggs_pattern, "arrow", None).unwrap_or_default();
         aggs_remove_files.extend(aggs_files);
 
         for file in aggs_remove_files {
-            match disk::remove("", file.strip_prefix(&prefix).unwrap()).await {
+            match disk::remove(file.strip_prefix(&prefix).unwrap()).await {
                 Ok(_) => {}
                 Err(e) => {
                     log::error!("Error deleting cache: {:?}", e);
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "Error deleting cache",
-                    ));
+                    return Err(std::io::Error::other("Error deleting cache"));
                 }
             }
         }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Refactor result cache deletion pattern formatting

- Add enterprise streaming aggregation cache deletion

- Import `STREAMING_AGGS_CACHE_DIR` under enterprise feature

- Improve error logging on aggregation deletion


___

### **Changes diagram**

```mermaid
flowchart LR
  A["delete_cache(path)"] -- "scan result files" --> B["Delete result caches"]
  B -- "scan aggs files (enterprise)" --> C["Delete aggregation caches"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cacher.rs</strong><dd><code>Add aggregation cache deletion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/cacher.rs

<li>Added import of <code>STREAMING_AGGS_CACHE_DIR</code><br> <li> Refactored result cache pattern and prefix formatting<br> <li> Added enterprise aggregation cache deletion block<br> <li> Enhanced aggregation deletion error logging


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7425/files#diff-8c387b22b2c0a282600ee41ca702b3db60f5a284d507c0feb7418608ff062c6c">+30/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>