### PR TITLE
chore: remove `bucket_num` from `histogram` UDF

### DIFF
--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -718,13 +718,10 @@ fn handle_histogram(
             .map(|v| v.trim().trim_matches(|v| (v == '\'' || v == '"')))
             .collect::<Vec<&str>>();
 
-        match attrs.get(1) {
-            Some(v) => match v.parse::<u16>() {
-                Ok(v) => generate_histogram_interval(q_time_range, v),
-                Err(_) => v.to_string(),
-            },
-            None => generate_histogram_interval(q_time_range, 0),
-        }
+        attrs.get(1).map_or_else(
+            || generate_histogram_interval(q_time_range),
+            |v| v.to_string(),
+        )
     };
 
     *origin_sql = origin_sql.replace(

--- a/src/service/search/datafusion/optimizer/rewrite_histogram.rs
+++ b/src/service/search/datafusion/optimizer/rewrite_histogram.rs
@@ -128,23 +128,14 @@ impl TreeNodeRewriter for HistogramToDatebin {
                         let interval = if self.histogram_interval > 0 {
                             format!("{} second", self.histogram_interval)
                         } else {
-                            generate_histogram_interval(Some((self.start_time, self.end_time)), 0)
+                            generate_histogram_interval(Some((self.start_time, self.end_time)))
                         };
                         cast(
                             Expr::Literal(ScalarValue::from(interval)),
                             DataType::Interval(IntervalUnit::MonthDayNano),
                         )
                     } else if args.len() == 2 {
-                        if let Expr::Literal(ScalarValue::Int64(Some(num))) = &args[1] {
-                            let interval = generate_histogram_interval(
-                                Some((self.start_time, self.end_time)),
-                                *num as u16,
-                            );
-                            cast(
-                                Expr::Literal(ScalarValue::from(interval)),
-                                DataType::Interval(IntervalUnit::MonthDayNano),
-                            )
-                        } else if let Expr::Literal(ScalarValue::Utf8(_)) = &args[1] {
+                        if let Expr::Literal(ScalarValue::Utf8(_)) = &args[1] {
                             cast(
                                 args[1].clone(),
                                 DataType::Interval(IntervalUnit::MonthDayNano),
@@ -232,20 +223,6 @@ mod tests {
                     "| 1970-01-01T00:00:00                       |",
                     "| 1970-01-01T00:00:00                       |",
                     "+-------------------------------------------+",
-                ],
-            ),
-            (
-                "select histogram(_timestamp, 5) from t",
-                vec![
-                    "+----------------------------------+",
-                    "| histogram(t._timestamp,Int64(5)) |",
-                    "+----------------------------------+",
-                    "| 1970-01-01T00:00:00              |",
-                    "| 1970-01-01T00:00:00              |",
-                    "| 1970-01-01T00:00:00              |",
-                    "| 1970-01-01T00:00:00              |",
-                    "| 1970-01-01T00:00:00              |",
-                    "+----------------------------------+",
                 ],
             ),
         ];


### PR DESCRIPTION
### **User description**
In signature of the UDF `histogram(field, v)`, when `v` was a number, it was treated as `bucket_num` and the interval was divided accordingly.

This argument is now removed and `histogram` now has only two forms:
- `histogram(field)`
- `histogram(field, interval)`

Additionally, the following changes have been made as part of this:
- `generate_histogram_interval` no longer accepts `num: u16`
- `intervals` inside the above function turned into a `const`
- `macro_rules! intervals` to generate interval pairs for above

Closes: #7406


___

### **PR Type**
Enhancement


___

### **Description**
- Simplify histogram UDF argument handling

- Remove numeric `bucket_num` support entirely

- Refactor `generate_histogram_interval` with macro

- Clean up related imports and parsing logic


___

### **Changes diagram**

```mermaid
flowchart LR
  A["histogram(field, v?)"]
  A -- "v present" --> B["use v as interval string"]
  A -- "v absent" --> C["generate_histogram_interval()"]
  B --> D["date_bin with interval"]
  C --> D
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cacher.rs</strong><dd><code>Simplified histogram arg parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/cacher.rs

<li>Simplified <code>attrs.get(1)</code> matching using <code>map_or_else</code><br> <li> Removed numeric parsing of the second argument<br> <li> Always treat second parameter as interval string


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7427/files#diff-8c387b22b2c0a282600ee41ca702b3db60f5a284d507c0feb7418608ff062c6c">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rewrite_histogram.rs</strong><dd><code>Removed numeric bucket support in rewrite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/datafusion/optimizer/rewrite_histogram.rs

<li>Removed numeric literal branch in histogram rewrite<br> <li> Only handle string interval in <code>DateBinFunc</code><br> <li> Cleaned up interval generation calls


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7427/files#diff-fa40d6f792f0ca212f799b0136f0f216c7f34cb3130738903a26c45749a81450">+2/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql.rs</strong><dd><code>Refactored histogram interval generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/sql.rs

<li>Removed numeric parse and import <code>chrono::Duration</code><br> <li> Updated <code>generate_histogram_interval</code> signature<br> <li> Introduced <code>intervals!</code> macro and <code>INTERVALS</code> const<br> <li> Refactored interval generation logic


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7427/files#diff-d9ccf393c53794b0ef2816eef12742c26e23d2788cde27780af7570662aea446">+30/-39</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>