### PR TITLE
fix: openfga migration for ai

### DIFF
--- a/src/common/infra/ofga/mod.rs
+++ b/src/common/infra/ofga/mod.rs
@@ -50,6 +50,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     let mut need_alert_folders_migration = false;
     let mut need_ratelimit_migration = false;
     let mut need_service_accounts_migration = false;
+    let mut need_ai_chat_permissions_migration = false;
     let mut existing_meta: Option<o2_openfga::meta::mapping::OFGAModel> =
         match db::ofga::get_ofga_model().await {
             Ok(Some(model)) => Some(model),
@@ -142,6 +143,8 @@ pub async fn init() -> Result<(), anyhow::Error> {
         let v0_0_13 = version_compare::Version::from("0.0.13").unwrap();
         let v0_0_15 = version_compare::Version::from("0.0.15").unwrap();
         let v0_0_16 = version_compare::Version::from("0.0.16").unwrap();
+        let v0_0_17 = version_compare::Version::from("0.0.17").unwrap();
+        let v0_0_18 = version_compare::Version::from("0.0.18").unwrap();
         if meta_version > v0_0_4 && existing_model_version < v0_0_5 {
             need_migrate_index_streams = true;
         }
@@ -163,6 +166,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
             log::info!("[OFGA:Local] Ratelimit migration needed");
             need_ratelimit_migration = true;
             need_service_accounts_migration = true;
+        }
+        if meta_version > v0_0_17 && existing_model_version < v0_0_18 {
+            log::info!("[OFGA:Local] AI chat permissions migration needed");
+            need_ai_chat_permissions_migration = true;
         }
     }
 
@@ -263,6 +270,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
                     }
                     if need_service_accounts_migration {
                         get_ownership_all_org_tuple(org_name, "service_accounts", &mut tuples);
+                    }
+                    if need_ai_chat_permissions_migration {
+                        get_ownership_all_org_tuple(org_name, "ai", &mut tuples);
                     }
                 }
                 if need_alert_folders_migration {

--- a/src/common/utils/auth.rs
+++ b/src/common/utils/auth.rs
@@ -624,7 +624,6 @@ impl FromRequest for AuthExtractor {
                 || path.contains("/short")
                 || path.contains("/ws")
                 || path.contains("/_values_stream")
-                || (url_len > 1 && path_columns[1].eq("ai"))
             {
                 return ready(Ok(AuthExtractor {
                     auth: auth_str.to_owned(),


### PR DESCRIPTION
Since, AI agent api is now RBAC controlled, this pr adds the migration needed for ai openfga queries.