### PR TITLE
fix: cancelled queries before switching stream in logs

### DIFF
--- a/web/src/components/alerts/ScheduledAlert.vue
+++ b/web/src/components/alerts/ScheduledAlert.vue
@@ -1729,8 +1729,6 @@ const addConditionGroup = (groupId: string) => {
 
 const updateDateTimePicker = (data: any) => {
   emits("update:multi_time_range", dateTimePicker.value);
-
-
 };
 
 const removeTimeShift = (index: any) => {
@@ -1992,7 +1990,6 @@ const filterColumns = (options: string[], val: string, update: Function) => {
       filteredOptions = [...options];
     });
   }
-
 
   update(() => {
     const value = val.toLowerCase();

--- a/web/src/components/functions/EnrichmentTableList.vue
+++ b/web/src/components/functions/EnrichmentTableList.vue
@@ -313,7 +313,7 @@ export default defineComponent({
           dismiss();
         })
         .catch((err) => {
-          console.log("--", err);
+          console.info("Error while fetching enrichment tables", err);
           dismiss();
           if (err.response.status != 403) {
             $q.notify({

--- a/web/src/components/functions/FunctionList.vue
+++ b/web/src/components/functions/FunctionList.vue
@@ -245,8 +245,7 @@ export default defineComponent({
     const confirmDelete = ref<boolean>(false);
     const confirmForceDelete = ref<boolean>(false);
     const { searchObj } = useLogs();
-    const pipelineList = ref([
-    ]);
+    const pipelineList = ref([]);
     const selectedPipeline = ref("");
     const columns: any = ref<QTableProps["columns"]>([
       {
@@ -331,7 +330,7 @@ export default defineComponent({
           dismiss();
         })
         .catch((err) => {
-          console.log("--", err);
+          console.error("Error while pulling function", err);
 
           dismiss();
           if (err.response.status != 403) {

--- a/web/src/components/pipeline/PipelineEditor.vue
+++ b/web/src/components/pipeline/PipelineEditor.vue
@@ -38,7 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <q-input
           v-model="pipelineObj.currentSelectedPipeline.name"
           :label="t('pipeline.pipelineName')"
-          style="border: 1px solid #eaeaea; width: calc(30vw);"
+          style="border: 1px solid #eaeaea; width: calc(30vw)"
           filled
           dense    
         />
@@ -95,7 +95,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <q-separator class="q-mb-md" />
 
       <div class="flex q-mt-sm">
-        <NodeSidebar v-show="!pipelineObj.dialog.show || pipelineObj.dialog.name != 'query'" :nodeTypes="nodeTypes"  />
+        <NodeSidebar
+          v-show="
+            !pipelineObj.dialog.show || pipelineObj.dialog.name != 'query'
+          "
+          :nodeTypes="nodeTypes"
+        />
       </div>
     </div>
     <div
@@ -150,8 +155,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <ExternalDestination
         v-if="pipelineObj.dialog.name === 'remote_stream'"
         @cancel:hideform="resetDialog"
-       />
-      
+      />
     </div>
   </q-dialog>
   <q-dialog
@@ -386,7 +390,7 @@ const nodeTypes: any = [
     icon: "img:" + streamOutputImage,
     tooltip: "Destination: Stream Node",
     isSectionHeader: false,
-  }
+  },
 ];
 const functions = ref<{ [key: string]: Function }>({});
 
@@ -487,7 +491,6 @@ onMounted(async () => {
 onUnmounted(() => {
   window.removeEventListener("beforeunload", beforeUnloadHandler);
 });
-
 
 let forceSkipBeforeUnloadListener = false;
 
@@ -697,15 +700,23 @@ const confirmSaveBasicPipeline = async () => {
 };
 const validatePipeline = () => {
   // Find input node
-  const inputNode = pipelineObj.currentSelectedPipeline.nodes?.find((node: any) => node.type === 'input');
+  const inputNode = pipelineObj.currentSelectedPipeline.nodes?.find(
+    (node: any) => node.type === "input",
+  );
 
-  const outputNode = pipelineObj.currentSelectedPipeline.nodes?.find((node: any) => node.type === 'output');
-  
+  const outputNode = pipelineObj.currentSelectedPipeline.nodes?.find(
+    (node: any) => node.type === "output",
+  );
 
   // If trying to use enrichment_tables with stream input, return false
-  if ( inputNode.data?.node_type === 'stream' && outputNode.data?.node_type === 'stream' && outputNode.data?.stream_type === 'enrichment_tables') {
+  if (
+    inputNode.data?.node_type === "stream" &&
+    outputNode.data?.node_type === "stream" &&
+    outputNode.data?.stream_type === "enrichment_tables"
+  ) {
     q.notify({
-      message: "Enrichment tables as destination stream is only available for scheduled pipelines",
+      message:
+        "Enrichment tables as destination stream is only available for scheduled pipelines",
       color: "negative",
       position: "bottom",
       timeout: 2000,

--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -38,119 +38,131 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         selection="multiple"
         v-model:selected="selectedPipelines"
       >
-      <template v-slot:body="props">
-        <q-tr
-          :data-test="`pipeline-list-table-${props.row.pipeline_id}-row`"
-          :props="props"
-          style="cursor: pointer"
-          @click="triggerExpand(props)"
-        >
-          <q-td auto-width>
-            <q-checkbox
-              v-model="props.selected"
-              color="secondary"
-              size="sm"
-              @click.stop
-            />
-          </q-td>
-          <q-td v-if="activeTab == 'scheduled'" auto-width>
-            <q-btn
-              dense
-              flat
-              size="xs"
-              :icon="
-                expandedRow != props.row.pipeline_id
-                  ? 'expand_more'
-                  : 'expand_less'
-              "
-            />
-          </q-td>
-          <q-td v-for="col in filterColumns()" :key="col.name" :props="props">
-            <template v-if="col.name  !== 'actions'">
-              {{ props.row[col.field] }}
-            </template>
-            <template v-else>
-              <!-- Actions Buttons -->
-              <q-btn
-                :data-test="`pipeline-list-${props.row.name}-pause-start-alert`"
-                :icon="props.row.enabled ? outlinedPause : outlinedPlayArrow"
-                class="q-ml-xs material-symbols-outlined"
-                padding="sm"
-                unelevated
+        <template v-slot:body="props">
+          <q-tr
+            :data-test="`pipeline-list-table-${props.row.pipeline_id}-row`"
+            :props="props"
+            style="cursor: pointer"
+            @click="triggerExpand(props)"
+          >
+            <q-td auto-width>
+              <q-checkbox
+                v-model="props.selected"
+                color="secondary"
                 size="sm"
-                :color="props.row.enabled ? 'negative' : 'positive'"
-                round
-                flat
-                :title="props.row.enabled ? t('alerts.pause') : t('alerts.start')"
-                @click.stop="toggleAlertState(props.row)"
+                @click.stop
               />
+            </q-td>
+            <q-td v-if="activeTab == 'scheduled'" auto-width>
               <q-btn
-                :data-test="`pipeline-list-${props.row.name}-update-pipeline`"
-                icon="edit"
-                class="q-ml-xs"
-                padding="sm"
-                unelevated
-                size="sm"
-                round
+                dense
                 flat
-                :title="t('pipeline.edit')"
-                @click.stop="editPipeline(props.row)"
-              ></q-btn>
-              <q-btn
-                :data-test="`pipeline-list-${props.row.name}-export-pipeline`"
-                icon="download"
-                class="q-ml-xs"
-                padding="sm"
-                unelevated
-                size="sm"
-                round
-                flat
-                :title="t('pipeline.export')"
-                @click.stop="exportPipeline(props.row)"
-              ></q-btn>
-              <q-btn
-                :data-test="`pipeline-list-${props.row.name}-delete-pipeline`"
-                :icon="outlinedDelete"
-                class="q-ml-xs"
-                padding="sm"
-                unelevated
-                size="sm"
-                round
-                flat
-                :title="t('pipeline.delete')"
-                @click.stop="openDeleteDialog(props.row)"
-              ></q-btn>
-              <q-btn
-                :data-test="`pipeline-list-${props.row.name}-view-pipeline`"
-                :icon="outlinedVisibility"
-                class="q-ml-xs"
-                padding="sm"
-                unelevated
-                size="sm"
-                round
-                flat
-                :title="t('pipeline.view')"
+                size="xs"
+                :icon="
+                  expandedRow != props.row.pipeline_id
+                    ? 'expand_more'
+                    : 'expand_less'
+                "
+              />
+            </q-td>
+            <q-td v-for="col in filterColumns()" :key="col.name" :props="props">
+              <template v-if="col.name !== 'actions'">
+                {{ props.row[col.field] }}
+              </template>
+              <template v-else>
+                <!-- Actions Buttons -->
+                <q-btn
+                  :data-test="`pipeline-list-${props.row.name}-pause-start-alert`"
+                  :icon="props.row.enabled ? outlinedPause : outlinedPlayArrow"
+                  class="q-ml-xs material-symbols-outlined"
+                  padding="sm"
+                  unelevated
+                  size="sm"
+                  :color="props.row.enabled ? 'negative' : 'positive'"
+                  round
+                  flat
+                  :title="
+                    props.row.enabled ? t('alerts.pause') : t('alerts.start')
+                  "
+                  @click.stop="toggleAlertState(props.row)"
+                />
+                <q-btn
+                  :data-test="`pipeline-list-${props.row.name}-update-pipeline`"
+                  icon="edit"
+                  class="q-ml-xs"
+                  padding="sm"
+                  unelevated
+                  size="sm"
+                  round
+                  flat
+                  :title="t('pipeline.edit')"
+                  @click.stop="editPipeline(props.row)"
+                ></q-btn>
+                <q-btn
+                  :data-test="`pipeline-list-${props.row.name}-export-pipeline`"
+                  icon="download"
+                  class="q-ml-xs"
+                  padding="sm"
+                  unelevated
+                  size="sm"
+                  round
+                  flat
+                  :title="t('pipeline.export')"
+                  @click.stop="exportPipeline(props.row)"
+                ></q-btn>
+                <q-btn
+                  :data-test="`pipeline-list-${props.row.name}-delete-pipeline`"
+                  :icon="outlinedDelete"
+                  class="q-ml-xs"
+                  padding="sm"
+                  unelevated
+                  size="sm"
+                  round
+                  flat
+                  :title="t('pipeline.delete')"
+                  @click.stop="openDeleteDialog(props.row)"
+                ></q-btn>
+                <q-btn
+                  :data-test="`pipeline-list-${props.row.name}-view-pipeline`"
+                  :icon="outlinedVisibility"
+                  class="q-ml-xs"
+                  padding="sm"
+                  unelevated
+                  size="sm"
+                  round
+                  flat
+                  :title="t('pipeline.view')"
+                >
+                  <q-tooltip position="bottom">
+                    <PipelineView :pipeline="props.row" />
+                  </q-tooltip>
+                </q-btn>
+              </template>
+            </q-td>
+          </q-tr>
+          <q-tr
+            data-test="scheduled-pipeline-row-expand"
+            v-show="expandedRow === props.row.pipeline_id"
+            :props="props"
+          >
+            <q-td v-if="props.row?.sql_query" colspan="100%">
+              <div
+                data-test="scheduled-pipeline-expanded-content"
+                class="text-left tw-px-2 q-mb-sm expanded-content"
               >
-              <q-tooltip position="bottom">
-                <PipelineView :pipeline="props.row" />
-              </q-tooltip>
-            </q-btn>
-            </template>
-          </q-td>
-        </q-tr>
-        <q-tr data-test="scheduled-pipeline-row-expand" v-show="expandedRow === props.row.pipeline_id" :props="props" >
-         
-          <q-td v-if="props.row?.sql_query"  colspan="100%">
-
-            <div data-test="scheduled-pipeline-expanded-content" class="text-left tw-px-2 q-mb-sm  expanded-content">
-            <div class="tw-flex tw-items-center q-py-sm  ">
-              <strong >SQL Query : <span></span></strong>
-            </div>
-              <div class="tw-flex tw-items-start  tw-justify-center" >
-            
-              <div data-test="scheduled-pipeline-expanded-sql" class="scrollable-content  expanded-sql ">
-                <pre style="text-wrap: wrap;">{{ props.row?.sql_query  }} </pre>
-
+                <div class="tw-flex tw-items-center q-py-sm">
+                  <strong>SQL Query : <span></span></strong>
+                </div>
+                <div class="tw-flex tw-items-start tw-justify-center">
+                  <div
+                    data-test="scheduled-pipeline-expanded-sql"
+                    class="scrollable-content expanded-sql"
+                  >
+                    <pre style="text-wrap: wrap"
+                      >{{ props.row?.sql_query }} </pre
+                    >
+                  </div>
+                </div>
               </div>
             </q-td>
           </q-tr>
@@ -159,20 +171,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <no-data />
         </template>
         <template #header-selection="scope">
-              <q-checkbox
-                v-model="scope.selected"
-                size="sm"
-                color="secondary"
-              />
-            </template>
-            <template v-slot:body-selection="scope">
-              <q-checkbox
-                v-model="scope.selected"
-                size="sm"
-                color="secondary"
-              />
-            </template>
- 
+          <q-checkbox v-model="scope.selected" size="sm" color="secondary" />
+        </template>
+        <template v-slot:body-selection="scope">
+          <q-checkbox v-model="scope.selected" size="sm" color="secondary" />
+        </template>
+
         <template v-slot:body-cell-function="props">
           <q-td :props="props">
             <q-tooltip>
@@ -238,25 +242,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </template>
 
         <template #bottom="scope">
-              <div class="bottom-btn">
-                <q-btn
-                  v-if="selectedPipelines.length > 0"
-                  data-test="pipeline-list-export-pipelines-btn"
-                  class="flex items-center tw-w-[14vw] no-border"
-                  color="secondary"
-                  icon="download"
-                  :label="'Export'"
-                  @click="exportBulkPipelines"
-                />
-                <QTablePagination
-                  :scope="scope"
-                  :position="'bottom'"
-                  :resultTotal="resultTotal"
-                  :perPageOptions="perPageOptions"
-                  @update:changeRecordPerPage="changePagination"
-                />
-              </div>
-            </template>
+          <div class="bottom-btn">
+            <q-btn
+              v-if="selectedPipelines.length > 0"
+              data-test="pipeline-list-export-pipelines-btn"
+              class="flex items-center tw-w-[14vw] no-border"
+              color="secondary"
+              icon="download"
+              :label="'Export'"
+              @click="exportBulkPipelines"
+            />
+            <QTablePagination
+              :scope="scope"
+              :position="'bottom'"
+              :resultTotal="resultTotal"
+              :perPageOptions="perPageOptions"
+              @update:changeRecordPerPage="changePagination"
+            />
+          </div>
+        </template>
       </q-table>
     </div>
   </div>
@@ -391,7 +395,6 @@ const changePagination = (val: { label: string; value: any }) => {
 };
 
 const selectedPipelines = ref<any[]>([]);
-
 
 const currentRouteName = computed(() => {
   return router.currentRoute.value.name;
@@ -780,7 +783,7 @@ const routeToAddPipeline = () => {
       org_identifier: store.state.selectedOrganization.identifier,
     },
   });
-}
+};
 
 const exportPipeline = (row: any) => {
   const pipelineToBeExported = row.name;
@@ -813,19 +816,19 @@ const routeToImportPipeline = () => {
       org_identifier: store.state.selectedOrganization.identifier,
     },
   });
-}
+};
 
 const exportBulkPipelines = () => {
   // Create an array of selected pipelines without modifying their structure
   const pipelinesToExport = selectedPipelines.value;
-  
+
   const exportJson = JSON.stringify(pipelinesToExport, null, 2);
-    const blob = new Blob([exportJson], { type: 'application/json' });
+  const blob = new Blob([exportJson], { type: "application/json" });
 
   const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
+  const link = document.createElement("a");
   link.href = url;
-  const date = new Date().toISOString().split('T')[0];
+  const date = new Date().toISOString().split("T")[0];
   link.download = `pipelines_export_${date}.json`;
 
   link.click();
@@ -839,7 +842,7 @@ const exportBulkPipelines = () => {
     position: "bottom",
     timeout: 3000,
   });
-}
+};
 </script>
 <style lang="scss" scoped>
 .pipeline-list-table {
@@ -959,9 +962,4 @@ const exportBulkPipelines = () => {
   justify-content: space-between;
   align-items: center;
 }
-
-
-
-
-
 </style>

--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -17,8 +17,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <template>
   <div v-if="currentRouteName === 'pipelines'">
     <div
-      :class="store.state.theme === 'dark' ? 'dark-mode dark-theme' : 'light-theme light-mode'"
-     class="full-wdith pipeline-list-table">
+      :class="
+        store.state.theme === 'dark'
+          ? 'dark-mode dark-theme'
+          : 'light-theme light-mode'
+      "
+      class="full-wdith pipeline-list-table"
+    >
       <q-table
         data-test="pipeline-list-table"
         ref="qTableRef"
@@ -147,14 +152,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <pre style="text-wrap: wrap;">{{ props.row?.sql_query  }} </pre>
 
               </div>
-              
-              
-              </div>
-            </div>
-
-          </q-td>
-        </q-tr>
-      </template>
+            </q-td>
+          </q-tr>
+        </template>
         <template #no-data>
           <no-data />
         </template>
@@ -176,7 +176,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <template v-slot:body-cell-function="props">
           <q-td :props="props">
             <q-tooltip>
-              <pre data-test="scheduled-pipeline-expanded-tooltip-sql">{{ props.row.sql }}</pre>
+              <pre data-test="scheduled-pipeline-expanded-tooltip-sql">{{
+                props.row.sql
+              }}</pre>
             </q-tooltip>
             <pre style="white-space: break-spaces">{{ props.row.sql }}</pre>
           </q-td>
@@ -184,39 +186,37 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <template #top="scope">
           <div class="q-table__title" data-test="pipeline-list-title">
             {{ t("pipeline.header") }}
-            
           </div>
           <div class="tw-flex tw-items-center report-list-tabs q-ml-auto">
-
-          <app-tabs
-                data-test="pipeline-list-tabs"
-                class="q-mr-md "
-                :tabs="tabs"
-                v-model:active-tab="activeTab"
-                @update:active-tab="updateActiveTab"
-              />
-          <q-input
-            data-test="pipeline-list-search-input"
-            v-model="filterQuery"
-            borderless
-            filled
-            dense
-            class=" q-mb-xs no-border"
-            :placeholder="t('pipeline.search')"
-          >
-            <template #prepend>
-              <q-icon name="search" class="cursor-pointer" />
-            </template>
-          </q-input>
-          <q-btn
+            <app-tabs
+              data-test="pipeline-list-tabs"
+              class="q-mr-md"
+              :tabs="tabs"
+              v-model:active-tab="activeTab"
+              @update:active-tab="updateActiveTab"
+            />
+            <q-input
+              data-test="pipeline-list-search-input"
+              v-model="filterQuery"
+              borderless
+              filled
+              dense
+              class="q-mb-xs no-border"
+              :placeholder="t('pipeline.search')"
+            >
+              <template #prepend>
+                <q-icon name="search" class="cursor-pointer" />
+              </template>
+            </q-input>
+            <q-btn
               data-test="pipeline-list-import-pipeline-btn"
               class="q-ml-md q-mb-xs text-bold"
               padding="sm lg"
               no-caps
               :label="t(`pipeline.import`)"
               @click="routeToImportPipeline"
-          />
-          <q-btn
+            />
+            <q-btn
               data-test="pipeline-list-add-pipeline-btn"
               class="q-ml-md q-mb-xs text-bold no-border"
               padding="sm lg"
@@ -224,8 +224,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               no-caps
               :label="t(`pipeline.addPipeline`)"
               @click="routeToAddPipeline"
-          />
-        </div>
+            />
+          </div>
 
           <q-table-pagination
             :scope="scope"
@@ -276,18 +276,31 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   />
 </template>
 <script setup lang="ts">
-import { ref, onBeforeMount, computed, watch, reactive, onActivated, onMounted } from "vue";
-import {MarkerType} from "@vue-flow/core";
+import {
+  ref,
+  onBeforeMount,
+  computed,
+  watch,
+  reactive,
+  onActivated,
+  onMounted,
+} from "vue";
+import { MarkerType } from "@vue-flow/core";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import StreamSelection from "./StreamSelection.vue";
 import pipelineService from "@/services/pipelines";
 import { useStore } from "vuex";
-import { useQuasar, type QTableProps  } from "quasar";
-import type { QTableColumn } from 'quasar';
+import { useQuasar, type QTableProps } from "quasar";
+import type { QTableColumn } from "quasar";
 
 import NoData from "../shared/grid/NoData.vue";
-import { outlinedDelete , outlinedPause , outlinedPlayArrow, outlinedVisibility } from "@quasar/extras/material-icons-outlined";
+import {
+  outlinedDelete,
+  outlinedPause,
+  outlinedPlayArrow,
+  outlinedVisibility,
+} from "@quasar/extras/material-icons-outlined";
 import QTablePagination from "@/components/shared/grid/Pagination.vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import useDragAndDrop from "@/plugins/pipelines/useDnD";
@@ -304,8 +317,6 @@ interface Column {
   sortable?: boolean;
 }
 
-
-
 const { t } = useI18n();
 const router = useRouter();
 
@@ -317,7 +328,7 @@ const filterQuery = ref("");
 
 const showCreatePipeline = ref(false);
 
-const  expandedRow : any = ref( []); // Array to track expanded rows
+const expandedRow: any = ref([]); // Array to track expanded rows
 
 const pipelines = ref([]);
 
@@ -342,11 +353,11 @@ const confirmDialogMeta: any = ref({
   onConfirm: () => {},
 });
 const activeTab = ref("all");
-const filteredPipelines : any = ref([]);
+const filteredPipelines: any = ref([]);
 const columns: any = ref([]);
 
-const tabs = reactive ([
-{
+const tabs = reactive([
+  {
     label: "All",
     value: "all",
   },
@@ -365,7 +376,7 @@ const perPageOptions: any = [
   { label: "10", value: 10 },
   { label: "20", value: 20 },
   { label: "50", value: 50 },
-  { label: "100", value: 100 }
+  { label: "100", value: 100 },
 ];
 const resultTotal = ref<number>(0);
 const maxRecordToReturn = ref<number>(100);
@@ -386,8 +397,8 @@ const currentRouteName = computed(() => {
   return router.currentRoute.value.name;
 });
 
-const filterColumns   = () : Column[] => {
-  if(activeTab.value === "realtime" || activeTab.value === "all"){
+const filterColumns = (): Column[] => {
+  if (activeTab.value === "realtime" || activeTab.value === "all") {
     return columns.value;
   }
 
@@ -396,96 +407,155 @@ const filterColumns   = () : Column[] => {
 
 const updateActiveTab = () => {
   if (activeTab.value === "all") {
-    filteredPipelines.value = pipelines.value.map((pipeline : any, index : any) => ({
-      ...pipeline,
-      "#": index + 1,
-    }));
+    filteredPipelines.value = pipelines.value.map(
+      (pipeline: any, index: any) => ({
+        ...pipeline,
+        "#": index + 1,
+      }),
+    );
     columns.value = getColumnsForActiveTab(activeTab.value);
     filteredPipelines.value = pipelines.value;
     resultTotal.value = pipelines.value.length;
     return;
   }
 
-
-
-
   filteredPipelines.value = pipelines.value
-    .filter((pipeline : any) => pipeline.source.source_type === activeTab.value)
-    .map((pipeline : any, index) => ({
+    .filter((pipeline: any) => pipeline.source.source_type === activeTab.value)
+    .map((pipeline: any, index) => ({
       ...pipeline,
       "#": index + 1,
     }));
 
   resultTotal.value = filteredPipelines.value.length;
   columns.value = getColumnsForActiveTab(activeTab.value);
-
 };
 
-
-const toggleAlertState = (row : any) =>{
+const toggleAlertState = (row: any) => {
   const newState = !row.enabled;
-  pipelineService.toggleState(store.state.selectedOrganization.identifier,row.pipeline_id,newState).then((response) => {
-    row.enabled = newState;
-    const message = row.enabled 
-    ? `${row.name} state resumed successfully` 
-    : `${row.name} state paused successfully`;
-    q.notify({
-      message: message,
-      color: "positive",
-      position: "bottom",
-      timeout: 3000,
-    });
-  }).catch((error) => {
-    if(error.response.status != 403){
+  pipelineService
+    .toggleState(
+      store.state.selectedOrganization.identifier,
+      row.pipeline_id,
+      newState,
+    )
+    .then((response) => {
+      row.enabled = newState;
+      const message = row.enabled
+        ? `${row.name} state resumed successfully`
+        : `${row.name} state paused successfully`;
       q.notify({
-      message: error.response?.data?.message || "Error while updating pipeline state",
-      color: "negative",
-      position: "bottom",
-      timeout: 3000,
+        message: message,
+        color: "positive",
+        position: "bottom",
+        timeout: 3000,
+      });
+    })
+    .catch((error) => {
+      if (error.response.status != 403) {
+        q.notify({
+          message:
+            error.response?.data?.message ||
+            "Error while updating pipeline state",
+          color: "negative",
+          position: "bottom",
+          timeout: 3000,
+        });
+      }
     });
-    }
-  });
-}
+};
 
-const triggerExpand = (props : any) =>{
-  if (expandedRow.value === props.row.pipeline_id || props.row.source.source_type === 'realtime') {
-      expandedRow.value = null;
-    } else {
-      // Otherwise, expand the clicked row and collapse any other row
-      expandedRow.value = props.row.pipeline_id;
+const triggerExpand = (props: any) => {
+  if (
+    expandedRow.value === props.row.pipeline_id ||
+    props.row.source.source_type === "realtime"
+  ) {
+    expandedRow.value = null;
+  } else {
+    // Otherwise, expand the clicked row and collapse any other row
+    expandedRow.value = props.row.pipeline_id;
   }
-}
+};
 
 const editingPipeline = ref<any | null>(null);
-
 
 // const updateActiveTab = (tab: string) => {
 //   isRealTime.value = tab === "realTime";
 // };
 
-
-const getColumnsForActiveTab = (tab : any) => {
+const getColumnsForActiveTab = (tab: any) => {
   let realTimeColumns = [
-  { name: "#", label: "#", field: "#", align: "left" },
+    { name: "#", label: "#", field: "#", align: "left" },
 
-  { name: "name", field: "name", label: t("common.name"), align: "left", sortable: true },
-    { name: "stream_name", field: "stream_name", label: t("alerts.stream_name"), align: "left", sortable: true },
-    { name: "stream_type", field: "stream_type", label: t("alerts.streamType"), align: "left", sortable: true },
+    {
+      name: "name",
+      field: "name",
+      label: t("common.name"),
+      align: "left",
+      sortable: true,
+    },
+    {
+      name: "stream_name",
+      field: "stream_name",
+      label: t("alerts.stream_name"),
+      align: "left",
+      sortable: true,
+    },
+    {
+      name: "stream_type",
+      field: "stream_type",
+      label: t("alerts.streamType"),
+      align: "left",
+      sortable: true,
+    },
   ];
 
   let scheduledColumns = [
     { name: "#", label: "#", field: "#", align: "left" },
 
-    { name: "name", field: "name", label: t("common.name"), align: "left", sortable: true },
-    { name: "stream_type", field: "stream_type", label: "Stream Type", align: "left", sortable: true },
-    { name: "frequency", field: "frequency", label: "Frequency", align: "left", sortable: true },
-    { name: "period", field: "period", label: "Period", align: "left", sortable: true },
-    { name: "cron", field: "cron", label: "Cron", align: "left", sortable: false },
-    { name: "sql_query", field: "sql_query", label: "SQL Query", align: "left", sortable: false
-      ,
-      style: "white-space: no-wrap; max-width: 200px; overflow: hidden; text-overflow: ellipsis;"
-
-     },
+    {
+      name: "name",
+      field: "name",
+      label: t("common.name"),
+      align: "left",
+      sortable: true,
+    },
+    {
+      name: "stream_type",
+      field: "stream_type",
+      label: "Stream Type",
+      align: "left",
+      sortable: true,
+    },
+    {
+      name: "frequency",
+      field: "frequency",
+      label: "Frequency",
+      align: "left",
+      sortable: true,
+    },
+    {
+      name: "period",
+      field: "period",
+      label: "Period",
+      align: "left",
+      sortable: true,
+    },
+    {
+      name: "cron",
+      field: "cron",
+      label: "Cron",
+      align: "left",
+      sortable: false,
+    },
+    {
+      name: "sql_query",
+      field: "sql_query",
+      label: "SQL Query",
+      align: "left",
+      sortable: false,
+      style:
+        "white-space: no-wrap; max-width: 200px; overflow: hidden; text-overflow: ellipsis;",
+    },
   ];
 
   const actionsColumn = {
@@ -495,80 +565,95 @@ const getColumnsForActiveTab = (tab : any) => {
     align: "center",
     sortable: false,
   };
-if(tab === "all"){
+  if (tab === "all") {
+    const allColumns = [...scheduledColumns, actionsColumn];
+    allColumns.splice(2, 0, {
+      name: "type",
+      field: "type",
+      label: "Type",
+      align: "left",
+      sortable: true,
+    });
 
-  
-  const allColumns = [ ...scheduledColumns, actionsColumn];
-  allColumns.splice(2,0 , { name: "type", field: "type", label: 'Type', align: "left", sortable: true });
+    allColumns.splice(3, 0, {
+      name: "stream_name",
+      field: "stream_name",
+      label: t("alerts.stream_name"),
+      align: "left",
+      sortable: true,
+    });
 
-  allColumns.splice(3,0 , { name: "stream_name", field: "stream_name", label: t("alerts.stream_name"), align: "left", sortable: true });
-
-  return allColumns;
-}
+    return allColumns;
+  }
   return tab === "realtime"
-    ? [ ...realTimeColumns, actionsColumn]
-    : [ ...scheduledColumns, actionsColumn];
+    ? [...realTimeColumns, actionsColumn]
+    : [...scheduledColumns, actionsColumn];
 };
 
-
-  onMounted(async () => {
-      await getPipelines(); // Ensure pipelines are fetched before updating
-      updateActiveTab();
-    });
+onMounted(async () => {
+  await getPipelines(); // Ensure pipelines are fetched before updating
+  updateActiveTab();
+});
 
 const createPipeline = () => {
   showCreatePipeline.value = true;
 };
 
 const getPipelines = async () => {
-      try {
-        const response = await pipelineService.getPipelines(store.state.selectedOrganization.identifier);
-        pipelines.value = [];
-        // resultTotal.value = response.data.list.length;
-        pipelines.value = response.data.list.map((pipeline : any, index : any) => {
-          const updatedEdges = pipeline.edges.map((edge : any) => ({
-            ...edge,
-            markerEnd: {
-                type: MarkerType.ArrowClosed,
-                width: 20,  // Increase arrow width
-                height: 20, // Increase arrow height
-              },
-              type: 'custom',
-              
-              style:{
-                strokeWidth: 2,
-              },
-              animated: true,
-            updatable: true 
-          }));
-          pipeline.type = pipeline.source.source_type;
-          if (pipeline.source.source_type === 'realtime') {
-            pipeline.stream_name = pipeline.source.stream_name;
-            pipeline.stream_type = pipeline.source.stream_type;
-          } else {
-            pipeline.stream_type = pipeline.source.stream_type;
-            pipeline.frequency = pipeline.source.trigger_condition.frequency_type == 'minutes' ? pipeline.source.trigger_condition.frequency + " Mins" : pipeline.source.trigger_condition.cron
-            pipeline.period = pipeline.source.trigger_condition.period + " Mins";
-            pipeline.cron = pipeline.source.trigger_condition.frequency_type == 'minutes' ? 'False' : 'True';
-            pipeline.sql_query = pipeline.source.query_condition.sql;
-          }
+  try {
+    const response = await pipelineService.getPipelines(
+      store.state.selectedOrganization.identifier,
+    );
+    pipelines.value = [];
+    // resultTotal.value = response.data.list.length;
+    pipelines.value = response.data.list.map((pipeline: any, index: any) => {
+      const updatedEdges = pipeline.edges.map((edge: any) => ({
+        ...edge,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20, // Increase arrow width
+          height: 20, // Increase arrow height
+        },
+        type: "custom",
 
-          pipeline.edges = updatedEdges;
-          return {
-            ...pipeline,
-            "#": index + 1,
-          };
-        });
-      } catch (error) {
-        console.error(error);
+        style: {
+          strokeWidth: 2,
+        },
+        animated: true,
+        updatable: true,
+      }));
+      pipeline.type = pipeline.source.source_type;
+      if (pipeline.source.source_type === "realtime") {
+        pipeline.stream_name = pipeline.source.stream_name;
+        pipeline.stream_type = pipeline.source.stream_type;
+      } else {
+        pipeline.stream_type = pipeline.source.stream_type;
+        pipeline.frequency =
+          pipeline.source.trigger_condition.frequency_type == "minutes"
+            ? pipeline.source.trigger_condition.frequency + " Mins"
+            : pipeline.source.trigger_condition.cron;
+        pipeline.period = pipeline.source.trigger_condition.period + " Mins";
+        pipeline.cron =
+          pipeline.source.trigger_condition.frequency_type == "minutes"
+            ? "False"
+            : "True";
+        pipeline.sql_query = pipeline.source.query_condition.sql;
       }
-    };
+
+      pipeline.edges = updatedEdges;
+      return {
+        ...pipeline,
+        "#": index + 1,
+      };
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};
 const editPipeline = (pipeline: any) => {
-  pipeline.nodes.forEach((node : any) => {
+  pipeline.nodes.forEach((node: any) => {
     node.type = node.io_type;
   });
-
-  console.log(pipeline,'pipeline')
 
   pipelineObj.currentSelectedPipeline = pipeline;
   pipelineObj.pipelineWithoutChange = pipeline;
@@ -616,15 +701,16 @@ const savePipeline = (data: any) => {
     })
     .catch((error) => {
       dismiss();
-      if(error.response.status != 403){
+      if (error.response.status != 403) {
         q.notify({
-        message: error.response?.data?.message || "Error while saving pipeline",
-        color: "negative",
-        position: "bottom",
-        timeout: 3000,
-      });
-      } 
-    })
+          message:
+            error.response?.data?.message || "Error while saving pipeline",
+          color: "negative",
+          position: "bottom",
+          timeout: 3000,
+        });
+      }
+    });
 };
 
 const deletePipeline = async () => {
@@ -633,15 +719,14 @@ const deletePipeline = async () => {
     position: "bottom",
     spinner: true,
   });
-  const { pipeline_id} = confirmDialogMeta.value.data;
+  const { pipeline_id } = confirmDialogMeta.value.data;
   const org_id = store.state.selectedOrganization.identifier;
   pipelineService
     .deletePipeline({
       pipeline_id,
-      org_id
+      org_id,
     })
     .then(async () => {
-     
       q.notify({
         message: "Pipeline deleted successfully",
         color: "positive",
@@ -650,20 +735,21 @@ const deletePipeline = async () => {
       });
     })
     .catch((error) => {
-      if(error.response.status != 403){
+      if (error.response.status != 403) {
         q.notify({
-        message: error.response?.data?.message || "Error while deleting pipeline",
-        color: "negative",
-        position: "bottom",
-        timeout: 3000,
-      });
+          message:
+            error.response?.data?.message || "Error while deleting pipeline",
+          color: "negative",
+          position: "bottom",
+          timeout: 3000,
+        });
       }
     })
     .finally(async () => {
       selectedPipelines.value = [];
       await getPipelines();
       updateActiveTab();
-         dismiss();
+      dismiss();
     });
 
   resetConfirmDialog();
@@ -697,31 +783,30 @@ const routeToAddPipeline = () => {
 }
 
 const exportPipeline = (row: any) => {
+  const pipelineToBeExported = row.name;
 
-  const pipelineToBeExported = row.name
+  const pipelineJson = JSON.stringify(row, null, 2);
+  // Create a Blob from the JSON string
+  const blob = new Blob([pipelineJson], { type: "application/json" });
 
-  const pipelineJson  = JSON.stringify(row,null, 2);
-    // Create a Blob from the JSON string
-    const blob = new Blob([pipelineJson], { type: 'application/json' });
+  // Create an object URL for the Blob
+  const url = URL.createObjectURL(blob);
 
-    // Create an object URL for the Blob
-    const url = URL.createObjectURL(blob);
+  // Create an anchor element to trigger the download
+  const link = document.createElement("a");
+  link.href = url;
 
-    // Create an anchor element to trigger the download
-    const link = document.createElement('a');
-    link.href = url;
+  // Set the filename of the download
+  link.download = `${pipelineToBeExported}.json`;
 
-    // Set the filename of the download
-    link.download = `${pipelineToBeExported}.json`;
+  // Trigger the download by simulating a click
+  link.click();
 
-    // Trigger the download by simulating a click
-    link.click();
+  // Clean up the URL object after download
+  URL.revokeObjectURL(url);
+};
 
-    // Clean up the URL object after download
-    URL.revokeObjectURL(url);
-}
-
-const routeToImportPipeline = () =>{
+const routeToImportPipeline = () => {
   router.push({
     name: "importPipeline",
     query: {
@@ -765,7 +850,6 @@ const exportBulkPipelines = () => {
     z-index: 1;
     box-shadow: -4px 0px 4px 0 rgba(0, 0, 0, 0.1);
     width: 100px;
-    
   }
 }
 
@@ -775,18 +859,14 @@ const exportBulkPipelines = () => {
     background: var(--q-dark);
     box-shadow: -4px 0px 4px 0 rgba(144, 144, 144, 0.1);
     width: 100px;
-
-
   }
 }
 
 .light-theme {
-
   th:last-child,
   td:last-child {
     background: #ffffff;
     width: 100px;
-
   }
 }
 .dark-mode {
@@ -811,7 +891,7 @@ const exportBulkPipelines = () => {
     }
   }
 }
-  .report-list-tabs {
+.report-list-tabs {
   height: fit-content;
 
   :deep(.rum-tabs) {
@@ -838,7 +918,7 @@ const exportBulkPipelines = () => {
 }
 
 .expanded-content {
-  padding: 0  3rem;
+  padding: 0 3rem;
   max-height: 100vh; /* Set a fixed height for the container */
   overflow: hidden; /* Hide overflow by default */
 }
@@ -850,22 +930,21 @@ const exportBulkPipelines = () => {
   border: 1px solid #ddd; /* Optional: border for visibility */
   height: 100%;
   max-height: 200px;
-   /* Use the full height of the parent */
+  /* Use the full height of the parent */
   text-wrap: normal;
   background-color: #e8e8e8;
   color: black;
 }
-.expanded-sql{
-  border-left: #7A54A2 3px solid;
+.expanded-sql {
+  border-left: #7a54a2 3px solid;
 }
-
 
 :deep(.pipeline-list-table thead th:last-child) {
   position: sticky;
   right: 0;
-    z-index: 1;
-    box-shadow: -4px 0px 4px 0 rgba(0, 0, 0, 0.1);
-    width: 100px;
+  z-index: 1;
+  box-shadow: -4px 0px 4px 0 rgba(0, 0, 0, 0.1);
+  width: 100px;
 }
 
 :deep(.dark-theme.pipeline-list-table thead th:last-child) {

--- a/web/src/components/pipeline/StreamSelection.vue
+++ b/web/src/components/pipeline/StreamSelection.vue
@@ -212,11 +212,10 @@ const isValidName = computed(() => {
 
 const updateStreams = (resetStream = true) => {
   if (resetStream) formData.value.stream_name = "";
-console.log(formData.value.stream_type,"type in res");
   if (!formData.value.stream_type) return Promise.resolve();
 
   isFetchingStreams.value = true;
-  
+
   return getStreams(formData.value.stream_type, false)
     .then((res: any) => {
       indexOptions.value = res.list.map((data: any) => {
@@ -244,7 +243,7 @@ const filterColumns = (options: any[], val: String, update: Function) => {
   update(() => {
     const value = val.toLowerCase();
     filteredOptions = options.filter(
-      (column: any) => column.toLowerCase().indexOf(value) > -1
+      (column: any) => column.toLowerCase().indexOf(value) > -1,
     );
   });
   return filteredOptions;

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1707,16 +1707,12 @@ const useLogs = () => {
       }
       // Reset cancel query on new search request initation
       searchObj.data.isOperationCancelled = false;
-      searchObj.data.searchRequestTraceIds = [];
-      searchObj.data.searchWebSocketTraceIds = [];
 
       // get websocket enable config from store
       // window will have more priority
       // if window has use_web_socket property then use that
       // else use organization settings
       searchObj.meta.jobId = "";
-      const shouldUseWebSocket = isWebSocketEnabled(store.state);
-      const shouldUseStreaming = isStreamingEnabled(store.state);
 
       setCommunicationMethod();
 

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -4541,6 +4541,7 @@ const useLogs = () => {
 
       const streamDataResults = await Promise.all(streamDataPromises);
 
+      // TODO : We can optimize filter + flatMap using a single reducer function
       // Collect all schema fields
       const allStreamFields = streamDataResults
         .filter((data) => data?.schema)
@@ -4550,8 +4551,7 @@ const useLogs = () => {
       searchObj.data.stream.selectedStreamFields = allStreamFields;
       //check if allStreamFields is empty or not 
       //if empty then we are displaying no events found... message on the UI instead of throwing in an error format
-      if (allStreamFields.length === 0) {
-
+      if (!allStreamFields.length) {
         // searchObj.data.errorMsg = t("search.noFieldFound");
         return;
       }
@@ -4696,6 +4696,7 @@ const useLogs = () => {
 
         if (!searchObj.data.searchRequestTraceIds.length) {
           searchObj.data.isOperationCancelled = false;
+          resolve(true);
           return;
         }
 

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -6326,9 +6326,15 @@ const useLogs = () => {
       errorMsg = message;
     }
 
-    searchObj.data.errorDetail = error_detail || "";
-    searchObj.data.errorMsg = errorMsg;
-    notificationMsg.value = errorMsg;
+    if(request.type === 'pageCount') {
+      searchObj.data.countErrorMsg = "Error while retrieving total events: ";
+      if (trace_id) searchObj.data.countErrorMsg += " TraceID: " + trace_id;
+      notificationMsg.value = searchObj.data.countErrorMsg;
+    } else {
+      searchObj.data.errorDetail = error_detail || "";
+      searchObj.data.errorMsg = errorMsg;
+      notificationMsg.value = errorMsg;
+    }
   };
 
   const constructErrorMessage = ({

--- a/web/src/composables/usePromqlSuggestions.ts
+++ b/web/src/composables/usePromqlSuggestions.ts
@@ -101,7 +101,6 @@ const usePromlqSuggestions = () => {
         const value = hasCurlyBraces[0][cursorIndex - start];
         const nextValue = hasCurlyBraces[0][cursorIndex - start + 1];
 
-        console.log("value", value);
         // Check is value
         if ((value === '"' && nextValue !== "}") || value === "=") {
           labelMeta["focusOn"] = "value";

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -576,6 +576,7 @@ export default defineComponent({
       initialLogsState,
       clearSearchObj,
       setCommunicationMethod,
+      cancelQuery,
     } = useLogs();
     const searchResultRef = ref(null);
     const searchBarRef = ref(null);
@@ -671,7 +672,8 @@ export default defineComponent({
       if (store.state.refreshIntervalID)
         clearInterval(store.state.refreshIntervalID);
 
-      cancelOnGoingSearchQueries();
+      cancelQuery();
+
       removeAiContextHandler();
 
       try {

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -1932,10 +1932,6 @@ export default defineComponent({
                   onStreamChange(searchObj.data.query);
                 }
               });
-              console.log(
-                "searchObj.data.streamResults.list",
-                JSON.parse(JSON.stringify(searchObj.data.streamResults.list)),
-              );
 
               if (streamFound == false) {
                 // searchObj.data.stream.selectedStream = { label: "", value: "" };
@@ -2662,7 +2658,7 @@ export default defineComponent({
                 searchObj.shouldIgnoreWatcher = false;
               } catch (e) {
                 searchObj.shouldIgnoreWatcher = false;
-                console.log(e);
+                console.log("Error while applying saved view", e);
               }
             }, 1000);
 
@@ -2714,7 +2710,7 @@ export default defineComponent({
             position: "bottom",
             timeout: 1000,
           });
-          console.log(err);
+          console.log("Error while applying saved view", err);
         });
     };
 
@@ -2788,7 +2784,7 @@ export default defineComponent({
               position: "bottom",
               timeout: 1000,
             });
-            console.log(err);
+            console.log("Error while deleting saved view", err);
           });
       } catch (e: any) {
         console.log("Error while getting saved views", e);
@@ -2884,7 +2880,7 @@ export default defineComponent({
               position: "bottom",
               timeout: 1000,
             });
-            console.log(err);
+            console.log("Error while creating saved view", err);
           });
       } catch (e: any) {
         isSavedViewAction.value = "create";
@@ -2958,7 +2954,7 @@ export default defineComponent({
               position: "bottom",
               timeout: 1000,
             });
-            console.log(err);
+            console.log("Error while updating saved view", err);
           });
       } catch (e: any) {
         isSavedViewAction.value = "create";
@@ -3157,7 +3153,6 @@ export default defineComponent({
               //     delete favoriteViewsList[key];
               //   }
               // }
-              console.log(favoriteViewsList);
               localSavedViews.value = favoriteViewsList;
             }
           }
@@ -3434,7 +3429,6 @@ export default defineComponent({
     };
 
     const selectTransform = (item: any, isSelected: boolean) => {
-      console.log("item", item);
       if (searchObj.data.transformType === "function") {
         populateFunctionImplementation(item, isSelected);
       }

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -3808,7 +3808,7 @@ export default defineComponent({
       this.resetEditorLayout();
     },
     resetFunction(newVal) {
-      if (newVal == "" && store?.state?.savedViewFlag == false) {
+      if (newVal == "" && store && !store?.state?.savedViewFlag) {
         this.resetFunctionContent();
       }
     },

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -316,7 +316,6 @@ import {
   onMounted,
   onUpdated,
   defineAsyncComponent,
-  watch,
 } from "vue";
 import { copyToClipboard, useQuasar } from "quasar";
 import { useStore } from "vuex";
@@ -603,7 +602,6 @@ export default defineComponent({
     };
 
     const getWidth = computed(() => {
-      console.log("get search width", searchListContainer);
       return "";
     });
 

--- a/web/src/plugins/pipelines/useDnD.ts
+++ b/web/src/plugins/pipelines/useDnD.ts
@@ -216,7 +216,6 @@ export default function useDragAndDrop() {
     if(changes.length > 0){
       pipelineObj.edgesChange = true;
     }
-    console.log("Edges change", changes);
   }
 
   function onConnect(connection:any) {

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -1116,8 +1116,6 @@ export default defineComponent({
     });
 
     const startResize = (event: any) => {
-      console.log("called");
-
       initialX.value = event.clientX;
       initialWidth.value = leftWidth.value;
 

--- a/web/src/plugins/traces/TraceTree.vue
+++ b/web/src/plugins/traces/TraceTree.vue
@@ -284,7 +284,6 @@ export default defineComponent({
     const updateSearch = () => {
       if (props.searchQuery?.trim()) {
         searchResults.value = findMatches(props.spanList, props.searchQuery);
-        console.log("Search Results", searchResults.value);
         currentIndex.value = 0; // Reset to first match
         nextTick(() => {
           scrollToMatch(); // Wait for DOM updates before scrolling

--- a/web/src/views/LogStream.vue
+++ b/web/src/views/LogStream.vue
@@ -730,7 +730,6 @@ export default defineComponent({
           }
 
           // Remove deleted streams from the list
-          console.log(selectedItems, "after deleting streams");
           selectedItems.forEach((stream: any) => {
             removeStream(stream.name, stream.stream_type);
             selected.value = selected.value.filter(


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement

1. Cancel running queries on changing stream 
2. When histogram query is running and user paginates loaded logs, cancel query button was getting disabled.
3. Removed console logs


___

### **Description**
- Convert cancelQuery to asynchronous promise

- Await query cancellation before stream change

- Add notifications on cancel success or failure

- Replace old cancelOnGoingSearchQueries call


___

### **Changes diagram**

```mermaid
flowchart LR
  A["onStreamChange"] -- "await cancelQuery()" --> B["cancelQuery Promise"]
  B -- "resolve" --> C["Reset query results"]
  C -- "continue" --> D["Stream reloaded"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Use cancelQuery on unmount</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/Index.vue

<li>Replace cancelOnGoingSearchQueries with cancelQuery<br> <li> Ensure cancellation before component unmount


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7438/files#diff-0323c3da69b369843c5d72bf4df5b00ca6b5147192a213baf331659ecf92af62">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useLogs.ts</strong><dd><code>Refactor cancelQuery to async promise</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs.ts

<li>Convert cancelQuery to return Promise<br> <li> Await cancelQuery in onStreamChange<br> <li> Add success/failure notifications<br> <li> Remove old traceIds after cancel


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7438/files#diff-1040f61354f92711e0e77ed4e9bfa15586d45a94c7e2ab06cc37372068030e7b">+55/-39</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>