### PR TITLE
feat: add env to show dashboard symbol

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1114,6 +1114,12 @@ pub struct Common {
     pub search_inspector_enabled: bool,
     #[env_config(name = "ZO_UTF8_VIEW_ENABLED", default = true)]
     pub utf8_view_enabled: bool,
+    #[env_config(
+        name = "ZO_DASHBOARD_SHOW_SYMBOL_ENABLED",
+        default = false,
+        help = "Enable to show symbol in dashboard"
+    )]
+    pub dashboard_show_symbol_enabled: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -133,6 +133,7 @@ struct ConfigResponse<'a> {
     max_query_range: i64,
     ai_enabled: bool,
     dashboard_placeholder: String,
+    dashboard_show_symbol_enabled: bool,
 }
 
 #[derive(Serialize)]
@@ -335,6 +336,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         max_query_range: cfg.limit.default_max_query_range_days * 24,
         ai_enabled,
         dashboard_placeholder: cfg.common.dashboard_placeholder.to_string(),
+        dashboard_show_symbol_enabled: cfg.common.dashboard_show_symbol_enabled,
     }))
 }
 

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -1568,6 +1568,8 @@ import Smooth from "@/components/icons/dashboards/Smooth.vue";
 import StepBefore from "@/components/icons/dashboards/StepBefore.vue";
 import StepAfter from "@/components/icons/dashboards/StepAfter.vue";
 import StepMiddle from "@/components/icons/dashboards/StepMiddle.vue";
+import { useStore } from "vuex";
+
 import { markRaw } from "vue";
 
 export default defineComponent({
@@ -1597,6 +1599,7 @@ export default defineComponent({
       dashboardPanelDataPageKey,
     );
     const { t } = useI18n();
+    const store = useStore();
 
     const basemapTypeOptions = [
       {
@@ -1685,7 +1688,9 @@ export default defineComponent({
       // by default, set show_symbol as false
       if (dashboardPanelData.data.config.show_symbol === undefined) {
         const isNewPanel = !dashboardPanelData.data.id;
-        dashboardPanelData.data.config.show_symbol = isNewPanel;
+        // if new panel, use config env
+        // else always false
+        dashboardPanelData.data.config.show_symbol = isNewPanel ? store?.state?.zoConfig?.dashboard_show_symbol_enabled ?? false : false;
       }
 
       // by default, set line interpolation as smooth

--- a/web/src/composables/useDashboardPanel.ts
+++ b/web/src/composables/useDashboardPanel.ts
@@ -38,7 +38,7 @@ const colors = [
 ];
 let parser: any;
 
-const getDefaultDashboardPanelData: any = () => ({
+const getDefaultDashboardPanelData: any = (store: any) => ({
   data: {
     version: 5,
     id: "",
@@ -68,7 +68,8 @@ const getDefaultDashboardPanelData: any = () => ({
         position: null,
         rotate: 0,
       },
-      show_symbol: true,
+      show_symbol:
+        store?.state?.zoConfig?.dashboard_show_symbol_enabled ?? false,
       line_interpolation: "smooth",
       legend_width: {
         value: null,
@@ -194,9 +195,7 @@ const getDefaultDashboardPanelData: any = () => ({
   },
 });
 
-const dashboardPanelDataObj: any = {
-  dashboard: reactive({ ...getDefaultDashboardPanelData() }),
-};
+const dashboardPanelDataObj: any = {};
 
 const getDefaultCustomChartText = () => {
   return `\ // To know more about ECharts , \n// visit: https://echarts.apache.org/examples/en/index.html \n// Example: https://echarts.apache.org/examples/en/editor.html?c=line-simple \n// Define your ECharts 'option' here. \n// 'data' variable is available for use and contains the response data from the search result and it is an array.\noption = {  \n \n};
@@ -211,7 +210,7 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
   // Initialize the state for this page key if it doesn't already exist
   if (!dashboardPanelDataObj[pageKey]) {
     dashboardPanelDataObj[pageKey] = reactive({
-      ...getDefaultDashboardPanelData(),
+      ...getDefaultDashboardPanelData(store),
     });
   }
 
@@ -227,7 +226,7 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
 
   // get default queries
   const getDefaultQueries = () => {
-    return getDefaultDashboardPanelData().data.queries;
+    return getDefaultDashboardPanelData(store).data.queries;
   };
 
   const addQuery = () => {
@@ -278,7 +277,7 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
   };
 
   const resetDashboardPanelData = () => {
-    Object.assign(dashboardPanelData, getDefaultDashboardPanelData());
+    Object.assign(dashboardPanelData, getDefaultDashboardPanelData(store));
   };
 
   const resetDashboardPanelDataAndAddTimeField = () => {


### PR DESCRIPTION
### **PR Type**
Enhancement

New Env: 
```sh
ZO_DASHBOARD_SHOW_SYMBOL_ENABLED=false # default
```

___

### **Description**
- Introduce env var ZO_DASHBOARD_SHOW_SYMBOL_ENABLED

- Add dashboard_show_symbol_enabled to Common config

- Include flag in ConfigResponse struct

- Return flag in /status HTTP endpoint


___

### **Changes diagram**

```mermaid
flowchart LR
  EC["EnvConfig: ZO_DASHBOARD_SHOW_SYMBOL_ENABLED"]
  CS["Common.dashboard_show_symbol_enabled"]
  CR["ConfigResponse.dashboard_show_symbol_enabled"]
  HR["/status HTTP response"]
  EC -- "load env var" --> CS
  CS -- "map to response" --> CR
  CR -- "included in JSON" --> HR
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add dashboard_show_symbol_enabled env config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<li>Added <code>ZO_DASHBOARD_SHOW_SYMBOL_ENABLED</code> env var<br> <li> Introduced <code>dashboard_show_symbol_enabled</code> boolean field


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7444/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Expose flag in status response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/status/mod.rs

<li>Added <code>dashboard_show_symbol_enabled</code> to ConfigResponse<br> <li> Mapped config field to HTTP response in zo_config


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7444/files#diff-ca09c9c9b020049bdbc3382c466bfcca80daac92e98760d9a9a76172abf34049">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>