### PR TITLE
fix: O2 ai add info

### DIFF
--- a/web/src/components/O2AIChat.vue
+++ b/web/src/components/O2AIChat.vue
@@ -247,12 +247,12 @@ import useAiChat from '@/composables/useAiChat';
 import { outlinedThumbUpOffAlt, outlinedThumbDownOffAlt } from '@quasar/extras/material-icons-outlined';
 import { getImageURL } from '@/utils/zincutils';
 
-interface ChatMessage {
+export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
 }
 
-interface ChatHistoryEntry {
+export interface ChatHistoryEntry {
   id: number;
   timestamp: string;
   title: string;
@@ -330,11 +330,16 @@ export default defineComponent({
     headerHeight: {
       type: Number,
       default: 0,
+    },
+    //this will be used to set the input message if the user sends the data from any page by clicking on the ai chat button
+    aiChatInputContext: {
+      type: String,
+      default: ''
     }
   },
   setup(props) {
     const $q = useQuasar();
-    const inputMessage = ref('');
+    const inputMessage = ref(props.aiChatInputContext ? props.aiChatInputContext : '');
     const chatMessages = ref<ChatMessage[]>([]);
     const isLoading = ref(false);
     const messagesContainer = ref<HTMLElement | null>(null);
@@ -400,6 +405,12 @@ export default defineComponent({
         messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight;
       }
     };
+
+    watch(() => props.aiChatInputContext, (newAiChatInputContext: string) => {
+      if(newAiChatInputContext) {
+        inputMessage.value = newAiChatInputContext;
+      }
+    });
 
 
     //fetchInitialMessage is called when the component is mounted and the isOpen prop is true

--- a/web/src/components/functions/AddFunction.vue
+++ b/web/src/components/functions/AddFunction.vue
@@ -110,6 +110,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :vrlFunction="formData"
               @function-error="handleFunctionError"
               :heightOffset="heightOffset"
+              @sendToAiChat="sendToAiChat"
             />
           </div>
         </template>
@@ -118,7 +119,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <div v-if="store.state.isAiChatEnabled && !isAddFunctionComponent" style="width: 25%; max-width: 100%; min-width: 75px;   " :class="store.state.theme == 'dark' ? 'dark-mode-chat-container' : 'light-mode-chat-container'" >
       <O2AIChat :style="{
         height: `calc(100vh - (112px + ${heightOffset}px))`
-      }"  :is-open="store.state.isAiChatEnabled" @close="store.state.isAiChatEnabled = false" />
+      }"  :is-open="store.state.isAiChatEnabled" @close="store.state.isAiChatEnabled = false" :aiChatInputContext="aiChatInputContext" />
     </div>
   </div>
   </div>
@@ -191,7 +192,7 @@ export default defineComponent({
     ConfirmDialog,
     O2AIChat,
   },
-  emits: ["update:list", "cancel:hideform"],
+  emits: ["update:list", "cancel:hideform", "sendToAiChat"],
   setup(props, { emit }) {
     const store: any = useStore();
     const router = useRouter();
@@ -216,6 +217,7 @@ export default defineComponent({
     const testFunctionRef = ref<typeof TestFunction>();
     const functionsToolbarRef = ref<typeof FunctionsToolbar>();
     const splitterModel = ref(50);
+    const aiChatInputContext = ref("");
     const confirmDialogMeta = ref({
       title: "",
       message: "",
@@ -462,6 +464,14 @@ end`;
         store.dispatch("setIsAiChatEnabled", val);
     };
 
+    const sendToAiChat = (value: any) => {
+      //this is for when user in pipeline add function page and click on ai chat button
+      aiChatInputContext.value = value;
+      store.dispatch("setIsAiChatEnabled", true);
+      //this is for when user in functions page and click on ai chat button
+      emit("sendToAiChat", value);
+    };
+
     return {
       t,
       $q,
@@ -496,7 +506,9 @@ end`;
       resetConfirmDialog,
       cancelAddFunction,
       openChat,
-      isAddFunctionComponent
+      isAddFunctionComponent,
+      sendToAiChat,
+      aiChatInputContext
     };
   },
   created() {

--- a/web/src/components/functions/FunctionList.vue
+++ b/web/src/components/functions/FunctionList.vue
@@ -136,6 +136,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         class="q-pa-sm"
         @update:list="refreshList"
         @cancel:hideform="hideForm"
+        @sendToAiChat="sendToAiChat"
       />
     </div>
     <ConfirmDialog
@@ -228,6 +229,7 @@ export default defineComponent({
     "updated:fields",
     "update:changeRecordPerPage",
     "update:maxRecordToReturn",
+    "sendToAiChat"
   ],
   setup(props, { emit }) {
     const store = useStore();
@@ -538,6 +540,10 @@ export default defineComponent({
 
     const forceDeleteFn = () => {};
 
+    const sendToAiChat = (value: any) => {
+      emit("sendToAiChat", value);
+    };
+
     return {
       t,
       qTable,
@@ -587,6 +593,7 @@ export default defineComponent({
       },
       getImageURL,
       verifyOrganizationStatus,
+      sendToAiChat
     };
   },
   computed: {

--- a/web/src/components/functions/TestFunction.vue
+++ b/web/src/components/functions/TestFunction.vue
@@ -208,6 +208,24 @@
             </q-tooltip>
           </q-icon>
         </template>
+        <template #right>
+          <q-btn
+            :ripple="false"
+            @click.prevent.stop="sendToAiChat(JSON.stringify(inputEvents))"
+            data-test="menu-link-ai-item"
+            no-caps
+            :borderless="true"
+            flat
+            size="6px"
+            class="tw-px-2 tw-mr-4 "
+            dense
+            style="border-radius: 100%;"
+          >
+            <div class="row items-center no-wrap">
+              <img height="16" width="16" :src="getBtnLogo" class="header-icon ai-icon" />
+            </div>
+          </q-btn>
+          </template>
       </FullViewContainer>
       <div
         v-show="expandState.events"
@@ -318,7 +336,7 @@ import FullViewContainer from "@/components/functions/FullViewContainer.vue";
 import useStreams from "@/composables/useStreams";
 import { outlinedLightbulb } from "@quasar/extras/material-icons-outlined";
 import useQuery from "@/composables/useQuery";
-import { b64EncodeUnicode } from "@/utils/zincutils";
+import { b64EncodeUnicode, getImageURL } from "@/utils/zincutils";
 import searchService from "@/services/search";
 import { useStore } from "vuex";
 import { event, useQuasar } from "quasar";
@@ -337,7 +355,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(["function-error"]);
+const emit = defineEmits(["function-error","sendToAiChat"]);
 
 const QueryEditor = defineAsyncComponent(
   () => import("@/components/CodeQueryEditor.vue"),
@@ -736,9 +754,20 @@ function highlightSpecificEvent() {
     console.log("Error in highlightSpecificEvent", e);
   }
 }
+const getBtnLogo = computed(() => {
+      return store.state.theme === 'dark'
+        ? getImageURL('images/common/ai_icon_dark.svg')
+        : getImageURL('images/common/ai_icon.svg')
+    });
+
+const sendToAiChat = (value: any) => {
+  emit("sendToAiChat", value);
+};
 
 defineExpose({
   testFunction,
+  sendToAiChat,
+  getBtnLogo
 });
 </script>
 

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -419,11 +419,33 @@ class="padding-none" />
         />
       </q-list>
     </q-drawer>
+    <div class="row full-height no-wrap">
+    <!-- Left Panel -->
+    <div
+      class="col"
+      v-show="isLoading"
+      :style="{ width: store.state.isAiChatEnabled ? '75%' : '100%' }"
+      :key="store.state.selectedOrganization?.identifier"
+    >
     <q-page-container v-if="isLoading">
       <router-view v-slot="{ Component }">
-        <component :is="Component" />
+        <component :is="Component"  @sendToAiChat="sendToAiChat" />
       </router-view>
     </q-page-container>
+    </div>
+
+    <!-- Right Panel (AI Chat) -->
+
+    <div
+      class="col-auto"
+      v-show="store.state.isAiChatEnabled && isLoading"
+      style="width: 25%; max-width: 100%; min-width: 75px; z-index: 10 "
+      :class="store.state.theme == 'dark' ? 'dark-mode-chat-container' : 'light-mode-chat-container'"
+    >
+      <O2AIChat :header-height="82.5" :is-open="store.state.isAiChatEnabled" @close="closeChat"   :aiChatInputContext="aiChatInputContext"  />
+    </div>
+  </div>
+
   </q-layout>
 </template>
 
@@ -589,6 +611,7 @@ export default defineComponent({
 
     const isMonacoEditorLoaded = ref(false);
     const isHovered = ref(false);
+    const aiChatInputContext = ref("");
 
     let customOrganization = router.currentRoute.value.query.hasOwnProperty(
       "org_identifier",
@@ -1231,6 +1254,10 @@ export default defineComponent({
         ? getImageURL('images/common/ai_icon_dark.svg')
         : getImageURL('images/common/ai_icon.svg')
     })
+    const sendToAiChat = (value: any) => {
+      store.dispatch("setIsAiChatEnabled", true);
+      aiChatInputContext.value = value;
+    }
 
     return {
       t,
@@ -1264,6 +1291,8 @@ export default defineComponent({
       closeChat,
       getBtnLogo,
       isHovered,
+      sendToAiChat,
+      aiChatInputContext
     };
   },
   computed: {

--- a/web/src/plugins/logs/DetailTable.vue
+++ b/web/src/plugins/logs/DetailTable.vue
@@ -51,6 +51,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             name="table"
             :label="t('common.table')"
           />
+          <q-btn
+            :ripple="false"
+            @click.prevent.stop="sendToAiChat(JSON.stringify(rowData))"
+            data-test="menu-link-ai-item"
+            no-caps
+            :borderless="true"
+            flat
+            size="6px"
+            class="tw-px-2 tw-py-2"
+            dense
+            style="border-radius: 100%;"
+          >
+            <div class="row items-center no-wrap">
+              <img :src="getBtnLogo" class="header-icon ai-icon" />
+            </div>
+          </q-btn>
         </q-tabs>
       </div>
       <div
@@ -89,6 +105,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             @add-field-to-table="addFieldToTable"
             @add-search-term="toggleIncludeSearchTerm"
             @view-trace="viewTrace"
+            @send-to-ai-chat="sendToAiChat"
+            @closeTable="closeTable"
           />
         </q-card-section>
       </q-tab-panel>
@@ -364,6 +382,8 @@ export default defineComponent({
     "search:timeboxed",
     "add:table",
     "view-trace",
+    "sendToAiChat",
+    "closeTable"
   ],
   props: {
     modelValue: {
@@ -481,6 +501,18 @@ export default defineComponent({
       emit("view-trace");
     };
 
+    const sendToAiChat = (value: any) => {
+      emit("sendToAiChat", value);
+      emit("closeTable");
+    };
+    const getBtnLogo = computed(() => {
+      return store.state.theme === 'dark'
+        ? getImageURL('images/common/ai_icon_dark.svg')
+        : getImageURL('images/common/ai_icon.svg')
+    });
+    const closeTable = () => {
+      emit("closeTable");
+    }
     return {
       t,
       store,
@@ -499,6 +531,9 @@ export default defineComponent({
       multiStreamFields,
       viewTrace,
       hasAggregationQuery,
+      sendToAiChat,
+      getBtnLogo,
+      closeTable
     };
   },
   async created() {

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -243,6 +243,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     @update:scroll="getMoreData"
                     @update:recordsPerPage="getMoreDataRecordsPerPage"
                     @expandlog="toggleExpandLog"
+                    @send-to-ai-chat="sendToAiChat"
                   />
                 </div>
                 <div class="text-center col-10 q-ma-none">
@@ -406,6 +407,7 @@ export default defineComponent({
     SearchHistory,
   },
   mixins: [MainLayoutCloudMixin],
+  emits: ["sendToAiChat"],
   methods: {
     setHistogramDate(date: any) {
       this.searchBarRef.dateTimeRef.setCustomDate("absolute", date);
@@ -529,7 +531,7 @@ export default defineComponent({
       this.disableMoreErrorDetails = !this.disableMoreErrorDetails;
     },
   },
-  setup() {
+  setup(props: any, { emit }: any) {
     const { t } = useI18n();
     const store = useStore();
     const router = useRouter();
@@ -1670,6 +1672,10 @@ export default defineComponent({
 
     // [END] O2 AI Context Handler
 
+    const sendToAiChat = (value: any) => {
+      emit("sendToAiChat", value);
+    };
+
     return {
       t,
       store,
@@ -1727,6 +1733,7 @@ export default defineComponent({
       isWithQuery,
       isStreamingEnabled,
       setCommunicationMethod,
+      sendToAiChat,
     };
   },
   computed: {

--- a/web/src/plugins/logs/JsonPreview.vue
+++ b/web/src/plugins/logs/JsonPreview.vue
@@ -203,6 +203,26 @@
                 >
               </q-item-section>
             </q-item>
+            <q-item  clickable v-close-popup>
+              <q-item-section>
+                <q-item-label
+                  data-test="send-to-ai-chat-btn"
+                  @click.stop="sendToAiChat(JSON.stringify({
+                    [key]: value[key],
+                  }))"
+                  v-close-popup
+                  ><q-btn
+                    title="Send to AI Chat"
+                    size="6px"
+                    round
+                    class="q-mr-sm pointer"
+                  >
+                  <q-img height="14px" width="14px" :src="getBtnLogo" />
+                  </q-btn
+                  >Send to AI Chat</q-item-label
+                >
+              </q-item-section>
+            </q-item>
           </q-list>
         </q-btn-dropdown>
 
@@ -273,7 +293,7 @@ export default {
       () => import("@/components/CodeQueryEditor.vue"),
     ),
   },
-  emits: ["copy", "addSearchTerm", "addFieldToTable", "view-trace"],
+  emits: ["copy", "addSearchTerm", "addFieldToTable", "view-trace", "sendToAiChat","closeTable"],
   setup(props: any, { emit }: any) {
     const { t } = useI18n();
     const store = useStore();
@@ -492,6 +512,17 @@ export default {
       return t("common.addFieldToTable");
     };
 
+    const sendToAiChat = (key: string, value: string) => {
+      emit("closeTable");
+      emit("sendToAiChat", key, value);
+    };
+
+    const getBtnLogo = computed(() => {
+      return store.state.theme === 'dark'
+        ? getImageURL('images/common/ai_icon_dark.svg')
+        : getImageURL('images/common/ai_icon.svg')
+    })
+
     return {
       t,
       copyLogToClipboard,
@@ -520,6 +551,8 @@ export default {
       setViewTraceBtn,
       getOriginalData,
       addOrRemoveLabel,
+      sendToAiChat,
+      getBtnLogo
     };
   },
 };

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -259,6 +259,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         @close-column="closeColumn"
         @click:data-row="openLogDetails"
         @expand-row="expandLog"
+        @send-to-ai-chat="sendToAiChat"
         @view-trace="redirectToTraces"
       />
 
@@ -299,6 +300,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               ],
             )
           "
+          @sendToAiChat="sendToAiChat"
+          @closeTable="closeTable"
         />
       </q-dialog>
     </div>
@@ -346,6 +349,7 @@ export default defineComponent({
     "expandlog",
     "update:recordsPerPage",
     "update:columnSizes",
+    "sendToAiChat",
   ],
   props: {
     expandedLogs: {
@@ -702,6 +706,14 @@ export default defineComponent({
       return searchObj.meta.showHistogram && searchObj.loadingHistogram == true;
     });
 
+    const sendToAiChat = (value: any) => {
+      emit("sendToAiChat", value);
+    };
+
+    const closeTable = () => {
+      searchObj.meta.showDetailTab = false;
+    }
+
     return {
       t,
       store,
@@ -741,6 +753,8 @@ export default defineComponent({
       refreshPagination,
       refreshJobPagination,
       histogramLoader,
+      sendToAiChat,
+      closeTable
     };
   },
   computed: {

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -249,6 +249,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   ? 'tw-bg-zinc-700'
                   : 'tw-bg-zinc-300'
                 : '',
+              'table-row-hover'
             ]"
             @click="
               !(formattedRows[virtualRow.index]?.original as any)
@@ -277,6 +278,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   viewTrace(formattedRows[virtualRow.index]?.original)
                 "
                 :streamName="jsonpreviewStreamName"
+                @send-to-ai-chat="sendToAiChat"
               />
             </td>
             <template v-else>
@@ -334,14 +336,37 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     @copy="copyLogToClipboard"
                     @add-search-term="addSearchTerm"
                     @add-field-to-table="addFieldToTable"
+                    @send-to-ai-chat="sendToAiChat"
                   />
                 </template>
+
                 <HighLight
                   :content="cell.renderValue()"
                   :query-string="
                     highlightQuery
                   "
                 />
+                <!-- Add copy button floating between columns -->
+                <q-btn
+                v-if="cell.column.columnDef.id === store.state.zoConfig.timestamp_column"
+                    :ripple="false"
+                    @click.stop="sendToAiChat(JSON.stringify(cell.row.original))"
+                    data-test="menu-link-ai-item"
+                    no-caps
+                    :borderless="true"
+                    flat
+                    size="xs"
+                    dense
+                    class="tw-absolute tw-right-[16px] tw-top-1/2 tw-transform tw--translate-y-1/2"
+                    :class="[
+                      'tw-invisible ai-btn'
+                    ]"
+                    style="border-radius: 100%;"
+                  >
+                    <div class="row items-center no-wrap">
+                      <img height="20px" width="20px"  :src="getBtnLogo" class="header-icon ai-icon" />
+                    </div>
+                  </q-btn>
               </td>
             </template>
           </tr>
@@ -377,6 +402,7 @@ import { useI18n } from "vue-i18n";
 import { VueDraggableNext as VueDraggable } from "vue-draggable-next";
 import CellActions from "@/plugins/logs/data-table/CellActions.vue";
 import { debounce } from "quasar";
+import { getImageURL } from "@/utils/zincutils";
 
 const props = defineProps({
   rows: {
@@ -443,6 +469,7 @@ const emits = defineEmits([
   "update:columnOrder",
   "expandRow",
   "view-trace",
+  "sendToAiChat",
 ]);
 
 const sorting = ref<SortingState>([]);
@@ -820,10 +847,22 @@ const handleCellMouseLeave = () => {
 const viewTrace = (row: any) => {
   emits("view-trace", row);
 };
+const getBtnLogo = computed(() => {
+      return store.state.theme === 'dark'
+        ? getImageURL('images/common/ai_icon_dark.svg')
+        : getImageURL('images/common/ai_icon.svg')
+    })
+const sendToAiChat = (value: any) => {
+  console.log("here")
+  emits("sendToAiChat", value);
+};
+
 
 defineExpose({
   parentRef,
   virtualRows,
+  getBtnLogo,
+  sendToAiChat
 });
 </script>
 <style scoped lang="scss">
@@ -914,6 +953,28 @@ td {
   &:hover {
     .table-cell-actions {
       display: block !important;
+    }
+    .copy-btn {
+      visibility: visible !important;
+    }
+  }
+}
+
+.copy-btn {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  width: 24px;
+  height: 24px;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.table-row-hover {
+  &:hover {
+    .ai-btn {
+      visibility: visible !important;
+      z-index: 2;
     }
   }
 }

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -853,7 +853,6 @@ const getBtnLogo = computed(() => {
         : getImageURL('images/common/ai_icon.svg')
     })
 const sendToAiChat = (value: any) => {
-  console.log("here")
   emits("sendToAiChat", value);
 };
 
@@ -954,21 +953,9 @@ td {
     .table-cell-actions {
       display: block !important;
     }
-    .copy-btn {
-      visibility: visible !important;
-    }
   }
 }
 
-.copy-btn {
-  position: absolute;
-  display: inline-flex;
-  align-items: center;
-  width: 24px;
-  height: 24px;
-  justify-content: center;
-  border-radius: 4px;
-}
 
 .table-row-hover {
   &:hover {

--- a/web/src/plugins/logs/data-table/CellActions.vue
+++ b/web/src/plugins/logs/data-table/CellActions.vue
@@ -36,6 +36,22 @@
         <NotEqualIcon></NotEqualIcon>
       </q-icon>
     </q-btn>
+    <q-btn
+    class="q-ml-xs"
+      :ripple="false"
+      @click.prevent.stop="sendToAiChat(JSON.stringify(row[column.id]))"
+      data-test="menu-link-ai-item"
+      no-caps
+      :borderless="true"
+      flat
+      size="6px"
+      dense
+      style="border-radius: 100%; border: 1px solid #fff;"
+    >
+      <div class="row items-center no-wrap">
+        <img height="14px" width="14px" :src="getBtnLogo" class="header-icon ai-icon" />
+      </div>
+    </q-btn>
   </div>
 </template>
 
@@ -44,6 +60,7 @@ import { defineProps, defineEmits, computed } from "vue";
 import { useStore } from "vuex";
 import EqualIcon from "@/components/icons/EqualIcon.vue";
 import NotEqualIcon from "@/components/icons/NotEqualIcon.vue";
+import { getImageURL } from "@/utils/zincutils";
 
 defineProps({
   column: {
@@ -58,7 +75,7 @@ defineProps({
 
 const store = useStore();
 
-const emit = defineEmits(["copy", "addSearchTerm", "addFieldToTable"]);
+const emit = defineEmits(["copy", "addSearchTerm", "addFieldToTable", "sendToAiChat"]);
 
 const copyLogToClipboard = (value: any) => {
   emit("copy", value, false);
@@ -74,4 +91,12 @@ const addSearchTerm = (
 const backgroundClass = computed(() =>
   store.state.theme === "dark" ? "tw-bg-black" : "tw-bg-white",
 );
+const sendToAiChat = (value: any) => {
+  emit("sendToAiChat", value);
+};
+const getBtnLogo = computed(() => {
+      return store.state.theme === 'dark'
+        ? getImageURL('images/common/ai_icon_dark.svg')
+        : getImageURL('images/common/ai_icon.svg')
+    })
 </script>

--- a/web/src/views/Functions.vue
+++ b/web/src/views/Functions.vue
@@ -98,7 +98,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :functionAssociatedStreams="functionAssociatedStreams"
             @get:functionAssociatedStreams="getFunctionAssociatedStreams"
             @get:templates="getTemplates" -->
-          <RouterView />
+          <RouterView v-slot="{ Component }">
+            <component :is="Component" @sendToAiChat="sendToAiChat" />
+          </RouterView>
         </div>
       </template>
     </q-splitter>
@@ -113,7 +115,8 @@ import { useI18n } from "vue-i18n";
 
 export default defineComponent({
   name: "AppFunctions",
-  setup() {
+  emits: ["sendToAiChat"],
+  setup(props, { emit }) {
     const store = useStore();
     const { t } = useI18n();
     const router = useRouter();
@@ -168,6 +171,10 @@ export default defineComponent({
       }
     };
 
+    const sendToAiChat = (value: any) => {
+      emit("sendToAiChat", value);
+    };
+
     return {
       t,
       store,
@@ -179,6 +186,7 @@ export default defineComponent({
       templates,
       collapseSidebar,
       showSidebar,
+      sendToAiChat
     };
   },
 });


### PR DESCRIPTION
1. This adds additional info  to the o2 ai chat
Add short cut at row to send the event to O2-ai

On inline expand of log row , add short cut at row to send the event to O2-ai

On Side panel with details of logs line , add short cut at row to send the event to O2-ai

On pipelines page send selected stream context

On functions creation page send the event to O2-ai