### PR TITLE
fix: multiselect stream share URL fix

### DIFF
--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -2976,6 +2976,9 @@ export default defineComponent({
 
     const shareLink = useLoading(async () => {
       const queryObj = generateURLQuery(true);
+      // Removed the 'type' property from the object to avoid issues when navigating from the stream to the logs page,
+      // especially when the user performs multi-select on streams and shares the URL.
+      delete queryObj?.type;
       const queryString = Object.entries(queryObj)
         .map(
           ([key, value]) =>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove `type` parameter from share URL query

- Fix multiselect streams share URL navigation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SearchBar.vue</strong><dd><code>Omit `type` property in shareLink query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/SearchBar.vue

<li>Removed <code>type</code> property from <code>queryObj</code><br> <li> Added comment explaining removal rationale


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7457/files#diff-81893de4edf186b0556f610acb280c87baa2ffe67d3b48a60a866094c7635baf">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>