### PR TITLE
chore: add UT for CI

### DIFF
--- a/src/service/users.rs
+++ b/src/service/users.rs
@@ -1215,7 +1215,39 @@ mod tests {
     };
 
     use super::*;
-    use crate::common::infra::config::USERS;
+    use crate::common::{infra::config::USERS, meta::user::get_default_user_role};
+
+    #[test]
+    fn test_is_user_from_org() {
+        let target_org = "org1".to_string();
+
+        let user_org = UserOrg {
+            name: "org2".to_string(),
+            token: "token2".to_string(),
+            rum_token: Some("rum2".to_string()),
+            role: get_default_user_role(),
+        };
+
+        let matched_org = UserOrg {
+            name: target_org.clone(),
+            token: "token1".to_string(),
+            rum_token: Some("rum1".to_string()),
+            role: get_default_user_role(),
+        };
+
+        let (found, org) = is_user_from_org(vec![], &target_org);
+        assert!(!found);
+        assert_eq!(org.name, "");
+
+        let (found, org) = is_user_from_org(vec![matched_org.clone()], &target_org);
+        assert!(!found);
+        assert_eq!(org.name, "");
+
+        let (found, org) =
+            is_user_from_org(vec![matched_org.clone(), user_org.clone()], &target_org);
+        assert!(found);
+        assert_eq!(org.name, "org2");
+    }
 
     async fn set_up() {
         let _ = ORM_CLIENT.get_or_init(connect_to_orm).await;


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Add unit tests for email validation

- Add unit tests for OFGA unsupported check

- Add tests for OFGA format conversion

- Add tests to validate if a user is part of organization

- Remove unused invite token stub


___

### **Changes diagram**

```mermaid
flowchart LR
  validTest["Test valid emails"] -- "calls" --> isValidEmail["is_valid_email"]
  ofgaTest["Test OFGA unsupported"] -- "calls" --> isOfgaUnsupported["is_ofga_unsupported"]
  formatTest["Test OFGA format"] -- "calls" --> intoFormat["into_ofga_supported_format"]
  userOrgTest["Test user from org"] -- "calls" --> isUserFromOrg["is_user_from_org"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.rs</strong><dd><code>Add tests and cleanup in auth utils</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/common/utils/auth.rs

<li>Removed stub <code>generate_invite_token</code><br> <li> Added <code>test_valid_emails</code> unit tests<br> <li> Added <code>test_is_ofga_unsupported</code> unit tests<br> <li> Added <code>test_into_ofga_supported_format</code> unit tests<br> <li> Updated <code>println!</code> macros to use inline variables


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7464/files#diff-9bc2b1841504a435f66ad094f72ddbe7b7fa75e5e1557b8adbfe36f7f0592e1b">+36/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>