### PR TITLE
fix: O2 ai additional info 

### DIFF
--- a/web/src/components/O2AIChat.vue
+++ b/web/src/components/O2AIChat.vue
@@ -247,12 +247,12 @@ import useAiChat from '@/composables/useAiChat';
 import { outlinedThumbUpOffAlt, outlinedThumbDownOffAlt } from '@quasar/extras/material-icons-outlined';
 import { getImageURL } from '@/utils/zincutils';
 
-interface ChatMessage {
+export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
 }
 
-interface ChatHistoryEntry {
+export interface ChatHistoryEntry {
   id: number;
   timestamp: string;
   title: string;
@@ -330,11 +330,16 @@ export default defineComponent({
     headerHeight: {
       type: Number,
       default: 0,
+    },
+    //this will be used to set the input message if the user sends the data from any page by clicking on the ai chat button
+    aiChatInputContext: {
+      type: String,
+      default: ''
     }
   },
   setup(props) {
     const $q = useQuasar();
-    const inputMessage = ref('');
+    const inputMessage = ref(props.aiChatInputContext ? props.aiChatInputContext : '');
     const chatMessages = ref<ChatMessage[]>([]);
     const isLoading = ref(false);
     const messagesContainer = ref<HTMLElement | null>(null);
@@ -400,6 +405,12 @@ export default defineComponent({
         messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight;
       }
     };
+
+    watch(() => props.aiChatInputContext, (newAiChatInputContext: string) => {
+      if(newAiChatInputContext) {
+        inputMessage.value = newAiChatInputContext;
+      }
+    });
 
 
     //fetchInitialMessage is called when the component is mounted and the isOpen prop is true

--- a/web/src/components/functions/AddFunction.vue
+++ b/web/src/components/functions/AddFunction.vue
@@ -140,6 +140,7 @@ import {
   computed,
   watch,
   onUnmounted,
+  nextTick,
 } from "vue";
 
 import jsTransformService from "../../services/jstransform";
@@ -464,7 +465,12 @@ end`;
 
     const sendToAiChat = (value: any) => {
       //this is for when user in pipeline add function page and click on ai chat button
-      aiChatInputContext.value = value;
+      //here we reset the value befoere setting it because if user clears the input then again click on the same value it wont trigger the watcher that is there in the child component
+      //so to force trigger we do this
+      aiChatInputContext.value = '';
+      nextTick(() => {
+        aiChatInputContext.value = value;
+      });
       store.dispatch("setIsAiChatEnabled", true);
       //this is for when user in functions page and click on ai chat button
       emit("sendToAiChat", value);

--- a/web/src/components/functions/AddFunction.vue
+++ b/web/src/components/functions/AddFunction.vue
@@ -110,6 +110,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :vrlFunction="formData"
               @function-error="handleFunctionError"
               :heightOffset="heightOffset"
+              @sendToAiChat="sendToAiChat"
             />
           </div>
         </template>
@@ -118,7 +119,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <div v-if="store.state.isAiChatEnabled && !isAddFunctionComponent" style="width: 25%; max-width: 100%; min-width: 75px;   " :class="store.state.theme == 'dark' ? 'dark-mode-chat-container' : 'light-mode-chat-container'" >
       <O2AIChat :style="{
         height: `calc(100vh - (112px + ${heightOffset}px))`
-      }"  :is-open="store.state.isAiChatEnabled" @close="store.state.isAiChatEnabled = false" />
+      }"  :is-open="store.state.isAiChatEnabled" @close="store.state.isAiChatEnabled = false" :aiChatInputContext="aiChatInputContext" />
     </div>
   </div>
   </div>
@@ -189,7 +190,7 @@ export default defineComponent({
     ConfirmDialog,
     O2AIChat,
   },
-  emits: ["update:list", "cancel:hideform"],
+  emits: ["update:list", "cancel:hideform", "sendToAiChat"],
   setup(props, { emit }) {
     const store: any = useStore();
     const router = useRouter();
@@ -214,6 +215,7 @@ export default defineComponent({
     const testFunctionRef = ref<typeof TestFunction>();
     const functionsToolbarRef = ref<typeof FunctionsToolbar>();
     const splitterModel = ref(50);
+    const aiChatInputContext = ref("");
     const confirmDialogMeta = ref({
       title: "",
       message: "",
@@ -460,6 +462,14 @@ end`;
         store.dispatch("setIsAiChatEnabled", val);
     };
 
+    const sendToAiChat = (value: any) => {
+      //this is for when user in pipeline add function page and click on ai chat button
+      aiChatInputContext.value = value;
+      store.dispatch("setIsAiChatEnabled", true);
+      //this is for when user in functions page and click on ai chat button
+      emit("sendToAiChat", value);
+    };
+
     return {
       t,
       $q,
@@ -494,7 +504,9 @@ end`;
       resetConfirmDialog,
       cancelAddFunction,
       openChat,
-      isAddFunctionComponent
+      isAddFunctionComponent,
+      sendToAiChat,
+      aiChatInputContext
     };
   },
   created() {

--- a/web/src/components/functions/FunctionList.vue
+++ b/web/src/components/functions/FunctionList.vue
@@ -136,6 +136,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         class="q-pa-sm"
         @update:list="refreshList"
         @cancel:hideform="hideForm"
+        @sendToAiChat="sendToAiChat"
       />
     </div>
     <ConfirmDialog
@@ -228,6 +229,7 @@ export default defineComponent({
     "updated:fields",
     "update:changeRecordPerPage",
     "update:maxRecordToReturn",
+    "sendToAiChat"
   ],
   setup(props, { emit }) {
     const store = useStore();
@@ -538,6 +540,10 @@ export default defineComponent({
 
     const forceDeleteFn = () => {};
 
+    const sendToAiChat = (value: any) => {
+      emit("sendToAiChat", value);
+    };
+
     return {
       t,
       qTable,
@@ -587,6 +593,7 @@ export default defineComponent({
       },
       getImageURL,
       verifyOrganizationStatus,
+      sendToAiChat
     };
   },
   computed: {

--- a/web/src/components/functions/TestFunction.vue
+++ b/web/src/components/functions/TestFunction.vue
@@ -208,6 +208,24 @@
             </q-tooltip>
           </q-icon>
         </template>
+        <template #right>
+          <q-btn
+            :ripple="false"
+            @click.prevent.stop="sendToAiChat(JSON.stringify(inputEvents))"
+            data-test="menu-link-ai-item"
+            no-caps
+            :borderless="true"
+            flat
+            size="6px"
+            class="tw-px-2 tw-mr-4 "
+            dense
+            style="border-radius: 100%;"
+          >
+            <div class="row items-center no-wrap">
+              <img height="16" width="16" :src="getBtnLogo" class="header-icon ai-icon" />
+            </div>
+          </q-btn>
+          </template>
       </FullViewContainer>
       <div
         v-show="expandState.events"
@@ -318,7 +336,7 @@ import FullViewContainer from "@/components/functions/FullViewContainer.vue";
 import useStreams from "@/composables/useStreams";
 import { outlinedLightbulb } from "@quasar/extras/material-icons-outlined";
 import useQuery from "@/composables/useQuery";
-import { b64EncodeUnicode } from "@/utils/zincutils";
+import { b64EncodeUnicode, getImageURL } from "@/utils/zincutils";
 import searchService from "@/services/search";
 import { useStore } from "vuex";
 import { event, useQuasar } from "quasar";
@@ -337,7 +355,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(["function-error"]);
+const emit = defineEmits(["function-error","sendToAiChat"]);
 
 const inputQuery = ref<string>("");
 const inputEvents = ref<string>("");
@@ -726,9 +744,20 @@ function highlightSpecificEvent() {
     console.log("Error in highlightSpecificEvent", e);
   }
 }
+const getBtnLogo = computed(() => {
+      return store.state.theme === 'dark'
+        ? getImageURL('images/common/ai_icon_dark.svg')
+        : getImageURL('images/common/ai_icon.svg')
+    });
+
+const sendToAiChat = (value: any) => {
+  emit("sendToAiChat", value);
+};
 
 defineExpose({
   testFunction,
+  sendToAiChat,
+  getBtnLogo
 });
 </script>
 

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -2153,6 +2153,18 @@ const getBtnLogo = computed(() => {
             }
           })
 
+          //if uds is enabled we need to push the timestamp and all fields name in the schema
+            if(userDefinedFields.value.length > 0){
+              userDefinedFields.value.push({
+                name:store.state.zoConfig.timestamp_column,
+                type:'Int64'
+              })
+              userDefinedFields.value.push({
+                name:store.state.zoConfig.all_fields_name,
+                type:'Utf8'
+              })
+            }
+
           payload["stream_name"] = selectedStreamName.value;
           payload["schema_"] = userDefinedFields.value.length > 0 ? userDefinedFields.value : schema;
 

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -2154,16 +2154,22 @@ const getBtnLogo = computed(() => {
           })
 
           //if uds is enabled we need to push the timestamp and all fields name in the schema
-            if(userDefinedFields.value.length > 0){
+          const hasTimestampColumn = userDefinedFields.value.some((field: any) => field.name === store.state.zoConfig.timestamp_column);
+          const hasAllFieldsName = userDefinedFields.value.some((field: any) => field.name === store.state.zoConfig.all_fields_name);
+            if(userDefinedFields.value.length > 0){ 
+              if(!hasTimestampColumn){
               userDefinedFields.value.push({
                 name:store.state.zoConfig.timestamp_column,
                 type:'Int64'
               })
+            }
+            if(!hasAllFieldsName){
               userDefinedFields.value.push({
                 name:store.state.zoConfig.all_fields_name,
                 type:'Utf8'
               })
             }
+          }
 
           payload["stream_name"] = selectedStreamName.value;
           payload["schema_"] = userDefinedFields.value.length > 0 ? userDefinedFields.value : schema;

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -1038,8 +1038,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     :expandedRows="expandedLogs"
                     @expand-row="expandLog"
                     @copy="copyLogToClipboard"
-
-
+                    @sendToAiChat="sendToAiChat"
                   />
                   <div v-if="loading" style="height: calc(100vh - 190px) !important;" class="flex justify-center items-center" >
                     <q-spinner-hourglass color="primary" size="lg" />
@@ -1133,7 +1132,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
 
           <div  class="q-ml-sm" v-if="store.state.isAiChatEnabled " style="width: 25%; max-width: 100%; min-width: 75px; height: calc(100vh - 70px) !important;  " :class="store.state.theme == 'dark' ? 'dark-mode-chat-container' : 'light-mode-chat-container'" >
-              <O2AIChat style="height: calc(100vh - 70px) !important;" :is-open="store.state.isAiChatEnabled" @close="store.state.isAiChatEnabled = false" />
+              <O2AIChat style="height: calc(100vh - 70px) !important;" :is-open="store.state.isAiChatEnabled" @close="store.state.isAiChatEnabled = false" :aiChatInputContext="aiChatInputContext" />
 
             </div>
 
@@ -1196,6 +1195,9 @@ import PreviewPromqlQuery from "./PreviewPromqlQuery.vue";
 
 import config from "../../../aws-exports";
 
+import useAiChat from "@/composables/useAiChat";
+import { onBeforeUnmount } from "vue";
+
 
 const QueryEditor = defineAsyncComponent(
   () => import("@/components/QueryEditor.vue"),
@@ -1250,11 +1252,13 @@ const emits = defineEmits([
 const {  pipelineObj } = useDragAndDrop();
 const { searchObj } = useLogs();
 const { getStream, getStreams } = useStreams ();
+const { registerAiChatHandler, removeAiChatHandler } = useAiChat();
 let parser: any;
 
 const selectedStreamName = ref("");
 
 const streamOptions = ref([]);
+
 
 const getColumns = computed(() => {
   return [
@@ -1281,7 +1285,7 @@ const getColumns = computed(() => {
         showWrap: false,
         wrapContent: true
       },
-      size: 200
+      size: 260
     },
     {
       name: "source",
@@ -1343,6 +1347,10 @@ const previewPromqlQueryRef : any = ref(null);
 const isHovered = ref(false);
 const loading = ref(false);
 
+const aiChatInputContext = ref("");
+
+const userDefinedFields = ref([]);
+
 
 const selectedStreamType = ref(props.streamType || "logs");
 
@@ -1399,7 +1407,13 @@ onMounted(async ()=>{
     getStreamFields();
   }
   }, 200);
+
+  registerAiContextHandler();
   
+})
+
+onBeforeUnmount(()=>{
+  removeAiContextHandler();
 })
 
 const importSqlParser = async () => {
@@ -1890,12 +1904,18 @@ const getStreamFields = () => {
     getStream(selectedStreamName.value, selectedStreamType.value, true)
       .then((stream: any) => {
         streamFields.value = [];
+        userDefinedFields.value = [];
         stream.schema?.forEach((field: any) => {
             streamFields.value.push({
               ...field,
               showValues: true,
             });
           
+        });
+        stream.uds_schema?.forEach((field: any) => {
+          userDefinedFields.value.push({
+            ...field,
+          });
         });
       })
       .finally(() => {
@@ -1907,7 +1927,6 @@ const getStreamFields = () => {
         }
         expandState.value.query = true;
         expandState.value.output = false;
-
         resolve(true);
       });
   });
@@ -2110,6 +2129,53 @@ const getBtnLogo = computed(() => {
     })
 
 
+    // [START] O2 AI Context Handler
+
+    const registerAiContextHandler = () => {
+      registerAiChatHandler(getContext);
+    };
+
+    const getContext = async () => {
+      return new Promise(async (resolve, reject) => {
+        try {
+          const payload = {};
+
+
+          if (!selectedStreamType.value || !selectedStreamName.value) {
+            resolve("");
+            return;
+          }
+
+          const schema = streamFields.value.map((field: any) => {
+            return {
+              name: field.name,
+              type: field.type
+            }
+          })
+
+          payload["stream_name"] = selectedStreamName.value;
+          payload["schema_"] = userDefinedFields.value.length > 0 ? userDefinedFields.value : schema;
+
+          resolve(payload);
+        } catch (error) {
+          console.error("Error in getContext for logs page", error);
+          resolve("");
+        }
+      });
+    };
+
+    const removeAiContextHandler = () => {
+      removeAiChatHandler();
+    };
+
+    // [END] O2 AI Context Handler
+
+    const sendToAiChat = (value: any) => {
+      aiChatInputContext.value = value;
+      store.dispatch("setIsAiChatEnabled", true);
+    };
+
+
 defineExpose({
   tab,
   validateInputs,
@@ -2143,7 +2209,9 @@ defineExpose({
   delayCondition,
   toggleAIChat,
   isHovered,
-  getBtnLogo
+  getBtnLogo,
+  sendToAiChat,
+  aiChatInputContext
 });
 
 </script>

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -1349,7 +1349,7 @@ const loading = ref(false);
 
 const aiChatInputContext = ref("");
 
-const userDefinedFields = ref([]);
+const userDefinedFields = ref<any[]>([]);
 
 
 const selectedStreamType = ref(props.streamType || "logs");
@@ -2138,7 +2138,7 @@ const getBtnLogo = computed(() => {
     const getContext = async () => {
       return new Promise(async (resolve, reject) => {
         try {
-          const payload = {};
+          const payload : any = {};
 
 
           if (!selectedStreamType.value || !selectedStreamName.value) {

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -473,7 +473,7 @@ class="padding-none" />
       style="width: 25%; max-width: 100%; min-width: 75px; z-index: 10 "
       :class="store.state.theme == 'dark' ? 'dark-mode-chat-container' : 'light-mode-chat-container'"
     >
-      <O2AIChat :header-height="82.5" :is-open="store.state.isAiChatEnabled" @close="closeChat" />
+      <O2AIChat :header-height="82.5" :is-open="store.state.isAiChatEnabled" @close="closeChat" :aiChatInputContext="aiChatInputContext" />
     </div>
   </div>
   </q-layout>

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -455,11 +455,11 @@ class="padding-none" />
         <router-view v-slot="{ Component }">
           <template v-if="$route.meta.keepAlive">
             <keep-alive>
-              <component :is="Component" />
+              <component :is="Component"  @sendToAiChat="sendToAiChat" />
             </keep-alive>
           </template>
           <template v-else>
-            <component :is="Component" />
+            <component :is="Component"  @sendToAiChat="sendToAiChat" />
           </template>
         </router-view>
       </q-page-container>
@@ -647,6 +647,7 @@ export default defineComponent({
 
     const isMonacoEditorLoaded = ref(false);
     const isHovered = ref(false);
+    const aiChatInputContext = ref("");
 
     let customOrganization = router.currentRoute.value.query.hasOwnProperty(
       "org_identifier",
@@ -1283,6 +1284,10 @@ export default defineComponent({
         ? getImageURL('images/common/ai_icon_dark.svg')
         : getImageURL('images/common/ai_icon.svg')
     })
+    const sendToAiChat = (value: any) => {
+      store.dispatch("setIsAiChatEnabled", true);
+      aiChatInputContext.value = value;
+    }
 
     return {
       t,
@@ -1316,6 +1321,8 @@ export default defineComponent({
       closeChat,
       getBtnLogo,
       isHovered,
+      sendToAiChat,
+      aiChatInputContext
     };
   },
   computed: {

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -1286,7 +1286,12 @@ export default defineComponent({
     })
     const sendToAiChat = (value: any) => {
       store.dispatch("setIsAiChatEnabled", true);
-      aiChatInputContext.value = value;
+      //here we reset the value befoere setting it because if user clears the input then again click on the same value it wont trigger the watcher that is there in the child component
+      //so to force trigger we do this
+      aiChatInputContext.value = '';
+      nextTick(() => {
+        aiChatInputContext.value = value;
+      });
     }
 
     return {

--- a/web/src/plugins/logs/DetailTable.vue
+++ b/web/src/plugins/logs/DetailTable.vue
@@ -51,6 +51,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             name="table"
             :label="t('common.table')"
           />
+          <q-btn
+            :ripple="false"
+            @click.prevent.stop="sendToAiChat(JSON.stringify(rowData))"
+            data-test="menu-link-ai-item"
+            no-caps
+            :borderless="true"
+            flat
+            size="6px"
+            class="tw-px-2 tw-py-2"
+            dense
+            style="border-radius: 100%;"
+          >
+            <div class="row items-center no-wrap">
+              <img :src="getBtnLogo" class="header-icon ai-icon" />
+            </div>
+          </q-btn>
         </q-tabs>
       </div>
       <div
@@ -89,6 +105,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             @add-field-to-table="addFieldToTable"
             @add-search-term="toggleIncludeSearchTerm"
             @view-trace="viewTrace"
+            @send-to-ai-chat="sendToAiChat"
+            @closeTable="closeTable"
           />
         </q-card-section>
       </q-tab-panel>
@@ -363,6 +381,8 @@ export default defineComponent({
     "search:timeboxed",
     "add:table",
     "view-trace",
+    "sendToAiChat",
+    "closeTable"
   ],
   props: {
     modelValue: {
@@ -476,6 +496,18 @@ export default defineComponent({
       emit("view-trace");
     };
 
+    const sendToAiChat = (value: any) => {
+      emit("sendToAiChat", value);
+      emit("closeTable");
+    };
+    const getBtnLogo = computed(() => {
+      return store.state.theme === 'dark'
+        ? getImageURL('images/common/ai_icon_dark.svg')
+        : getImageURL('images/common/ai_icon.svg')
+    });
+    const closeTable = () => {
+      emit("closeTable");
+    }
     return {
       t,
       store,
@@ -493,6 +525,9 @@ export default defineComponent({
       searchObj,
       multiStreamFields,
       viewTrace,
+      sendToAiChat,
+      getBtnLogo,
+      closeTable
     };
   },
   async created() {

--- a/web/src/plugins/logs/DetailTable.vue
+++ b/web/src/plugins/logs/DetailTable.vue
@@ -353,7 +353,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, onBeforeMount } from "vue";
+import { defineComponent, ref, onBeforeMount, computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { useStore } from "vuex";

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -374,6 +374,7 @@ import config from "@/aws-exports";
 import {
   verifyOrganizationStatus,
   useLocalInterestingFields,
+  deepCopy,
 } from "@/utils/zincutils";
 import MainLayoutCloudMixin from "@/enterprise/mixins/mainLayout.mixin";
 import SanitizedHtmlRenderer from "@/components/SanitizedHtmlRenderer.vue";
@@ -1608,11 +1609,27 @@ export default defineComponent({
           }
 
           for (let i = 0; i < streams.length; i++) {
-            const schema = await getStream(streams[i], streamType, true);
 
+            const schema = await getStream(streams[i], streamType, true);
+            //here we are deep copying the schema before assiging it to schemaData so that we dont mutatat the orginial data 
+            //if we do this we dont get duplicate fields in the schema
+            let schemaData = deepCopy(schema.uds_schema || schema.schema || []);
+            let isUdsEnabled = schema.uds_schema?.length > 0;
+            //we only push the timestamp and all fields name in the schema if uds is enabled for that stream
+            if(isUdsEnabled){
+              let timestampColumn = store.state.zoConfig.timestamp_column;
+              let allFieldsName = store.state.zoConfig.all_fields_name;
+              schemaData.push({
+                name:timestampColumn,
+                type:'Int64'
+              })
+                schemaData.push({
+                  name:allFieldsName,
+                  type:'Utf8'
+                })
+              }
             payload["stream_name_" + (i + 1)] = streams[i];
-            payload["schema_" + (i + 1)] =
-              schema.uds_schema || schema.schema || [];
+            payload["schema_" + (i + 1)] = schemaData;
           }
 
           resolve(payload);

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -247,6 +247,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     @update:scroll="getMoreData"
                     @update:recordsPerPage="getMoreDataRecordsPerPage"
                     @expandlog="toggleExpandLog"
+                    @send-to-ai-chat="sendToAiChat"
                   />
                 </div>
                 <div class="text-center col-10 q-ma-none">
@@ -410,6 +411,7 @@ export default defineComponent({
     SearchHistory,
   },
   mixins: [MainLayoutCloudMixin],
+  emits: ["sendToAiChat"],
   methods: {
     setHistogramDate(date: any) {
       this.searchBarRef.dateTimeRef.setCustomDate("absolute", date);
@@ -533,7 +535,7 @@ export default defineComponent({
       this.disableMoreErrorDetails = !this.disableMoreErrorDetails;
     },
   },
-  setup() {
+  setup(props: any, { emit }: any) {
     const { t } = useI18n();
     const store = useStore();
     const router = useRouter();
@@ -1627,6 +1629,10 @@ export default defineComponent({
 
     // [END] O2 AI Context Handler
 
+    const sendToAiChat = (value: any) => {
+      emit("sendToAiChat", value);
+    };
+
     return {
       t,
       store,
@@ -1684,6 +1690,7 @@ export default defineComponent({
       isDistinctQuery,
       isWithQuery,
       isStreamingEnabled,
+      sendToAiChat,
     };
   },
   computed: {

--- a/web/src/plugins/logs/JsonPreview.vue
+++ b/web/src/plugins/logs/JsonPreview.vue
@@ -203,6 +203,26 @@
                 >
               </q-item-section>
             </q-item>
+            <q-item  clickable v-close-popup>
+              <q-item-section>
+                <q-item-label
+                  data-test="send-to-ai-chat-btn"
+                  @click.stop="sendToAiChat(JSON.stringify({
+                    [key]: value[key],
+                  }))"
+                  v-close-popup
+                  ><q-btn
+                    title="Send to AI Chat"
+                    size="6px"
+                    round
+                    class="q-mr-sm pointer"
+                  >
+                  <q-img height="14px" width="14px" :src="getBtnLogo" />
+                  </q-btn
+                  >Send to AI Chat</q-item-label
+                >
+              </q-item-section>
+            </q-item>
           </q-list>
         </q-btn-dropdown>
 
@@ -274,7 +294,7 @@ export default {
       () => import("@/components/QueryEditor.vue"),
     ),
   },
-  emits: ["copy", "addSearchTerm", "addFieldToTable", "view-trace"],
+  emits: ["copy", "addSearchTerm", "addFieldToTable", "view-trace", "sendToAiChat","closeTable"],
   setup(props: any, { emit }: any) {
     const { t } = useI18n();
     const store = useStore();
@@ -489,6 +509,17 @@ export default {
       return t("common.addFieldToTable");
     };
 
+    const sendToAiChat = (key: string, value: string) => {
+      emit("closeTable");
+      emit("sendToAiChat", key, value);
+    };
+
+    const getBtnLogo = computed(() => {
+      return store.state.theme === 'dark'
+        ? getImageURL('images/common/ai_icon_dark.svg')
+        : getImageURL('images/common/ai_icon.svg')
+    })
+
     return {
       t,
       copyLogToClipboard,
@@ -517,6 +548,8 @@ export default {
       setViewTraceBtn,
       getOriginalData,
       addOrRemoveLabel,
+      sendToAiChat,
+      getBtnLogo
     };
   },
 };

--- a/web/src/plugins/logs/JsonPreview.vue
+++ b/web/src/plugins/logs/JsonPreview.vue
@@ -509,9 +509,9 @@ export default {
       return t("common.addFieldToTable");
     };
 
-    const sendToAiChat = (key: string, value: string) => {
+    const sendToAiChat = (value: string) => {
       emit("closeTable");
-      emit("sendToAiChat", key, value);
+      emit("sendToAiChat", value);
     };
 
     const getBtnLogo = computed(() => {

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -254,6 +254,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         @close-column="closeColumn"
         @click:data-row="openLogDetails"
         @expand-row="expandLog"
+        @send-to-ai-chat="sendToAiChat"
         @view-trace="redirectToTraces"
       />
 
@@ -294,6 +295,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               ],
             )
           "
+          @sendToAiChat="sendToAiChat"
+          @closeTable="closeTable"
         />
       </q-dialog>
     </div>
@@ -341,6 +344,7 @@ export default defineComponent({
     "expandlog",
     "update:recordsPerPage",
     "update:columnSizes",
+    "sendToAiChat",
   ],
   props: {
     expandedLogs: {
@@ -697,6 +701,14 @@ export default defineComponent({
       return searchObj.meta.showHistogram && searchObj.loadingHistogram == true;
     });
 
+    const sendToAiChat = (value: any) => {
+      emit("sendToAiChat", value);
+    };
+
+    const closeTable = () => {
+      searchObj.meta.showDetailTab = false;
+    }
+
     return {
       t,
       store,
@@ -736,6 +748,8 @@ export default defineComponent({
       refreshPagination,
       refreshJobPagination,
       histogramLoader,
+      sendToAiChat,
+      closeTable
     };
   },
   computed: {

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -346,7 +346,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <q-btn
                 v-if="cell.column.columnDef.id === store.state.zoConfig.timestamp_column"
                     :ripple="false"
-                    @click.stop="sendToAiChat(JSON.stringify(cell.row.original))"
+                    @click.stop="sendToAiChat(JSON.stringify(cell.row.original),true)"
                     data-test="menu-link-ai-item"
                     no-caps
                     :borderless="true"
@@ -823,9 +823,44 @@ const getBtnLogo = computed(() => {
         ? getImageURL('images/common/ai_icon_dark.svg')
         : getImageURL('images/common/ai_icon.svg')
     })
-const sendToAiChat = (value: any) => {
-  emits("sendToAiChat", value);
+const sendToAiChat = (value: any,isEntireRow: boolean = false) => {
+  if(isEntireRow){
+    //here we will get the original value of the row
+    //and we need to filter the row if props.columns have any filtered cols that user applied
+    //the format of the props.columns is like this:
+    //if user have not applied any filter then the props.columns will be like this:
+    //it contains _timestamp column and source column 
+    //else we get _timestamp column and other filter columns so if user have applied any filter then we need to filter the row based on the filter columns
+    const row = JSON.parse(value);
+    //lets filter based on props.columns so lets ignore _timestamp column as it is always present and now we want to check if source is present we can directly send the row 
+    //otherwise we need to filter the row based on the columns that user have applied
+    if(checkIfSourceColumnPresent(props.columns)){
+      emits("sendToAiChat", JSON.stringify(row));
+    }else{
+      //we need to filter the row based on the columns that user have applied
+      const filteredRow = filterRowBasedOnColumns(row,props.columns);
+      emits("sendToAiChat", JSON.stringify(filteredRow));
+    }
+  }else{
+    emits("sendToAiChat", value);
+  }
 };
+
+const checkIfSourceColumnPresent = (columns: any) => {
+  //we need to check if source column is present in the columns
+  //if present then we need to return true else false
+  return columns.some((column: any) => column.id === 'source');
+}
+
+const filterRowBasedOnColumns = (row: any,columns: any) => {
+  //we need to filter the row based on the columns that user have applied
+  //here we need to filter row not columns based on the columns that user have applied
+  const columnsToFilter = columns.filter((column: any) => column.id !== 'source');
+  return columnsToFilter.reduce((acc: any, column: any) => {
+    acc[column.id] = row[column.id];
+    return acc;
+  }, {});
+}
 
 
 defineExpose({

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -248,6 +248,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   ? 'tw-bg-zinc-700'
                   : 'tw-bg-zinc-300'
                 : '',
+              'table-row-hover'
             ]"
             @click="
               !(formattedRows[virtualRow.index]?.original as any)
@@ -280,6 +281,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 
                 "
                 :streamName="jsonpreviewStreamName"
+                @send-to-ai-chat="sendToAiChat"
               />
             </td>
             <template v-else>
@@ -337,9 +339,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     @copy="copyLogToClipboard"
                     @add-search-term="addSearchTerm"
                     @add-field-to-table="addFieldToTable"
+                    @send-to-ai-chat="sendToAiChat"
                   />
                 </template>
                 {{ cell.renderValue() }}
+                <q-btn
+                v-if="cell.column.columnDef.id === store.state.zoConfig.timestamp_column"
+                    :ripple="false"
+                    @click.stop="sendToAiChat(JSON.stringify(cell.row.original))"
+                    data-test="menu-link-ai-item"
+                    no-caps
+                    :borderless="true"
+                    flat
+                    size="xs"
+                    dense
+                    class="tw-absolute tw-right-[16px] tw-top-1/2 tw-transform tw--translate-y-1/2"
+                    :class="[
+                      'tw-invisible ai-btn'
+                    ]"
+                    style="border-radius: 100%;"
+                  >
+                    <div class="row items-center no-wrap">
+                      <img height="20px" width="20px"  :src="getBtnLogo" class="header-icon ai-icon" />
+                    </div>
+                  </q-btn>
               </td>
             </template>
           </tr>
@@ -366,6 +389,7 @@ import { useI18n } from "vue-i18n";
 import { VueDraggableNext as VueDraggable } from "vue-draggable-next";
 import CellActions from "@/plugins/logs/data-table/CellActions.vue";
 import { debounce } from "quasar";
+import { getImageURL } from "@/utils/zincutils";
 
 const props = defineProps({
   rows: {
@@ -427,6 +451,7 @@ const emits = defineEmits([
   "update:columnOrder",
   "expandRow",
   "view-trace",
+  "sendToAiChat",
 ]);
 
 const sorting = ref<SortingState>([]);
@@ -793,9 +818,20 @@ const handleCellMouseLeave = () => {
 const viewTrace = (row: any) => {
   emits("view-trace", row);
 };
+const getBtnLogo = computed(() => {
+      return store.state.theme === 'dark'
+        ? getImageURL('images/common/ai_icon_dark.svg')
+        : getImageURL('images/common/ai_icon.svg')
+    })
+const sendToAiChat = (value: any) => {
+  emits("sendToAiChat", value);
+};
+
 
 defineExpose({
   parentRef,
+  getBtnLogo,
+  sendToAiChat
 });
 </script>
 <style scoped lang="scss">
@@ -886,6 +922,16 @@ td {
   &:hover {
     .table-cell-actions {
       display: block !important;
+    }
+  }
+}
+
+
+.table-row-hover {
+  &:hover {
+    .ai-btn {
+      visibility: visible !important;
+      z-index: 2;
     }
   }
 }

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -493,6 +493,7 @@ watch(
   },
   {
     deep: true,
+    immediate: true,
   },
 );
 

--- a/web/src/plugins/logs/data-table/CellActions.vue
+++ b/web/src/plugins/logs/data-table/CellActions.vue
@@ -36,6 +36,22 @@
         <NotEqualIcon></NotEqualIcon>
       </q-icon>
     </q-btn>
+    <q-btn
+    class="q-ml-xs"
+      :ripple="false"
+      @click.prevent.stop="sendToAiChat(JSON.stringify(row[column.id]))"
+      data-test="menu-link-ai-item"
+      no-caps
+      :borderless="true"
+      flat
+      size="6px"
+      dense
+      style="border-radius: 100%; border: 1px solid #fff;"
+    >
+      <div class="row items-center no-wrap">
+        <img height="14px" width="14px" :src="getBtnLogo" class="header-icon ai-icon" />
+      </div>
+    </q-btn>
   </div>
 </template>
 
@@ -44,6 +60,7 @@ import { defineProps, defineEmits, computed } from "vue";
 import { useStore } from "vuex";
 import EqualIcon from "@/components/icons/EqualIcon.vue";
 import NotEqualIcon from "@/components/icons/NotEqualIcon.vue";
+import { getImageURL } from "@/utils/zincutils";
 
 defineProps({
   column: {
@@ -58,7 +75,7 @@ defineProps({
 
 const store = useStore();
 
-const emit = defineEmits(["copy", "addSearchTerm", "addFieldToTable"]);
+const emit = defineEmits(["copy", "addSearchTerm", "addFieldToTable", "sendToAiChat"]);
 
 const copyLogToClipboard = (value: any) => {
   emit("copy", value, false);
@@ -74,4 +91,12 @@ const addSearchTerm = (
 const backgroundClass = computed(() =>
   store.state.theme === "dark" ? "tw-bg-black" : "tw-bg-white",
 );
+const sendToAiChat = (value: any) => {
+  emit("sendToAiChat", value);
+};
+const getBtnLogo = computed(() => {
+      return store.state.theme === 'dark'
+        ? getImageURL('images/common/ai_icon_dark.svg')
+        : getImageURL('images/common/ai_icon.svg')
+    })
 </script>

--- a/web/src/views/Functions.vue
+++ b/web/src/views/Functions.vue
@@ -98,7 +98,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :functionAssociatedStreams="functionAssociatedStreams"
             @get:functionAssociatedStreams="getFunctionAssociatedStreams"
             @get:templates="getTemplates" -->
-          <RouterView />
+          <RouterView v-slot="{ Component }">
+            <component :is="Component" @sendToAiChat="sendToAiChat" />
+          </RouterView>
         </div>
       </template>
     </q-splitter>
@@ -113,7 +115,8 @@ import { useI18n } from "vue-i18n";
 
 export default defineComponent({
   name: "AppFunctions",
-  setup() {
+  emits: ["sendToAiChat"],
+  setup(props, { emit }) {
     const store = useStore();
     const { t } = useI18n();
     const router = useRouter();
@@ -168,6 +171,10 @@ export default defineComponent({
       }
     };
 
+    const sendToAiChat = (value: any) => {
+      emit("sendToAiChat", value);
+    };
+
     return {
       t,
       store,
@@ -179,6 +186,7 @@ export default defineComponent({
       templates,
       collapseSidebar,
       showSidebar,
+      sendToAiChat
     };
   },
 });


### PR DESCRIPTION
1. This adds additional info  to the o2 ai chat
Add short cut at row to send the event to O2-ai

On inline expand of log row , add short cut at row to send the event to
O2-ai

On Side panel with details of logs line , add short cut at row to send
the event to O2-ai

On pipelines page send selected stream context

On functions creation page send the event to O2-ai

when there is uds enabled , we need to send _timestamp and _all field in the context 