### PR TITLE
fix: change some error to warn

### DIFF
--- a/src/handler/http/request/search/search_stream.rs
+++ b/src/handler/http/request/search/search_stream.rs
@@ -100,10 +100,8 @@ pub async fn search_http2_stream(
         .to_string();
 
     // Log the request
-    log::info!(
-        "[trace_id: {}] Received HTTP/2 stream request at handler for org_id: {}",
-        trace_id,
-        org_id
+    log::debug!(
+        "[HTTP2_STREAM trace_id {trace_id}] Received HTTP/2 stream request at handler for org_id: {org_id}"
     );
 
     #[cfg(feature = "enterprise")]
@@ -282,7 +280,7 @@ pub async fn search_http2_stream(
     {
         Ok(v) => v,
         Err(e) => {
-            log::error!("[trace_id: {}] Error parsing sql: {:?}", trace_id, e);
+            log::error!("[HTTP2_STREAM trace_id {trace_id}] Error parsing sql: {e}");
 
             #[cfg(feature = "enterprise")]
             let error_message = e.to_string();
@@ -360,11 +358,7 @@ pub async fn search_http2_stream(
         let chunks_iter = match result {
             Ok(v) => v.to_chunks(),
             Err(err) => {
-                log::error!(
-                    "[HTTP2_STREAM] trace_id: {} Error in stream: {}",
-                    trace_id,
-                    err
-                );
+                log::error!("[HTTP2_STREAM trace_id {trace_id}] Error in search stream: {err}",);
                 let err_res = match err {
                     infra::errors::Error::ErrorCode(ref code) => {
                         // if err code is cancelled return cancelled response
@@ -484,10 +478,8 @@ pub async fn values_http2_stream(
         .to_string();
 
     // Log the request
-    log::info!(
-        "[trace_id: {}] Received values HTTP/2 stream request for org_id: {}",
-        trace_id,
-        org_id
+    log::debug!(
+        "[HTTP2_STREAM trace_id {trace_id}] Received values HTTP/2 stream request for org_id: {org_id}"
     );
 
     // Get query params
@@ -663,11 +655,7 @@ pub async fn values_http2_stream(
         let chunks_iter = match result {
             Ok(v) => v.to_chunks(),
             Err(err) => {
-                log::error!(
-                    "[HTTP2_STREAM] trace_id: {} Error in stream: {}",
-                    trace_id,
-                    err
-                );
+                log::error!("[HTTP2_STREAM trace_id {trace_id}] Error in values stream: {err}",);
                 let err_res = match err {
                     infra::errors::Error::ErrorCode(ref code) => {
                         let message = code.get_message();

--- a/src/handler/http/request/search/search_stream.rs
+++ b/src/handler/http/request/search/search_stream.rs
@@ -358,7 +358,7 @@ pub async fn search_http2_stream(
         let chunks_iter = match result {
             Ok(v) => v.to_chunks(),
             Err(err) => {
-                log::error!("[HTTP2_STREAM trace_id {trace_id}] Error in search stream: {err}",);
+                log::error!("[HTTP2_STREAM trace_id {trace_id}] Error in search stream: {err}");
                 let err_res = match err {
                     infra::errors::Error::ErrorCode(ref code) => {
                         // if err code is cancelled return cancelled response
@@ -655,7 +655,7 @@ pub async fn values_http2_stream(
         let chunks_iter = match result {
             Ok(v) => v.to_chunks(),
             Err(err) => {
-                log::error!("[HTTP2_STREAM trace_id {trace_id}] Error in values stream: {err}",);
+                log::error!("[HTTP2_STREAM trace_id {trace_id}] Error in values stream: {err}");
                 let err_res = match err {
                     infra::errors::Error::ErrorCode(ref code) => {
                         let message = code.get_message();

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -269,10 +269,13 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
     #[cfg(not(feature = "enterprise"))]
     let ai_enabled = false;
 
+    #[cfg(feature = "cloud")]
+    let build_type = "cloud";
     #[cfg(feature = "enterprise")]
     let build_type = "enterprise";
-    #[cfg(not(feature = "enterprise"))]
+    #[cfg(not(any(feature = "cloud", feature = "enterprise")))]
     let build_type = "opensource";
+
     let cfg = get_config();
     Ok(HttpResponse::Ok().json(ConfigResponse {
         version: config::VERSION.to_string(),

--- a/src/job/metrics.rs
+++ b/src/job/metrics.rs
@@ -112,7 +112,7 @@ async fn load_query_cache_limit_bytes() -> Result<(), anyhow::Error> {
         .set(cfg.memory_cache.max_size as i64);
     metrics::QUERY_DISK_CACHE_LIMIT_BYTES
         .with_label_values(&[])
-        .set((cfg.disk_cache.max_size*cfg.disk_cache.bucket_num) as i64);
+        .set((cfg.disk_cache.max_size * cfg.disk_cache.bucket_num) as i64);
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,7 @@ async fn main() -> Result<(), anyhow::Error> {
     );
     log::info!(
         "Caches info: Disk max size {}, MEM max size {}, Datafusion pool size: {}",
-        bytes_to_human_readable(cfg.disk_cache.max_size as f64),
+        bytes_to_human_readable((cfg.disk_cache.max_size * cfg.disk_cache.bucket_num) as f64),
         bytes_to_human_readable((cfg.memory_cache.max_size * cfg.memory_cache.bucket_num) as f64),
         bytes_to_human_readable(cfg.memory_cache.datafusion_max_size as f64),
     );

--- a/src/service/logs/loki.rs
+++ b/src/service/logs/loki.rs
@@ -106,7 +106,7 @@ fn validate_and_process_json_request(
         for (entry_idx, entry) in loki_stream.values.into_iter().enumerate() {
             if entry.line.trim().is_empty() {
                 return Err(LokiError::InvalidTimestamp {
-                    message: format!("Stream {stream_idx} entry {entry_idx} has empty log line",),
+                    message: format!("Stream {stream_idx} entry {entry_idx} has empty log line"),
                 });
             }
 
@@ -181,7 +181,7 @@ fn validate_and_process_protobuf_request(
         for (entry_idx, entry) in loki_stream.entries.into_iter().enumerate() {
             if entry.line.trim().is_empty() {
                 return Err(LokiError::InvalidTimestamp {
-                    message: format!("Stream {stream_idx} entry {entry_idx} has empty log line",),
+                    message: format!("Stream {stream_idx} entry {entry_idx} has empty log line"),
                 });
             }
 

--- a/src/service/search/cache/multi.rs
+++ b/src/service/search/cache/multi.rs
@@ -40,7 +40,7 @@ pub async fn get_cached_results(
     let is_cached = r.get(&query_key).cloned();
     drop(r);
     if is_cached.is_none() {
-        log::info!(
+        log::debug!(
             "[CACHE RESULT {trace_id}] No cache found during get_cached_results for query key: {}, cache_query: {:?}",
             query_key,
             cache_req
@@ -75,7 +75,7 @@ async fn recursive_process_multiple_metas(
 ) -> Result<(), anyhow::Error> {
     if cache_metas.is_empty() {
         if results.is_empty() {
-            log::info!(
+            log::debug!(
                 "[CACHE RESULT {trace_id}] No cache found during recursive_process_multiple_metas for query key: {}, cached_metas: {:?}",
                 query_key,
                 cache_metas

--- a/src/service/search/datafusion/distributed_plan/empty_exec.rs
+++ b/src/service/search/datafusion/distributed_plan/empty_exec.rs
@@ -176,7 +176,7 @@ impl DisplayAs for NewEmptyExec {
         };
 
         write!(f, "NewEmptyExec: ")?;
-        write!(f, "{name}{projection}{filters}{limit}{sorted_by_time}",)
+        write!(f, "{name}{projection}{filters}{limit}{sorted_by_time}")
     }
 }
 

--- a/src/service/search/search_stream.rs
+++ b/src/service/search/search_stream.rs
@@ -771,7 +771,7 @@ pub async fn do_partitioned_search(
             };
 
             if sender.send(Ok(response)).await.is_err() {
-                log::warn!("[trace_id {trace_id}] Sender is closed, stop sending response",);
+                log::warn!("[trace_id {trace_id}] Sender is closed, stop sending response");
                 return Ok(());
             }
         }
@@ -1041,7 +1041,7 @@ pub async fn handle_cache_responses_and_deltas(
             }
         } else if let Some(&delta) = delta_iter.peek() {
             // Process remaining deltas
-            log::info!("[HTTP2_STREAM trace_id {trace_id}] Processing remaining delta",);
+            log::info!("[HTTP2_STREAM trace_id {trace_id}] Processing remaining delta");
             process_delta(
                 req,
                 trace_id,
@@ -1286,7 +1286,7 @@ async fn process_delta(
             );
 
             if sender.send(Ok(response)).await.is_err() {
-                log::warn!("[trace_id {trace_id}] Sender is closed, stop sending search response",);
+                log::warn!("[trace_id {trace_id}] Sender is closed, stop sending search response");
                 return Ok(());
             }
         }
@@ -1411,7 +1411,7 @@ async fn send_partial_search_resp(
     );
 
     if sender.send(Ok(response)).await.is_err() {
-        log::warn!("[trace_id {trace_id}] Sender is closed, stop sending partial search response",);
+        log::warn!("[trace_id {trace_id}] Sender is closed, stop sending partial search response");
         return Ok(());
     }
 
@@ -1503,7 +1503,7 @@ async fn send_cached_responses(
     };
 
     if sender.send(Ok(response)).await.is_err() {
-        log::warn!("[trace_id {trace_id}] Sender is closed, stop sending cached search response",);
+        log::warn!("[trace_id {trace_id}] Sender is closed, stop sending cached search response");
         return Ok(());
     }
 

--- a/src/service/tantivy/puffin/mod.rs
+++ b/src/service/tantivy/puffin/mod.rs
@@ -24,11 +24,11 @@ pub mod writer;
 /// puffin specs constants
 pub const MAGIC: [u8; 4] = [0x50, 0x46, 0x41, 0x31];
 pub const MAGIC_SIZE: u64 = MAGIC.len() as u64;
-pub const MIN_FILE_SIZE: u64 = MAGIC_SIZE + MIN_FOOTER_SIZE;
+pub const MIN_FILE_SIZE: u64 = MAGIC_SIZE + MIN_DATA_SIZE;
 pub const FLAGS_SIZE: u64 = 4;
 pub const FOOTER_PAYLOAD_SIZE_SIZE: u64 = 4;
-pub const FOOTER_SIZE: u64 = MAGIC_SIZE + FLAGS_SIZE + FOOTER_PAYLOAD_SIZE_SIZE + MAGIC_SIZE;
-pub const MIN_FOOTER_SIZE: u64 = MAGIC_SIZE + FLAGS_SIZE + FOOTER_PAYLOAD_SIZE_SIZE + MAGIC_SIZE; // without any blobs
+pub const FOOTER_SIZE: u64 = MAGIC_SIZE + FLAGS_SIZE + FOOTER_PAYLOAD_SIZE_SIZE;
+pub const MIN_DATA_SIZE: u64 = MAGIC_SIZE + FLAGS_SIZE + FOOTER_PAYLOAD_SIZE_SIZE + MAGIC_SIZE; // without any blobs
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -173,8 +173,8 @@ mod tests {
         assert_eq!(MAGIC_SIZE, 4);
         assert_eq!(FLAGS_SIZE, 4);
         assert_eq!(FOOTER_PAYLOAD_SIZE_SIZE, 4);
-        assert_eq!(FOOTER_SIZE, 16);
-        assert_eq!(MIN_FOOTER_SIZE, 16);
+        assert_eq!(FOOTER_SIZE, 12);
+        assert_eq!(MIN_DATA_SIZE, 16);
         assert_eq!(MIN_FILE_SIZE, 20);
     }
 

--- a/src/service/tantivy/puffin/writer.rs
+++ b/src/service/tantivy/puffin/writer.rs
@@ -131,7 +131,7 @@ impl PuffinFooterWriter {
         let payload = self.get_payload()?;
         let payload_size = payload.len();
 
-        let capacity = MIN_FOOTER_SIZE as usize + payload_size;
+        let capacity = MIN_DATA_SIZE as usize + payload_size;
         let mut buf = Vec::with_capacity(capacity);
 
         // HeadMagic
@@ -246,7 +246,7 @@ mod tests {
 
         let total_bytes = result.unwrap();
         // Should write header + footer even with no blobs
-        assert!(total_bytes >= MAGIC_SIZE + MIN_FOOTER_SIZE);
+        assert!(total_bytes >= MAGIC_SIZE + MIN_DATA_SIZE);
     }
 
     #[test]
@@ -345,7 +345,7 @@ mod tests {
         let footer_bytes = result.unwrap();
 
         // Should contain: header magic + payload + payload_size + flags + footer magic
-        assert!(footer_bytes.len() >= MIN_FOOTER_SIZE as usize);
+        assert!(footer_bytes.len() >= MIN_DATA_SIZE as usize);
 
         // Check header magic
         assert_eq!(&footer_bytes[0..MAGIC_SIZE as usize], &MAGIC);
@@ -378,7 +378,7 @@ mod tests {
         let footer_bytes = result.unwrap();
 
         // Should be larger than minimum size due to payload
-        assert!(footer_bytes.len() > MIN_FOOTER_SIZE as usize);
+        assert!(footer_bytes.len() > MIN_DATA_SIZE as usize);
 
         // Check structure
         assert_eq!(&footer_bytes[0..MAGIC_SIZE as usize], &MAGIC);

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -276,7 +276,7 @@ pub async fn handle_search_request(
         } else {
             // Step 2: Search without cache
             // no caches found process req directly
-            log::info!(
+            log::debug!(
                 "[WS_SEARCH] trace_id: {} No cache found, processing search request",
                 trace_id
             );

--- a/src/service/websocket_events/values.rs
+++ b/src/service/websocket_events/values.rs
@@ -207,7 +207,7 @@ pub async fn handle_values_request(
             } else {
                 // Step 2: Search without cache
                 // no caches found process req directly
-                log::info!(
+                log::debug!(
                     "[WS_VALUES] trace_id: {} No cache found, processing search request",
                     trace_id
                 );


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- lower HTTP2 stream logs to debug

- unify log format with trace_id context

- replace sender error logs with warnings

- adjust cache and WS logs to debug level


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>search_stream.rs</strong><dd><code>refine HTTP2_STREAM handler logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/search/search_stream.rs

<li>log level changed from info to debug<br> <li> unified format "[HTTP2_STREAM trace_id {trace_id}]"<br> <li> updated error and sql parsing logs<br> <li> replaced sender error logs with warnings


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7481/files#diff-642de43ff6b19ae41087a9f1efc02d8b0b873809e0c92cbddfac1a30ef3f1184">+7/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>multi.rs</strong><dd><code>adjust cache metrics logging level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/multi.rs

<li>changed cache miss logs info->debug<br> <li> added structured trace_id context


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7481/files#diff-7eb49bf810eab33aedff3aa5af2f03dfef49c27d62dcaf85d182e8dad10b66d8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>search_stream.rs</strong><dd><code>unify and lower stream service logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/search_stream.rs

<li>converted various logs from info->debug<br> <li> unified "[HTTP2_STREAM trace_id]" format across logs<br> <li> replaced error logs with warnings for closed sender<br> <li> simplified write_to_cache error formatting


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7481/files#diff-b952a89375f2745a0daa273f1bdefc80c22997759a9b17a8fccbc70ae294e8e4">+101/-131</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>search.rs</strong><dd><code>lower WS search logging level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/websocket_events/search.rs

- lowered no-cache info log to debug


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7481/files#diff-13476631e2e604b75e2dfdd8fb7b7a91c46dcd85faa50813afa0b87583bcdb26">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.rs</strong><dd><code>lower WS values logging level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/websocket_events/values.rs

- lowered no-cache info log to debug


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7481/files#diff-d5c53f3f28432f096cb4788fa89c0e9bc8551aefe75c4a62be084a08d9025f97">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>