### PR TITLE
fix: aggs cache ratio usage reporting

### DIFF
--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -502,7 +502,9 @@ pub async fn run_datafusion(
 
         // no need to run datafusion, return empty result
         if is_complete_cache_hit_with_no_data {
-            return Ok((vec![], ScanStats::default(), "".to_string()));
+            let mut scan_stats = ScanStats::default();
+            scan_stats.aggs_cache_ratio = aggs_cache_ratio;
+            return Ok((vec![], scan_stats, "".to_string()));
         }
     }
 

--- a/src/service/search/super_cluster/leader.rs
+++ b/src/service/search/super_cluster/leader.rs
@@ -329,7 +329,9 @@ async fn run_datafusion(
 
         // no need to run datafusion, return empty result
         if is_complete_cache_hit_with_no_data {
-            return Ok((vec![], ScanStats::default(), "".to_string()));
+            let mut scan_stats = ScanStats::default();
+            scan_stats.aggs_cache_ratio = aggs_cache_ratio;
+            return Ok((vec![], scan_stats, "".to_string()));
         }
     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Propagate `aggs_cache_ratio` on no-data cache hits

- Update return logic in cluster flight module

- Update return logic in super cluster leader module


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flight.rs</strong><dd><code>Propagate cache ratio on no-data hit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cluster/flight.rs

<li>Added <code>scan_stats.aggs_cache_ratio</code> assignment<br> <li> Modified return for no-data cache-hit path


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7501/files#diff-dbffb1a03b65f6a9163b18c5bb1241ba2966735657be39bbe9f4d0e3260d8c1d">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>leader.rs</strong><dd><code>Propagate cache ratio on no-data hit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/super_cluster/leader.rs

<li>Added <code>scan_stats.aggs_cache_ratio</code> assignment<br> <li> Modified return for no-data cache-hit path


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7501/files#diff-21a32af318adcd10e62fb0d45944993f623fb3d2d6df4bb70d882dfc8f677fdc">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>