### PR TITLE
fix: fix for histogram getting blank after clicking on logs menu

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -709,6 +709,7 @@ export default defineComponent({
           !type
         ) {
           searchObj.meta.pageType = "logs";
+          searchObj.meta.refreshHistogram = true;
           loadLogsData();
         }
       },


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Refresh histogram when navigating back to logs


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Enable histogram refresh flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/Index.vue

- Added `searchObj.meta.refreshHistogram = true` before load


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7506/files#diff-0323c3da69b369843c5d72bf4df5b00ca6b5147192a213baf331659ecf92af62">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>