### PR TITLE
feat: reset old data job if exists

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -251,6 +251,15 @@ pub static MEM_TABLE_INDIVIDUAL_STREAMS: Lazy<HashMap<String, usize>> = Lazy::ne
     map
 });
 
+pub static COMPACT_OLD_DATA_STREAM_SET: Lazy<HashSet<String>> = Lazy::new(|| {
+    get_config()
+        .compact
+        .old_data_streams
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .collect()
+});
+
 pub static CONFIG: Lazy<ArcSwap<Config>> = Lazy::new(|| ArcSwap::from(Arc::new(init())));
 static INSTANCE_ID: Lazy<RwHashMap<String, String>> = Lazy::new(Default::default);
 
@@ -1453,6 +1462,8 @@ pub struct Compact {
     pub max_file_size: usize,
     #[env_config(name = "ZO_COMPACT_EXTENDED_DATA_RETENTION_DAYS", default = 3650)] // days
     pub extended_data_retention_days: i64,
+    #[env_config(name = "ZO_COMPACT_OLD_DATA_STREAMS", default = "")] // use comma to split
+    pub old_data_streams: String,
     #[env_config(name = "ZO_COMPACT_DATA_RETENTION_DAYS", default = 3650)] // days
     pub data_retention_days: i64,
     #[env_config(name = "ZO_COMPACT_OLD_DATA_MAX_DAYS", default = 7)] // days

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -613,12 +613,23 @@ pub struct MergeJobPendingRecord {
 }
 
 #[derive(Debug, Clone, sqlx::Type, PartialEq, Default)]
-#[repr(i32)]
+#[repr(i64)]
 pub enum FileListJobStatus {
     #[default]
     Pending,
     Running,
     Done,
+}
+
+impl From<i64> for FileListJobStatus {
+    fn from(status: i64) -> Self {
+        match status {
+            0 => Self::Pending,
+            1 => Self::Running,
+            2 => Self::Done,
+            _ => Self::Pending,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, sqlx::FromRow)]

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -1015,6 +1015,7 @@ UPDATE stream_stats
     ) -> Result<i64> {
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
+        let mut tx = pool.begin().await?;
         DB_QUERY_NUMS
             .with_label_values(&["insert", "file_list_jobs", ""])
             .inc();
@@ -1025,7 +1026,7 @@ UPDATE stream_stats
         .bind(&stream_key)
         .bind(offset)
         .bind(super::FileListJobStatus::Pending)
-        .execute(&pool)
+        .execute(&mut *tx)
         .await
         {
             Err(sqlx::Error::Database(e)) => if !e.is_unique_violation() {
@@ -1038,15 +1039,46 @@ UPDATE stream_stats
         };
 
         // get job id
-        let ret = sqlx::query(
-            "SELECT id FROM file_list_jobs WHERE org = ? AND stream = ? AND offsets = ?;",
+        let ret = match sqlx::query(
+            "SELECT id, status FROM file_list_jobs WHERE org = ? AND stream = ? AND offsets = ?;",
         )
         .bind(org_id)
         .bind(&stream_key)
         .bind(offset)
-        .fetch_one(&pool)
-        .await?;
-        Ok(ret.try_get::<i64, &str>("id").unwrap_or_default())
+        .fetch_one(&mut *tx)
+        .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                if let Err(e) = tx.rollback().await {
+                    log::error!("[MYSQL] rollback add job error: {e}");
+                }
+                return Err(e.into());
+            }
+        };
+        // check job status
+        let id = ret.try_get::<i64, &str>("id").unwrap_or_default();
+        let status = ret.try_get::<i64, &str>("status").unwrap_or_default();
+        if id > 0 && super::FileListJobStatus::from(status) == super::FileListJobStatus::Done {
+            if let Err(e) =
+                sqlx::query("UPDATE file_list_jobs SET status = ? WHERE status = ? AND id = ?;")
+                    .bind(super::FileListJobStatus::Pending)
+                    .bind(super::FileListJobStatus::Done)
+                    .bind(id)
+                    .execute(&mut *tx)
+                    .await
+            {
+                if let Err(e) = tx.rollback().await {
+                    log::error!("[MYSQL] rollback update job status error: {e}");
+                }
+                return Err(e.into());
+            }
+        }
+        if let Err(e) = tx.commit().await {
+            log::error!("[MYSQL] commit add job error: {e}");
+            return Err(e.into());
+        }
+        Ok(id)
     }
 
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1030,6 +1030,7 @@ UPDATE stream_stats
     ) -> Result<i64> {
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let pool = CLIENT.clone();
+        let mut tx = pool.begin().await?;
         DB_QUERY_NUMS
             .with_label_values(&["insert", "file_list_jobs", ""])
             .inc();
@@ -1042,7 +1043,7 @@ UPDATE stream_stats
                 .bind(&stream_key)
                 .bind(offset)
                 .bind(super::FileListJobStatus::Pending)
-                .execute(&pool).await
+                .execute(&mut *tx).await
         {
             Err(sqlx::Error::Database(e)) => if !e.is_unique_violation() {
                 return Err(Error::Message(e.to_string()));
@@ -1054,15 +1055,44 @@ UPDATE stream_stats
         };
 
         // get job id
-        let ret = sqlx::query(
-            "SELECT id FROM file_list_jobs WHERE org = $1 AND stream = $2 AND offsets = $3;",
+        let ret = match sqlx::query(
+            "SELECT id, status FROM file_list_jobs WHERE org = $1 AND stream = $2 AND offsets = $3;",
         )
         .bind(org_id)
         .bind(&stream_key)
         .bind(offset)
-        .fetch_one(&pool)
-        .await?;
-        Ok(ret.try_get::<i64, &str>("id").unwrap_or_default())
+        .fetch_one(&mut *tx)
+        .await {
+            Ok(r) => r,
+            Err(e) => {
+                if let Err(e) = tx.rollback().await {
+                    log::error!("[POSTGRES] rollback add job error: {e}");
+                }
+                return Err(e.into());
+            }
+        };
+        let id = ret.try_get::<i64, &str>("id").unwrap_or_default();
+        let status = ret.try_get::<i64, &str>("status").unwrap_or_default();
+        if id > 0 && super::FileListJobStatus::from(status) == super::FileListJobStatus::Done {
+            if let Err(e) =
+                sqlx::query("UPDATE file_list_jobs SET status = $1 WHERE status = $2 AND id = $3;")
+                    .bind(super::FileListJobStatus::Pending)
+                    .bind(super::FileListJobStatus::Done)
+                    .bind(id)
+                    .execute(&mut *tx)
+                    .await
+            {
+                if let Err(e) = tx.rollback().await {
+                    log::error!("[POSTGRES] rollback update job status error: {e}");
+                }
+                return Err(e.into());
+            }
+        }
+        if let Err(e) = tx.commit().await {
+            log::error!("[POSTGRES] commit add job error: {e}");
+            return Err(e.into());
+        }
+        Ok(id)
     }
 
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -909,6 +909,7 @@ UPDATE stream_stats
         let stream_key = format!("{org_id}/{stream_type}/{stream}");
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
+        let mut tx = client.begin().await?;
         match sqlx::query(
             "INSERT INTO file_list_jobs (org, stream, offsets, status, node, started_at, updated_at) VALUES ($1, $2, $3, $4, '', 0, 0);",
         )
@@ -916,7 +917,7 @@ UPDATE stream_stats
         .bind(&stream_key)
         .bind(offset)
         .bind(super::FileListJobStatus::Pending)
-        .execute(&*client)
+        .execute(&mut *tx)
         .await
         {
             Err(sqlx::Error::Database(e)) => if !e.is_unique_violation() {
@@ -929,15 +930,45 @@ UPDATE stream_stats
         };
 
         // get job id
-        let ret = sqlx::query(
-            "SELECT id FROM file_list_jobs WHERE org = $1 AND stream = $2 AND offsets = $3;",
+        let ret = match sqlx::query(
+            "SELECT id, status FROM file_list_jobs WHERE org = $1 AND stream = $2 AND offsets = $3;",
         )
         .bind(org_id)
         .bind(&stream_key)
         .bind(offset)
-        .fetch_one(&*client)
-        .await?;
-        Ok(ret.try_get::<i64, &str>("id").unwrap_or_default())
+        .fetch_one(&mut *tx)
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                if let Err(e) = tx.rollback().await {
+                    log::error!("[SQLITE] rollback add job error: {e}");
+                }
+                return Err(e.into());
+            }
+        };
+        let id = ret.try_get::<i64, &str>("id").unwrap_or_default();
+        let status = ret.try_get::<i64, &str>("status").unwrap_or_default();
+        if id > 0 && super::FileListJobStatus::from(status) == super::FileListJobStatus::Done {
+            if let Err(e) =
+                sqlx::query("UPDATE file_list_jobs SET status = $1 WHERE status = $2 AND id = $3;")
+                    .bind(super::FileListJobStatus::Pending)
+                    .bind(super::FileListJobStatus::Done)
+                    .bind(id)
+                    .execute(&mut *tx)
+                    .await
+            {
+                if let Err(e) = tx.rollback().await {
+                    log::error!("[SQLITE] rollback update job status error: {e}");
+                }
+                return Err(e.into());
+            }
+        }
+        if let Err(e) = tx.commit().await {
+            log::error!("[SQLITE] commit add job error: {e}");
+            return Err(e.into());
+        }
+        Ok(id)
     }
 
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<super::MergeJobRecord>> {

--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 
 use chrono::{Datelike, Duration, TimeZone, Timelike, Utc};
 use config::{
+    COMPACT_OLD_DATA_STREAM_SET,
     cluster::LOCAL_NODE,
     get_config,
     meta::{
@@ -219,6 +220,11 @@ pub async fn run_generate_job(job_type: CompactionJobType) -> Result<(), anyhow:
                         }
                     }
                     CompactionJobType::Historical => {
+                        if !COMPACT_OLD_DATA_STREAM_SET.is_empty()
+                            && !COMPACT_OLD_DATA_STREAM_SET.contains(&stream_name)
+                        {
+                            continue;
+                        }
                         if let Err(e) = merge::generate_old_data_job_by_stream(
                             &org_id,
                             stream_type,


### PR DESCRIPTION

In this PR we will reset the existing file_list_job when we check old data. Also add one new ENV:

```
ZO_COMPACT_OLD_DATA_STREAMS=""
```

Default is empty, if you want to control which stream can be checking old data. you can set it like this:

```
ZO_COMPACT_OLD_DATA_STREAMS=stream1,stream2
```
