### PR TITLE
fix: case-insensitive stream search (#7462)

### DIFF
--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -418,62 +418,13 @@ async fn list(org_id: web::Path<String>, req: HttpRequest) -> impl Responder {
     .await;
 
     // filter by keyword
-    if let Some(keyword) = query.get("keyword")
-        && !keyword.is_empty()
+    if let Some(keyword) = query
+        .get("keyword")
+        .filter(|kw| !kw.is_empty())
+        .map(|kw| kw.to_lowercase())
     {
-        indices.retain(|s| s.name.contains(keyword));
+        indices.retain(|s| s.name.to_lowercase().contains(&keyword));
     }
-
-    // sort by
-    let mut sort = "name".to_string();
-    if let Some(s) = query.get("sort") {
-        let s = s.to_lowercase();
-        if !s.is_empty() {
-            sort = s;
-        }
-    }
-    let asc = if let Some(asc) = query.get("asc") {
-        asc.to_lowercase() == "true" || asc.to_lowercase() == "1"
-    } else {
-        true
-    };
-    indices.sort_by(|a, b| match (sort.as_str(), asc) {
-        ("name", true) => a.name.cmp(&b.name),
-        ("name", false) => b.name.cmp(&a.name),
-        ("doc_num", true) => a.stats.doc_num.cmp(&b.stats.doc_num),
-        ("doc_num", false) => b.stats.doc_num.cmp(&a.stats.doc_num),
-        ("storage_size", true) => a
-            .stats
-            .storage_size
-            .partial_cmp(&b.stats.storage_size)
-            .unwrap_or(Ordering::Equal),
-        ("storage_size", false) => b
-            .stats
-            .storage_size
-            .partial_cmp(&a.stats.storage_size)
-            .unwrap_or(Ordering::Equal),
-        ("compressed_size", true) => a
-            .stats
-            .compressed_size
-            .partial_cmp(&b.stats.compressed_size)
-            .unwrap_or(Ordering::Equal),
-        ("compressed_size", false) => b
-            .stats
-            .compressed_size
-            .partial_cmp(&a.stats.compressed_size)
-            .unwrap_or(Ordering::Equal),
-        ("index_size", true) => a
-            .stats
-            .index_size
-            .partial_cmp(&b.stats.index_size)
-            .unwrap_or(Ordering::Equal),
-        ("index_size", false) => b
-            .stats
-            .index_size
-            .partial_cmp(&a.stats.index_size)
-            .unwrap_or(Ordering::Equal),
-        _ => a.name.cmp(&b.name),
-    });
 
     // set total streams
     let total = indices.len();
@@ -489,14 +440,67 @@ async fn list(org_id: web::Path<String>, req: HttpRequest) -> impl Responder {
         .unwrap_or(0);
     if offset >= indices.len() {
         indices = vec![];
-    } else if limit > 0 {
-        let end = std::cmp::min(offset + limit, indices.len());
-        indices = indices[offset..end].to_vec();
+
+        return Ok(HttpResponse::Ok().json(ListStream {
+            list: indices,
+            total,
+        }));
     }
+
+    // sort by
+    let sort = query
+        .get("sort")
+        .filter(|v| !v.is_empty())
+        .map(String::to_string)
+        .unwrap_or_else(|| "name".to_string());
+    let asc = query
+        .get("asc")
+        .map(|asc| asc.eq_ignore_ascii_case("true") || asc.eq_ignore_ascii_case("1"))
+        .unwrap_or(true);
+
+    indices.sort_by(|a, b| stream_comparator(a, b, &sort, asc));
+
+    if limit > 0 {
+        let end = std::cmp::min(offset + limit, indices.len());
+        indices.drain(end..);
+        indices.drain(..offset);
+    }
+
     Ok(HttpResponse::Ok().json(ListStream {
         list: indices,
         total,
     }))
+}
+
+/// Compares two streams for sorting based on the field and ASC/DESC
+fn stream_comparator(
+    a: &meta::stream::Stream,
+    b: &meta::stream::Stream,
+    sort: &str,
+    asc: bool,
+) -> Ordering {
+    let ord = match sort {
+        "name" => a.name.cmp(&b.name),
+        "doc_num" => a.stats.doc_num.cmp(&b.stats.doc_num),
+        "storage_size" => a
+            .stats
+            .storage_size
+            .partial_cmp(&b.stats.storage_size)
+            .unwrap_or(Ordering::Equal),
+        "compressed_size" => a
+            .stats
+            .compressed_size
+            .partial_cmp(&b.stats.compressed_size)
+            .unwrap_or(Ordering::Equal),
+        "index_size" => a
+            .stats
+            .index_size
+            .partial_cmp(&b.stats.index_size)
+            .unwrap_or(Ordering::Equal),
+        _ => a.name.cmp(&b.name),
+    };
+
+    if asc { ord } else { ord.reverse() }
 }
 
 /// StreamDeleteCache


### PR DESCRIPTION
### **User description**
Fixes #7462


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enable case-insensitive stream name filtering

- Extract `stream_comparator` for sorting logic

- Simplify parsing of `sort` and `asc` parameters

- Refactor pagination with early return and drains


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Extract `keyword` query"] --> B["Convert keyword to lowercase"]
  B --> C["Filter streams with lowercase names"]
  C --> D["Parse `sort` and `asc` parameters"]
  D --> E["Call `stream_comparator`"]
  E --> F["Sort stream list"]
  F --> G["Apply pagination (drains/early return)"]
  G --> H["Return JSON `ListStream` response"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Case-insensitive search and sort refactor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/stream/mod.rs

<li>Updated keyword filtering to use <code>to_lowercase</code> for search<br> <li> Removed inline sort block; added <code>stream_comparator</code> helper<br> <li> Simplified <code>sort</code> and <code>asc</code> query parameter parsing<br> <li> Adjusted pagination logic with early return and index drains


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7522/files#diff-619eafba0f0509d905b021f4a16659010aca23c62cffd9cd3e6c2bbe204ce200">+60/-56</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>