### PR TITLE
fix: replace function drops "$'" while applying filter in the query

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1045,15 +1045,18 @@ const useLogs = () => {
 
           whereClause = parsedSQL.join(" ");
 
-          req.query.sql = req.query.sql.replace(
-            "[WHERE_CLAUSE]",
-            " WHERE " + whereClause,
-          );
+          // req.query.sql = req.query.sql.replace(
+          //   "[WHERE_CLAUSE]",
+          //   " WHERE " + whereClause,
+          // );
+          req.query.sql = req.query.sql.split("[WHERE_CLAUSE]").join(" WHERE " + whereClause);
 
-          req.aggs.histogram = req.aggs.histogram.replace(
-            "[WHERE_CLAUSE]",
-            " WHERE " + whereClause,
-          );
+
+          // req.aggs.histogram = req.aggs.histogram.replace(
+          //   "[WHERE_CLAUSE]",
+          //   " WHERE " + whereClause,
+          // );
+          req.aggs.histogram = req.aggs.histogram.split("[WHERE_CLAUSE]").join(" WHERE " + whereClause);
         } else {
           req.query.sql = req.query.sql.replace("[WHERE_CLAUSE]", "");
           req.aggs.histogram = req.aggs.histogram.replace("[WHERE_CLAUSE]", "");

--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -961,10 +961,11 @@ export default defineComponent({
 
             whereClause = parsedSQL.join(" ");
 
-            query_context = query_context.replace(
-              "[WHERE_CLAUSE]",
-              " WHERE " + whereClause,
-            );
+            // query_context = query_context.replace(
+            //   "[WHERE_CLAUSE]",
+            //   " WHERE " + whereClause,
+            // );
+            query_context = query_context.split("[WHERE_CLAUSE]").join(" WHERE " + whereClause);
           } else {
             query_context = query_context.replace("[WHERE_CLAUSE]", "");
           }

--- a/web/src/plugins/traces/fields-sidebar/BasicValuesFilter.vue
+++ b/web/src/plugins/traces/fields-sidebar/BasicValuesFilter.vue
@@ -199,10 +199,11 @@ const openFilterCreator = (event: any, { name, ftsKey }: any) => {
 
       whereClause = parsedSQL.join(" ");
 
-      query_context = query_context.replace(
-        "[WHERE_CLAUSE]",
-        " WHERE " + whereClause,
-      );
+      // query_context = query_context.replace(
+      //   "[WHERE_CLAUSE]",
+      //   " WHERE " + whereClause,
+      // );
+      query_context = query_context.split("[WHERE_CLAUSE]").join(" WHERE " + whereClause);
     } else {
       query_context = query_context.replace("[WHERE_CLAUSE]", "");
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Use split().join() for global replacements

- Comment out deprecated replace() calls

- Ensure all [WHERE_CLAUSE] placeholders replaced

- Apply fix in logs, traces, composables


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Query/Context with [WHERE_CLAUSE]"] -- "split/join replacement" --> B["Final query with WHERE clause"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IndexList.vue</strong><dd><code>Use split.join for WHERE clause replacement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/IndexList.vue

<li>Comment out single replace() call<br> <li> Introduce split('[WHERE_CLAUSE]').join(...)<br> <li> Preserve node quoting logic


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7535/files#diff-08f058f883b659e713e606991a7ea37ae1ff016b7cccef970489ab5840dc3d09">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BasicValuesFilter.vue</strong><dd><code>Global WHERE clause replacement in filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/traces/fields-sidebar/BasicValuesFilter.vue

<li>Comment out replace() for placeholder<br> <li> Use split().join() for global replace<br> <li> Keep Base64 encoding step


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7535/files#diff-3ec23f0cdf1bbf9075cfc995045d2597f9d9adb2a64ec55be7f3b9cf9da2e9ea">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useLogs.ts</strong><dd><code>Fix global WHERE clause placeholder replacement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs.ts

<li>Replace replace() with split().join() on SQL<br> <li> Apply same change to histogram aggs<br> <li> Comment out old replace() code


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7535/files#diff-1040f61354f92711e0e77ed4e9bfa15586d45a94c7e2ab06cc37372068030e7b">+12/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>