### PR TITLE
fix: fix histogram issue when user redirected from streams to logs an…

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -712,6 +712,9 @@ export default defineComponent({
           !type
         ) {
           searchObj.meta.pageType = "logs";
+          if(prev === "stream_explorer" && (type == undefined || type !== "stream_explorer")) {
+            searchObj.meta.refreshHistogram = true;
+          }
           loadLogsData();
         }
       },


### PR DESCRIPTION
### **User description**
…d clicking on logs menu again


___

### **PR Type**
Bug fix


___

### **Description**
- Enable histogram refresh after streams-to-logs navigation

- Preserve existing `loadLogsData()` invocation


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Previous route 'stream_explorer'"] --> B["Set `refreshHistogram` flag"]
  B --> C["Invoke `loadLogsData()`"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Enable histogram refresh flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/Index.vue

<li>Add condition for <code>refreshHistogram</code> flag<br> <li> Ensure histogram refresh on logs view


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7540/files#diff-0323c3da69b369843c5d72bf4df5b00ca6b5147192a213baf331659ecf92af62">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>