### PR TITLE
chore: multiple improvements

### DIFF
--- a/src/common/infra/cluster/etcd.rs
+++ b/src/common/infra/cluster/etcd.rs
@@ -76,7 +76,7 @@ async fn register() -> Result<()> {
     let locker = dist_lock::lock("/nodes/register", cfg.limit.node_heartbeat_ttl as u64).await?;
 
     // 2. watch node list
-    tokio::task::spawn(async move { super::watch_node_list().await });
+    tokio::task::spawn(super::watch_node_list());
 
     // 3. get node list
     let node_list = match super::list_nodes().await {

--- a/src/common/infra/config.rs
+++ b/src/common/infra/config.rs
@@ -179,7 +179,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_cache() {
         let (tx, rx) = mpsc::channel(100);
-        tokio::spawn(async move { update_cache(rx).await });
+        tokio::spawn(update_cache(rx));
         tx.send(infra::db::nats::NatsEvent::Connected)
             .await
             .unwrap();

--- a/src/common/meta/ingestion.rs
+++ b/src/common/meta/ingestion.rs
@@ -124,8 +124,7 @@ pub struct BulkResponseItem {
     pub status: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<BulkResponseError>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "originalRecord")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "originalRecord")]
     #[schema(value_type = Object)]
     pub original_record: Option<json::Value>,
 }

--- a/src/common/meta/stream.rs
+++ b/src/common/meta/stream.rs
@@ -35,8 +35,8 @@ pub struct Stream {
     pub stats: StreamStats,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub schema: Vec<StreamProperty>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub uds_schema: Option<Vec<StreamProperty>>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub uds_schema: Vec<StreamProperty>,
     pub settings: StreamSettings,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metrics_meta: Option<Metadata>,
@@ -149,7 +149,7 @@ mod tests {
                 name: "field1".to_string(),
                 prop_type: "string".to_string(),
             }],
-            uds_schema: None,
+            uds_schema: vec![],
             settings: StreamSettings::default(),
             metrics_meta: None,
             total_fields: 1,
@@ -225,16 +225,16 @@ mod tests {
             stream_type: StreamType::Logs,
             stats: StreamStats::default(),
             schema: vec![],
-            uds_schema: Some(vec![StreamProperty {
+            uds_schema: vec![StreamProperty {
                 name: "uds_field".to_string(),
                 prop_type: "string".to_string(),
-            }]),
+            }],
             settings: StreamSettings::default(),
             metrics_meta: None,
             total_fields: 1,
         };
 
-        assert!(stream.uds_schema.is_some_and(|schema| schema.len() == 1));
+        assert!(stream.uds_schema.len() == 1);
     }
 
     #[test]

--- a/src/config/src/meta/dashboards/v3/mod.rs
+++ b/src/config/src/meta/dashboards/v3/mod.rs
@@ -222,7 +222,7 @@ pub struct PanelConfig {
 pub struct DrillDown {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename="type")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     type_field: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_blank: Option<bool>,

--- a/src/config/src/meta/dashboards/v3/mod.rs
+++ b/src/config/src/meta/dashboards/v3/mod.rs
@@ -222,8 +222,7 @@ pub struct PanelConfig {
 pub struct DrillDown {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none", rename="type")]
     type_field: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_blank: Option<bool>,

--- a/src/config/src/meta/dashboards/v4/mod.rs
+++ b/src/config/src/meta/dashboards/v4/mod.rs
@@ -234,8 +234,7 @@ pub struct PanelConfig {
 pub struct DrillDown {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     type_field: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_blank: Option<bool>,
@@ -250,8 +249,7 @@ pub struct DrillDown {
 pub struct MarkLine {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     typee: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<String>,

--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -318,8 +318,7 @@ pub struct ColorCfg {
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Mapping {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none", rename="type")]
     typee: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<String>,
@@ -329,8 +328,7 @@ pub struct Mapping {
     to: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pattern: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "match")]
+    #[serde(skip_serializing_if = "Option::is_none", rename="match")]
     matchh: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<String>,
@@ -343,8 +341,7 @@ pub struct Mapping {
 pub struct DrillDown {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none", rename="type")]
     type_field: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_blank: Option<bool>,
@@ -359,8 +356,7 @@ pub struct DrillDown {
 pub struct MarkLine {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none", rename="type")]
     typee: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<String>,

--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -318,7 +318,7 @@ pub struct ColorCfg {
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Mapping {
-    #[serde(skip_serializing_if = "Option::is_none", rename="type")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     typee: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<String>,
@@ -328,7 +328,7 @@ pub struct Mapping {
     to: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pattern: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename="match")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "match")]
     matchh: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<String>,
@@ -341,7 +341,7 @@ pub struct Mapping {
 pub struct DrillDown {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename="type")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     type_field: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_blank: Option<bool>,
@@ -356,7 +356,7 @@ pub struct DrillDown {
 pub struct MarkLine {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename="type")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     typee: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<String>,

--- a/src/config/src/meta/self_reporting/error.rs
+++ b/src/config/src/meta/self_reporting/error.rs
@@ -48,8 +48,7 @@ pub struct PipelineError {
     pub pipeline_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    #[serde(serialize_with = "serialize_values_only")]
+    #[serde(skip_serializing_if = "HashMap::is_empty", serialize_with = "serialize_values_only")]
     pub node_errors: HashMap<String, NodeErrors>,
 }
 

--- a/src/config/src/meta/self_reporting/error.rs
+++ b/src/config/src/meta/self_reporting/error.rs
@@ -48,7 +48,10 @@ pub struct PipelineError {
     pub pipeline_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    #[serde(skip_serializing_if = "HashMap::is_empty", serialize_with = "serialize_values_only")]
+    #[serde(
+        skip_serializing_if = "HashMap::is_empty",
+        serialize_with = "serialize_values_only"
+    )]
     pub node_errors: HashMap<String, NodeErrors>,
 }
 

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -553,8 +553,7 @@ pub struct UpdateSettingsWrapper<D> {
 pub struct UpdateStreamSettings {
     #[serde(skip_serializing_if = "Option::None")]
     pub partition_time_level: Option<PartitionTimeLevel>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub partition_keys: UpdateSettingsWrapper<StreamPartition>,
     #[serde(default)]
     pub full_text_search_keys: UpdateSettingsWrapper<String>,
@@ -562,11 +561,9 @@ pub struct UpdateStreamSettings {
     pub index_fields: UpdateSettingsWrapper<String>,
     #[serde(default)]
     pub bloom_filter_fields: UpdateSettingsWrapper<String>,
-    #[serde(skip_serializing_if = "Option::None")]
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::None", default)]
     pub data_retention: Option<i64>,
-    #[serde(skip_serializing_if = "Option::None")]
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::None", default)]
     pub flatten_level: Option<i64>,
     #[serde(default)]
     pub defined_schema_fields: UpdateSettingsWrapper<String>,
@@ -681,14 +678,11 @@ impl TimeRange {
 pub struct StreamSettings {
     #[serde(skip_serializing_if = "Option::None")]
     pub partition_time_level: Option<PartitionTimeLevel>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub partition_keys: Vec<StreamPartition>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub full_text_search_keys: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub index_fields: Vec<String>,
     #[serde(default)]
     pub bloom_filter_fields: Vec<String>,
@@ -704,8 +698,7 @@ pub struct StreamSettings {
     pub store_original_data: bool,
     #[serde(default)]
     pub approx_partition: bool,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub distinct_value_fields: Vec<DistinctField>,
     #[serde(default)]
     pub index_updated_at: i64,

--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -77,18 +77,19 @@ async fn schema(
             "stream not found",
         )));
     };
-    if let Some(uds_fields) = schema.settings.defined_schema_fields.as_ref() {
+    if !schema.settings.defined_schema_fields.is_empty() {
         let mut schema_fields = schema
             .schema
             .iter()
             .map(|f| (&f.name, f))
             .collect::<HashMap<_, _>>();
-        schema.uds_schema = Some(
-            uds_fields
-                .iter()
-                .filter_map(|f| schema_fields.remove(f).map(|f| f.to_owned()))
-                .collect::<Vec<_>>(),
-        );
+        schema.uds_schema = schema
+            .settings
+            .defined_schema_fields
+            .iter()
+            .filter_map(|f| schema_fields.remove(f))
+            .cloned()
+            .collect::<Vec<_>>();
     }
 
     // filter by keyword

--- a/src/infra/src/db/etcd.rs
+++ b/src/infra/src/db/etcd.rs
@@ -52,7 +52,7 @@ pub async fn init() {
         return;
     }
     // enable keep alive for auth token
-    tokio::task::spawn(async move { keep_alive_connection().await });
+    tokio::task::spawn(keep_alive_connection());
 }
 
 pub struct Etcd {

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -270,7 +270,7 @@ pub fn unwrap_partition_time_level(
 pub fn get_stream_setting_defined_schema_fields(settings: &Option<StreamSettings>) -> Vec<String> {
     settings
         .as_ref()
-        .map(|settings| settings.defined_schema_fields.clone().unwrap_or_default())
+        .map(|settings| settings.defined_schema_fields.clone())
         .unwrap_or_default()
 }
 
@@ -575,23 +575,10 @@ pub async fn delete_fields(
 
             let mut settings = unwrap_stream_settings(&latest_schema).unwrap_or_default();
 
-            if let Some(schema_fields) = settings.defined_schema_fields {
-                let defined_schema_fields = schema_fields
-                    .iter()
-                    .filter_map(|f| {
-                        if deleted_fields.contains(f) {
-                            None
-                        } else {
-                            Some(f.clone())
-                        }
-                    })
-                    .collect::<Vec<_>>();
-                if defined_schema_fields.is_empty() {
-                    settings.defined_schema_fields = None;
-                } else {
-                    settings.defined_schema_fields = Some(defined_schema_fields);
-                }
-            };
+            settings
+                .defined_schema_fields
+                .retain(|f| !deleted_fields.contains(f));
+
             new_metadata.insert("settings".to_string(), json::to_string(&settings).unwrap());
             let new_schema = vec![Schema::new_with_metadata(fields, new_metadata)];
             Ok(Some((

--- a/src/infra/src/table/migration/m20250107_160900_delete_bad_dashboards.rs
+++ b/src/infra/src/table/migration/m20250107_160900_delete_bad_dashboards.rs
@@ -687,8 +687,7 @@ mod v3 {
     pub struct DrillDown {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(rename = "type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
         type_field: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         target_blank: Option<bool>,
@@ -1027,8 +1026,7 @@ mod v4 {
     pub struct DrillDown {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(rename = "type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
         type_field: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         target_blank: Option<bool>,
@@ -1043,8 +1041,7 @@ mod v4 {
     pub struct MarkLine {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(rename = "type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
         typee: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,
@@ -1433,8 +1430,7 @@ mod v5 {
     #[derive(Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Mapping {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(rename = "type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
         typee: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,
@@ -1444,8 +1440,7 @@ mod v5 {
         to: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pattern: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(rename = "match")]
+        #[serde(skip_serializing_if = "Option::is_none", rename="match")]
         matchh: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         color: Option<String>,
@@ -1458,8 +1453,7 @@ mod v5 {
     pub struct DrillDown {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(rename = "type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
         type_field: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         target_blank: Option<bool>,
@@ -1474,8 +1468,7 @@ mod v5 {
     pub struct MarkLine {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(rename = "type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
         typee: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,

--- a/src/infra/src/table/migration/m20250107_160900_delete_bad_dashboards.rs
+++ b/src/infra/src/table/migration/m20250107_160900_delete_bad_dashboards.rs
@@ -687,7 +687,7 @@ mod v3 {
     pub struct DrillDown {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
         type_field: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         target_blank: Option<bool>,
@@ -1026,7 +1026,7 @@ mod v4 {
     pub struct DrillDown {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
         type_field: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         target_blank: Option<bool>,
@@ -1041,7 +1041,7 @@ mod v4 {
     pub struct MarkLine {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
         typee: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,
@@ -1430,7 +1430,7 @@ mod v5 {
     #[derive(Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Mapping {
-        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
         typee: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,
@@ -1440,7 +1440,7 @@ mod v5 {
         to: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pattern: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none", rename="match")]
+        #[serde(skip_serializing_if = "Option::is_none", rename = "match")]
         matchh: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         color: Option<String>,
@@ -1453,7 +1453,7 @@ mod v5 {
     pub struct DrillDown {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
         type_field: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         target_blank: Option<bool>,
@@ -1468,7 +1468,7 @@ mod v5 {
     pub struct MarkLine {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none", rename="type")]
+        #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
         typee: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,

--- a/src/job/alert_manager.rs
+++ b/src/job/alert_manager.rs
@@ -60,14 +60,14 @@ pub async fn run() -> Result<(), anyhow::Error> {
         .await?;
     }
 
-    tokio::task::spawn(async move { run_schedule_jobs().await });
-    tokio::task::spawn(async move { watch_timeout_jobs().await });
+    tokio::task::spawn(run_schedule_jobs());
+    tokio::task::spawn(watch_timeout_jobs());
     for i in 0..cfg.limit.search_job_workers {
-        tokio::task::spawn(async move { run_search_jobs(i).await });
+        tokio::task::spawn(run_search_jobs(i));
     }
-    tokio::task::spawn(async move { run_check_running_search_jobs().await });
-    tokio::task::spawn(async move { run_delete_jobs_by_retention().await });
-    tokio::task::spawn(async move { run_delete_jobs().await });
+    tokio::task::spawn(run_check_running_search_jobs());
+    tokio::task::spawn(run_delete_jobs_by_retention());
+    tokio::task::spawn(run_delete_jobs());
 
     Ok(())
 }

--- a/src/job/compactor.rs
+++ b/src/job/compactor.rs
@@ -46,19 +46,19 @@ pub async fn run() -> Result<(), anyhow::Error> {
         log::error!("[COMPACTOR::JOB] start merge job scheduler error: {e}");
     }
 
-    tokio::task::spawn(async move { run_generate_job().await });
-    tokio::task::spawn(async move { run_generate_old_data_job().await });
+    tokio::task::spawn(run_generate_job());
+    tokio::task::spawn(run_generate_old_data_job());
     #[cfg(feature = "enterprise")]
-    tokio::task::spawn(async move { run_generate_downsampling_job().await });
-    tokio::task::spawn(async move { run_merge(scheduler.tx()).await });
-    tokio::task::spawn(async move { run_retention().await });
-    tokio::task::spawn(async move { run_delay_deletion().await });
-    tokio::task::spawn(async move { run_sync_to_db().await });
+    tokio::task::spawn(run_generate_downsampling_job());
+    tokio::task::spawn(run_merge(scheduler.tx()));
+    tokio::task::spawn(run_retention());
+    tokio::task::spawn(run_delay_deletion());
+    tokio::task::spawn(run_sync_to_db());
     #[cfg(feature = "enterprise")]
-    tokio::task::spawn(async move { run_downsampling_sync_to_db().await });
-    tokio::task::spawn(async move { run_check_running_jobs().await });
-    tokio::task::spawn(async move { run_clean_done_jobs().await });
-    tokio::task::spawn(async move { run_compactor_pending_jobs_metric().await });
+    tokio::task::spawn(run_downsampling_sync_to_db());
+    tokio::task::spawn(run_check_running_jobs());
+    tokio::task::spawn(run_clean_done_jobs());
+    tokio::task::spawn(run_compactor_pending_jobs_metric());
 
     Ok(())
 }

--- a/src/job/files/mod.rs
+++ b/src/job/files/mod.rs
@@ -31,9 +31,9 @@ pub async fn run() -> Result<(), anyhow::Error> {
     // load pending delete files to memory cache
     crate::service::db::file_list::local::load_pending_delete().await?;
 
-    tokio::task::spawn(async move { parquet::run().await });
-    tokio::task::spawn(async move { broadcast::run().await });
-    tokio::task::spawn(async move { clean_empty_dirs().await });
+    tokio::task::spawn(parquet::run());
+    tokio::task::spawn(broadcast::run());
+    tokio::task::spawn(clean_empty_dirs());
 
     Ok(())
 }

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -666,7 +666,7 @@ async fn merge_files(
     let (defined_schema_fields, need_original, index_original_data, index_all_values) =
         match stream_settings {
             Some(s) => (
-                s.defined_schema_fields.unwrap_or_default(),
+                s.defined_schema_fields,
                 s.store_original_data,
                 s.index_original_data,
                 s.index_all_values,

--- a/src/job/flatten_compactor.rs
+++ b/src/job/flatten_compactor.rs
@@ -58,7 +58,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
         });
     }
 
-    tokio::task::spawn(async move { run_generate(tx).await });
+    tokio::task::spawn(run_generate(tx));
     Ok(())
 }
 

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -97,7 +97,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         && (LOCAL_NODE.is_ingester() || LOCAL_NODE.is_querier() || LOCAL_NODE.is_alert_manager())
     {
         // Try to download the mmdb files, if its not disabled.
-        tokio::task::spawn(async move { mmdb_downloader::run().await });
+        tokio::task::spawn(mmdb_downloader::run());
     }
 
     db::user::cache().await.expect("user cache failed");
@@ -111,9 +111,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
         .expect("organization settings cache sync failed");
 
     // watch org users
-    tokio::task::spawn(async move { db::user::watch().await });
-    tokio::task::spawn(async move { db::org_users::watch().await });
-    tokio::task::spawn(async move { db::organization::watch().await });
+    tokio::task::spawn(db::user::watch());
+    tokio::task::spawn(db::org_users::watch());
+    tokio::task::spawn(db::organization::watch());
 
     // check version
     db::metas::version::set()
@@ -125,13 +125,13 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
     // Auth auditing should be done by router also
     #[cfg(feature = "enterprise")]
-    tokio::task::spawn(async move { self_reporting::run_audit_publish().await });
+    tokio::task::spawn(self_reporting::run_audit_publish());
     #[cfg(feature = "cloud")]
-    tokio::task::spawn(async move { self_reporting::cloud_events::flush_cloud_events().await });
+    tokio::task::spawn(self_reporting::cloud_events::flush_cloud_events());
 
     #[cfg(feature = "enterprise")]
     {
-        tokio::task::spawn(async move { db::ofga::watch().await });
+        tokio::task::spawn(db::ofga::watch());
         db::ofga::cache().await.expect("ofga model cache failed");
         o2_openfga::authorizer::authz::init_open_fga().await;
         // RBAC model
@@ -142,7 +142,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         }
     }
 
-    tokio::task::spawn(async move { promql_self_consume::run().await });
+    tokio::task::spawn(promql_self_consume::run());
     // Router doesn't need to initialize job
     if LOCAL_NODE.is_router() && LOCAL_NODE.is_single_role() {
         return Ok(());
@@ -150,27 +150,27 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
     // telemetry run
     if cfg.common.telemetry_enabled && LOCAL_NODE.is_querier() {
-        tokio::task::spawn(async move { telemetry::run().await });
+        tokio::task::spawn(telemetry::run());
     }
 
-    tokio::task::spawn(async move { self_reporting::run().await });
+    tokio::task::spawn(self_reporting::run());
 
     // cache short_urls
-    tokio::task::spawn(async move { db::short_url::watch().await });
+    tokio::task::spawn(db::short_url::watch());
     db::short_url::cache()
         .await
         .expect("short url cache failed");
 
     // initialize metadata watcher
-    tokio::task::spawn(async move { db::schema::watch().await });
-    tokio::task::spawn(async move { db::functions::watch().await });
-    tokio::task::spawn(async move { db::compact::retention::watch().await });
-    tokio::task::spawn(async move { db::metrics::watch_prom_cluster_leader().await });
-    tokio::task::spawn(async move { db::alerts::templates::watch().await });
-    tokio::task::spawn(async move { db::alerts::destinations::watch().await });
-    tokio::task::spawn(async move { db::alerts::realtime_triggers::watch().await });
-    tokio::task::spawn(async move { db::alerts::alert::watch().await });
-    tokio::task::spawn(async move { db::organization::org_settings_watch().await });
+    tokio::task::spawn(db::schema::watch());
+    tokio::task::spawn(db::functions::watch());
+    tokio::task::spawn(db::compact::retention::watch());
+    tokio::task::spawn(db::metrics::watch_prom_cluster_leader());
+    tokio::task::spawn(db::alerts::templates::watch());
+    tokio::task::spawn(db::alerts::destinations::watch());
+    tokio::task::spawn(db::alerts::realtime_triggers::watch());
+    tokio::task::spawn(db::alerts::alert::watch());
+    tokio::task::spawn(db::organization::org_settings_watch());
 
     // pipeline not used on compactors
     if LOCAL_NODE.is_ingester() || LOCAL_NODE.is_querier() || LOCAL_NODE.is_alert_manager() {
@@ -179,10 +179,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
     #[cfg(feature = "enterprise")]
     if LOCAL_NODE.is_ingester() || LOCAL_NODE.is_querier() {
-        tokio::task::spawn(async move { db::session::watch().await });
+        tokio::task::spawn(db::session::watch());
     }
     if LOCAL_NODE.is_ingester() || LOCAL_NODE.is_querier() || LOCAL_NODE.is_alert_manager() {
-        tokio::task::spawn(async move { db::enrichment_table::watch().await });
+        tokio::task::spawn(db::enrichment_table::watch());
     }
 
     tokio::task::yield_now().await;
@@ -235,31 +235,29 @@ pub async fn init() -> Result<(), anyhow::Error> {
         }
     }
 
-    tokio::task::spawn(async move { files::run().await });
-    tokio::task::spawn(async move { stats::run().await });
-    tokio::task::spawn(async move { compactor::run().await });
-    tokio::task::spawn(async move { flatten_compactor::run().await });
-    tokio::task::spawn(async move { metrics::run().await });
-    tokio::task::spawn(async move { promql::run().await });
-    tokio::task::spawn(async move { alert_manager::run().await });
-    tokio::task::spawn(async move { file_downloader::run().await });
+    tokio::task::spawn(files::run());
+    tokio::task::spawn(stats::run());
+    tokio::task::spawn(compactor::run());
+    tokio::task::spawn(flatten_compactor::run());
+    tokio::task::spawn(metrics::run());
+    tokio::task::spawn(promql::run());
+    tokio::task::spawn(alert_manager::run());
+    tokio::task::spawn(file_downloader::run());
 
     if LOCAL_NODE.is_compactor() {
-        tokio::task::spawn(async move { file_list_dump::run().await });
+        tokio::task::spawn(file_list_dump::run());
     }
 
     // load metrics disk cache
-    tokio::task::spawn(async move { crate::service::promql::search::init().await });
+    tokio::task::spawn(crate::service::promql::search::init());
     // start pipeline data retention
     #[cfg(feature = "enterprise")]
-    tokio::task::spawn(
-        async move { o2_enterprise::enterprise::pipeline::pipeline_job::run().await },
-    );
+    tokio::task::spawn(o2_enterprise::enterprise::pipeline::pipeline_job::run());
 
     #[cfg(feature = "enterprise")]
-    tokio::task::spawn(async move { cipher::run().await });
+    tokio::task::spawn(cipher::run());
     #[cfg(feature = "enterprise")]
-    tokio::task::spawn(async move { db::keys::watch().await });
+    tokio::task::spawn(db::keys::watch());
 
     // additional for cloud
     #[cfg(feature = "cloud")]
@@ -279,8 +277,8 @@ pub async fn init() -> Result<(), anyhow::Error> {
     log::info!("Job initialization complete");
 
     // Syslog server start
-    tokio::task::spawn(async move { db::syslog::watch().await });
-    tokio::task::spawn(async move { db::syslog::watch_syslog_settings().await });
+    tokio::task::spawn(db::syslog::watch());
+    tokio::task::spawn(db::syslog::watch_syslog_settings());
 
     let start_syslog = *SYSLOG_ENABLED.read();
     if start_syslog {

--- a/src/job/stats.rs
+++ b/src/job/stats.rs
@@ -19,9 +19,9 @@ use tokio::time;
 use crate::service::{compact::stats::update_stats_from_file_list, db};
 
 pub async fn run() -> Result<(), anyhow::Error> {
-    tokio::task::spawn(async move { update_node_memory_usage().await });
-    tokio::task::spawn(async move { file_list_update_stats().await });
-    tokio::task::spawn(async move { cache_stream_stats().await });
+    tokio::task::spawn(update_node_memory_usage());
+    tokio::task::spawn(file_list_update_stats());
+    tokio::task::spawn(cache_stream_stats());
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,7 +359,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .expect("Deferred jobs failed to init");
 
     if cfg.log.events_enabled {
-        tokio::task::spawn(async move { zo_logger::send_logs().await });
+        tokio::task::spawn(zo_logger::send_logs());
     }
     if cfg.common.telemetry_enabled {
         tokio::task::spawn(async move {
@@ -753,9 +753,7 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
         .disable_signals()
         .run();
     let handle = server.handle();
-    tokio::task::spawn(async move {
-        graceful_shutdown(handle).await;
-    });
+    tokio::task::spawn(graceful_shutdown(handle));
     server.await?;
     Ok(())
 }
@@ -861,9 +859,7 @@ async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
         .disable_signals()
         .run();
     let handle = server.handle();
-    tokio::task::spawn(async move {
-        graceful_shutdown(handle).await;
-    });
+    tokio::task::spawn(graceful_shutdown(handle));
     server.await?;
     Ok(())
 }
@@ -1104,9 +1100,7 @@ async fn init_script_server() -> Result<(), anyhow::Error> {
         .disable_signals()
         .run();
     let handle = server.handle();
-    tokio::task::spawn(async move {
-        graceful_shutdown(handle).await;
-    });
+    tokio::task::spawn(graceful_shutdown(handle));
     server.await?;
 
     log::info!("HTTP server stopped");

--- a/src/report_server/src/server.rs
+++ b/src/report_server/src/server.rs
@@ -40,9 +40,7 @@ pub async fn spawn_server() -> Result<(), anyhow::Error> {
     .run();
 
     let handle = server.handle();
-    tokio::task::spawn(async move {
-        graceful_shutdown(handle).await;
-    });
+    tokio::task::spawn(graceful_shutdown(handle));
     server.await?;
     log::info!("Report server stopped");
     Ok(())

--- a/src/service/alerts/scheduler/worker.rs
+++ b/src/service/alerts/scheduler/worker.rs
@@ -140,7 +140,6 @@ impl SchedulerWorker {
         if let Err(e) = handler_job.await {
             return Err(anyhow::anyhow!("Error in handler: {}", e));
         }
-
         Ok(())
     }
 }

--- a/src/service/compact/flatten.rs
+++ b/src/service/compact/flatten.rs
@@ -63,7 +63,7 @@ pub async fn run_generate(worker_tx: mpsc::Sender<FileKey>) -> Result<(), anyhow
                         .await
                         .unwrap_or_default();
                 let defined_schema_fields =
-                    stream_setting.defined_schema_fields.unwrap_or_default();
+                    stream_setting.defined_schema_fields;
                 if defined_schema_fields.is_empty() {
                     continue;
                 }

--- a/src/service/compact/flatten.rs
+++ b/src/service/compact/flatten.rs
@@ -62,8 +62,7 @@ pub async fn run_generate(worker_tx: mpsc::Sender<FileKey>) -> Result<(), anyhow
                     infra::schema::get_settings(&org_id, &stream_name, stream_type)
                         .await
                         .unwrap_or_default();
-                let defined_schema_fields =
-                    stream_setting.defined_schema_fields;
+                let defined_schema_fields = stream_setting.defined_schema_fields;
                 if defined_schema_fields.is_empty() {
                     continue;
                 }

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -776,7 +776,7 @@ pub async fn merge_files(
     let (defined_schema_fields, need_original, index_original_data, index_all_values) =
         match stream_settings {
             Some(s) => (
-                s.defined_schema_fields.unwrap_or_default(),
+                s.defined_schema_fields,
                 s.store_original_data,
                 s.index_original_data,
                 s.index_all_values,

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -549,16 +549,15 @@ pub async fn get_uds_and_original_data_streams(
             stream.stream_name.to_string(),
             stream_settings.index_all_values,
         );
-        if let Some(fields) = &stream_settings.defined_schema_fields {
-            if !fields.is_empty() {
-                let mut fields: HashSet<_> = fields.iter().cloned().collect();
-                if !fields.contains(TIMESTAMP_COL_NAME) {
-                    fields.insert(TIMESTAMP_COL_NAME.to_string());
-                }
-                user_defined_schema_map.insert(stream.stream_name.to_string(), Some(fields));
-            } else {
-                user_defined_schema_map.insert(stream.stream_name.to_string(), None);
+
+        if !stream_settings.defined_schema_fields.is_empty() {
+            let mut fields = HashSet::<_>::from_iter(stream_settings.defined_schema_fields);
+            if !fields.contains(TIMESTAMP_COL_NAME) {
+                fields.insert(TIMESTAMP_COL_NAME.to_string());
             }
+            user_defined_schema_map.insert(stream.stream_name.to_string(), Some(fields));
+        } else {
+            user_defined_schema_map.insert(stream.stream_name.to_string(), None);
         }
     }
 }

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -109,7 +109,7 @@ impl Default for DistinctValues {
 
 impl DistinctValues {
     pub fn new() -> Self {
-        tokio::task::spawn(async move { run_flush().await });
+        tokio::task::spawn(run_flush());
         Self {
             channel: handle_channel(),
             shutdown: Arc::new(AtomicBool::new(false)),

--- a/src/service/metadata/trace_list_index.rs
+++ b/src/service/metadata/trace_list_index.rs
@@ -208,7 +208,7 @@ impl TraceListIndex {
                 data_retention: 0,
                 flatten_level: None,
                 max_query_range: 0,
-                defined_schema_fields: None,
+                defined_schema_fields: vec![],
                 store_original_data: false,
                 approx_partition: false,
                 distinct_value_fields: vec![],

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -220,7 +220,7 @@ impl ExecutablePipeline {
         }
 
         // Spawn tasks for each node
-        let mut node_tasks = Vec::new();
+        let mut node_tasks = Vec::with_capacity(self.sorted_nodes.len());
         for (idx, node_id) in self.sorted_nodes.iter().enumerate() {
             let pl_id_cp = self.id.to_string();
             let org_id_cp = org_id.to_string();
@@ -239,22 +239,19 @@ impl ExecutablePipeline {
 
             // WARN: Do not change. Processing node can only be done in a task, as the internals of
             // remote wal writer depends on the task id.
-            let task = tokio::spawn(async move {
-                process_node(
-                    pl_id_cp,
-                    idx,
-                    org_id_cp,
-                    node,
-                    node_receiver,
-                    child_senders,
-                    vrl_runtime,
-                    result_sender_cp,
-                    error_sender_cp,
-                    pipeline_name,
-                    stream_name,
-                )
-                .await
-            });
+            let task = tokio::spawn(process_node(
+                pl_id_cp,
+                idx,
+                org_id_cp,
+                node,
+                node_receiver,
+                child_senders,
+                vrl_runtime,
+                result_sender_cp,
+                error_sender_cp,
+                pipeline_name,
+                stream_name,
+            ));
             node_tasks.push(task);
         }
 

--- a/src/service/schema.rs
+++ b/src/service/schema.rs
@@ -120,7 +120,7 @@ pub async fn check_for_schema(
             let (defined_schema_fields, need_original, index_original_data, index_all_values) =
                 match stream_setting {
                     Some(s) => (
-                        s.defined_schema_fields.unwrap_or_default(),
+                        s.defined_schema_fields,
                         s.store_original_data,
                         s.index_original_data,
                         s.index_all_values,
@@ -324,10 +324,7 @@ async fn handle_diff_schema(
 
     // check defined_schema_fields
     let mut stream_setting = unwrap_stream_settings(&final_schema).unwrap_or_default();
-    let mut defined_schema_fields = stream_setting
-        .defined_schema_fields
-        .clone()
-        .unwrap_or_default();
+    let mut defined_schema_fields = stream_setting.defined_schema_fields.clone();
 
     // Automatically enable User-defined schema when
     // 1. allow_user_defined_schemas is enabled
@@ -390,7 +387,7 @@ async fn handle_diff_schema(
         }
 
         defined_schema_fields = uds_fields.into_iter().collect::<Vec<_>>();
-        stream_setting.defined_schema_fields = Some(defined_schema_fields.clone());
+        stream_setting.defined_schema_fields = defined_schema_fields.clone();
         final_schema.metadata.insert(
             "settings".to_string(),
             json::to_string(&stream_setting).unwrap(),
@@ -512,7 +509,7 @@ pub fn get_schema_changes(schema: &SchemaCache, inferred_schema: &Schema) -> (bo
 
     let stream_setting = unwrap_stream_settings(schema.schema());
     let defined_schema_fields = stream_setting
-        .and_then(|s| s.defined_schema_fields)
+        .map(|s| s.defined_schema_fields)
         .unwrap_or_default();
 
     for item in inferred_schema.fields.iter() {

--- a/src/service/self_reporting/queues.rs
+++ b/src/service/self_reporting/queues.rs
@@ -56,9 +56,12 @@ fn initialize_usage_queue() -> ReportingQueue {
 
     for thread_id in 0..cfg.limit.usage_reporting_thread_num {
         let msg_receiver = msg_receiver.clone();
-        tokio::task::spawn(async move {
-            self_reporting_ingest_job(thread_id, msg_receiver, batch_size, timeout).await
-        });
+        tokio::task::spawn(self_reporting_ingest_job(
+            thread_id,
+            msg_receiver,
+            batch_size,
+            timeout,
+        ));
     }
 
     ReportingQueue::new(msg_sender)
@@ -81,9 +84,12 @@ fn initialize_error_queue() -> ReportingQueue {
 
     for thread_id in 0..cfg.limit.usage_reporting_thread_num {
         let msg_receiver = msg_receiver.clone();
-        tokio::task::spawn(async move {
-            self_reporting_ingest_job(thread_id, msg_receiver, batch_size, timeout).await
-        });
+        tokio::task::spawn(self_reporting_ingest_job(
+            thread_id,
+            msg_receiver,
+            batch_size,
+            timeout,
+        ));
     }
 
     ReportingQueue::new(msg_sender)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Consolidate `serde` annotations into single attributes

- Convert `Option<Vec<T>>` fields to `Vec<T>` defaults

- Simplify code using `is_empty` and `default`

- Refactor `tokio::spawn` calls to direct futures


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td><strong>config.rs</strong><dd><code>Use direct tokio::spawn call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-cda0d9179ed982fa5f0989c9b26f21cfa49dd1de28195a98135650ffcc7c602a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingestion.rs</strong><dd><code>Combine serde annotations on original_record</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-5effcbeb41f448c6f75b1f17baa683a02d668865eb09f898633797cd1327e3a2">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stream.rs</strong><dd><code>Convert uds_schema Option to Vec default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-6f5ee19bbcc9cc7fb699fc1c0f43fc96d42698ae1168a2827b5c65f7948d5dbc">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Inline serde rename in DrillDown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-84b6c5b1ecc108223434a008e1e382d4cc494668a12b6ac22ab457a72e308dd4">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Merge serde skip and rename on type fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-63a64145239e03a59debc87c63764d425a36746d00f1bd6563ce2be1847b1213">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Fix serde annotations in Mapping and DrillDown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-da49585bbcb02bf0f737bb68739ebc248edd15c7ad9427c0e68f7728bb4a8c17">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error.rs</strong><dd><code>Merge serde annotations on node_errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-00a00a557343475be7131843f748fbae2d0c1a4041a5c4dddec56c940a03e613">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stream.rs</strong><dd><code>Convert defined_schema_fields to Vec default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-2438d04c3fe97bc5452e5b74a303163b8723d93455cda32c95f0525435ad46bd">+21/-36</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Return defined_schema_fields Vec directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-386fd4fad1e48ab0a90516cab1947b1888b270b2fe912f30d2255cc38e6c519b">+5/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>m20250107_160900_delete_bad_dashboards.rs</strong><dd><code>Update serde rename in dashboard migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-193ae70c0cf20659f673ee1b6538fa70dc5ccf20297377dbbadb3ece696b4a50">+7/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>parquet.rs</strong><dd><code>Use Vec defined_schema_fields without unwrap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-27f710981cfe1b938aeeb53abaed05961596c32e2edf3b8a2a59d3e72b2f542b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>worker.rs</strong><dd><code>Remove redundant spawn for handle_triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-3d37991258d3f26b16ad99bba59b63adfa614bfbc4866c4088544ca9308ae49d">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flatten.rs</strong><dd><code>Access defined_schema_fields Vec directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-93a66ecfe3a7fdfe5509dda69e4d444f02b18c841c34ab3078f1fb314af8e3ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>merge.rs</strong><dd><code>Use Vec defined_schema_fields without unwrap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-0ab016dbd5129c9c285c9c459bf78928147bce97dc92a03aa754da3da71168d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Simplify user_defined_schema_map logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-7c7b5bca85f0ced652965cae66540c96f56dfcca4f4c16b77bf7b45aac203d1b">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>trace_list_index.rs</strong><dd><code>Initialize defined_schema_fields with empty Vec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-ed0b8fd6271d025477c8f433dd32908c47f8fef22b09ecd8bbaea37c041ceeb1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batch_execution.rs</strong><dd><code>Preallocate tasks and simplify tokio::spawn</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-3f6824a6eddaf1603e5cb0f1a4311ac6a45e1ffb967266ccc1f0bba944625e69">+14/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>schema.rs</strong><dd><code>Simplify defined_schema_fields handling in schema diff</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-d9596182a0c7a46a6a7ff5cee822554cdae05ceec312f86c93b538db9f73bbfd">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stream.rs</strong><dd><code>Default uds_schema to Vec and validate fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-41452a7fb29b4634437174fd6aecf6a9050dbfdef41b9077a21d59af3d79e9ed">+9/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7541/files#diff-619eafba0f0509d905b021f4a16659010aca23c62cffd9cd3e6c2bbe204ce200">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>