### PR TITLE
fix: optimize topk

### DIFF
--- a/src/common/utils/auth_tests.rs
+++ b/src/common/utils/auth_tests.rs
@@ -46,7 +46,6 @@ mod tests {
     const GROUP_NAME: &str = "TEST_GROUP_NAME";
     const PIPELINE_ID: &str = "TEST_PIPELINE_ID";
     const SHORT_URL_ID: &str = "TEST_SHORT_URL_ID";
-    const WS_REQUEST_ID: &str = "TEST_WS_REQUEST_ID";
     const ACTION_KSUID: &str = "TEST_ACTION_KSUID";
     const CIPHER_KEY_ID: &str = "TEST_CIPHER_KEY_ID";
 
@@ -2985,6 +2984,10 @@ mod tests {
                 timeout: u64::default(),
                 max_connections: usize::default(),
             },
+            http_streaming: config::HttpStreaming {
+                streaming_response_chunk_size: usize::default(),
+                streaming_enabled: bool::default(),
+            },
             common: config::Common {
                 app_name: String::default(),
                 local_mode: bool::default(),
@@ -3115,6 +3118,7 @@ mod tests {
                 file_list_dump_min_hour: Default::default(),
                 file_list_dump_debug_check: Default::default(),
                 aggregation_cache_enabled: bool::default(),
+                aggregation_topk_enabled: bool::default(),
                 use_stream_settings_for_partitions_enabled: Default::default(),
                 dashboard_placeholder: Default::default(),
                 search_inspector_enabled: bool::default(),
@@ -3291,7 +3295,6 @@ mod tests {
                 multi_dir: String::default(),
                 aggregation_max_size: usize::default(),
                 delay_window_mins: i64::default(),
-                aggregation_cache_enabled: bool::default(),
             },
             log: config::Log {
                 level: String::default(),

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1093,6 +1093,8 @@ pub struct Common {
     pub dashboard_placeholder: String,
     #[env_config(name = "ZO_AGGREGATION_CACHE_ENABLED", default = true)]
     pub aggregation_cache_enabled: bool,
+    #[env_config(name = "ZO_AGGREGATION_TOPK_ENABLED", default = true)]
+    pub aggregation_topk_enabled: bool,
     #[env_config(name = "ZO_SEARCH_INSPECTOR_ENABLED", default = false)]
     pub search_inspector_enabled: bool,
     #[env_config(name = "ZO_UTF8_VIEW_ENABLED", default = true)]
@@ -1568,8 +1570,6 @@ pub struct DiskCache {
     pub result_max_size: usize,
     #[env_config(name = "ZO_DISK_AGGREGATION_CACHE_MAX_SIZE", default = 0)]
     pub aggregation_max_size: usize,
-    #[env_config(name = "ZO_AGGREGATION_CACHE_ENABLED", default = true)]
-    pub aggregation_cache_enabled: bool,
     // MB, will skip the cache when a query need cache great than this value, default is 50% of
     // max_size
     #[env_config(name = "ZO_DISK_CACHE_SKIP_SIZE", default = 0)]

--- a/src/config/src/utils/record_batch_ext.rs
+++ b/src/config/src/utils/record_batch_ext.rs
@@ -546,7 +546,7 @@ pub fn concat_batches(
 pub fn merge_record_batches(
     job_name: &str,
     thread_id: usize,
-    mut schema: Arc<Schema>,
+    schema: Arc<Schema>,
     record_batches: Vec<RecordBatch>,
 ) -> Result<(Arc<Schema>, RecordBatch), DataFusionError> {
     // 1. format the record batch by schema (after format all record batch have the same schema)
@@ -570,42 +570,60 @@ pub fn merge_record_batches(
         for (deleted_num, idx) in null_columns.into_iter().enumerate() {
             concated_record_batch.remove_column(idx - deleted_num);
         }
-        schema = concated_record_batch.schema().clone();
     }
 
     // 4. sort concatenated record batch by timestamp col in desc order
-    let sort_indices = arrow::compute::sort_to_indices(
-        concated_record_batch
-            .column_by_name(TIMESTAMP_COL_NAME)
-            .ok_or_else(|| {
-                log::error!(
-                    "[{job_name}:JOB:{thread_id}] merge small files failed to find _timestamp column from merged record batch.",
-                );
-                DataFusionError::Execution(
-                    "No _timestamp column found in merged record batch".to_string(),
-                )
-            })?,
-        Some(arrow_schema::SortOptions {
-            descending: true,
-            nulls_first: false,
-        }),
+    let sorted_batch = sort_record_batch_by_column(
+        concated_record_batch,
+        TIMESTAMP_COL_NAME,
+        true,
         None,
+    ).inspect_err(|e| {
+        log::error!(
+            "[{job_name}:JOB:{thread_id}] merge small files failed to find _timestamp column from merged record batch, err: {e}",
+        );
+    })?;
+    let schema = sorted_batch.schema();
+
+    Ok((schema, sorted_batch))
+}
+
+pub fn sort_record_batch_by_column(
+    batch: RecordBatch,
+    column_name: &str,
+    descending: bool,
+    limit: Option<usize>,
+) -> Result<RecordBatch, DataFusionError> {
+    if batch.num_rows() == 0 {
+        return Ok(batch);
+    }
+
+    // Create sort options
+    let sort_options = arrow::compute::SortOptions {
+        descending,
+        nulls_first: false,
+    };
+
+    // Get sorted indices
+    let indices = arrow::compute::sort_to_indices(
+        batch.column_by_name(column_name).ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "No {column_name} column found in sort record batch",
+            ))
+        })?,
+        Some(sort_options),
+        limit,
     )?;
 
-    let batch_columns_len = concated_record_batch.columns().len();
-    let mut sorted_columns = Vec::with_capacity(batch_columns_len);
-    for i in 0..batch_columns_len {
-        let i = i - sorted_columns.len();
-        let sorted_column =
-            arrow::compute::take(&concated_record_batch.remove_column(i), &sort_indices, None)?;
-        sorted_columns.push(sorted_column);
-    }
-    drop(concated_record_batch);
+    // Apply indices to all columns
+    let sorted_columns: Result<Vec<_>, _> = batch
+        .columns()
+        .iter()
+        .map(|col| arrow::compute::take(col, &indices, None))
+        .collect();
 
-    let final_record_batch = RecordBatch::try_new(schema.clone(), sorted_columns)?;
-    let schema = final_record_batch.schema();
-
-    Ok((schema, final_record_batch))
+    // Create new RecordBatch with sorted data
+    RecordBatch::try_new(batch.schema(), sorted_columns?).map_err(|e| e.into())
 }
 
 #[cfg(test)]
@@ -763,6 +781,320 @@ mod test {
 | Bob     | 30  | London   |
 | Charlie | 35  | Paris    |
 +---------+-----+----------+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_record_batch_by_column_string_ascending() {
+        // Create a sample schema
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+            Field::new("city", DataType::Utf8, true),
+        ]));
+
+        // Create a sample record batch with unsorted data
+        let name = StringArray::from(vec!["Charlie", "Alice", "Bob"]);
+        let age = Int64Array::from(vec![35, 25, 30]);
+        let city = StringArray::from(vec!["Paris", "New York", "London"]);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(name) as ArrayRef,
+                Arc::new(age) as ArrayRef,
+                Arc::new(city) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        // Sort by name column in ascending order
+        let sorted_batch = sort_record_batch_by_column(record_batch, "name", false, None).unwrap();
+
+        // Assert that the batch is sorted by name
+        assert_eq!(
+            pretty_format_batches(&[sorted_batch]).unwrap().to_string(),
+            "+---------+-----+----------+
+| name    | age | city     |
++---------+-----+----------+
+| Alice   | 25  | New York |
+| Bob     | 30  | London   |
+| Charlie | 35  | Paris    |
++---------+-----+----------+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_record_batch_by_column_string_descending() {
+        // Create a sample schema
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+            Field::new("city", DataType::Utf8, true),
+        ]));
+
+        // Create a sample record batch with unsorted data
+        let name = StringArray::from(vec!["Alice", "Charlie", "Bob"]);
+        let age = Int64Array::from(vec![25, 35, 30]);
+        let city = StringArray::from(vec!["New York", "Paris", "London"]);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(name) as ArrayRef,
+                Arc::new(age) as ArrayRef,
+                Arc::new(city) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        // Sort by name column in descending order
+        let sorted_batch = sort_record_batch_by_column(record_batch, "name", true, None).unwrap();
+
+        // Assert that the batch is sorted by name in descending order
+        assert_eq!(
+            pretty_format_batches(&[sorted_batch]).unwrap().to_string(),
+            "+---------+-----+----------+
+| name    | age | city     |
++---------+-----+----------+
+| Charlie | 35  | Paris    |
+| Bob     | 30  | London   |
+| Alice   | 25  | New York |
++---------+-----+----------+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_record_batch_by_column_numeric_ascending() {
+        // Create a sample schema
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+            Field::new("score", DataType::Float64, false),
+        ]));
+
+        // Create a sample record batch with unsorted data
+        let name = StringArray::from(vec!["Alice", "Bob", "Charlie"]);
+        let age = Int64Array::from(vec![30, 25, 35]);
+        let score = Float64Array::from(vec![85.5, 92.3, 78.1]);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(name) as ArrayRef,
+                Arc::new(age) as ArrayRef,
+                Arc::new(score) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        // Sort by age column in ascending order
+        let sorted_batch = sort_record_batch_by_column(record_batch, "age", false, None).unwrap();
+
+        // Assert that the batch is sorted by age
+        assert_eq!(
+            pretty_format_batches(&[sorted_batch]).unwrap().to_string(),
+            "+---------+-----+-------+
+| name    | age | score |
++---------+-----+-------+
+| Bob     | 25  | 92.3  |
+| Alice   | 30  | 85.5  |
+| Charlie | 35  | 78.1  |
++---------+-----+-------+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_record_batch_by_column_numeric_descending() {
+        // Create a sample schema
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+            Field::new("score", DataType::Float64, false),
+        ]));
+
+        // Create a sample record batch with unsorted data
+        let name = StringArray::from(vec!["Alice", "Bob", "Charlie"]);
+        let age = Int64Array::from(vec![30, 25, 35]);
+        let score = Float64Array::from(vec![85.5, 92.3, 78.1]);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(name) as ArrayRef,
+                Arc::new(age) as ArrayRef,
+                Arc::new(score) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        // Sort by score column in descending order
+        let sorted_batch = sort_record_batch_by_column(record_batch, "score", true, None).unwrap();
+
+        // Assert that the batch is sorted by score in descending order
+        assert_eq!(
+            pretty_format_batches(&[sorted_batch]).unwrap().to_string(),
+            "+---------+-----+-------+
+| name    | age | score |
++---------+-----+-------+
+| Bob     | 25  | 92.3  |
+| Alice   | 30  | 85.5  |
+| Charlie | 35  | 78.1  |
++---------+-----+-------+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_record_batch_by_column_nonexistent_column() {
+        // Create a sample schema
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+        ]));
+
+        // Create a sample record batch
+        let name = StringArray::from(vec!["Alice", "Bob", "Charlie"]);
+        let age = Int64Array::from(vec![25, 30, 35]);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(name) as ArrayRef, Arc::new(age) as ArrayRef],
+        )
+        .unwrap();
+
+        // Try to sort by a non-existent column
+        let result = sort_record_batch_by_column(record_batch, "nonexistent", false, None);
+
+        // Assert that it returns an error
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("No nonexistent column found in sort record batch")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_record_batch_by_column_empty_batch() {
+        // Create a sample schema
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+        ]));
+
+        // Create an empty record batch
+        let name = StringArray::from(vec![] as Vec<&str>);
+        let age = Int64Array::from(vec![] as Vec<i64>);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(name) as ArrayRef, Arc::new(age) as ArrayRef],
+        )
+        .unwrap();
+
+        // Sort by name column
+        let sorted_batch = sort_record_batch_by_column(record_batch, "name", false, None).unwrap();
+
+        // Assert that the batch is still empty
+        assert_eq!(sorted_batch.num_rows(), 0);
+        assert_eq!(sorted_batch.schema(), schema);
+    }
+
+    #[tokio::test]
+    async fn test_sort_record_batch_by_column_with_nulls() {
+        // Create a sample schema
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("age", DataType::Int64, false),
+        ]));
+
+        // Create a sample record batch with null values
+        let name = StringArray::from(vec![Some("Charlie"), None, Some("Alice"), Some("Bob")]);
+        let age = Int64Array::from(vec![35, 40, 25, 30]);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(name) as ArrayRef, Arc::new(age) as ArrayRef],
+        )
+        .unwrap();
+
+        // Sort by name column in ascending order (nulls should be last due to nulls_first: false)
+        let sorted_batch = sort_record_batch_by_column(record_batch, "name", false, None).unwrap();
+
+        // Assert that the batch is sorted correctly with nulls at the end
+        assert_eq!(
+            pretty_format_batches(&[sorted_batch]).unwrap().to_string(),
+            "+---------+-----+
+| name    | age |
++---------+-----+
+| Alice   | 25  |
+| Bob     | 30  |
+| Charlie | 35  |
+|         | 40  |
++---------+-----+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_record_batch_by_column_with_limit() {
+        // Create a sample schema
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+        ]));
+
+        // Create a sample record batch with unsorted data
+        let name = StringArray::from(vec!["Eve", "Alice", "Bob", "Charlie", "Diana"]);
+        let age = Int64Array::from(vec![22, 25, 30, 35, 28]);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(name) as ArrayRef, Arc::new(age) as ArrayRef],
+        )
+        .unwrap();
+
+        // Sort by name column in ascending order with limit of 3
+        let sorted_batch =
+            sort_record_batch_by_column(record_batch, "name", false, Some(3)).unwrap();
+
+        // Assert that the batch is sorted by name and limited to 3 rows
+        assert_eq!(sorted_batch.num_rows(), 3);
+        assert_eq!(
+            pretty_format_batches(&[sorted_batch]).unwrap().to_string(),
+            "+---------+-----+
+| name    | age |
++---------+-----+
+| Alice   | 25  |
+| Bob     | 30  |
+| Charlie | 35  |
++---------+-----+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_record_batch_by_column_with_limit_larger_than_data() {
+        // Create a sample schema
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+        ]));
+
+        // Create a sample record batch with unsorted data
+        let name = StringArray::from(vec!["Bob", "Alice"]);
+        let age = Int64Array::from(vec![30, 25]);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(name) as ArrayRef, Arc::new(age) as ArrayRef],
+        )
+        .unwrap();
+
+        // Sort by name column in ascending order with limit larger than data size
+        let sorted_batch =
+            sort_record_batch_by_column(record_batch, "name", false, Some(10)).unwrap();
+
+        // Assert that the batch is sorted by name and contains all rows (not limited)
+        assert_eq!(sorted_batch.num_rows(), 2);
+        assert_eq!(
+            pretty_format_batches(&[sorted_batch]).unwrap().to_string(),
+            "+-------+-----+
+| name  | age |
++-------+-----+
+| Alice | 25  |
+| Bob   | 30  |
++-------+-----+"
         );
     }
 }

--- a/src/handler/http/request/organization/settings.rs
+++ b/src/handler/http/request/organization/settings.rs
@@ -96,7 +96,7 @@ async fn create(
 
     #[cfg(feature = "enterprise")]
     if let Some(aggregation_cache_enabled) = settings.aggregation_cache_enabled
-        && config::get_config().disk_cache.aggregation_cache_enabled
+        && config::get_config().common.aggregation_cache_enabled
     {
         field_found = true;
         data.aggregation_cache_enabled = aggregation_cache_enabled;

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -559,6 +559,19 @@ pub async fn redirect(req: HttpRequest) -> Result<HttpResponse, Error> {
                             .json("Service accounts are not allowed to login".to_string()));
                     }
 
+                    // get domain from email
+                    let domain = res.0.user_email.split('@').nth(1).unwrap_or_default();
+                    if !get_dex_config().allowed_domains.is_empty()
+                        && !get_dex_config().allowed_domains.contains(domain)
+                    {
+                        audit_message.response_meta.http_response_code = 400;
+                        audit_message._timestamp = now_micros();
+                        audit(audit_message).await;
+                        return Ok(
+                            HttpResponse::Unauthorized().json("Unauthorized access".to_string())
+                        );
+                    }
+
                     audit_message.user_email = res.0.user_email.clone();
                     id_token = json::to_string(&json::json!({
                         "email": res.0.user_email,

--- a/src/proto/proto/cluster/plan.proto
+++ b/src/proto/proto/cluster/plan.proto
@@ -20,6 +20,12 @@ message NewEmptyExecNode {
     datafusion_common.Schema        full_schema = 7;
 }
 
+message AggregateTopkExecNode {
+    string  sort_field = 1;
+    bool    descending = 2;
+    uint64       limit = 3;
+}
+
 // Search request
 message FlightSearchRequest {
     QueryIdentifier         query_identifier = 1;

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -2886,6 +2886,16 @@ pub struct NewEmptyExecNode {
     #[prost(message, optional, tag = "7")]
     pub full_schema: ::core::option::Option<::datafusion_proto::protobuf::Schema>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AggregateTopkExecNode {
+    #[prost(string, tag = "1")]
+    pub sort_field: ::prost::alloc::string::String,
+    #[prost(bool, tag = "2")]
+    pub descending: bool,
+    #[prost(uint64, tag = "3")]
+    pub limit: u64,
+}
 /// Search request
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/service/alerts/scheduler/worker.rs
+++ b/src/service/alerts/scheduler/worker.rs
@@ -166,7 +166,7 @@ impl SchedulerJobPuller {
             // Check how many workers are available
             let trace_id = config::ider::uuid();
 
-            log::info!("[SCHEDULER][JobPuller-{trace_id}] Pulling jobs");
+            log::debug!("[SCHEDULER][JobPuller-{trace_id}] Pulling jobs");
 
             // Pull only as many jobs as we have workers
             let triggers = match self.pull().await {
@@ -177,7 +177,7 @@ impl SchedulerJobPuller {
                 }
             };
 
-            log::info!(
+            log::debug!(
                 "[SCHEDULER][JobPuller-{}] Pulled {} jobs from scheduler",
                 trace_id,
                 triggers.len()
@@ -198,7 +198,7 @@ impl SchedulerJobPuller {
 
                 // Print counts for each module
                 for (module, triggers) in grouped_triggers {
-                    log::info!(
+                    log::debug!(
                         "[SCHEDULER] [JobPuller-{}] Pulled {:?}: {} jobs",
                         trace_id,
                         module,

--- a/src/service/compact/stats.rs
+++ b/src/service/compact/stats.rs
@@ -33,7 +33,7 @@ pub async fn update_stats_from_file_list() -> Result<Option<(i64, i64)>, anyhow:
         log::info!("keep updating stream stats from file list, offset: {offset:?} ...");
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
     }
-    log::info!("done updating stream stats from file list");
+    log::debug!("done updating stream stats from file list");
     Ok(None)
 }
 

--- a/src/service/search/datafusion/distributed_plan/codec/aggregate_topk_exec.rs
+++ b/src/service/search/datafusion/distributed_plan/codec/aggregate_topk_exec.rs
@@ -1,0 +1,139 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use datafusion::{
+    common::{Result, internal_err},
+    error::DataFusionError,
+    execution::FunctionRegistry,
+    physical_plan::ExecutionPlan,
+};
+use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+use o2_enterprise::enterprise::search::datafusion::distributed_plan::aggregate_topk_exec::AggregateTopkExec;
+use prost::Message;
+use proto::cluster_rpc;
+
+/// A PhysicalExtensionCodec that can serialize and deserialize ChildExec
+#[derive(Debug)]
+pub struct AggregateTopkExecPhysicalExtensionCodec;
+
+impl PhysicalExtensionCodec for AggregateTopkExecPhysicalExtensionCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[Arc<dyn ExecutionPlan>],
+        _registry: &dyn FunctionRegistry,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let proto = cluster_rpc::AggregateTopkExecNode::decode(buf).map_err(|e| {
+            DataFusionError::Internal(format!(
+                "failed to decode AggregateTopkExecNode writer execution plan: {e:?}"
+            ))
+        })?;
+        Ok(Arc::new(AggregateTopkExec::new(
+            inputs[0].clone(),
+            &proto.sort_field,
+            proto.descending,
+            proto.limit,
+        )))
+    }
+
+    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
+        let Some(node) = node.as_any().downcast_ref::<AggregateTopkExec>() else {
+            return internal_err!("Not supported");
+        };
+        let proto = cluster_rpc::AggregateTopkExecNode {
+            sort_field: node.sort_field().to_string(),
+            descending: node.descending(),
+            limit: node.limit(),
+        };
+        proto.encode(buf).map_err(|e| {
+            DataFusionError::Internal(format!(
+                "failed to encode AggregateTopkExecNode writer execution plan: {e:?}"
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::datatypes::{DataType, Field, Schema},
+        functions_aggregate::count::count_udaf,
+        physical_expr::aggregate::AggregateExprBuilder,
+        physical_plan::{
+            aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy},
+            empty::EmptyExec,
+            expressions::{col, lit},
+        },
+    };
+    use datafusion_proto::bytes::{
+        physical_plan_from_bytes_with_extension_codec, physical_plan_to_bytes_with_extension_codec,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_datafusion_codec() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        let grouping_set = PhysicalGroupBy::new(
+            vec![(col("a", &schema)?, "a".to_string())],
+            vec![],
+            vec![vec![false]],
+        );
+
+        let aggregates = vec![Arc::new(
+            AggregateExprBuilder::new(count_udaf(), vec![lit(1i32)])
+                .schema(Arc::clone(&schema))
+                .alias("COUNT(1)")
+                .build()?,
+        )];
+
+        let agg_plan = AggregateExec::try_new(
+            AggregateMode::Partial,
+            grouping_set.clone(),
+            aggregates.clone(),
+            vec![None],
+            Arc::new(EmptyExec::new(Arc::clone(&schema))),
+            Arc::clone(&schema),
+        )?;
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(AggregateTopkExec::new(
+            Arc::new(agg_plan) as Arc<dyn ExecutionPlan>,
+            "COUNT(1)",
+            false,
+            10,
+        ));
+
+        // encode
+        let proto = super::super::ComposedPhysicalExtensionCodec {
+            codecs: vec![Arc::new(AggregateTopkExecPhysicalExtensionCodec {})],
+        };
+        let plan_bytes = physical_plan_to_bytes_with_extension_codec(plan.clone(), &proto).unwrap();
+
+        // decode
+        let ctx = datafusion::prelude::SessionContext::new();
+        let plan2 = physical_plan_from_bytes_with_extension_codec(&plan_bytes, &ctx, &proto)?;
+        let plan2 = plan2.as_any().downcast_ref::<AggregateTopkExec>().unwrap();
+        let plan = plan.as_any().downcast_ref::<AggregateTopkExec>().unwrap();
+
+        // check
+        assert_eq!(plan.limit(), plan2.limit());
+        assert_eq!(plan.descending(), plan2.descending());
+
+        Ok(())
+    }
+}

--- a/src/service/search/datafusion/distributed_plan/codec/mod.rs
+++ b/src/service/search/datafusion/distributed_plan/codec/mod.rs
@@ -1,0 +1,94 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use datafusion::{
+    common::Result, execution::FunctionRegistry, logical_expr::ScalarUDF,
+    physical_plan::ExecutionPlan,
+};
+use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+
+#[cfg(feature = "enterprise")]
+mod aggregate_topk_exec;
+mod empty_exec;
+
+pub fn get_physical_extension_codec() -> ComposedPhysicalExtensionCodec {
+    ComposedPhysicalExtensionCodec {
+        codecs: vec![
+            Arc::new(empty_exec::EmptyExecPhysicalExtensionCodec {}),
+            #[cfg(feature = "enterprise")]
+            Arc::new(aggregate_topk_exec::AggregateTopkExecPhysicalExtensionCodec {}),
+        ],
+    }
+}
+
+/// A PhysicalExtensionCodec that tries one of multiple inner codecs
+/// until one works
+#[derive(Debug)]
+pub struct ComposedPhysicalExtensionCodec {
+    pub codecs: Vec<Arc<dyn PhysicalExtensionCodec>>,
+}
+
+impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[Arc<dyn ExecutionPlan>],
+        registry: &dyn FunctionRegistry,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let mut last_err = None;
+        for codec in &self.codecs {
+            match codec.try_decode(buf, inputs, registry) {
+                Ok(plan) => return Ok(plan),
+                Err(e) => last_err = Some(e),
+            }
+        }
+        Err(last_err.unwrap())
+    }
+
+    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
+        let mut last_err = None;
+        for codec in &self.codecs {
+            match codec.try_encode(node.clone(), buf) {
+                Ok(_) => return Ok(()),
+                Err(e) => last_err = Some(e),
+            }
+        }
+        Err(last_err.unwrap())
+    }
+
+    fn try_decode_udf(&self, name: &str, _buf: &[u8]) -> Result<Arc<ScalarUDF>> {
+        let mut last_err = None;
+        for codec in &self.codecs {
+            match codec.try_decode_udf(name, _buf) {
+                Ok(plan) => return Ok(plan),
+                Err(e) => last_err = Some(e),
+            }
+        }
+        Err(last_err.unwrap())
+    }
+
+    fn try_encode_udf(&self, _node: &ScalarUDF, _buf: &mut Vec<u8>) -> Result<()> {
+        let mut last_err = None;
+        for codec in &self.codecs {
+            match codec.try_encode_udf(_node, _buf) {
+                Ok(_) => return Ok(()),
+                Err(e) => last_err = Some(e),
+            }
+        }
+        Err(last_err.unwrap())
+    }
+}

--- a/src/service/search/datafusion/distributed_plan/codec/mod.rs
+++ b/src/service/search/datafusion/distributed_plan/codec/mod.rs
@@ -70,10 +70,10 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         Err(last_err.unwrap())
     }
 
-    fn try_decode_udf(&self, name: &str, _buf: &[u8]) -> Result<Arc<ScalarUDF>> {
+    fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>> {
         let mut last_err = None;
         for codec in &self.codecs {
-            match codec.try_decode_udf(name, _buf) {
+            match codec.try_decode_udf(name, buf) {
                 Ok(plan) => return Ok(plan),
                 Err(e) => last_err = Some(e),
             }
@@ -81,10 +81,10 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         Err(last_err.unwrap())
     }
 
-    fn try_encode_udf(&self, _node: &ScalarUDF, _buf: &mut Vec<u8>) -> Result<()> {
+    fn try_encode_udf(&self, _node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<()> {
         let mut last_err = None;
         for codec in &self.codecs {
-            match codec.try_encode_udf(_node, _buf) {
+            match codec.try_encode_udf(_node, buf) {
                 Ok(_) => return Ok(()),
                 Err(e) => last_err = Some(e),
             }

--- a/src/service/search/grpc/flight.rs
+++ b/src/service/search/grpc/flight.rs
@@ -48,8 +48,7 @@ use crate::service::{
     search::{
         datafusion::{
             distributed_plan::{
-                NewEmptyExecVisitor, ReplaceTableScanExec,
-                codec::{ComposedPhysicalExtensionCodec, EmptyExecPhysicalExtensionCodec},
+                NewEmptyExecVisitor, ReplaceTableScanExec, codec::get_physical_extension_codec,
                 empty_exec::NewEmptyExec,
             },
             exec::{prepare_datafusion_context, register_udf},
@@ -94,9 +93,7 @@ pub async fn search(
     datafusion_functions_json::register_all(&mut ctx)?;
 
     // Decode physical plan from bytes
-    let proto = ComposedPhysicalExtensionCodec {
-        codecs: vec![Arc::new(EmptyExecPhysicalExtensionCodec {})],
-    };
+    let proto = get_physical_extension_codec();
     let mut physical_plan =
         physical_plan_from_bytes_with_extension_codec(&req.search_info.plan, &ctx, &proto)?;
 

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -869,7 +869,7 @@ pub async fn search_partition(
     });
 
     #[cfg(feature = "enterprise")]
-    let streaming_aggs = is_streaming_aggregate && req.streaming_output;
+    let streaming_aggs = is_streaming_aggregate && req.streaming_output && streaming_id.is_some();
 
     let mut resp = search::SearchPartitionResponse {
         trace_id: trace_id.to_string(),

--- a/src/service/search/streaming/mod.rs
+++ b/src/service/search/streaming/mod.rs
@@ -26,16 +26,13 @@ use config::meta::{
     stream::StreamType,
 };
 use log;
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::common::{
+    auditor::{AuditMessage, Protocol, ResponseMeta},
+    config::get_config as get_o2_config,
+};
 use tokio::sync::mpsc;
 use tracing::Instrument;
-#[cfg(feature = "enterprise")]
-use {
-    o2_enterprise::enterprise::common::{
-        auditor::{AuditMessage, Protocol, ResponseMeta},
-        config::get_config as get_o2_config,
-    },
-    o2_enterprise::enterprise::search::datafusion::distributed_plan::streaming_aggs_exec,
-};
 
 use crate::{
     common::{

--- a/src/service/search/super_cluster/follower.rs
+++ b/src/service/search/super_cluster/follower.rs
@@ -43,7 +43,7 @@ use crate::service::{
         datafusion::{
             distributed_plan::{
                 NewEmptyExecVisitor,
-                codec::{ComposedPhysicalExtensionCodec, EmptyExecPhysicalExtensionCodec},
+                codec::get_physical_extension_codec,
                 empty_exec::NewEmptyExec,
                 node::{RemoteScanNode, SearchInfos},
                 remote_scan::RemoteScanExec,
@@ -94,9 +94,7 @@ pub async fn search(
     datafusion_functions_json::register_all(&mut ctx)?;
 
     // Decode physical plan from bytes
-    let proto = ComposedPhysicalExtensionCodec {
-        codecs: vec![Arc::new(EmptyExecPhysicalExtensionCodec {})],
-    };
+    let proto = get_physical_extension_codec();
     let mut physical_plan = physical_plan_from_bytes_with_extension_codec(
         &flight_request.search_info.plan,
         &ctx,

--- a/src/service/search/super_cluster/leader.rs
+++ b/src/service/search/super_cluster/leader.rs
@@ -312,15 +312,16 @@ async fn run_datafusion(
             .unwrap_or_default();
         let use_cache = use_cache && org_settings.aggregation_cache_enabled;
         let target_partitions = ctx.state().config().target_partitions();
-        let (plan, is_complete_cache_hit, is_complete_cache_hit_with_no_data) = o2_enterprise::enterprise::search::datafusion::distributed_plan::rewrite::rewrite_aggregate_plan(
-            streaming_id,
-            start_time,
-            end_time,
-            use_cache,
-            target_partitions,
-            physical_plan,
-        )
-        .await?;
+        let (plan, is_complete_cache_hit, is_complete_cache_hit_with_no_data) =
+            o2_enterprise::enterprise::search::datafusion::rewrite::rewrite_streaming_agg_plan(
+                streaming_id,
+                start_time,
+                end_time,
+                use_cache,
+                target_partitions,
+                physical_plan,
+            )
+            .await?;
         physical_plan = plan;
         // Check for aggs cache hit
         if is_complete_cache_hit {
@@ -336,6 +337,14 @@ async fn run_datafusion(
             return Ok((vec![], scan_stats, "".to_string()));
         }
     }
+
+    // rewrite physical plan for merge aggregation and get topk
+    let plan = o2_enterprise::enterprise::search::datafusion::rewrite::rewrite_topk_agg_plan(
+        sql.limit,
+        physical_plan,
+    )
+    .await?;
+    physical_plan = plan;
 
     if cfg.common.print_key_sql {
         let plan = displayable(physical_plan.as_ref())


### PR DESCRIPTION
### **User description**
Add new optimize rule for RAW topk query:
```
SELECT clientip, count(*) as cnt FROM default GROUP BY clientip ORDER BY cnt DESC LIMIT 10
```

It also will only return `4k.max(1000)` records to leader with this optimize rule:

```
ZO_AGGREGATION_TOPK_ENABLED=true
```


___

### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Implement TopK aggregation exec and plan rewrite

- Add sort_record_batch_by_column helper function

- Introduce `ZO_AGGREGATION_TOPK_ENABLED` config flag

- Add comprehensive tests for sort and codec


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>auth_tests.rs</strong><dd><code>Update tests for new config defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-2688cbdc0b009b3f0dd829c69ab86c6a7d0778ab3e65e916a410a76aa6ae6480">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config.rs</strong><dd><code>Add aggregation_topk_enabled config flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>record_batch_ext.rs</strong><dd><code>Implement sort_record_batch_by_column and refactor merge</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-f84aa2842a164d6e85aa05a718159e87a325cac139c59e561f6f59313c6d7c5d">+361/-29</a></td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Enforce allowed email domains in redirect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-ca09c9c9b020049bdbc3382c466bfcca80daac92e98760d9a9a76172abf34049">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cluster.rs</strong><dd><code>Add AggregateTopkExecNode proto message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-542d8f27a174c845740ca1c3fe0b697db89c3db666437c1c4dd8c9745510080c">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flight.rs</strong><dd><code>Integrate rewrite_topk_agg_plan in flight</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-dbffb1a03b65f6a9163b18c5bb1241ba2966735657be39bbe9f4d0e3260d8c1d">+21/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>aggregate_topk_exec.rs</strong><dd><code>Add AggregateTopkExecPhysicalExtensionCodec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-c240541c2c8c20e71b8ab501e3b3323aca5b0db16a102d61349c4f6421875a52">+139/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>empty_exec.rs</strong><dd><code>Refactor EmptyExec codec import paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-5c0bea6e3c3a5a24e925e262355db32a53a3609bf63b0d38cd74ad1110d22778">+2/-61</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Compose extension codecs including TopK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-bf29436fa2e898322627944aff76f6da9e2551c3d2395a700af774509bcba346">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remote_scan.rs</strong><dd><code>Use centralized extension codec in RemoteScan</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-bedf6eb5852c3d7f49b8a7aad163acd5eaef2c2a5f73961020c7822cedab3fef">+11/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flight.rs</strong><dd><code>Use centralized extension codec in gRPC flight</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-8f9464a4df8af407ec61aef1ac4853c0474c99c8698fae38f9cfea344207fc2f">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>follower.rs</strong><dd><code>Use centralized extension codec in follower</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-59e0cc386582cf8baf201977475fd9a7e479fd8ed000bbaa6746a51ecb28632f">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>leader.rs</strong><dd><code>Apply TopK rewrite in leader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-21a32af318adcd10e62fb0d45944993f623fb3d2d6df4bb70d882dfc8f677fdc">+18/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plan.proto</strong><dd><code>Define AggregateTopkExecNode in proto</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-4f1a05aba1b09b2db2ffae983dcdf4ed294ed3698204af80d50ae2d7b711551b">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>settings.rs</strong><dd><code>Correct aggregation_cache_enabled config path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-1e807254f2faf8fd09b802f71b23412f203eed289033f96bfc62b15dd997db8c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Include streaming_id in streaming_aggs flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-c3b85ea662a885fbd39797968928b291cb59a58f53a03f7b7dfd7ba8b6a7985a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>worker.rs</strong><dd><code>Lower scheduler logs to debug level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-3d37991258d3f26b16ad99bba59b63adfa614bfbc4866c4088544ca9308ae49d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stats.rs</strong><dd><code>Lower stats update log to debug level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-0cd00223b45e800b2e02ad809eccb99e99cb7b7b5a0546a87e1513e4ac692c21">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Reorder imports for enterprise streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7552/files#diff-f236c6c880ed80233fd264e657d5ab658c16c7368bdc70e20f123862b7214374">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>