### PR TITLE
fix: update cancelQueryAbort to set isPartialData

### DIFF
--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -333,9 +333,12 @@ export const usePanelDataLoader = (
   };
 
   const cancelQueryAbort = () => {
+    // Only set isPartialData to true if the panel was still loading
+    if (state.loading) {
+      state.isPartialData = true; // Set to true when cancelled
+    }
     state.loading = false;
     state.isOperationCancelled = true;
-    state.isPartialData = true; // Set to true when cancelled
 
     if (
       isStreamingEnabled(store.state) &&


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Conditionally set `isPartialData` only when loading

- Prevent incorrect partial data flag on cancel


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usePanelDataLoader.ts</strong><dd><code>Guard partial data flag by loading state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/dashboard/usePanelDataLoader.ts

<li>Wrapped <code>state.isPartialData</code> assignment in <code>if (state.loading)</code><br> <li> Removed unconditional <code>isPartialData</code> toggle<br> <li> Added comment clarifying conditional logic


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7574/files#diff-5a42e9493a7bcd722b88e61fd38883c4f61001bc9cafa399f65f8eafda3aace9">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>