### PR TITLE
feat: add derived stream to stream meta

### DIFF
--- a/src/common/meta/stream.rs
+++ b/src/common/meta/stream.rs
@@ -41,6 +41,8 @@ pub struct Stream {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metrics_meta: Option<Metadata>,
     pub total_fields: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_derived: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]

--- a/src/common/meta/stream.rs
+++ b/src/common/meta/stream.rs
@@ -155,6 +155,7 @@ mod tests {
             settings: StreamSettings::default(),
             metrics_meta: None,
             total_fields: 1,
+            is_derived: None,
         };
 
         let list_stream = ListStream {
@@ -234,6 +235,7 @@ mod tests {
             settings: StreamSettings::default(),
             metrics_meta: None,
             total_fields: 1,
+            is_derived: None,
         };
 
         assert!(stream.uds_schema.len() == 1);

--- a/src/handler/grpc/request/ingest.rs
+++ b/src/handler/grpc/request/ingest.rs
@@ -42,6 +42,15 @@ impl Ingest for Ingester {
         let stream_type: StreamType = req.stream_type.into();
         let stream_name = req.stream_name;
         let in_data = req.data.unwrap_or_default();
+        let is_derived = req
+            .metadata
+            .as_ref()
+            .and_then(|m| {
+                m.data
+                    .get("is_derived")
+                    .and_then(|v| v.parse::<bool>().ok())
+            })
+            .unwrap_or(false);
 
         let resp = match stream_type {
             StreamType::Logs => {
@@ -56,6 +65,7 @@ impl Ingest for Ingester {
                         ingestion_req,
                         "",
                         None,
+                        is_derived,
                     )
                     .await
                     .map_or_else(Err, |_| Ok(())),

--- a/src/handler/http/request/logs/ingest.rs
+++ b/src/handler/http/request/logs/ingest.rs
@@ -134,6 +134,7 @@ pub async fn multi(
         IngestionRequest::Multi(&body),
         user_email,
         None,
+        false,
     )
     .await
     {
@@ -207,6 +208,7 @@ pub async fn json(
         IngestionRequest::JSON(&body),
         user_email,
         None,
+        false,
     )
     .await
     {
@@ -277,6 +279,7 @@ pub async fn handle_kinesis_request(
             IngestionRequest::KinesisFH(&post_data.into_inner()),
             user_email,
             None,
+            false,
         )
         .await
         {
@@ -322,6 +325,7 @@ pub async fn handle_gcp_request(
             IngestionRequest::GCP(&post_data.into_inner()),
             user_email,
             None,
+            false,
         )
         .await
         {

--- a/src/handler/http/request/rum/ingest.rs
+++ b/src/handler/http/request/rum/ingest.rs
@@ -121,6 +121,7 @@ pub async fn data(
             IngestionRequest::RUM(&body),
             "",
             Some(extend_json),
+            false,
         )
         .await
         {
@@ -163,6 +164,7 @@ pub async fn log(
             IngestionRequest::RUM(&body),
             "",
             Some(extend_json),
+            false,
         )
         .await
         {
@@ -221,6 +223,7 @@ pub async fn sessionreplay(
             IngestionRequest::RUM(&body.into()),
             "",
             Some(extend_json),
+            false,
         )
         .await
         {

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -245,6 +245,13 @@ pub fn unwrap_stream_created_at(schema: &Schema) -> Option<i64> {
         .and_then(|v| v.parse().ok())
 }
 
+pub fn unwrap_stream_is_derived(schema: &Schema) -> Option<bool> {
+    schema
+        .metadata()
+        .get("is_derived")
+        .and_then(|v| v.parse().ok())
+}
+
 pub fn unwrap_partition_time_level(
     level: Option<PartitionTimeLevel>,
     stream_type: StreamType,
@@ -671,6 +678,7 @@ pub struct SchemaCache {
     schema: SchemaRef,
     fields_map: HashMap<String, usize>,
     hash_key: String,
+    is_derived: bool,
 }
 
 impl SchemaCache {
@@ -690,6 +698,7 @@ impl SchemaCache {
             schema,
             fields_map,
             hash_key,
+            is_derived: false,
         }
     }
 

--- a/src/service/enrichment_table/mod.rs
+++ b/src/service/enrichment_table/mod.rs
@@ -176,6 +176,7 @@ pub async fn save_enrichment_data(
                 &mut stream_schema_map,
                 vec![&json_record],
                 timestamp,
+                false, // is_derived is false for enrichment tables
             )
             .await
             .is_ok()

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -94,6 +94,7 @@ pub async fn ingest(
     let mut store_original_when_pipeline_exists = false;
 
     let mut json_data_by_stream = HashMap::new();
+    let mut derived_streams = HashSet::new();
     let mut size_by_stream = HashMap::new();
     let mut next_line_is_data = false;
     let reader = BufReader::new(body.as_ref());
@@ -408,6 +409,10 @@ pub async fn ingest(
                         }
 
                         let destination_stream = stream_params.stream_name.to_string();
+                        if !derived_streams.contains(&destination_stream) {
+                            derived_streams.insert(destination_stream.clone());
+                        }
+
                         if !user_defined_schema_map.contains_key(&destination_stream) {
                             // a new dynamically created stream. need to check the two maps again
                             crate::service::ingestion::get_uds_and_original_data_streams(
@@ -592,6 +597,7 @@ pub async fn ingest(
             &mut status,
             json_data_by_stream,
             size_by_stream,
+            derived_streams,
         )
         .await;
         let IngestionStatus::Bulk(mut bulk_res) = status else {

--- a/src/service/logs/hec.rs
+++ b/src/service/logs/hec.rs
@@ -103,7 +103,7 @@ pub async fn ingest(
     for (stream, entries) in streams {
         let in_req = IngestionRequest::Hec(&entries);
         if let Err(e) =
-            super::ingest::ingest(thread_id, org_id, &stream, in_req, user_email, None).await
+            super::ingest::ingest(thread_id, org_id, &stream, in_req, user_email, None, false).await
         {
             return Ok(HecStatus::Custom(e.to_string(), 400).into());
         }

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -65,6 +65,7 @@ pub async fn ingest(
     in_req: IngestionRequest<'_>,
     user_email: &str,
     extend_json: Option<&HashMap<String, serde_json::Value>>,
+    is_derived: bool,
 ) -> Result<IngestionResponse> {
     let start = std::time::Instant::now();
     let started_at: i64 = Utc::now().timestamp_micros();
@@ -89,6 +90,11 @@ pub async fn ingest(
         .timestamp_micros();
 
     let mut stream_params = vec![StreamParams::new(org_id, &stream_name, StreamType::Logs)];
+    let mut derived_streams = HashSet::new();
+
+    if is_derived {
+        derived_streams.insert(stream_name.to_string());
+    }
 
     // Start retrieve associated pipeline and construct pipeline components
     let executable_pipeline = crate::service::ingestion::get_stream_executable_pipeline(
@@ -340,6 +346,10 @@ pub async fn ingest(
                     }
 
                     let destination_stream = stream_params.stream_name.to_string();
+                    if !derived_streams.contains(&destination_stream) {
+                        derived_streams.insert(destination_stream.clone());
+                    }
+
                     if !user_defined_schema_map.contains_key(&destination_stream) {
                         // a new dynamically created stream. need to check the two maps again
                         crate::service::ingestion::get_uds_and_original_data_streams(
@@ -478,6 +488,7 @@ pub async fn ingest(
             &mut status,
             json_data_by_stream,
             size_by_stream,
+            derived_streams,
         )
         .await;
         stream_status.status = match status {

--- a/src/service/logs/loki.rs
+++ b/src/service/logs/loki.rs
@@ -60,6 +60,7 @@ pub async fn handle_request(
             IngestionRequest::Loki(&records),
             user_email,
             None,
+            false,
         )
         .await
         .map_err(|e| {

--- a/src/service/logs/otlp.rs
+++ b/src/service/logs/otlp.rs
@@ -114,7 +114,7 @@ pub async fn handle_request(
     let mut stream_status = StreamStatus::new(&stream_name);
     let mut json_data_by_stream = HashMap::new();
     let mut size_by_stream = HashMap::new();
-
+    let mut derived_streams = HashSet::new();
     let mut res = ExportLogsServiceResponse {
         partial_success: None,
     };
@@ -340,6 +340,9 @@ pub async fn handle_request(
                     }
 
                     let destination_stream = stream_params.stream_name.to_string();
+                    if !derived_streams.contains(&destination_stream) {
+                        derived_streams.insert(destination_stream.clone());
+                    }
                     if !user_defined_schema_map.contains_key(&destination_stream) {
                         // a new dynamically created stream. need to check the two maps again
                         crate::service::ingestion::get_uds_and_original_data_streams(
@@ -464,6 +467,7 @@ pub async fn handle_request(
         &mut status,
         json_data_by_stream,
         size_by_stream,
+        derived_streams,
     )
     .await
     {

--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -369,6 +369,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
                 &mut stream_schema_map,
                 vec![record],
                 timestamp,
+                false, // is_derived is false for metrics
             )
             .await;
 

--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -428,6 +428,7 @@ pub async fn handle_otlp_request(
                     &mut metric_schema_map,
                     vec![val_map],
                     timestamp,
+                    false, // is_derived is false for metrics
                 )
                 .await
                 .is_ok()

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -443,6 +443,7 @@ pub async fn remote_write(
                     &mut metric_schema_map,
                     vec![val_map],
                     timestamp,
+                    false, // is_derived is false for metrics
                 )
                 .await
                 .is_ok()

--- a/src/service/self_reporting/ingestion.rs
+++ b/src/service/self_reporting/ingestion.rs
@@ -212,7 +212,7 @@ pub(super) async fn ingest_reporting_data(
         );
         let bytes = bytes::Bytes::from(json::to_string(&reporting_data_json).unwrap());
         let req = ingestion::IngestionRequest::Usage(&bytes);
-        match service::logs::ingest::ingest(0, &org_id, &stream_name, req, "", None).await {
+        match service::logs::ingest::ingest(0, &org_id, &stream_name, req, "", None, false).await {
             Ok(resp) if resp.code == 200 => {
                 log::info!(
                     "[SELF-REPORTING] ReportingData successfully ingested to stream {org_id}/{stream_name}"

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -34,7 +34,8 @@ use infra::{
     cache::stats,
     schema::{
         STREAM_RECORD_ID_GENERATOR, STREAM_SCHEMAS, STREAM_SCHEMAS_LATEST, STREAM_SETTINGS,
-        unwrap_partition_time_level, unwrap_stream_created_at, unwrap_stream_settings,
+        unwrap_partition_time_level, unwrap_stream_created_at, unwrap_stream_is_derived,
+        unwrap_stream_settings,
     },
     table::distinct_values::{DistinctFieldRecord, OriginType, check_field_use},
 };
@@ -193,6 +194,8 @@ pub fn stream_res(
         stream_type,
     ));
 
+    let is_derived = unwrap_stream_is_derived(&schema);
+
     Stream {
         name: stream_name.to_string(),
         storage_type: storage_type.to_string(),
@@ -203,6 +206,7 @@ pub fn stream_res(
         stats,
         settings,
         metrics_meta,
+        is_derived,
     }
 }
 

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -831,6 +831,7 @@ async fn write_traces(
         &mut traces_schema_map,
         json_data.iter().map(|(_, v)| v).collect(),
         *min_timestamp,
+        false, // is_derived is false for traces
     )
     .await;
     let record_schema = traces_schema_map


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `is_derived` Stream metadata flag

- Extract `is_derived` in ingest pipeline

- Pass default false to non-derived handlers

- Integrate `is_derived` in schema checks


___

### **Changes diagram**

```mermaid
flowchart LR
  RM["Request Metadata: extract is_derived"]
  IS["Ingestion Service: ingest(..., is_derived)"]
  SC["Schema Check: check_for_schema(is_derived)"]
  DB["DB Schema Merge: include is_derived"]
  RM -- "passes flag" --> IS
  IS -- "invokes" --> SC
  SC -- "updates" --> DB
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td><strong>stream.rs</strong><dd><code>Add `is_derived` field to Stream struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-6f5ee19bbcc9cc7fb699fc1c0f43fc96d42698ae1168a2827b5c65f7948d5dbc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingest.rs</strong><dd><code>Extract `is_derived` metadata in gRPC ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-27ffe683f384ff836c6aac746240d755bdf17f3c6e0a65d8ec1a1ff82aaf7d5c">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingest.rs</strong><dd><code>Pass false `is_derived` in HTTP logs ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-24f250254ecfdbe004af9dc0ea23f8a2c0105ae0898690ed3e565089e5d8eef9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingest.rs</strong><dd><code>Pass false `is_derived` in HTTP RUM ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-40fa0a7da7845799e5bed864e8ccc8111330a3d76fcc8e50af0b76251d566b45">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Add `unwrap_stream_is_derived` and SchemaCache flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-386fd4fad1e48ab0a90516cab1947b1888b270b2fe912f30d2255cc38e6c519b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>handlers.rs</strong><dd><code>Inject `is_derived` metadata into scheduled ingests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-5eca8995a88fcecb6d6b8efd3c7c4496f4a96a4b060fb4ed85593574f7cf49eb">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Pass false `is_derived` for enrichment tables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-3e2b6d3b8da1f9e73aca279052a97e683184d68256c23215b18ffee885836bbf">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bulk.rs</strong><dd><code>Track derived streams in bulk ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-2017dbe9076c78a7e7919ed5c8738729123d630038803cef0ce2c356d6fa2c48">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hec.rs</strong><dd><code>Pass false `is_derived` to HEC ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-5434f454898e66d4a982801761a349ac7e6862836e15eefaf643b31d0d2933dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingest.rs</strong><dd><code>Accept `is_derived` in ingest function signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-e62118e45be183266d39ffa08491f255017954235ff0f3d6937683e314da406f">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>loki.rs</strong><dd><code>Pass false `is_derived` in Loki handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-a970c8c4785d4e4d878218615b17eec0cf4b4976121766b002c2b2f76371bfe6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Forward `is_derived` flag to write_logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-ce72aea3fa4c44904cbd9ec07bd844bec71b49c9676d667b14056aa5798f96b2">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>otlp.rs</strong><dd><code>Accumulate derived_streams in OTLP ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-183498d98b17ddf344cbab4da6b2d9fe89ac81112db51655c142a89023b46ef3">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>syslog.rs</strong><dd><code>Accumulate derived_streams in syslog ingestion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-4bc46f36fad79f5df8c42b8a8d5d8c4a70b1320b966bcff3421deeb96a1981fa">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>json.rs</strong><dd><code>Pass false `is_derived` in metrics JSON ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-506987e61095a54e47f7f208dad89f9f1bce595fa6bf1ba8a7d746f2b2ff6c4a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>otlp.rs</strong><dd><code>Pass false `is_derived` in metrics OTLP ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-a24391bef75a4678c50724e8b5f305ec0ee8c2c74c68be9d677765de68b5d8dd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prom.rs</strong><dd><code>Pass false `is_derived` in metrics Prom ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-c4e9e1d49a2bd0fefe67684b3768c4792be63cebcf727d71a48141f5b5957b8c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.rs</strong><dd><code>Propagate `is_derived` through schema checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-d9596182a0c7a46a6a7ff5cee822554cdae05ceec312f86c93b538db9f73bbfd">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingestion.rs</strong><dd><code>Pass false `is_derived` in self-report ingestion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-3edd5f4ed1eed0f765b7b450ef0fbf587632e6b22302006a5e397049e297057f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stream.rs</strong><dd><code>Include `is_derived` in stream response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-41452a7fb29b4634437174fd6aecf6a9050dbfdef41b9077a21d59af3d79e9ed">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7586/files#diff-66f3b4f5e7927092fd6e57738687a1091b6f316638f7c58f8d7be9addb72bc30">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>