### PR TITLE
perf: fix slowness by improving file movement for the ingester

### DIFF
--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -59,7 +59,7 @@ use crate::{
 static PROCESSING_FILES: Lazy<RwLock<HashSet<String>>> = Lazy::new(|| RwLock::new(HashSet::new()));
 
 pub async fn run() -> Result<(), anyhow::Error> {
-    // add the pending delete files to processing list
+    // add the pending delete files to processing set
     let pending_delete_files = db::file_list::local::get_pending_delete().await;
     for file in pending_delete_files {
         PROCESSING_FILES.write().await.insert(file);
@@ -128,12 +128,12 @@ async fn scan_pending_delete_files() -> Result<(), anyhow::Error> {
         let Ok(file_size) = get_file_size(&file) else {
             continue;
         };
+        // delete metadata from cache
+        WAL_PARQUET_METADATA.write().await.remove(&file_key);
+        // delete file from disk
         if let Err(e) = remove_file(&file) {
             log::error!("[INGESTER:JOB] Failed to remove parquet file: {file_key}, {e}");
         }
-
-        // delete metadata from cache
-        WAL_PARQUET_METADATA.write().await.remove(&file_key);
         // need release the file
         PROCESSING_FILES.write().await.remove(&file_key);
         // delete from pending delete list
@@ -260,11 +260,12 @@ async fn prepare_files(
         };
         if parquet_meta.eq(&FileMeta::default()) {
             log::warn!("[INGESTER:JOB] the file is empty, just delete file: {file}");
+            // delete metadata from cache
+            WAL_PARQUET_METADATA.write().await.remove(&file_key);
+            // delete file from disk
             if let Err(e) = remove_file(wal_dir.join(&file)) {
                 log::error!("[INGESTER:JOB] Failed to remove parquet file from disk: {file}, {e}");
             }
-            // delete metadata from cache
-            WAL_PARQUET_METADATA.write().await.remove(&file_key);
             continue;
         }
         let prefix = file_key[..file_key.rfind('/').unwrap()].to_string();
@@ -311,6 +312,9 @@ async fn move_files(
                 &stream_name,
                 file.key,
             );
+            // delete metadata from cache
+            WAL_PARQUET_METADATA.write().await.remove(&file.key);
+            // delete file from disk
             if let Err(e) = remove_file(wal_dir.join(&file.key)) {
                 log::error!(
                     "[INGESTER:JOB:{thread_id}] Failed to remove parquet file from disk: {}, {}",
@@ -318,8 +322,7 @@ async fn move_files(
                     e
                 );
             }
-            // delete metadata from cache
-            WAL_PARQUET_METADATA.write().await.remove(&file.key);
+            // remove the file from processing set
             PROCESSING_FILES.write().await.remove(&file.key);
         }
         return Ok(());
@@ -355,6 +358,9 @@ async fn move_files(
                 &stream_name,
                 file.key,
             );
+            // delete metadata from cache
+            WAL_PARQUET_METADATA.write().await.remove(&file.key);
+            // delete file from disk
             if let Err(e) = remove_file(wal_dir.join(&file.key)) {
                 log::error!(
                     "[INGESTER:JOB:{thread_id}] Failed to remove parquet file from disk: {}, {}",
@@ -362,8 +368,7 @@ async fn move_files(
                     e
                 );
             }
-            // delete metadata from cache
-            WAL_PARQUET_METADATA.write().await.remove(&file.key);
+            // remove the file from processing set
             PROCESSING_FILES.write().await.remove(&file.key);
         }
         return Ok(());
@@ -388,6 +393,9 @@ async fn move_files(
                     &stream_name,
                     file.key,
                 );
+                // delete metadata from cache
+                WAL_PARQUET_METADATA.write().await.remove(&file.key);
+                // delete file from disk
                 if let Err(e) = remove_file(wal_dir.join(&file.key)) {
                     log::error!(
                         "[INGESTER:JOB:{thread_id}] Failed to remove parquet file from disk: {}, {}",
@@ -395,8 +403,7 @@ async fn move_files(
                         e
                     );
                 }
-                // delete metadata from cache
-                WAL_PARQUET_METADATA.write().await.remove(&file.key);
+                // remove the file from processing set
                 PROCESSING_FILES.write().await.remove(&file.key);
             }
             return Ok(());
@@ -499,9 +506,6 @@ async fn move_files(
 
         // check if allowed to delete the file
         for file in new_file_list.iter() {
-            // use same lock to combine the operations of check lock and add to removing list
-            let wal_lock = infra::local_lock::lock("wal").await?;
-            let lock_guard = wal_lock.lock().await;
             let can_delete = if wal::lock_files_exists(&file.key) {
                 log::warn!(
                     "[INGESTER:JOB:{thread_id}] the file is in use, set to pending delete list: {}",
@@ -523,9 +527,11 @@ async fn move_files(
                 db::file_list::local::add_removing(&file.key).await?;
                 true
             };
-            drop(lock_guard);
 
             if can_delete {
+                // delete metadata from cache
+                WAL_PARQUET_METADATA.write().await.remove(&file.key);
+                // delete file from disk
                 match remove_file(wal_dir.join(&file.key)) {
                     Err(e) => {
                         log::warn!(
@@ -549,8 +555,6 @@ async fn move_files(
                         }
                     }
                     Ok(_) => {
-                        // delete metadata from cache
-                        WAL_PARQUET_METADATA.write().await.remove(&file.key);
                         // remove the file from processing set
                         PROCESSING_FILES.write().await.remove(&file.key);
                         // deleted successfully then update metrics

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -79,6 +79,12 @@ pub async fn search_parquet(
         search_partition_keys,
     )
     .await?;
+    log::info!(
+        "[trace_id {}] wal->parquet->search: get file list files: {}, took {} ms",
+        query.trace_id,
+        files.len(),
+        load_start.elapsed().as_millis()
+    );
     if files.is_empty() {
         return Ok((vec![], ScanStats::new()));
     }
@@ -90,12 +96,11 @@ pub async fn search_parquet(
     let files_num = files.len();
     let mut new_files = Vec::with_capacity(files_num);
     let files_metadata = futures::stream::iter(files)
-        .map(|file| async move {
+        .map(|mut file| async move {
             let cfg = get_config();
             let r = WAL_PARQUET_METADATA.read().await;
             let source_file = cfg.common.data_wal_dir.to_string() + file.key.as_str();
             if let Some(meta) = r.get(file.key.as_str()) {
-                let mut file = file;
                 file.meta = meta.clone();
                 // reset file meta if it already removed
                 if !is_exists(&source_file) {
@@ -107,12 +112,7 @@ pub async fn search_parquet(
             let meta = read_metadata_from_file(&source_file.into())
                 .await
                 .unwrap_or_default();
-            let mut file = file;
             file.meta = meta;
-            WAL_PARQUET_METADATA
-                .write()
-                .await
-                .insert(file.key.clone(), file.meta.clone());
             file
         })
         .buffer_unordered(cfg.limit.cpu_num)
@@ -565,9 +565,9 @@ async fn get_file_list_inner(
         })
         .collect::<Vec<_>>();
 
-    // use same lock to combine the operations of filter by pending delete and lock files
-    let wal_lock = infra::local_lock::lock("wal").await?;
-    let lock_guard = wal_lock.lock().await;
+    if files.is_empty() {
+        return Ok(vec![]);
+    }
 
     // filter by pending delete
     let mut files = crate::service::db::file_list::local::filter_by_pending_delete(files).await;
@@ -589,7 +589,6 @@ async fn get_file_list_inner(
 
     // lock theses files
     wal::lock_files(&files);
-    drop(lock_guard);
 
     let stream_params = Arc::new(StreamParams::new(
         &query.org_id,


### PR DESCRIPTION
### **User description**
Earlier we use a local lock for guarantee that, only one thread can lock file or delete file. it works. but it looks the Lock contention is intense, causing the get wal file list to be slow.

This PR removed the lock and use the bellow logic to guarantee file lock succeed:
1. get file list from local directory.
2. filter the file list by deleting list.
3. lock file list.

It is possible some files was deleted by moving file job after get file_list before lock the files. 

So, after we lock the file, we will check the file again. if we can't get metadata of the file, we will release the file and remove from file list.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Optimize WAL file deletion order and cleanup.

- Remove redundant WAL locks around file operations.

- Early return on empty file lists.

- Add performance logs for WAL search listing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parquet.rs</strong><dd><code>Reorder and optimize parquet file deletions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/job/files/parquet.rs

<li>Remove metadata from cache before disk deletion.<br> <li> Reorder file deletion and processing set removal.<br> <li> Eliminate redundant metadata removal calls.<br> <li> Remove redundant WAL lock usage.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7590/files#diff-27f710981cfe1b938aeeb53abaed05961596c32e2edf3b8a2a59d3e72b2f542b">+22/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wal.rs</strong><dd><code>Simplify WAL search metadata and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/grpc/wal.rs

<li>Add performance logging for file listing.<br> <li> Early return when file list is empty.<br> <li> Remove metadata cache writes on search.<br> <li> Remove WAL locks around file listing.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7590/files#diff-48aea52fd870678e577e03f29fc9769920b7f74761b1447242835dbf1b8ac8df">+10/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>