### PR TITLE
fix: UI loading scansize fix rc7

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2373,24 +2373,29 @@ const useLogs = () => {
 
 
   const fetchAllParitions = async(queryReq: any) => {
-    if (
-      searchObj.data.queryResults.partitionDetail.partitions[
-        searchObj.data.queryResults.subpage
-      ]?.length
-    ) {
-      queryReq.query.start_time =
+    return new Promise(async (resolve) => {
+      if (
         searchObj.data.queryResults.partitionDetail.partitions[
           searchObj.data.queryResults.subpage
-        ][0];
-      queryReq.query.end_time =
-        searchObj.data.queryResults.partitionDetail.partitions[
-          searchObj.data.queryResults.subpage
-        ][1];
-      queryReq.query.from = 0;
-      queryReq.query.size = -1;
-      searchObj.data.queryResults.subpage++;
-      await getPaginatedData(queryReq, true, false);
-    }
+        ]?.length
+      ) {
+        queryReq.query.start_time =
+          searchObj.data.queryResults.partitionDetail.partitions[
+            searchObj.data.queryResults.subpage
+          ][0];
+        queryReq.query.end_time =
+          searchObj.data.queryResults.partitionDetail.partitions[
+            searchObj.data.queryResults.subpage
+          ][1];
+        queryReq.query.from = 0;
+        queryReq.query.size = -1;
+        searchObj.data.queryResults.subpage++;
+
+        await getPaginatedData(queryReq, true, false);
+        resolve(true);
+      }
+      resolve(true);
+    });
   }
 
   const getPaginatedData = async (
@@ -2572,15 +2577,18 @@ const useLogs = () => {
             searchObj.data.queryResults.scan_size = (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
             searchObj.data.queryResults.took = (searchObj.data.queryResults.took || 0) + res.data.took;
             searchObj.data.queryResults.hits = res.data.hits;
-            fetchAllParitions(queryReq);
+            await processPostPaginationData();
+            await fetchAllParitions(queryReq);
           } else if(isAggregation) {
             searchObj.data.queryResults.from = res.data.from;
             searchObj.data.queryResults.total = (searchObj.data.queryResults.total || 0) + res.data.total;
             searchObj.data.queryResults.scan_size = (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
             searchObj.data.queryResults.took = (searchObj.data.queryResults.took || 0) + res.data.took;
             searchObj.data.queryResults.hits.push(...res.data.hits);
-            fetchAllParitions(queryReq);
+            await processPostPaginationData();
+            await fetchAllParitions(queryReq);
           } else if (res.data.from > 0 || searchObj.data.queryResults.subpage > 1) {
+
             if (appendResult && !queryReq.query?.streaming_output) {
               searchObj.data.queryResults.from += res.data.from;
               searchObj.data.queryResults.scan_size += res.data.scan_size;

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1697,9 +1697,6 @@ const useLogs = () => {
         searchObjDebug["partitionEndTime"] = performance.now();
       }
 
-      searchObj.data.queryResults.scan_size = 0;
-      searchObj.data.queryResults.took = 0;
-
       //reset the plot chart when the query is run 
       //this is to avoid the issue of chart not updating when histogram is disabled and enabled and clicking the run query button
       //only reset the plot chart when the query is not run for pagination

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1697,6 +1697,9 @@ const useLogs = () => {
         searchObjDebug["partitionEndTime"] = performance.now();
       }
 
+      searchObj.data.queryResults.scan_size = 0;
+      searchObj.data.queryResults.took = 0;
+
       //reset the plot chart when the query is run 
       //this is to avoid the issue of chart not updating when histogram is disabled and enabled and clicking the run query button
       //only reset the plot chart when the query is not run for pagination

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2571,16 +2571,16 @@ const useLogs = () => {
           if(queryReq.query?.streaming_output) {
             searchObj.data.queryResults.total = searchObj.data.queryResults.hits.length;
             searchObj.data.queryResults.from = res.data.from;
-            searchObj.data.queryResults.scan_size = (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
-            searchObj.data.queryResults.took = (searchObj.data.queryResults.took || 0) + res.data.took;
+            searchObj.data.queryResults.scan_size = isInitialRequest ? res.data.scan_size : (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size ;
+            searchObj.data.queryResults.took = isInitialRequest ? res.data.took : (searchObj.data.queryResults.took || 0) + res.data.took;
             searchObj.data.queryResults.hits = res.data.hits;
             await processPostPaginationData();
             await fetchAllParitions(queryReq);
           } else if(isAggregation) {
             searchObj.data.queryResults.from = res.data.from;
-            searchObj.data.queryResults.total = (searchObj.data.queryResults.total || 0) + res.data.total;
-            searchObj.data.queryResults.scan_size = (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
-            searchObj.data.queryResults.took = (searchObj.data.queryResults.took || 0) + res.data.took;
+            searchObj.data.queryResults.total = isInitialRequest ? res.data.total : (searchObj.data.queryResults.total || 0) + res.data.total;
+            searchObj.data.queryResults.scan_size = isInitialRequest ? res.data.scan_size : (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
+            searchObj.data.queryResults.took = isInitialRequest ? res.data.took : (searchObj.data.queryResults.took || 0) + res.data.took;
             searchObj.data.queryResults.hits.push(...res.data.hits);
             await processPostPaginationData();
             await fetchAllParitions(queryReq);


### PR DESCRIPTION
1. Fixed an issue where scan_size and time_taken were not resetting after running a query.
2. In streaming aggregate queries, the No Events Found message appeared before the actual results were displayed.