### PR TITLE
fix: streaming aggregates scansize tooktime and noevents found issue fix

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -2508,24 +2508,28 @@ const useLogs = () => {
 
 
   const fetchAllParitions = async(queryReq: any) => {
-    if (
-      searchObj.data.queryResults.partitionDetail.partitions[
-        searchObj.data.queryResults.subpage
-      ]?.length
-    ) {
-      queryReq.query.start_time =
+    return new Promise(async (resolve) => {
+      if (
         searchObj.data.queryResults.partitionDetail.partitions[
           searchObj.data.queryResults.subpage
-        ][0];
-      queryReq.query.end_time =
-        searchObj.data.queryResults.partitionDetail.partitions[
-          searchObj.data.queryResults.subpage
-        ][1];
-      queryReq.query.from = 0;
-      queryReq.query.size = -1;
-      searchObj.data.queryResults.subpage++;
-      await getPaginatedData(queryReq, true, false);
-    }
+        ]?.length
+      ) {
+        queryReq.query.start_time =
+          searchObj.data.queryResults.partitionDetail.partitions[
+            searchObj.data.queryResults.subpage
+          ][0];
+        queryReq.query.end_time =
+          searchObj.data.queryResults.partitionDetail.partitions[
+            searchObj.data.queryResults.subpage
+          ][1];
+        queryReq.query.from = 0;
+        queryReq.query.size = -1;
+        searchObj.data.queryResults.subpage++;
+        await getPaginatedData(queryReq, true, false);
+        resolve(true);
+      }
+      resolve(true);
+    });
   }
 
   const getPaginatedData = async (
@@ -2748,17 +2752,19 @@ const useLogs = () => {
           if(queryReq.query?.streaming_output) {
             searchObj.data.queryResults.total = searchObj.data.queryResults.hits.length;
             searchObj.data.queryResults.from = res.data.from;
-            searchObj.data.queryResults.scan_size = (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
-            searchObj.data.queryResults.took = (searchObj.data.queryResults.took || 0) + res.data.took;
+            searchObj.data.queryResults.scan_size = isInitialRequest ? res.data.scan_size : (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size ;
+            searchObj.data.queryResults.took = isInitialRequest ? res.data.took : (searchObj.data.queryResults.took || 0) + res.data.took;
             searchObj.data.queryResults.hits = res.data.hits;
-            fetchAllParitions(queryReq);
+            await processPostPaginationData();
+            await fetchAllParitions(queryReq);
           } else if(isAggregation) {
             searchObj.data.queryResults.from = res.data.from;
-            searchObj.data.queryResults.total = (searchObj.data.queryResults.total || 0) + res.data.total;
-            searchObj.data.queryResults.scan_size = (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
-            searchObj.data.queryResults.took = (searchObj.data.queryResults.took || 0) + res.data.took;
+            searchObj.data.queryResults.total = isInitialRequest ? res.data.total : (searchObj.data.queryResults.total || 0) + res.data.total;
+            searchObj.data.queryResults.scan_size = isInitialRequest ? res.data.scan_size : (searchObj.data.queryResults.scan_size || 0) + res.data.scan_size;
+            searchObj.data.queryResults.took = isInitialRequest ? res.data.took : (searchObj.data.queryResults.took || 0) + res.data.took;
             searchObj.data.queryResults.hits.push(...res.data.hits);
-            fetchAllParitions(queryReq);
+            await processPostPaginationData();
+            await fetchAllParitions(queryReq);
           } else if (res.data.from > 0 || searchObj.data.queryResults.subpage > 1) {
             if (appendResult && !queryReq.query?.streaming_output) {
               searchObj.data.queryResults.from += res.data.from;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Wrap partition fetching in a Promise

- Reset metrics on initial request

- Await `processPostPaginationData()` pre-pagination

- Sequentially await `fetchAllParitions` calls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getPaginatedData"] -- "on response" --> B["processPostPaginationData"]
  B -- "then" --> C["fetchAllParitions"]
  C -- "recurses" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useLogs.ts</strong><dd><code>Update pagination and metrics in logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs.ts

<ul><li>Promisified <code>fetchAllParitions</code> with resolve calls<br> <li> Initialize <code>scan_size</code>, <code>took</code>, <code>total</code> on first request<br> <li> Inserted <code>await processPostPaginationData()</code> before pagination<br> <li> Changed to awaiting <code>fetchAllParitions</code> invocations</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7618/files#diff-1040f61354f92711e0e77ed4e9bfa15586d45a94c7e2ab06cc37372068030e7b">+29/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

