### PR TITLE
fix: UDFs panic for invalid JSON (#7614) (rc7)

### DIFF
--- a/src/service/search/datafusion/udf/arrindex_udf.rs
+++ b/src/service/search/datafusion/udf/arrindex_udf.rs
@@ -77,38 +77,40 @@ pub fn arr_index_impl(args: &[ColumnarValue]) -> datafusion::error::Result<Colum
     // 2. perform the computation
     let array = zip(arr_field1.iter(), start.iter())
         .map(|(arr_field1, start)| {
-            let mut index_arrs = vec![];
-
             match (arr_field1, start) {
-                // in arrow, any value can be null.
-                // Here we decide to make our UDF to return null when either argument is null.
                 (Some(arr_field1), Some(start)) => {
                     let start = start as usize;
-                    let arr_field1: json::Value =
-                        json::from_str(arr_field1).expect("Failed to deserialize arrzip field1");
-                    // This field is assumed to be an array field
-                    if let json::Value::Array(field1) = arr_field1 {
-                        if field1.len() > start {
-                            if let Some(end) = end {
-                                // end is min(end, field1.len)
-                                let end = if end.as_usize() < field1.len() {
-                                    end as usize
-                                } else {
-                                    field1.len() - 1
-                                };
-                                if start <= end && end < field1.len() {
-                                    for item in field1.into_iter().take(end + 1).skip(start) {
-                                        index_arrs.push(item);
+                    json::from_str::<json::Value>(arr_field1)
+                        .ok()
+                        .and_then(|arr_field1| {
+                            if let json::Value::Array(field1) = arr_field1 {
+                                let mut index_arrs: Vec<json::Value> = vec![];
+                                if field1.len() > start {
+                                    if let Some(end) = end {
+                                        // end is min(end, field1.len)
+                                        let end = if end.as_usize() < field1.len() {
+                                            end as usize
+                                        } else {
+                                            field1.len() - 1
+                                        };
+                                        if start <= end && end < field1.len() {
+                                            for item in field1.into_iter().take(end + 1).skip(start)
+                                            {
+                                                index_arrs.push(item);
+                                            }
+                                        }
+                                        // If start > end or end >= field1.len(), index_arrs remains empty
+                                    } else {
+                                        index_arrs.push(field1[start].clone());
                                     }
                                 }
+                                // If start >= field1.len(), index_arrs remains empty
+                                // Always return the array, even if empty
+                                json::to_string(&index_arrs).ok()
                             } else {
-                                index_arrs.push(field1[start].clone());
+                                None
                             }
-                        }
-                    }
-                    let index_arrs =
-                        json::to_string(&index_arrs).expect("Failed to stringify arrs");
-                    Some(index_arrs)
+                        })
                 }
                 _ => None,
             }
@@ -236,5 +238,120 @@ mod tests {
             let data = df.collect().await.unwrap();
             assert_batches_eq!(item.1, &data);
         }
+    }
+
+    #[tokio::test]
+    async fn test_arr_index_edge_cases() {
+        // Test cases that should return null or empty arrays
+        let edge_cases = [
+            (r#"not json"#, 0, 1, "invalid JSON"),
+            (r#"{"key": "value"}"#, 0, 1, "object"),
+            (r#""just a string""#, 0, 1, "string"),
+            (r#"42"#, 0, 1, "number"),
+            (r#"true"#, 0, 1, "boolean"),
+            (r#"null"#, 0, 1, "null"),
+            (r#"[]"#, 0, 1, "empty array"),
+        ];
+
+        for (json_input, start, end, _test_name) in edge_cases {
+            let sql = format!(
+                "select arrindex(test_col, {}, {}) as ret from t",
+                start, end
+            );
+            // Empty arrays return [] instead of null, other invalid inputs return null
+            let expected = if json_input == r#"[]"# {
+                vec!["+-----+", "| ret |", "+-----+", "| []  |", "+-----+"]
+            } else {
+                vec!["+-----+", "| ret |", "+-----+", "|     |", "+-----+"]
+            };
+
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                DataType::Utf8,
+                false,
+            )]));
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(StringArray::from(vec![json_input]))],
+            )
+            .unwrap();
+
+            let ctx = SessionContext::new();
+            ctx.register_udf(ARR_INDEX_UDF.clone());
+            let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+            ctx.register_table("t", Arc::new(provider)).unwrap();
+
+            let df = ctx.sql(&sql).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(expected, &data);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_arr_index_null_input() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "test_col",
+            DataType::Utf8,
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![None::<String>]))],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_INDEX_UDF.clone());
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        let df = ctx
+            .sql("select arrindex(test_col, 0, 1) as ret from t")
+            .await
+            .unwrap();
+        let data = df.collect().await.unwrap();
+        assert_batches_eq!(
+            vec!["+-----+", "| ret |", "+-----+", "|     |", "+-----+"],
+            &data
+        );
+    }
+
+
+
+    #[tokio::test]
+    async fn test_arr_index_wrong_arguments() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_INDEX_UDF.clone());
+
+        // Test with no arguments
+        let result = ctx.sql("select arrindex() as ret").await;
+        assert!(result.is_err());
+
+        // Test with only one argument
+        let result = ctx.sql("select arrindex('a') as ret").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_arr_index_invalid_json_no_panic() {
+        // Test that invalid JSON doesn't cause a panic
+        let schema = Arc::new(Schema::new(vec![Field::new("test_col", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["not json"]))],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_INDEX_UDF.clone());
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        let df = ctx
+            .sql("select arrindex(test_col, 0, 1) as ret from t")
+            .await
+            .unwrap();
+        let data = df.collect().await.unwrap();
+        assert_batches_eq!(vec!["+-----+", "| ret |", "+-----+", "|     |", "+-----+"], &data);
     }
 }

--- a/src/service/search/datafusion/udf/arrjoin_udf.rs
+++ b/src/service/search/datafusion/udf/arrjoin_udf.rs
@@ -66,17 +66,19 @@ pub fn arr_join_impl(args: &[ColumnarValue]) -> datafusion::error::Result<Column
                 // in arrow, any value can be null.
                 // Here we decide to make our UDF to return null when either argument is null.
                 (Some(arr_field1), Some(delim)) => {
-                    let arr_field1: json::Value =
-                        json::from_str(arr_field1).expect("Failed to deserialize arrzip field1");
-                    let mut join_arrs = vec![];
-                    if let json::Value::Array(field1) = arr_field1 {
-                        field1.iter().for_each(|field| {
-                            let field = super::stringify_json_value(field);
-                            join_arrs.push(field);
-                        });
-                    }
-                    let join_arrs = join_arrs.join(delim);
-                    Some(join_arrs)
+                    json::from_str::<json::Value>(arr_field1)
+                        .ok()
+                        .and_then(|arr_field1| {
+                            if let json::Value::Array(field1) = arr_field1 {
+                                let join_arrs: Vec<String> = field1
+                                    .iter()
+                                    .map(super::stringify_json_value)
+                                    .collect();
+                                Some(join_arrs.join(delim))
+                            } else {
+                                None
+                            }
+                        })
                 }
                 _ => None,
             }
@@ -102,12 +104,51 @@ mod tests {
 
     use super::*;
 
+    // Helper function to run a single test case
+    async fn run_single_test(arr_field: &str, delimiter: &str, expected_output: Vec<&str>) {
+        let sql = format!("select arrjoin(arr_field, '{}') as ret from t", delimiter);
+        let sqls = [(sql.as_str(), expected_output)];
+
+        let schema = Arc::new(Schema::new(vec![Field::new("arr_field", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![arr_field]))],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_JOIN_UDF.clone());
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+
+    // Helper function to run multiple test cases that should all return null
+    async fn run_null_returning_tests(test_cases: &[(&str, &str)]) {
+        let expected_output = vec![
+            "+-----+",
+            "| ret |",
+            "+-----+",
+            "|     |",
+            "+-----+",
+        ];
+
+        for &(arr_field, delimiter) in test_cases {
+            run_single_test(arr_field, delimiter, expected_output.clone()).await;
+        }
+    }
+
     #[tokio::test]
-    async fn test_arr_join_udf() {
-        let sqls = [
+    async fn test_arr_join_valid_arrays() {
+        let test_cases = [
             (
-                // Should include values at index 0 to index 1 (inclusive)
-                "select arrjoin(bools, ',') as ret from t",
+                r#"[true,false,true]"#,
+                ",",
                 vec![
                     "+-----------------+",
                     "| ret             |",
@@ -117,8 +158,8 @@ mod tests {
                 ],
             ),
             (
-                // Should include all the elements
-                "select arrjoin(names, ',') as ret from t",
+                r#"["hello2","hi2","bye2"]"#,
+                ",",
                 vec![
                     "+-----------------+",
                     "| ret             |",
@@ -128,7 +169,8 @@ mod tests {
                 ],
             ),
             (
-                "select arrjoin(nums, ',') as ret from t",
+                r#"[12, 345, 23, 45]"#,
+                ",",
                 vec![
                     "+--------------+",
                     "| ret          |",
@@ -138,7 +180,8 @@ mod tests {
                 ],
             ),
             (
-                "select arrjoin(floats, ',') as ret from t",
+                r#"[1.9, 34.5, 2.6, 4.5]"#,
+                ",",
                 vec![
                     "+------------------+",
                     "| ret              |",
@@ -148,7 +191,8 @@ mod tests {
                 ],
             ),
             (
-                "select arrjoin(mixed, ',') as ret from t",
+                r#"["hello2","hi2",123, 23.9, false]"#,
+                ",",
                 vec![
                     "+---------------------------+",
                     "| ret                       |",
@@ -157,48 +201,133 @@ mod tests {
                     "+---------------------------+",
                 ],
             ),
+            (
+                r#"["a", "b", "c"]"#,
+                "|",
+                vec![
+                    "+-------+",
+                    "| ret   |",
+                    "+-------+",
+                    "| a|b|c |",
+                    "+-------+",
+                ],
+            ),
+            (
+                r#"["single"]"#,
+                ",",
+                vec![
+                    "+--------+",
+                    "| ret    |",
+                    "+--------+",
+                    "| single |",
+                    "+--------+",
+                ],
+            ),
         ];
 
-        // define a schema.
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("log", DataType::Utf8, false),
-            Field::new("bools", DataType::Utf8, false),
-            Field::new("names", DataType::Utf8, false),
-            Field::new("nums", DataType::Utf8, false),
-            Field::new("floats", DataType::Utf8, false),
-            Field::new("mixed", DataType::Utf8, false),
-        ]));
+        for (arr_field, delimiter, expected_output) in test_cases {
+            run_single_test(arr_field, delimiter, expected_output).await;
+        }
+    }
 
-        // define data.
+    #[tokio::test]
+    async fn test_arr_join_null_returning_cases() {
+        // Test cases that should return null
+        let null_cases = [
+            (r#"[]"#, ","),                    // empty array
+            (r#"not json"#, ","),              // invalid JSON
+            (r#"{"key": "value"}"#, ","),      // object
+            (r#""just a string""#, ","),       // string
+            (r#"42"#, ","),                    // number
+            (r#"true"#, ","),                  // boolean
+            (r#"null"#, ","),                  // null
+        ];
+
+        run_null_returning_tests(&null_cases).await;
+    }
+
+    #[tokio::test]
+    async fn test_arr_join_null_input() {
+        let expected_output = vec![
+            "+-----+",
+            "| ret |",
+            "+-----+",
+            "|     |",
+            "+-----+",
+        ];
+
+        let schema = Arc::new(Schema::new(vec![Field::new("arr_field", DataType::Utf8, true)]));
         let batch = RecordBatch::try_new(
             schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["a"])),
-                Arc::new(StringArray::from(vec!["[true,false,true]"])),
-                Arc::new(StringArray::from(vec!["[\"hello2\",\"hi2\",\"bye2\"]"])),
-                Arc::new(StringArray::from(vec!["[12, 345, 23, 45]"])),
-                Arc::new(StringArray::from(vec!["[1.9, 34.5, 2.6, 4.5]"])),
-                Arc::new(StringArray::from(vec![
-                    "[\"hello2\",\"hi2\",123, 23.9, false]",
-                ])),
-            ],
+            vec![Arc::new(StringArray::from(vec![None::<String>]))],
         )
         .unwrap();
 
-        // declare a new context. In spark API, this corresponds to a new spark
-        // SQLsession
         let ctx = SessionContext::new();
         ctx.register_udf(ARR_JOIN_UDF.clone());
-
-        // declare a table in memory. In spark API, this corresponds to
-        // createDataFrame(...).
         let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
         ctx.register_table("t", Arc::new(provider)).unwrap();
 
-        for item in sqls {
-            let df = ctx.sql(item.0).await.unwrap();
-            let data = df.collect().await.unwrap();
-            assert_batches_eq!(item.1, &data);
-        }
+        let sql = "select arrjoin(arr_field, ',') as ret from t";
+        let df = ctx.sql(sql).await.unwrap();
+        let data = df.collect().await.unwrap();
+        assert_batches_eq!(expected_output, &data);
+    }
+
+    #[tokio::test]
+    async fn test_arr_join_multiple_rows() {
+        let arr_fields = vec![
+            r#"["a", "b", "c"]"#,
+            r#"[]"#,
+            r#"not json"#,
+            r#"["x", "y"]"#,
+            r#"{"key": "value"}"#,
+        ];
+        let sql = "select arrjoin(arr_field, ',') as ret from t";
+        let expected_output = vec![
+            "+-------+",
+            "| ret   |",
+            "+-------+",
+            "| a,b,c |",
+            "|       |",
+            "|       |",
+            "| x,y   |",
+            "|       |",
+            "+-------+",
+        ];
+
+        let schema = Arc::new(Schema::new(vec![Field::new("arr_field", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(arr_fields))],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_JOIN_UDF.clone());
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        let df = ctx.sql(sql).await.unwrap();
+        let data = df.collect().await.unwrap();
+        assert_batches_eq!(expected_output, &data);
+    }
+
+    #[tokio::test]
+    async fn test_arr_join_wrong_arguments() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_JOIN_UDF.clone());
+
+        // Test with no arguments
+        let result = ctx.sql("select arrjoin() as ret").await;
+        assert!(result.is_err());
+
+        // Test with one argument
+        let result = ctx.sql("select arrjoin('a') as ret").await;
+        assert!(result.is_err());
+
+        // Test with three arguments
+        let result = ctx.sql("select arrjoin('a', 'b', 'c') as ret").await;
+        assert!(result.is_err());
     }
 }

--- a/src/service/search/datafusion/udf/arrsort_udf.rs
+++ b/src/service/search/datafusion/udf/arrsort_udf.rs
@@ -64,37 +64,38 @@ pub fn arr_sort_impl(args: &[ColumnarValue]) -> datafusion::error::Result<Column
     let array = arr_field
         .iter()
         .map(|arr_field| {
-            let mut arr_sorted = vec![];
-
-            if let Some(arr_field) = arr_field {
-                let arr_field: json::Value =
-                    json::from_str(arr_field).expect("Failed to deserialize arrzip field1");
-                // This field is assumed to be a multivalue field
-                if let json::Value::Array(mut field) = arr_field {
-                    field.sort_by(|a, b| {
-                        // Assuming the array having elements of same type
-                        if a.is_f64() {
-                            a.as_f64().unwrap().total_cmp(b.as_f64().as_ref().unwrap())
-                        } else if a.is_i64() {
-                            a.as_i64().unwrap().cmp(b.as_i64().as_ref().unwrap())
-                        } else if a.is_u64() {
-                            a.as_u64().unwrap().cmp(b.as_u64().as_ref().unwrap())
-                        } else if a.is_string() {
-                            a.as_str().unwrap().cmp(b.as_str().unwrap())
-                        } else if a.is_boolean() {
-                            a.as_bool().unwrap().cmp(b.as_bool().as_ref().unwrap())
-                        } else {
-                            Ordering::Less
-                        }
-                    });
-                    arr_sorted.append(&mut field);
-                }
-                let arr_sorted =
-                    json::to_string(&arr_sorted).expect("Failed to stringify sorted arrs");
-                Some(arr_sorted)
-            } else {
-                None
-            }
+            arr_field
+                .and_then(|arr_field| {
+                    json::from_str::<json::Value>(arr_field)
+                        .ok()
+                        .and_then(|arr_field| {
+                            if let json::Value::Array(mut field) = arr_field {
+                                if field.is_empty() {
+                                    None
+                                } else {
+                                    field.sort_by(|a, b| {
+                                        // Assuming the array having elements of same type
+                                        if a.is_f64() {
+                                            a.as_f64().unwrap().total_cmp(b.as_f64().as_ref().unwrap())
+                                        } else if a.is_i64() {
+                                            a.as_i64().unwrap().cmp(b.as_i64().as_ref().unwrap())
+                                        } else if a.is_u64() {
+                                            a.as_u64().unwrap().cmp(b.as_u64().as_ref().unwrap())
+                                        } else if a.is_string() {
+                                            a.as_str().unwrap().cmp(b.as_str().unwrap())
+                                        } else if a.is_boolean() {
+                                            a.as_bool().unwrap().cmp(b.as_bool().as_ref().unwrap())
+                                        } else {
+                                            Ordering::Less
+                                        }
+                                    });
+                                    json::to_string(&field).ok()
+                                }
+                            } else {
+                                None
+                            }
+                        })
+                })
         })
         .collect::<StringArray>();
 
@@ -117,11 +118,50 @@ mod tests {
 
     use super::*;
 
+    // Helper function to run a single test case
+    async fn run_single_test(arr_field: &str, expected_output: Vec<&str>) {
+        let sql = "select arrsort(arr_field) as ret from t";
+        let sqls = [(sql, expected_output)];
+
+        let schema = Arc::new(Schema::new(vec![Field::new("arr_field", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![arr_field]))],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_SORT_UDF.clone());
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+
+    // Helper function to run multiple test cases that should all return null
+    async fn run_null_returning_tests(test_cases: &[&str]) {
+        let expected_output = vec![
+            "+-----+",
+            "| ret |",
+            "+-----+",
+            "|     |",
+            "+-----+",
+        ];
+
+        for &arr_field in test_cases {
+            run_single_test(arr_field, expected_output.clone()).await;
+        }
+    }
+
     #[tokio::test]
-    async fn test_arr_sort_udf() {
-        let sqls = [
+    async fn test_arr_sort_valid_arrays() {
+        let test_cases = [
             (
-                "select arrsort(bools) as ret from t",
+                r#"[true,false,true]"#,
                 vec![
                     "+-------------------+",
                     "| ret               |",
@@ -131,7 +171,7 @@ mod tests {
                 ],
             ),
             (
-                "select arrsort(names) as ret from t",
+                r#"["hello2","hi2","bye2"]"#,
                 vec![
                     "+-------------------------+",
                     "| ret                     |",
@@ -141,7 +181,7 @@ mod tests {
                 ],
             ),
             (
-                "select arrsort(nums) as ret from t",
+                r#"[12, 345, 23, 45]"#,
                 vec![
                     "+----------------+",
                     "| ret            |",
@@ -151,7 +191,7 @@ mod tests {
                 ],
             ),
             (
-                "select arrsort(floats) as ret from t",
+                r#"[1.9, 34.5, 2.6, 4.5]"#,
                 vec![
                     "+--------------------+",
                     "| ret                |",
@@ -160,44 +200,126 @@ mod tests {
                     "+--------------------+",
                 ],
             ),
+            (
+                r#"[3, 1, 4, 1, 5]"#,
+                vec![
+                    "+-------------+",
+                    "| ret         |",
+                    "+-------------+",
+                    "| [1,1,3,4,5] |",
+                    "+-------------+",
+                ],
+            ),
+            (
+                r#"["zebra", "apple", "banana"]"#,
+                vec![
+                    "+----------------------------+",
+                    "| ret                        |",
+                    "+----------------------------+",
+                    "| [\"apple\",\"banana\",\"zebra\"] |",
+                    "+----------------------------+",
+                ],
+            ),
         ];
 
-        // define a schema.
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("log", DataType::Utf8, false),
-            Field::new("bools", DataType::Utf8, false),
-            Field::new("names", DataType::Utf8, false),
-            Field::new("nums", DataType::Utf8, false),
-            Field::new("floats", DataType::Utf8, false),
-        ]));
+        for (arr_field, expected_output) in test_cases {
+            run_single_test(arr_field, expected_output).await;
+        }
+    }
 
-        // define data.
+    #[tokio::test]
+    async fn test_arr_sort_null_returning_cases() {
+        // Test cases that should return null
+        let null_cases = [
+            r#"not json"#,              // invalid JSON
+            r#"{"key": "value"}"#,      // object
+            r#""just a string""#,       // string
+            r#"42"#,                    // number
+            r#"true"#,                  // boolean
+            r#"null"#,                  // null
+        ];
+
+        run_null_returning_tests(&null_cases).await;
+    }
+
+    #[tokio::test]
+    async fn test_arr_sort_null_input() {
+        let expected_output = vec![
+            "+-----+",
+            "| ret |",
+            "+-----+",
+            "|     |",
+            "+-----+",
+        ];
+
+        let schema = Arc::new(Schema::new(vec![Field::new("arr_field", DataType::Utf8, true)]));
         let batch = RecordBatch::try_new(
             schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["a"])),
-                Arc::new(StringArray::from(vec!["[true,false,true]"])),
-                Arc::new(StringArray::from(vec!["[\"hello2\",\"hi2\",\"bye2\"]"])),
-                Arc::new(StringArray::from(vec!["[12, 345, 23, 45]"])),
-                Arc::new(StringArray::from(vec!["[1.9, 34.5, 2.6, 4.5]"])),
-            ],
+            vec![Arc::new(StringArray::from(vec![None::<String>]))],
         )
         .unwrap();
 
-        // declare a new context. In spark API, this corresponds to a new spark
-        // SQLsession
         let ctx = SessionContext::new();
         ctx.register_udf(ARR_SORT_UDF.clone());
-
-        // declare a table in memory. In spark API, this corresponds to
-        // createDataFrame(...).
         let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
         ctx.register_table("t", Arc::new(provider)).unwrap();
 
-        for item in sqls {
-            let df = ctx.sql(item.0).await.unwrap();
-            let data = df.collect().await.unwrap();
-            assert_batches_eq!(item.1, &data);
-        }
+        let sql = "select arrsort(arr_field) as ret from t";
+        let df = ctx.sql(sql).await.unwrap();
+        let data = df.collect().await.unwrap();
+        assert_batches_eq!(expected_output, &data);
+    }
+
+    #[tokio::test]
+    async fn test_arr_sort_multiple_rows() {
+        let arr_fields = vec![
+            r#"[3, 1, 4]"#,
+            r#"[]"#,
+            r#"not json"#,
+            r#"["b", "a", "c"]"#,
+            r#"{"key": "value"}"#,
+        ];
+        let sql = "select arrsort(arr_field) as ret from t";
+        let expected_output = vec![
+            "+---------------+",
+            "| ret           |",
+            "+---------------+",
+            "| [1,3,4]       |",
+            "|               |",
+            "|               |",
+            "| [\"a\",\"b\",\"c\"] |",
+            "|               |",
+            "+---------------+",
+        ];
+
+        let schema = Arc::new(Schema::new(vec![Field::new("arr_field", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(arr_fields))],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_SORT_UDF.clone());
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        let df = ctx.sql(sql).await.unwrap();
+        let data = df.collect().await.unwrap();
+        assert_batches_eq!(expected_output, &data);
+    }
+
+    #[tokio::test]
+    async fn test_arr_sort_wrong_arguments() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_SORT_UDF.clone());
+
+        // Test with no arguments
+        let result = ctx.sql("select arrsort() as ret").await;
+        assert!(result.is_err());
+
+        // Test with multiple arguments
+        let result = ctx.sql("select arrsort('a', 'b') as ret").await;
+        assert!(result.is_err());
     }
 }

--- a/src/service/search/datafusion/udf/arrzip_udf.rs
+++ b/src/service/search/datafusion/udf/arrzip_udf.rs
@@ -66,28 +66,33 @@ pub fn arr_zip_impl(args: &[ColumnarValue]) -> datafusion::error::Result<Columna
     let array = zip(arr_field1.iter(), zip(arr_field2.iter(), delim.iter()))
         .map(|(arr_field1, val)| {
             match (arr_field1, val) {
-                // in arrow, any value can be null.
-                // Here we decide to make our UDF to return null when either argument is null.
                 (Some(arr_field1), (Some(arr_field2), Some(delim))) => {
-                    let arr_field1: json::Value =
-                        json::from_str(arr_field1).expect("Failed to deserialize arrzip field1");
-                    let arr_field2: json::Value =
-                        json::from_str(arr_field2).expect("Failed to deserialize arrzip field2");
-                    let mut zipped_arrs = vec![];
-                    if let (json::Value::Array(field1), json::Value::Array(field2)) =
-                        (arr_field1, arr_field2)
-                    {
-                        // Field1 and field2 can be of different types
-                        zip(field1.iter(), field2.iter()).for_each(|(field1, field2)| {
-                            let field1 = super::stringify_json_value(field1);
-                            let field2 = super::stringify_json_value(field2);
-
-                            zipped_arrs.push(format!("{field1}{delim}{field2}"));
-                        });
-                    }
-                    let zipped_arrs =
-                        json::to_string(&zipped_arrs).expect("Failed to stringify zipped arrs");
-                    Some(zipped_arrs)
+                    json::from_str::<json::Value>(arr_field1)
+                        .ok()
+                        .and_then(|arr_field1| {
+                            json::from_str::<json::Value>(arr_field2)
+                                .ok()
+                                .and_then(|arr_field2| {
+                                    if let (json::Value::Array(field1), json::Value::Array(field2)) =
+                                        (arr_field1, arr_field2)
+                                    {
+                                        if field1.is_empty() || field2.is_empty() {
+                                            None
+                                        } else {
+                                            let zipped_arrs: Vec<String> = zip(field1.iter(), field2.iter())
+                                                .map(|(field1, field2)| {
+                                                    let field1 = super::stringify_json_value(field1);
+                                                    let field2 = super::stringify_json_value(field2);
+                                                    format!("{field1}{delim}{field2}")
+                                                })
+                                                .collect();
+                                            json::to_string(&zipped_arrs).ok()
+                                        }
+                                    } else {
+                                        None
+                                    }
+                                })
+                        })
                 }
                 _ => None,
             }
@@ -113,12 +118,58 @@ mod tests {
 
     use super::*;
 
+    // Helper function to run a single test case
+    async fn run_single_test(arr_field1: &str, arr_field2: &str, delimiter: &str, expected_output: Vec<&str>) {
+        let sql = format!("select arrzip(arr_field1, arr_field2, '{}') as ret from t", delimiter);
+        let sqls = [(sql.as_str(), expected_output)];
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("arr_field1", DataType::Utf8, false),
+            Field::new("arr_field2", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![arr_field1])),
+                Arc::new(StringArray::from(vec![arr_field2])),
+            ],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_ZIP_UDF.clone());
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+
+    // Helper function to run multiple test cases that should all return null
+    async fn run_null_returning_tests(test_cases: &[(&str, &str, &str)]) {
+        let expected_output = vec![
+            "+-----+",
+            "| ret |",
+            "+-----+",
+            "|     |",
+            "+-----+",
+        ];
+
+        for &(arr_field1, arr_field2, delimiter) in test_cases {
+            run_single_test(arr_field1, arr_field2, delimiter, expected_output.clone()).await;
+        }
+    }
+
     #[tokio::test]
-    async fn test_arr_zip_udf() {
-        let sqls = [
+    async fn test_arr_zip_valid_arrays() {
+        let test_cases = [
             (
-                // Should include values at index 0 to index 1 (inclusive)
-                "select arrzip(bools, names, ',') as ret from t",
+                r#"[true,false,true]"#,
+                r#"["hello2","hi2","bye2"]"#,
+                ",",
                 vec![
                     "+-----------------------------------------+",
                     "| ret                                     |",
@@ -128,8 +179,9 @@ mod tests {
                 ],
             ),
             (
-                // Should include all the elements
-                "select arrzip(nums, floats, ',') as ret from t",
+                r#"[12, 345, 23, 45]"#,
+                r#"[1.9, 34.5, 2.6, 4.5]"#,
+                ",",
                 vec![
                     "+-----------------------------------------+",
                     "| ret                                     |",
@@ -139,7 +191,9 @@ mod tests {
                 ],
             ),
             (
-                "select arrzip(nums, mixed, ',') as ret from t",
+                r#"[12, 345, 23, 45]"#,
+                r#"["hello2","hi2",123, 23.9, false]"#,
+                ",",
                 vec![
                     "+--------------------------------------------+",
                     "| ret                                        |",
@@ -148,48 +202,160 @@ mod tests {
                     "+--------------------------------------------+",
                 ],
             ),
+            (
+                r#"["a", "b", "c"]"#,
+                r#"[1, 2, 3]"#,
+                "|",
+                vec![
+                    "+---------------------+",
+                    "| ret                 |",
+                    "+---------------------+",
+                    "| [\"a|1\",\"b|2\",\"c|3\"] |",
+                    "+---------------------+",
+                ],
+            ),
+            (
+                r#"["single"]"#,
+                r#"[42]"#,
+                "-",
+                vec![
+                    "+---------------+",
+                    "| ret           |",
+                    "+---------------+",
+                    "| [\"single-42\"] |",
+                    "+---------------+",
+                ],
+            ),
         ];
 
-        // define a schema.
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("log", DataType::Utf8, false),
-            Field::new("bools", DataType::Utf8, false),
-            Field::new("names", DataType::Utf8, false),
-            Field::new("nums", DataType::Utf8, false),
-            Field::new("floats", DataType::Utf8, false),
-            Field::new("mixed", DataType::Utf8, false),
-        ]));
+        for (arr_field1, arr_field2, delimiter, expected_output) in test_cases {
+            run_single_test(arr_field1, arr_field2, delimiter, expected_output).await;
+        }
+    }
 
-        // define data.
+    #[tokio::test]
+    async fn test_arr_zip_null_returning_cases() {
+        // Test cases that should return null
+        let null_cases = [
+            (r#"[]"#, r#"[1,2,3]"#, ","),                    // empty array
+            (r#"not json"#, r#"[1,2,3]"#, ","),              // invalid JSON
+            (r#"{"key": "value"}"#, r#"[1,2,3]"#, ","),      // object
+            (r#""just a string""#, r#"[1,2,3]"#, ","),       // string
+            (r#"42"#, r#"[1,2,3]"#, ","),                    // number
+            (r#"true"#, r#"[1,2,3]"#, ","),                  // boolean
+            (r#"null"#, r#"[1,2,3]"#, ","),                  // null
+            (r#"[1,2,3]"#, r#"[]"#, ","),                    // second array empty
+            (r#"[1,2,3]"#, r#"not json"#, ","),              // second array invalid JSON
+        ];
+
+        run_null_returning_tests(&null_cases).await;
+    }
+
+    #[tokio::test]
+    async fn test_arr_zip_null_input() {
+        let expected_output = vec![
+            "+-----+",
+            "| ret |",
+            "+-----+",
+            "|     |",
+            "+-----+",
+        ];
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("arr_field1", DataType::Utf8, true),
+            Field::new("arr_field2", DataType::Utf8, true),
+        ]));
         let batch = RecordBatch::try_new(
             schema.clone(),
             vec![
-                Arc::new(StringArray::from(vec!["a"])),
-                Arc::new(StringArray::from(vec!["[true,false,true]"])),
-                Arc::new(StringArray::from(vec!["[\"hello2\",\"hi2\",\"bye2\"]"])),
-                Arc::new(StringArray::from(vec!["[12, 345, 23, 45]"])),
-                Arc::new(StringArray::from(vec!["[1.9, 34.5, 2.6, 4.5]"])),
-                Arc::new(StringArray::from(vec![
-                    "[\"hello2\",\"hi2\",123, 23.9, false]",
-                ])),
+                Arc::new(StringArray::from(vec![None::<String>])),
+                Arc::new(StringArray::from(vec![None::<String>])),
             ],
         )
         .unwrap();
 
-        // declare a new context. In spark API, this corresponds to a new spark
-        // SQLsession
         let ctx = SessionContext::new();
         ctx.register_udf(ARR_ZIP_UDF.clone());
-
-        // declare a table in memory. In spark API, this corresponds to
-        // createDataFrame(...).
         let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
         ctx.register_table("t", Arc::new(provider)).unwrap();
 
-        for item in sqls {
-            let df = ctx.sql(item.0).await.unwrap();
-            let data = df.collect().await.unwrap();
-            assert_batches_eq!(item.1, &data);
-        }
+        let sql = "select arrzip(arr_field1, arr_field2, ',') as ret from t";
+        let df = ctx.sql(sql).await.unwrap();
+        let data = df.collect().await.unwrap();
+        assert_batches_eq!(expected_output, &data);
+    }
+
+    #[tokio::test]
+    async fn test_arr_zip_multiple_rows() {
+        let arr_fields1 = vec![
+            r#"[1, 2, 3]"#,
+            r#"[]"#,
+            r#"not json"#,
+            r#"["a", "b"]"#,
+            r#"{"key": "value"}"#,
+        ];
+        let arr_fields2 = vec![
+            r#"[4, 5, 6]"#,
+            r#"[1, 2]"#,
+            r#"[1, 2]"#,
+            r#"[x, y]"#,
+            r#"[1, 2]"#,
+        ];
+        let sql = "select arrzip(arr_field1, arr_field2, ',') as ret from t";
+        let expected_output = vec![
+            "+---------------------+",
+            "| ret                 |",
+            "+---------------------+",
+            "| [\"1,4\",\"2,5\",\"3,6\"] |",
+            "|                     |",
+            "|                     |",
+            "|                     |",
+            "|                     |",
+            "+---------------------+",
+        ];
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("arr_field1", DataType::Utf8, false),
+            Field::new("arr_field2", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(arr_fields1)),
+                Arc::new(StringArray::from(arr_fields2)),
+            ],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_ZIP_UDF.clone());
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        let df = ctx.sql(sql).await.unwrap();
+        let data = df.collect().await.unwrap();
+        assert_batches_eq!(expected_output, &data);
+    }
+
+    #[tokio::test]
+    async fn test_arr_zip_wrong_arguments() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(ARR_ZIP_UDF.clone());
+
+        // Test with no arguments
+        let result = ctx.sql("select arrzip() as ret").await;
+        assert!(result.is_err());
+
+        // Test with one argument
+        let result = ctx.sql("select arrzip('a') as ret").await;
+        assert!(result.is_err());
+
+        // Test with two arguments
+        let result = ctx.sql("select arrzip('a', 'b') as ret").await;
+        assert!(result.is_err());
+
+        // Test with four arguments
+        let result = ctx.sql("select arrzip('a', 'b', 'c', 'd') as ret").await;
+        assert!(result.is_err());
     }
 }

--- a/src/service/search/datafusion/udf/cast_to_arr_udf.rs
+++ b/src/service/search/datafusion/udf/cast_to_arr_udf.rs
@@ -62,17 +62,17 @@ pub fn cast_to_arr_impl(args: &[ColumnarValue]) -> datafusion::error::Result<Col
     ));
 
     string_array.iter().for_each(|string| {
-        if let Some(string) = string {
-            let arr: json::Value =
-                json::from_str(string).expect("Failed to deserialize the field into an array");
-            if let json::Value::Array(arr) = arr {
-                arr.iter().for_each(|field| {
-                    let field = super::stringify_json_value(field);
-                    if !field.is_empty() {
+        if let Some(arr) = string.and_then(|s| json::from_str::<json::Value>(s).ok()) {
+            if let Some(arr) = arr.as_array().filter(|arr| !arr.is_empty()) {
+                arr.iter()
+                    .map(super::stringify_json_value)
+                    .filter(|field| !field.is_empty())
+                    .for_each(|field| {
                         list_builder.values().append_value(field);
-                    }
-                });
+                    });
                 list_builder.append(true);
+            } else {
+                list_builder.append_null();
             }
         } else {
             list_builder.append_null();
@@ -94,37 +94,173 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
-    async fn test_cast_to_arr() {
-        let log_line = r#"[12, 345, 23, 45]"#;
-        let sqls = [(
-            "select cast_to_arr(log) as ret from t",
-            vec![
-                "+-------------------+",
-                "| ret               |",
-                "+-------------------+",
-                "| [12, 345, 23, 45] |",
-                "+-------------------+",
-            ],
-        )];
+    // Helper function to run a single test case
+    async fn run_single_test(log_line: &str, expected_output: Vec<&str>, nullable: bool) {
+        let sqls = [("select cast_to_arr(log) as ret from t", expected_output)];
 
-        // define a schema.
-        let schema = Arc::new(Schema::new(vec![Field::new("log", DataType::Utf8, false)]));
-
-        // define data.
+        let schema = Arc::new(Schema::new(vec![Field::new("log", DataType::Utf8, nullable)]));
         let batch = RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(StringArray::from(vec![log_line]))],
         )
         .unwrap();
 
-        // declare a new context. In spark API, this corresponds to a new spark
-        // SQLsession
         let ctx = SessionContext::new();
         ctx.register_udf(CAST_TO_ARR_UDF.clone());
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
 
-        // declare a table in memory. In spark API, this corresponds to
-        // createDataFrame(...).
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+
+    // Helper function to run multiple test cases that should all return null
+    async fn run_null_returning_tests(test_cases: &[&str]) {
+        let expected_output = vec![
+            "+-----+",
+            "| ret |",
+            "+-----+",
+            "|     |",
+            "+-----+",
+        ];
+
+        for &log_line in test_cases {
+            run_single_test(log_line, expected_output.clone(), false).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cast_to_arr_valid_arrays() {
+        let test_cases = [
+            (
+                r#"[12, 345, 23, 45]"#,
+                vec![
+                    "+-------------------+",
+                    "| ret               |",
+                    "+-------------------+",
+                    "| [12, 345, 23, 45] |",
+                    "+-------------------+",
+                ],
+            ),
+            (
+                r#"["hello2","hi2","bye2"]"#,
+                vec![
+                    "+---------------------+",
+                    "| ret                 |",
+                    "+---------------------+",
+                    "| [hello2, hi2, bye2] |",
+                    "+---------------------+",
+                ],
+            ),
+            (
+                r#"[1, "string", true, {"nested": "object"}, [1, 2, 3]]"#,
+                vec![
+                    "+-------------------------------------------------+",
+                    "| ret                                             |",
+                    "+-------------------------------------------------+",
+                    "| [1, string, true, {\"nested\":\"object\"}, [1,2,3]] |",
+                    "+-------------------------------------------------+",
+                ],
+            ),
+            (
+                r#"["", "valid", "", "another", ""]"#,
+                vec![
+                    "+------------------+",
+                    "| ret              |",
+                    "+------------------+",
+                    "| [valid, another] |",
+                    "+------------------+",
+                ],
+            ),
+        ];
+
+        for (log_line, expected_output) in test_cases {
+            run_single_test(log_line, expected_output, false).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cast_to_arr_null_returning_cases() {
+        // Test cases that should return null
+        let null_cases = [
+            r#"[]"#,                    // empty array
+            r#"not json"#,              // invalid JSON
+            r#"{"key": "value"}"#,      // object
+            r#""just a string""#,       // string
+            r#"42"#,                    // number
+            r#"true"#,                  // boolean
+            r#"null"#,                  // null
+        ];
+
+        run_null_returning_tests(&null_cases).await;
+    }
+
+    #[tokio::test]
+    async fn test_cast_to_arr_null_input() {
+        let expected_output = vec![
+            "+-----+",
+            "| ret |",
+            "+-----+",
+            "|     |",
+            "+-----+",
+        ];
+
+        let schema = Arc::new(Schema::new(vec![Field::new("log", DataType::Utf8, true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![None::<String>]))],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(CAST_TO_ARR_UDF.clone());
+        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(provider)).unwrap();
+
+        let sqls = [("select cast_to_arr(log) as ret from t", expected_output)];
+        for item in sqls {
+            let df = ctx.sql(item.0).await.unwrap();
+            let data = df.collect().await.unwrap();
+            assert_batches_eq!(item.1, &data);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cast_to_arr_multiple_rows() {
+        let log_lines = vec![
+            r#"["a", "b", "c"]"#,
+            r#"[]"#,
+            r#"not json"#,
+            r#"["x", "y"]"#,
+            r#"{"key": "value"}"#,
+        ];
+        let sqls = [(
+            "select cast_to_arr(log) as ret from t",
+            vec![
+                "+-----------+",
+                "| ret       |",
+                "+-----------+",
+                "| [a, b, c] |",
+                "|           |",
+                "|           |",
+                "| [x, y]    |",
+                "|           |",
+                "+-----------+",
+            ],
+        )];
+
+        let schema = Arc::new(Schema::new(vec![Field::new("log", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(log_lines))],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(CAST_TO_ARR_UDF.clone());
         let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
         ctx.register_table("t", Arc::new(provider)).unwrap();
 
@@ -136,43 +272,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cast_to_arr_string() {
-        let log_line = r#"["hello2","hi2","bye2"]"#;
-        let sqls = [(
-            "select cast_to_arr(log) as ret from t",
-            vec![
-                "+---------------------+",
-                "| ret                 |",
-                "+---------------------+",
-                "| [hello2, hi2, bye2] |",
-                "+---------------------+",
-            ],
-        )];
-
-        // define a schema.
-        let schema = Arc::new(Schema::new(vec![Field::new("log", DataType::Utf8, false)]));
-
-        // define data.
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(StringArray::from(vec![log_line]))],
-        )
-        .unwrap();
-
-        // declare a new context. In spark API, this corresponds to a new spark
-        // SQLsession
+    async fn test_cast_to_arr_wrong_arguments() {
         let ctx = SessionContext::new();
         ctx.register_udf(CAST_TO_ARR_UDF.clone());
 
-        // declare a table in memory. In spark API, this corresponds to
-        // createDataFrame(...).
-        let provider = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
-        ctx.register_table("t", Arc::new(provider)).unwrap();
+        // Test with no arguments
+        let result = ctx.sql("select cast_to_arr() as ret").await;
+        assert!(result.is_err());
 
-        for item in sqls {
-            let df = ctx.sql(item.0).await.unwrap();
-            let data = df.collect().await.unwrap();
-            assert_batches_eq!(item.1, &data);
-        }
+        // Test with multiple arguments
+        let result = ctx.sql("select cast_to_arr('a', 'b') as ret").await;
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
- Replace `.expect()` calls with `.ok()` and option chaining in array UDFs
- Add comprehensive test coverage for edge cases and invalid inputs
- Update UDFs to return null for invalid input following DataFusion standards
- Fix potential panics in `arrcount_udf`, `arrindex_udf`, `arrjoin_udf`, `arrsort_udf`, `arr_descending_udf`, `arrzip_udf`, and `to_arr_string_udf`

The UDFs previously used .expect() calls that could panic on invalid JSON or serialization errors. This change makes them more robust by:
- Use `.ok()` to convert `Result` to `Option` and chain with `.and_then()`
- Return `null` (`None`) for invalid inputs instead of panicking
- Add test coverage for edge cases including:
  - Invalid JSON input
  - Null inputs
  - Empty arrays
  - Out-of-bounds indices
  - Wrong argument counts
  - Mixed data types
  - Batch processing scenarios