### PR TITLE
fix: only show o2 ai btn when ai chat is enabled

### DIFF
--- a/web/src/components/functions/TestFunction.vue
+++ b/web/src/components/functions/TestFunction.vue
@@ -208,7 +208,7 @@
             </q-tooltip>
           </q-icon>
         </template>
-        <template #right>
+        <template v-if="config.isEnterprise == 'true' && store.state.zoConfig.ai_enabled" #right>
           <q-btn
             :ripple="false"
             @click.prevent.stop="sendToAiChat(JSON.stringify(inputEvents))"
@@ -343,6 +343,7 @@ import { event, useQuasar } from "quasar";
 import { getConsumableRelativeTime } from "@/utils/date";
 import AppTabs from "@/components/common/AppTabs.vue";
 import jstransform from "@/services/jstransform";
+import config from "@/aws-exports";
 
 const props = defineProps({
   vrlFunction: {
@@ -767,7 +768,9 @@ const sendToAiChat = (value: any) => {
 defineExpose({
   testFunction,
   sendToAiChat,
-  getBtnLogo
+  getBtnLogo,
+  config,
+  store
 });
 </script>
 

--- a/web/src/plugins/logs/DetailTable.vue
+++ b/web/src/plugins/logs/DetailTable.vue
@@ -52,6 +52,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :label="t('common.table')"
           />
           <q-btn
+            v-if="config.isEnterprise == 'true' && store.state.zoConfig.ai_enabled"
             :ripple="false"
             @click.prevent.stop="sendToAiChat(JSON.stringify(rowData))"
             data-test="menu-link-ai-item"
@@ -364,6 +365,7 @@ import EqualIcon from "@/components/icons/EqualIcon.vue";
 import NotEqualIcon from "@/components/icons/NotEqualIcon.vue";
 import { copyToClipboard, useQuasar } from "quasar";
 import JsonPreview from "./JsonPreview.vue";
+import config from "@/aws-exports";
 
 const defaultValue: any = () => {
   return {
@@ -533,7 +535,8 @@ export default defineComponent({
       hasAggregationQuery,
       sendToAiChat,
       getBtnLogo,
-      closeTable
+      closeTable,
+      config
     };
   },
   async created() {

--- a/web/src/plugins/logs/JsonPreview.vue
+++ b/web/src/plugins/logs/JsonPreview.vue
@@ -196,7 +196,7 @@
                 >
               </q-item-section>
             </q-item>
-            <q-item  clickable v-close-popup>
+            <q-item  clickable v-close-popup v-if="config.isEnterprise == 'true' && store.state.zoConfig.ai_enabled">
               <q-item-section>
                 <q-item-label
                   data-test="send-to-ai-chat-btn"
@@ -255,6 +255,7 @@ import searchService from "@/services/search";
 import { generateTraceContext } from "@/utils/zincutils";
 import { defineAsyncComponent } from "vue";
 import { useQuasar } from "quasar";
+import config from "@/aws-exports";
 
 export default {
   name: "JsonPreview",
@@ -544,7 +545,8 @@ export default {
       getOriginalData,
       addOrRemoveLabel,
       sendToAiChat,
-      getBtnLogo
+      getBtnLogo,
+      config
     };
   },
 };

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -346,9 +346,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     highlightQuery
                   "
                 />
-                <!-- Add copy button floating between columns -->
+                <!-- show o2 ai button only for timestamp column -->
                 <q-btn
-                v-if="cell.column.columnDef.id === store.state.zoConfig.timestamp_column"
+                    v-if="cell.column.columnDef.id === store.state.zoConfig.timestamp_column && config.isEnterprise == 'true' && store.state.zoConfig.ai_enabled"
                     :ripple="false"
                     @click.stop="sendToAiChat(JSON.stringify(cell.row.original),true)"
                     data-test="menu-link-ai-item"
@@ -403,6 +403,7 @@ import { VueDraggableNext as VueDraggable } from "vue-draggable-next";
 import CellActions from "@/plugins/logs/data-table/CellActions.vue";
 import { debounce } from "quasar";
 import { getImageURL } from "@/utils/zincutils";
+import config from "@/aws-exports";
 
 const props = defineProps({
   rows: {
@@ -896,7 +897,9 @@ defineExpose({
   parentRef,
   virtualRows,
   getBtnLogo,
-  sendToAiChat
+  sendToAiChat,
+  store,
+  config
 });
 </script>
 <style scoped lang="scss">

--- a/web/src/plugins/logs/data-table/CellActions.vue
+++ b/web/src/plugins/logs/data-table/CellActions.vue
@@ -37,6 +37,7 @@
       </q-icon>
     </q-btn>
     <q-btn
+    v-if="config.isEnterprise == 'true' && store.state.zoConfig.ai_enabled"
     class="q-ml-xs"
       :ripple="false"
       @click.prevent.stop="sendToAiChat(JSON.stringify(row[column.id]))"
@@ -61,6 +62,7 @@ import { useStore } from "vuex";
 import EqualIcon from "@/components/icons/EqualIcon.vue";
 import NotEqualIcon from "@/components/icons/NotEqualIcon.vue";
 import { getImageURL } from "@/utils/zincutils";
+import config from "@/aws-exports";
 
 defineProps({
   column: {


### PR DESCRIPTION
### **User description**
show o2 ai button when ai chat is enabled


___

### **PR Type**
Bug fix


___

### **Description**
- Wrap AI chat buttons with enterprise & AI enabled checks

- Import and expose `config` and `store` in affected components

- Hide O2 AI UI when AI chat is disabled or non-enterprise


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestFunction.vue</strong><dd><code>Feature-flag AI button in TestFunction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/functions/TestFunction.vue

<ul><li>Wrapped AI button template with v-if feature flag<br> <li> Imported <code>config</code> from aws-exports<br> <li> Exposed <code>config</code> and <code>store</code> in script setup</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7638/files#diff-b9af9a2d1bf04d23422c26a13e6a763c6953c8713357a2f64ed8073ce6c926a3">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DetailTable.vue</strong><dd><code>Conditional AI button in detail table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/DetailTable.vue

<ul><li>Added v-if on AI chat QBtn using feature flag<br> <li> Imported <code>config</code> and exposed in component</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7638/files#diff-80552b5d25fa6cef9fbbe430b1865d761c4b132284c2d2175afceea8cbabc8c7">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JsonPreview.vue</strong><dd><code>Toggle AI chat option in JSON preview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/JsonPreview.vue

<ul><li>Wrapped send-to-AI list item with v-if feature flag<br> <li> Imported <code>config</code> and added to returned refs</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7638/files#diff-3985073134d35ff074742944b114d0905524038b42e6d2ac887fef2c8436fb16">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TenstackTable.vue</strong><dd><code>Conditional AI button in data table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/TenstackTable.vue

<ul><li>Added v-if feature flag on timestamp column AI QBtn<br> <li> Imported <code>config</code> and exposed <code>store</code> in setup</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7638/files#diff-bc3c669f5ab65a42ae378df1f7d6b35014c9c220790bdcc72b47f55d1385dc22">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CellActions.vue</strong><dd><code>Feature-flag AI action in CellActions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/data-table/CellActions.vue

<ul><li>Wrapped AI action QBtn with v-if feature flag<br> <li> Imported <code>config</code> to enable enterprise check</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7638/files#diff-de54e5b8cd9503c53f3f802ac7bc7e3d25846f1657c77cd99534d9f60673992e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

