### PR TITLE
fix: align partitions for indexed search (#7642)

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1107,6 +1107,12 @@ pub struct Common {
     pub dashboard_show_symbol_enabled: bool,
     #[env_config(name = "ZO_INGEST_DEFAULT_HEC_STREAM", default = "")]
     pub default_hec_stream: String,
+    #[env_config(
+        name = "ZO_ALIGN_PARTITIONS_FOR_INDEX",
+        default = false,
+        help = "Enable to use large partition for index. This will apply for all streams"
+    )]
+    pub align_partitions_for_index: bool,
 }
 
 #[derive(EnvConfig)]

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -994,7 +994,7 @@ pub async fn search_partition(
         is_histogram,
     );
 
-    if cfg.common.align_partitions_for_index && is_use_inverted_index(&Arc::new(sql)).0 {
+    if cfg.common.align_partitions_for_index && is_use_inverted_index(&Arc::new(sql)) {
         step *= step_factor;
     }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `align_partitions_for_index` config option.

- Compute `step_factor` using index vs storage sizes.

- Adjust partition `step` when index-based search.

- Refactor stats retrieval in `search_partition`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Cfg["Config: align_partitions_for_index"]
  Search["search_partition"]
  Stats["Calculate step_factor"]
  Step["Adjust partition step"]
  Gen["Generate_partitions"]

  Cfg -- "enabled" --> Search
  Search -- "retrieve stats" --> Stats
  Stats -- "index vs storage" --> Step
  Step -- "apply to step" --> Gen
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add `align_partitions_for_index` config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<ul><li>Added <code>align_partitions_for_index</code> config field.<br> <li> Defined default <code>false</code> with help text.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7644/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Align partitions based on index size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/mod.rs

<ul><li>Introduced <code>step_factor</code> variable.<br> <li> Tracked <code>index_size</code> and <code>original_size</code>.<br> <li> Moved stats retrieval earlier.<br> <li> Applied <code>step_factor</code> when enabled.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7644/files#diff-c3b85ea662a885fbd39797968928b291cb59a58f53a03f7b7dfd7ba8b6a7985a">+16/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

