### PR TITLE
fix: values api read stream type from body

### DIFF
--- a/src/handler/http/request/search/search_stream.rs
+++ b/src/handler/http/request/search/search_stream.rs
@@ -524,7 +524,6 @@ pub async fn values_http2_stream(
 
     // Get query params
     let query = web::Query::<HashMap<String, String>>::from_query(in_req.query_string()).unwrap();
-    let stream_type = get_stream_type_from_request(&query).unwrap_or_default();
 
     #[cfg(feature = "enterprise")]
     let body_bytes = String::from_utf8_lossy(&body).to_string();
@@ -565,7 +564,7 @@ pub async fn values_http2_stream(
     let reqs = match build_search_request_per_field(
         &values_req,
         &org_id,
-        stream_type,
+        values_req.stream_type,
         &values_req.stream_name,
     )
     .await

--- a/src/service/search/datafusion/distributed_plan/enrich_exec.rs
+++ b/src/service/search/datafusion/distributed_plan/enrich_exec.rs
@@ -153,8 +153,7 @@ async fn get_data(
 ) -> Result<SendableRecordBatchStream> {
     let clean_name = name.trim_matches('"');
     let data = match crate::service::db::enrichment_table::get_enrichment_data_from_db(
-        &org_id,
-        &clean_name,
+        &org_id, clean_name,
     )
     .await
     {


### PR DESCRIPTION
We were depending on query params for stream type in HTTP2 streaming APIs but the value was being sent in body. 