### PR TITLE
perf: improve disk cache lock time

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -713,6 +713,8 @@ pub struct Common {
     pub data_db_dir: String,
     #[env_config(name = "ZO_DATA_CACHE_DIR", default = "")] // ./data/openobserve/cache/
     pub data_cache_dir: String,
+    #[env_config(name = "ZO_DATA_TMP_DIR", default = "")] // ./data/openobserve/tmp/
+    pub data_tmp_dir: String,
     // TODO: should rename to column_all
     #[env_config(name = "ZO_CONCATENATED_SCHEMA_FIELD_NAME", default = "_all")]
     pub column_all: String,
@@ -2335,6 +2337,12 @@ fn check_path_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
     if !cfg.common.data_cache_dir.ends_with('/') {
         cfg.common.data_cache_dir = format!("{}/", cfg.common.data_cache_dir);
+    }
+    if cfg.common.data_tmp_dir.is_empty() {
+        cfg.common.data_tmp_dir = format!("{}tmp/", cfg.common.data_dir);
+    }
+    if !cfg.common.data_tmp_dir.ends_with('/') {
+        cfg.common.data_tmp_dir = format!("{}/", cfg.common.data_tmp_dir);
     }
     if cfg.common.mmdb_data_dir.is_empty() {
         cfg.common.mmdb_data_dir = format!("{}mmdb/", cfg.common.data_dir);

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -28,6 +28,7 @@ use config::{
     utils::{
         file::*,
         hash::{Sum64, gxhash},
+        time::{get_ymdh_from_micros, now_micros},
     },
 };
 use hashbrown::HashMap;
@@ -167,7 +168,7 @@ impl FileData {
                 .multi_dir
                 .split(',')
                 .filter(|s| !s.trim().is_empty())
-                .map(|s| s.to_string())
+                .map(|s| s.trim().to_string())
                 .collect(),
             file_type,
             data: CacheStrategy::new(strategy),
@@ -201,8 +202,12 @@ impl FileData {
         }
     }
 
-    async fn set(&mut self, file: &str, data: Bytes) -> Result<(), anyhow::Error> {
-        let data_size = data.len();
+    async fn set(
+        &mut self,
+        file: &str,
+        tmp_file: &str,
+        data_size: usize,
+    ) -> Result<(), anyhow::Error> {
         if self.cur_size + data_size >= self.max_size {
             log::info!(
                 "[CacheType:{}] File disk cache is full, can't cache extra {} bytes",
@@ -217,10 +222,18 @@ impl FileData {
             self.gc(need_release_size).await?;
         }
 
-        // write file into local disk
+        // rename tmp file to real file
         let file_path = self.get_file_path(file);
         fs::create_dir_all(Path::new(&file_path).parent().unwrap())?;
-        put_file_contents(&file_path, &data)?;
+        fs::rename(tmp_file, &file_path).map_err(|e| {
+            anyhow::anyhow!(
+                "[CacheType:{}] File disk cache rename tmp file {} to real file {} error: {}",
+                self.file_type,
+                tmp_file,
+                file_path,
+                e
+            )
+        })?;
 
         // set size
         self.set_size(file, data_size).await
@@ -419,6 +432,12 @@ impl FileData {
 
 pub async fn init() -> Result<(), anyhow::Error> {
     let cfg = get_config();
+    // clean the tmp dir
+    if let Err(e) = std::fs::remove_dir_all(&cfg.common.data_tmp_dir) {
+        log::warn!("clean tmp dir error: {}", e);
+    }
+    std::fs::create_dir_all(&cfg.common.data_tmp_dir).expect("create tmp dir success");
+
     for file in FILES.iter() {
         let root_dir = file.read().await.root_dir.clone();
         std::fs::create_dir_all(&root_dir).expect("create cache dir success");
@@ -538,8 +557,12 @@ pub async fn set(file: &str, data: Bytes) -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
+    // write to tmp file
+    let data_size = data.len();
+    let (file, tmp_file) = write_tmp_file(file, data).await?;
+
     // hash the file name and get the bucket index
-    let idx = get_bucket_idx(file);
+    let idx = get_bucket_idx(&file);
 
     // get all the files from the bucket
     let mut files = if file.starts_with("files") {
@@ -551,10 +574,19 @@ pub async fn set(file: &str, data: Bytes) -> Result<(), anyhow::Error> {
     } else {
         RESULT_FILES[idx].write().await
     };
-    if files.exist(file).await {
+    if files.exist(&file).await {
+        // remove the tmp file
+        if let Err(e) = std::fs::remove_file(&tmp_file) {
+            log::warn!(
+                "[CacheType:{}] File disk cache remove tmp file {} error: {}",
+                files.file_type,
+                tmp_file,
+                e
+            );
+        }
         return Ok(());
     }
-    files.set(file, data).await
+    files.set(&file, &tmp_file, data_size).await
 }
 
 #[inline]
@@ -958,26 +990,55 @@ pub fn parse_aggregation_cache_key(
     Some((org_id, stream_type, query_key, meta))
 }
 
+// Write data to a temporary random file and return the file path
+async fn write_tmp_file(file: &str, data: Bytes) -> Result<(String, String), anyhow::Error> {
+    let tmp_path = format!(
+        "{}/{}",
+        get_config().common.data_tmp_dir,
+        get_ymdh_from_micros(now_micros())
+    );
+    if let Err(e) = std::fs::create_dir_all(&tmp_path) {
+        return Err(anyhow::anyhow!(
+            "[FileData::Disk] create tmp dir {}, failed: {}",
+            tmp_path,
+            e
+        ));
+    }
+    let tmp_path = Path::new(&tmp_path).canonicalize().unwrap();
+    let tmp_file = tmp_path.join(format!("{}.tmp", config::ider::generate()));
+    let tmp_file = tmp_file.to_str().unwrap();
+    if let Err(e) = config::utils::async_file::put_file_contents(tmp_file, &data).await {
+        return Err(anyhow::anyhow!(
+            "[FileData::Disk] write tmp file {}, failed: {}",
+            tmp_file,
+            e
+        ));
+    }
+    Ok((file.to_string(), tmp_file.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_lru_cache_set_file() {
+    async fn test_disk_lru_cache_set_file() {
         let mut file_data = FileData::with_capacity_and_cache_strategy(FileType::Data, 1024, "lru");
         let content = Bytes::from("Some text Need to store in cache");
+        let data_size = content.len();
         for i in 0..50 {
             let file_key = format!(
                 "files/default/logs/disk/2022/10/03/10/6982652937134804993_1_{}.parquet",
                 i
             );
-            let resp = file_data.set(&file_key, content.clone()).await;
+            let (_file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
+            let resp = file_data.set(&file_key, &tmp_file, data_size).await;
             assert!(resp.is_ok());
         }
     }
 
     #[tokio::test]
-    async fn test_lru_cache_get_file() {
+    async fn test_disk_lru_cache_get_file() {
         let mut file_data = FileData::with_capacity_and_cache_strategy(
             FileType::Data,
             get_config().disk_cache.max_size,
@@ -985,42 +1046,62 @@ mod tests {
         );
         let file_key = "files/default/logs/disk/2022/10/03/10/6982652937134804993_2_1.parquet";
         let content = Bytes::from("Some text");
+        let data_size = content.len();
+        let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
 
-        file_data.set(file_key, content.clone()).await.unwrap();
-        assert!(file_data.exist(file_key).await);
+        file_data
+            .set(&file_key, &tmp_file, data_size)
+            .await
+            .unwrap();
+        assert!(file_data.exist(&file_key).await);
 
-        file_data.set(file_key, content.clone()).await.unwrap();
-        assert!(file_data.exist(file_key).await);
+        let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
+        file_data
+            .set(&file_key, &tmp_file, data_size)
+            .await
+            .unwrap();
+        assert!(file_data.exist(&file_key).await);
         assert!(file_data.size().0 > 0);
     }
 
     #[tokio::test]
-    async fn test_lru_cache_miss() {
+    async fn test_disk_lru_cache_miss() {
         let mut file_data = FileData::with_capacity_and_cache_strategy(FileType::Data, 10, "lru");
         let file_key1 = "files/default/logs/disk/2022/10/03/10/6982652937134804993_3_1.parquet";
         let file_key2 = "files/default/logs/disk/2022/10/03/10/6982652937134804993_3_2.parquet";
         let content = Bytes::from("Some text");
+        let data_size = content.len();
+        let (file_key1, tmp_file) = write_tmp_file(&file_key1, content.clone()).await.unwrap();
         // set one key
-        file_data.set(file_key1, content.clone()).await.unwrap();
-        assert!(file_data.exist(file_key1).await);
+        file_data
+            .set(&file_key1, &tmp_file, data_size)
+            .await
+            .unwrap();
+        assert!(file_data.exist(&file_key1).await);
         // set another key, will release first key
-        file_data.set(file_key2, content.clone()).await.unwrap();
-        assert!(file_data.exist(file_key2).await);
+        let (file_key2, tmp_file) = write_tmp_file(&file_key2, content.clone()).await.unwrap();
+        file_data
+            .set(&file_key2, &tmp_file, data_size)
+            .await
+            .unwrap();
+        assert!(file_data.exist(&file_key2).await);
         // get first key, should get error
-        assert!(!file_data.exist(file_key1).await);
+        assert!(!file_data.exist(&file_key1).await);
     }
 
     #[tokio::test]
-    async fn test_fifo_cache_set_file() {
+    async fn test_disk_fifo_cache_set_file() {
         let mut file_data =
             FileData::with_capacity_and_cache_strategy(FileType::Data, 1024, "fifo");
         let content = Bytes::from("Some text Need to store in cache");
+        let data_size = content.len();
         for i in 0..50 {
             let file_key = format!(
                 "files/default/logs/disk/2022/10/03/10/6982652937134804993_4_{}.parquet",
                 i
             );
-            let resp = file_data.set(&file_key, content.clone()).await;
+            let (_file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
+            let resp = file_data.set(&file_key, &tmp_file, data_size).await;
             if let Some(e) = resp.as_ref().err() {
                 println!("set file_key: {} error: {:?}", file_key, e);
             }
@@ -1029,7 +1110,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fifo_cache_get_file() {
+    async fn test_disk_fifo_cache_get_file() {
         let mut file_data = FileData::with_capacity_and_cache_strategy(
             FileType::Data,
             get_config().disk_cache.max_size,
@@ -1037,37 +1118,55 @@ mod tests {
         );
         let file_key = "files/default/logs/disk/2022/10/03/10/6982652937134804993_5_1.parquet";
         let content = Bytes::from("Some text");
+        let data_size = content.len();
+        let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
 
-        file_data.set(file_key, content.clone()).await.unwrap();
-        assert!(file_data.exist(file_key).await);
+        file_data
+            .set(&file_key, &tmp_file, data_size)
+            .await
+            .unwrap();
+        assert!(file_data.exist(&file_key).await);
 
-        file_data.set(file_key, content.clone()).await.unwrap();
-        assert!(file_data.exist(file_key).await);
+        let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
+        file_data
+            .set(&file_key, &tmp_file, data_size)
+            .await
+            .unwrap();
+        assert!(file_data.exist(&file_key).await);
         assert!(file_data.size().0 > 0);
     }
 
     #[tokio::test]
-    async fn test_fifo_cache_miss() {
+    async fn test_disk_fifo_cache_miss() {
         let mut file_data = FileData::with_capacity_and_cache_strategy(FileType::Data, 10, "fifo");
         let file_key1 = "files/default/logs/disk/2022/10/03/10/6982652937134804993_6_1.parquet";
         let file_key2 = "files/default/logs/disk/2022/10/03/10/6982652937134804993_6_2.parquet";
         let content = Bytes::from("Some text");
+        let data_size = content.len();
+        let (file_key1, tmp_file) = write_tmp_file(&file_key1, content.clone()).await.unwrap();
         // set one key
-        file_data.set(file_key1, content.clone()).await.unwrap();
-        assert!(file_data.exist(file_key1).await);
+        file_data
+            .set(&file_key1, &tmp_file, data_size)
+            .await
+            .unwrap();
+        assert!(file_data.exist(&file_key1).await);
         // set another key, will release first key
-        file_data.set(file_key2, content.clone()).await.unwrap();
-        assert!(file_data.exist(file_key2).await);
+        let (file_key2, tmp_file) = write_tmp_file(&file_key2, content.clone()).await.unwrap();
+        file_data
+            .set(&file_key2, &tmp_file, data_size)
+            .await
+            .unwrap();
+        assert!(file_data.exist(&file_key2).await);
         // get first key, should get error
-        assert!(!file_data.exist(file_key1).await);
+        assert!(!file_data.exist(&file_key1).await);
     }
 
     #[tokio::test]
-    async fn test_multi_dir() {
+    async fn test_disk_multi_dir() {
         let multi_dir: Vec<String> = "dir1 , dir2 , dir3"
             .split(',')
             .filter(|s| !s.trim().is_empty())
-            .map(|s| s.to_string())
+            .map(|s| s.trim().to_string())
             .collect();
 
         let mut file_data = FileData::with_capacity_and_cache_strategy(
@@ -1078,19 +1177,28 @@ mod tests {
         file_data.multi_dir = multi_dir;
         let file_key = "files/default/logs/disk/2022/10/03/10/6982652937134804993_7_1.parquet";
         let content = Bytes::from("Some text");
+        let data_size = content.len();
+        let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
 
-        file_data.set(file_key, content.clone()).await.unwrap();
-        assert!(file_data.exist(file_key).await);
+        file_data
+            .set(&file_key, &tmp_file, data_size)
+            .await
+            .unwrap();
+        assert!(file_data.exist(&file_key).await);
 
-        file_data.set(file_key, content.clone()).await.unwrap();
-        assert!(file_data.exist(file_key).await);
+        let (file_key, tmp_file) = write_tmp_file(&file_key, content.clone()).await.unwrap();
+        file_data
+            .set(&file_key, &tmp_file, data_size)
+            .await
+            .unwrap();
+        assert!(file_data.exist(&file_key).await);
         assert!(file_data.size().0 > 0);
 
         assert_eq!(file_data.get(&file_key, None).await, Some(content))
     }
 
     #[tokio::test]
-    async fn test_parse_result_cache_key() {
+    async fn test_disk_parse_result_cache_key() {
         let file_key = "results/default/logs/default/16042959487540176184_30_zo_sql_key/1744081170000000_1744081170000000_1_0.json";
         let Some((org_id, stream_type, query_key, meta)) = parse_result_cache_key(file_key) else {
             panic!("parse result cache key error");
@@ -1104,7 +1212,7 @@ mod tests {
         assert_eq!(meta.start_time, 1744081170000000);
         assert_eq!(meta.end_time, 1744081170000000);
         assert!(meta.is_aggregate);
-        assert_eq!(meta.is_descending, false);
+        assert!(!meta.is_descending);
     }
 
     #[tokio::test]
@@ -1119,5 +1227,74 @@ mod tests {
         assert_eq!(query_key, "default_logs_default_16042959487540176184");
         assert_eq!(meta.start_time, 1744081170000000);
         assert_eq!(meta.end_time, 1744081170000000);
+    }
+
+    #[tokio::test]
+    async fn test_disk_write_tmp_file() {
+        let file_key = "files/default/logs/disk/2022/10/03/10/test_file.parquet";
+        let test_data = Bytes::from("test content for temporary file");
+
+        // Test successful write
+        let result = write_tmp_file(file_key, test_data.clone()).await;
+        assert!(result.is_ok());
+
+        let (returned_file_key, tmp_file_path) = result.unwrap();
+        assert_eq!(returned_file_key, file_key);
+
+        // Verify the temporary file exists and contains the correct data
+        let tmp_path = Path::new(&tmp_file_path);
+        assert!(tmp_path.exists());
+        assert!(tmp_path.is_file());
+
+        // Read back the file content to verify it matches
+        let file_content = std::fs::read(tmp_path).unwrap();
+        assert_eq!(file_content, test_data);
+
+        // Clean up
+        let _ = std::fs::remove_file(tmp_path);
+    }
+
+    #[tokio::test]
+    async fn test_disk_write_tmp_file_with_empty_data() {
+        let file_key = "files/default/logs/disk/2022/10/03/10/empty_file.parquet";
+        let empty_data = Bytes::new();
+
+        let result = write_tmp_file(file_key, empty_data).await;
+        assert!(result.is_ok());
+
+        let (returned_file_key, tmp_file_path) = result.unwrap();
+        assert_eq!(returned_file_key, file_key);
+
+        // Verify the temporary file exists but is empty
+        let tmp_path = Path::new(&tmp_file_path);
+        assert!(tmp_path.exists());
+        assert_eq!(tmp_path.metadata().unwrap().len(), 0);
+
+        // Clean up
+        let _ = std::fs::remove_file(tmp_path);
+    }
+
+    #[tokio::test]
+    async fn test_disk_write_tmp_file_with_large_data() {
+        let file_key = "files/default/logs/disk/2022/10/03/10/large_file.parquet";
+        let large_data = Bytes::from(vec![b'a'; 1024 * 1024]); // 1MB of data
+
+        let result = write_tmp_file(file_key, large_data.clone()).await;
+        assert!(result.is_ok());
+
+        let (returned_file_key, tmp_file_path) = result.unwrap();
+        assert_eq!(returned_file_key, file_key);
+
+        // Verify the temporary file exists and has correct size
+        let tmp_path = Path::new(&tmp_file_path);
+        assert!(tmp_path.exists());
+        assert_eq!(tmp_path.metadata().unwrap().len(), 1024 * 1024);
+
+        // Read back the file content to verify it matches
+        let file_content = std::fs::read(tmp_path).unwrap();
+        assert_eq!(file_content, large_data);
+
+        // Clean up
+        let _ = std::fs::remove_file(tmp_path);
     }
 }

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -408,6 +408,7 @@ pub async fn cache_files(
     let mut cached_files = HashSet::with_capacity(files.len());
     let (mut cache_hits, mut cache_misses) = (0, 0);
 
+    let start = std::time::Instant::now();
     for (_id, _account, file, _size, max_ts) in files.iter() {
         if file_data::memory::exist(file).await {
             scan_stats.querier_memory_cached_files += 1;
@@ -446,6 +447,13 @@ pub async fn cache_files(
                 .with_label_values(&[&stream_type.to_string()])
                 .observe(file_age_hours);
         }
+    }
+
+    let check_cache_took = start.elapsed().as_millis() as usize;
+    if check_cache_took > 1000 {
+        log::warn!(
+            "[trace_id {trace_id}] search->storage: check file cache took: {check_cache_took} ms",
+        );
     }
 
     let files_num = files.len() as i64;


### PR DESCRIPTION
We get a write lock then write the files to disk, if the file is big it will lock the lock for a long time, in the mean time others check file exists calls need read lock will both blocked until the write file done.

This PR improved this case by:

1. check file is exists or not.
2. if cache is not exists, write file to local disk with a tmp file name.
3. get write lock and rename the tmp file to real file name.
4. release lock.

This can much improve the lock contention.