### PR TITLE
fix: issue 7640 match_all operator getting replaced

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -55,7 +55,8 @@ import {
   generateTraceContext,
   arraysMatch,
   isWebSocketEnabled,
-  isStreamingEnabled
+  isStreamingEnabled,
+  addSpacesToOperators
 } from "@/utils/zincutils";
 import {
   convertDateToTimestamp,
@@ -1011,16 +1012,8 @@ const useLogs = () => {
           .filter((line: string) => !line.trim().startsWith("--"))
           .join("\n");
         if (whereClause.trim() != "") {
-          whereClause = whereClause
-            .replace(/=(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " =")
-            .replace(/>(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " >")
-            .replace(/<(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " <");
-
-          whereClause = whereClause
-            .replace(/!=(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " !=")
-            .replace(/! =(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " !=")
-            .replace(/< =(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " <=")
-            .replace(/> =(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " >=");
+          // Use efficient state-based approach to avoid regex backtracking
+          whereClause = addSpacesToOperators(whereClause);
 
           //remove everything after -- in where clause
           const parsedSQL = whereClause.split(" ");

--- a/web/src/composables/useQuery.ts
+++ b/web/src/composables/useQuery.ts
@@ -1,6 +1,6 @@
 import { useStore } from "vuex";
 import useNotifications from "@/composables/useNotifications";
-import { b64EncodeUnicode } from "@/utils/zincutils";
+import { b64EncodeUnicode, addSpacesToOperators } from "@/utils/zincutils";
 import { onBeforeMount, onBeforeUnmount } from "vue";
 
 interface BuildQueryPayload {
@@ -117,16 +117,9 @@ const useQuery = () => {
       }
 
       if (whereClause.trim() != "") {
-        whereClause = whereClause
-          .replace(/=(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " =")
-          .replace(/>(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " >")
-          .replace(/<(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " <");
-
-        whereClause = whereClause
-          .replace(/!=(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " !=")
-          .replace(/! =(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " !=")
-          .replace(/< =(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " <=")
-          .replace(/> =(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " >=");
+        // More efficient approach: replace operators only when not inside quotes or parentheses
+        // This avoids catastrophic backtracking by using a simpler state-based approach
+        whereClause = addSpacesToOperators(whereClause);
 
         // const parsedSQL = whereClause.split(" ");
         // searchObj.data.stream.selectedStreamFields.forEach((field: any) => {

--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -686,6 +686,7 @@ import {
   isWebSocketEnabled,
   isStreamingEnabled,
   b64EncodeStandard,
+  addSpacesToOperators,
 } from "../../utils/zincutils";
 import streamService from "../../services/stream";
 import {
@@ -958,16 +959,7 @@ export default defineComponent({
           query_context = `SELECT *${queryFunctions} FROM "[INDEX_NAME]" [WHERE_CLAUSE]`;
 
           if (whereClause.trim() != "") {
-            whereClause = whereClause
-              .replace(/=(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " =")
-              .replace(/>(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " >")
-              .replace(/<(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " <");
-
-            whereClause = whereClause
-              .replace(/!=(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " !=")
-              .replace(/! =(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " !=")
-              .replace(/< =(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " <=")
-              .replace(/> =(?=(?:[^"']*"[^"']*"')*[^"']*$)/g, " >=");
+            whereClause = addSpacesToOperators(whereClause);
 
             const parsedSQL = whereClause.split(" ");
             searchObj.data.stream.selectedStreamFields.forEach((field: any) => {

--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -564,6 +564,104 @@ export function formatDuration(ms: number) {
 
   return formatted.trim();
 }
+
+/**
+ * Efficiently adds spaces around operators without using complex regex
+ * Avoids exponential backtracking by using a simple state-based approach
+ * This function safely handles operators within quoted strings and function calls
+ * 
+ * @param input - The input string to process
+ * @returns The processed string with properly spaced operators
+ */
+export function addSpacesToOperators(input: string): string {
+  let result = '';
+  let i = 0;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let parenDepth = 0;
+
+  while (i < input.length) {
+    const char = input[i];
+    const nextChar = input[i + 1];
+    const prevChar = i > 0 ? input[i - 1] : '';
+
+    // Track quote states
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+    } else if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+    }
+
+    // Track parentheses depth (for function calls)
+    if (!inSingleQuote && !inDoubleQuote) {
+      if (char === '(') {
+        parenDepth++;
+      } else if (char === ')') {
+        parenDepth--;
+      }
+    }
+
+    // Only process operators when we're outside quotes and parentheses
+    const shouldProcessOperators = !inSingleQuote && !inDoubleQuote && parenDepth === 0;
+
+    if (shouldProcessOperators) {
+      // Handle two-character operators first
+      if (i < input.length - 1) {
+        const twoChar = char + nextChar;
+        if (twoChar === '!=' || twoChar === '<=' || twoChar === '>=') {
+          // Add space before if needed
+          if (prevChar && prevChar !== ' ') {
+            result += ' ';
+          }
+          result += twoChar;
+          // Add space after if needed
+          if (i + 2 < input.length && input[i + 2] !== ' ') {
+            result += ' ';
+          }
+          i += 2;
+          continue;
+        }
+      }
+
+      // Handle special case of "! =" (space between ! and =)
+      if (char === '!' && nextChar === ' ' && i + 2 < input.length && input[i + 2] === '=') {
+        // Add space before if needed
+        if (prevChar && prevChar !== ' ') {
+          result += ' ';
+        }
+        result += '!=';
+        // Add space after if needed
+        if (i + 3 < input.length && input[i + 3] !== ' ') {
+          result += ' ';
+        }
+        i += 3;
+        continue;
+      }
+
+      // Handle single-character operators
+      if (char === '=' || char === '>' || char === '<') {
+        // Add space before if needed
+        if (prevChar && prevChar !== ' ') {
+          result += ' ';
+        }
+        result += char;
+        // Add space after if needed
+        if (nextChar && nextChar !== ' ') {
+          result += ' ';
+        }
+        i++;
+        continue;
+      }
+    }
+
+    // Default: just add the character
+    result += char;
+    i++;
+  }
+
+  return result;
+}
+
 export const timestampToTimezoneDate = (
   unixMilliTimestamp: number,
   timezone: string = "UTC",


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace regex-based operator spacing with util

- Add state-based `addSpacesToOperators` function

- Update composables and component imports

- Prevent catastrophic regex backtracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw whereClause"] -- "addSpacesToOperators" --> B["Spaced whereClause"]
  B -- "used in" --> C["IndexList.vue / useLogs / useQuery"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IndexList.vue</strong><dd><code>Replace regex spacing with util call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/IndexList.vue

<ul><li>Imported <code>addSpacesToOperators</code> util<br> <li> Removed inline regex-based spacing<br> <li> Replaced with <code>addSpacesToOperators(whereClause)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7653/files#diff-08f058f883b659e713e606991a7ea37ae1ff016b7cccef970489ab5840dc3d09">+2/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useLogs.ts</strong><dd><code>Use util for query operator spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs.ts

<ul><li>Added <code>addSpacesToOperators</code> import<br> <li> Removed chained <code>.replace</code> regex calls<br> <li> Applied <code>addSpacesToOperators</code> for whereClause</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7653/files#diff-1040f61354f92711e0e77ed4e9bfa15586d45a94c7e2ab06cc37372068030e7b">+4/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useQuery.ts</strong><dd><code>Replace regex in useQuery with util</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useQuery.ts

<ul><li>Imported <code>addSpacesToOperators</code><br> <li> Removed manual regex replacements<br> <li> Called <code>addSpacesToOperators(whereClause)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7653/files#diff-fe0bf52b216893c6a31f2923aab979e0d817c742b0cfd75e524e60db75b1d3e8">+4/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zincutils.ts</strong><dd><code>Implement addSpacesToOperators utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/zincutils.ts

<ul><li>Added <code>addSpacesToOperators</code> function<br> <li> Implements state-based spacing logic<br> <li> Handles quotes, parentheses, two-char operators<br> <li> Avoids exponential regex backtracking</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7653/files#diff-d3d59688cccdcc6c84ebe88b698c6910030abecc3125f4c0ef81b0df023699ba">+98/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

