### PR TITLE
perf: improve disk cache lock time

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -725,6 +725,8 @@ pub struct Common {
     pub data_db_dir: String,
     #[env_config(name = "ZO_DATA_CACHE_DIR", default = "")] // ./data/openobserve/cache/
     pub data_cache_dir: String,
+    #[env_config(name = "ZO_DATA_TMP_DIR", default = "")] // ./data/openobserve/tmp/
+    pub data_tmp_dir: String,
     // TODO: should rename to column_all
     #[env_config(name = "ZO_CONCATENATED_SCHEMA_FIELD_NAME", default = "_all")]
     pub column_all: String,
@@ -2353,6 +2355,12 @@ fn check_path_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
     if !cfg.common.data_cache_dir.ends_with('/') {
         cfg.common.data_cache_dir = format!("{}/", cfg.common.data_cache_dir);
+    }
+    if cfg.common.data_tmp_dir.is_empty() {
+        cfg.common.data_tmp_dir = format!("{}tmp/", cfg.common.data_dir);
+    }
+    if !cfg.common.data_tmp_dir.ends_with('/') {
+        cfg.common.data_tmp_dir = format!("{}/", cfg.common.data_tmp_dir);
     }
     if cfg.common.mmdb_data_dir.is_empty() {
         cfg.common.mmdb_data_dir = format!("{}mmdb/", cfg.common.data_dir);

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -365,11 +365,11 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
 
     let mem_file_num = cache::file_data::memory::len().await;
     let (mem_max_size, mem_cur_size) = cache::file_data::memory::stats().await;
-    let disk_file_num = cache::file_data::disk::len(FileType::DATA).await;
-    let (disk_max_size, disk_cur_size) = cache::file_data::disk::stats(FileType::DATA).await;
-    let disk_result_file_num = cache::file_data::disk::len(FileType::RESULT).await;
+    let disk_file_num = cache::file_data::disk::len(FileType::Data).await;
+    let (disk_max_size, disk_cur_size) = cache::file_data::disk::stats(FileType::Data).await;
+    let disk_result_file_num = cache::file_data::disk::len(FileType::Result).await;
     let (disk_result_max_size, disk_result_cur_size) =
-        cache::file_data::disk::stats(FileType::RESULT).await;
+        cache::file_data::disk::stats(FileType::Result).await;
     stats.insert(
         "FILE_DATA",
         json::json!({

--- a/src/service/search/datafusion/distributed_plan/enrich_exec.rs
+++ b/src/service/search/datafusion/distributed_plan/enrich_exec.rs
@@ -153,8 +153,7 @@ async fn get_data(
 ) -> Result<SendableRecordBatchStream> {
     let clean_name = name.trim_matches('"');
     let data = match crate::service::db::enrichment_table::get_enrichment_data_from_db(
-        &org_id,
-        &clean_name,
+        &org_id, clean_name,
     )
     .await
     {

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -405,6 +405,8 @@ pub async fn cache_files(
     // check how many files already cached
     let mut cached_files = HashSet::with_capacity(files.len());
     let (mut cache_hits, mut cache_misses) = (0, 0);
+
+    let start = std::time::Instant::now();
     for (file, _, max_ts) in files.iter() {
         if file_data::memory::exist(file).await {
             scan_stats.querier_memory_cached_files += 1;
@@ -443,6 +445,13 @@ pub async fn cache_files(
                 .with_label_values(&[&stream_type.to_string()])
                 .observe(file_age_hours);
         }
+    }
+
+    let check_cache_took = start.elapsed().as_millis() as usize;
+    if check_cache_took > 1000 {
+        log::warn!(
+            "[trace_id {trace_id}] search->storage: check file cache took: {check_cache_took} ms",
+        );
     }
 
     let files_num = files.len() as i64;


### PR DESCRIPTION
### **User description**
We get a write lock then write the files to disk, if the file is big it will lock the lock for a long time, in the mean time others check file exists calls need read lock will both blocked until the write file done.

This PR improved this case by:

1. check file is exists or not.
2. if cache is not exists, write file to local disk with a tmp file name.
3. get write lock and rename the tmp file to real file name.
4. release lock.

This can much improve the lock contention.
