### PR TITLE
fix: show index size when search tantivy

### DIFF
--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -105,20 +105,23 @@ pub async fn search(trace_id: &str, sql: Arc<Sql>, mut req: Request) -> Result<S
     .await?;
     let file_id_list_vec = file_id_list.values().flatten().collect::<Vec<_>>();
     let file_id_list_num = file_id_list_vec.len();
+    let file_id_list_records = file_id_list_vec.iter().map(|v| v.records).sum::<i64>();
     let file_id_list_took = start.elapsed().as_millis() as usize;
     log::info!(
         "{}",
         search_inspector_fields(
             format!(
-                "[trace_id {trace_id}] flight->search: get file_list time_range: {:?}, files: {}, took: {} ms",
-                sql.time_range, file_id_list_num, file_id_list_took,
+                "[trace_id {trace_id}] flight->search: get file_list time_range: {:?}, files: {}, records: {}, took: {} ms",
+                sql.time_range, file_id_list_num, file_id_list_records, file_id_list_took,
             ),
             SearchInspectorFieldsBuilder::new()
                 .node_name(LOCAL_NODE.name.clone())
                 .component("flight:leader get file id".to_string())
                 .search_role("leader".to_string())
                 .duration(file_id_list_took)
-                .desc(format!("get files {file_id_list_num} ids"))
+                .desc(format!(
+                    "get files {file_id_list_num} ids, records {file_id_list_records}"
+                ))
                 .build()
         )
     );

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -591,12 +591,13 @@ pub async fn filter_file_list_by_tantivy_index(
         "{}",
         search_inspector_fields(
             format!(
-                "[trace_id {}] search->tantivy: stream {}/{}/{}, load tantivy index files {}, memory cached {}, disk cached {}, cached ratio {}%,{download_msg} took: {} ms",
+                "[trace_id {}] search->tantivy: stream {}/{}/{}, load tantivy index files {}, index size: {}, memory cached {}, disk cached {}, cached ratio {}%,{download_msg} took: {} ms",
                 query.trace_id,
                 query.org_id,
                 query.stream_type,
                 query.stream_name,
                 scan_stats.querier_files,
+                bytes_to_human_readable(scan_stats.compressed_size as f64),
                 scan_stats.querier_memory_cached_files,
                 scan_stats.querier_disk_cached_files,
                 (cached_ratio * 100.0) as usize,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add human-readable index size to logs

- Use bytes_to_human_readable for compressed_size

- Modify log message in storage.rs

- Improve search observability


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.rs</strong><dd><code>Include index size in search logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/grpc/storage.rs

<ul><li>Include <code>index size: {}</code> placeholder in log format<br> <li> Add <code>bytes_to_human_readable(scan_stats.compressed_size as f64)</code><br> <li> Update log message to reflect index size field</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7674/files#diff-ab2d867e1e2e3dd8307505c2e130039628a84f8131a9b38cd2e7b4e1c141e094">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

