### PR TITLE
fix: use single event for alert skipped event triggers reporting

### DIFF
--- a/src/config/src/meta/self_reporting/usage.rs
+++ b/src/config/src/meta/self_reporting/usage.rs
@@ -66,6 +66,8 @@ pub struct TriggerData {
     pub start_time: i64,
     pub end_time: i64,
     pub retries: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skipped_alerts_count: Option<i64>,
     pub error: Option<String>,
     pub success_response: Option<String>,
     pub is_partial: Option<bool>,

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -953,6 +953,7 @@ async fn handle_derived_stream_triggers(
             query_took: None,
             scheduler_trace_id: Some(scheduler_trace_id.clone()),
             time_in_queue_ms: Some(time_in_queue),
+            skipped_alerts_count: None,
         };
         log::info!("[SCHEDULER trace_id {scheduler_trace_id}] {}", msg);
         new_trigger_data.reset();

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -259,6 +259,7 @@ pub async fn evaluate_trigger(triggers: TriggerAlertData) {
             query_took: None,
             scheduler_trace_id: None,
             time_in_queue_ms: None,
+            skipped_alerts_count: None,
         };
         match alert.send_notification(val, now, None, now).await {
             Err(e) => {


### PR DESCRIPTION
When for some reason, alert manager is stuck for long time, once it is starts working fine, it can report hundreds/thousands of skipped events potentially keeping the alert manager stuck with every alert.