### PR TITLE
fix: o2 ai add context button as component

### DIFF
--- a/web/src/components/common/O2AIContextAddBtn.spec.js
+++ b/web/src/components/common/O2AIContextAddBtn.spec.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { installQuasar } from '@/test/unit/helpers/install-quasar-plugin';
+import { Dialog, Notify } from 'quasar';
+import O2AIContextAddBtn from './O2AIContextAddBtn.vue';
+import { getImageURL } from '@/utils/zincutils';
+import store from '@/test/unit/helpers/store';
+
+// Mock the getImageURL function
+vi.mock('@/utils/zincutils', () => ({
+  getImageURL: vi.fn((path) => path)
+}));
+
+// Mock aws-exports config
+vi.mock('@/aws-exports', () => ({
+  default: {
+    isEnterprise: 'true'
+  }
+}));
+
+// Create a div for mounting
+const node = document.createElement('div');
+node.setAttribute('id', 'app');
+document.body.appendChild(node);
+
+// Install Quasar
+installQuasar({
+  plugins: [Dialog, Notify],
+});
+
+describe('O2AIContextAddBtn', () => {
+  let wrapper;
+
+  beforeEach(async () => {
+    // Create a fresh store before each test
+    store.state.theme = 'light';
+    store.state.zoConfig = {
+      ai_enabled: true
+    };
+
+    // Mount component with Quasar
+    wrapper = mount(O2AIContextAddBtn, {
+      attachTo: document.body,
+      global: {
+        plugins: [],
+        provide: { store },
+        stubs: {
+          'q-btn': false // Don't stub q-btn to test actual Quasar button
+        }
+      },
+      props: {
+        class: '',
+        size: 'xs',
+        style: '',
+        imageHeight: '20px',
+        imageWidth: '20px'
+      }
+    });
+
+    await flushPromises();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('renders when enterprise and AI are enabled', () => {
+    expect(wrapper.find('[data-test="o2-ai-context-add-btn"]').exists()).toBe(true);
+  });
+
+  it('does not render when AI is disabled', async () => {
+    store.state.zoConfig.ai_enabled = false;
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="o2-ai-context-add-btn"]').exists()).toBe(false);
+  });
+
+  it('emits sendToAiChat event when clicked', async () => {
+    const button = wrapper.find('[data-test="o2-ai-context-add-btn"]');
+    await button.trigger('click');
+    expect(wrapper.emitted('sendToAiChat')).toBeTruthy();
+    expect(wrapper.emitted('sendToAiChat')).toHaveLength(1);
+  });
+
+  it('applies custom class when provided', async () => {
+    await wrapper.setProps({ class: 'custom-class' });
+    expect(wrapper.find('[data-test="o2-ai-context-add-btn"]').classes()).toContain('custom-class');
+  });
+
+
+  it('applies custom style when provided', async () => {
+    await wrapper.setProps({ style: 'margin: 10px' });
+    const button = wrapper.find('[data-test="o2-ai-context-add-btn"]');
+    expect(button.attributes('style')).toContain('margin: 10px');
+  });
+
+  it('applies custom image dimensions when provided', async () => {
+    await wrapper.setProps({
+      imageHeight: '30px',
+      imageWidth: '30px'
+    });
+    const img = wrapper.find('img');
+    expect(img.attributes('height')).toBe('30px');
+    expect(img.attributes('width')).toBe('30px');
+  });
+
+  it('uses correct icon based on theme', async () => {
+    // Test light theme
+    expect(getImageURL).toHaveBeenCalledWith('images/common/ai_icon.svg');
+
+    // Test dark theme
+    store.state.theme = 'dark';
+    await wrapper.vm.$nextTick();
+    expect(getImageURL).toHaveBeenCalledWith('images/common/ai_icon_dark.svg');
+  });
+
+  it('has correct button attributes', () => {
+    const button = wrapper.find('[data-test="o2-ai-context-add-btn"]');
+    expect(button.attributes('borderless')).toBe('true');
+    expect(button.attributes('flat')).toBe(undefined);
+    expect(button.attributes('style')).toContain('border-radius: 100%');
+  });
+});

--- a/web/src/components/common/O2AIContextAddBtn.vue
+++ b/web/src/components/common/O2AIContextAddBtn.vue
@@ -1,0 +1,77 @@
+<template>
+    <!-- ai button is only enabled when it is enteprise version and also ai is enabled from the BE -->
+    <q-btn
+        v-if="config.isEnterprise == 'true' && store.state.zoConfig.ai_enabled"
+        :ripple="false"
+        @click.stop="sendToAiChat"
+        data-test="o2-ai-context-add-btn"
+        no-caps
+        :borderless="true"
+        flat
+        :size="props.size"
+        dense
+        :class="[
+            props.class,
+        ]"
+        :style="props.style"
+        style="border-radius: 100%;"
+        >
+        <div class="row items-center no-wrap">
+            <img :height="props.imageHeight" :width="props.imageWidth"  :src="getBtnLogo" class="header-icon ai-icon" />
+        </div>
+    </q-btn>
+</template>
+
+<script setup lang="ts">
+import { getImageURL } from '@/utils/zincutils';
+import { computed } from 'vue';
+import { useStore } from 'vuex';
+import config from '@/aws-exports';
+//we can pass class to the button to make it customized
+//all of the props are optional
+const props = defineProps({
+    class: {
+        type: String,
+        default: '',
+        required: false
+    },
+    //the size of the button can be in xs , sm , md , lg , xl
+    //can be in pixels as well
+    size: {
+        type: String,
+        default: 'xs',
+        required: false
+    },
+    style:{
+        type: String,
+        default: '',
+        required: false
+    },
+    //this is for image height and width sometimes we need to change the size of the image 
+    imageHeight:{
+        type: String,
+        default: '20px',
+        required: false
+    },
+    imageWidth:{
+        type: String,
+        default: '20px',
+        required: false
+    }
+});
+//once user clicks on the button, it will emit the event to the parent component
+const emit = defineEmits(["sendToAiChat"]);
+const store = useStore();
+const getBtnLogo = computed(() => {
+    return store.state.theme === 'dark'
+    ? getImageURL('images/common/ai_icon_dark.svg')
+    : getImageURL('images/common/ai_icon.svg')
+})
+//this function is responsible for sending the event / button is clicked to the parent component
+const sendToAiChat = () => {
+    emit('sendToAiChat')
+}
+</script>
+
+<style scoped lang="scss">
+</style>

--- a/web/src/components/functions/TestFunction.vue
+++ b/web/src/components/functions/TestFunction.vue
@@ -208,23 +208,15 @@
             </q-tooltip>
           </q-icon>
         </template>
-        <template v-if="config.isEnterprise == 'true' && store.state.zoConfig.ai_enabled" #right>
-          <q-btn
-            :ripple="false"
-            @click.prevent.stop="sendToAiChat(JSON.stringify(inputEvents))"
-            data-test="menu-link-ai-item"
-            no-caps
-            :borderless="true"
-            flat
-            size="6px"
-            class="tw-px-2 tw-mr-4 "
-            dense
-            style="border-radius: 100%;"
-          >
-            <div class="row items-center no-wrap">
-              <img height="16" width="16" :src="getBtnLogo" class="header-icon ai-icon" />
-            </div>
-          </q-btn>
+        <template #right>
+           <!-- o2 ai context add button in the test function -->
+           <O2AIContextAddBtn
+            @send-to-ai-chat="sendToAiChat(JSON.stringify(inputEvents))"
+            :size="'6px'"
+            :imageHeight="'16px'"
+            :imageWidth="'16px'"
+            :class="'tw-px-2 tw-mr-4'"
+           />
           </template>
       </FullViewContainer>
       <div
@@ -343,7 +335,7 @@ import { event, useQuasar } from "quasar";
 import { getConsumableRelativeTime } from "@/utils/date";
 import AppTabs from "@/components/common/AppTabs.vue";
 import jstransform from "@/services/jstransform";
-import config from "@/aws-exports";
+import O2AIContextAddBtn from "@/components/common/O2AIContextAddBtn.vue";
 
 const props = defineProps({
   vrlFunction: {
@@ -755,11 +747,6 @@ function highlightSpecificEvent() {
     console.log("Error in highlightSpecificEvent", e);
   }
 }
-const getBtnLogo = computed(() => {
-      return store.state.theme === 'dark'
-        ? getImageURL('images/common/ai_icon_dark.svg')
-        : getImageURL('images/common/ai_icon.svg')
-    });
 
 const sendToAiChat = (value: any) => {
   emit("sendToAiChat", value);
@@ -768,8 +755,6 @@ const sendToAiChat = (value: any) => {
 defineExpose({
   testFunction,
   sendToAiChat,
-  getBtnLogo,
-  config,
   store
 });
 </script>

--- a/web/src/plugins/logs/DetailTable.vue
+++ b/web/src/plugins/logs/DetailTable.vue
@@ -51,23 +51,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             name="table"
             :label="t('common.table')"
           />
-          <q-btn
-            v-if="config.isEnterprise == 'true' && store.state.zoConfig.ai_enabled"
-            :ripple="false"
-            @click.prevent.stop="sendToAiChat(JSON.stringify(rowData))"
-            data-test="menu-link-ai-item"
-            no-caps
-            :borderless="true"
-            flat
-            size="6px"
-            class="tw-px-2 tw-py-2"
-            dense
-            style="border-radius: 100%;"
-          >
-            <div class="row items-center no-wrap">
-              <img :src="getBtnLogo" class="header-icon ai-icon" />
-            </div>
-          </q-btn>
+          <!-- o2 ai context add button in the detail table -->
+          <O2AIContextAddBtn 
+            class="tw-px-2 tw-py-2" 
+            @sendToAiChat="sendToAiChat(JSON.stringify(rowData))"
+             />
         </q-tabs>
       </div>
       <div
@@ -365,7 +353,7 @@ import EqualIcon from "@/components/icons/EqualIcon.vue";
 import NotEqualIcon from "@/components/icons/NotEqualIcon.vue";
 import { copyToClipboard, useQuasar } from "quasar";
 import JsonPreview from "./JsonPreview.vue";
-import config from "@/aws-exports";
+import O2AIContextAddBtn from "@/components/common/O2AIContextAddBtn.vue";
 
 const defaultValue: any = () => {
   return {
@@ -375,7 +363,7 @@ const defaultValue: any = () => {
 
 export default defineComponent({
   name: "SearchDetail",
-  components: { EqualIcon, NotEqualIcon, JsonPreview },
+  components: { EqualIcon, NotEqualIcon, JsonPreview, O2AIContextAddBtn },
   emits: [
     "showPrevDetail",
     "showNextDetail",
@@ -507,11 +495,6 @@ export default defineComponent({
       emit("sendToAiChat", value);
       emit("closeTable");
     };
-    const getBtnLogo = computed(() => {
-      return store.state.theme === 'dark'
-        ? getImageURL('images/common/ai_icon_dark.svg')
-        : getImageURL('images/common/ai_icon.svg')
-    });
     const closeTable = () => {
       emit("closeTable");
     }
@@ -534,9 +517,7 @@ export default defineComponent({
       viewTrace,
       hasAggregationQuery,
       sendToAiChat,
-      getBtnLogo,
-      closeTable,
-      config
+      closeTable
     };
   },
   async created() {

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -346,27 +346,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     highlightQuery
                   "
                 />
-                <!-- show o2 ai button only for timestamp column -->
-                <q-btn
-                    v-if="cell.column.columnDef.id === store.state.zoConfig.timestamp_column && config.isEnterprise == 'true' && store.state.zoConfig.ai_enabled"
-                    :ripple="false"
-                    @click.stop="sendToAiChat(JSON.stringify(cell.row.original),true)"
-                    data-test="menu-link-ai-item"
-                    no-caps
-                    :borderless="true"
-                    flat
-                    size="xs"
-                    dense
-                    class="tw-absolute tw-right-[16px] tw-top-1/2 tw-transform tw--translate-y-1/2"
-                    :class="[
-                      'tw-invisible ai-btn'
-                    ]"
-                    style="border-radius: 100%;"
-                  >
-                    <div class="row items-center no-wrap">
-                      <img height="20px" width="20px"  :src="getBtnLogo" class="header-icon ai-icon" />
-                    </div>
-                  </q-btn>
+                <O2AIContextAddBtn
+                    v-if="cell.column.columnDef.id === store.state.zoConfig.timestamp_column" class="tw-absolute tw-right-[16px] tw-top-1/2 tw-transform tw-invisible tw--translate-y-1/2 ai-btn" 
+                    @send-to-ai-chat="sendToAiChat(JSON.stringify(cell.row.original),true)"
+                    />
               </td>
             </template>
           </tr>
@@ -403,7 +386,7 @@ import { VueDraggableNext as VueDraggable } from "vue-draggable-next";
 import CellActions from "@/plugins/logs/data-table/CellActions.vue";
 import { debounce } from "quasar";
 import { getImageURL } from "@/utils/zincutils";
-import config from "@/aws-exports";
+import O2AIContextAddBtn from "@/components/common/O2AIContextAddBtn.vue";
 
 const props = defineProps({
   rows: {
@@ -848,11 +831,6 @@ const handleCellMouseLeave = () => {
 const viewTrace = (row: any) => {
   emits("view-trace", row);
 };
-const getBtnLogo = computed(() => {
-      return store.state.theme === 'dark'
-        ? getImageURL('images/common/ai_icon_dark.svg')
-        : getImageURL('images/common/ai_icon.svg')
-    })
 const sendToAiChat = (value: any,isEntireRow: boolean = false) => {
   if(isEntireRow){
     //here we will get the original value of the row
@@ -896,10 +874,8 @@ const filterRowBasedOnColumns = (row: any,columns: any) => {
 defineExpose({
   parentRef,
   virtualRows,
-  getBtnLogo,
   sendToAiChat,
-  store,
-  config
+  store
 });
 </script>
 <style scoped lang="scss">

--- a/web/src/plugins/logs/data-table/CellActions.vue
+++ b/web/src/plugins/logs/data-table/CellActions.vue
@@ -36,23 +36,15 @@
         <NotEqualIcon></NotEqualIcon>
       </q-icon>
     </q-btn>
-    <q-btn
-    v-if="config.isEnterprise == 'true' && store.state.zoConfig.ai_enabled"
-    class="q-ml-xs"
-      :ripple="false"
-      @click.prevent.stop="sendToAiChat(JSON.stringify(row[column.id]))"
-      data-test="menu-link-ai-item"
-      no-caps
-      :borderless="true"
-      flat
-      size="6px"
-      dense
-      style="border-radius: 100%; border: 1px solid #fff;"
-    >
-      <div class="row items-center no-wrap">
-        <img height="14px" width="14px" :src="getBtnLogo" class="header-icon ai-icon" />
-      </div>
-    </q-btn>
+    <!-- o2 ai context add button in the cell actions when user adds a interesting field to the table 
+     then we show some options there we need this  -->
+     <O2AIContextAddBtn
+        @send-to-ai-chat="sendToAiChat(JSON.stringify(row[column.id]))"
+        :style="'border: 1px solid #fff;'"
+        :size="'6px'"
+        :imageHeight="'16px'"
+        :imageWidth="'16px'"
+      />
   </div>
 </template>
 
@@ -62,7 +54,7 @@ import { useStore } from "vuex";
 import EqualIcon from "@/components/icons/EqualIcon.vue";
 import NotEqualIcon from "@/components/icons/NotEqualIcon.vue";
 import { getImageURL } from "@/utils/zincutils";
-import config from "@/aws-exports";
+import O2AIContextAddBtn from "@/components/common/O2AIContextAddBtn.vue";
 
 defineProps({
   column: {
@@ -96,9 +88,4 @@ const backgroundClass = computed(() =>
 const sendToAiChat = (value: any) => {
   emit("sendToAiChat", value);
 };
-const getBtnLogo = computed(() => {
-      return store.state.theme === 'dark'
-        ? getImageURL('images/common/ai_icon_dark.svg')
-        : getImageURL('images/common/ai_icon.svg')
-    })
 </script>

--- a/web/src/utils/validatePipeline.ts
+++ b/web/src/utils/validatePipeline.ts
@@ -121,12 +121,7 @@ export function validatePipeline(pipeline: Pipeline, context?: ValidationContext
           streamName = node.data.stream_name.value;
         }
 
-        if (streamName) {
-          // Check if stream exists
-          if (!context.streamList.includes(streamName)) {
-            result.errors.push(`Input stream "${streamName}" in node ${node.id} does not exist in the stream list`);
-          }
-          
+        if (streamName) {          
           // Only show error if this is a new stream name (different from original)
           const originalNode = context.originalPipeline?.nodes?.find((n: any) => n.id === node.id);
           const originalStreamName = typeof originalNode?.data?.stream_name === 'string' 


### PR DESCRIPTION
### **User description**
fix: o2 ai add context button as component


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce `O2AIContextAddBtn` component

- Refactor AI buttons across components

- Remove redundant logo and config logic

- Centralize AI button styling and emit


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["O2AIContextAddBtn"] --> B["TestFunction.vue"]
  A --> C["DetailTable.vue"]
  A --> D["TenstackTable.vue"]
  A --> E["CellActions.vue"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>O2AIContextAddBtn.vue</strong><dd><code>Create reusable AI context button component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/common/O2AIContextAddBtn.vue

<ul><li>Add new <code>O2AIContextAddBtn</code> Vue component<br> <li> Define props for size, style, image dimensions<br> <li> Emit <code>sendToAiChat</code> event on click</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7686/files#diff-52fc09cf5f0727766340f4bf4c08587f4623ddeec3fc708869b566130e633421">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TestFunction.vue</strong><dd><code>Refactor TestFunction to use AI button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/functions/TestFunction.vue

<ul><li>Replace manual AI button with <code>O2AIContextAddBtn</code><br> <li> Remove direct <code>config</code> import and <code>getBtnLogo</code> logic<br> <li> Import and register new AI button component</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7686/files#diff-b9af9a2d1bf04d23422c26a13e6a763c6953c8713357a2f64ed8073ce6c926a3">+10/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DetailTable.vue</strong><dd><code>Swap manual AI button for reusable component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/DetailTable.vue

<ul><li>Use <code>O2AIContextAddBtn</code> instead of manual Q-btn<br> <li> Remove redundant <code>getBtnLogo</code> and <code>config</code> imports<br> <li> Register new AI button component</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7686/files#diff-80552b5d25fa6cef9fbbe430b1865d761c4b132284c2d2175afceea8cbabc8c7">+8/-27</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TenstackTable.vue</strong><dd><code>Integrate AI context button in table rows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/TenstackTable.vue

<ul><li>Replace conditional AI Q-btn with <code>O2AIContextAddBtn</code><br> <li> Remove logo computation and config imports<br> <li> Add component import and use in table cells</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7686/files#diff-bc3c669f5ab65a42ae378df1f7d6b35014c9c220790bdcc72b47f55d1385dc22">+6/-30</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CellActions.vue</strong><dd><code>Refactor cell actions to use AI button component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/data-table/CellActions.vue

<ul><li>Replace inline AI Q-btn with <code>O2AIContextAddBtn</code><br> <li> Remove direct <code>getBtnLogo</code> and <code>config</code> import<br> <li> Import and integrate new AI button component</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7686/files#diff-de54e5b8cd9503c53f3f802ac7bc7e3d25846f1657c77cd99534d9f60673992e">+10/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

