### PR TITLE
perf: improve concurrency for index search

### DIFF
--- a/src/common/utils/auth_tests.rs
+++ b/src/common/utils/auth_tests.rs
@@ -3153,6 +3153,7 @@ mod tests {
                 mem_dump_thread_num: usize::default(),
                 usage_reporting_thread_num: usize::default(),
                 query_thread_num: usize::default(),
+                query_index_thread_num: usize::default(),
                 query_timeout: u64::default(),
                 query_ingester_timeout: u64::default(),
                 query_default_limit: i64::default(),

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1199,6 +1199,8 @@ pub struct Limit {
     pub usage_reporting_thread_num: usize,
     #[env_config(name = "ZO_QUERY_THREAD_NUM", default = 0)]
     pub query_thread_num: usize,
+    #[env_config(name = "ZO_QUERY_INDEX_THREAD_NUM", default = 0)]
+    pub query_index_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_THREAD_NUM", default = 0)]
     pub file_download_thread_num: usize,
     #[env_config(name = "ZO_FILE_DOWNLOAD_PRIORITY_QUEUE_THREAD_NUM", default = 0)]
@@ -2091,6 +2093,13 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
             cfg.limit.query_thread_num = cpu_num * 2;
         } else {
             cfg.limit.query_thread_num = cpu_num * 4;
+        }
+    }
+    if cfg.limit.query_index_thread_num == 0 {
+        if cfg.common.local_mode {
+            cfg.limit.query_index_thread_num = cpu_num;
+        } else {
+            cfg.limit.query_index_thread_num = cpu_num * 4;
         }
     }
 

--- a/src/config/src/utils/record_batch_ext.rs
+++ b/src/config/src/utils/record_batch_ext.rs
@@ -645,7 +645,10 @@ pub fn sort_record_batch_by_column(
 
 #[cfg(test)]
 mod test {
-    use arrow::{array::{Array, StringViewArray}, util::pretty::pretty_format_batches};
+    use arrow::{
+        array::{Array, StringViewArray},
+        util::pretty::pretty_format_batches,
+    };
     use arrow_schema::Field;
 
     use super::*;
@@ -1146,7 +1149,7 @@ mod test {
 
         assert_eq!(record_batch.num_rows(), 3);
         assert_eq!(record_batch.schema(), schema);
-        
+
         // Test Utf8View column
         let name_array = record_batch
             .column(0)
@@ -1156,7 +1159,7 @@ mod test {
         assert_eq!(name_array.value(0), "Alice");
         assert_eq!(name_array.value(1), "Bob");
         assert_eq!(name_array.value(2), "Charlie");
-        
+
         // Test Int64 column
         let age_array = record_batch
             .column(1)
@@ -1166,7 +1169,7 @@ mod test {
         assert_eq!(age_array.value(0), 25);
         assert_eq!(age_array.value(1), 30);
         assert_eq!(age_array.value(2), 35);
-        
+
         // Test Utf8 column with null values
         let city_array = record_batch
             .column(2)

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -628,7 +628,7 @@ pub async fn filter_file_list_by_tantivy_index(
     let target_partitions = if cache_type == file_data::CacheType::None {
         cfg.limit.query_thread_num
     } else {
-        cfg.limit.cpu_num
+        cfg.limit.query_index_thread_num
     };
 
     let search_start = std::time::Instant::now();
@@ -646,6 +646,12 @@ pub async fn filter_file_list_by_tantivy_index(
         .map(|g| g.len())
         .max()
         .unwrap_or(0);
+
+    log::info!(
+        "[trace_id {}] search->tantivy: target_partitions: {target_partitions}, group_num: {group_num}, max_group_len: {max_group_len}",
+        query.trace_id,
+    );
+
     for _ in 0..max_group_len {
         if no_more_files {
             // delete the rest of the files
@@ -1056,6 +1062,7 @@ fn partition_tantivy_files(
 // use the min_ts & max_ts of the file.meta to group files and each group can't contains crossing
 // time range files
 fn group_files_by_time_range(mut files: Vec<FileKey>, partition_num: usize) -> Vec<Vec<FileKey>> {
+    let expect_group_elements = files.len().div_ceil(partition_num);
     // sort files by max_ts in ascending order
     files.sort_unstable_by(|a, b| a.meta.max_ts.cmp(&b.meta.max_ts));
     // group by time range
@@ -1075,70 +1082,39 @@ fn group_files_by_time_range(mut files: Vec<FileKey>, partition_num: usize) -> V
         }
     }
     // regroup if the number of groups is less than expect partitions
-    if file_groups_indices.len() >= partition_num {
+    if file_groups_indices
+        .first()
+        .is_some_and(|g| g.len() <= expect_group_elements)
+    {
         file_groups_indices
     } else {
-        repartition_sorted_groups(file_groups_indices, partition_num)
+        repartition_sorted_groups(file_groups_indices, expect_group_elements)
     }
 }
 
-// 1. first get larger group
-// 2. split larger groups based on odd and even numbers
-// 3. loop until the group reaches the number of partitions
+// repartition the groups to the number of partitions
 fn repartition_sorted_groups(
     mut groups: Vec<Vec<FileKey>>,
-    partition_num: usize,
+    expect_group_elements: usize,
 ) -> Vec<Vec<FileKey>> {
     if groups.is_empty() {
         return groups;
     }
 
-    while groups.len() < partition_num {
-        let max_index = find_max_group_index(&groups);
-        let max_group = groups.remove(max_index);
-
-        // if the max group has less than 1 files, we don't split it further
-        if max_group.len() <= 1 {
-            groups.push(max_group);
+    loop {
+        if groups[0].len() <= expect_group_elements {
             break;
         }
-
-        // split max_group into odd and even groups
-        let group_cap = max_group.len().div_ceil(2);
-        let mut odd_group = Vec::with_capacity(group_cap);
-        let mut even_group = Vec::with_capacity(group_cap);
-
-        for (idx, file) in max_group.into_iter().enumerate() {
-            if idx % 2 == 0 {
-                even_group.push(file);
-            } else {
-                odd_group.push(file);
-            }
+        let max_group = groups.remove(0);
+        let chunk_num = max_group.len().div_ceil(expect_group_elements);
+        let mut new_groups = vec![vec![]; chunk_num];
+        for (k, item) in max_group.into_iter().enumerate() {
+            new_groups[k % chunk_num].push(item);
         }
-
-        if !odd_group.is_empty() {
-            groups.push(odd_group);
-        }
-        if !even_group.is_empty() {
-            groups.push(even_group);
-        }
+        groups.extend(new_groups);
     }
 
     groups
-}
-
-// find the index of the group with the most files
-fn find_max_group_index(groups: &[Vec<FileKey>]) -> usize {
-    groups
-        .iter()
-        .enumerate()
-        .fold(0, |max_index, (idx, group)| {
-            if group.len() > groups[max_index].len() {
-                idx
-            } else {
-                max_index
-            }
-        })
 }
 
 // Helper function to extract a file from a group at the specified index
@@ -1216,8 +1192,8 @@ mod tests {
             vec![create_file_key(1, 10), create_file_key(11, 20)],
             vec![create_file_key(21, 30), create_file_key(31, 40)],
         ];
-        let partition_num = 4;
-        let repartitioned_groups = repartition_sorted_groups(groups, partition_num);
+        let expect_group_elements = 1;
+        let repartitioned_groups = repartition_sorted_groups(groups, expect_group_elements);
         assert_eq!(repartitioned_groups.len(), 4);
     }
 
@@ -1230,20 +1206,9 @@ mod tests {
             create_file_key(31, 40),
             create_file_key(41, 50),
         ]];
-        let partition_num = 3;
-        let repartitioned_groups = repartition_sorted_groups(groups, partition_num);
+        let expect_group_elements = 2;
+        let repartitioned_groups = repartition_sorted_groups(groups, expect_group_elements);
         assert_eq!(repartitioned_groups.len(), 3);
-    }
-
-    #[test]
-    fn test_find_max_group_index() {
-        let groups = vec![
-            vec![create_file_key(1, 10)],
-            vec![create_file_key(11, 20), create_file_key(21, 30)],
-            vec![create_file_key(31, 40)],
-        ];
-        let max_index = find_max_group_index(&groups);
-        assert_eq!(max_index, 1);
     }
 
     #[test]

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -1160,7 +1160,7 @@ mod tests {
         ];
         let partition_num = 3;
         let groups = group_files_by_time_range(files, partition_num);
-        assert_eq!(groups.len(), 3);
+        assert!(groups.len() >= 3);
     }
 
     #[test]
@@ -1175,7 +1175,7 @@ mod tests {
         ];
         let partition_num = 2;
         let groups = group_files_by_time_range(files, partition_num);
-        assert_eq!(groups.len(), 2);
+        assert!(groups.len() >= 2);
     }
 
     #[test]
@@ -1183,7 +1183,7 @@ mod tests {
         let files = vec![create_file_key(1, 10), create_file_key(11, 20)];
         let partition_num = 3;
         let groups = group_files_by_time_range(files, partition_num);
-        assert_eq!(groups.len(), 2);
+        assert!(groups.len() >= 2);
     }
 
     #[test]
@@ -1194,7 +1194,7 @@ mod tests {
         ];
         let expect_group_elements = 1;
         let repartitioned_groups = repartition_sorted_groups(groups, expect_group_elements);
-        assert_eq!(repartitioned_groups.len(), 4);
+        assert!(repartitioned_groups.len() >= 4);
     }
 
     #[test]
@@ -1208,7 +1208,7 @@ mod tests {
         ]];
         let expect_group_elements = 2;
         let repartitioned_groups = repartition_sorted_groups(groups, expect_group_elements);
-        assert_eq!(repartitioned_groups.len(), 3);
+        assert!(repartitioned_groups.len() >= 3);
     }
 
     #[test]

--- a/src/service/search/streaming/mod.rs
+++ b/src/service/search/streaming/mod.rs
@@ -207,12 +207,8 @@ pub async fn process_search_stream_request(
             .unwrap_or_default();
 
         log::info!(
-            "[HTTP2_STREAM trace_id {trace_id}] found cache responses len:{}, with hits: {},
-        cache_start_time: {:#?}, cache_end_time: {:#?}",
+            "[HTTP2_STREAM trace_id {trace_id}] found cache responses len:{}, cache_start_time: {c_start_time}, cache_end_time: {c_end_time}",
             cached_resp.len(),
-            cached_hits,
-            c_start_time,
-            c_end_time
         );
 
         // handle cache responses and deltas


### PR DESCRIPTION
### **User description**
Add new env 
```
ZO_QUERY_INDEX_THREAD_NUM = 0
```
Default value is `CPU * 4`.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add env var for index search concurrency

- Configure default query_index thread counts

- Use new thread count in search filter

- Refactor file grouping and update tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Load ZO_QUERY_INDEX_THREAD_NUM env"] --> B["Set query_index_thread_num default"]
  B --> C["filter_file_list_by_tantivy_index uses new count"]
  C --> D["Refactor group & repartition logic"]
  D --> E["Update grouping tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add query index thread configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<ul><li>Introduce <code>ZO_QUERY_INDEX_THREAD_NUM</code> env var<br> <li> Set default based on local_mode vs production<br> <li> Apply new var in <code>check_limit_config</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7695/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>record_batch_ext.rs</strong><dd><code>Cleanup imports and whitespace in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/utils/record_batch_ext.rs

<ul><li>Reformat import statements for arrow util<br> <li> Remove trailing whitespace in tests</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7695/files#diff-f84aa2842a164d6e85aa05a718159e87a325cac139c59e561f6f59313c6d7c5d">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.rs</strong><dd><code>Enhance storage search partitioning logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/grpc/storage.rs

<ul><li>Use <code>query_index_thread_num</code> for target_partitions<br> <li> Log target_partitions, group_num, max_group_len<br> <li> Compute <code>expect_group_elements</code> in grouping<br> <li> Simplify <code>repartition_sorted_groups</code> logic<br> <li> Remove unused <code>find_max_group_index</code><br> <li> Update tests to use <code>expect_group_elements</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7695/files#diff-ab2d867e1e2e3dd8307505c2e130039628a84f8131a9b38cd2e7b4e1c141e094">+27/-62</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Simplify search stream logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/streaming/mod.rs

<ul><li>Simplify log message placeholders<br> <li> Remove unused variables in cache log</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7695/files#diff-f236c6c880ed80233fd264e657d5ab658c16c7368bdc70e20f123862b7214374">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

