### PR TITLE
fix: rbac migration needed for re patterns

### DIFF
--- a/src/common/infra/ofga/mod.rs
+++ b/src/common/infra/ofga/mod.rs
@@ -147,7 +147,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         let v0_0_16 = version_compare::Version::from("0.0.16").unwrap();
         let v0_0_17 = version_compare::Version::from("0.0.17").unwrap();
         let v0_0_18 = version_compare::Version::from("0.0.18").unwrap();
-        let v0_0_19 = version_compare::Version::from("0.0.19").unwrap();
+        let v0_0_20 = version_compare::Version::from("0.0.20").unwrap();
         if meta_version > v0_0_5 && existing_model_version < v0_0_6 {
             need_pipeline_migration = true;
         }
@@ -171,7 +171,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
             log::info!("[OFGA:Local] AI chat permissions migration needed");
             need_ai_chat_permissions_migration = true;
         }
-        if meta_version > v0_0_19 && existing_model_version < v0_0_19 {
+        if meta_version > v0_0_20 && existing_model_version < v0_0_20 {
             log::info!("[OFGA:Local] Re patterns migration needed");
             need_re_pattern_migration = true;
         }

--- a/src/common/infra/ofga/mod.rs
+++ b/src/common/infra/ofga/mod.rs
@@ -54,6 +54,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     let mut need_ratelimit_migration = false;
     let mut need_service_accounts_migration = false;
     let mut need_ai_chat_permissions_migration = false;
+    let mut need_re_pattern_migration = false;
     let mut existing_meta: Option<o2_openfga::meta::mapping::OFGAModel> =
         match db::ofga::get_ofga_model().await {
             Ok(Some(model)) => Some(model),
@@ -146,6 +147,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         let v0_0_16 = version_compare::Version::from("0.0.16").unwrap();
         let v0_0_17 = version_compare::Version::from("0.0.17").unwrap();
         let v0_0_18 = version_compare::Version::from("0.0.18").unwrap();
+        let v0_0_19 = version_compare::Version::from("0.0.19").unwrap();
         if meta_version > v0_0_5 && existing_model_version < v0_0_6 {
             need_pipeline_migration = true;
         }
@@ -168,6 +170,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
         if meta_version > v0_0_17 && existing_model_version < v0_0_18 {
             log::info!("[OFGA:Local] AI chat permissions migration needed");
             need_ai_chat_permissions_migration = true;
+        }
+        if meta_version > v0_0_19 && existing_model_version < v0_0_19 {
+            log::info!("[OFGA:Local] Re patterns migration needed");
+            need_re_pattern_migration = true;
         }
     }
 
@@ -278,6 +284,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
                     }
                     if need_ai_chat_permissions_migration {
                         get_ownership_all_org_tuple(org_name, "ai", &mut tuples);
+                    }
+                    if need_re_pattern_migration {
+                        get_ownership_all_org_tuple(org_name, "re_patterns", &mut tuples);
                     }
                 }
                 if need_alert_folders_migration {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Introduce re_patterns migration flag

- Add v0.0.19 version constant

- Implement migration triggering condition

- Include re_patterns in ownership tuples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check OFGA model version"] -->|meta>0.0.19 & existing<0.0.19| B["Set need_re_pattern_migration"]
  B --> C["Collect re_patterns ownership tuples"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add re_patterns migration support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/common/infra/ofga/mod.rs

<ul><li>Introduced <code>need_re_pattern_migration</code> flag<br> <li> Added <code>v0.0.19</code> version constant<br> <li> Added conditional migration for re_patterns<br> <li> Extended ownership tuple generation</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7700/files#diff-1b8694fad31c8249afeb419d92a9facbd170289db2c89100552883df876bb275">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

