### PR TITLE
fix: rbac migration for re_patterns

### DIFF
--- a/src/common/infra/ofga/mod.rs
+++ b/src/common/infra/ofga/mod.rs
@@ -148,7 +148,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         let v0_0_16 = version_compare::Version::from("0.0.16").unwrap();
         let v0_0_17 = version_compare::Version::from("0.0.17").unwrap();
         let v0_0_18 = version_compare::Version::from("0.0.18").unwrap();
-        let v0_0_19 = version_compare::Version::from("0.0.19").unwrap();
+        let v0_0_20 = version_compare::Version::from("0.0.20").unwrap();
 
         if meta_version > v0_0_5 && existing_model_version < v0_0_6 {
             need_pipeline_migration = true;
@@ -173,7 +173,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
             log::info!("[OFGA:Local] AI chat permissions migration needed");
             need_ai_chat_permissions_migration = true;
         }
-        if existing_model_version < v0_0_19 {
+        if existing_model_version < v0_0_20 {
             log::info!("[OFGA:Local] re_patterns permissions migration needed");
             need_re_pattern_permission_migration = true;
         }

--- a/src/common/infra/ofga/mod.rs
+++ b/src/common/infra/ofga/mod.rs
@@ -54,6 +54,8 @@ pub async fn init() -> Result<(), anyhow::Error> {
     let mut need_ratelimit_migration = false;
     let mut need_service_accounts_migration = false;
     let mut need_ai_chat_permissions_migration = false;
+    let mut need_re_pattern_permission_migration = false;
+
     let mut existing_meta: Option<o2_openfga::meta::mapping::OFGAModel> =
         match db::ofga::get_ofga_model().await {
             Ok(Some(model)) => Some(model),
@@ -146,6 +148,8 @@ pub async fn init() -> Result<(), anyhow::Error> {
         let v0_0_16 = version_compare::Version::from("0.0.16").unwrap();
         let v0_0_17 = version_compare::Version::from("0.0.17").unwrap();
         let v0_0_18 = version_compare::Version::from("0.0.18").unwrap();
+        let v0_0_19 = version_compare::Version::from("0.0.19").unwrap();
+
         if meta_version > v0_0_5 && existing_model_version < v0_0_6 {
             need_pipeline_migration = true;
         }
@@ -168,6 +172,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
         if meta_version > v0_0_17 && existing_model_version < v0_0_18 {
             log::info!("[OFGA:Local] AI chat permissions migration needed");
             need_ai_chat_permissions_migration = true;
+        }
+        if existing_model_version < v0_0_19 {
+            log::info!("[OFGA:Local] re_patterns permissions migration needed");
+            need_re_pattern_permission_migration = true;
         }
     }
 
@@ -278,6 +286,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
                     }
                     if need_ai_chat_permissions_migration {
                         get_ownership_all_org_tuple(org_name, "ai", &mut tuples);
+                    }
+                    if need_re_pattern_permission_migration {
+                        get_ownership_all_org_tuple(org_name, "re_patterns", &mut tuples);
                     }
                 }
                 if need_alert_folders_migration {


### PR DESCRIPTION
### **User description**
adds a ofga migration missed in first PR


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing re_patterns permissions migration

- Define migration version threshold to v0.0.19

- Introduce migration flag for re_patterns

- Trigger ownership tuple generation for re_patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  VersionCheck["Check existing_model_version < \"0.0.19\""]
  FlagSet["Set need_re_pattern_permission_migration = true"]
  TupleGen["Call get_ownership_all_org_tuple(\"re_patterns\")"]
  VersionCheck -- "true" --> FlagSet
  FlagSet --> TupleGen
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add re_patterns migration support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/common/infra/ofga/mod.rs

<ul><li>Initialize need_re_pattern_permission_migration flag<br> <li> Add version v0.0.19 for migration check<br> <li> Insert condition for re_patterns migration<br> <li> Invoke get_ownership_all_org_tuple for re_patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7701/files#diff-1b8694fad31c8249afeb419d92a9facbd170289db2c89100552883df876bb275">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

