### PR TITLE
perf: improve search memtable

### DIFF
--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -719,3 +719,305 @@ fn adapt_batch(
     let schema = Arc::new(Schema::new(fields));
     (RecordBatch::try_new(schema, cols).unwrap(), diff_fields)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray, Array};
+    use arrow_schema::Field;
+
+    #[test]
+    fn test_adapt_batch_exact_match() {
+        // Test case: batch schema exactly matches latest schema
+        let batch_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        
+        let latest_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            batch_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+            ],
+        ).unwrap();
+
+        let (result_batch, diff_fields) = adapt_batch(latest_schema, batch);
+
+        assert_eq!(result_batch.schema().fields().len(), 2);
+        assert_eq!(result_batch.num_rows(), 3);
+        assert!(diff_fields.is_empty());
+        
+        // Verify data is preserved
+        let id_col = result_batch.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let name_col = result_batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(id_col.value(0), 1);
+        assert_eq!(id_col.value(1), 2);
+        assert_eq!(id_col.value(2), 3);
+        assert_eq!(name_col.value(0), "a");
+        assert_eq!(name_col.value(1), "b");
+        assert_eq!(name_col.value(2), "c");
+    }
+
+    #[test]
+    fn test_adapt_batch_missing_field() {
+        // Test case: batch is missing a field that exists in latest schema
+        let batch_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+        ]));
+        
+        let latest_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("active", DataType::Boolean, true), // Make nullable since we'll add nulls
+        ]));
+
+        let batch = RecordBatch::try_new(
+            batch_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+            ],
+        ).unwrap();
+
+        let (result_batch, diff_fields) = adapt_batch(latest_schema, batch);
+
+        assert_eq!(result_batch.schema().fields().len(), 3);
+        assert_eq!(result_batch.num_rows(), 3);
+        assert!(diff_fields.is_empty());
+        
+        // Verify existing data is preserved
+        let id_col = result_batch.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(id_col.value(0), 1);
+        assert_eq!(id_col.value(1), 2);
+        assert_eq!(id_col.value(2), 3);
+        
+        // Verify missing fields are null
+        let name_col = result_batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(name_col.null_count(), 3);
+        
+        let active_col = result_batch.column(2).as_any().downcast_ref::<arrow::array::BooleanArray>().unwrap();
+        assert_eq!(active_col.null_count(), 3);
+    }
+
+    #[test]
+    fn test_adapt_batch_utf8view_field() {
+        // Test case: latest schema has Utf8View field that's missing in batch
+        let batch_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+        ]));
+        
+        let latest_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("description", DataType::Utf8View, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            batch_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+            ],
+        ).unwrap();
+
+        let (result_batch, diff_fields) = adapt_batch(latest_schema, batch);
+
+        assert_eq!(result_batch.schema().fields().len(), 2);
+        assert_eq!(result_batch.num_rows(), 3);
+        assert_eq!(diff_fields.len(), 1);
+        assert_eq!(diff_fields.get("description"), Some(&DataType::Utf8View));
+        
+        // Verify existing data is preserved
+        let id_col = result_batch.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(id_col.value(0), 1);
+        assert_eq!(id_col.value(1), 2);
+        assert_eq!(id_col.value(2), 3);
+        
+        // Verify Utf8View field is added as Utf8 with nulls
+        let desc_col = result_batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(desc_col.null_count(), 3);
+        assert_eq!(desc_col.data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn test_adapt_batch_extra_field() {
+        // Test case: batch has extra fields not in latest schema
+        let batch_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("extra_field", DataType::Int32, false),
+        ]));
+        
+        let latest_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            batch_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(arrow::array::Int32Array::from(vec![10, 20, 30])),
+            ],
+        ).unwrap();
+
+        let (result_batch, diff_fields) = adapt_batch(latest_schema, batch);
+
+        assert_eq!(result_batch.schema().fields().len(), 2);
+        assert_eq!(result_batch.num_rows(), 3);
+        assert!(diff_fields.is_empty());
+        
+        // Verify only fields from latest schema are included
+        let id_col = result_batch.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let name_col = result_batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(id_col.value(0), 1);
+        assert_eq!(id_col.value(1), 2);
+        assert_eq!(id_col.value(2), 3);
+        assert_eq!(name_col.value(0), "a");
+        assert_eq!(name_col.value(1), "b");
+        assert_eq!(name_col.value(2), "c");
+    }
+
+    #[test]
+    fn test_adapt_batch_empty_batch() {
+        // Test case: empty batch
+        let batch_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+        ]));
+        
+        let latest_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            batch_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(Vec::<i64>::new())),
+            ],
+        ).unwrap();
+
+        let (result_batch, diff_fields) = adapt_batch(latest_schema, batch);
+
+        assert_eq!(result_batch.schema().fields().len(), 2);
+        assert_eq!(result_batch.num_rows(), 0);
+        assert!(diff_fields.is_empty());
+    }
+
+    #[test]
+    fn test_adapt_batch_field_order() {
+        // Test case: fields in different order
+        let batch_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("id", DataType::Int64, false),
+        ]));
+        
+        let latest_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            batch_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+            ],
+        ).unwrap();
+
+        let (result_batch, diff_fields) = adapt_batch(latest_schema, batch);
+
+        assert_eq!(result_batch.schema().fields().len(), 2);
+        assert_eq!(result_batch.num_rows(), 3);
+        assert!(diff_fields.is_empty());
+        
+        // Verify fields are in the order of latest schema
+        let id_col = result_batch.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let name_col = result_batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(id_col.value(0), 1);
+        assert_eq!(id_col.value(1), 2);
+        assert_eq!(id_col.value(2), 3);
+        assert_eq!(name_col.value(0), "a");
+        assert_eq!(name_col.value(1), "b");
+        assert_eq!(name_col.value(2), "c");
+    }
+
+    #[test]
+    fn test_adapt_batch_multiple_utf8view_fields() {
+        // Test case: multiple Utf8View fields in latest schema
+        let batch_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+        ]));
+        
+        let latest_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("title", DataType::Utf8View, true),
+            Field::new("description", DataType::Utf8View, true), // Make nullable since we'll add nulls
+        ]));
+
+        let batch = RecordBatch::try_new(
+            batch_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+            ],
+        ).unwrap();
+
+        let (result_batch, diff_fields) = adapt_batch(latest_schema, batch);
+
+        assert_eq!(result_batch.schema().fields().len(), 3);
+        assert_eq!(result_batch.num_rows(), 3);
+        assert_eq!(diff_fields.len(), 2);
+        assert_eq!(diff_fields.get("title"), Some(&DataType::Utf8View));
+        assert_eq!(diff_fields.get("description"), Some(&DataType::Utf8View));
+        
+        // Verify existing data is preserved
+        let id_col = result_batch.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(id_col.value(0), 1);
+        assert_eq!(id_col.value(1), 2);
+        assert_eq!(id_col.value(2), 3);
+        
+        // Verify Utf8View fields are added as Utf8 with nulls
+        let title_col = result_batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        let desc_col = result_batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(title_col.null_count(), 3);
+        assert_eq!(desc_col.null_count(), 3);
+        assert_eq!(title_col.data_type(), &DataType::Utf8);
+        assert_eq!(desc_col.data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn test_adapt_batch_nullable_vs_non_nullable() {
+        // Test case: field exists but with different nullability
+        let batch_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, true), // nullable in batch
+        ]));
+        
+        let latest_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false), // non-nullable in latest
+        ]));
+
+        let batch = RecordBatch::try_new(
+            batch_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![Some(1), None, Some(3)])),
+            ],
+        ).unwrap();
+
+        let (result_batch, diff_fields) = adapt_batch(latest_schema, batch);
+
+        assert_eq!(result_batch.schema().fields().len(), 1);
+        assert_eq!(result_batch.num_rows(), 3);
+        assert!(diff_fields.is_empty());
+        
+        // Verify data is preserved (including nulls)
+        let id_col = result_batch.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(id_col.null_count(), 1);
+        assert_eq!(id_col.value(0), 1);
+        assert!(id_col.is_null(1));
+        assert_eq!(id_col.value(2), 3);
+    }
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Parallelized batch adaptation and merging using Rayon

- Added logs measuring adapt and merge durations

- Refactored `adapt_batch` to return `diff_fields`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wal.rs</strong><dd><code>Parallel batch processing and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/grpc/wal.rs

<ul><li>Imported <code>rayon</code> for parallel iteration<br> <li> Adapted and merged batches in parallel<br> <li> Logged timing and batch statistics<br> <li> Refactored <code>adapt_batch</code> signature and logic</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7710/files#diff-48aea52fd870678e577e03f29fc9769920b7f74761b1447242835dbf1b8ac8df">+49/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

