### PR TITLE
fix: update rust toolchain version in release yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
       - "v*.*.*"
 name: Release
 env:
-  RUST_TOOLCHAIN: nightly-2025-03-02
+  RUST_TOOLCHAIN: nightly-2025-05-20
 jobs:
   build:
     name: Build binary


### PR DESCRIPTION
### **User description**
https://github.com/openobserve/openobserve/pull/7316 upgraded rust version, but the release flow still used old version. This PR updates that version as well.


___

### **PR Type**
Bug fix


___

### **Description**
- Update Rust toolchain in release workflow


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Update Rust toolchain setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

- Replaced `RUST_TOOLCHAIN` value in env


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7715/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

