### PR TITLE
fix: environment FTS and secondary fields default selected

### DIFF
--- a/web/src/components/logstream/schema.vue
+++ b/web/src/components/logstream/schema.vue
@@ -447,6 +447,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           props.row.name == allFieldsName
                         )
                       "
+                      :disable="isEnvironmentSettings(props.row)"
                       v-model="props.row.index_type"
                       :options="streamIndexType"
                       :popup-content-style="{ textTransform: 'capitalize' }"
@@ -468,8 +469,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       filled
                       dense
                       style="min-width: 15rem; max-width: 15rem"
-                      @update:model-value="markFormDirty(props.row.name, 'fts')"
+                      @update:model-value="isEnvironmentSettings(props.row) == false ? markFormDirty(props.row.name, 'fts') : null"
                     />
+                    <q-tooltip
+                      v-if="isEnvironmentSettings(props.row)"
+                      style="font-size: 14px; width: 250px;"
+                    >
+                      This is a predefined environment setting and cannot be changed.
+                    </q-tooltip>
                   </q-td>
                 </template>
                 <!-- here we will render the number of regex patterns associated with the specific field -->
@@ -810,6 +817,16 @@ export default defineComponent({
       { label: "All", value: 0 },
     ];
 
+    const isEnvironmentSettings = computed(() => {
+      return (row: any) => {
+        if (!row || !row.index_type) return false;
+        return (
+          row?.index_type?.includes("fullTextSearchKeyEnv") ||
+          row?.index_type?.includes("secondaryIndexKeyEnv")
+        );
+      };
+    });
+
     const changePagination = (val: { label: string; value: any }) => {
       selectedPerPage.value = val.value;
       pagination.value.rowsPerPage = val.value;
@@ -881,6 +898,8 @@ export default defineComponent({
     const streamIndexType = [
       { label: "Full text search", value: "fullTextSearchKey" },
       { label: "Secondary index", value: "secondaryIndexKey" },
+      { label: "Full text search (Environment setting)", value: "fullTextSearchKeyEnv" },
+      { label: "Secondary index (Environment setting)", value: "secondaryIndexKeyEnv" },
       { label: "Bloom filter", value: "bloomFilterKey" },
       { label: "KeyValue partition", value: "keyPartition" },
       { label: "Prefix partition", value: "prefixPartition" },
@@ -967,13 +986,14 @@ export default defineComponent({
 
     const getFieldIndices = (property, settings) => {
       const fieldIndices = [];
-      if (
-        (settings.full_text_search_keys.length > 0 &&
-          settings.full_text_search_keys.includes(property.name)) ||
-        (settings.full_text_search_keys.length == 0 &&
-          store.state.zoConfig.default_fts_keys.includes(property.name))
+      if (settings.full_text_search_keys.length > 0 &&
+          settings.full_text_search_keys.includes(property.name)
       ) {
         fieldIndices.push("fullTextSearchKey");
+      }
+
+      if(!settings?.full_text_search_keys.includes(property.name) && store.state.zoConfig.default_fts_keys.includes(property.name)) {
+        fieldIndices.push("fullTextSearchKeyEnv");
       }
 
       if (
@@ -981,6 +1001,10 @@ export default defineComponent({
         settings.index_fields.includes(property.name)
       ) {
         fieldIndices.push("secondaryIndexKey");
+      }
+
+      if(!settings?.index_fields.includes(property.name) && store.state.zoConfig.default_secondary_index_fields.includes(property.name)) {
+        fieldIndices.push("secondaryIndexKeyEnv");
       }
 
       if (
@@ -1827,7 +1851,8 @@ export default defineComponent({
       openPatternAssociationDialog,
       handleAddPattern,
       handleRemovePattern,
-      handleUpdateAppliedPattern
+      handleUpdateAppliedPattern,
+      isEnvironmentSettings,
     };
   },
   created() {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Detect environment-specific index fields

- Disable selection and show tooltip for env settings

- Add environment options to index type dropdown

- Extend getFieldIndices to include env defaults


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.vue</strong><dd><code>Support environment settings for index fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/logstream/schema.vue

<ul><li>Bound <code>disable</code> on q-select to <code>isEnvironmentSettings</code><br> <li> Conditional <code>markFormDirty</code> call only when not env<br> <li> Added <code><q-tooltip></code> for environment-only rows<br> <li> Introduced <code>isEnvironmentSettings</code> computed function<br> <li> Added env options to <code>streamIndexType</code><br> <li> Updated <code>getFieldIndices</code> to include env keys</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7716/files#diff-9196be2ccae4054a00b0b1aa9d1e87b366c10920d6eaf9ef8c6e6293d50bcf46">+32/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

