### PR TITLE
fix: dashboard go to logs with long url (#7712)

### DIFF
--- a/web/src/components/dashboards/PanelContainer.vue
+++ b/web/src/components/dashboards/PanelContainer.vue
@@ -383,6 +383,7 @@ import { getFunctionErrorMessage } from "@/utils/zincutils";
 import useNotifications from "@/composables/useNotifications";
 import { isEqual } from "lodash-es";
 import { b64EncodeUnicode } from "@/utils/zincutils";
+import shortURL from "@/services/short_url";
 
 const QueryInspector = defineAsyncComponent(() => {
   return import("@/components/dashboards/QueryInspector.vue");
@@ -591,6 +592,12 @@ export default defineComponent({
     };
 
     const onLogPanel = async () => {
+      const showNotification = showPositiveNotification(
+        "Redirecting to logs page",
+        {
+          color: "warning",
+        },
+      );
       const queryDetails = props.data;
       if (!queryDetails) {
         console.error("Data is undefined.");
@@ -633,7 +640,23 @@ export default defineComponent({
         vrlFunctionQueryEncoded,
       );
 
-      window.open(logsUrl.toString(), "_blank");
+      // Use short_url service to shorten the URL and redirect
+      try {
+        const org_identifier = store.state.selectedOrganization.identifier;
+        const response = await shortURL.create(
+          org_identifier,
+          logsUrl.toString(),
+        );
+        const shortUrl = response?.data?.short_url;
+        if (shortUrl) {
+          window.open(shortUrl, "_blank");
+        } else {
+          window.open(logsUrl.toString(), "_blank");
+        }
+        showNotification();
+      } catch (error) {
+        window.open(logsUrl.toString(), "_blank");
+      }
     };
 
     //create a duplicate panel


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Integrate short URL service for log panel redirection

- Show warning notification before redirecting

- Fallback to original URL on shortening error


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Log panel click"] --> B["Construct logsUrl"]
  B --> C["Call shortURL.create"]
  C --> D{"short_url exists?"}
  D -- yes --> E["Open short_url"]
  D -- no/fail --> F["Open original URL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>PanelContainer.vue</strong><dd><code>Short URL integration for logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/PanelContainer.vue

<ul><li>Imported shortURL service<br> <li> Added warning notification before redirect<br> <li> Integrated shortURL.create for URL shortening<br> <li> Implemented fallback to original logs URL</ul>


</details>


  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/7712/files#diff-414737cba6064461f7026e0b016afcb9620bd5bb29c4708fc170dee789dbcd4d">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___