### PR TITLE
fix: improve log message of partition file by consistent hashing

### DIFF
--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -877,7 +877,7 @@ pub(crate) async fn partition_file_by_hash(
             Some(node_name) => match node_idx.get(&node_name) {
                 Some(idx) => *idx,
                 None => {
-                    log::warn!("partition_file_by_hash: {node_name} not found in node_idx",);
+                    log::warn!("partition_file_by_hash: {node_name} not found in node_idx");
                     0
                 }
             },

--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -872,12 +872,20 @@ pub(crate) async fn partition_file_by_hash(
     for fk in file_id_list {
         let node_name =
             infra_cluster::get_node_from_consistent_hash(&fk.id.to_string(), &Role::Querier, group)
-                .await
-                .expect("there is no querier node in consistent hash ring");
-        let idx = match node_idx.get(&node_name) {
-            Some(idx) => *idx,
+                .await;
+        let idx = match node_name {
+            Some(node_name) => match node_idx.get(&node_name) {
+                Some(idx) => *idx,
+                None => {
+                    log::warn!("partition_file_by_hash: {node_name} not found in node_idx",);
+                    0
+                }
+            },
             None => {
-                log::error!("partition_file_by_hash: {node_name} not found in node_idx");
+                log::warn!(
+                    "partition_file_by_hash: {} can't get a node from consistent hashing",
+                    fk.id
+                );
                 0
             }
         };


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace panic with graceful Option handling

- Log warnings for missing nodes or indices

- Default partition index to zero on failure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Iterate file IDs"] --> B["get_node_from_consistent_hash"]
  B -- "Some(node_name)" --> C["Lookup in node_idx"]
  B -- "None result" --> F["Warn and idx=0"]
  C -- "Found index" --> D["Use idx"]
  C -- "Index missing" --> E["Warn and idx=0"]
  D --> G["Push to partitions[idx]"]
  E --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flight.rs</strong><dd><code>Gracefully handle missing hash nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cluster/flight.rs

<ul><li>Remove panic and expect() on hash lookup<br> <li> Add Option match to handle missing nodes<br> <li> Log warnings and fallback to index 0</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7738/files#diff-dbffb1a03b65f6a9163b18c5bb1241ba2966735657be39bbe9f4d0e3260d8c1d">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

