### PR TITLE
fix: hist interval bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.13",
 ]
 
 [[package]]
@@ -40,7 +40,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.13",
  "tracing",
 ]
 
@@ -94,7 +94,7 @@ dependencies = [
  "sha1",
  "smallvec",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.13",
  "tracing",
  "zstd",
 ]
@@ -217,9 +217,9 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
- "tokio-util",
+ "tokio-util 0.7.13",
  "tracing",
- "webpki-roots",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -290,7 +290,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.13",
 ]
 
 [[package]]
@@ -961,6 +961,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,7 +1040,7 @@ dependencies = [
  "portable-atomic",
  "rand",
  "regex",
- "ring",
+ "ring 0.17.13",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.2.0",
  "rustls-webpki 0.102.8",
@@ -1040,7 +1052,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls 0.26.1",
- "tokio-util",
+ "tokio-util 0.7.13",
  "tokio-websockets",
  "tracing",
  "tryhard",
@@ -1201,7 +1213,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 0.2.12",
- "ring",
+ "ring 0.17.13",
  "time",
  "tokio",
  "tracing",
@@ -1476,7 +1488,7 @@ dependencies = [
  "serde",
  "time",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.13",
 ]
 
 [[package]]
@@ -1595,6 +1607,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.15",
+ "instant",
+ "rand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +1645,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base62"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1664,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -2134,15 +2169,15 @@ dependencies = [
  "futures",
  "futures-timer",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.12.9",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",
- "which",
- "winreg",
+ "which 6.0.3",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -2164,7 +2199,7 @@ dependencies = [
  "anyhow",
  "directories",
  "os_info",
- "reqwest",
+ "reqwest 0.12.9",
  "thiserror 1.0.69",
  "tokio",
  "zip 0.6.6",
@@ -2504,7 +2539,7 @@ dependencies = [
  "proto",
  "rand",
  "regex",
- "reqwest",
+ "reqwest 0.12.9",
  "sea-orm",
  "segment",
  "serde",
@@ -2514,11 +2549,11 @@ dependencies = [
  "sqlx",
  "strum",
  "svix-ksuid",
- "sysinfo",
+ "sysinfo 0.33.1",
  "tantivy",
  "tantivy-fst",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.13",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -2797,6 +2832,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2865,6 +2912,7 @@ dependencies = [
  "fiat-crypto",
  "rustc_version",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2978,7 +3026,7 @@ dependencies = [
  "sqlparser",
  "tempfile",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.13",
  "url",
  "uuid",
  "xz2",
@@ -3484,6 +3532,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3670,11 +3749,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
@@ -3686,9 +3780,23 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2",
  "signature",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3698,6 +3806,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3749,6 +3878,46 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "vrl",
+]
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3830,6 +3999,25 @@ dependencies = [
  "tonic-build 0.10.2",
  "tower 0.4.13",
  "tower-service",
+]
+
+[[package]]
+name = "etcd-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c74c79944c81dfb4cf0bd47ca2e24be6233c27fb2e85c35e65dcc07ea9eec2"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "futures",
+ "http 0.2.12",
+ "prost 0.9.0",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.6.2",
+ "tonic-build 0.6.2",
 ]
 
 [[package]]
@@ -3916,6 +4104,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3996,7 +4194,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -4266,6 +4464,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "gxhash"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4289,7 +4498,7 @@ dependencies = [
  "indexmap 2.7.1",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.13",
  "tracing",
 ]
 
@@ -4308,7 +4517,7 @@ dependencies = [
  "indexmap 2.7.1",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.13",
  "tracing",
 ]
 
@@ -4321,6 +4530,22 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
+]
+
+[[package]]
+name = "handlebars"
+version = "6.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759e2d5aea3287cb1190c8ec394f42866cb5bf74fcbf213f354e3c856ea26098"
+dependencies = [
+ "derive_builder",
+ "log",
+ "num-order",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -4374,6 +4599,39 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.2.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.2.0",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -4590,6 +4848,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.2.0",
+ "hyper 1.5.2",
+ "hyper-rustls 0.27.4",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4615,13 +4893,14 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.5.2",
  "hyper-util",
+ "log",
  "rustls 0.23.20",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -4850,6 +5129,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -4927,7 +5207,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "parquet",
- "reqwest",
+ "reqwest 0.12.9",
  "sea-orm",
  "sea-orm-migration",
  "serde",
@@ -5145,6 +5425,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5153,10 +5468,23 @@ dependencies = [
  "base64 0.21.7",
  "js-sys",
  "pem",
- "ring",
+ "ring 0.17.13",
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
 ]
 
 [[package]]
@@ -5166,6 +5494,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "kube"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32053dc495efad4d188c7b33cc7c02ef4a6e43038115348348876efd39a53cba"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+ "kube-derive",
+ "kube-runtime",
+]
+
+[[package]]
+name = "kube-client"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d34ad38cdfbd1fa87195d42569f57bb1dda6ba5f260ee32fef9570b7937a0c9"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-http-proxy",
+ "hyper-rustls 0.27.4",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls 0.23.20",
+ "rustls-pemfile 2.2.0",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.9.34+deprecated",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-util 0.7.13",
+ "tower 0.5.2",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97aa830b288a178a90e784d1b0f1539f2d200d2188c7b4a3146d9dc983d596f3"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http 1.2.0",
+ "json-patch",
+ "k8s-openapi",
+ "schemars 0.8.22",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "kube-derive"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37745d8a4076b77e0b1952e94e358726866c8e14ec94baaca677d47dcdb98658"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "kube-runtime"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a41af186a0fe80c71a13a13994abdc3ebff80859ca6a4b8a6079948328c135b"
+dependencies = [
+ "ahash 0.8.11",
+ "async-broadcast",
+ "async-stream",
+ "async-trait",
+ "backoff",
+ "educe",
+ "futures",
+ "hashbrown 0.15.2",
+ "hostname 0.4.0",
+ "json-patch",
+ "jsonptr",
+ "k8s-openapi",
+ "kube-client",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-util 0.7.13",
+ "tracing",
 ]
 
 [[package]]
@@ -5211,7 +5650,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -5242,7 +5681,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.1",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -5430,6 +5869,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5532,6 +5977,15 @@ dependencies = [
  "serde",
  "sparsevec",
  "vob",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -5737,6 +6191,12 @@ dependencies = [
  "triomphe",
  "uuid",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multimap"
@@ -5981,6 +6441,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6039,6 +6514,148 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "o2_dex"
+version = "0.1.0"
+dependencies = [
+ "ahash 0.8.11",
+ "anyhow",
+ "arc-swap",
+ "chrono",
+ "config",
+ "dotenv_config",
+ "dotenvy",
+ "log",
+ "oauth2",
+ "once_cell",
+ "openidconnect",
+ "rand",
+ "reqwest 0.12.9",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "o2_enterprise"
+version = "0.1.0"
+dependencies = [
+ "aes-siv",
+ "ahash 0.8.11",
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "async-walkdir",
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "config",
+ "dashmap",
+ "dotenv_config",
+ "dotenvy",
+ "either",
+ "futures-util",
+ "handlebars",
+ "hashbrown 0.15.2",
+ "http 1.2.0",
+ "infra",
+ "ingester",
+ "itertools 0.13.0",
+ "k8s-openapi",
+ "kube",
+ "log",
+ "o2_openfga",
+ "once_cell",
+ "opentelemetry 0.26.0",
+ "parquet",
+ "proto",
+ "rand",
+ "regex",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.9.34+deprecated",
+ "snafu 0.7.5",
+ "sqlparser",
+ "svix-ksuid",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.3",
+ "tracing",
+ "tracing-opentelemetry",
+ "url",
+ "wal",
+ "zip 3.0.0",
+]
+
+[[package]]
+name = "o2_openfga"
+version = "0.1.0"
+dependencies = [
+ "ahash 0.8.11",
+ "anyhow",
+ "arc-swap",
+ "config",
+ "dashmap",
+ "dotenv_config",
+ "dotenvy",
+ "log",
+ "o2_dex",
+ "once_cell",
+ "openfga-sdk",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "o2_ratelimit"
+version = "0.1.0"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "config",
+ "futures",
+ "infra",
+ "log",
+ "o2_enterprise",
+ "o2_openfga",
+ "once_cell",
+ "regex",
+ "sentinel-core",
+ "serde",
+ "serde_json",
+ "tokio",
+ "utoipa",
+]
+
+[[package]]
+name = "oauth2"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom 0.2.15",
+ "http 0.2.12",
+ "rand",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -6104,8 +6721,8 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.37.2",
  "rand",
- "reqwest",
- "ring",
+ "reqwest 0.12.9",
+ "ring 0.17.13",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -6183,6 +6800,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openfga-sdk"
+version = "1.0.2"
+source = "git+https://github.com/openobserve/openfga-sdk?rev=122eb78d28f31dd3512a3a10304552dae4465a53#122eb78d28f31dd3512a3a10304552dae4465a53"
+dependencies = [
+ "reqwest 0.12.9",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "openidconnect"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47e80a9cfae4462dd29c41e987edd228971d6565553fbc14b8a11e666d91590"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac",
+ "http 0.2.12",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_derive",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "openobserve"
 version = "0.14.6"
 dependencies = [
@@ -6258,6 +6920,10 @@ dependencies = [
  "memchr",
  "mimalloc",
  "mime",
+ "o2_dex",
+ "o2_enterprise",
+ "o2_openfga",
+ "o2_ratelimit",
  "object_store",
  "once_cell",
  "opentelemetry 0.26.0",
@@ -6280,7 +6946,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.5",
  "report_server",
- "reqwest",
+ "reqwest 0.12.9",
  "rust-embed-for-web",
  "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
@@ -6304,7 +6970,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util",
+ "tokio-util 0.7.13",
  "tonic 0.12.3",
  "tracing",
  "tracing-appender",
@@ -6365,7 +7031,7 @@ dependencies = [
  "bytes",
  "http 1.2.0",
  "opentelemetry 0.26.0",
- "reqwest",
+ "reqwest 0.12.9",
 ]
 
 [[package]]
@@ -6382,7 +7048,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.4",
- "reqwest",
+ "reqwest 0.12.9",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -6527,6 +7193,30 @@ name = "owo-colors"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "packedvec"
@@ -6917,7 +7607,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prost 0.12.6",
- "prost-build",
+ "prost-build 0.12.6",
  "prost-derive 0.12.6",
  "sha2",
  "smallvec",
@@ -6993,6 +7683,15 @@ dependencies = [
  "lazy_static",
  "term 0.7.0",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -7138,6 +7837,16 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
@@ -7168,6 +7877,26 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap 0.8.3",
+ "petgraph 0.6.5",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "regex",
+ "tempfile",
+ "which 4.4.2",
+]
+
+[[package]]
+name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
@@ -7176,7 +7905,7 @@ dependencies = [
  "heck 0.5.0",
  "itertools 0.12.1",
  "log",
- "multimap",
+ "multimap 0.10.0",
  "once_cell",
  "petgraph 0.6.5",
  "prettyplease",
@@ -7185,6 +7914,19 @@ dependencies = [
  "regex",
  "syn 2.0.90",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7239,6 +7981,16 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost 0.9.0",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
@@ -7263,7 +8015,7 @@ dependencies = [
  "datafusion",
  "datafusion-proto",
  "prost 0.13.4",
- "prost-build",
+ "prost-build 0.12.6",
  "serde",
  "serde_json",
  "tokio",
@@ -7426,7 +8178,7 @@ dependencies = [
  "log",
  "names",
  "prost 0.11.9",
- "reqwest",
+ "reqwest 0.12.9",
  "serde_json",
  "thiserror 1.0.69",
  "url",
@@ -7517,7 +8269,7 @@ dependencies = [
  "bytes",
  "getrandom 0.2.15",
  "rand",
- "ring",
+ "ring 0.17.13",
  "rustc-hash 2.1.0",
  "rustls 0.23.20",
  "rustls-pki-types",
@@ -7690,6 +8442,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7776,6 +8548,47 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.25.4",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
@@ -7796,6 +8609,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7810,15 +8624,25 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.1",
- "tokio-util",
+ "tokio-util 0.7.13",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.7",
  "windows-registry",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -7832,6 +8656,21 @@ dependencies = [
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
@@ -7840,7 +8679,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -8079,14 +8918,27 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.1",
+ "log",
+ "ring 0.16.20",
+ "sct 0.6.1",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.13",
  "rustls-webpki 0.101.7",
- "sct",
+ "sct 0.7.1",
 ]
 
 [[package]]
@@ -8097,7 +8949,7 @@ checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "log",
  "once_cell",
- "ring",
+ "ring 0.17.13",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -8174,8 +9026,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.13",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8184,9 +9036,9 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring",
+ "ring 0.17.13",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8248,6 +9100,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8255,12 +9155,22 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.13",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8429,6 +9339,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8471,7 +9404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bdca318192c89bb31bffa2ef8e9e9898bc80f15a78db2fdd41cd051f1b41d01"
 dependencies = [
  "async-trait",
- "reqwest",
+ "reqwest 0.12.9",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -8483,6 +9416,28 @@ name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+
+[[package]]
+name = "sentinel-core"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df414b30ed5b82da4badac3071fa6dddf8b77d497de79c3ef4b5af1a39fe2f3e"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "enum-map",
+ "etcd-rs",
+ "futures",
+ "lazy_static",
+ "log",
+ "lru 0.7.8",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.8.26",
+ "sysinfo 0.26.9",
+ "time",
+ "uuid",
+]
 
 [[package]]
 name = "seq-macro"
@@ -8500,10 +9455,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8545,6 +9521,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_plain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8574,6 +9560,50 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.7.1",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap 1.9.3",
+ "ryu",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -8851,6 +9881,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
@@ -8941,7 +9977,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -9283,6 +10319,21 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "sysinfo"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
@@ -9303,6 +10354,27 @@ checksum = "161028c00842709450114c39db3b29f44c898055ed8833bb9b535aba7facf30e"
 dependencies = [
  "chrono",
  "nom",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -9334,7 +10406,7 @@ dependencies = [
  "itertools 0.12.1",
  "levenshtein_automata",
  "log",
- "lru",
+ "lru 0.12.5",
  "lz4_flex",
  "measure_time",
  "memmap2",
@@ -9709,6 +10781,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
@@ -9752,6 +10835,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
@@ -9761,6 +10858,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -9777,12 +10875,12 @@ dependencies = [
  "http 1.2.0",
  "httparse",
  "rand",
- "ring",
+ "ring 0.17.13",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
- "tokio-util",
- "webpki-roots",
+ "tokio-util 0.7.13",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -9811,6 +10909,38 @@ dependencies = [
  "indexmap 2.7.1",
  "toml_datetime",
  "winnow 0.6.20",
+]
+
+[[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-timeout 0.4.1",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -9878,13 +11008,25 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build 0.9.0",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "tonic-build"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.12.6",
  "quote",
  "syn 2.0.90",
 ]
@@ -9897,7 +11039,7 @@ checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.12.6",
  "quote",
  "syn 2.0.90",
 ]
@@ -9916,7 +11058,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9932,8 +11074,29 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-util 0.7.13",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.9.0",
+ "bytes",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "mime",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -9991,6 +11154,16 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -10121,7 +11294,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_derive",
- "serde_yaml",
+ "serde_yaml 0.9.34+deprecated",
 ]
 
 [[package]]
@@ -10208,6 +11381,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -10674,12 +11853,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -11086,6 +12293,16 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
@@ -11153,6 +12370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
 ]
 
 [[package]]
@@ -40,7 +40,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tracing",
 ]
 
@@ -94,7 +94,7 @@ dependencies = [
  "sha1",
  "smallvec",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tracing",
  "zstd",
 ]
@@ -217,9 +217,9 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tracing",
- "webpki-roots 0.26.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -290,7 +290,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
 ]
 
 [[package]]
@@ -961,18 +961,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,7 +1028,7 @@ dependencies = [
  "portable-atomic",
  "rand",
  "regex",
- "ring 0.17.13",
+ "ring",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.2.0",
  "rustls-webpki 0.102.8",
@@ -1052,7 +1040,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls 0.26.1",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tokio-websockets",
  "tracing",
  "tryhard",
@@ -1213,7 +1201,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 0.2.12",
- "ring 0.17.13",
+ "ring",
  "time",
  "tokio",
  "tracing",
@@ -1488,7 +1476,7 @@ dependencies = [
  "serde",
  "time",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1607,17 +1595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "getrandom 0.2.15",
- "instant",
- "rand",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,12 +1622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base62"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,12 +1635,6 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -2169,15 +2134,15 @@ dependencies = [
  "futures",
  "futures-timer",
  "pin-project-lite",
- "reqwest 0.12.9",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",
- "which 6.0.3",
- "winreg 0.52.0",
+ "which",
+ "winreg",
 ]
 
 [[package]]
@@ -2199,7 +2164,7 @@ dependencies = [
  "anyhow",
  "directories",
  "os_info",
- "reqwest 0.12.9",
+ "reqwest",
  "thiserror 1.0.69",
  "tokio",
  "zip 0.6.6",
@@ -2539,7 +2504,7 @@ dependencies = [
  "proto",
  "rand",
  "regex",
- "reqwest 0.12.9",
+ "reqwest",
  "sea-orm",
  "segment",
  "serde",
@@ -2549,11 +2514,11 @@ dependencies = [
  "sqlx",
  "strum",
  "svix-ksuid",
- "sysinfo 0.33.1",
+ "sysinfo",
  "tantivy",
  "tantivy-fst",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -2832,18 +2797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2912,7 +2865,6 @@ dependencies = [
  "fiat-crypto",
  "rustc_version",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -3026,7 +2978,7 @@ dependencies = [
  "sqlparser",
  "tempfile",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "url",
  "uuid",
  "xz2",
@@ -3532,37 +3484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,26 +3670,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
@@ -3780,23 +3686,9 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "serde",
  "sha2",
  "signature",
  "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "educe"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -3806,27 +3698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core",
- "sec1",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -3878,46 +3749,6 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "vrl",
-]
-
-[[package]]
-name = "enum-map"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
-dependencies = [
- "enum-map-derive",
-]
-
-[[package]]
-name = "enum-map-derive"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -3999,25 +3830,6 @@ dependencies = [
  "tonic-build 0.10.2",
  "tower 0.4.13",
  "tower-service",
-]
-
-[[package]]
-name = "etcd-rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c74c79944c81dfb4cf0bd47ca2e24be6233c27fb2e85c35e65dcc07ea9eec2"
-dependencies = [
- "async-stream",
- "async-trait",
- "bytes",
- "futures",
- "http 0.2.12",
- "prost 0.9.0",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tonic 0.6.2",
- "tonic-build 0.6.2",
 ]
 
 [[package]]
@@ -4104,16 +3916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4194,7 +3996,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -4464,17 +4266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "gxhash"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,7 +4289,7 @@ dependencies = [
  "indexmap 2.7.1",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tracing",
 ]
 
@@ -4517,7 +4308,7 @@ dependencies = [
  "indexmap 2.7.1",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tracing",
 ]
 
@@ -4530,22 +4321,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
-]
-
-[[package]]
-name = "handlebars"
-version = "6.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759e2d5aea3287cb1190c8ec394f42866cb5bf74fcbf213f354e3c856ea26098"
-dependencies = [
- "derive_builder",
- "log",
- "num-order",
- "pest",
- "pest_derive",
- "serde",
- "serde_json",
- "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -4599,39 +4374,6 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
-]
-
-[[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "headers-core",
- "http 1.2.0",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http 1.2.0",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -4848,26 +4590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-http-proxy"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
-dependencies = [
- "bytes",
- "futures-util",
- "headers",
- "http 1.2.0",
- "hyper 1.5.2",
- "hyper-rustls 0.27.4",
- "hyper-util",
- "pin-project-lite",
- "rustls-native-certs 0.7.3",
- "tokio",
- "tokio-rustls 0.26.1",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4893,14 +4615,13 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.5.2",
  "hyper-util",
- "log",
  "rustls 0.23.20",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
  "tower-service",
- "webpki-roots 0.26.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5129,7 +4850,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -5207,7 +4927,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "parquet",
- "reqwest 0.12.9",
+ "reqwest",
  "sea-orm",
  "sea-orm-migration",
  "serde",
@@ -5425,41 +5145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json-patch"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
-dependencies = [
- "jsonptr",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "jsonpath-rust"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
-dependencies = [
- "pest",
- "pest_derive",
- "regex",
- "serde_json",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "jsonptr"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "jsonwebtoken"
 version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5468,23 +5153,10 @@ dependencies = [
  "base64 0.21.7",
  "js-sys",
  "pem",
- "ring 0.17.13",
+ "ring",
  "serde",
  "serde_json",
  "simple_asn1",
-]
-
-[[package]]
-name = "k8s-openapi"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "serde",
- "serde-value",
- "serde_json",
 ]
 
 [[package]]
@@ -5494,117 +5166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
-]
-
-[[package]]
-name = "kube"
-version = "0.98.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32053dc495efad4d188c7b33cc7c02ef4a6e43038115348348876efd39a53cba"
-dependencies = [
- "k8s-openapi",
- "kube-client",
- "kube-core",
- "kube-derive",
- "kube-runtime",
-]
-
-[[package]]
-name = "kube-client"
-version = "0.98.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d34ad38cdfbd1fa87195d42569f57bb1dda6ba5f260ee32fef9570b7937a0c9"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "chrono",
- "either",
- "futures",
- "home",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.5.2",
- "hyper-http-proxy",
- "hyper-rustls 0.27.4",
- "hyper-timeout 0.5.2",
- "hyper-util",
- "jsonpath-rust",
- "k8s-openapi",
- "kube-core",
- "pem",
- "rustls 0.23.20",
- "rustls-pemfile 2.2.0",
- "secrecy",
- "serde",
- "serde_json",
- "serde_yaml 0.9.34+deprecated",
- "thiserror 2.0.11",
- "tokio",
- "tokio-util 0.7.13",
- "tower 0.5.2",
- "tower-http",
- "tracing",
-]
-
-[[package]]
-name = "kube-core"
-version = "0.98.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97aa830b288a178a90e784d1b0f1539f2d200d2188c7b4a3146d9dc983d596f3"
-dependencies = [
- "chrono",
- "form_urlencoded",
- "http 1.2.0",
- "json-patch",
- "k8s-openapi",
- "schemars 0.8.22",
- "serde",
- "serde-value",
- "serde_json",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "kube-derive"
-version = "0.98.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37745d8a4076b77e0b1952e94e358726866c8e14ec94baaca677d47dcdb98658"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "kube-runtime"
-version = "0.98.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a41af186a0fe80c71a13a13994abdc3ebff80859ca6a4b8a6079948328c135b"
-dependencies = [
- "ahash 0.8.11",
- "async-broadcast",
- "async-stream",
- "async-trait",
- "backoff",
- "educe",
- "futures",
- "hashbrown 0.15.2",
- "hostname 0.4.0",
- "json-patch",
- "jsonptr",
- "k8s-openapi",
- "kube-client",
- "parking_lot",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 2.0.11",
- "tokio",
- "tokio-util 0.7.13",
- "tracing",
 ]
 
 [[package]]
@@ -5650,7 +5211,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -5681,7 +5242,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.1",
  "url",
- "webpki-roots 0.26.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5869,12 +5430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5977,15 +5532,6 @@ dependencies = [
  "serde",
  "sparsevec",
  "vob",
-]
-
-[[package]]
-name = "lru"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-dependencies = [
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -6191,12 +5737,6 @@ dependencies = [
  "triomphe",
  "uuid",
 ]
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multimap"
@@ -6441,21 +5981,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-modular"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
-
-[[package]]
-name = "num-order"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
-dependencies = [
- "num-modular",
-]
-
-[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6514,148 +6039,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "o2_dex"
-version = "0.1.0"
-dependencies = [
- "ahash 0.8.11",
- "anyhow",
- "arc-swap",
- "chrono",
- "config",
- "dotenv_config",
- "dotenvy",
- "log",
- "oauth2",
- "once_cell",
- "openidconnect",
- "rand",
- "reqwest 0.12.9",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "o2_enterprise"
-version = "0.1.0"
-dependencies = [
- "aes-siv",
- "ahash 0.8.11",
- "anyhow",
- "arc-swap",
- "async-trait",
- "async-walkdir",
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "chrono",
- "config",
- "dashmap",
- "dotenv_config",
- "dotenvy",
- "either",
- "futures-util",
- "handlebars",
- "hashbrown 0.15.2",
- "http 1.2.0",
- "infra",
- "ingester",
- "itertools 0.13.0",
- "k8s-openapi",
- "kube",
- "log",
- "o2_openfga",
- "once_cell",
- "opentelemetry 0.26.0",
- "parquet",
- "proto",
- "rand",
- "regex",
- "reqwest 0.12.9",
- "serde",
- "serde_json",
- "serde_yaml 0.9.34+deprecated",
- "snafu 0.7.5",
- "sqlparser",
- "svix-ksuid",
- "tempfile",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tonic 0.12.3",
- "tracing",
- "tracing-opentelemetry",
- "url",
- "wal",
- "zip 3.0.0",
-]
-
-[[package]]
-name = "o2_openfga"
-version = "0.1.0"
-dependencies = [
- "ahash 0.8.11",
- "anyhow",
- "arc-swap",
- "config",
- "dashmap",
- "dotenv_config",
- "dotenvy",
- "log",
- "o2_dex",
- "once_cell",
- "openfga-sdk",
- "reqwest 0.12.9",
- "serde",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "o2_ratelimit"
-version = "0.1.0"
-dependencies = [
- "actix-utils",
- "actix-web",
- "anyhow",
- "async-trait",
- "bytes",
- "chrono",
- "config",
- "futures",
- "infra",
- "log",
- "o2_enterprise",
- "o2_openfga",
- "once_cell",
- "regex",
- "sentinel-core",
- "serde",
- "serde_json",
- "tokio",
- "utoipa",
-]
-
-[[package]]
-name = "oauth2"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "getrandom 0.2.15",
- "http 0.2.12",
- "rand",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2",
- "thiserror 1.0.69",
- "url",
 ]
 
 [[package]]
@@ -6721,8 +6104,8 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.37.2",
  "rand",
- "reqwest 0.12.9",
- "ring 0.17.13",
+ "reqwest",
+ "ring",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -6800,51 +6183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openfga-sdk"
-version = "1.0.2"
-source = "git+https://github.com/openobserve/openfga-sdk?rev=122eb78d28f31dd3512a3a10304552dae4465a53#122eb78d28f31dd3512a3a10304552dae4465a53"
-dependencies = [
- "reqwest 0.12.9",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "openidconnect"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47e80a9cfae4462dd29c41e987edd228971d6565553fbc14b8a11e666d91590"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "dyn-clone",
- "ed25519-dalek",
- "hmac",
- "http 0.2.12",
- "itertools 0.10.5",
- "log",
- "oauth2",
- "p256",
- "p384",
- "rand",
- "rsa",
- "serde",
- "serde-value",
- "serde_derive",
- "serde_json",
- "serde_path_to_error",
- "serde_plain",
- "serde_with",
- "sha2",
- "subtle",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
 name = "openobserve"
 version = "0.14.6"
 dependencies = [
@@ -6920,10 +6258,6 @@ dependencies = [
  "memchr",
  "mimalloc",
  "mime",
- "o2_dex",
- "o2_enterprise",
- "o2_openfga",
- "o2_ratelimit",
  "object_store",
  "once_cell",
  "opentelemetry 0.26.0",
@@ -6946,7 +6280,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.5",
  "report_server",
- "reqwest 0.12.9",
+ "reqwest",
  "rust-embed-for-web",
  "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
@@ -6970,7 +6304,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tonic 0.12.3",
  "tracing",
  "tracing-appender",
@@ -7031,7 +6365,7 @@ dependencies = [
  "bytes",
  "http 1.2.0",
  "opentelemetry 0.26.0",
- "reqwest 0.12.9",
+ "reqwest",
 ]
 
 [[package]]
@@ -7048,7 +6382,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.4",
- "reqwest 0.12.9",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -7193,30 +6527,6 @@ name = "owo-colors"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
 
 [[package]]
 name = "packedvec"
@@ -7607,7 +6917,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prost 0.12.6",
- "prost-build 0.12.6",
+ "prost-build",
  "prost-derive 0.12.6",
  "sha2",
  "smallvec",
@@ -7683,15 +6993,6 @@ dependencies = [
  "lazy_static",
  "term 0.7.0",
  "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -7837,16 +7138,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
@@ -7877,26 +7168,6 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap 0.8.3",
- "petgraph 0.6.5",
- "prost 0.9.0",
- "prost-types 0.9.0",
- "regex",
- "tempfile",
- "which 4.4.2",
-]
-
-[[package]]
-name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
@@ -7905,7 +7176,7 @@ dependencies = [
  "heck 0.5.0",
  "itertools 0.12.1",
  "log",
- "multimap 0.10.0",
+ "multimap",
  "once_cell",
  "petgraph 0.6.5",
  "prettyplease",
@@ -7914,19 +7185,6 @@ dependencies = [
  "regex",
  "syn 2.0.90",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7981,16 +7239,6 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost 0.9.0",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
@@ -8015,7 +7263,7 @@ dependencies = [
  "datafusion",
  "datafusion-proto",
  "prost 0.13.4",
- "prost-build 0.12.6",
+ "prost-build",
  "serde",
  "serde_json",
  "tokio",
@@ -8178,7 +7426,7 @@ dependencies = [
  "log",
  "names",
  "prost 0.11.9",
- "reqwest 0.12.9",
+ "reqwest",
  "serde_json",
  "thiserror 1.0.69",
  "url",
@@ -8269,7 +7517,7 @@ dependencies = [
  "bytes",
  "getrandom 0.2.15",
  "rand",
- "ring 0.17.13",
+ "ring",
  "rustc-hash 2.1.0",
  "rustls 0.23.20",
  "rustls-pki-types",
@@ -8442,26 +7690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8548,47 +7776,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg 0.50.0",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
@@ -8609,7 +7796,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -8624,25 +7810,15 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.1",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.7",
+ "webpki-roots",
  "windows-registry",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -8656,21 +7832,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
@@ -8679,7 +7840,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -8918,27 +8079,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.1",
- "log",
- "ring 0.16.20",
- "sct 0.6.1",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.13",
+ "ring",
  "rustls-webpki 0.101.7",
- "sct 0.7.1",
+ "sct",
 ]
 
 [[package]]
@@ -8949,7 +8097,7 @@ checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.13",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -9026,8 +8174,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.13",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -9036,9 +8184,9 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.13",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -9100,54 +8248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9155,22 +8255,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
-
-[[package]]
-name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.13",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -9339,29 +8429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9404,7 +8471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bdca318192c89bb31bffa2ef8e9e9898bc80f15a78db2fdd41cd051f1b41d01"
 dependencies = [
  "async-trait",
- "reqwest 0.12.9",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -9416,28 +8483,6 @@ name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
-
-[[package]]
-name = "sentinel-core"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df414b30ed5b82da4badac3071fa6dddf8b77d497de79c3ef4b5af1a39fe2f3e"
-dependencies = [
- "anyhow",
- "cfg-if",
- "enum-map",
- "etcd-rs",
- "futures",
- "lazy_static",
- "log",
- "lru 0.7.8",
- "serde",
- "serde_json",
- "serde_yaml 0.8.26",
- "sysinfo 0.26.9",
- "time",
- "uuid",
-]
 
 [[package]]
 name = "seq-macro"
@@ -9455,31 +8500,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float 2.10.1",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9521,16 +8545,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
-dependencies = [
- "itoa",
- "serde",
-]
-
-[[package]]
 name = "serde_plain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9560,50 +8574,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.7.1",
- "schemars 0.9.0",
- "schemars 1.0.4",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]
@@ -9881,12 +8851,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
@@ -9977,7 +8941,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 0.26.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -10319,21 +9283,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
@@ -10354,27 +9303,6 @@ checksum = "161028c00842709450114c39db3b29f44c898055ed8833bb9b535aba7facf30e"
 dependencies = [
  "chrono",
  "nom",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -10406,7 +9334,7 @@ dependencies = [
  "itertools 0.12.1",
  "levenshtein_automata",
  "log",
- "lru 0.12.5",
+ "lru",
  "lz4_flex",
  "measure_time",
  "memmap2",
@@ -10781,17 +9709,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
@@ -10835,20 +9752,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
@@ -10858,7 +9761,6 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "pin-project-lite",
- "slab",
  "tokio",
 ]
 
@@ -10875,12 +9777,12 @@ dependencies = [
  "http 1.2.0",
  "httparse",
  "rand",
- "ring 0.17.13",
+ "ring",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
- "tokio-util 0.7.13",
- "webpki-roots 0.26.7",
+ "tokio-util",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -10909,38 +9811,6 @@ dependencies = [
  "indexmap 2.7.1",
  "toml_datetime",
  "winnow 0.6.20",
-]
-
-[[package]]
-name = "tonic"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64 0.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout 0.4.1",
- "percent-encoding",
- "pin-project",
- "prost 0.9.0",
- "prost-derive 0.9.0",
- "tokio",
- "tokio-rustls 0.22.0",
- "tokio-stream",
- "tokio-util 0.6.10",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -11008,25 +9878,13 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
-dependencies = [
- "proc-macro2",
- "prost-build 0.9.0",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "tonic-build"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.12.6",
+ "prost-build",
  "quote",
  "syn 2.0.90",
 ]
@@ -11039,7 +9897,7 @@ checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.12.6",
+ "prost-build",
  "quote",
  "syn 2.0.90",
 ]
@@ -11058,7 +9916,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -11074,29 +9932,8 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 1.0.2",
- "tokio",
- "tokio-util 0.7.13",
  "tower-layer",
  "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
-dependencies = [
- "base64 0.22.1",
- "bitflags 2.9.0",
- "bytes",
- "http 1.2.0",
- "http-body 1.0.1",
- "mime",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -11154,16 +9991,6 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -11294,7 +10121,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_derive",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -11381,12 +10208,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -11853,40 +10674,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]
@@ -12293,16 +11086,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
@@ -12370,15 +11153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["enterprise"]
-enterprise = [
-    "dep:o2_enterprise",
-    "dep:o2_openfga",
-    "dep:o2_dex",
-    "dep:o2_ratelimit",
-]
+default = []
+enterprise = []
 mimalloc = ["dep:mimalloc"]
 jemalloc = ["dep:tikv-jemallocator"]
 profiling = ["dep:pprof"]
@@ -110,6 +105,7 @@ hashlink.workspace = true
 hashbrown.workspace = true
 hex.workspace = true
 http-auth-basic = "0.3"
+tantivy-fst.workspace = true
 ipnetwork.workspace = true
 itertools.workspace = true
 jsonwebtoken = "9.3"
@@ -117,10 +113,6 @@ log.workspace = true
 maxminddb = "0.25"
 memchr.workspace = true
 mimalloc = { version = "0.1.43", default-features = false, optional = true }
-o2_dex = { version = "0.1.0", path = "../o2-enterprise/o2_dex", optional = true }
-o2_enterprise = { version = "0.1.0", path = "../o2-enterprise/o2_enterprise", optional = true, default-features = false }
-o2_openfga = { version = "0.1.0", path = "../o2-enterprise/o2_openfga", optional = true }
-o2_ratelimit = { version = "0.1.0", path = "../o2-enterprise/o2_ratelimit", optional = true }
 once_cell.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
@@ -181,7 +173,6 @@ report_server.workspace = true
 chromiumoxide.workspace = true
 lettre.workspace = true
 tantivy.workspace = true
-tantivy-fst.workspace = true
 zip.workspace = true
 futures-util = "0.3.31"
 tokio-tungstenite = "0.24.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,13 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
-enterprise = []
+default = ["enterprise"]
+enterprise = [
+    "dep:o2_enterprise",
+    "dep:o2_openfga",
+    "dep:o2_dex",
+    "dep:o2_ratelimit",
+]
 mimalloc = ["dep:mimalloc"]
 jemalloc = ["dep:tikv-jemallocator"]
 profiling = ["dep:pprof"]
@@ -105,7 +110,6 @@ hashlink.workspace = true
 hashbrown.workspace = true
 hex.workspace = true
 http-auth-basic = "0.3"
-tantivy-fst.workspace = true
 ipnetwork.workspace = true
 itertools.workspace = true
 jsonwebtoken = "9.3"
@@ -113,6 +117,10 @@ log.workspace = true
 maxminddb = "0.25"
 memchr.workspace = true
 mimalloc = { version = "0.1.43", default-features = false, optional = true }
+o2_dex = { version = "0.1.0", path = "../o2-enterprise/o2_dex", optional = true }
+o2_enterprise = { version = "0.1.0", path = "../o2-enterprise/o2_enterprise", optional = true, default-features = false }
+o2_openfga = { version = "0.1.0", path = "../o2-enterprise/o2_openfga", optional = true }
+o2_ratelimit = { version = "0.1.0", path = "../o2-enterprise/o2_ratelimit", optional = true }
 once_cell.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
@@ -173,6 +181,7 @@ report_server.workspace = true
 chromiumoxide.workspace = true
 lettre.workspace = true
 tantivy.workspace = true
+tantivy-fst.workspace = true
 zip.workspace = true
 futures-util = "0.3.31"
 tokio-tungstenite = "0.24.0"

--- a/src/common/utils/auth_tests.rs
+++ b/src/common/utils/auth_tests.rs
@@ -3142,6 +3142,7 @@ mod tests {
                 data_tmp_dir: String::default(),
                 default_hec_stream: String::default(),
                 align_partitions_for_index: bool::default(),
+                meta_ddl_dsn: String::default(),
             },
             limit: config::Limit {
                 cpu_num: usize::default(),

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -233,6 +233,8 @@ pub struct Response {
     pub order_by: Option<OrderBy>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub converted_histogram_query: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_histogram_eligible: Option<bool>,
 }
 
 /// Iterator for Streaming response of search `Response`
@@ -395,6 +397,7 @@ impl Response {
             work_group: None,
             order_by: None,
             converted_histogram_query: None,
+            is_histogram_eligible: None,
         }
     }
 

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -564,6 +564,8 @@ pub struct SearchPartitionResponse {
     pub streaming_output: bool,
     pub streaming_aggs: bool,
     pub streaming_id: Option<String>,
+    #[serde(default)]
+    pub is_histogram_eligible: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, ToSchema)]

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -235,6 +235,8 @@ pub struct Response {
     pub converted_histogram_query: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_histogram_eligible: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub converted_histogram_query: Option<String>,
 }
 
 /// Iterator for Streaming response of search `Response`
@@ -398,6 +400,7 @@ impl Response {
             order_by: None,
             converted_histogram_query: None,
             is_histogram_eligible: None,
+            converted_histogram_query: None,
         }
     }
 

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -235,8 +235,6 @@ pub struct Response {
     pub converted_histogram_query: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_histogram_eligible: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub converted_histogram_query: Option<String>,
 }
 
 /// Iterator for Streaming response of search `Response`
@@ -400,7 +398,6 @@ impl Response {
             order_by: None,
             converted_histogram_query: None,
             is_histogram_eligible: None,
-            converted_histogram_query: None,
         }
     }
 

--- a/src/config/src/utils/sql.rs
+++ b/src/config/src/utils/sql.rs
@@ -171,8 +171,7 @@ pub fn is_eligible_for_histogram(query: &str) -> Result<bool, sqlparser::parser:
     let ast = Parser::parse_sql(&GenericDialect {}, query)?;
     for statement in ast.iter() {
         if let Statement::Query(query) = statement {
-            if has_subquery(statement) || has_distinct(query) || has_limit(query) || has_cte(query)
-            {
+            if has_distinct(query) || has_limit(query) || has_cte(query) {
                 return Ok(false);
             }
         }

--- a/src/handler/http/request/search/error_utils.rs
+++ b/src/handler/http/request/search/error_utils.rs
@@ -37,7 +37,8 @@ pub fn map_error_to_http_response(err: &errors::Error, trace_id: Option<String>)
             | errors::ErrorCodes::SearchFieldNotFound(_)
             | errors::ErrorCodes::SearchSQLNotValid(_)
             | errors::ErrorCodes::SearchStreamNotFound(_)
-            | errors::ErrorCodes::SearchCancelQuery(_) => HttpResponse::BadRequest()
+            | errors::ErrorCodes::SearchCancelQuery(_)
+            | errors::ErrorCodes::SearchHistogramNotAvailable(_) => HttpResponse::BadRequest()
                 .append_header((ERROR_HEADER, code.to_json()))
                 .json(MetaHttpResponse::error_code_with_trace_id(code, trace_id)),
 

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -257,7 +257,7 @@ pub async fn search(
                 converted_histogram_query = Some(req.query.sql.clone());
             }
             Err(e) => {
-                return Ok(map_error_to_http_response(&(e.into()), Some(trace_id)));
+                return Ok(map_error_to_http_response(&(e), Some(trace_id)));
             }
         }
     }

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -257,7 +257,7 @@ pub async fn search(
                 converted_histogram_query = Some(req.query.sql.clone());
             }
             Err(e) => {
-                return Ok(MetaHttpResponse::bad_request(e));
+                return Ok(map_error_to_http_response(&(e.into()), Some(trace_id)));
             }
         }
     }

--- a/src/handler/http/request/search/search_stream.rs
+++ b/src/handler/http/request/search/search_stream.rs
@@ -221,7 +221,7 @@ pub async fn search_http2_stream(
                 req.query.sql = histogram_query;
             }
             Err(e) => {
-                return map_error_to_http_response(&(e.into()), Some(trace_id));
+                return map_error_to_http_response(&(e), Some(trace_id));
             }
         }
     }

--- a/src/handler/http/request/search/search_stream.rs
+++ b/src/handler/http/request/search/search_stream.rs
@@ -221,7 +221,7 @@ pub async fn search_http2_stream(
                 req.query.sql = histogram_query;
             }
             Err(e) => {
-                return MetaHttpResponse::bad_request(e);
+                return map_error_to_http_response(&(e.into()), Some(trace_id));
             }
         }
     }

--- a/src/infra/src/errors/mod.rs
+++ b/src/infra/src/errors/mod.rs
@@ -193,6 +193,7 @@ pub enum ErrorCodes {
     SearchTimeout(String),
     InvalidParams(String),
     RatelimitExceeded(String),
+    SearchHistogramNotAvailable(String),
 }
 
 impl From<sea_orm::DbErr> for Error {
@@ -247,6 +248,7 @@ impl ErrorCodes {
             ErrorCodes::SearchTimeout(_) => 20010,
             ErrorCodes::InvalidParams(_) => 20011,
             ErrorCodes::RatelimitExceeded(_) => 20012,
+            ErrorCodes::SearchHistogramNotAvailable(_) => 20013,
         }
     }
 
@@ -273,6 +275,9 @@ impl ErrorCodes {
             ErrorCodes::SearchTimeout(_) => "Search query timed out".to_string(),
             ErrorCodes::InvalidParams(_) => "Invalid parameters".to_string(),
             ErrorCodes::RatelimitExceeded(_) => "Ratelimit exceeded".to_string(),
+            ErrorCodes::SearchHistogramNotAvailable(_) => {
+                "Search histogram not available".to_string()
+            }
         }
     }
 
@@ -291,6 +296,7 @@ impl ErrorCodes {
             ErrorCodes::SearchTimeout(msg) => msg.to_owned(),
             ErrorCodes::InvalidParams(msg) => msg.to_owned(),
             ErrorCodes::RatelimitExceeded(msg) => msg.to_owned(),
+            ErrorCodes::SearchHistogramNotAvailable(msg) => msg.to_owned(),
         }
     }
 
@@ -309,6 +315,7 @@ impl ErrorCodes {
             ErrorCodes::SearchTimeout(msg) => msg.to_owned(),
             ErrorCodes::InvalidParams(msg) => msg.to_owned(),
             ErrorCodes::RatelimitExceeded(msg) => msg.to_owned(),
+            ErrorCodes::SearchHistogramNotAvailable(msg) => msg.to_owned(),
         }
     }
 
@@ -358,6 +365,9 @@ impl ErrorCodes {
             20008 => Ok(ErrorCodes::SearchSQLExecuteError(message)),
             20009 => Ok(ErrorCodes::SearchCancelQuery(message)),
             20010 => Ok(ErrorCodes::SearchTimeout(message)),
+            20011 => Ok(ErrorCodes::InvalidParams(message)),
+            20012 => Ok(ErrorCodes::RatelimitExceeded(message)),
+            20013 => Ok(ErrorCodes::SearchHistogramNotAvailable(message)),
             _ => Ok(ErrorCodes::ServerInternalError(json.to_string())),
         }
     }

--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -852,6 +852,7 @@ mod tests {
                 work_group: None,
                 order_by: Some(OrderBy::Asc),
                 is_histogram_eligible: None,
+                converted_histogram_query: None,
             },
             deltas: vec![],
             has_cached_data: true,

--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -728,7 +728,7 @@ pub fn handle_histogram(
         )
     };
 
-    let field = args.get(0).unwrap_or(&"_timestamp");
+    let field = args.first().unwrap_or(&"_timestamp");
 
     *origin_sql = origin_sql.replace(
         caps.get(0).unwrap().as_str(),

--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -851,6 +851,7 @@ mod tests {
                 result_cache_ratio: 33,
                 work_group: None,
                 order_by: Some(OrderBy::Asc),
+                is_histogram_eligible: None,
             },
             deltas: vec![],
             has_cached_data: true,

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -431,7 +431,9 @@ pub async fn search(
         res.new_end_time = Some(req.query.end_time);
     }
 
-    res.is_histogram_eligible = is_eligible_for_histogram(&req.query.sql).ok();
+    res.is_histogram_eligible = is_eligible_for_histogram(&req.query.sql)
+        .ok()
+        .map(|(is_eligible, _)| is_eligible);
 
     // There are 3 types of partial responses:
     // 1. VRL error

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -26,7 +26,13 @@ use config::{
         sql::{OrderBy, resolve_stream_names},
         stream::StreamType,
     },
-    utils::{base64, hash::Sum64, json, sql::is_aggregate_query, time::format_duration},
+    utils::{
+        base64,
+        hash::Sum64,
+        json,
+        sql::{is_aggregate_query, is_eligible_for_histogram},
+        time::format_duration,
+    },
 };
 use infra::{
     cache::{file_data::disk::QUERY_RESULT_CACHE, meta::ResultCacheMeta},
@@ -368,7 +374,7 @@ pub async fn search(
         } else {
             None
         },
-        request_body: Some(req.query.sql),
+        request_body: Some(req.query.sql.clone()),
         function: req.query.query_fn,
         user_email: user_id,
         min_ts: Some(req.query.start_time),
@@ -424,6 +430,8 @@ pub async fn search(
         res.new_start_time = Some(req.query.start_time);
         res.new_end_time = Some(req.query.end_time);
     }
+
+    res.is_histogram_eligible = is_eligible_for_histogram(&req.query.sql).ok();
 
     // There are 3 types of partial responses:
     // 1. VRL error

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -1311,6 +1311,8 @@ pub async fn search_partition_multi(
         };
     }
     res.records = total_rec;
+    // Histogram is not eligible for multi-stream search
+    res.is_histogram_eligible = false;
     Ok(res)
 }
 

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -775,7 +775,7 @@ pub async fn search_partition(
         (records + f.records, original_size + f.original_size)
     });
 
-    let is_histogram_eligible = is_eligible_for_histogram(&req.sql).unwrap_or(false);
+    let (is_histogram_eligible, _) = is_eligible_for_histogram(&req.sql).unwrap_or((false, false));
 
     let mut resp = search::SearchPartitionResponse {
         trace_id: trace_id.to_string(),

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -869,11 +869,14 @@ pub async fn search_partition(
     }
 
     let mut is_histogram = sql.histogram_interval.is_some();
+    let mut add_mini_partition = false;
     // Set this to true to generate partitions aligned with interval
     // only for logs page when query is non-histogram, so that logs can reuse the same partitions
     // for histogram query
     if !is_histogram && req.search_type.eq(&Some(SearchEventType::UI)) {
         is_histogram = true;
+        // add mini partition for the histogram aligned partitions in the UI search
+        add_mini_partition = true;
     }
 
     let sql_order_by = sql
@@ -908,8 +911,13 @@ pub async fn search_partition(
     }
 
     // Generate partitions
-    let partitions =
-        generator.generate_partitions(req.start_time, req.end_time, step, sql_order_by);
+    let partitions = generator.generate_partitions(
+        req.start_time,
+        req.end_time,
+        step,
+        sql_order_by,
+        add_mini_partition,
+    );
 
     if sql_order_by == OrderBy::Asc {
         resp.order_by = OrderBy::Asc;

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -912,7 +912,7 @@ pub async fn search_partition(
         })
         .unwrap_or(OrderBy::Desc);
 
-    log::debug!(
+    log::info!(
         "[trace_id {trace_id}] total_secs: {}, partition_num: {}, step: {}, min_step: {}, is_histogram: {}",
         total_secs,
         part_num,

--- a/src/service/search/partition.rs
+++ b/src/service/search/partition.rs
@@ -206,7 +206,7 @@ impl PartitionGenerator {
                         remaining_end,
                         end_time,
                         step,
-                        OrderBy::Desc,
+                        OrderBy::Asc,
                     );
                     partitions.extend(remaining_partitions);
                 }
@@ -572,12 +572,13 @@ mod tests {
         );
     }
 
+    // Actual start
     #[test]
-    fn test_partition_generator_with_histogram_alignment_and_mini_partition() {
-        // Test case: 10:02 - 10:17 with 5-minute histogram interval and mini partition
-        let start_time = 1617267720000000; // 10:02
-        let end_time = 1617268620000000; // 10:17
-        let min_step = 300000000; // 5 minutes in microseconds
+    fn test_partition_generator_with_histogram_alignment_no_mini_partition_order_by_desc() {
+        let start_time = 1753763400000000; // Tuesday, July 29, 2025 at 10:00:00 AM GMT+5:30
+        let end_time = 1753806600000000; // Tuesday, July 29, 2025 at 10:00:00 PM GMT+5:30
+        let min_step_seconds = 1800; // 30 minutes in seconds
+        let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
         let mini_partition_duration_secs = 60;
 
         let generator = PartitionGenerator::new(
@@ -585,65 +586,285 @@ mod tests {
             mini_partition_duration_secs,
             true, // is_histogram = true
         );
-        let step = 300000000; // 5 minutes
+        let step = min_step; // 30 minutes in microseconds
 
         let partitions = generator.generate_partitions(
             start_time,
             end_time,
             step,
             OrderBy::Desc,
-            true, // add_mini_partition = true
+            false, // add_mini_partition = false
         );
 
-        // Expected partitions with mini partition and histogram alignment:
-        // 1. 10:16 - 10:17 (mini partition)
-        // 2. 10:15 - 10:16 (histogram aligned)
-        // 3. 10:10 - 10:15 (histogram aligned)
-        // 4. 10:05 - 10:10 (histogram aligned)
-        // 5. 10:02 - 10:05 (histogram aligned)
+        // Print the actual partitions for debugging
+        println!("HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):");
+        println!("Number of partitions: {}", partitions.len());
+        for (i, [start, end]) in partitions.iter().enumerate() {
+            // Convert to human-readable time for debugging
+            let start = chrono::DateTime::from_timestamp_micros(*start)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string();
+            let end = chrono::DateTime::from_timestamp_micros(*end)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string();
+            println!("Partition {}: {} - {}", i + 1, start, end);
+        }
+
+        // HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):
+        // Number of partitions: 24
+        // Partition 1: 2025-07-29 21:30:00 - 2025-07-29 22:00:00
+        // Partition 2: 2025-07-29 21:00:00 - 2025-07-29 21:30:00
+        // Partition 3: 2025-07-29 20:30:00 - 2025-07-29 21:00:00
+        // Partition 4: 2025-07-29 20:00:00 - 2025-07-29 20:30:00
+        // Partition 5: 2025-07-29 19:30:00 - 2025-07-29 20:00:00
+        // Partition 6: 2025-07-29 19:00:00 - 2025-07-29 19:30:00
+        // Partition 7: 2025-07-29 18:30:00 - 2025-07-29 19:00:00
+        // Partition 8: 2025-07-29 18:00:00 - 2025-07-29 18:30:00
+        // Partition 9: 2025-07-29 17:30:00 - 2025-07-29 18:00:00
+        // Partition 10: 2025-07-29 17:00:00 - 2025-07-29 17:30:00
+        // Partition 11: 2025-07-29 16:30:00 - 2025-07-29 17:00:00
+        // Partition 12: 2025-07-29 16:00:00 - 2025-07-29 16:30:00
+        // Partition 13: 2025-07-29 15:30:00 - 2025-07-29 16:00:00
+        // Partition 14: 2025-07-29 15:00:00 - 2025-07-29 15:30:00
+        // Partition 15: 2025-07-29 14:30:00 - 2025-07-29 15:00:00
+        // Partition 16: 2025-07-29 14:00:00 - 2025-07-29 14:30:00
+        // Partition 17: 2025-07-29 13:30:00 - 2025-07-29 14:00:00
+        // Partition 18: 2025-07-29 13:00:00 - 2025-07-29 13:30:00
+        // Partition 19: 2025-07-29 12:30:00 - 2025-07-29 13:00:00
+        // Partition 20: 2025-07-29 12:00:00 - 2025-07-29 12:30:00
+        // Partition 21: 2025-07-29 11:30:00 - 2025-07-29 12:00:00
+        // Partition 22: 2025-07-29 11:00:00 - 2025-07-29 11:30:00
+        // Partition 23: 2025-07-29 10:30:00 - 2025-07-29 11:00:00
+        // Partition 24: 2025-07-29 10:00:00 - 2025-07-29 10:30:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.last().unwrap()[0], start_time);
+        assert_eq!(partitions.first().unwrap()[1], end_time);
+    }
+
+    #[test]
+    fn test_partition_generator_with_histogram_alignment_and_mini_partition_order_by_desc() {
+        let start_time = 1753763400000000; // Tuesday, July 29, 2025 at 10:00:00 AM GMT+5:30
+        let end_time = 1753806600000000; // Tuesday, July 29, 2025 at 10:00:00 PM GMT+5:30
+        let min_step_seconds = 1800; // 30 minutes in seconds
+        let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            true, // is_histogram = true
+        );
+        let step = min_step; // 30 minutes in microseconds
+
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Desc,
+            true, // add_mini_partition = false
+        );
 
         // Print the actual partitions for debugging
         println!("HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):");
         println!("Number of partitions: {}", partitions.len());
         for (i, [start, end]) in partitions.iter().enumerate() {
             // Convert to human-readable time for debugging
-            let start_mins = (start - 1617267600000000) / 60000000; // Minutes since 10:00
-            let end_mins = (end - 1617267600000000) / 60000000;
-            println!(
-                "Partition {}: 10:{:02} - 10:{:02} ({} - {})",
-                i + 1,
-                start_mins,
-                end_mins,
-                start,
-                end
-            );
+            let start = chrono::DateTime::from_timestamp_micros(*start)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string();
+            let end = chrono::DateTime::from_timestamp_micros(*end)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string();
+            println!("Partition {}: {} - {}", i + 1, start, end);
         }
+
+        // HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):
+        // Number of partitions: 25
+        // Partition 1: 2025-07-29 21:59:00 - 2025-07-29 22:00:00
+        // Partition 2: 2025-07-29 21:30:00 - 2025-07-29 21:59:00
+        // Partition 3: 2025-07-29 21:00:00 - 2025-07-29 21:30:00
+        // Partition 4: 2025-07-29 20:30:00 - 2025-07-29 21:00:00
+        // Partition 5: 2025-07-29 20:00:00 - 2025-07-29 20:30:00
+        // Partition 6: 2025-07-29 19:30:00 - 2025-07-29 20:00:00
+        // Partition 7: 2025-07-29 19:00:00 - 2025-07-29 19:30:00
+        // Partition 8: 2025-07-29 18:30:00 - 2025-07-29 19:00:00
+        // Partition 9: 2025-07-29 18:00:00 - 2025-07-29 18:30:00
+        // Partition 10: 2025-07-29 17:30:00 - 2025-07-29 18:00:00
+        // Partition 11: 2025-07-29 17:00:00 - 2025-07-29 17:30:00
+        // Partition 12: 2025-07-29 16:30:00 - 2025-07-29 17:00:00
+        // Partition 13: 2025-07-29 16:00:00 - 2025-07-29 16:30:00
+        // Partition 14: 2025-07-29 15:30:00 - 2025-07-29 16:00:00
+        // Partition 15: 2025-07-29 15:00:00 - 2025-07-29 15:30:00
+        // Partition 16: 2025-07-29 14:30:00 - 2025-07-29 15:00:00
+        // Partition 17: 2025-07-29 14:00:00 - 2025-07-29 14:30:00
+        // Partition 18: 2025-07-29 13:30:00 - 2025-07-29 14:00:00
+        // Partition 19: 2025-07-29 13:00:00 - 2025-07-29 13:30:00
+        // Partition 20: 2025-07-29 12:30:00 - 2025-07-29 13:00:00
+        // Partition 21: 2025-07-29 12:00:00 - 2025-07-29 12:30:00
+        // Partition 22: 2025-07-29 11:30:00 - 2025-07-29 12:00:00
+        // Partition 23: 2025-07-29 11:00:00 - 2025-07-29 11:30:00
+        // Partition 24: 2025-07-29 10:30:00 - 2025-07-29 11:00:00
+        // Partition 25: 2025-07-29 10:00:00 - 2025-07-29 10:30:00
 
         // Verify full coverage of time range
         assert_eq!(partitions.last().unwrap()[0], start_time);
         assert_eq!(partitions.first().unwrap()[1], end_time);
+    }
 
-        // Verify mini partition is at the end (DESC order)
-        let mini_partition = &partitions[0];
-        let mini_partition_duration = mini_partition[1] - mini_partition[0];
-        assert!(
-            mini_partition_duration <= (mini_partition_duration_secs * 1_000_000) as i64,
-            "Mini partition size should not exceed the configured duration"
+    #[test]
+    fn test_partition_generator_with_histogram_alignment_no_mini_partition_order_by_asc() {
+        let start_time = 1753763400000000; // Tuesday, July 29, 2025 at 10:00:00 AM GMT+5:30
+        let end_time = 1753806600000000; // Tuesday, July 29, 2025 at 10:00:00 PM GMT+5:30
+        let min_step_seconds = 1800; // 30 minutes in seconds
+        let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            true, // is_histogram = true
         );
-        assert_eq!(
-            mini_partition[1], end_time,
-            "Mini partition should end at end_time"
+        let step = min_step; // 30 minutes in microseconds
+
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Asc,
+            false, // add_mini_partition = false
         );
 
-        // Verify histogram alignment for non-mini partitions
-        for (_i, [start, end]) in partitions.iter().enumerate().skip(1) {
-            if *start != start_time && *end != end_time {
-                assert_eq!(
-                    *start % min_step,
-                    0,
-                    "Partition start should align with histogram interval"
-                );
-            }
+        // Print the actual partitions for debugging
+        println!("HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):");
+        println!("Number of partitions: {}", partitions.len());
+        for (i, [start, end]) in partitions.iter().enumerate() {
+            // Convert to human-readable time for debugging
+            let start = chrono::DateTime::from_timestamp_micros(*start)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string();
+            let end = chrono::DateTime::from_timestamp_micros(*end)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string();
+            println!("Partition {}: {} - {}", i + 1, start, end);
         }
+
+        // HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):
+        // Number of partitions: 24
+        // Partition 1: 2025-07-29 10:00:00 - 2025-07-29 10:30:00
+        // Partition 2: 2025-07-29 10:30:00 - 2025-07-29 11:00:00
+        // Partition 3: 2025-07-29 11:00:00 - 2025-07-29 11:30:00
+        // Partition 4: 2025-07-29 11:30:00 - 2025-07-29 12:00:00
+        // Partition 5: 2025-07-29 12:00:00 - 2025-07-29 12:30:00
+        // Partition 6: 2025-07-29 12:30:00 - 2025-07-29 13:00:00
+        // Partition 7: 2025-07-29 13:00:00 - 2025-07-29 13:30:00
+        // Partition 8: 2025-07-29 13:30:00 - 2025-07-29 14:00:00
+        // Partition 9: 2025-07-29 14:00:00 - 2025-07-29 14:30:00
+        // Partition 10: 2025-07-29 14:30:00 - 2025-07-29 15:00:00
+        // Partition 11: 2025-07-29 15:00:00 - 2025-07-29 15:30:00
+        // Partition 12: 2025-07-29 15:30:00 - 2025-07-29 16:00:00
+        // Partition 13: 2025-07-29 16:00:00 - 2025-07-29 16:30:00
+        // Partition 14: 2025-07-29 16:30:00 - 2025-07-29 17:00:00
+        // Partition 15: 2025-07-29 17:00:00 - 2025-07-29 17:30:00
+        // Partition 16: 2025-07-29 17:30:00 - 2025-07-29 18:00:00
+        // Partition 17: 2025-07-29 18:00:00 - 2025-07-29 18:30:00
+        // Partition 18: 2025-07-29 18:30:00 - 2025-07-29 19:00:00
+        // Partition 19: 2025-07-29 19:00:00 - 2025-07-29 19:30:00
+        // Partition 20: 2025-07-29 19:30:00 - 2025-07-29 20:00:00
+        // Partition 21: 2025-07-29 20:00:00 - 2025-07-29 20:30:00
+        // Partition 22: 2025-07-29 20:30:00 - 2025-07-29 21:00:00
+        // Partition 23: 2025-07-29 21:00:00 - 2025-07-29 21:30:00
+        // Partition 24: 2025-07-29 21:30:00 - 2025-07-29 22:00:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.first().unwrap()[0], start_time);
+        assert_eq!(partitions.last().unwrap()[1], end_time);
+    }
+
+    #[test]
+    fn test_partition_generator_with_histogram_alignment_mini_partition_order_by_asc() {
+        // Test case: 10:02 - 10:17 with 5-minute histogram interval and mini partition
+        let start_time = 1753763400000000; // Tuesday, July 29, 2025 at 10:00:00 AM GMT+5:30
+        let end_time = 1753806600000000; // Tuesday, July 29, 2025 at 10:00:00 PM GMT+5:30
+        let min_step_seconds = 1800; // 30 minutes in seconds
+        let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            true, // is_histogram = true
+        );
+        let step = min_step; // 30 minutes in microseconds
+
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Asc,
+            true, // add_mini_partition = true
+        );
+
+        // Print the actual partitions for debugging
+        println!("HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):");
+        println!("Number of partitions: {}", partitions.len());
+        for (i, [start, end]) in partitions.iter().enumerate() {
+            // Convert to human-readable time for debugging
+            let start = chrono::DateTime::from_timestamp_micros(*start)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string();
+            let end = chrono::DateTime::from_timestamp_micros(*end)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string();
+            println!("Partition {}: {} - {}", i + 1, start, end);
+        }
+
+        // HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):
+        // Number of partitions: 25
+        // Partition 1: 2025-07-29 10:00:00 - 2025-07-29 10:01:00
+        // Partition 2: 2025-07-29 10:01:00 - 2025-07-29 10:30:00
+        // Partition 3: 2025-07-29 10:30:00 - 2025-07-29 11:00:00
+        // Partition 4: 2025-07-29 11:00:00 - 2025-07-29 11:30:00
+        // Partition 5: 2025-07-29 11:30:00 - 2025-07-29 12:00:00
+        // Partition 6: 2025-07-29 12:00:00 - 2025-07-29 12:30:00
+        // Partition 7: 2025-07-29 12:30:00 - 2025-07-29 13:00:00
+        // Partition 8: 2025-07-29 13:00:00 - 2025-07-29 13:30:00
+        // Partition 9: 2025-07-29 13:30:00 - 2025-07-29 14:00:00
+        // Partition 10: 2025-07-29 14:00:00 - 2025-07-29 14:30:00
+        // Partition 11: 2025-07-29 14:30:00 - 2025-07-29 15:00:00
+        // Partition 12: 2025-07-29 15:00:00 - 2025-07-29 15:30:00
+        // Partition 13: 2025-07-29 15:30:00 - 2025-07-29 16:00:00
+        // Partition 14: 2025-07-29 16:00:00 - 2025-07-29 16:30:00
+        // Partition 15: 2025-07-29 16:30:00 - 2025-07-29 17:00:00
+        // Partition 16: 2025-07-29 17:00:00 - 2025-07-29 17:30:00
+        // Partition 17: 2025-07-29 17:30:00 - 2025-07-29 18:00:00
+        // Partition 18: 2025-07-29 18:00:00 - 2025-07-29 18:30:00
+        // Partition 19: 2025-07-29 18:30:00 - 2025-07-29 19:00:00
+        // Partition 20: 2025-07-29 19:00:00 - 2025-07-29 19:30:00
+        // Partition 21: 2025-07-29 19:30:00 - 2025-07-29 20:00:00
+        // Partition 22: 2025-07-29 20:00:00 - 2025-07-29 20:30:00
+        // Partition 23: 2025-07-29 20:30:00 - 2025-07-29 21:00:00
+        // Partition 24: 2025-07-29 21:00:00 - 2025-07-29 21:30:00
+        // Partition 25: 2025-07-29 21:30:00 - 2025-07-29 22:00:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.first().unwrap()[0], start_time);
+        assert_eq!(partitions.last().unwrap()[1], end_time);
     }
 }

--- a/src/service/search/partition.rs
+++ b/src/service/search/partition.rs
@@ -150,7 +150,8 @@ impl PartitionGenerator {
 
         while end > start_time {
             let mut start = max(end - step, start_time);
-            // If the step is greater than the duration, handle the alignment for the boundary partition
+            // If the step is greater than the duration, handle the alignment for the boundary
+            // partition
             if last_partition_step > 0 && duration > step {
                 // Handle alignment for the first partition
                 partitions.push([end - last_partition_step, end]);

--- a/src/service/search/partition.rs
+++ b/src/service/search/partition.rs
@@ -152,7 +152,7 @@ impl PartitionGenerator {
             let mut start = max(end - step, start_time);
             // If the step is greater than the duration, handle the alignment for the boundary
             // partition
-            if last_partition_step > 0 && duration > step {
+            if last_partition_step > 0 && duration > self.min_step {
                 // Handle alignment for the first partition
                 partitions.push([end - last_partition_step, end]);
                 start -= last_partition_step;
@@ -386,7 +386,8 @@ mod tests {
         // Input
         // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
         // HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):
-        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
+        // 2025-07-29 21:30:00 - 2025-07-29 22:00:00
+        // 2025-07-29 10:00:00 - 2025-07-29 21:30:00
 
         // Verify full coverage of time range
         assert_eq!(partitions.last().unwrap()[0], start_time);
@@ -407,11 +408,12 @@ mod tests {
         // Input
         // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
         // HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):
-        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
+        // 2025-07-29 10:00:00 - 2025-07-29 21:30:00
+        // 2025-07-29 21:30:00 - 2025-07-29 22:00:00
 
         // Verify full coverage of time range
-        assert_eq!(partitions.last().unwrap()[0], start_time);
-        assert_eq!(partitions.first().unwrap()[1], end_time);
+        assert_eq!(partitions.first().unwrap()[0], start_time);
+        assert_eq!(partitions.last().unwrap()[1], end_time);
     }
 
     #[test]

--- a/src/service/search/partition.rs
+++ b/src/service/search/partition.rs
@@ -150,7 +150,8 @@ impl PartitionGenerator {
 
         while end > start_time {
             let mut start = max(end - step, start_time);
-            if last_partition_step > 0 && duration > self.min_step {
+            // If the step is greater than the duration, handle the alignment for the boundary partition
+            if last_partition_step > 0 && duration > step {
                 // Handle alignment for the first partition
                 partitions.push([end - last_partition_step, end]);
                 start -= last_partition_step;
@@ -158,6 +159,8 @@ impl PartitionGenerator {
             } else {
                 start = max(start - last_partition_step, start_time);
             }
+            // Ensure the start time is not less than the start time of the query
+            start = max(start, start_time);
             partitions.push([start, end]);
             end = start;
             last_partition_step = 0;
@@ -330,254 +333,30 @@ impl PartitionGenerator {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_partition_generator_with_histogram_alignment_desc_order() {
-        // Test case: 10:02 - 10:17 with 5-minute histogram interval
-        let start_time = 1617267720000000; // 10:02
-        let end_time = 1617268620000000; // 10:17
-        let min_step = 300000000; // 5 minutes in microseconds
-        let mini_partition_duration_secs = 60;
-
-        let generator = PartitionGenerator::new(
-            min_step,
-            mini_partition_duration_secs,
-            true, // is_histogram = true
-        );
-        let step = 300000000; // 5 minutes
-
-        let partitions =
-            generator.generate_partitions(start_time, end_time, step, OrderBy::Desc, false);
-
-        // Expected partitions:
-        // Partition 1: 10:15 - 10:17
-        // Partition 2: 10:10 - 10:15
-        // Partition 3: 10:05 - 10:10
-        // Partition 4: 10:02 - 10:05
-
-        // Print the actual partitions for debugging
-        println!("HISTOGRAM PARTITIONS (DESC):");
-        println!("Number of partitions: {}", partitions.len());
-        for (i, [start, end]) in partitions.iter().enumerate() {
-            // Convert to human-readable time for debugging
-            let start_mins = (start - 1617267600000000) / 60000000; // Minutes since 10:00
-            let end_mins = (end - 1617267600000000) / 60000000;
-            println!(
-                "Partition {}: 10:{:02} - 10:{:02} ({} - {})",
-                i + 1,
-                start_mins,
-                end_mins,
-                start,
-                end
-            );
+    fn print_partitions(title: &str, partitions: &[[i64; 2]]) {
+        println!("{}", title);
+        for (_i, [start, end]) in partitions.iter().enumerate() {
+            let start = chrono::DateTime::from_timestamp_micros(*start)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string();
+            let end = chrono::DateTime::from_timestamp_micros(*end)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string();
+            println!("{} - {}", start, end);
         }
-
-        // Verify histogram alignment
-        for [start, end] in &partitions {
-            if *start != start_time && *end != end_time {
-                assert_eq!(
-                    *start % min_step,
-                    0,
-                    "Partition start should align with histogram interval"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_partition_generator_with_histogram_alignment_asc_order() {
-        // Test case: 10:02 - 10:17 with 5-minute histogram interval
-        let start_time = 1617267720000000; // 10:02
-        let end_time = 1617268620000000; // 10:17
-        let min_step = 300000000; // 5 minutes in microseconds
-        let mini_partition_duration_secs = 60;
-
-        let generator = PartitionGenerator::new(
-            min_step,
-            mini_partition_duration_secs,
-            true, // is_histogram = true
-        );
-        let step = 300000000; // 5 minutes
-
-        let partitions =
-            generator.generate_partitions(start_time, end_time, step, OrderBy::Asc, false);
-
-        // Expected partitions for ASC order:
-        // Partition 1: 10:02 - 10:05
-        // Partition 2: 10:05 - 10:10
-        // Partition 3: 10:10 - 10:15
-        // Partition 4: 10:15 - 10:17
-
-        // Print the actual partitions for debugging
-        println!("HISTOGRAM PARTITIONS (ASC):");
-        println!("Number of partitions: {}", partitions.len());
-        for (i, [start, end]) in partitions.iter().enumerate() {
-            // Convert to human-readable time for debugging
-            let start_mins = (start - 1617267600000000) / 60000000; // Minutes since 10:00
-            let end_mins = (end - 1617267600000000) / 60000000;
-            println!(
-                "Partition {}: 10:{:02} - 10:{:02} ({} - {})",
-                i + 1,
-                start_mins,
-                end_mins,
-                start,
-                end
-            );
-        }
-
-        // Verify histogram alignment and ASC order
-        assert_eq!(
-            partitions.first().unwrap()[0],
-            start_time,
-            "First partition should start at start_time"
-        );
-        assert_eq!(
-            partitions.last().unwrap()[1],
-            end_time,
-            "Last partition should end at end_time"
-        );
-
-        // Verify histogram alignment
-        for [start, end] in &partitions {
-            if *start != start_time && *end != end_time {
-                assert_eq!(
-                    *start % min_step,
-                    0,
-                    "Partition start should align with histogram interval"
-                );
-            }
-        }
-
-        // Verify the partitions are in ascending order
-        let mut prev_end = start_time;
-        for [start, end] in &partitions {
-            assert_eq!(*start, prev_end, "Partitions should be contiguous");
-            assert!(*end > *start, "End time should be greater than start time");
-            prev_end = *end;
-        }
-    }
-
-    #[test]
-    fn test_partition_generator_without_histogram_alignment_mini_partition() {
-        // Test case: 10:02 - 10:17 with the same parameters as the histogram test
-        let start_time = 1617267720000000; // 10:02
-        let end_time = 1617268620000000; // 10:17
-        let min_step = 300000000; // 5 minutes in microseconds
-        let mini_partition_duration_secs = 60;
-
-        let generator = PartitionGenerator::new(
-            min_step,
-            mini_partition_duration_secs,
-            false, // is_histogram = false
-        );
-        let step = 300000000; // 5 minutes
-
-        let partitions =
-            generator.generate_partitions(start_time, end_time, step, OrderBy::Desc, true);
-
-        // Expected partitions:
-        // 1. 10:16 - 10:17 (mini partition)
-        // 2. 10:11 - 10:16
-        // 3. 10:06 - 10:11
-        // 4. 10:02 - 10:06
-
-        // Print the actual partitions for debugging
-        println!("NON-HISTOGRAM PARTITIONS (DESC):");
-        println!("Number of partitions: {}", partitions.len());
-        for (i, [start, end]) in partitions.iter().enumerate() {
-            // Convert to human-readable time for debugging
-            let start_mins = (start - 1617267600000000) / 60000000; // Minutes since 10:00
-            let end_mins = (end - 1617267600000000) / 60000000;
-            println!(
-                "Partition {}: 10:{:02} - 10:{:02} ({} - {})",
-                i + 1,
-                start_mins,
-                end_mins,
-                start,
-                end
-            );
-        }
-
-        // Verify full coverage of time range
-        assert_eq!(partitions.last().unwrap()[0], start_time);
-        assert_eq!(partitions.first().unwrap()[1], end_time);
-
-        // Verify mini partition is at the end (DESC order)
-        let mini_partition = &partitions[0];
-        let mini_partition_duration = mini_partition[1] - mini_partition[0];
-        assert!(
-            mini_partition_duration <= (mini_partition_duration_secs * 1_000_000) as i64,
-            "Mini partition size should not exceed the configured duration"
-        );
-        assert_eq!(
-            mini_partition[1], end_time,
-            "Mini partition should end at end_time"
-        );
-    }
-
-    #[test]
-    fn test_partition_generator_asc_order_with_mini_partition() {
-        // Test case: 10:02 - 10:17 with 5-minute intervals
-        let start_time = 1617267720000000; // 10:02
-        let end_time = 1617268620000000; // 10:17
-        let min_step = 300000000; // 5 minutes in microseconds
-        let mini_partition_duration_secs = 60;
-
-        let generator = PartitionGenerator::new(
-            min_step,
-            mini_partition_duration_secs,
-            false, // is_histogram = false
-        );
-        let step = 300000000; // 5 minutes
-
-        let partitions =
-            generator.generate_partitions(start_time, end_time, step, OrderBy::Asc, true);
-
-        // Expected partitions with ASC order:
-        // 1. 10:02 - 10:03 (mini partition)
-        // 2. 10:03 - 10:08
-        // 3. 10:08 - 10:13
-        // 4. 10:13 - 10:17
-
-        // Print the actual partitions for debugging
-        println!("NON-HISTOGRAM PARTITIONS (ASC):");
-        println!("Number of partitions: {}", partitions.len());
-        for (i, [start, end]) in partitions.iter().enumerate() {
-            // Convert to human-readable time for debugging
-            let start_mins = (start - 1617267600000000) / 60000000; // Minutes since 10:00
-            let end_mins = (end - 1617267600000000) / 60000000;
-            println!(
-                "Partition {}: 10:{:02} - 10:{:02} ({} - {})",
-                i + 1,
-                start_mins,
-                end_mins,
-                start,
-                end
-            );
-        }
-
-        // Verify full coverage of time range
-        assert_eq!(partitions.first().unwrap()[0], start_time);
-        assert_eq!(partitions.last().unwrap()[1], end_time);
-
-        // Verify mini partition is at the start (ASC order)
-        let mini_partition = &partitions[0];
-        let mini_partition_duration = mini_partition[1] - mini_partition[0];
-        assert!(
-            mini_partition_duration <= (mini_partition_duration_secs * 1_000_000) as i64,
-            "Mini partition size should not exceed the configured duration"
-        );
-        assert_eq!(
-            mini_partition[0], start_time,
-            "Mini partition should start at start_time"
-        );
     }
 
     // Actual start
     #[test]
-    fn test_partition_generator_with_histogram_alignment_no_mini_partition_order_by_desc() {
+    fn test_partition_generator_with_histogram_alignment_no_mini_partition_where_step_is_equal_to_query_duration()
+     {
         let start_time = 1753763400000000; // Tuesday, July 29, 2025 at 10:00:00 AM GMT+5:30
         let end_time = 1753806600000000; // Tuesday, July 29, 2025 at 10:00:00 PM GMT+5:30
-        let min_step_seconds = 1800; // 30 minutes in seconds
+        let min_step_seconds = 3600; // 60 minutes in seconds
         let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
         let mini_partition_duration_secs = 60;
 
@@ -586,8 +365,9 @@ mod tests {
             mini_partition_duration_secs,
             true, // is_histogram = true
         );
-        let step = min_step; // 30 minutes in microseconds
+        let step = 43200000000; // 12 hours in microseconds
 
+        // Test Descending
         let partitions = generator.generate_partitions(
             start_time,
             end_time,
@@ -596,145 +376,22 @@ mod tests {
             false, // add_mini_partition = false
         );
 
-        // Print the actual partitions for debugging
-        println!("HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):");
-        println!("Number of partitions: {}", partitions.len());
-        for (i, [start, end]) in partitions.iter().enumerate() {
-            // Convert to human-readable time for debugging
-            let start = chrono::DateTime::from_timestamp_micros(*start)
-                .unwrap()
-                .with_timezone(&chrono::Local)
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string();
-            let end = chrono::DateTime::from_timestamp_micros(*end)
-                .unwrap()
-                .with_timezone(&chrono::Local)
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string();
-            println!("Partition {}: {} - {}", i + 1, start, end);
-        }
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):",
+            &partitions,
+        );
 
+        // Input
+        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
         // HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):
-        // Number of partitions: 24
-        // Partition 1: 2025-07-29 21:30:00 - 2025-07-29 22:00:00
-        // Partition 2: 2025-07-29 21:00:00 - 2025-07-29 21:30:00
-        // Partition 3: 2025-07-29 20:30:00 - 2025-07-29 21:00:00
-        // Partition 4: 2025-07-29 20:00:00 - 2025-07-29 20:30:00
-        // Partition 5: 2025-07-29 19:30:00 - 2025-07-29 20:00:00
-        // Partition 6: 2025-07-29 19:00:00 - 2025-07-29 19:30:00
-        // Partition 7: 2025-07-29 18:30:00 - 2025-07-29 19:00:00
-        // Partition 8: 2025-07-29 18:00:00 - 2025-07-29 18:30:00
-        // Partition 9: 2025-07-29 17:30:00 - 2025-07-29 18:00:00
-        // Partition 10: 2025-07-29 17:00:00 - 2025-07-29 17:30:00
-        // Partition 11: 2025-07-29 16:30:00 - 2025-07-29 17:00:00
-        // Partition 12: 2025-07-29 16:00:00 - 2025-07-29 16:30:00
-        // Partition 13: 2025-07-29 15:30:00 - 2025-07-29 16:00:00
-        // Partition 14: 2025-07-29 15:00:00 - 2025-07-29 15:30:00
-        // Partition 15: 2025-07-29 14:30:00 - 2025-07-29 15:00:00
-        // Partition 16: 2025-07-29 14:00:00 - 2025-07-29 14:30:00
-        // Partition 17: 2025-07-29 13:30:00 - 2025-07-29 14:00:00
-        // Partition 18: 2025-07-29 13:00:00 - 2025-07-29 13:30:00
-        // Partition 19: 2025-07-29 12:30:00 - 2025-07-29 13:00:00
-        // Partition 20: 2025-07-29 12:00:00 - 2025-07-29 12:30:00
-        // Partition 21: 2025-07-29 11:30:00 - 2025-07-29 12:00:00
-        // Partition 22: 2025-07-29 11:00:00 - 2025-07-29 11:30:00
-        // Partition 23: 2025-07-29 10:30:00 - 2025-07-29 11:00:00
-        // Partition 24: 2025-07-29 10:00:00 - 2025-07-29 10:30:00
+        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
 
         // Verify full coverage of time range
         assert_eq!(partitions.last().unwrap()[0], start_time);
         assert_eq!(partitions.first().unwrap()[1], end_time);
-    }
 
-    #[test]
-    fn test_partition_generator_with_histogram_alignment_and_mini_partition_order_by_desc() {
-        let start_time = 1753763400000000; // Tuesday, July 29, 2025 at 10:00:00 AM GMT+5:30
-        let end_time = 1753806600000000; // Tuesday, July 29, 2025 at 10:00:00 PM GMT+5:30
-        let min_step_seconds = 1800; // 30 minutes in seconds
-        let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
-        let mini_partition_duration_secs = 60;
-
-        let generator = PartitionGenerator::new(
-            min_step,
-            mini_partition_duration_secs,
-            true, // is_histogram = true
-        );
-        let step = min_step; // 30 minutes in microseconds
-
-        let partitions = generator.generate_partitions(
-            start_time,
-            end_time,
-            step,
-            OrderBy::Desc,
-            true, // add_mini_partition = false
-        );
-
-        // Print the actual partitions for debugging
-        println!("HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):");
-        println!("Number of partitions: {}", partitions.len());
-        for (i, [start, end]) in partitions.iter().enumerate() {
-            // Convert to human-readable time for debugging
-            let start = chrono::DateTime::from_timestamp_micros(*start)
-                .unwrap()
-                .with_timezone(&chrono::Local)
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string();
-            let end = chrono::DateTime::from_timestamp_micros(*end)
-                .unwrap()
-                .with_timezone(&chrono::Local)
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string();
-            println!("Partition {}: {} - {}", i + 1, start, end);
-        }
-
-        // HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):
-        // Number of partitions: 25
-        // Partition 1: 2025-07-29 21:59:00 - 2025-07-29 22:00:00
-        // Partition 2: 2025-07-29 21:30:00 - 2025-07-29 21:59:00
-        // Partition 3: 2025-07-29 21:00:00 - 2025-07-29 21:30:00
-        // Partition 4: 2025-07-29 20:30:00 - 2025-07-29 21:00:00
-        // Partition 5: 2025-07-29 20:00:00 - 2025-07-29 20:30:00
-        // Partition 6: 2025-07-29 19:30:00 - 2025-07-29 20:00:00
-        // Partition 7: 2025-07-29 19:00:00 - 2025-07-29 19:30:00
-        // Partition 8: 2025-07-29 18:30:00 - 2025-07-29 19:00:00
-        // Partition 9: 2025-07-29 18:00:00 - 2025-07-29 18:30:00
-        // Partition 10: 2025-07-29 17:30:00 - 2025-07-29 18:00:00
-        // Partition 11: 2025-07-29 17:00:00 - 2025-07-29 17:30:00
-        // Partition 12: 2025-07-29 16:30:00 - 2025-07-29 17:00:00
-        // Partition 13: 2025-07-29 16:00:00 - 2025-07-29 16:30:00
-        // Partition 14: 2025-07-29 15:30:00 - 2025-07-29 16:00:00
-        // Partition 15: 2025-07-29 15:00:00 - 2025-07-29 15:30:00
-        // Partition 16: 2025-07-29 14:30:00 - 2025-07-29 15:00:00
-        // Partition 17: 2025-07-29 14:00:00 - 2025-07-29 14:30:00
-        // Partition 18: 2025-07-29 13:30:00 - 2025-07-29 14:00:00
-        // Partition 19: 2025-07-29 13:00:00 - 2025-07-29 13:30:00
-        // Partition 20: 2025-07-29 12:30:00 - 2025-07-29 13:00:00
-        // Partition 21: 2025-07-29 12:00:00 - 2025-07-29 12:30:00
-        // Partition 22: 2025-07-29 11:30:00 - 2025-07-29 12:00:00
-        // Partition 23: 2025-07-29 11:00:00 - 2025-07-29 11:30:00
-        // Partition 24: 2025-07-29 10:30:00 - 2025-07-29 11:00:00
-        // Partition 25: 2025-07-29 10:00:00 - 2025-07-29 10:30:00
-
-        // Verify full coverage of time range
-        assert_eq!(partitions.last().unwrap()[0], start_time);
-        assert_eq!(partitions.first().unwrap()[1], end_time);
-    }
-
-    #[test]
-    fn test_partition_generator_with_histogram_alignment_no_mini_partition_order_by_asc() {
-        let start_time = 1753763400000000; // Tuesday, July 29, 2025 at 10:00:00 AM GMT+5:30
-        let end_time = 1753806600000000; // Tuesday, July 29, 2025 at 10:00:00 PM GMT+5:30
-        let min_step_seconds = 1800; // 30 minutes in seconds
-        let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
-        let mini_partition_duration_secs = 60;
-
-        let generator = PartitionGenerator::new(
-            min_step,
-            mini_partition_duration_secs,
-            true, // is_histogram = true
-        );
-        let step = min_step; // 30 minutes in microseconds
-
+        // Test Ascending
         let partitions = generator.generate_partitions(
             start_time,
             end_time,
@@ -743,62 +400,26 @@ mod tests {
             false, // add_mini_partition = false
         );
 
-        // Print the actual partitions for debugging
-        println!("HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):");
-        println!("Number of partitions: {}", partitions.len());
-        for (i, [start, end]) in partitions.iter().enumerate() {
-            // Convert to human-readable time for debugging
-            let start = chrono::DateTime::from_timestamp_micros(*start)
-                .unwrap()
-                .with_timezone(&chrono::Local)
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string();
-            let end = chrono::DateTime::from_timestamp_micros(*end)
-                .unwrap()
-                .with_timezone(&chrono::Local)
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string();
-            println!("Partition {}: {} - {}", i + 1, start, end);
-        }
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions("HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):", &partitions);
 
+        // Input
+        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
         // HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):
-        // Number of partitions: 24
-        // Partition 1: 2025-07-29 10:00:00 - 2025-07-29 10:30:00
-        // Partition 2: 2025-07-29 10:30:00 - 2025-07-29 11:00:00
-        // Partition 3: 2025-07-29 11:00:00 - 2025-07-29 11:30:00
-        // Partition 4: 2025-07-29 11:30:00 - 2025-07-29 12:00:00
-        // Partition 5: 2025-07-29 12:00:00 - 2025-07-29 12:30:00
-        // Partition 6: 2025-07-29 12:30:00 - 2025-07-29 13:00:00
-        // Partition 7: 2025-07-29 13:00:00 - 2025-07-29 13:30:00
-        // Partition 8: 2025-07-29 13:30:00 - 2025-07-29 14:00:00
-        // Partition 9: 2025-07-29 14:00:00 - 2025-07-29 14:30:00
-        // Partition 10: 2025-07-29 14:30:00 - 2025-07-29 15:00:00
-        // Partition 11: 2025-07-29 15:00:00 - 2025-07-29 15:30:00
-        // Partition 12: 2025-07-29 15:30:00 - 2025-07-29 16:00:00
-        // Partition 13: 2025-07-29 16:00:00 - 2025-07-29 16:30:00
-        // Partition 14: 2025-07-29 16:30:00 - 2025-07-29 17:00:00
-        // Partition 15: 2025-07-29 17:00:00 - 2025-07-29 17:30:00
-        // Partition 16: 2025-07-29 17:30:00 - 2025-07-29 18:00:00
-        // Partition 17: 2025-07-29 18:00:00 - 2025-07-29 18:30:00
-        // Partition 18: 2025-07-29 18:30:00 - 2025-07-29 19:00:00
-        // Partition 19: 2025-07-29 19:00:00 - 2025-07-29 19:30:00
-        // Partition 20: 2025-07-29 19:30:00 - 2025-07-29 20:00:00
-        // Partition 21: 2025-07-29 20:00:00 - 2025-07-29 20:30:00
-        // Partition 22: 2025-07-29 20:30:00 - 2025-07-29 21:00:00
-        // Partition 23: 2025-07-29 21:00:00 - 2025-07-29 21:30:00
-        // Partition 24: 2025-07-29 21:30:00 - 2025-07-29 22:00:00
+        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
 
         // Verify full coverage of time range
-        assert_eq!(partitions.first().unwrap()[0], start_time);
-        assert_eq!(partitions.last().unwrap()[1], end_time);
+        assert_eq!(partitions.last().unwrap()[0], start_time);
+        assert_eq!(partitions.first().unwrap()[1], end_time);
     }
 
     #[test]
-    fn test_partition_generator_with_histogram_alignment_mini_partition_order_by_asc() {
-        // Test case: 10:02 - 10:17 with 5-minute histogram interval and mini partition
+    fn test_partition_generator_with_histogram_alignment_no_mini_partition_where_step_is_less_than_query_duration()
+     {
         let start_time = 1753763400000000; // Tuesday, July 29, 2025 at 10:00:00 AM GMT+5:30
         let end_time = 1753806600000000; // Tuesday, July 29, 2025 at 10:00:00 PM GMT+5:30
-        let min_step_seconds = 1800; // 30 minutes in seconds
+        // let min_step_seconds = 1800; // 30 minutes in seconds
+        let min_step_seconds = 3600; // 60 minutes in seconds
         let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
         let mini_partition_duration_secs = 60;
 
@@ -807,8 +428,241 @@ mod tests {
             mini_partition_duration_secs,
             true, // is_histogram = true
         );
-        let step = min_step; // 30 minutes in microseconds
+        // let step = min_step; // 30 minutes in microseconds
+        let step = 14400000000; // 4 hours in microseconds
 
+        // Test Descending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Desc,
+            false, // add_mini_partition = false
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):",
+            &partitions,
+        );
+
+        // Input
+        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
+        // HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):
+        // 2025-07-29 21:30:00 - 2025-07-29 22:00:00
+        // 2025-07-29 17:30:00 - 2025-07-29 21:30:00
+        // 2025-07-29 13:30:00 - 2025-07-29 17:30:00
+        // 2025-07-29 10:00:00 - 2025-07-29 13:30:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.last().unwrap()[0], start_time);
+        assert_eq!(partitions.first().unwrap()[1], end_time);
+
+        // Test Ascending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Asc,
+            false, // add_mini_partition = false
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions("HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):", &partitions);
+
+        // Input
+        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
+        // HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):
+        // 2025-07-29 10:00:00 - 2025-07-29 13:30:00
+        // 2025-07-29 13:30:00 - 2025-07-29 17:30:00
+        // 2025-07-29 17:30:00 - 2025-07-29 21:30:00
+        // 2025-07-29 21:30:00 - 2025-07-29 22:00:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.first().unwrap()[0], start_time);
+        assert_eq!(partitions.last().unwrap()[1], end_time);
+    }
+
+    #[test]
+    fn test_partition_generator_with_histogram_alignment_no_mini_partition_with_uneven_time_range()
+    {
+        let start_time = 1746074700000000; // Thursday, May 1, 2025 at 10:15:00 AM GMT+5:30
+        let end_time = 1746117300000000; // Thursday, May 1, 2025 at 10:05:00 PM GMT+5:30
+        let min_step_seconds = 3600; // 60 minutes in seconds
+        let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            true, // is_histogram = true
+        );
+        // let step = 39600000000; // 11 hours in microseconds
+        let step = 14400000000; // 4 hours in microseconds
+
+        // Test Descending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Desc,
+            false, // add_mini_partition = false
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):",
+            &partitions,
+        );
+
+        // Input
+        // 2025-05-01 10:15:00 - 2025-05-01 22:05:00
+        // HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):
+        // 2025-05-01 21:30:00 - 2025-05-01 22:05:00
+        // 2025-05-01 17:30:00 - 2025-05-01 21:30:00
+        // 2025-05-01 13:30:00 - 2025-05-01 17:30:00
+        // 2025-05-01 10:15:00 - 2025-05-01 13:30:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.last().unwrap()[0], start_time);
+        assert_eq!(partitions.first().unwrap()[1], end_time);
+
+        // Test Ascending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Asc,
+            false, // add_mini_partition = false
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions("HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):", &partitions);
+        // Input
+        // 2025-05-01 10:15:00 - 2025-05-01 22:05:00
+        // HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):
+        // 2025-05-01 10:15:00 - 2025-05-01 13:30:00
+        // 2025-05-01 13:30:00 - 2025-05-01 17:30:00
+        // 2025-05-01 17:30:00 - 2025-05-01 21:30:00
+        // 2025-05-01 21:30:00 - 2025-05-01 22:05:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.first().unwrap()[0], start_time);
+        assert_eq!(partitions.last().unwrap()[1], end_time);
+    }
+
+    #[test]
+    fn test_partition_generator_with_histogram_alignment_no_mini_partition_with_uneven_time_range_2()
+     {
+        let start_time = 1746073920000000; // Thursday, May 1, 2025 at 10:02:00 AM GMT+5:30 
+        let end_time = 1746074820000000; // Thursday, May 1, 2025 at 10:17:00 AM GMT+5:30
+        let min_step_seconds = 300; // 5 minutes in seconds
+        let min_step = min_step_seconds * 1_000_000; // 5 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            true, // is_histogram = true
+        );
+        let step = min_step; // 5 minutes in microseconds
+
+        // Test Descending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Desc,
+            false, // add_mini_partition = false
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):",
+            &partitions,
+        );
+
+        // Input
+        // 2025-05-01 10:02:00 - 2025-05-01 10:17:00
+        // HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):
+        // 2025-05-01 10:15:00 - 2025-05-01 10:17:00
+        // 2025-05-01 10:10:00 - 2025-05-01 10:15:00
+        // 2025-05-01 10:05:00 - 2025-05-01 10:10:00
+        // 2025-05-01 10:02:00 - 2025-05-01 10:05:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.last().unwrap()[0], start_time);
+        assert_eq!(partitions.first().unwrap()[1], end_time);
+
+        // Test Ascending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Asc,
+            false, // add_mini_partition = false
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions("HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):", &partitions);
+
+        // Input
+        // 2025-05-01 10:02:00 - 2025-05-01 10:17:00
+        // HISTOGRAM PARTITIONS NO MINI PARTITION (ASC):
+        // 2025-05-01 10:02:00 - 2025-05-01 10:05:00
+        // 2025-05-01 10:05:00 - 2025-05-01 10:10:00
+        // 2025-05-01 10:10:00 - 2025-05-01 10:15:00
+        // 2025-05-01 10:15:00 - 2025-05-01 10:17:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.first().unwrap()[0], start_time);
+        assert_eq!(partitions.last().unwrap()[1], end_time);
+    }
+
+    #[test]
+    fn test_partition_generator_with_histogram_alignment_mini_partition_with_uneven_time_range_2() {
+        let start_time = 1746073920000000; // Thursday, May 1, 2025 at 10:02:00 AM GMT+5:30 
+        let end_time = 1746074820000000; // Thursday, May 1, 2025 at 10:17:00 AM GMT+5:30
+        let min_step_seconds = 300; // 5 minutes in seconds
+        let min_step = min_step_seconds * 1_000_000; // 5 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            true, // is_histogram = true
+        );
+        let step = min_step; // 5 minutes in microseconds
+
+        // Test Descending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Desc,
+            true, // add_mini_partition = true
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):",
+            &partitions,
+        );
+
+        // Input
+        // 2025-05-01 10:02:00 - 2025-05-01 10:17:00
+        // HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):
+        // 2025-05-01 10:16:00 - 2025-05-01 10:17:00
+        // 2025-05-01 10:15:00 - 2025-05-01 10:16:00
+        // 2025-05-01 10:10:00 - 2025-05-01 10:15:00
+        // 2025-05-01 10:05:00 - 2025-05-01 10:10:00
+        // 2025-05-01 10:02:00 - 2025-05-01 10:05:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.last().unwrap()[0], start_time);
+        assert_eq!(partitions.first().unwrap()[1], end_time);
+
+        // Test Ascending
         let partitions = generator.generate_partitions(
             start_time,
             end_time,
@@ -817,51 +671,229 @@ mod tests {
             true, // add_mini_partition = true
         );
 
-        // Print the actual partitions for debugging
-        println!("HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):");
-        println!("Number of partitions: {}", partitions.len());
-        for (i, [start, end]) in partitions.iter().enumerate() {
-            // Convert to human-readable time for debugging
-            let start = chrono::DateTime::from_timestamp_micros(*start)
-                .unwrap()
-                .with_timezone(&chrono::Local)
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string();
-            let end = chrono::DateTime::from_timestamp_micros(*end)
-                .unwrap()
-                .with_timezone(&chrono::Local)
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string();
-            println!("Partition {}: {} - {}", i + 1, start, end);
-        }
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS WITH MINI PARTITION (ASC):",
+            &partitions,
+        );
 
-        // HISTOGRAM PARTITIONS NO MINI PARTITION (DESC):
-        // Number of partitions: 25
-        // Partition 1: 2025-07-29 10:00:00 - 2025-07-29 10:01:00
-        // Partition 2: 2025-07-29 10:01:00 - 2025-07-29 10:30:00
-        // Partition 3: 2025-07-29 10:30:00 - 2025-07-29 11:00:00
-        // Partition 4: 2025-07-29 11:00:00 - 2025-07-29 11:30:00
-        // Partition 5: 2025-07-29 11:30:00 - 2025-07-29 12:00:00
-        // Partition 6: 2025-07-29 12:00:00 - 2025-07-29 12:30:00
-        // Partition 7: 2025-07-29 12:30:00 - 2025-07-29 13:00:00
-        // Partition 8: 2025-07-29 13:00:00 - 2025-07-29 13:30:00
-        // Partition 9: 2025-07-29 13:30:00 - 2025-07-29 14:00:00
-        // Partition 10: 2025-07-29 14:00:00 - 2025-07-29 14:30:00
-        // Partition 11: 2025-07-29 14:30:00 - 2025-07-29 15:00:00
-        // Partition 12: 2025-07-29 15:00:00 - 2025-07-29 15:30:00
-        // Partition 13: 2025-07-29 15:30:00 - 2025-07-29 16:00:00
-        // Partition 14: 2025-07-29 16:00:00 - 2025-07-29 16:30:00
-        // Partition 15: 2025-07-29 16:30:00 - 2025-07-29 17:00:00
-        // Partition 16: 2025-07-29 17:00:00 - 2025-07-29 17:30:00
-        // Partition 17: 2025-07-29 17:30:00 - 2025-07-29 18:00:00
-        // Partition 18: 2025-07-29 18:00:00 - 2025-07-29 18:30:00
-        // Partition 19: 2025-07-29 18:30:00 - 2025-07-29 19:00:00
-        // Partition 20: 2025-07-29 19:00:00 - 2025-07-29 19:30:00
-        // Partition 21: 2025-07-29 19:30:00 - 2025-07-29 20:00:00
-        // Partition 22: 2025-07-29 20:00:00 - 2025-07-29 20:30:00
-        // Partition 23: 2025-07-29 20:30:00 - 2025-07-29 21:00:00
-        // Partition 24: 2025-07-29 21:00:00 - 2025-07-29 21:30:00
-        // Partition 25: 2025-07-29 21:30:00 - 2025-07-29 22:00:00
+        // Input
+        // 2025-05-01 10:02:00 - 2025-05-01 10:17:00
+        // HISTOGRAM PARTITIONS WITH MINI PARTITION (ASC):
+        // 2025-05-01 10:02:00 - 2025-05-01 10:03:00
+        // 2025-05-01 10:03:00 - 2025-05-01 10:05:00
+        // 2025-05-01 10:05:00 - 2025-05-01 10:10:00
+        // 2025-05-01 10:10:00 - 2025-05-01 10:15:00
+        // 2025-05-01 10:15:00 - 2025-05-01 10:17:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.first().unwrap()[0], start_time);
+        assert_eq!(partitions.last().unwrap()[1], end_time);
+    }
+
+    #[test]
+    fn test_partition_generator_with_histogram_alignment_and_mini_partition_with_step_equal_to_query_duration()
+     {
+        let start_time = 1753763400000000; // Tuesday, July 29, 2025 at 10:00:00 AM GMT+5:30
+        let end_time = 1753806600000000; // Tuesday, July 29, 2025 at 10:00:00 PM GMT+5:30
+        let min_step_seconds = 1800; // 30 minutes in seconds
+        let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            true, // is_histogram = true
+        );
+        let step = 43200000000; // 12 hours in microseconds
+
+        // Test Descending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Desc,
+            true, // add_mini_partition = true
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):",
+            &partitions,
+        );
+
+        // Input
+        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
+        // HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):
+        // 2025-07-29 21:59:00 - 2025-07-29 22:00:00
+        // 2025-07-29 10:00:00 - 2025-07-29 21:59:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.last().unwrap()[0], start_time);
+        assert_eq!(partitions.first().unwrap()[1], end_time);
+
+        // Test Ascending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Asc,
+            true, // add_mini_partition = true
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS WITH MINI PARTITION (ASC):",
+            &partitions,
+        );
+
+        // Input
+        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
+        // HISTOGRAM PARTITIONS WITH MINI PARTITION (ASC):
+        // 2025-07-29 10:00:00 - 2025-07-29 10:01:00
+        // 2025-07-29 10:01:00 - 2025-07-29 22:00:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.first().unwrap()[0], start_time);
+        assert_eq!(partitions.last().unwrap()[1], end_time);
+    }
+
+    #[test]
+    fn test_partition_generator_with_histogram_alignment_and_mini_partition_with_step_less_than_query_duration()
+     {
+        let start_time = 1753763400000000; // Tuesday, July 29, 2025 at 10:00:00 AM GMT+5:30
+        let end_time = 1753806600000000; // Tuesday, July 29, 2025 at 10:00:00 PM GMT+5:30
+        let min_step_seconds = 3600; // 60 minutes in seconds
+        let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            true, // is_histogram = true
+        );
+        let step = 14400000000; // 4 hours in microseconds
+
+        // Test Descending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Desc,
+            true, // add_mini_partition = true
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):",
+            &partitions,
+        );
+
+        // Input
+        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
+        // HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):
+        // 2025-07-29 21:59:00 - 2025-07-29 22:00:00
+        // 2025-07-29 21:30:00 - 2025-07-29 21:59:00
+        // 2025-07-29 17:30:00 - 2025-07-29 21:30:00
+        // 2025-07-29 13:30:00 - 2025-07-29 17:30:00
+        // 2025-07-29 10:00:00 - 2025-07-29 13:30:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.last().unwrap()[0], start_time);
+        assert_eq!(partitions.first().unwrap()[1], end_time);
+
+        // Test Ascending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Asc,
+            true, // add_mini_partition = true
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS WITH MINI PARTITION (ASC):",
+            &partitions,
+        );
+
+        // Input
+        // 2025-07-29 10:00:00 - 2025-07-29 22:00:00
+        // HISTOGRAM PARTITIONS WITH MINI PARTITION (ASC):
+        // 2025-07-29 10:00:00 - 2025-07-29 10:01:00
+        // 2025-07-29 10:01:00 - 2025-07-29 13:30:00
+        // 2025-07-29 13:30:00 - 2025-07-29 17:30:00
+        // 2025-07-29 17:30:00 - 2025-07-29 21:30:00
+        // 2025-07-29 21:30:00 - 2025-07-29 22:00:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.first().unwrap()[0], start_time);
+        assert_eq!(partitions.last().unwrap()[1], end_time);
+    }
+
+    #[test]
+    fn test_partition_generator_with_histogram_alignment_and_mini_partition_with_step_greater_than_query_duration()
+     {
+        let start_time = 1746073920000000; // Thursday, May 1, 2025 at 10:02:00 AM GMT+5:30 
+        let end_time = 1746161220000000; // Friday, May 2, 2025 at 10:17:00 AM GMT+5:30
+        let min_step_seconds = 3600; // 60 minutes in seconds
+        let min_step = min_step_seconds * 1_000_000; // 30 minutes in microseconds
+        let mini_partition_duration_secs = 60;
+
+        let generator = PartitionGenerator::new(
+            min_step,
+            mini_partition_duration_secs,
+            true, // is_histogram = true
+        );
+        let step = 86400000000; // 24 hours in microseconds
+
+        // Test Descending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Desc,
+            true, // add_mini_partition = true
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):",
+            &partitions,
+        );
+
+        // Input
+        // 2025-05-01 10:02:00 - 2025-05-02 10:17:00
+        // HISTOGRAM PARTITIONS WITH MINI PARTITION (DESC):
+        // 2025-05-02 10:16:00 - 2025-05-02 10:17:00
+        // 2025-05-02 09:30:00 - 2025-05-02 10:16:00
+        // 2025-05-01 10:02:00 - 2025-05-02 09:30:00
+
+        // Verify full coverage of time range
+        assert_eq!(partitions.last().unwrap()[0], start_time);
+        assert_eq!(partitions.first().unwrap()[1], end_time);
+
+        // Test Ascending
+        let partitions = generator.generate_partitions(
+            start_time,
+            end_time,
+            step,
+            OrderBy::Asc,
+            true, // add_mini_partition = true
+        );
+
+        print_partitions("Input", &[[start_time, end_time]]);
+        print_partitions(
+            "HISTOGRAM PARTITIONS WITH MINI PARTITION (ASC):",
+            &partitions,
+        );
+
+        // Input
+        // 2025-05-01 10:02:00 - 2025-05-02 10:17:00
+        // HISTOGRAM PARTITIONS WITH MINI PARTITION (ASC):
+        // 2025-05-01 10:02:00 - 2025-05-01 10:03:00
+        // 2025-05-01 10:03:00 - 2025-05-02 09:30:00
+        // 2025-05-02 09:30:00 - 2025-05-02 10:17:00
 
         // Verify full coverage of time range
         assert_eq!(partitions.first().unwrap()[0], start_time);

--- a/src/service/search/sql/histogram.rs
+++ b/src/service/search/sql/histogram.rs
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use anyhow::Result;
 use config::utils::sql::is_eligible_for_histogram;
+use infra::errors::{Error, ErrorCodes};
 use sqlparser::{
     ast::{SetExpr, Statement},
     dialect::PostgreSqlDialect,
@@ -23,12 +23,17 @@ use sqlparser::{
 
 /// Converts an original query to a histogram query
 /// Extracts WHERE clause and builds histogram query with provided stream name
-pub fn convert_to_histogram_query(original_query: &str, stream_names: &[String]) -> Result<String> {
-    let is_eligible = is_eligible_for_histogram(original_query)?;
+pub fn convert_to_histogram_query(
+    original_query: &str,
+    stream_names: &[String],
+) -> Result<String, Error> {
+    let is_eligible =
+        is_eligible_for_histogram(original_query).map_err(|e| Error::Message(e.to_string()))?;
     if !is_eligible {
-        return Err(anyhow::anyhow!(
-            "Histogram unavailable for SUBQUERY, CTE, DISTINCT and LIMIT queries."
+        let error = Error::ErrorCode(ErrorCodes::SearchHistogramNotAvailable(
+            "Histogram unavailable for SUBQUERY, CTE, DISTINCT and LIMIT queries.".to_string(),
         ));
+        return Err(error);
     }
 
     // Parse the original query
@@ -63,7 +68,7 @@ pub fn convert_to_histogram_query(original_query: &str, stream_names: &[String])
 }
 
 /// Extract WHERE clause from SQL statement
-fn extract_where_clause(statement: &Statement) -> Result<String> {
+fn extract_where_clause(statement: &Statement) -> Result<String, Error> {
     if let Statement::Query(query) = statement {
         if let SetExpr::Select(select) = &*query.body {
             // Extract WHERE clause
@@ -75,10 +80,16 @@ fn extract_where_clause(statement: &Statement) -> Result<String> {
 
             Ok(where_clause)
         } else {
-            Err(anyhow::anyhow!("Query is not a SELECT statement"))
+            let error = Error::ErrorCode(ErrorCodes::SearchSQLNotValid(
+                "Query is not a SELECT statement".to_string(),
+            ));
+            return Err(error);
         }
     } else {
-        Err(anyhow::anyhow!("Statement is not a query"))
+        let error = Error::ErrorCode(ErrorCodes::SearchSQLNotValid(
+            "Statement is not a query".to_string(),
+        ));
+        return Err(error);
     }
 }
 

--- a/src/service/search/sql/histogram.rs
+++ b/src/service/search/sql/histogram.rs
@@ -83,13 +83,13 @@ fn extract_where_clause(statement: &Statement) -> Result<String, Error> {
             let error = Error::ErrorCode(ErrorCodes::SearchSQLNotValid(
                 "Query is not a SELECT statement".to_string(),
             ));
-            return Err(error);
+            Err(error)
         }
     } else {
         let error = Error::ErrorCode(ErrorCodes::SearchSQLNotValid(
             "Statement is not a query".to_string(),
         ));
-        return Err(error);
+        Err(error)
     }
 }
 

--- a/src/service/search/sql/histogram.rs
+++ b/src/service/search/sql/histogram.rs
@@ -27,7 +27,7 @@ pub fn convert_to_histogram_query(
     original_query: &str,
     stream_names: &[String],
 ) -> Result<String, Error> {
-    let is_eligible =
+    let (is_eligible, is_sub_query) =
         is_eligible_for_histogram(original_query).map_err(|e| Error::Message(e.to_string()))?;
     if !is_eligible {
         let error = Error::ErrorCode(ErrorCodes::SearchHistogramNotAvailable(
@@ -57,7 +57,8 @@ pub fn convert_to_histogram_query(
     );
 
     // Add WHERE clause if it exists
-    if !where_clause.is_empty() {
+    // skip where clause for sub query
+    if !where_clause.is_empty() && !is_sub_query {
         histogram_query.push_str(&format!(" WHERE {}", where_clause));
     }
 

--- a/src/service/search/super_cluster/leader.rs
+++ b/src/service/search/super_cluster/leader.rs
@@ -28,10 +28,7 @@ use config::{
     metrics,
     utils::json,
 };
-use datafusion::{
-    common::tree_node::TreeNode,
-    physical_plan::{displayable, visit_execution_plan},
-};
+use datafusion::{common::tree_node::TreeNode, physical_plan::visit_execution_plan};
 use hashbrown::HashMap;
 use infra::errors::{Error, ErrorCodes, Result};
 use itertools::Itertools;

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -4826,8 +4826,8 @@ const useLogs = () => {
     try {
       const parsedSQL = fnParsedSQL();
 
-      if (!Object.hasOwn(parsedSQL, "from") || parsedSQL?.from.length === 0) {
-        console.error("Failed to parse SQL query:", value);
+      if (!Object.hasOwn(parsedSQL, "from") || parsedSQL?.from == null || parsedSQL?.from?.length == 0) {
+        console.info("Failed to parse SQL query:", value);
         throw new Error("Invalid SQL syntax");
       }
 
@@ -5187,7 +5187,7 @@ const useLogs = () => {
 
       if(!queryReq) return;
       
-      if(!isPagination) {
+      if(!isPagination && searchObj.meta.refreshInterval === 0) {
         resetQueryData();
         histogramResults = [];
         searchObj.data.queryResults.hits = [];

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1812,7 +1812,7 @@ const useLogs = () => {
           await processHttpHistogramResults(queryReq);
         } else if (searchObj.meta.sqlMode && isLimitQuery(parsedSQL)) {
           resetHistogramWithError(
-            "Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries.",
+            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
             -1
           );
           searchObj.meta.histogramDirtyFlag = false;
@@ -1835,13 +1835,13 @@ const useLogs = () => {
           }
           if(isWithQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible){
             resetHistogramWithError(
-              "Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries.",
+              "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
               -1
             );
           }
           else{
             resetHistogramWithError(
-              "Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries.",
+              "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
               -1
             );
 
@@ -6170,7 +6170,7 @@ const useLogs = () => {
         addTraceId(payload.traceId);
       }
     } else if (searchObj.meta.sqlMode && isLimitQuery(parsedSQL)) {
-      resetHistogramWithError("Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries.", -1);
+      resetHistogramWithError("Histogram unavailable for CTEs, DISTINCT and LIMIT queries.", -1);
       searchObj.meta.histogramDirtyFlag = false;
     } else if (searchObj.meta.sqlMode && (isDistinctQuery(parsedSQL) || isWithQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible)) {
       if (shouldGetPageCount(queryReq, parsedSQL) && isFromZero) {
@@ -6182,14 +6182,14 @@ const useLogs = () => {
       }
       if(isWithQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible){
         resetHistogramWithError(
-          "Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries..",
+          "Histogram unavailable for CTEs, DISTINCT and LIMIT queries..",
           -1
         );
         searchObj.meta.histogramDirtyFlag = false;
       }
       else{
         resetHistogramWithError(
-          "Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries.",
+          "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
           -1
         );
       }

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1213,6 +1213,7 @@ const useLogs = () => {
               //here we need to get the histogram interval for the histogram query that needs to be called
               searchObj.data.queryResults.histogram_interval = res.data?.histogram_interval;
               //we get is_histogram_eligible flag to check from the BE so that if it is false then we dont need to make histogram call
+              //this is coming as a part of partition response
               searchObj.data.queryResults.is_histogram_eligible = res.data?.is_histogram_eligible;
 
               // check if histogram interval is undefined, then set current response as histogram response
@@ -2594,7 +2595,10 @@ const useLogs = () => {
               };
             }
           }
-
+          //here also we are getting the is_histogram_eligible flag from the BE
+          //so that we can use it whenever we might not send the partition call from here also it will get updated
+          //this is coming as a part of data api call which is search call
+          searchObj.data.queryResults.is_histogram_eligible = res.data.is_histogram_eligible;
           // check for pagination request for the partition and check for subpage if we have to pull data from multiple partitions
           // it will check for subpage and if subpage is present then it will send pagination request for next partition
           if (

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1755,6 +1755,10 @@ const useLogs = () => {
           searchObj.data.resultGrid.currentPage - 1
         ][0].streaming_id;
 
+        // for custom download we need to set the streaming_output and streaming_id
+        searchObj.data.customDownloadQueryObj.query.streaming_output = queryReq.query.streaming_output;
+        searchObj.data.customDownloadQueryObj.query.streaming_id = queryReq.query.streaming_id;
+
         // setting subpage for pagination to handle below scenario
         // for one particular page, if we have to fetch data from multiple partitions in that case we need to set subpage
         // in below example we have 2 partitions and we need to fetch data from both partitions for page 2 to match recordsPerPage
@@ -1805,75 +1809,7 @@ const useLogs = () => {
             searchObj.data.stream.selectedStream.length <= 1 &&
             searchObj.meta.refreshHistogram == true)
         ) {
-          searchObj.meta.refreshHistogram = false;
-          if (searchObj.data.queryResults.hits.length > 0) {
-            if (searchObj.data.stream.selectedStream.length > 1) {
-              searchObj.data.histogram = {
-                xData: [],
-                yData: [],
-                chartParams: {
-                  title: getHistogramTitle(),
-                  unparsed_x_data: [],
-                  timezone: "",
-                },
-                errorCode: 0,
-                errorMsg: "Histogram is not available for multi stream search.",
-                errorDetail: "",
-              };
-            } else {
-              searchObjDebug["histogramStartTime"] = performance.now();
-              searchObj.data.histogram.errorMsg = "";
-              searchObj.data.histogram.errorCode = 0;
-              searchObj.data.histogram.errorDetail = "";
-              searchObj.loadingHistogram = true;
-
-              const parsedSQL: any = fnParsedSQL();
-              searchObj.data.queryResults.aggs = [];
-
-              const partitions = JSON.parse(
-                JSON.stringify(
-                  searchObj.data.queryResults.partitionDetail.partitions,
-                ),
-              );
-
-              // is _timestamp orderby ASC then reverse the partition array
-              if (isTimestampASC(parsedSQL?.orderby) && partitions.length > 1) {
-                partitions.reverse();
-              }
-
-              await generateHistogramSkeleton();
-              for (const partition of partitions) {
-                searchObj.data.histogramQuery.query.start_time = partition[0];
-                searchObj.data.histogramQuery.query.end_time = partition[1];
-                //to improve the cancel query UI experience we add additional check here and further we need to remove it
-                if (searchObj.data.isOperationCancelled) {
-                  searchObj.loadingHistogram = false;
-                  searchObj.data.isOperationCancelled = false;
-
-                  if (!searchObj.data.histogram?.xData?.length) {
-                    notificationMsg.value = "Search query was cancelled";
-                    searchObj.data.histogram.errorMsg =
-                      "Search query was cancelled";
-                    searchObj.data.histogram.errorDetail =
-                      "Search query was cancelled";
-                  }
-
-                  showCancelSearchNotification();
-                  break;
-                }
-                await getHistogramQueryData(searchObj.data.histogramQuery);
-                if (partitions.length > 1) {
-                  setTimeout(async () => {
-                    await generateHistogramData();
-                    if(!queryReq.query?.streaming_output)  refreshPartitionPagination(true);
-                  }, 100);
-                }
-              }
-              searchObj.loadingHistogram = false;
-            }
-          }
-          await generateHistogramData();
-          if(!queryReq.query?.streaming_output) refreshPartitionPagination(true);
+          await processHttpHistogramResults(queryReq);
         } else if (searchObj.meta.sqlMode && isLimitQuery(parsedSQL)) {
           resetHistogramWithError(
             "Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries.",
@@ -1961,6 +1897,87 @@ const useLogs = () => {
       notificationMsg.value = "";
     }
   };
+
+  const processHttpHistogramResults = async (queryReq: any) => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        searchObj.meta.refreshHistogram = false;
+        if (searchObj.data.queryResults.hits.length > 0) {
+          if (searchObj.data.stream.selectedStream.length > 1) {
+            searchObj.data.histogram = {
+              xData: [],
+              yData: [],
+              chartParams: {
+                title: getHistogramTitle(),
+                unparsed_x_data: [],
+                timezone: "",
+              },
+              errorCode: 0,
+              errorMsg: "Histogram is not available for multi stream search.",
+              errorDetail: "",
+            };
+          } else {
+            searchObjDebug["histogramStartTime"] = performance.now();
+            searchObj.data.histogram.errorMsg = "";
+            searchObj.data.histogram.errorCode = 0;
+            searchObj.data.histogram.errorDetail = "";
+            searchObj.loadingHistogram = true;
+
+            const parsedSQL: any = fnParsedSQL();
+            searchObj.data.queryResults.aggs = [];
+
+            const partitions = JSON.parse(
+              JSON.stringify(
+                searchObj.data.queryResults.partitionDetail.partitions,
+              ),
+            );
+
+            // is _timestamp orderby ASC then reverse the partition array
+            if (isTimestampASC(parsedSQL?.orderby) && partitions.length > 1) {
+              partitions.reverse();
+            }
+
+            await generateHistogramSkeleton();
+            for (const partition of partitions) {
+              searchObj.data.histogramQuery.query.start_time = partition[0];
+              searchObj.data.histogramQuery.query.end_time = partition[1];
+              //to improve the cancel query UI experience we add additional check here and further we need to remove it
+              if (searchObj.data.isOperationCancelled) {
+                searchObj.loadingHistogram = false;
+                searchObj.data.isOperationCancelled = false;
+
+                if (!searchObj.data.histogram?.xData?.length) {
+                  notificationMsg.value = "Search query was cancelled";
+                  searchObj.data.histogram.errorMsg =
+                    "Search query was cancelled";
+                  searchObj.data.histogram.errorDetail =
+                    "Search query was cancelled";
+                }
+
+                showCancelSearchNotification();
+                break;
+              }
+              await getHistogramQueryData(searchObj.data.histogramQuery);
+              if (partitions.length > 1) {
+                setTimeout(async () => {
+                  await generateHistogramData();
+                  if(!queryReq.query?.streaming_output)  refreshPartitionPagination(true);
+                }, 100);
+              }
+            }
+            searchObj.loadingHistogram = false;
+          }
+        }
+        await generateHistogramData();
+        if(!queryReq.query?.streaming_output) refreshPartitionPagination(true);
+        resolve(true);
+      } catch (error) {
+        console.info("Error while processing http histogram results", error);
+        resolve(true);
+      }
+    })
+  }
+
   const getJobData = async (isPagination = false) => {
     try {
       // get websocket enable config from store
@@ -4461,7 +4478,7 @@ const useLogs = () => {
   const onStreamChange = async (queryStr: string) => {
     try {
       searchObj.loadingStream = true;
-      
+
       await cancelQuery();
       // Reset query results
       searchObj.data.queryResults = { hits: [] };
@@ -6609,6 +6626,7 @@ const useLogs = () => {
     isWithQuery,
     getStream,
     loadVisualizeData,
+    processHttpHistogramResults
   };
 };
 

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -6266,9 +6266,15 @@ const useLogs = () => {
       errorMsg = message;
     }
 
-    searchObj.data.errorDetail = error_detail || "";
-    searchObj.data.errorMsg = errorMsg;
-    notificationMsg.value = errorMsg;
+    if(request.type === 'pageCount') {
+      searchObj.data.countErrorMsg = "Error while retrieving total events: ";
+      if (trace_id) searchObj.data.countErrorMsg += " TraceID: " + trace_id;
+      notificationMsg.value = searchObj.data.countErrorMsg;
+    } else {
+      searchObj.data.errorDetail = error_detail || "";
+      searchObj.data.errorMsg = errorMsg;
+      notificationMsg.value = errorMsg;
+    }
   };
 
   const constructErrorMessage = ({

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -4455,7 +4455,8 @@ const useLogs = () => {
   const onStreamChange = async (queryStr: string) => {
     try {
       searchObj.loadingStream = true;
-
+      
+      await cancelQuery();
       // Reset query results
       searchObj.data.queryResults = { hits: [] };
 
@@ -4614,11 +4615,14 @@ const useLogs = () => {
     }
   };
 
-  const cancelQuery = () => {
+  const cancelQuery = async () : Promise<boolean> => {
+    return new Promise((resolve, reject) => {
+      try {
     if (searchObj.communicationMethod === "ws") {
       sendCancelSearchMessage([
         ...searchObj.data.searchWebSocketTraceIds,
       ]);
+          resolve(true);
       return;
     }
 
@@ -4626,6 +4630,7 @@ const useLogs = () => {
 
     if (!searchObj.data.searchRequestTraceIds.length) {
       searchObj.data.isOperationCancelled = false;
+      resolve(true);
       return;
     }
 
@@ -4662,6 +4667,17 @@ const useLogs = () => {
           searchObj.data.searchRequestTraceIds.filter(
             (id: string) => !tracesIds.includes(id),
           );
+            resolve(true);
+          });
+      } catch (error) {
+        $q.notify({
+          message: "Failed to cancel running query",
+          color: "negative",
+          position: "bottom",
+          timeout: 1500,
+        });
+        resolve(true);
+      }
       });
   };
 

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -586,6 +586,7 @@ export default defineComponent({
       getStream,
       loadVisualizeData,
       buildSearch,
+      cancelQuery,
     } = useLogs();
     const searchResultRef = ref(null);
     const searchBarRef = ref(null);
@@ -681,7 +682,7 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       // Cancel all the search queries
-      cancelOnGoingSearchQueries();
+      cancelQuery();
       removeAiContextHandler();
     });
 
@@ -1937,25 +1938,24 @@ export default defineComponent({
           }
 
           for (let i = 0; i < streams.length; i++) {
-
             const schema = await getStream(streams[i], streamType, true);
-            //here we are deep copying the schema before assiging it to schemaData so that we dont mutatat the orginial data 
+            //here we are deep copying the schema before assiging it to schemaData so that we dont mutatat the orginial data
             //if we do this we dont get duplicate fields in the schema
             let schemaData = deepCopy(schema.uds_schema || schema.schema || []);
             let isUdsEnabled = schema.uds_schema?.length > 0;
             //we only push the timestamp and all fields name in the schema if uds is enabled for that stream
-            if(isUdsEnabled){
+            if (isUdsEnabled) {
               let timestampColumn = store.state.zoConfig.timestamp_column;
               let allFieldsName = store.state.zoConfig.all_fields_name;
               schemaData.push({
-                name:timestampColumn,
-                type:'Int64'
-              })
-                schemaData.push({
-                  name:allFieldsName,
-                  type:'Utf8'
-                })
-              }
+                name: timestampColumn,
+                type: "Int64",
+              });
+              schemaData.push({
+                name: allFieldsName,
+                type: "Utf8",
+              });
+            }
             payload["stream_name_" + (i + 1)] = streams[i];
             payload["schema_" + (i + 1)] = schemaData;
           }

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -2166,7 +2166,13 @@ export default defineComponent({
           this.resetHistogramWithError(
             "Histogram is not available for multi stream search.",
           );
-        } else if (
+        }else if(!this.searchObj.data.queryResults.is_histogram_eligible){
+          this.resetHistogramWithError(
+            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
+            -1,
+          );
+          this.searchObj.meta.histogramDirtyFlag = false;
+        }else if (
           this.searchObj.meta.histogramDirtyFlag == true &&
           this.searchObj.meta.jobId == ""
         ) {
@@ -2216,13 +2222,7 @@ export default defineComponent({
               this.searchObj.loadingHistogram = false;
             });
         }
-        else if(!this.searchObj.data.queryResults.is_histogram_eligible){
-          this.resetHistogramWithError(
-            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
-            -1,
-          );
-          this.searchObj.meta.histogramDirtyFlag = false;
-        }
+
       }
 
       this.updateUrlQueryParams();

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -2147,8 +2147,7 @@ export default defineComponent({
         !this.searchObj.shouldIgnoreWatcher
       ) {
         this.searchObj.data.queryResults.aggs = [];
-
-        if (this.searchObj.meta.sqlMode && this.isLimitQuery(parsedSQL) || !this.searchObj.data.queryResults.is_histogram_eligible) {
+        if (this.searchObj.meta.sqlMode && this.isLimitQuery(parsedSQL)) {
           this.resetHistogramWithError(
             "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
             -1,
@@ -2156,7 +2155,7 @@ export default defineComponent({
           this.searchObj.meta.histogramDirtyFlag = false;
         } else if (
           this.searchObj.meta.sqlMode &&
-          (this.isDistinctQuery(parsedSQL) || this.isWithQuery(parsedSQL) || !this.searchObj.data.queryResults.is_histogram_eligible)
+          (this.isDistinctQuery(parsedSQL) || this.isWithQuery(parsedSQL))
         ) {
           this.resetHistogramWithError(
             "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
@@ -2216,6 +2215,13 @@ export default defineComponent({
             .finally(() => {
               this.searchObj.loadingHistogram = false;
             });
+        }
+        else if(!this.searchObj.data.queryResults.is_histogram_eligible){
+          this.resetHistogramWithError(
+            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
+            -1,
+          );
+          this.searchObj.meta.histogramDirtyFlag = false;
         }
       }
 

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -2148,18 +2148,18 @@ export default defineComponent({
       ) {
         this.searchObj.data.queryResults.aggs = [];
 
-        if (this.searchObj.meta.sqlMode && this.isLimitQuery(parsedSQL)) {
+        if (this.searchObj.meta.sqlMode && this.isLimitQuery(parsedSQL) || !this.searchObj.data.queryResults.is_histogram_eligible) {
           this.resetHistogramWithError(
-            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
+            "Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries.",
             -1,
           );
           this.searchObj.meta.histogramDirtyFlag = false;
         } else if (
           this.searchObj.meta.sqlMode &&
-          (this.isDistinctQuery(parsedSQL) || this.isWithQuery(parsedSQL))
+          (this.isDistinctQuery(parsedSQL) || this.isWithQuery(parsedSQL) || !this.searchObj.data.queryResults.is_histogram_eligible)
         ) {
           this.resetHistogramWithError(
-            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
+            "Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries.",
             -1,
           );
           this.searchObj.meta.histogramDirtyFlag = false;

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -2167,6 +2167,7 @@ export default defineComponent({
               "histogram",
               {
                 isHistogramOnly: this.searchObj.meta.histogramDirtyFlag,
+                is_ui_histogram: true
               },
             );
             const requestId = this.initializeSearchConnection(payload);

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -2150,7 +2150,7 @@ export default defineComponent({
 
         if (this.searchObj.meta.sqlMode && this.isLimitQuery(parsedSQL) || !this.searchObj.data.queryResults.is_histogram_eligible) {
           this.resetHistogramWithError(
-            "Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries.",
+            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
             -1,
           );
           this.searchObj.meta.histogramDirtyFlag = false;
@@ -2159,7 +2159,7 @@ export default defineComponent({
           (this.isDistinctQuery(parsedSQL) || this.isWithQuery(parsedSQL) || !this.searchObj.data.queryResults.is_histogram_eligible)
         ) {
           this.resetHistogramWithError(
-            "Histogram unavailable for SUBQUERY, CTEs, DISTINCT and LIMIT queries.",
+            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
             -1,
           );
           this.searchObj.meta.histogramDirtyFlag = false;

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -2355,7 +2355,8 @@ export default defineComponent({
       savedViewDropdownModel.value = false;
     };
 
-    const applySavedView = (item) => {
+    const applySavedView = async (item) => {
+      await cancelQuery();
       searchObj.shouldIgnoreWatcher = true;
       searchObj.meta.sqlMode = false;
       savedviewsService

--- a/web/src/ts/interfaces/query.ts
+++ b/web/src/ts/interfaces/query.ts
@@ -58,6 +58,7 @@ export interface WebSocketSearchResponse {
       result_cache_ratio?: number;
       order_by?: string;
       histogram_interval?: number;
+      is_histogram_eligible?: boolean;
     };
     streaming_aggs?: boolean;
     total?: number;


### PR DESCRIPTION
1. Error code `20013` for histogram not applicable
```
{
    "code": 20013,
    "message": "Search histogram not available",
    "error_detail": "Histogram unavailable for SUBQUERY, CTE, DISTINCT and LIMIT queries.",
    "trace_id": "bb560cf815ae458680a6f506be58f0ed"
}
```
2. Modify partitions generation to able to generate mini partition for histogram query only when `search_type=ui` 
```
        // Expected partitions with mini partition and histogram alignment:
        // 1. 10:16 - 10:17 (mini partition)
        // 2. 10:15 - 10:16 
        // 3. 10:10 - 10:15 (histogram aligned)
        // 4. 10:05 - 10:10 (histogram aligned)
        // 5. 10:02 - 10:05 
```
cons: There could be an overlap of data points only for the mini partition. Hence, its limited only to `search_type=ui`