### PR TITLE
fix: dashboard values api filter query

### DIFF
--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -1459,7 +1459,7 @@ export default defineComponent({
       let dummyQuery: string;
 
       if (searchText) {
-        dummyQuery = `SELECT ${timestamp_column} FROM '${variableObject.query_data.stream}' WHERE CAST(${variableObject.query_data.field} AS TEXT) LIKE '%${escapeSingleQuotes(searchText.trim())}%'`;
+        dummyQuery = `SELECT ${timestamp_column} FROM '${variableObject.query_data.stream}' WHERE str_match(${variableObject.query_data.field}, ${escapeSingleQuotes(searchText.trim())})`;
       } else {
         dummyQuery = `SELECT ${timestamp_column} FROM '${variableObject.query_data.stream}'`;
       }
@@ -2070,7 +2070,7 @@ export default defineComponent({
       }
 
       // 2. Cancel any ongoing WebSocket/Streaming operations
-      cancelTraceId(variableName);      
+      cancelTraceId(variableName);
 
       // 3. Reset loading states for the variable only if not in search mode
       const variableObject = variablesData.values.find(
@@ -2078,7 +2078,7 @@ export default defineComponent({
       );
 
       if (variableObject) {
-        variableObject.isLoading = false;        
+        variableObject.isLoading = false;
         variableObject.isVariableLoadingPending = false;
       }
     };

--- a/web/src/components/dashboards/addPanel/DashboardQueryBuilder.vue
+++ b/web/src/components/dashboards/addPanel/DashboardQueryBuilder.vue
@@ -1190,8 +1190,14 @@ export default defineComponent({
               ? false
               : true;
         } else {
-          // For existing panels: set all to false (unchecked) initially
-          field.treatAsNonTimestamp = false;
+          // For existing panels: only set if treatAsNonTimestamp is not already defined
+          // This preserves the saved values from the database
+          if (
+            field.treatAsNonTimestamp === undefined ||
+            field.treatAsNonTimestamp === null
+          ) {
+            field.treatAsNonTimestamp = false;
+          }
         }
       };
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Use `str_match` for filtering in variable queries

- Preserve existing `treatAsNonTimestamp` panel settings

- Remove redundant whitespace in function call


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VariablesValueSelector.vue</strong><dd><code>Update dummyQuery to use str_match</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/VariablesValueSelector.vue

<ul><li>Replace <code>LIKE '%…%'</code> filter with <code>str_match</code> function<br> <li> Update <code>dummyQuery</code> construction for <code>searchText</code><br> <li> Remove trailing whitespace around <code>cancelTraceId</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7743/files#diff-5c6e3bcb87cb64f25bf8157a541604b7a4904c1282acf662cab5d76a5be6bd56">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DashboardQueryBuilder.vue</strong><dd><code>Preserve panel treatAsNonTimestamp settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/DashboardQueryBuilder.vue

<ul><li>Preserve existing <code>treatAsNonTimestamp</code> values<br> <li> Initialize only if <code>undefined</code> or <code>null</code><br> <li> Remove unconditional reset for existing panels</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7743/files#diff-a4f9abbeaad1156ab6ba5740d59ccb869d6a9172ca1c64b89cff78f3d7783409">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

