### PR TITLE
fix: value api with complex query

### DIFF
--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -805,14 +805,13 @@ pub async fn build_search_request_per_field(
                     .any(|fn_name| decoded_sql.contains(&format!("{fn_name}(")));
 
                 // pick up where clause from sql
-                let sql_where_from_query =
-                    match SearchService::sql::pickup_where(&decoded_sql, None) {
-                        Ok(Some(v)) => format!("WHERE {v}"),
-                        Ok(None) => "".to_string(),
-                        Err(e) => {
-                            return Err(Error::other(e));
-                        }
-                    };
+                let sql_where_from_query = match SearchService::sql::pickup_where(&decoded_sql) {
+                    Ok(Some(v)) => format!("WHERE {v}"),
+                    Ok(None) => "".to_string(),
+                    Err(e) => {
+                        return Err(Error::other(e));
+                    }
+                };
                 let can_use_distinct_stream = can_use_distinct_stream(
                     org_id,
                     stream_name,
@@ -993,7 +992,7 @@ async fn values_v1(
     };
 
     // pick up where clause from sql
-    let where_str = match SearchService::sql::pickup_where(&query_sql, None) {
+    let where_str = match SearchService::sql::pickup_where(&query_sql) {
         Ok(v) => v.unwrap_or_default(),
         Err(e) => {
             return Err(Error::other(e));

--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -21,9 +21,7 @@ use config::{
     meta::{
         inverted_index::IndexOptimizeMode,
         search::SearchEventType,
-        sql::{
-            MAX_LIMIT, OrderBy, Sql as MetaSql, TableReferenceExt, resolve_stream_names_with_type,
-        },
+        sql::{MAX_LIMIT, OrderBy, TableReferenceExt, resolve_stream_names_with_type},
         stream::StreamType,
     },
     utils::sql::AGGREGATE_UDF_LIST,
@@ -81,7 +79,6 @@ use crate::service::search::{
 
 pub static RE_ONLY_SELECT: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)select[ ]+\*").unwrap());
 pub static RE_SELECT_FROM: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)SELECT (.*) FROM").unwrap());
-pub static RE_WHERE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i) where (.*)").unwrap());
 
 pub static RE_HISTOGRAM: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?i)histogram\(([^\)]*)\)").unwrap());
@@ -2158,46 +2155,81 @@ pub fn convert_histogram_interval_to_seconds(interval: &str) -> Result<i64, Erro
     Ok(seconds)
 }
 
-pub fn pickup_where(sql: &str, meta: Option<MetaSql>) -> Result<Option<String>, Error> {
-    #[allow(deprecated)]
-    let meta = match meta {
-        Some(v) => v,
-        None => match MetaSql::new(sql) {
-            Ok(meta) => meta,
-            Err(_) => {
-                return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(
-                    sql.to_string(),
-                )));
+pub fn pickup_where(sql: &str) -> Result<Option<String>, Error> {
+    // disable subquery, join, union, except, intersect, etc.
+    let mut statement = Parser::parse_sql(&PostgreSqlDialect {}, sql)
+        .map_err(|e| Error::Message(e.to_string()))?
+        .pop()
+        .unwrap();
+    let mut visitor = PickupWhereVisitor::new();
+    let _ = statement.visit(&mut visitor);
+    if let Some(where_str) = visitor.where_str {
+        return Ok(Some(where_str));
+    }
+    Ok(None)
+}
+
+struct PickupWhereVisitor {
+    where_str: Option<String>,
+}
+
+impl PickupWhereVisitor {
+    fn new() -> Self {
+        Self { where_str: None }
+    }
+}
+
+impl VisitorMut for PickupWhereVisitor {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &mut Query) -> ControlFlow<Self::Break> {
+        if query.with.is_some() {
+            self.where_str = None;
+            return ControlFlow::Break(());
+        }
+        match query.body.as_ref() {
+            sqlparser::ast::SetExpr::Select(select) => {
+                if select.from.len() > 1
+                    || select.from.iter().any(|from| {
+                        !from.joins.is_empty()
+                            || matches!(
+                                from.relation,
+                                TableFactor::Derived { .. } | TableFactor::Function { .. }
+                            )
+                    })
+                {
+                    self.where_str = None;
+                    return ControlFlow::Break(());
+                }
+
+                if let Some(selection) = select.selection.as_ref() {
+                    self.where_str = Some(selection.to_string());
+                    return ControlFlow::Continue(());
+                } else {
+                    self.where_str = None;
+                    return ControlFlow::Break(());
+                }
             }
-        },
-    };
-    let Some(caps) = RE_WHERE.captures(sql) else {
-        return Ok(None);
-    };
-    let mut where_str = caps.get(1).unwrap().as_str().to_string();
-    let where_str_lower = where_str.to_lowercase();
-
-    let clause_to_strip = if !meta.group_by.is_empty() {
-        Some(" group ")
-    } else if meta.having {
-        Some(" having ")
-    } else if !meta.order_by.is_empty() {
-        Some(" order ")
-    } else if meta.limit > 0 || where_str_lower.ends_with(" limit 0") {
-        Some(" limit ")
-    } else if meta.offset > 0 {
-        Some(" offset ")
-    } else {
-        None
-    };
-
-    if let Some(clause) = clause_to_strip
-        && let Some(pos) = where_str_lower.rfind(clause)
-    {
-        where_str.truncate(pos);
+            sqlparser::ast::SetExpr::SetOperation { .. } => {
+                self.where_str = None;
+                return ControlFlow::Break(());
+            }
+            _ => {}
+        }
+        ControlFlow::Continue(())
     }
 
-    Ok(Some(where_str))
+    fn pre_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
+        match expr {
+            // check if has subquery
+            Expr::Subquery(_) | Expr::Exists { .. } | Expr::InSubquery { .. } => {
+                self.where_str = None;
+                return ControlFlow::Break(());
+            }
+            _ => {}
+        }
+        ControlFlow::Continue(())
+    }
 }
 
 fn o2_id_is_needed(
@@ -3945,5 +3977,188 @@ mod tests {
             statement.to_string(),
             "SELECT approx_percentile_cont(0.5) WITHIN GROUP (ORDER BY CAST(json_get_str(array_element(cast_to_arr(spath(log, 'error')), 1), 'code') AS INT)) FROM stream"
         );
+    }
+
+    #[test]
+    fn test_pickup_where_normal_sql() {
+        // Test normal SQL with WHERE clause
+        let sql = "SELECT * FROM logs WHERE level = 'error'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, Some("level = 'error'".to_string()));
+
+        // Test normal SQL with complex WHERE clause
+        let sql = "SELECT * FROM logs WHERE level = 'error' AND timestamp > 1234567890";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(
+            result,
+            Some("level = 'error' AND timestamp > 1234567890".to_string())
+        );
+
+        // Test normal SQL with OR condition
+        let sql = "SELECT * FROM logs WHERE level = 'error' OR level = 'warn'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(
+            result,
+            Some("level = 'error' OR level = 'warn'".to_string())
+        );
+
+        // Test normal SQL with IN clause
+        let sql = "SELECT * FROM logs WHERE level IN ('error', 'warn', 'info')";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(
+            result,
+            Some("level IN ('error', 'warn', 'info')".to_string())
+        );
+
+        // Test normal SQL with LIKE clause
+        let sql = "SELECT * FROM logs WHERE message LIKE '%error%'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, Some("message LIKE '%error%'".to_string()));
+    }
+
+    #[test]
+    fn test_pickup_where_no_where_clause() {
+        // Test SQL without WHERE clause
+        let sql = "SELECT * FROM logs";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        // Test SQL with only SELECT and FROM
+        let sql = "SELECT id, name FROM users";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_pickup_where_with_joins() {
+        // Test SQL with JOIN - should return None
+        let sql = "SELECT * FROM logs l JOIN users u ON l.user_id = u.id WHERE l.level = 'error'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        // Test SQL with multiple FROM tables - should return None
+        let sql = "SELECT * FROM logs, users WHERE logs.user_id = users.id";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        // Test SQL with LEFT JOIN - should return None
+        let sql =
+            "SELECT * FROM logs l LEFT JOIN users u ON l.user_id = u.id WHERE l.level = 'error'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        // Test SQL with INNER JOIN - should return None
+        let sql =
+            "SELECT * FROM logs l INNER JOIN users u ON l.user_id = u.id WHERE l.level = 'error'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_pickup_where_with_subqueries() {
+        // Test SQL with subquery in WHERE - should return None
+        let sql = "SELECT * FROM logs WHERE user_id IN (SELECT id FROM users WHERE active = true)";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        // Test SQL with EXISTS subquery - should return None
+        let sql =
+            "SELECT * FROM logs WHERE EXISTS (SELECT 1 FROM users WHERE users.id = logs.user_id)";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        // Test SQL with subquery in FROM - should return None
+        let sql = "SELECT * FROM (SELECT * FROM logs WHERE level = 'error') sub WHERE sub.timestamp > 1234567890";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        let sql = "with t1 as (select log, message, kubernetes_namespace_name from default where kubernetes_namespace_name = 'ziox') select * from t1;";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        let sql = "with t1 as (select log, message, kubernetes_namespace_name from default) select * from t1 where kubernetes_namespace_name = 'ziox';";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_pickup_where_with_union() {
+        // Test SQL with UNION - should return None
+        let sql = "SELECT * FROM logs WHERE level = 'error' UNION SELECT * FROM logs WHERE level = 'warn'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        // Test SQL with UNION ALL - should return None
+        let sql = "SELECT * FROM logs WHERE level = 'error' UNION ALL SELECT * FROM logs WHERE level = 'warn'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        // Test SQL with INTERSECT - should return None
+        let sql = "SELECT * FROM logs WHERE level = 'error' INTERSECT SELECT * FROM logs WHERE level = 'warn'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+
+        // Test SQL with EXCEPT - should return None
+        let sql = "SELECT * FROM logs WHERE level = 'error' EXCEPT SELECT * FROM logs WHERE level = 'warn'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_pickup_where_complex_where_clauses() {
+        // Test complex WHERE with parentheses
+        let sql = "SELECT * FROM logs WHERE (level = 'error' OR level = 'warn') AND timestamp > 1234567890";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(
+            result,
+            Some("(level = 'error' OR level = 'warn') AND timestamp > 1234567890".to_string())
+        );
+
+        // Test WHERE with function calls
+        let sql = "SELECT * FROM logs WHERE LENGTH(message) > 100 AND level = 'error'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(
+            result,
+            Some("LENGTH(message) > 100 AND level = 'error'".to_string())
+        );
+
+        // Test WHERE with BETWEEN
+        let sql = "SELECT * FROM logs WHERE timestamp BETWEEN 1234567890 AND 1234567999";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(
+            result,
+            Some("timestamp BETWEEN 1234567890 AND 1234567999".to_string())
+        );
+
+        // Test WHERE with IS NULL
+        let sql = "SELECT * FROM logs WHERE user_id IS NULL AND level = 'error'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(
+            result,
+            Some("user_id IS NULL AND level = 'error'".to_string())
+        );
+
+        // Test WHERE with IS NOT NULL
+        let sql = "SELECT * FROM logs WHERE user_id IS NOT NULL";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, Some("user_id IS NOT NULL".to_string()));
+    }
+
+    #[test]
+    fn test_pickup_where_edge_cases() {
+        // Test SQL with table alias but no joins
+        let sql = "SELECT * FROM logs l WHERE l.level = 'error'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, Some("l.level = 'error'".to_string()));
+
+        // Test SQL with quoted identifiers
+        let sql = "SELECT * FROM \"logs\" WHERE \"level\" = 'error'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, Some("\"level\" = 'error'".to_string()));
+
+        // Test SQL with schema prefix
+        let sql = "SELECT * FROM public.logs WHERE level = 'error'";
+        let result = pickup_where(sql).unwrap();
+        assert_eq!(result, Some("level = 'error'".to_string()));
     }
 }


### PR DESCRIPTION
### **User description**
close #7751


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Refactor `pickup_where` with proper SQL parsing  

- Skip filters on subqueries, joins, CTEs  

- Update handler calls to new signature  

- Add extensive unit tests for extraction


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Request"] --> B["Search Handler"]
  B --> C["Call pickup_where(sql)"]
  C --> D["SQL Parser Visitor"]
  D -- "simple WHERE" --> E["Return filter string"]
  D -- "complex query" --> F["Return None"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update calls to new `pickup_where` signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/search/mod.rs

<ul><li>Remove deprecated <code>meta</code> parameter from calls  <br> <li> Adapt WHERE pickup integration in handler</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7755/files#diff-96630a0dbb6dd7b2b0248fa325c7c7041ce31340c32826675a4a70772e9d29f6">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql.rs</strong><dd><code>Replace regex-based WHERE extraction with parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/sql.rs

<ul><li>Remove old regex <code>pickup_where</code> implementation  <br> <li> Add <code>PickupWhereVisitor</code> using <code>sqlparser</code>  <br> <li> Update function signature, drop <code>MetaSql</code> arg  <br> <li> Add comprehensive unit tests for various SQL cases</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7755/files#diff-d9ccf393c53794b0ef2816eef12742c26e23d2788cde27780af7570662aea446">+256/-41</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

