### PR TITLE
fix: visualization enhancement minor fixes

### DIFF
--- a/src/service/search/sql/histogram.rs
+++ b/src/service/search/sql/histogram.rs
@@ -31,7 +31,7 @@ pub fn convert_to_histogram_query(
         is_eligible_for_histogram(original_query).map_err(|e| Error::Message(e.to_string()))?;
     if !is_eligible {
         let error = Error::ErrorCode(ErrorCodes::SearchHistogramNotAvailable(
-            "Histogram unavailable for SUBQUERY, CTE, DISTINCT and LIMIT queries.".to_string(),
+            "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.".to_string(),
         ));
         return Err(error);
     }

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1014,7 +1014,7 @@ export default defineComponent({
 
     // Helper function for handling the visualize tab
     function handleVisualizeTab() {
-      handleRunQueryFn();
+      // handleRunQueryFn();
     }
 
     const refreshTimezone = () => {

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1710,7 +1710,7 @@ export default defineComponent({
       try {
 
         let logsPageQuery = searchObj.data.query;        
-        // return if query is emptry and stream is not selected 
+        // return if query is empty and stream is not selected 
         if(logsPageQuery === "" && searchObj?.data?.stream?.selectedStream?.length === 0){ 
           showErrorNotification("Query is empty, please write query to visualize");
           variablesAndPanelsDataLoadingState.fieldsExtractionLoading = false;

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -838,7 +838,6 @@ export default defineComponent({
       await setupLogsTab();
       if (!isLogsTab()) {
         await importSqlParser();
-        handleVisualizeTab();
       }
     }
 
@@ -1014,7 +1013,7 @@ export default defineComponent({
 
     // Helper function for handling the visualize tab
     function handleVisualizeTab() {
-      // handleRunQueryFn();
+      handleRunQueryFn();
     }
 
     const refreshTimezone = () => {

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -54,18 +54,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 "
                 class="button button-right tw-flex tw-justify-center tw-items-center no-border no-outline !tw-rounded-l-none q-px-sm"
                 @click="onLogsVisualizeToggleUpdate('visualize')"
-                :disabled="isVisualizeToggleDisabled"
                 no-caps
                 size="sm"
                 style="height: 32px"
               >
-                <q-tooltip>
-                  {{
-                    isVisualizeToggleDisabled
-                      ? t("search.visualizeDisabledForMultiStream")
-                      : t("search.visualize")
-                  }}
-                </q-tooltip>
                 <img
                   :src="visualizeIcon"
                   alt="Visualize"
@@ -3276,10 +3268,6 @@ export default defineComponent({
     const { dashboardPanelData, resetDashboardPanelData } =
       useDashboardPanelData(dashboardPanelDataPageKey);
 
-    const isVisualizeToggleDisabled = computed(() => {
-      return searchObj.data.stream.selectedStream.length > 1;
-    });
-
     // [START] cancel running queries
 
     const variablesAndPanelsDataLoadingState =
@@ -3598,7 +3586,6 @@ export default defineComponent({
       resetRegionFilter,
       validateFilterForMultiStream,
       cancelQuery,
-      isVisualizeToggleDisabled,
       onLogsVisualizeToggleUpdate,
       visualizeSearchRequestTraceIds,
       disable,

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -864,6 +864,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               style="width: 100%; height: 100%"
             >
               <template v-if="showFunctionEditor">
+              <div class="tw-relative tw-h-full tw-w-full"
+              >
                 <query-editor
                   data-test="logs-vrl-function-editor"
                   ref="fnEditorRef"
@@ -881,6 +883,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   @focus="searchObj.meta.functionEditorPlaceholderFlag = false"
                   @blur="searchObj.meta.functionEditorPlaceholderFlag = true"
                 />
+             </div>
+               <div v-if="searchObj.meta.logsVisualizeToggle === 'visualize'" 
+               :class="store.state.theme == 'dark' ? 'tw-bg-white tw-bg-opacity-10' : 'tw-bg-black tw-bg-opacity-10'"
+               class="tw-absolute tw-bottom-0 tw-w-full " style="margin-top: 12px; display: flex; align-items: center; flex">
+                <q-icon name="warning" color="warning" size="20px" class="q-mx-sm" />
+                <span class="text-negative q-pa-sm" style="font-weight: semibold; font-size: 14px;">VRL Function Editor is not supported in visualize mode.</span>
+              </div>
               </template>
               <template v-else-if="searchObj.data.transformType === 'action'">
                 <query-editor
@@ -1658,16 +1667,6 @@ export default defineComponent({
     watch(
       () => searchObj.meta.functionEditorPlaceholderFlag,
       (val) => {
-
-        if (searchObj.meta.logsVisualizeToggle === 'visualize' && val == false){
-          // show warning
-          $q.notify({
-            message: "Function editor is not supported for visualization",
-            color: "warning",
-            position: "bottom",
-            timeout: 5000,
-          });
-        }
 
         if (
           searchObj.meta.jobId != "" &&

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -522,9 +522,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           icon="wrap_text"
           class="float-left"
           size="32px"
+          :disable="searchObj.meta.logsVisualizeToggle === 'visualize'"
         >
           <q-tooltip>
-            {{ t("search.messageWrapContent") }}
+           {{ searchObj.meta.logsVisualizeToggle === 'visualize' ? 'Not supported for visualization' : t("search.messageWrapContent") }}
           </q-tooltip>
         </q-toggle>
 
@@ -1654,6 +1655,17 @@ export default defineComponent({
     watch(
       () => searchObj.meta.functionEditorPlaceholderFlag,
       (val) => {
+
+        if (searchObj.meta.logsVisualizeToggle === 'visualize' && val == false){
+          // show warning
+          $q.notify({
+            message: "Function editor is not supported for visualization",
+            color: "warning",
+            position: "bottom",
+            timeout: 5000,
+          });
+        }
+
         if (
           searchObj.meta.jobId != "" &&
           val == true &&

--- a/web/src/plugins/logs/TransformSelector.vue
+++ b/web/src/plugins/logs/TransformSelector.vue
@@ -162,16 +162,6 @@ const { t } = useI18n();
 
 const { searchObj, isActionsEnabled } = useLogs();
 
-// Watch logsVisualizeToggle and set showTransformEditor to false if condition matches
-watch(
-  () => searchObj.meta.logsVisualizeToggle,
-  () => {
-    if (searchObj.meta.logsVisualizeToggle === 'visualize') {
-      searchObj.meta.showTransformEditor = false;
-    }
-  }
-);
-
 const store = useStore();
 
 const functionModel = ref(false);

--- a/web/src/plugins/logs/TransformSelector.vue
+++ b/web/src/plugins/logs/TransformSelector.vue
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :icon="transformIcon"
     class="float-left tw-cursor-pointer"
     size="32px"
-    :disable="!searchObj.data.transformType"
+    :disable="!searchObj.data.transformType || searchObj.meta.logsVisualizeToggle === 'visualize'"
   >
     <q-tooltip class="tw-text-[12px]" :offset="[0, 2]">
       {{ getTransformLabelTooltip }}
@@ -46,6 +46,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         class="saved-views-dropdown btn-function no-case q-pl-sm q-pr-none"
         :class="`${searchObj.data.transformType || 'transform'}-icon`"
         label-class="no-case"
+        :disable="searchObj.meta.logsVisualizeToggle === 'visualize'"
       >
         <q-list data-test="logs-search-saved-function-list">
           <!-- Search Input -->
@@ -129,14 +130,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       class="q-mr-xs save-transform-btn q-px-sm"
       size="sm"
       icon="save"
-      :disable="searchObj.data.transformType !== 'function'"
+      :disable="searchObj.data.transformType !== 'function' || searchObj.meta.logsVisualizeToggle === 'visualize'"
       @click="fnSavedFunctionDialog"
     >
       <q-tooltip class="tw-text-[12px]" :offset="[0, 6]">
         {{
           searchObj.data.transformType === "action"
             ? t("search.saveActionDisabled")
-            : t("common.save")
+            : searchObj.meta.logsVisualizeToggle === 'visualize' ? 'Not supported for visualization' : t("common.save")
         }}
       </q-tooltip>
     </q-btn>
@@ -144,7 +145,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import useLogs from "@/composables/useLogs";
 import { getImageURL } from "@/utils/zincutils";
@@ -160,6 +161,16 @@ const emit = defineEmits(["select:function", "save:function"]);
 const { t } = useI18n();
 
 const { searchObj, isActionsEnabled } = useLogs();
+
+// Watch logsVisualizeToggle and set showTransformEditor to false if condition matches
+watch(
+  () => searchObj.meta.logsVisualizeToggle,
+  () => {
+    if (searchObj.meta.logsVisualizeToggle === 'visualize') {
+      searchObj.meta.showTransformEditor = false;
+    }
+  }
+);
 
 const store = useStore();
 
@@ -234,6 +245,8 @@ const transformsLabel = computed(() => {
     return searchObj.data.selectedTransform.name;
   }
 
+  if (searchObj.meta.logsVisualizeToggle === 'visualize') return "Function selection is not supported for visualization";
+
   if (!isActionsEnabled.value) return "Function";
 
   return searchObj.data.transformType === "action"
@@ -302,6 +315,10 @@ const fnSavedFunctionDialog = () => {
 };
 
 const getTransformLabelTooltip = computed(() => {
+
+  // function selection is not supported for visualization
+  if (searchObj.meta.logsVisualizeToggle === 'visualize') return "Function selection is not supported for visualization";
+
   if (!isActionsEnabled.value) return "Toggle Function Editor";
 
   return searchObj.meta.showTransformEditor

--- a/web/src/plugins/logs/VisualizeLogsQuery.vue
+++ b/web/src/plugins/logs/VisualizeLogsQuery.vue
@@ -141,7 +141,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         min-height: calc(100% - 24px);
                         height: calc(100% - 24px);
                         width: 100%;
-                        margin-top: 24px;
+                        margin-top: 36px;
                       "
                     >
                       <PanelSchemaRenderer


### PR DESCRIPTION
# Visualization Behavior

## When is the user-written query used and when is the *histogram query* (a bar chart that shows counts over time on the logs page) used?

* **When is the histogram query chosen?**  
  If your query **does not** use `GROUP BY` at all — that is, `group_by` is *empty* — then there’s no natural way to aggregate the rows, so the visualization will show the same histogram chart as shown on the logs page.

* **When is the user-written query chosen?**  
  If your query already has a `GROUP BY`, the normal results are good enough.

---

## Picking the Chart Type

By default, only two chart types will be selected.

After the histogram check, the app looks at `group_by` fields to decide between a **Line chart** and a **Table**.

### A. Line Chart (Time Series)

The app chooses a *line chart* when **all** of these are true:

1. There **is** a *timeseries field* (a column that represents time).  
2. There are **zero, one, or two** `GROUP BY` columns.

What goes where:

* **X-axis** – the timeseries field.
* **Breakdown** – any `GROUP BY` column that isn’t the time field.
* **Y-axis** – every other projected field (anything not in `GROUP BY` and not the time field).

### B. Table (List or Pivot-style View)

If the conditions for a line chart are **not** met, it falls back to a *table*.

Typical reasons:

* No time column was returned.  
* There are **three or more** `GROUP BY` columns.

---

## Putting It All Together – Quick Cheat Sheet

| Scenario                                                                  | Chart Chosen | Reasoning                                                             |
|---------------------------------------------------------------------------|--------------|-----------------------------------------------------------------------|
| No `GROUP BY` clause                                                      | Histogram     | Needs automatic aggregation over time buckets.                        |
| Time field present **and** ≤ 2 `GROUP BY` columns                         | Line Chart    | Clean timeline with optional breakdown; easy to read.                 |
| Time field missing **or** ≥ 3 `GROUP BY` columns                          | Table         | Too many categories or no timeline makes a table clearer.             |

> ⚠️ **Note:** You can change the chart type manually, but it may not be compatible with all data configurations. Some chart types might not render correctly depending on the query.

---

## Share Visualization

- The option to share visualizations is now available.
- Please note that shared visualizations will open with the **default configuration** — this means the default chart type will be used, and any custom settings will not be preserved.

---

## Why Some Queries Fail to Visualize

1. **Empty Query** – You will see: “Query is empty, please write query to visualize.”
2. **Missing Column Aliases** – Every projected field must have an alias so the chart axes have unique labels. The app prompts you to add aliases if they are missing.

Fix those and try again!
