### PR TITLE
fix: update string matching logic to include 'Contains' operator

### DIFF
--- a/web/src/composables/useDashboardPanel.ts
+++ b/web/src/composables/useDashboardPanel.ts
@@ -2032,7 +2032,10 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
           )})`;
         } else if (condition.operator === "match_all") {
           selectFilter += `match_all(${formatValue(condition.value, condition.column)})`;
-        } else if (condition.operator === "str_match") {
+        } else if (
+          condition.operator === "str_match" ||
+          condition.operator === "Contains"
+        ) {
           selectFilter += `str_match(${condition.column}, ${formatValue(
             condition.value,
             condition.column,
@@ -2065,12 +2068,12 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
                 condition.column,
               )}`;
               break;
-            case "Contains":
-              selectFilter +=
-                columnType === "Utf8"
-                  ? `LIKE '%${condition.value}%'`
-                  : `LIKE %${condition.value}%`;
-              break;
+            // case "Contains":
+            //   selectFilter +=
+            //     columnType === "Utf8"
+            //       ? `LIKE '%${condition.value}%'`
+            //       : `LIKE %${condition.value}%`;
+            //   break;
             case "Not Contains":
               selectFilter +=
                 columnType === "Utf8"

--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -97,7 +97,7 @@ export const addLabelToSQlQuery = async (
 
   if (operator === "match_all") {
     condition = `match_all(${formatValue(value)})`;
-  } else if (operator === "str_match") {
+  } else if (operator === "str_match" || operator === "Contains") {
     condition = `str_match(${label}, ${formatValue(value)})`;
   } else if (operator === "str_match_ignore_case") {
     condition = `str_match_ignore_case(${label}, ${formatValue(value)})`;
@@ -107,10 +107,10 @@ export const addLabelToSQlQuery = async (
     condition = `re_not_match(${label}, ${formatValue(value)})`;
   } else {
     switch (operator) {
-      case "Contains":
-        operator = "LIKE";
-        value = "%" + escapeSingleQuotes(value) + "%";
-        break;
+      // case "Contains":
+      //   operator = "LIKE";
+      //   value = "%" + escapeSingleQuotes(value) + "%";
+      //   break;
       case "Not Contains":
         operator = "NOT LIKE";
         value = "%" + escapeSingleQuotes(value) + "%";


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Support "Contains" operator in str_match logic

- Deprecate legacy LIKE-based Contains handling

- Update DashboardPanel and SQL utils


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useDashboardPanel.ts</strong><dd><code>Add Contains operator to str_match logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useDashboardPanel.ts

<ul><li>Map "Contains" to str_match filter<br> <li> Commented out old LIKE-based Contains logic</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7765/files#diff-fbba1700750053b9eaf38ddd30dab84531bc44131c795ebb713811e4930cd7cb">+10/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sqlUtils.ts</strong><dd><code>Map Contains to str_match in SQL utils</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/query/sqlUtils.ts

<ul><li>Treat "Contains" as str_match in addLabelToSQlQuery<br> <li> Commented out legacy Contains LIKE branch</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7765/files#diff-dde40e8fcb5c37b06c011ede08922c44a3c025682fbc341aee97ba046b73a0e3">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

