### PR TITLE
fix: convert microseconds to seconds for delay_in_secs in triggers stream

### DIFF
--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -312,7 +312,7 @@ async fn handle_alert_triggers(
                 start_time,
                 end_time: *skipped_last_timestamp,
                 retries: trigger.retries,
-                delay_in_secs: Some(delay),
+                delay_in_secs: Some(Duration::microseconds(delay).num_seconds()),
                 error: None,
                 success_response: None,
                 is_partial: None,


### PR DESCRIPTION
Currently there is a bug in reporting the delay_in_secs field in triggers stream for skipped events. It uses microseconds in the delay_in_seconds field instead of seconds.