### PR TITLE
fix: histogram interval bug fixes

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -1580,7 +1580,14 @@ impl StreamResponses {
                     let metadata_bytes = format_event("search_response_metadata", &metadata_data);
 
                     // Send empty hits
-                    let hits_bytes = format_event("search_response_hits", "{\"hits\":[]}");
+                    let hits = StreamResponses::SearchResponseHits {
+                        hits: results.hits.clone(),
+                    };
+                    let hits_data = serde_json::to_string(&hits).unwrap_or_else(|_| {
+                        log::error!("Failed to serialize hits: {:?}", hits);
+                        String::new()
+                    });
+                    let hits_bytes = format_event("search_response_hits", &hits_data);
 
                     // Return both chunks in sequence
                     let chunks_iter =

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -1101,10 +1101,6 @@ const useLogs = () => {
     return parsedSQL?.distinct?.type === "DISTINCT";
   };
 
-  const isWithQuery = (parsedSQL: any = null) => {
-    return parsedSQL?.with && parsedSQL?.with?.length > 0;
-  };
-
   const getQueryPartitions = async (queryReq: any) => {
     try {
       // const queryReq = buildSearch();
@@ -1407,7 +1403,7 @@ const useLogs = () => {
             searchObj.meta.showHistogram == true &&
             searchObj.data.stream.selectedStream.length <= 1 &&
             (!searchObj.meta.sqlMode ||
-              (searchObj.meta.sqlMode && !isLimitQuery(parsedSQL) && !isDistinctQuery(parsedSQL) && !isWithQuery(parsedSQL) && searchObj.data.queryResults.is_histogram_eligible))) ||
+              (searchObj.meta.sqlMode && !isLimitQuery(parsedSQL) && !isDistinctQuery(parsedSQL) && searchObj.data.queryResults.is_histogram_eligible))) ||
           (searchObj.loadingHistogram == false &&
             searchObj.meta.showHistogram == true &&
             searchObj.data.stream.selectedStream.length <= 1 &&
@@ -1816,7 +1812,7 @@ const useLogs = () => {
             -1
           );
           searchObj.meta.histogramDirtyFlag = false;
-        } else if (searchObj.meta.sqlMode && (isDistinctQuery(parsedSQL) || isWithQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible)) {
+        } else if (searchObj.meta.sqlMode && (isDistinctQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible)) {
           let aggFlag = false;
           if (parsedSQL) {
             aggFlag = hasAggregation(parsedSQL?.columns);
@@ -1833,7 +1829,7 @@ const useLogs = () => {
               searchObjDebug["pagecountEndTime"] = performance.now();
             }, 0);
           }
-          if(isWithQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible){
+          if(!searchObj.data.queryResults.is_histogram_eligible){
             resetHistogramWithError(
               "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
               -1
@@ -2419,7 +2415,7 @@ const useLogs = () => {
           delete queryReq.query.track_total_hits;
         }
 
-        if (isDistinctQuery(parsedSQL) || isWithQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible) {
+        if (isDistinctQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible) {
           delete queryReq.query.track_total_hits;
         }
       }
@@ -5173,7 +5169,7 @@ const useLogs = () => {
           delete queryReq.query.track_total_hits;
         }
 
-        if (isDistinctQuery(parsedSQL) || isWithQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible) {
+        if (isDistinctQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible) {
           delete queryReq.query.track_total_hits;
         }
       }
@@ -6172,7 +6168,7 @@ const useLogs = () => {
     } else if (searchObj.meta.sqlMode && isLimitQuery(parsedSQL)) {
       resetHistogramWithError("Histogram unavailable for CTEs, DISTINCT and LIMIT queries.", -1);
       searchObj.meta.histogramDirtyFlag = false;
-    } else if (searchObj.meta.sqlMode && (isDistinctQuery(parsedSQL) || isWithQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible)) {
+    } else if (searchObj.meta.sqlMode && (isDistinctQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible)) {
       if (shouldGetPageCount(queryReq, parsedSQL) && isFromZero) {
         setTimeout(async () => {
           searchObjDebug["pagecountStartTime"] = performance.now();
@@ -6180,7 +6176,7 @@ const useLogs = () => {
           searchObjDebug["pagecountEndTime"] = performance.now();
         }, 0);
       }
-      if(isWithQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible){
+      if(!searchObj.data.queryResults.is_histogram_eligible){
         resetHistogramWithError(
           "Histogram unavailable for CTEs, DISTINCT and LIMIT queries..",
           -1
@@ -6220,7 +6216,7 @@ const useLogs = () => {
   function isNonAggregatedSQLMode(searchObj: any, parsedSQL: any) {
     return !(
       searchObj.meta.sqlMode &&
-      (isLimitQuery(parsedSQL) || isDistinctQuery(parsedSQL) || isWithQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible)
+      (isLimitQuery(parsedSQL) || isDistinctQuery(parsedSQL) || !searchObj.data.queryResults.is_histogram_eligible)
     );
   }
 
@@ -6623,7 +6619,6 @@ const useLogs = () => {
     isActionsEnabled,
     sendCancelSearchMessage,
     isDistinctQuery,
-    isWithQuery,
     getStream,
     loadVisualizeData,
     processHttpHistogramResults

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -5183,7 +5183,7 @@ const useLogs = () => {
 
       if(!queryReq) return;
       
-      if(!isPagination && searchObj.meta.refreshInterval === 0) {
+      if(!isPagination && searchObj.meta.refreshInterval == 0) {
         resetQueryData();
         histogramResults = [];
         searchObj.data.queryResults.hits = [];
@@ -5199,13 +5199,11 @@ const useLogs = () => {
           errorMsg: "",
           errorDetail: "",
         };
-
-        if(searchObj.meta.refreshInterval == 0) searchObj.meta.resetPlotChart = true;
       }
 
       const payload = buildWebSocketPayload(queryReq, isPagination, "search");
       
-      if(shouldGetPageCount(queryReq, fnParsedSQL()) && searchObj.meta.refreshInterval === 0) {
+      if(shouldGetPageCount(queryReq, fnParsedSQL()) && searchObj.meta.refreshInterval == 0) {
         queryReq.query.size = queryReq.query.size + 1;
       }
 
@@ -5438,7 +5436,7 @@ const useLogs = () => {
       );
     } 
     
-    if (searchObj.meta.refreshInterval === 0) {
+    if (searchObj.meta.refreshInterval == 0) {
       updatePageCountTotal(payload.queryReq, response.content.results.hits.length, searchObj.data.queryResults.hits.length);
       trimPageCountExtraHit(payload.queryReq, searchObj.data.queryResults.hits.length);
     }
@@ -5503,7 +5501,7 @@ const useLogs = () => {
       searchObj.data.queryResults.is_histogram_eligible = response.content.results.is_histogram_eligible;
     }
 
-    if(searchObj.meta.refreshInterval === 0) {
+    if(searchObj.meta.refreshInterval == 0) {
       if(shouldGetPageCount(payload.queryReq, fnParsedSQL()) && (response.content.results.total === payload.queryReq.query.size)) {
         searchObj.data.queryResults.pageCountTotal = payload.queryReq.query.size * searchObj.data.resultGrid.currentPage;
       } else if(shouldGetPageCount(payload.queryReq, fnParsedSQL()) && (response.content.results.total != payload.queryReq.query.size)){
@@ -5879,7 +5877,7 @@ const useLogs = () => {
       searchObj.data.queryResults.hits = response.content.results.hits;
     }
 
-    if (!searchObj.meta.refreshInterval) {
+    if (searchObj.meta.refreshInterval == 0) {
       // In page count we set track_total_hits
       if (!queryReq.query.hasOwnProperty("track_total_hits")) {
         delete response.content.total;
@@ -6264,6 +6262,10 @@ const useLogs = () => {
 
     if(!searchObj.data.queryResults.hasOwnProperty('hits')){
       searchObj.data.queryResults.hits = [];
+    }
+
+    if(payload.type === "search" && !payload.isPagination && searchObj.meta.refreshInterval == 0) {
+      searchObj.meta.resetPlotChart = true;
     }
 
     if (

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -387,10 +387,7 @@ import useDashboardPanelData from "@/composables/useDashboardPanel";
 import { reactive } from "vue";
 import { getConsumableRelativeTime } from "@/utils/date";
 import { cloneDeep, debounce } from "lodash-es";
-import {
-  buildSqlQuery,
-  getFieldsFromQuery,
-} from "@/utils/query/sqlUtils";
+import { buildSqlQuery, getFieldsFromQuery } from "@/utils/query/sqlUtils";
 import useNotifications from "@/composables/useNotifications";
 import SearchBar from "@/plugins/logs/SearchBar.vue";
 import SearchHistory from "@/plugins/logs/SearchHistory.vue";
@@ -713,7 +710,10 @@ export default defineComponent({
           !type
         ) {
           searchObj.meta.pageType = "logs";
-          if(prev === "stream_explorer" && (type == undefined || type !== "stream_explorer")) {
+          if (
+            prev === "stream_explorer" &&
+            (type == undefined || type !== "stream_explorer")
+          ) {
             searchObj.meta.refreshHistogram = true;
           }
           loadLogsData();
@@ -831,10 +831,13 @@ export default defineComponent({
 
     // Main method for handling before mount logic
     async function handleBeforeMount() {
-      if(Object.hasOwn(router.currentRoute.value?.query, "logs_visualize_toggle")) {
-        searchObj.meta.logsVisualizeToggle = router.currentRoute.value.query.logs_visualize_toggle;
+      if (
+        Object.hasOwn(router.currentRoute.value?.query, "logs_visualize_toggle")
+      ) {
+        searchObj.meta.logsVisualizeToggle =
+          router.currentRoute.value.query.logs_visualize_toggle;
       }
-      
+
       await setupLogsTab();
       if (!isLogsTab()) {
         await importSqlParser();
@@ -861,6 +864,9 @@ export default defineComponent({
 
         resetStreamData();
 
+        searchObj.meta.quickMode = isQuickModeEnabled();
+        searchObj.meta.showHistogram = isHistogramEnabled();
+
         restoreUrlQueryParams();
 
         await importSqlParser();
@@ -869,7 +875,7 @@ export default defineComponent({
           await getRegionInfo();
         }
 
-        if(isLogsTab()) {
+        if (isLogsTab()) {
           loadLogsData();
         } else {
           loadVisualizeData();
@@ -879,9 +885,6 @@ export default defineComponent({
         if (isCloudEnvironment()) {
           setupCloudSpecificThreshold();
         }
-
-        searchObj.meta.quickMode = isQuickModeEnabled();
-        searchObj.meta.showHistogram = isHistogramEnabled();
 
         isLogsMounted.value = true;
       } catch (error) {
@@ -1452,8 +1455,12 @@ export default defineComponent({
               };
 
               // if hits is empty and filteredHit is present, then set hits to filteredHit
-              if (searchResponseForVisualization?.value?.hits?.length === 0 && searchResponseForVisualization?.value?.filteredHit) {
-                searchResponseForVisualization.value.hits = searchResponseForVisualization?.value?.filteredHit ?? [];
+              if (
+                searchResponseForVisualization?.value?.hits?.length === 0 &&
+                searchResponseForVisualization?.value?.filteredHit
+              ) {
+                searchResponseForVisualization.value.hits =
+                  searchResponseForVisualization?.value?.filteredHit ?? [];
               }
             }
 
@@ -1461,8 +1468,8 @@ export default defineComponent({
             const dateTime =
               searchObj.data.datetime.type === "relative"
                 ? getConsumableRelativeTime(
-                  searchObj.data.datetime.relativeTimePeriod,
-                )
+                    searchObj.data.datetime.relativeTimePeriod,
+                  )
                 : cloneDeep(searchObj.data.datetime);
 
             dashboardPanelData.meta.dateTime = {
@@ -1486,12 +1493,12 @@ export default defineComponent({
           // this will clear dummy trace id
           cancelFieldExtraction();
 
-          if(err.name === "AbortError"){
+          if (err.name === "AbortError") {
             return;
           }
 
-           // show error notification
-           showErrorNotification(
+          // show error notification
+          showErrorNotification(
             err.message ?? "Error in updating visualization",
           );
           return;
@@ -1578,7 +1585,7 @@ export default defineComponent({
         // wait to extract fields if its ongoing; if promise rejects due to abort just return silently
         try {
           const success = await updateVisualization();
-          if(!success){
+          if (!success) {
             return;
           }
         } catch (err: any) {
@@ -1601,7 +1608,7 @@ export default defineComponent({
         const currentQuery =
           dashboardPanelData.data.queries[
             dashboardPanelData.layout.currentQueryIndex
-          ].query;        
+          ].query;
 
         // check if query is assigned and not empty
         // this prevents hard refresh early validation before query is assigned
@@ -1620,8 +1627,8 @@ export default defineComponent({
         const dateTime =
           searchObj.data.datetime.type === "relative"
             ? getConsumableRelativeTime(
-              searchObj.data.datetime.relativeTimePeriod,
-            )
+                searchObj.data.datetime.relativeTimePeriod,
+              )
             : cloneDeep(searchObj.data.datetime);
 
         dashboardPanelData.meta.dateTime = {
@@ -1709,28 +1716,33 @@ export default defineComponent({
       };
 
       try {
-
-        let logsPageQuery = searchObj.data.query;        
-        // return if query is emptry and stream is not selected 
-        if(logsPageQuery === "" && searchObj?.data?.stream?.selectedStream?.length === 0){ 
-          showErrorNotification("Query is empty, please write query to visualize");
+        let logsPageQuery = searchObj.data.query;
+        // return if query is emptry and stream is not selected
+        if (
+          logsPageQuery === "" &&
+          searchObj?.data?.stream?.selectedStream?.length === 0
+        ) {
+          showErrorNotification(
+            "Query is empty, please write query to visualize",
+          );
           variablesAndPanelsDataLoadingState.fieldsExtractionLoading = false;
           return null;
         }
 
         // handle sql mode
-        if(!searchObj.data.sqlMode){
-          const queryBuild= buildSearch();
+        if (!searchObj.data.sqlMode) {
+          const queryBuild = buildSearch();
           logsPageQuery = queryBuild?.query?.sql ?? "";
         }
 
         // check if query is empty
-        if(logsPageQuery === ""){
-          showErrorNotification("Query is empty, please write query to visualize");
+        if (logsPageQuery === "") {
+          showErrorNotification(
+            "Query is empty, please write query to visualize",
+          );
           variablesAndPanelsDataLoadingState.fieldsExtractionLoading = false;
           return null;
         }
-
 
         /* ------------------------------------------------------------- */
         /* 1) Fetch schema for the user query                            */
@@ -1797,7 +1809,9 @@ export default defineComponent({
         const finalQuery = logsPageQuery;
 
         if (!finalQuery) {
-          showErrorNotification("Query is empty, please write query to visualize");
+          showErrorNotification(
+            "Query is empty, please write query to visualize",
+          );
           variablesAndPanelsDataLoadingState.fieldsExtractionLoading = false;
           return null;
         }
@@ -1827,7 +1841,10 @@ export default defineComponent({
           };
         }
 
-        fieldsExtractionPromise = setCustomQueryFields(fieldsForVisualization, signal);
+        fieldsExtractionPromise = setCustomQueryFields(
+          fieldsForVisualization,
+          signal,
+        );
 
         await fieldsExtractionPromise;
 
@@ -2166,13 +2183,13 @@ export default defineComponent({
           this.resetHistogramWithError(
             "Histogram is not available for multi stream search.",
           );
-        }else if(!this.searchObj.data.queryResults.is_histogram_eligible){
+        } else if (!this.searchObj.data.queryResults.is_histogram_eligible) {
           this.resetHistogramWithError(
             "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",
             -1,
           );
           this.searchObj.meta.histogramDirtyFlag = false;
-        }else if (
+        } else if (
           this.searchObj.meta.histogramDirtyFlag == true &&
           this.searchObj.meta.jobId == ""
         ) {
@@ -2194,7 +2211,7 @@ export default defineComponent({
               "histogram",
               {
                 isHistogramOnly: this.searchObj.meta.histogramDirtyFlag,
-                is_ui_histogram: true
+                is_ui_histogram: true,
               },
             );
             const requestId = this.initializeSearchConnection(payload);
@@ -2222,7 +2239,6 @@ export default defineComponent({
               this.searchObj.loadingHistogram = false;
             });
         }
-
       }
 
       this.updateUrlQueryParams();

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -579,7 +579,6 @@ export default defineComponent({
       addTraceId,
       sendCancelSearchMessage,
       isDistinctQuery,
-      isWithQuery,
       getStream,
       loadVisualizeData,
       buildSearch,
@@ -2067,7 +2066,6 @@ export default defineComponent({
       showSearchScheduler,
       closeSearchSchedulerFn,
       isDistinctQuery,
-      isWithQuery,
       isStreamingEnabled,
       sendToAiChat,
       processInterestingFiledInSQLQuery,
@@ -2172,7 +2170,7 @@ export default defineComponent({
           this.searchObj.meta.histogramDirtyFlag = false;
         } else if (
           this.searchObj.meta.sqlMode &&
-          (this.isDistinctQuery(parsedSQL) || this.isWithQuery(parsedSQL))
+          (this.isDistinctQuery(parsedSQL))
         ) {
           this.resetHistogramWithError(
             "Histogram unavailable for CTEs, DISTINCT and LIMIT queries.",

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -144,14 +144,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           style="max-height: 100px"
           @updated:dataZoom="onChartUpdate"
         />
-
         <div
           style="height: 100px"
           v-else-if="
             searchObj.meta.showHistogram &&
-            Object.keys(plotChart)?.length == 0 &&
-            searchObj.loadingHistogram == false &&
-            searchObj.loading == false
+            !searchObj.loadingHistogram &&
+            !searchObj.loading
           "
         >
           <h3 class="text-center">
@@ -161,11 +159,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             >
           </h3>
         </div>
-
         <div
           style="height: 100px"
           v-else-if="
-            searchObj.meta.showHistogram && Object.keys(plotChart)?.length == 0
+            searchObj.meta.showHistogram && Object.keys(plotChart)?.length === 0
           "
         >
           <h3 class="text-center">
@@ -707,7 +704,18 @@ export default defineComponent({
 
     const closeTable = () => {
       searchObj.meta.showDetailTab = false;
-    }
+    };
+
+    const resetPlotChart = computed(() => {
+      return searchObj.meta.resetPlotChart;
+    });
+
+    watch(resetPlotChart, (newVal) => {
+      if (newVal) {
+        plotChart.value = {};
+        searchObj.meta.resetPlotChart = false;
+      }
+    });
 
     return {
       t,
@@ -749,7 +757,7 @@ export default defineComponent({
       refreshJobPagination,
       histogramLoader,
       sendToAiChat,
-      closeTable
+      closeTable,
     };
   },
   computed: {
@@ -765,9 +773,6 @@ export default defineComponent({
     reDrawChartData() {
       return this.searchObj.data.histogram;
     },
-    resetPlotChart() {
-      return this.searchObj.meta.resetPlotChart;
-    },
   },
   watch: {
     toggleWrapFlag() {
@@ -778,12 +783,6 @@ export default defineComponent({
     },
     updateTitle() {
       this.noOfRecordsTitle = this.searchObj.data.histogram.chartParams.title;
-    },
-    resetPlotChart(newVal: boolean) {
-      if (newVal) {
-        this.plotChart = {};
-        this.searchObj.meta.resetPlotChart = false;
-      }
     },
     reDrawChartData: {
       deep: true,


### PR DESCRIPTION
This PR fixes 
1. when user refreshes the page with histogram toggle off it was auto enabling it to on
2. in search streaming when there is no data for histogram and if we have already a chart rendered it was not getting cleared 
3. removed WITH(CTE) query check as we are not depending on the BE whether to call histogram or not based up on the flag that we get from the BE that is is_histogram_eligible
4. modified BE response whenever we have no data for histogram BE was giving no search_response_hits event 