### PR TITLE
fix: alert list refresh when user tries to refresh in non default folder

### DIFF
--- a/web/src/components/common/sidebar/FolderList.vue
+++ b/web/src/components/common/sidebar/FolderList.vue
@@ -230,10 +230,10 @@ export default defineComponent({
 
 
       const router = useRouter();
-
+      //here we are checking if the foldersByType is empty then we are fetching the folders from the BE on mounted 
       onMounted(async () => {
-        if(store.state.organizationData.foldersByType.length == 0) {
-          await getFoldersListByType(store, "alerts");
+        if(Object.keys(store.state.organizationData.foldersByType).length == 0) {          
+          await getFoldersListByType(store, props.type);
         }
         if(router.currentRoute.value.query.folder) {
           activeFolderId.value = router.currentRoute.value.query.folder;

--- a/web/src/utils/commons.ts
+++ b/web/src/utils/commons.ts
@@ -199,7 +199,7 @@ export const getFoldersListByType = async (store: any, type: any) => {
       ],
     });
 
-    return store.state.organizationData.folders;
+    return store.state.organizationData.foldersByType[type];
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
currently sometimes it is not giving the results of the current folder when user tries to refresh the page when user is non default folder