### PR TITLE
fix: http2_streaming bugs with new histogram flow

### DIFF
--- a/src/handler/http/request/search/search_stream.rs
+++ b/src/handler/http/request/search/search_stream.rs
@@ -771,6 +771,6 @@ async fn get_sql(
     stream_type: StreamType,
     search_type: Option<SearchEventType>,
 ) -> Result<crate::service::search::sql::Sql, infra::errors::Error> {
-    crate::service::search::sql::Sql::new(&query.clone().into(), &org_id, stream_type, search_type)
+    crate::service::search::sql::Sql::new(&query.clone().into(), org_id, stream_type, search_type)
         .await
 }

--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -549,23 +549,7 @@ async fn delete_stream_cache(
     }
     let query = web::Query::<HashMap<String, String>>::from_query(req.query_string()).unwrap();
     let stream_type = get_stream_type_from_request(&query).unwrap_or_default();
-    let delete_ts = match get_ts_from_request_with_key(&query, "ts") {
-        Ok(ts) => ts,
-        Err(e) => {
-            return Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(
-                http::StatusCode::BAD_REQUEST.into(),
-                e,
-            )));
-        }
-    };
-
-    // If ts parameter is present, it must be > 0
-    if delete_ts <= 0 {
-        return Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(
-            http::StatusCode::BAD_REQUEST.into(),
-            "Timestamp parameter must be greater than 0".to_string(),
-        )));
-    }
+    let delete_ts = get_ts_from_request_with_key(&query, "ts").unwrap_or(0);
 
     let path = if stream_name.eq("_all") {
         org_id

--- a/src/service/search/search_stream.rs
+++ b/src/service/search/search_stream.rs
@@ -830,9 +830,9 @@ pub async fn handle_cache_responses_and_deltas(
 ) -> Result<(), infra::errors::Error> {
     // Force set order_by to desc for dashboards & histogram
     // so that deltas are processed in the reverse order
-    let cache_order_by = if req.search_type.expect("search_type is required")
-        == SearchEventType::Dashboards
-        || req.query.size == -1
+    let search_type = req.search_type.expect("search_type is required");
+    let cache_order_by = if search_type == SearchEventType::Dashboards
+        || (req.query.size == -1 && search_type != SearchEventType::UI)
     {
         &OrderBy::Desc
     } else {


### PR DESCRIPTION
- fix order by for histogram query if alredy present in the query and the `search_type=ui` the partitions should honor the same

```
SELECT 
    histogram(_timestamp) AS x_axis_1,
  COUNT(k8s_namespace_name) AS "y_axis_1"
FROM default
GROUP BY x_axis_1
ORDER BY x_axis_1 ASC
```
- [fix: delete cahce api return error when no ts query param provided](https://github.com/openobserve/openobserve/pull/7787/commits/c0bc005e3f36015ea0c9470a0dc50939053f741d)