### PR TITLE
fix: tantivy histogram interval

### DIFF
--- a/src/service/search/sql.rs
+++ b/src/service/search/sql.rs
@@ -327,7 +327,7 @@ impl Sql {
             if visitor.is_simple_count {
                 index_optimize_mode = Some(IndexOptimizeMode::SimpleCount);
             } else if visitor.is_simple_histogram && histogram_interval_visitor.interval.is_some() {
-                let bucket_width = histogram_interval_visitor.interval.unwrap() as u64 * 1_000_000;
+                let bucket_width = histogram_interval.unwrap() as u64 * 1_000_000;
                 // round the bucket edges to even start
                 let rounding_by = bucket_width as i64;
                 let min_value = query.start_time - query.start_time % rounding_by;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix histogram interval variable usage

- Correct bucket width calculation


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql.rs</strong><dd><code>Correct histogram interval variable usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/sql.rs

<ul><li>Replace <code>histogram_interval_visitor.interval</code> with <code>histogram_interval</code><br> <li> Multiply interval by 1,000,000 for microseconds<br> <li> Round bucket edges to even boundaries</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7795/files#diff-d9ccf393c53794b0ef2816eef12742c26e23d2788cde27780af7570662aea446">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

