### PR TITLE
fix: reset the toggle of visualise when user moves to other page

### DIFF
--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -2182,6 +2182,8 @@ export default defineComponent({
         fnEditorRef?.value?.resetEditorLayout();
       });
       window.removeEventListener("keydown", handleEscKey);
+      //here we need to reset the visualize toggle to logs
+      searchObj.meta.logsVisualizeToggle = 'logs';
     });
 
     onActivated(() => {


### PR DESCRIPTION
1. This PR fixes the issue that when user moves to other page which doesn't keep alive true then if user is in visualise page , we should redirect user to logs page