### PR TITLE
fix: enrichment table issues #7815

### DIFF
--- a/tests/ui-testing/playwright-tests/GeneralTests/enrichment.spec.js
+++ b/tests/ui-testing/playwright-tests/GeneralTests/enrichment.spec.js
@@ -142,7 +142,7 @@ test.describe("Enrichment data testcases", () => {
     await page.getByText("Save").click({ force: true });
 
     // Wait for the process to complete
-    await page.reload();
+    // await page.reload();
     await page.waitForTimeout(3000);
     await page.getByPlaceholder("Search Enrichment Table").fill(fileName);
     await page.waitForTimeout(3000);
@@ -182,7 +182,7 @@ test.describe("Enrichment data testcases", () => {
     await page.getByText("Save").click({ force: true });
 
     // Reload the page to ensure table is updated
-    await page.reload();
+    // await page.reload();
     await page.waitForTimeout(3000);
 
     // Search for the uploaded file name
@@ -280,7 +280,7 @@ abc, err = get_enrichment_table_record("${fileName}", {
     await page.getByText("Save").click({ force: true });
   
     // Wait for the process to complete
-    await page.reload();
+    // await page.reload();
     await page.waitForTimeout(3000);
     await page.getByPlaceholder("Search Enrichment Table").fill(fileName);
     await page.waitForTimeout(3000);

--- a/web/src/components/functions/AddEnrichmentTable.vue
+++ b/web/src/components/functions/AddEnrichmentTable.vue
@@ -54,6 +54,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             class="col-12 q-py-md showLabelOnTop lookup-table-file-uploader"
             stack-label
             outlined
+            accept=".csv"
             dense
             :rules="[(val: any) => !!val || 'CSV File is required!']"
           >

--- a/web/src/components/functions/EnrichmentTableList.vue
+++ b/web/src/components/functions/EnrichmentTableList.vue
@@ -187,7 +187,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script lang="ts">
-import { defineComponent, onBeforeMount, ref } from "vue";
+import { defineComponent, onBeforeMount, onMounted, ref } from "vue";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import { useQuasar, type QTableProps } from "quasar";
@@ -297,6 +297,25 @@ export default defineComponent({
     onBeforeMount(() => {
       getLookupTables();
     });
+    //here we need to check if the action is there or not 
+    //because if action is there user before refresh the page user was there in add / update page
+    //so to maitain consistency we are checking the action and if action is there we are showing the add / update page
+    //else we are showing the list of enrichment tables
+    onMounted(()=>{
+      //it is for showing empty add page when user refresh the page
+      if(router.currentRoute.value.query.action == "add"){
+        showAddUpdateFn({})
+      }
+      //it is for showing the update page when user refresh the page
+      //we are passing the name of the enrichment table to the update page
+      else if(router.currentRoute.value.query.action == "update"){
+        showAddUpdateFn({
+          row: {
+            name: router.currentRoute.value.query.name,
+          }
+        })
+      }
+    })
 
     const getLookupTables = (force: boolean = false) => {
       const dismiss = $q.notify({

--- a/web/src/components/functions/EnrichmentTableList.vue
+++ b/web/src/components/functions/EnrichmentTableList.vue
@@ -303,12 +303,12 @@ export default defineComponent({
     //else we are showing the list of enrichment tables
     onMounted(()=>{
       //it is for showing empty add page when user refresh the page
-      if(router.currentRoute.value.query.action == "add"){
+      if(router.currentRoute.value.query.action === "add"){
         showAddUpdateFn({})
       }
       //it is for showing the update page when user refresh the page
       //we are passing the name of the enrichment table to the update page
-      else if(router.currentRoute.value.query.action == "update"){
+      else if(router.currentRoute.value.query.action === "update"){
         showAddUpdateFn({
           row: {
             name: router.currentRoute.value.query.name,


### PR DESCRIPTION
### **User description**
This PR fixes the issues that are there in #7815


___

### **PR Type**
Bug fix


___

### **Description**
- Frontend restricts enrichment file uploads to CSV.

- Retains add/update form on page refresh.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AddEnrichmentTable: accept .csv"]
  B["EnrichmentTableList: onMounted check action"]
  B -- "action=add" --> C["Show add form"]
  B -- "action=update" --> D["Show update form"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddEnrichmentTable.vue</strong><dd><code>Restrict file uploader to CSV</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/functions/AddEnrichmentTable.vue

<ul><li>Added <code>accept=".csv"</code> attribute to file uploader.<br> <li> Enforces CSV-only uploads for enrichment tables.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7836/files#diff-9aad551dbc051edfdb3994a664506ed6d5e27dcb64f9c2fa917b02e51a35d86e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EnrichmentTableList.vue</strong><dd><code>Persist add/update view on refresh</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/functions/EnrichmentTableList.vue

<ul><li>Imported <code>onMounted</code> hook from Vue.<br> <li> Added mount logic for <code>action</code> query.<br> <li> Displays add/update form on page refresh.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7836/files#diff-6a29e253f59405d3c0f756dba36afd7483f10ad86927cbbc3348ede6372c3077">+20/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

