### PR TITLE
fix: enrichment table rewrite should not create compact jobs

### DIFF
--- a/src/service/compact/retention.rs
+++ b/src/service/compact/retention.rs
@@ -421,7 +421,7 @@ pub async fn delete_by_date(
     handle_delete_by_date_done(org_id, stream_type, stream_name, date_range).await
 }
 
-async fn delete_from_file_list(
+pub async fn delete_from_file_list(
     org_id: &str,
     stream_type: StreamType,
     stream_name: &str,

--- a/src/service/db/enrichment_table.rs
+++ b/src/service/db/enrichment_table.rs
@@ -60,7 +60,12 @@ pub async fn get_enrichment_table_data(
         use_cache: false,
         local_mode: Some(true),
     };
-    log::debug!("get enrichment table {name} data req start time: {start_time}");
+    log::info!(
+        "get enrichment table {}/{} data req start time: {}",
+        org_id,
+        name,
+        start_time
+    );
     // do search
     match SearchService::search("", org_id, StreamType::EnrichmentTables, None, &req).await {
         Ok(res) => {
@@ -71,7 +76,12 @@ pub async fn get_enrichment_table_data(
             }
         }
         Err(err) => {
-            log::error!("get enrichment table data error: {err:?}");
+            log::error!(
+                "get enrichment table {}/{} data error: {:?}",
+                org_id,
+                name,
+                err
+            );
             Ok(vec![])
         }
     }

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -720,6 +720,25 @@ pub async fn delete_stream(
         }
     }
 
+    // create delete for compactor
+    if let Err(e) =
+        db::compact::retention::delete_stream(org_id, stream_type, stream_name, None).await
+    {
+        log::error!(
+            "Failed to create retention job for stream: {}/{}/{}, error: {}",
+            org_id,
+            stream_type,
+            stream_name,
+            e
+        );
+        return Ok(HttpResponse::InternalServerError()
+            .append_header((ERROR_HEADER, format!("failed to delete stream: {e}")))
+            .json(MetaHttpResponse::error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to delete stream: {e}"),
+            )));
+    }
+
     // delete related resource
     if let Err(e) = stream_delete_inner(org_id, stream_type, stream_name).await {
         return Ok(HttpResponse::InternalServerError()
@@ -761,16 +780,6 @@ pub async fn stream_delete_inner(
     {
         use super::db::re_pattern::remove_stream_associations_after_deletion;
         remove_stream_associations_after_deletion(org_id, stream_name, stream_type).await?;
-    }
-
-    // create delete for compactor
-    if let Err(e) =
-        db::compact::retention::delete_stream(org_id, stream_type, stream_name, None).await
-    {
-        log::error!(
-            "Failed to create retention job for stream: {org_id}/{stream_type}/{stream_name}, error: {e}"
-        );
-        return Err(e);
     }
 
     // delete stream schema cache

--- a/src/super_cluster_queue/enrichment_table.rs
+++ b/src/super_cluster_queue/enrichment_table.rs
@@ -1,0 +1,50 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use config::meta::stream::StreamType;
+use infra::errors::{Error, Result};
+use o2_enterprise::enterprise::super_cluster::queue::Message;
+
+pub(crate) async fn process_file_list_delete(msg: Message) -> Result<()> {
+    let key_parts = msg.key.split('/').collect::<Vec<&str>>();
+    if key_parts.len() != 5 {
+        let err_msg = format!(
+            "enrichment table super cluster queue file list delete key is not valid: {}",
+            msg.key
+        );
+        log::error!("{err_msg}");
+        return Err(Error::Message(err_msg));
+    }
+    // Format is /enrichment_file_list_delete/{org_id}/{stream_type}/{stream_name}
+    let org_id = key_parts[2];
+    let stream_name = key_parts[4];
+    let time_range: config::meta::stream::TimeRange = serde_json::from_slice(&msg.value.unwrap())?;
+    crate::service::compact::retention::delete_from_file_list(
+        org_id,
+        StreamType::EnrichmentTables,
+        stream_name,
+        (time_range.start, time_range.end),
+    )
+    .await
+    .map_err(|e| {
+        let err_msg = format!(
+            "[ENRICHMENT_TABLE] delete_from_file_list {}/{} failed: {}",
+            org_id, stream_name, e
+        );
+        log::error!("{err_msg}");
+        Error::Message(err_msg)
+    })?;
+    Ok(())
+}

--- a/src/super_cluster_queue/mod.rs
+++ b/src/super_cluster_queue/mod.rs
@@ -22,6 +22,7 @@ mod dashboards;
 mod destinations;
 mod distinct_values;
 mod domain_management;
+mod enrichment_table;
 mod folders;
 mod meta;
 mod org_user;
@@ -62,6 +63,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         on_re_patterns_msg: re_pattern::process,
         on_domain_management_msg: domain_management::process,
         on_compactor_manual_job_msg: compactor_manual_jobs::process,
+        on_enrichment_file_list_delete_msg: enrichment_table::process_file_list_delete,
     };
     let schema_queue = SchemasQueue {
         on_schema_msg: schemas::process,


### PR DESCRIPTION
### **User description**
Enrichment table deletion should not create compact jobs, that is because compaction is a background job, and until that happens, the search on enrichment table is blocked. So, instead, we can directly delete the file_lists when enrichment tables are deleted.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Directly delete enrichment file lists on rewrite

- Remove redundant compactor job creation

- Enhance logs with org_id and table name context

- Broadcast file list deletions in enterprise


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rewrite enrichment table"] --> B["Compute time_range"]
  B --> C["delete_enrichment_table(...)"]
  C --> D["delete_from_file_list(...)"]
  D --> E["Compact service removes file lists"]
  D --> F{"Enterprise mode?"}
  F -- "yes" --> G["Broadcast delete event"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>retention.rs</strong><dd><code>Expose delete_from_file_list in retention module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/compact/retention.rs

<ul><li>Made <code>delete_from_file_list</code> public<br> <li> Exposed file list deletion API</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7841/files#diff-6abd048f5ef4e7163cffbb51cb4bee10c07fb88b871469d5b3724f7cd04743dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enrichment_table.rs</strong><dd><code>Add context-rich logging for enrichment queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/db/enrichment_table.rs

<ul><li>Upgraded debug logs to info with org/name context<br> <li> Included org_id and name in error logs</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7841/files#diff-6ce27ddf8a0d8b4e790bda90d088ff692a5da31a8d330beea8a9dd843294572b">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Refactor enrichment table deletion workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/enrichment_table/mod.rs

<ul><li>Extended <code>delete_enrichment_table</code> with <code>time_range</code><br> <li> Replaced compaction job creation with file list deletion<br> <li> Added <code>delete_from_file_list</code> helper implementation<br> <li> Added enterprise broadcast in helper</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7841/files#diff-3e2b6d3b8da1f9e73aca279052a97e683184d68256c23215b18ffee885836bbf">+83/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enrichment_table.rs</strong><dd><code>Handle enrichment file list delete queue messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/super_cluster_queue/enrichment_table.rs

<ul><li>Added handler <code>process_file_list_delete</code> for enrichment deletes<br> <li> Parses queue message and invokes file list deletion</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7841/files#diff-b1344df0b7cefa60532a15a4ef200ab95434dddd5aad98b16c48a5edf184a45d">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stream.rs</strong><dd><code>Align stream delete with retention jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/stream.rs

<ul><li>Added retention job creation in <code>delete_stream</code><br> <li> Removed duplicate job creation in <code>stream_delete_inner</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7841/files#diff-41452a7fb29b4634437174fd6aecf6a9050dbfdef41b9077a21d59af3d79e9ed">+19/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Register enrichment table queue handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/super_cluster_queue/mod.rs

- Registered `on_enrichment_file_list_delete_msg` handler


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7841/files#diff-6ed0f1dd36b7216fffde573232a49869f247330ecb03b50f94b2ddd723742e46">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

