### PR TITLE
fix: remove module key from zo_db_query_nums metrics (#7845)

### DIFF
--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -692,7 +692,7 @@ pub static DB_QUERY_NUMS: Lazy<IntCounterVec> = Lazy::new(|| {
         Opts::new("db_query_nums", "db query number")
             .namespace(NAMESPACE)
             .const_labels(create_const_labels()),
-        &["operation", "table", "key"],
+        &["operation", "table"],
     )
     .expect("Metric created")
 });

--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -69,7 +69,7 @@ fn connect(readonly: bool, ddl: bool) -> Pool<MySql> {
 async fn cache_indices() -> HashSet<DBIndex> {
     let client = CLIENT.clone();
     DB_QUERY_NUMS
-        .with_label_values(&["select", "information_schema.statistics", ""])
+        .with_label_values(&["select", "information_schema.statistics"])
         .inc();
     let var_name = r#"SELECT INDEX_NAME,TABLE_NAME FROM information_schema.statistics;"#;
     let sql = var_name;
@@ -114,9 +114,7 @@ impl super::Db for MysqlDb {
 
     async fn stats(&self) -> Result<super::Stats> {
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let keys_count: i64 =
             sqlx::query_scalar(r#"SELECT CAST(COUNT(*) AS SIGNED) AS num FROM meta;"#)
                 .fetch_one(&pool)
@@ -131,9 +129,7 @@ impl super::Db for MysqlDb {
     async fn get(&self, key: &str) -> Result<Bytes> {
         let (module, key1, key2) = super::parse_key(key);
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let query = format!(
             "SELECT value FROM meta WHERE module = '{module}' AND key1 = '{key1}' AND key2 = '{key2}' ORDER BY start_dt DESC;"
         );
@@ -164,9 +160,7 @@ impl super::Db for MysqlDb {
         let pool = CLIENT.clone();
         let local_start_dt = start_dt.unwrap_or_default();
         let mut tx = pool.begin().await?;
-        DB_QUERY_NUMS
-            .with_label_values(&["insert", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
         let start = std::time::Instant::now();
         if let Err(e) = sqlx::query(
             r#"INSERT IGNORE INTO meta (module, key1, key2, start_dt, value) VALUES (?, ?, ?, ?, '');"#
@@ -189,9 +183,7 @@ impl super::Db for MysqlDb {
             return Err(e.into());
         }
 
-        DB_QUERY_NUMS
-            .with_label_values(&["update", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "meta"]).inc();
         let mut tx = pool.begin().await?;
         if let Err(e) = sqlx::query(
               r#"UPDATE meta SET value = ? WHERE module = ? AND key1 = ? AND key2 = ? AND start_dt = ?;"#
@@ -246,7 +238,7 @@ impl super::Db for MysqlDb {
         );
         let unlock_sql = format!("SELECT RELEASE_LOCK('{lock_id}')");
         let mut lock_tx = lock_pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["get_lock", "", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         match sqlx::query_scalar::<_, i64>(&lock_sql)
             .fetch_one(&mut *lock_tx)
             .await
@@ -285,9 +277,7 @@ impl super::Db for MysqlDb {
         };
         let mut need_watch_dt = 0;
         let row = if let Some(start_dt) = start_dt {
-            DB_QUERY_NUMS
-                .with_label_values(&["select", "meta", ""])
-                .inc();
+            DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
             match sqlx::query_as::<_,super::MetaRecord>(
                 r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = ? AND key1 = ? AND key2 = ? AND start_dt = ?;"#
             )
@@ -306,7 +296,7 @@ impl super::Db for MysqlDb {
                         if let Err(e) = tx.rollback().await {
                             log::error!("[MYSQL] rollback get_for_update error: {e}");
                         }
-                        DB_QUERY_NUMS.with_label_values(&["release_lock", "", ""]).inc();
+                        DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                         if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                             log::error!("[MYSQL] unlock get_for_update error: {e}");
                         }
@@ -318,9 +308,7 @@ impl super::Db for MysqlDb {
                 }
             }
         } else {
-            DB_QUERY_NUMS
-                .with_label_values(&["select", "meta", ""])
-                .inc();
+            DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
             match sqlx::query_as::<_,super::MetaRecord>(
                 r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = ? AND key1 = ? AND key2 = ? ORDER BY start_dt DESC, id DESC;"#
             )
@@ -338,7 +326,7 @@ impl super::Db for MysqlDb {
                         if let Err(e) = tx.rollback().await {
                             log::error!("[MYSQL] rollback get_for_update error: {e}");
                         }
-                        DB_QUERY_NUMS.with_label_values(&["release_lock", "", ""]).inc();
+                        DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                         if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                             log::error!("[MYSQL] unlock get_for_update error: {e}");
                         }
@@ -358,9 +346,7 @@ impl super::Db for MysqlDb {
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback get_for_update error: {e}");
                 }
-                DB_QUERY_NUMS
-                    .with_label_values(&["release_lock", "", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_for_update error: {e}");
                 }
@@ -373,9 +359,7 @@ impl super::Db for MysqlDb {
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback get_for_update error: {e}");
                 }
-                DB_QUERY_NUMS
-                    .with_label_values(&["release_lock", "", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_for_update error: {e}");
                 }
@@ -390,18 +374,14 @@ impl super::Db for MysqlDb {
         // update value
         if let Some(value) = value {
             let ret = if exist {
-                DB_QUERY_NUMS
-                    .with_label_values(&["update", "meta", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["update", "meta"]).inc();
                 sqlx::query(r#"UPDATE meta SET value = ? WHERE id = ?;"#)
                     .bind(String::from_utf8(value.to_vec()).unwrap_or_default())
                     .bind(row_id.unwrap())
                     .execute(&mut *tx)
                     .await
             } else {
-                DB_QUERY_NUMS
-                    .with_label_values(&["insert", "meta", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
                 sqlx::query(
                     r#"INSERT INTO meta (module, key1, key2, start_dt, value) VALUES (?, ?, ?, ?, ?);"#,
                 )
@@ -417,9 +397,7 @@ impl super::Db for MysqlDb {
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback get_for_update error: {e}");
                 }
-                DB_QUERY_NUMS
-                    .with_label_values(&["release_lock", "", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_for_update error: {e}");
                 }
@@ -434,9 +412,7 @@ impl super::Db for MysqlDb {
         if let Some((new_key, new_value, new_start_dt)) = new_value {
             need_watch_dt = new_start_dt.unwrap_or_default();
             let (module, key1, key2) = super::parse_key(&new_key);
-            DB_QUERY_NUMS
-                .with_label_values(&["insert", "meta", ""])
-                .inc();
+            DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
             if let Err(e) = sqlx::query(
                 r#"INSERT INTO meta (module, key1, key2, start_dt, value) VALUES (?, ?, ?, ?, ?);"#,
             )
@@ -451,9 +427,7 @@ impl super::Db for MysqlDb {
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback get_for_update error: {e}");
                 }
-                DB_QUERY_NUMS
-                    .with_label_values(&["release_lock", "", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_for_update error: {e}");
                 }
@@ -468,9 +442,7 @@ impl super::Db for MysqlDb {
             log::error!("[MYSQL] commit get_for_update error: {e}");
             return Err(e.into());
         }
-        DB_QUERY_NUMS
-            .with_label_values(&["release_lock", "", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
         if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
             log::error!("[MYSQL] unlock get_for_update error: {e}");
         }
@@ -548,9 +520,7 @@ impl super::Db for MysqlDb {
         };
 
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["delete", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["delete", "meta"]).inc();
         sqlx::query(&sql).execute(&pool).await?;
 
         Ok(())
@@ -571,9 +541,7 @@ impl super::Db for MysqlDb {
         sql = format!("{sql} ORDER BY start_dt ASC");
 
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -603,9 +571,7 @@ impl super::Db for MysqlDb {
 
         sql = format!("{sql} ORDER BY start_dt ASC");
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -651,9 +617,7 @@ impl super::Db for MysqlDb {
         sql = format!("{sql} AND start_dt >= {min_dt} AND start_dt <= {max_dt}");
         sql = format!("{sql} ORDER BY start_dt ASC");
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -676,9 +640,7 @@ impl super::Db for MysqlDb {
             sql = format!("{sql} AND (key2 = '{key2}' OR key2 LIKE '{key2}/%')");
         }
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let count: i64 = sqlx::query_scalar(&sql).fetch_one(&pool).await?;
         Ok(count)
     }
@@ -700,9 +662,7 @@ impl super::Db for MysqlDb {
 
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT_DDL.clone();
-    DB_QUERY_NUMS
-        .with_label_values(&["create", "meta", ""])
-        .inc();
+    DB_QUERY_NUMS.with_label_values(&["create", "meta"]).inc();
     // create table
     _ = sqlx::query(
         r#"
@@ -720,7 +680,7 @@ CREATE TABLE IF NOT EXISTS meta
     .execute(&pool)
     .await?;
     DB_QUERY_NUMS
-        .with_label_values(&["select", "information_schema.columns", ""])
+        .with_label_values(&["select", "information_schema.columns"])
         .inc();
     // create start_dt column for old version <= 0.9.2
     let has_start_dt = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='meta' AND column_name='start_dt';")
@@ -760,9 +720,7 @@ async fn add_start_dt_column() -> Result<()> {
     let pool = CLIENT_DDL.clone();
     let mut tx = pool.begin().await?;
 
-    DB_QUERY_NUMS
-        .with_label_values(&["alter", "meta", ""])
-        .inc();
+    DB_QUERY_NUMS.with_label_values(&["alter", "meta"]).inc();
     if let Err(e) =
         sqlx::query(r#"ALTER TABLE meta ADD COLUMN start_dt BIGINT NOT NULL DEFAULT 0;"#)
             .execute(&mut *tx)
@@ -799,7 +757,7 @@ async fn create_meta_backup() -> Result<()> {
     let pool = CLIENT_DDL.clone();
     let mut tx = pool.begin().await?;
     DB_QUERY_NUMS
-        .with_label_values(&["create", "meta_backup_20240330", ""])
+        .with_label_values(&["create", "meta_backup_20240330"])
         .inc();
     // Create the meta_backup table like meta
     if let Err(e) = sqlx::query(r#"CREATE TABLE IF NOT EXISTS meta_backup_20240330 like meta;"#)
@@ -813,7 +771,7 @@ async fn create_meta_backup() -> Result<()> {
     }
 
     DB_QUERY_NUMS
-        .with_label_values(&["select", "meta_backup_20240330", ""])
+        .with_label_values(&["select", "meta_backup_20240330"])
         .inc();
     // Check if meta_backup is empty before attempting to insert data
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM meta_backup_20240330")
@@ -822,7 +780,7 @@ async fn create_meta_backup() -> Result<()> {
 
     if count == 0 {
         DB_QUERY_NUMS
-            .with_label_values(&["insert", "meta_backup_20240330", ""])
+            .with_label_values(&["insert", "meta_backup_20240330"])
             .inc();
         // Attempt to insert data into meta_backup from meta since it's empty
         if let Err(e) = sqlx::query(r#"INSERT INTO meta_backup_20240330 SELECT * FROM meta;"#)
@@ -860,7 +818,7 @@ pub async fn create_index(index: IndexStatement<'_>) -> Result<()> {
         index.table
     );
     DB_QUERY_NUMS
-        .with_label_values(&["create", index.table, ""])
+        .with_label_values(&["create", index.table])
         .inc();
     let sql = format!(
         "CREATE {} INDEX {} ON {} ({});",
@@ -889,7 +847,7 @@ pub async fn delete_index(idx_name: &str, table: &str) -> Result<()> {
         return Ok(());
     }
     log::info!("[MYSQL] deleting index {idx_name} on table {table}");
-    DB_QUERY_NUMS.with_label_values(&["drop", table, ""]).inc();
+    DB_QUERY_NUMS.with_label_values(&["drop", table]).inc();
     let sql = format!("DROP INDEX {idx_name} ON {table};");
     let start = std::time::Instant::now();
     sqlx::query(&sql).execute(&client).await?;

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -68,7 +68,7 @@ fn connect(readonly: bool, ddl: bool) -> Pool<Postgres> {
 async fn cache_indices() -> HashSet<DBIndex> {
     let client = CLIENT.clone();
     DB_QUERY_NUMS
-        .with_label_values(&["select", "pg_indexes", ""])
+        .with_label_values(&["select", "pg_indexes"])
         .inc();
     let sql = r#"SELECT indexname, tablename FROM pg_indexes;"#;
     let res = sqlx::query_as::<_, (String, String)>(sql)
@@ -104,9 +104,7 @@ impl super::Db for PostgresDb {
 
     async fn stats(&self) -> Result<super::Stats> {
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let keys_count: i64 = sqlx::query_scalar(r#"SELECT COUNT(*)::BIGINT AS num FROM meta;"#)
             .fetch_one(&pool)
             .await
@@ -120,9 +118,7 @@ impl super::Db for PostgresDb {
     async fn get(&self, key: &str) -> Result<Bytes> {
         let (module, key1, key2) = super::parse_key(key);
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let query = format!(
             "SELECT value FROM meta WHERE module = '{module}' AND key1 = '{key1}' AND key2 = '{key2}' ORDER BY start_dt DESC;"
         );
@@ -153,9 +149,7 @@ impl super::Db for PostgresDb {
         let pool = CLIENT.clone();
         let local_start_dt = start_dt.unwrap_or_default();
         let mut tx = pool.begin().await?;
-        DB_QUERY_NUMS
-            .with_label_values(&["insert", "meta", key])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
         let start = std::time::Instant::now();
         if let Err(e) = sqlx::query(
             r#"INSERT INTO meta (module, key1, key2, start_dt, value) VALUES ($1, $2, $3, $4, '') ON CONFLICT DO NOTHING;"#
@@ -178,9 +172,7 @@ impl super::Db for PostgresDb {
             return Err(e.into());
         }
 
-        DB_QUERY_NUMS
-            .with_label_values(&["update", "meta", key])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["update", "meta"]).inc();
         let mut tx = pool.begin().await?;
         if let Err(e) = sqlx::query(
                 r#"UPDATE meta SET value = $1 WHERE module = $2 AND key1 = $3 AND key2 = $4 AND start_dt = $5;"#
@@ -236,7 +228,7 @@ impl super::Db for PostgresDb {
             lock_id as i64
         };
         let lock_sql = format!("SELECT pg_advisory_xact_lock({lock_id})");
-        DB_QUERY_NUMS.with_label_values(&["get_lock", "", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         if let Err(e) = sqlx::query(&lock_sql).execute(&mut *tx).await {
             if let Err(e) = tx.rollback().await {
                 log::error!("[POSTGRES] rollback get_for_update error: {e}");
@@ -245,9 +237,7 @@ impl super::Db for PostgresDb {
         };
         let mut need_watch_dt = 0;
         let row = if let Some(start_dt) = start_dt {
-            DB_QUERY_NUMS
-                .with_label_values(&["select", "meta", ""])
-                .inc();
+            DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
             match sqlx::query_as::<_,super::MetaRecord>(
                 r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = $1 AND key1 = $2 AND key2 = $3 AND start_dt = $4;"#
             )
@@ -271,9 +261,7 @@ impl super::Db for PostgresDb {
                 }
             }
         } else {
-            DB_QUERY_NUMS
-                .with_label_values(&["select", "meta", ""])
-                .inc();
+            DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
             match sqlx::query_as::<_,super::MetaRecord>(
                 r#"SELECT id, module, key1, key2, start_dt, value FROM meta WHERE module = $1 AND key1 = $2 AND key2 = $3 ORDER BY start_dt DESC, id DESC;"#
             )
@@ -318,18 +306,14 @@ impl super::Db for PostgresDb {
         // update value
         if let Some(value) = value {
             let ret = if exist {
-                DB_QUERY_NUMS
-                    .with_label_values(&["update", "meta", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["update", "meta"]).inc();
                 sqlx::query(r#"UPDATE meta SET value = $1 WHERE id = $2;"#)
                     .bind(String::from_utf8(value.to_vec()).unwrap_or_default())
                     .bind(row_id.unwrap())
                     .execute(&mut *tx)
                     .await
             } else {
-                DB_QUERY_NUMS
-                    .with_label_values(&["insert", "meta", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
                 sqlx::query(
                 r#"INSERT INTO meta (module, key1, key2, start_dt, value) VALUES ($1, $2, $3, $4, $5);"#
             )
@@ -353,9 +337,7 @@ impl super::Db for PostgresDb {
         if let Some((new_key, new_value, new_start_dt)) = new_value {
             need_watch_dt = new_start_dt.unwrap_or_default();
             let (module, key1, key2) = super::parse_key(&new_key);
-            DB_QUERY_NUMS
-                .with_label_values(&["insert", "meta", ""])
-                .inc();
+            DB_QUERY_NUMS.with_label_values(&["insert", "meta"]).inc();
             if let Err(e) = sqlx::query(
                 r#"INSERT INTO meta (module, key1, key2, start_dt, value) VALUES ($1, $2, $3, $4, $5);"#
             )
@@ -449,9 +431,7 @@ impl super::Db for PostgresDb {
         };
 
         let pool = CLIENT.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["delete", "meta", key])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["delete", "meta"]).inc();
         sqlx::query(&sql).execute(&pool).await?;
 
         Ok(())
@@ -472,9 +452,7 @@ impl super::Db for PostgresDb {
         sql = format!("{sql} ORDER BY start_dt ASC");
 
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -503,9 +481,7 @@ impl super::Db for PostgresDb {
         }
         sql = format!("{sql} ORDER BY start_dt ASC");
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -551,9 +527,7 @@ impl super::Db for PostgresDb {
         sql = format!("{sql} ORDER BY start_dt ASC");
 
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
             .fetch_all(&pool)
             .await?;
@@ -576,9 +550,7 @@ impl super::Db for PostgresDb {
             sql = format!("{sql} AND (key2 = '{key2}' OR key2 LIKE '{key2}/%')");
         }
         let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "meta", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
         let count: i64 = sqlx::query_scalar(&sql).fetch_one(&pool).await?;
         Ok(count)
     }
@@ -601,9 +573,7 @@ impl super::Db for PostgresDb {
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT_DDL.clone();
 
-    DB_QUERY_NUMS
-        .with_label_values(&["create", "meta", ""])
-        .inc();
+    DB_QUERY_NUMS.with_label_values(&["create", "meta"]).inc();
     // create table
     _ = sqlx::query(
         r#"
@@ -623,7 +593,7 @@ CREATE TABLE IF NOT EXISTS meta
 
     // create start_dt column for old version <= 0.9.2
     DB_QUERY_NUMS
-        .with_label_values(&["select", "information_schema.columns", ""])
+        .with_label_values(&["select", "information_schema.columns"])
         .inc();
     let has_start_dt = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='meta' AND column_name='start_dt';")
             .fetch_one(&pool)
@@ -661,9 +631,7 @@ CREATE TABLE IF NOT EXISTS meta
 async fn add_start_dt_column() -> Result<()> {
     let pool = CLIENT_DDL.clone();
     let mut tx = pool.begin().await?;
-    DB_QUERY_NUMS
-        .with_label_values(&["alter", "meta", ""])
-        .inc();
+    DB_QUERY_NUMS.with_label_values(&["alter", "meta"]).inc();
     if let Err(e) = sqlx::query(
         r#"ALTER TABLE meta ADD COLUMN IF NOT EXISTS start_dt BIGINT NOT NULL DEFAULT 0;"#,
     )
@@ -695,7 +663,7 @@ async fn create_meta_backup() -> Result<()> {
     let pool = CLIENT_DDL.clone();
     let mut tx = pool.begin().await?;
     DB_QUERY_NUMS
-        .with_label_values(&["create", "meta_backup_20240330", ""])
+        .with_label_values(&["create", "meta_backup_20240330"])
         .inc();
     if let Err(e) =
         sqlx::query(r#"CREATE TABLE IF NOT EXISTS meta_backup_20240330 AS SELECT * FROM meta;"#)
@@ -730,7 +698,7 @@ pub async fn create_index(index: IndexStatement<'_>) -> Result<()> {
         index.table
     );
     DB_QUERY_NUMS
-        .with_label_values(&["create", index.table, ""])
+        .with_label_values(&["create", index.table])
         .inc();
     let sql = format!(
         "CREATE {} INDEX IF NOT EXISTS {} ON {} ({});",
@@ -761,7 +729,7 @@ pub async fn delete_index(idx_name: &str, table: &str) -> Result<()> {
     }
     log::info!("[POSTGRES] deleting index {idx_name} on table {table}");
     let sql = format!("DROP INDEX IF EXISTS {idx_name};");
-    DB_QUERY_NUMS.with_label_values(&["drop", table, ""]).inc();
+    DB_QUERY_NUMS.with_label_values(&["drop", table]).inc();
     let start = std::time::Instant::now();
     sqlx::query(&sql).execute(&client).await?;
     let time = start.elapsed().as_secs_f64();

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -77,7 +77,7 @@ impl super::FileList for MysqlFileList {
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["delete", "file_list", ""])
+            .with_label_values(&["delete", "file_list"])
             .inc();
         sqlx::query(
             r#"UPDATE file_list SET deleted = true WHERE stream = ? AND date = ? AND file = ?;"#,
@@ -204,7 +204,7 @@ impl super::FileList for MysqlFileList {
                     .push_bind(created_at);
             });
             DB_QUERY_NUMS
-                .with_label_values(&["insert", "file_list_deleted", ""])
+                .with_label_values(&["insert", "file_list_deleted"])
                 .inc();
             if let Err(e) = query_builder.build().execute(&mut *tx).await {
                 if let Err(e) = tx.rollback().await {
@@ -237,7 +237,7 @@ impl super::FileList for MysqlFileList {
                 let (stream_key, date_key, file_name) =
                     parse_file_key_columns(&file.key).map_err(|e| Error::Message(e.to_string()))?;
                 DB_QUERY_NUMS
-                    .with_label_values(&["select", "file_list_deleted", ""])
+                    .with_label_values(&["select", "file_list_deleted"])
                     .inc();
                 let ret: Option<i64> = match sqlx::query_scalar(
                     r#"SELECT id FROM file_list_deleted WHERE stream = ? AND date = ? AND file = ?"#,
@@ -269,7 +269,7 @@ impl super::FileList for MysqlFileList {
                     ids.join(",")
                 );
                 DB_QUERY_NUMS
-                    .with_label_values(&["delete", "file_list_deleted", ""])
+                    .with_label_values(&["delete", "file_list_deleted"])
                     .inc();
                 _ = pool.execute(sql.as_str()).await?;
             }
@@ -281,9 +281,7 @@ impl super::FileList for MysqlFileList {
         let pool = CLIENT_RO.clone();
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
-        DB_QUERY_NUMS
-            .with_label_values(&["get", "file_list", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["get", "file_list"]).inc();
         let start = std::time::Instant::now();
         let ret = sqlx::query_as::<_, super::FileRecord>(
             r#"
@@ -308,7 +306,7 @@ SELECT min_ts, max_ts, records, original_size, compressed_size, index_size, flat
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["contains", "file_list", ""])
+            .with_label_values(&["contains", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret =
@@ -333,7 +331,7 @@ SELECT min_ts, max_ts, records, original_size, compressed_size, index_size, flat
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list", ""])
+            .with_label_values(&["update", "file_list"])
             .inc();
         sqlx::query(
             r#"UPDATE file_list SET flattened = ? WHERE stream = ? AND date = ? AND file = ?;"#,
@@ -352,7 +350,7 @@ SELECT min_ts, max_ts, records, original_size, compressed_size, index_size, flat
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list", ""])
+            .with_label_values(&["update", "file_list"])
             .inc();
         sqlx::query(
             r#"UPDATE file_list SET compressed_size = ? WHERE stream = ? AND date = ? AND file = ?;"#,
@@ -390,7 +388,7 @@ SELECT min_ts, max_ts, records, original_size, compressed_size, index_size, flat
 
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["query", "file_list", ""])
+            .with_label_values(&["query", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = if flattened.is_some() {
@@ -450,7 +448,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
 
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["query_for_merge", "file_list", ""])
+            .with_label_values(&["query_for_merge", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let (date_start, date_end) = date_range.unwrap_or(("".to_string(), "".to_string()));
@@ -496,7 +494,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
                 "SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, compressed_size, index_size FROM file_list WHERE id IN ({ids})"
             );
             DB_QUERY_NUMS
-                .with_label_values(&["query_by_ids", "file_list", ""])
+                .with_label_values(&["query_by_ids", "file_list"])
                 .inc();
             let start = std::time::Instant::now();
             let res = sqlx::query_as::<_, super::FileRecord>(&query_str)
@@ -554,7 +552,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
             tasks.push(tokio::task::spawn(async move {
                 let pool = CLIENT_RO.clone();
                 DB_QUERY_NUMS
-                .with_label_values(&["query_ids", "file_list", ""])
+                .with_label_values(&["query_ids", "file_list"])
                 .inc();
                     let max_ts_upper_bound = super::calculate_max_ts_upper_bound(time_end, stream_type);
                     let query = "SELECT id, records, original_size, deleted FROM file_list WHERE stream = ? AND max_ts >= ? AND max_ts <= ? AND min_ts <= ?;";
@@ -647,7 +645,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
 
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["query_old_data_hours", "file_list", ""])
+            .with_label_values(&["query_old_data_hours", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let (time_start, time_end) = time_range.unwrap_or((0, 0));
@@ -700,7 +698,7 @@ SELECT date
         );
         let unlock_sql = format!("SELECT RELEASE_LOCK('{lock_id}')");
         let mut lock_tx = lock_pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["get_lock", "", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         match sqlx::query_scalar::<_, i64>(&lock_sql)
             .fetch_one(&mut *lock_tx)
             .await
@@ -739,7 +737,7 @@ SELECT date
         };
 
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list_deleted", ""])
+            .with_label_values(&["select", "file_list_deleted"])
             .inc();
         let items: Vec<FileListDeleted> = match sqlx::query_as::<_, super::FileDeletedRecord>(
             r#"SELECT id, account, stream, date, file, index_file, flattened FROM file_list_deleted WHERE org = ? AND created_at < ? ORDER BY created_at ASC LIMIT ?;"#,
@@ -766,7 +764,7 @@ SELECT date
                     );
                 }
                 DB_QUERY_NUMS
-                    .with_label_values(&["release_lock", "", ""])
+                    .with_label_values(&["release_lock", ""])
                     .inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock query_deleted error: {e}");
@@ -784,9 +782,7 @@ SELECT date
             if let Err(e) = tx.rollback().await {
                 log::error!("[MYSQL] rollback select query_deleted error: {e}");
             }
-            DB_QUERY_NUMS
-                .with_label_values(&["release_lock", "", ""])
-                .inc();
+            DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
             if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                 log::error!("[MYSQL] unlock query_deleted error: {e}");
             }
@@ -801,7 +797,7 @@ SELECT date
         );
         let now = config::utils::time::now_micros();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_deleted", ""])
+            .with_label_values(&["update", "file_list_deleted"])
             .inc();
         let ret = match sqlx::query(&sql).bind(now).execute(&mut *tx).await {
             Ok(v) => v,
@@ -809,9 +805,7 @@ SELECT date
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback update query_deleted status error: {e}");
                 }
-                DB_QUERY_NUMS
-                    .with_label_values(&["release_lock", "", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock query_deleted error: {e}");
                 }
@@ -830,9 +824,7 @@ SELECT date
             if let Err(e) = tx.rollback().await {
                 log::error!("[MYSQL] rollback update query_deleted status error: {e}");
             }
-            DB_QUERY_NUMS
-                .with_label_values(&["release_lock", "", ""])
-                .inc();
+            DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
             if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                 log::error!("[MYSQL] unlock query_deleted error: {e}");
             }
@@ -846,9 +838,7 @@ SELECT date
             log::error!("[MYSQL] commit select query_deleted error: {e}");
             return Err(e.into());
         }
-        DB_QUERY_NUMS
-            .with_label_values(&["release_lock", "", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
         if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
             log::error!("[MYSQL] unlock query_deleted error: {e}");
         }
@@ -861,7 +851,7 @@ SELECT date
     async fn list_deleted(&self) -> Result<Vec<FileListDeleted>> {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list_deleted", ""])
+            .with_label_values(&["select", "file_list_deleted"])
             .inc();
         let ret = sqlx::query_as::<_, super::FileDeletedRecord>(
             r#"SELECT id, account, stream, date, file, index_file, flattened FROM file_list_deleted;"#,
@@ -890,7 +880,7 @@ SELECT date
         let min_ts = config::utils::time::BASE_TIME.timestamp_micros();
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list", ""])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret: Option<i64> = sqlx::query_scalar(
             r#"SELECT MIN(min_ts) AS id FROM file_list WHERE stream = ? AND min_ts > ?;"#,
@@ -905,7 +895,7 @@ SELECT date
     async fn get_max_pk_value(&self) -> Result<i64> {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list", ""])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret: Option<i64> = sqlx::query_scalar(r#"SELECT MAX(id) AS id FROM file_list;"#)
             .fetch_one(&pool)
@@ -916,7 +906,7 @@ SELECT date
     async fn get_min_pk_value(&self) -> Result<i64> {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list", ""])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret: Option<i64> = sqlx::query_scalar(r#"SELECT MIN(id) AS id FROM file_list;"#)
             .fetch_one(&pool)
@@ -975,7 +965,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         let pool = CLIENT_RO.clone();
         let op_name = if deleted { "stats_deleted" } else { "stats" };
         DB_QUERY_NUMS
-            .with_label_values(&[op_name, "file_list", ""])
+            .with_label_values(&[op_name, "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
@@ -1008,7 +998,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         };
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "stream_stats", ""])
+            .with_label_values(&["select", "stream_stats"])
             .inc();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
             .fetch_all(&pool)
@@ -1030,7 +1020,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         );
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["delete", "stream_stats", ""])
+            .with_label_values(&["delete", "stream_stats"])
             .inc();
         sqlx::query(&sql).execute(&pool).await?;
         Ok(())
@@ -1063,7 +1053,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
         for stream_key in new_streams {
             let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
             DB_QUERY_NUMS
-                .with_label_values(&["insert", "stream_stats", ""])
+                .with_label_values(&["insert", "stream_stats"])
                 .inc();
             if let Err(e) = sqlx::query(
                 r#"
@@ -1092,7 +1082,7 @@ INSERT INTO stream_stats
         // update stats
         for (stream_key, stats) in update_streams {
             DB_QUERY_NUMS
-                .with_label_values(&["update", "stream_stats", ""])
+                .with_label_values(&["update", "stream_stats"])
                 .inc();
             if let Err(e) = sqlx::query(
                 r#"
@@ -1121,7 +1111,7 @@ UPDATE stream_stats
         // delete files which already marked deleted
         if let Some((_min_id, max_id)) = pk_value {
             DB_QUERY_NUMS
-                .with_label_values(&["clean_deleted", "file_list", ""])
+                .with_label_values(&["clean_deleted", "file_list"])
                 .inc();
             let start = std::time::Instant::now();
             let limit = config::get_config().limit.calculate_stats_step_limit;
@@ -1182,7 +1172,7 @@ UPDATE stream_stats
     async fn reset_stream_stats(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "stream_stats", ""])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx::query(r#"UPDATE stream_stats SET file_num = 0, min_ts = 0, max_ts = 0, records = 0, original_size = 0, compressed_size = 0, index_size = 0;"#)
              .execute(&pool)
@@ -1198,7 +1188,7 @@ UPDATE stream_stats
     ) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "stream_stats", ""])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx::query(r#"UPDATE stream_stats SET min_ts = ? WHERE stream = ?;"#)
             .bind(min_ts)
@@ -1206,7 +1196,7 @@ UPDATE stream_stats
             .execute(&pool)
             .await?;
         DB_QUERY_NUMS
-            .with_label_values(&["update", "stream_stats", ""])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx::query(
             r#"UPDATE stream_stats SET max_ts = min_ts WHERE stream = ? AND max_ts < min_ts;"#,
@@ -1220,7 +1210,7 @@ UPDATE stream_stats
     async fn len(&self) -> usize {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list", ""])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret = match sqlx::query(r#"SELECT CAST(COUNT(*) AS SIGNED) AS num FROM file_list;"#)
             .fetch_one(&pool)
@@ -1257,7 +1247,7 @@ UPDATE stream_stats
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
         DB_QUERY_NUMS
-            .with_label_values(&["insert", "file_list_jobs", ""])
+            .with_label_values(&["insert", "file_list_jobs"])
             .inc();
         match sqlx::query(
             "INSERT IGNORE INTO file_list_jobs (org, stream, offsets, status, node, started_at, updated_at) VALUES (?, ?, ?, ?, '', 0, 0);",
@@ -1331,7 +1321,7 @@ UPDATE stream_stats
         );
         let unlock_sql = format!("SELECT RELEASE_LOCK('{lock_id}')");
         let mut lock_tx = lock_pool.begin().await?;
-        DB_QUERY_NUMS.with_label_values(&["get_lock", "", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         match sqlx::query_scalar::<_, i64>(&lock_sql)
             .fetch_one(&mut *lock_tx)
             .await
@@ -1370,7 +1360,7 @@ UPDATE stream_stats
         };
         // get pending jobs group by stream and order by num desc
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list_jobs", ""])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(
             r#"
@@ -1393,9 +1383,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
                         "[MYSQL] rollback select file_list_jobs pending jobs for update error: {e}"
                     );
                 }
-                DB_QUERY_NUMS
-                    .with_label_values(&["release_lock", "", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_pending_jobs error: {e}");
                 }
@@ -1411,9 +1399,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
             if let Err(e) = tx.rollback().await {
                 log::error!("[MYSQL] rollback select file_list_jobs pending jobs error: {e}");
             }
-            DB_QUERY_NUMS
-                .with_label_values(&["release_lock", "", ""])
-                .inc();
+            DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
             if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                 log::error!("[MYSQL] unlock get_pending_jobs error: {e}");
             }
@@ -1428,7 +1414,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         );
         let now = config::utils::time::now_micros();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_jobs", ""])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         if let Err(e) = sqlx::query(&sql)
             .bind(super::FileListJobStatus::Running)
@@ -1441,9 +1427,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
             if let Err(e) = tx.rollback().await {
                 log::error!("[MYSQL] rollback update file_list_jobs status error: {e}");
             }
-            DB_QUERY_NUMS
-                .with_label_values(&["release_lock", "", ""])
-                .inc();
+            DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
             if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                 log::error!("[MYSQL] unlock get_pending_jobs error: {e}");
             }
@@ -1458,7 +1442,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
             ids.join(",")
         );
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list_jobs", ""])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret = match sqlx::query_as::<_, super::MergeJobRecord>(&sql)
             .fetch_all(&mut *tx)
@@ -1469,9 +1453,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
                 if let Err(e) = tx.rollback().await {
                     log::error!("[MYSQL] rollback select file_list_jobs by ids error: {e}");
                 }
-                DB_QUERY_NUMS
-                    .with_label_values(&["release_lock", "", ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[MYSQL] unlock get_pending_jobs error: {e}");
                 }
@@ -1485,9 +1467,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
             log::error!("[MYSQL] commit select file_list_jobs pending jobs error: {e}");
             return Err(e.into());
         }
-        DB_QUERY_NUMS
-            .with_label_values(&["release_lock", "", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["release_lock", ""]).inc();
         if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
             log::error!("[MYSQL] unlock get_pending_jobs error: {e}");
         }
@@ -1500,7 +1480,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
     async fn set_job_pending(&self, ids: &[i64]) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_jobs", ""])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         let sql = format!(
             "UPDATE file_list_jobs SET status = ? WHERE id IN ({});",
@@ -1520,7 +1500,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         let config = get_config();
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_jobs", ""])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         let sql = format!(
             "UPDATE file_list_jobs SET status = ?, updated_at = ?, dumped = ? WHERE id IN ({});",
@@ -1543,7 +1523,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
     async fn update_running_jobs(&self, ids: &[i64]) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_jobs", ""])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         let sql = format!(
             r#"UPDATE file_list_jobs SET updated_at = ? WHERE id IN ({})"#,
@@ -1562,7 +1542,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
     async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_jobs", ""])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         let ret = sqlx::query(
             r#"UPDATE file_list_jobs SET status = ? WHERE status = ? AND updated_at < ?;"#,
@@ -1581,7 +1561,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
     async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["delete", "file_list_jobs", ""])
+            .with_label_values(&["delete", "file_list_jobs"])
             .inc();
         let ret = sqlx::query(
             r#"DELETE FROM file_list_jobs WHERE status = ? AND updated_at < ? AND dumped  = ?;"#,
@@ -1601,7 +1581,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         let pool = CLIENT.clone();
 
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list_jobs", ""])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret =
             sqlx::query(r#"SELECT stream, status, count(*) as counts FROM file_list_jobs WHERE status = ? GROUP BY stream, status ORDER BY status desc;"#)
@@ -1751,9 +1731,7 @@ impl MysqlFileList {
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
-        DB_QUERY_NUMS
-            .with_label_values(&["insert", table, ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", table]).inc();
         match  sqlx::query(
             format!(r#"
 INSERT IGNORE INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened)
@@ -1818,9 +1796,7 @@ INSERT IGNORE INTO {table} (account, org, stream, date, file, deleted, min_ts, m
                         .push_bind(item.meta.index_size)
                         .push_bind(item.meta.flattened);
                 });
-                DB_QUERY_NUMS
-                    .with_label_values(&["insert", table, ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["insert", table]).inc();
                 if let Err(e) = query_builder.build().execute(&mut *tx).await {
                     if let Err(e) = tx.rollback().await {
                         log::error!("[MYSQL] rollback {table} batch process for add error: {e}");
@@ -1844,7 +1820,7 @@ INSERT IGNORE INTO {table} (account, org, stream, date, file, deleted, min_ts, m
                     let (stream_key, date_key, file_name) = parse_file_key_columns(&file.key)
                         .map_err(|e| Error::Message(e.to_string()))?;
                     DB_QUERY_NUMS
-                        .with_label_values(&["select_id", "file_list", ""])
+                        .with_label_values(&["select_id", "file_list"])
                         .inc();
                     let start = std::time::Instant::now();
                     let query_res: std::result::Result<Option<i64>, sea_orm::SqlxError> = sqlx::query_scalar(
@@ -1880,7 +1856,7 @@ INSERT IGNORE INTO {table} (account, org, stream, date, file, deleted, min_ts, m
                         ids.join(",")
                     );
                     DB_QUERY_NUMS
-                        .with_label_values(&["delete_id", "file_list", ""])
+                        .with_label_values(&["delete_id", "file_list"])
                         .inc();
                     let start = std::time::Instant::now();
                     if let Err(e) = sqlx::query(sql.as_str()).execute(&mut *tx).await {

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -78,7 +78,7 @@ impl super::FileList for PostgresFileList {
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
 
         DB_QUERY_NUMS
-            .with_label_values(&["delete", "file_list", ""])
+            .with_label_values(&["delete", "file_list"])
             .inc();
         sqlx::query(
             r#"UPDATE file_list SET deleted = true WHERE stream = $1 AND date = $2 AND file = $3;"#,
@@ -208,7 +208,7 @@ impl super::FileList for PostgresFileList {
                     .push_bind(created_at);
             });
             DB_QUERY_NUMS
-                .with_label_values(&["insert", "file_list_deleted", ""])
+                .with_label_values(&["insert", "file_list_deleted"])
                 .inc();
             if let Err(e) = query_builder.build().execute(&mut *tx).await {
                 if let Err(e) = tx.rollback().await {
@@ -241,7 +241,7 @@ impl super::FileList for PostgresFileList {
                 let (stream_key, date_key, file_name) =
                     parse_file_key_columns(&file.key).map_err(|e| Error::Message(e.to_string()))?;
                 DB_QUERY_NUMS
-                    .with_label_values(&["select", "file_list_deleted", ""])
+                    .with_label_values(&["select", "file_list_deleted"])
                     .inc();
                 let ret: Option<i64> = match
                     sqlx
@@ -274,7 +274,7 @@ impl super::FileList for PostgresFileList {
             // delete files by ids
             if !ids.is_empty() {
                 DB_QUERY_NUMS
-                    .with_label_values(&["delete", "file_list_deleted", ""])
+                    .with_label_values(&["delete", "file_list_deleted"])
                     .inc();
                 let sql = format!(
                     "DELETE FROM file_list_deleted WHERE id IN({});",
@@ -290,9 +290,7 @@ impl super::FileList for PostgresFileList {
         let pool = CLIENT_RO.clone();
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
-        DB_QUERY_NUMS
-            .with_label_values(&["get", "file_list", ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["get", "file_list"]).inc();
         let start = std::time::Instant::now();
         let ret = sqlx::query_as::<_, super::FileRecord>(
             r#"
@@ -317,7 +315,7 @@ SELECT min_ts, max_ts, records, original_size, compressed_size, index_size, flat
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["contains", "file_list", ""])
+            .with_label_values(&["contains", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = sqlx::query(
@@ -343,7 +341,7 @@ SELECT min_ts, max_ts, records, original_size, compressed_size, index_size, flat
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list", ""])
+            .with_label_values(&["update", "file_list"])
             .inc();
         sqlx::query(
             r#"UPDATE file_list SET flattened = $1 WHERE stream = $2 AND date = $3 AND file = $4;"#,
@@ -362,7 +360,7 @@ SELECT min_ts, max_ts, records, original_size, compressed_size, index_size, flat
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list", ""])
+            .with_label_values(&["update", "file_list"])
             .inc();
         sqlx::query(
             r#"UPDATE file_list SET compressed_size = $1 WHERE stream = $2 AND date = $3 AND file = $4;"#,
@@ -400,7 +398,7 @@ SELECT min_ts, max_ts, records, original_size, compressed_size, index_size, flat
 
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["query", "file_list", ""])
+            .with_label_values(&["query", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = if flattened.is_some() {
@@ -459,7 +457,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
 
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["query_for_merge", "file_list", ""])
+            .with_label_values(&["query_for_merge", "file_list"])
             .inc();
         let start = std::time::Instant::now();
 
@@ -506,7 +504,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
                 "SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, compressed_size, index_size FROM file_list WHERE id IN ({ids})"
             );
             DB_QUERY_NUMS
-                .with_label_values(&["query_by_ids", "file_list", ""])
+                .with_label_values(&["query_by_ids", "file_list"])
                 .inc();
             let start = std::time::Instant::now();
             let res = sqlx::query_as::<_, super::FileRecord>(&query_str)
@@ -564,7 +562,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
             tasks.push(tokio::task::spawn(async move {
                 let pool = CLIENT_RO.clone();
                 DB_QUERY_NUMS
-                .with_label_values(&["query_ids", "file_list", ""])
+                .with_label_values(&["query_ids", "file_list"])
                 .inc();
                 let max_ts_upper_bound = super::calculate_max_ts_upper_bound(time_end, stream_type);
                 let query = "SELECT id, records, original_size, deleted FROM file_list WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4;";
@@ -657,7 +655,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
 
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["query_old_data_hours", "file_list", ""])
+            .with_label_values(&["query_old_data_hours", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let (time_start, time_end) = time_range.unwrap_or((0, 0));
@@ -710,7 +708,7 @@ SELECT date
             lock_id as i64
         };
         let lock_sql = format!("SELECT pg_advisory_xact_lock({lock_id})");
-        DB_QUERY_NUMS.with_label_values(&["get_lock", "", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         if let Err(e) = sqlx::query(&lock_sql).execute(&mut *tx).await {
             if let Err(e) = tx.rollback().await {
                 log::error!("[POSTGRES] rollback query_deleted error: {e}");
@@ -719,7 +717,7 @@ SELECT date
         }
 
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list_deleted", ""])
+            .with_label_values(&["select", "file_list_deleted"])
             .inc();
         let items: Vec<FileListDeleted> = match sqlx::query_as::<_, super::FileDeletedRecord>(
             r#"SELECT id, account, stream, date, file, index_file, flattened FROM file_list_deleted WHERE org = $1 AND created_at < $2 ORDER BY created_at ASC LIMIT $3;"#
@@ -763,7 +761,7 @@ SELECT date
         );
         let now = config::utils::time::now_micros();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_deleted", ""])
+            .with_label_values(&["update", "file_list_deleted"])
             .inc();
         let ret = match sqlx::query(&sql).bind(now).execute(&mut *tx).await {
             Ok(v) => v,
@@ -796,7 +794,7 @@ SELECT date
     async fn list_deleted(&self) -> Result<Vec<FileListDeleted>> {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list_deleted", ""])
+            .with_label_values(&["select", "file_list_deleted"])
             .inc();
         let ret = sqlx::query_as::<_, super::FileDeletedRecord>(
             r#"SELECT id, account, stream, date, file, index_file, flattened FROM file_list_deleted;"#,
@@ -825,7 +823,7 @@ SELECT date
         let min_ts = config::utils::time::BASE_TIME.timestamp_micros();
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list", ""])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret: Option<i64> = sqlx::query_scalar(
             r#"SELECT MIN(min_ts)::BIGINT AS id FROM file_list WHERE stream = $1 AND min_ts > $2;"#,
@@ -840,7 +838,7 @@ SELECT date
     async fn get_max_pk_value(&self) -> Result<i64> {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list", ""])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret: Option<i64> =
             sqlx::query_scalar(r#"SELECT MAX(id)::BIGINT AS id FROM file_list;"#)
@@ -852,7 +850,7 @@ SELECT date
     async fn get_min_pk_value(&self) -> Result<i64> {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list", ""])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret: Option<i64> =
             sqlx::query_scalar(r#"SELECT MIN(id)::BIGINT AS id FROM file_list;"#)
@@ -912,7 +910,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
         let pool = CLIENT_RO.clone();
         let op_name = if deleted { "stats_deleted" } else { "stats" };
         DB_QUERY_NUMS
-            .with_label_values(&[op_name, "file_list", ""])
+            .with_label_values(&[op_name, "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
@@ -946,7 +944,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
         };
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "stream_stats", ""])
+            .with_label_values(&["select", "stream_stats"])
             .inc();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
             .fetch_all(&pool)
@@ -968,7 +966,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
         );
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["delete", "stream_stats", ""])
+            .with_label_values(&["delete", "stream_stats"])
             .inc();
         sqlx::query(&sql).execute(&pool).await?;
         Ok(())
@@ -1001,7 +999,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
         for stream_key in new_streams {
             let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
             DB_QUERY_NUMS
-                .with_label_values(&["insert", "stream_stats", ""])
+                .with_label_values(&["insert", "stream_stats"])
                 .inc();
             if let Err(e) = sqlx::query(
                 r#"
@@ -1030,7 +1028,7 @@ INSERT INTO stream_stats
         // update stats
         for (stream_key, stats) in update_streams {
             DB_QUERY_NUMS
-                .with_label_values(&["update", "stream_stats", ""])
+                .with_label_values(&["update", "stream_stats"])
                 .inc();
             if
                 let Err(e) = sqlx
@@ -1061,7 +1059,7 @@ UPDATE stream_stats
         // delete files which already marked deleted
         if let Some((_min_id, max_id)) = pk_value {
             DB_QUERY_NUMS
-                .with_label_values(&["clean_deleted", "file_list", ""])
+                .with_label_values(&["clean_deleted", "file_list"])
                 .inc();
             let start = std::time::Instant::now();
             let limit = config::get_config().limit.calculate_stats_step_limit;
@@ -1108,7 +1106,7 @@ UPDATE stream_stats
     async fn reset_stream_stats(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "stream_stats", ""])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx
             ::query(
@@ -1126,7 +1124,7 @@ UPDATE stream_stats
     ) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "stream_stats", ""])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx::query(r#"UPDATE stream_stats SET min_ts = $1 WHERE stream = $2;"#)
             .bind(min_ts)
@@ -1134,7 +1132,7 @@ UPDATE stream_stats
             .execute(&pool)
             .await?;
         DB_QUERY_NUMS
-            .with_label_values(&["update", "stream_stats", ""])
+            .with_label_values(&["update", "stream_stats"])
             .inc();
         sqlx::query(
             r#"UPDATE stream_stats SET max_ts = min_ts WHERE stream = $1 AND max_ts < min_ts;"#,
@@ -1148,7 +1146,7 @@ UPDATE stream_stats
     async fn len(&self) -> usize {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list", ""])
+            .with_label_values(&["select", "file_list"])
             .inc();
         let ret = match sqlx::query(r#"SELECT COUNT(*)::BIGINT AS num FROM file_list;"#)
             .fetch_one(&pool)
@@ -1185,7 +1183,7 @@ UPDATE stream_stats
         let pool = CLIENT.clone();
         let mut tx = pool.begin().await?;
         DB_QUERY_NUMS
-            .with_label_values(&["insert", "file_list_jobs", ""])
+            .with_label_values(&["insert", "file_list_jobs"])
             .inc();
         match
             sqlx
@@ -1259,7 +1257,7 @@ UPDATE stream_stats
             lock_id as i64
         };
         let lock_sql = format!("SELECT pg_advisory_xact_lock({lock_id})");
-        DB_QUERY_NUMS.with_label_values(&["get_lock", "", ""]).inc();
+        DB_QUERY_NUMS.with_label_values(&["get_lock", ""]).inc();
         if let Err(e) = sqlx::query(&lock_sql).execute(&mut *tx).await {
             if let Err(e) = tx.rollback().await {
                 log::error!("[POSTGRES] rollback get_pending_jobs error: {e}");
@@ -1268,7 +1266,7 @@ UPDATE stream_stats
         }
         // get pending jobs group by stream and order by num desc
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list_jobs", ""])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(
             r#"
@@ -1308,7 +1306,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         );
         let now = config::utils::time::now_micros();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_jobs", ""])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         if let Err(e) = sqlx::query(&sql)
             .bind(super::FileListJobStatus::Running)
@@ -1325,7 +1323,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         }
         // get jobs by ids
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list_jobs", ""])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let sql = format!(
             "SELECT * FROM file_list_jobs WHERE id IN ({});",
@@ -1360,7 +1358,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
                 .join(",")
         );
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_jobs", ""])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         sqlx::query(&sql)
             .bind(super::FileListJobStatus::Pending)
@@ -1373,7 +1371,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         let config = get_config();
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_jobs", ""])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         let sql = format!(
             "UPDATE file_list_jobs SET status = $1, updated_at = $2, dumped = $3 WHERE id IN ({});",
@@ -1396,7 +1394,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
     async fn update_running_jobs(&self, ids: &[i64]) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_jobs", ""])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         let sql = format!(
             r#"UPDATE file_list_jobs SET updated_at = $1 WHERE id IN ({})"#,
@@ -1415,7 +1413,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
     async fn check_running_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "file_list_jobs", ""])
+            .with_label_values(&["update", "file_list_jobs"])
             .inc();
         let ret = sqlx::query(
             r#"UPDATE file_list_jobs SET status = $1 WHERE status = $2 AND updated_at < $3;"#,
@@ -1434,7 +1432,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
     async fn clean_done_jobs(&self, before_date: i64) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["delete", "file_list_jobs", ""])
+            .with_label_values(&["delete", "file_list_jobs"])
             .inc();
         let ret = sqlx::query(
             r#"DELETE FROM file_list_jobs WHERE status = $1 AND updated_at < $2 AND dumped = $3;"#,
@@ -1454,7 +1452,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         let pool = CLIENT.clone();
 
         DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list_jobs", ""])
+            .with_label_values(&["select", "file_list_jobs"])
             .inc();
         let ret = sqlx
             ::query(
@@ -1607,9 +1605,7 @@ impl PostgresFileList {
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
         let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
-        DB_QUERY_NUMS
-            .with_label_values(&["insert", table, ""])
-            .inc();
+        DB_QUERY_NUMS.with_label_values(&["insert", table]).inc();
         let ret: std::result::Result<Option<i64>, sea_orm::SqlxError> = sqlx::query_scalar(
             format!(
                 r#"
@@ -1680,9 +1676,7 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
                         .push_bind(item.meta.index_size)
                         .push_bind(item.meta.flattened);
                 });
-                DB_QUERY_NUMS
-                    .with_label_values(&["insert", table, ""])
-                    .inc();
+                DB_QUERY_NUMS.with_label_values(&["insert", table]).inc();
                 if let Err(e) = query_builder.build().execute(&mut *tx).await {
                     if let Err(e) = tx.rollback().await {
                         log::error!("[POSTGRES] rollback {table} batch process for add error: {e}");
@@ -1706,7 +1700,7 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
                     let (stream_key, date_key, file_name) = parse_file_key_columns(&file.key)
                         .map_err(|e| Error::Message(e.to_string()))?;
                     DB_QUERY_NUMS
-                        .with_label_values(&["select_id", "file_list", ""])
+                        .with_label_values(&["select_id", "file_list"])
                         .inc();
                     let start = std::time::Instant::now();
                     let query_res: std::result::Result<Option<i64>, sea_orm::SqlxError> = sqlx::query_scalar(
@@ -1738,7 +1732,7 @@ INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, 
                 // delete files by ids
                 if !ids.is_empty() {
                     DB_QUERY_NUMS
-                        .with_label_values(&["delete_id", "file_list", ""])
+                        .with_label_values(&["delete_id", "file_list"])
                         .inc();
                     let sql = format!(
                         "UPDATE file_list SET deleted = true WHERE id IN({});",

--- a/src/infra/src/scheduler/mysql.rs
+++ b/src/infra/src/scheduler/mysql.rs
@@ -53,7 +53,7 @@ impl super::Scheduler for MySqlScheduler {
     async fn create_table(&self) -> Result<()> {
         let pool = CLIENT_DDL.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["create", "scheduled_jobs", ""])
+            .with_label_values(&["create", "scheduled_jobs"])
             .inc();
         sqlx::query(
             r#"
@@ -80,7 +80,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
 
         // create data column for old version <= 0.10.9
         DB_QUERY_NUMS
-            .with_label_values(&["select", "information_schema.columns", ""])
+            .with_label_values(&["select", "information_schema.columns"])
             .inc();
         let has_data_column = sqlx::query_scalar::<_,i64>("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='scheduled_jobs' AND column_name='data';")
             .fetch_one(&pool)
@@ -121,7 +121,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs
     async fn len_module(&self, module: TriggerModule) -> usize {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "scheduled_jobs", ""])
+            .with_label_values(&["select", "scheduled_jobs"])
             .inc();
         let ret = match sqlx::query(
             r#"
@@ -149,7 +149,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs WHERE module = ?;"#,
         let mut tx = pool.begin().await?;
 
         DB_QUERY_NUMS
-            .with_label_values(&["insert", "scheduled_jobs", ""])
+            .with_label_values(&["insert", "scheduled_jobs"])
             .inc();
         if let Err(e) = sqlx::query(
             r#"
@@ -200,7 +200,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     async fn delete(&self, org: &str, module: TriggerModule, key: &str) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["delete", "scheduled_jobs", key])
+            .with_label_values(&["delete", "scheduled_jobs"])
             .inc();
         sqlx::query(
             r#"DELETE FROM scheduled_jobs WHERE org = ? AND module = ? AND module_key = ?;"#,
@@ -235,7 +235,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     ) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "scheduled_jobs", key])
+            .with_label_values(&["update", "scheduled_jobs"])
             .inc();
         let query = match data {
             Some(data) => {
@@ -272,7 +272,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
     async fn update_trigger(&self, trigger: Trigger, clone: bool) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "scheduled_jobs", &trigger.module_key])
+            .with_label_values(&["update", "scheduled_jobs"])
             .inc();
 
         let query = if clone {
@@ -394,7 +394,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         let unlock_sql = format!("SELECT RELEASE_LOCK('{lock_id}')");
         let mut lock_tx = lock_pool.begin().await?;
         DB_QUERY_NUMS
-            .with_label_values(&["get_lock", "scheduled_jobs", ""])
+            .with_label_values(&["get_lock", "scheduled_jobs"])
             .inc();
         match sqlx::query_scalar::<_, i64>(&lock_sql)
             .fetch_one(&mut *lock_tx)
@@ -434,7 +434,7 @@ INSERT IGNORE INTO scheduled_jobs (org, module, module_key, is_realtime, is_sile
         };
 
         DB_QUERY_NUMS
-            .with_label_values(&["select", "scheduled_jobs", ""])
+            .with_label_values(&["select", "scheduled_jobs"])
             .inc();
         let job_ids: Vec<TriggerId> = match sqlx::query_as::<_, TriggerId>(
             r#"SELECT id
@@ -458,7 +458,7 @@ LIMIT ?;
                     log::error!("[SCHEDULER] rollback select jobs for update error: {e}");
                 }
                 DB_QUERY_NUMS
-                    .with_label_values(&["release_lock", "scheduled_jobs", ""])
+                    .with_label_values(&["release_lock", "scheduled_jobs"])
                     .inc();
                 if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                     log::error!("[SCHEDULER] unlock pull scheduled_jobs error: {e}");
@@ -479,7 +479,7 @@ LIMIT ?;
                 log::error!("[SCHEDULER] rollback scheduler pull error: {e}");
             }
             DB_QUERY_NUMS
-                .with_label_values(&["release_lock", "scheduled_jobs", ""])
+                .with_label_values(&["release_lock", "scheduled_jobs"])
                 .inc();
             if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                 log::error!("[SCHEDULER] unlock pull scheduled_jobs error: {e}");
@@ -492,7 +492,7 @@ LIMIT ?;
 
         let job_ids: Vec<String> = job_ids.into_iter().map(|id| id.id.to_string()).collect();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "scheduled_jobs", ""])
+            .with_label_values(&["update", "scheduled_jobs"])
             .inc();
         let query = format!(
             "UPDATE scheduled_jobs
@@ -517,7 +517,7 @@ WHERE id IN ({});",
                 log::error!("[MYSQL] rollback update scheduled jobs status error: {e}");
             }
             DB_QUERY_NUMS
-                .with_label_values(&["release_lock", "scheduled_jobs", ""])
+                .with_label_values(&["release_lock", "scheduled_jobs"])
                 .inc();
             if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                 log::error!("[SCHEDULER] unlock pull scheduled_jobs error: {e}");
@@ -532,7 +532,7 @@ WHERE id IN ({});",
         if let Err(e) = tx.commit().await {
             log::error!("[SCHEDULER] commit scheduler pull update error: {e}");
             DB_QUERY_NUMS
-                .with_label_values(&["release_lock", "scheduled_jobs", ""])
+                .with_label_values(&["release_lock", "scheduled_jobs"])
                 .inc();
             if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
                 log::error!("[SCHEDULER] unlock pull scheduled_jobs error: {e}");
@@ -544,7 +544,7 @@ WHERE id IN ({});",
         }
 
         DB_QUERY_NUMS
-            .with_label_values(&["release_lock", "scheduled_jobs", ""])
+            .with_label_values(&["release_lock", "scheduled_jobs"])
             .inc();
         if let Err(e) = sqlx::query(&unlock_sql).execute(&mut *lock_tx).await {
             log::error!("[SCHEDULER] unlock pull scheduled_jobs error: {e}");
@@ -559,7 +559,7 @@ WHERE id IN ({});",
         );
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "scheduled_jobs", ""])
+            .with_label_values(&["select", "scheduled_jobs"])
             .inc();
         let jobs: Vec<Trigger> = sqlx::query_as::<_, Trigger>(query.as_str())
             .fetch_all(&pool)
@@ -571,7 +571,7 @@ WHERE id IN ({});",
     async fn get(&self, org: &str, module: TriggerModule, key: &str) -> Result<Trigger> {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "scheduled_jobs", ""])
+            .with_label_values(&["select", "scheduled_jobs"])
             .inc();
         let query =
             r#"SELECT * FROM scheduled_jobs WHERE org = ? AND module = ? AND module_key = ?;"#;
@@ -595,7 +595,7 @@ WHERE id IN ({});",
     async fn list(&self, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "scheduled_jobs", ""])
+            .with_label_values(&["select", "scheduled_jobs"])
             .inc();
         let jobs: Vec<Trigger> = if let Some(module) = module {
             let query = r#"SELECT * FROM scheduled_jobs WHERE module = ? ORDER BY id;"#;
@@ -614,7 +614,7 @@ WHERE id IN ({});",
     async fn list_by_org(&self, org: &str, module: Option<TriggerModule>) -> Result<Vec<Trigger>> {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "scheduled_jobs", ""])
+            .with_label_values(&["select", "scheduled_jobs"])
             .inc();
         let jobs: Vec<Trigger> = if let Some(module) = module {
             let query = r#"SELECT * FROM scheduled_jobs WHERE org = ? AND module = ? ORDER BY id;"#;
@@ -642,7 +642,7 @@ WHERE id IN ({});",
         }
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["delete", "scheduled_jobs", ""])
+            .with_label_values(&["delete", "scheduled_jobs"])
             .inc();
         // Since alert scheduled_jobs contain last_satisfied_at field, we should not delete them
         sqlx::query(
@@ -666,7 +666,7 @@ WHERE id IN ({});",
         let pool = CLIENT.clone();
         let now = now_micros();
         DB_QUERY_NUMS
-            .with_label_values(&["update", "scheduled_jobs", ""])
+            .with_label_values(&["update", "scheduled_jobs"])
             .inc();
         let res = sqlx::query(
             r#"UPDATE scheduled_jobs
@@ -689,7 +689,7 @@ WHERE status = ? AND end_time <= ?
     async fn len(&self) -> usize {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["select", "scheduled_jobs", ""])
+            .with_label_values(&["select", "scheduled_jobs"])
             .inc();
         let ret = match sqlx::query(
             r#"
@@ -717,7 +717,7 @@ SELECT CAST(COUNT(*) AS SIGNED) AS num FROM scheduled_jobs;"#,
     async fn clear(&self) -> Result<()> {
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["delete", "scheduled_jobs", ""])
+            .with_label_values(&["delete", "scheduled_jobs"])
             .inc();
         match sqlx::query(r#"DELETE FROM scheduled_jobs;"#)
             .execute(&pool)
@@ -735,7 +735,7 @@ async fn add_data_column() -> Result<()> {
     log::info!("[MYSQL] Adding data column to scheduled_jobs table");
     let pool = CLIENT_DDL.clone();
     DB_QUERY_NUMS
-        .with_label_values(&["alter", "scheduled_jobs", ""])
+        .with_label_values(&["alter", "scheduled_jobs"])
         .inc();
     if let Err(e) = sqlx::query(r#"ALTER TABLE scheduled_jobs ADD COLUMN data LONGTEXT NOT NULL;"#)
         .execute(&pool)

--- a/src/infra/src/schema/history/mysql.rs
+++ b/src/infra/src/schema/history/mysql.rs
@@ -60,7 +60,7 @@ impl super::SchemaHistory for MysqlSchemaHistory {
         let value = json::to_string(&schema)?;
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["insert", "schema_history", ""])
+            .with_label_values(&["insert", "schema_history"])
             .inc();
         match sqlx::query(
             r#"
@@ -92,7 +92,7 @@ INSERT IGNORE INTO schema_history (org, stream_type, stream_name, start_dt, valu
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT_DDL.clone();
     DB_QUERY_NUMS
-        .with_label_values(&["create", "schema_history", ""])
+        .with_label_values(&["create", "schema_history"])
         .inc();
     sqlx::query(
         r#"

--- a/src/infra/src/schema/history/postgres.rs
+++ b/src/infra/src/schema/history/postgres.rs
@@ -60,7 +60,7 @@ impl super::SchemaHistory for PostgresSchemaHistory {
         let value = json::to_string(&schema)?;
         let pool = CLIENT.clone();
         DB_QUERY_NUMS
-            .with_label_values(&["insert", "schema_history", ""])
+            .with_label_values(&["insert", "schema_history"])
             .inc();
         match sqlx::query(
             r#"
@@ -93,7 +93,7 @@ INSERT INTO schema_history (org, stream_type, stream_name, start_dt, value)
 pub async fn create_table() -> Result<()> {
     let pool = CLIENT_DDL.clone();
     DB_QUERY_NUMS
-        .with_label_values(&["create", "schema_history", ""])
+        .with_label_values(&["create", "schema_history"])
         .inc();
     sqlx::query(
         r#"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove third 'key' label dimension in DB_QUERY_NUMS

- Update all with_label_values to two labels only

- Remove empty-string label arguments across modules

- Applies to file_list, db, scheduler, schema, and metrics config


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___

