### PR TITLE
fix: dashboard time conversion (#7869)

### DIFF
--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -307,34 +307,6 @@ export const isTimeStamp = (sample: any, treatAsNonTimestamp: any) => {
   }
 };
 
-/**
- * Converts 16-digit microsecond timestamps to readable date format
- * @param value - The value to convert (can be single value or array)
- * @returns The converted value(s) in date format
- */
-export const convert16DigitTimestamp = (value: any): any => {
-  // If value is an array, convert each element
-  if (Array.isArray(value)) {
-    return value.map((item: any) => convert16DigitTimestamp(item));
-  }
-
-  // If value is a string or number, convert it
-  if (typeof value === "string" || typeof value === "number") {
-    const strValue = value.toString();
-    const microsecondsPattern = /^\d{16}$/;
-
-    if (microsecondsPattern.test(strValue)) {
-      // Convert microseconds to milliseconds (divide by 1000)
-      const milliseconds = parseInt(strValue) / 1000;
-      const date = new Date(milliseconds);
-      return formatDate(date);
-    }
-  }
-
-  // Return original value if not a 16-digit timestamp
-  return value;
-};
-
 export function convertOffsetToSeconds(
   offset: string,
   endISOTimestamp: number,


### PR DESCRIPTION
### **User description**
- #7864


___

### **PR Type**
Bug fix


___

### **Description**
- Removed outdated timestamp converter function

- Introduced inline microsecond timestamp parsing

- Unified ISO string and Date handling

- Formatted dates using timezone consistently


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["val (any)"] --> B{"16-digit micro?"}
  B -- yes --> C["timestamp = parseInt(val)/1000"]
  B -- no --> D{"string ISO?"}
  D -- yes --> E["timestamp = `${val}Z`"]
  D -- no --> F["timestamp = new Date(val).getTime()/1000"]
  C --> G["formatDate(toZonedTime(timestamp, timezone))"]
  E --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>convertDataIntoUnitValue.ts</strong><dd><code>Remove convert16DigitTimestamp utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/dashboard/convertDataIntoUnitValue.ts

<ul><li>Removed <code>convert16DigitTimestamp</code> function<br> <li> Deleted associated JSDoc comments</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7872/files#diff-14c6fe442ef231566ec411f9e0262cdd24ec912fc67b9154eec743282ab7211a">+0/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>convertTableData.ts</strong><dd><code>Inline unified timestamp conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/dashboard/convertTableData.ts

<ul><li>Dropped <code>convert16DigitTimestamp</code> import<br> <li> Added inline timestamp handling in data conversion<br> <li> Branches for microseconds, ISO strings, Date objects</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7872/files#diff-a672094c46e697ee7b7a3949a901cc1f7f88ec06cddaf67370474b508d5b0960">+42/-29</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

