### PR TITLE
fix: make insert task to query manager later for rc9

### DIFF
--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -150,32 +150,7 @@ pub async fn search(
         trace_id.to_string()
     };
 
-    #[cfg(feature = "enterprise")]
-    {
-        let sql = Some(in_req.query.sql.clone());
-        let start_time = Some(in_req.query.start_time);
-        let end_time = Some(in_req.query.end_time);
-        let s_event_type = in_req
-            .search_type
-            .map(|s_event_type| s_event_type.to_string());
-        // set search task
-        SEARCH_SERVER
-            .insert(
-                trace_id.clone(),
-                TaskStatus::new_leader(
-                    vec![],
-                    true,
-                    user_id.clone(),
-                    Some(org_id.to_string()),
-                    Some(stream_type.to_string()),
-                    sql,
-                    start_time,
-                    end_time,
-                    s_event_type,
-                ),
-            )
-            .await;
-    }
+
 
     #[cfg(not(feature = "enterprise"))]
     let req_regions = vec![];
@@ -206,6 +181,34 @@ pub async fn search(
     }
     request.set_use_cache(in_req.use_cache);
     let meta = Sql::new_from_req(&request, &query).await?;
+
+    #[cfg(feature = "enterprise")]
+    {
+        let sql = Some(in_req.query.sql.clone());
+        let start_time = Some(in_req.query.start_time);
+        let end_time = Some(in_req.query.end_time);
+        let s_event_type = in_req
+            .search_type
+            .map(|s_event_type| s_event_type.to_string());
+        // set search task
+        SEARCH_SERVER
+            .insert(
+                trace_id.clone(),
+                TaskStatus::new_leader(
+                    vec![],
+                    true,
+                    user_id.clone(),
+                    Some(org_id.to_string()),
+                    Some(stream_type.to_string()),
+                    sql,
+                    start_time,
+                    end_time,
+                    s_event_type,
+                ),
+            )
+            .await;
+    }
+
     let span = tracing::span::Span::current();
     let handle = tokio::task::spawn(
         async move { cluster::http::search(request, query, req_regions, req_clusters, true).await }


### PR DESCRIPTION
after insert trace_id to query_manager, any error should not return until we remove this tracd_id.