### PR TITLE
fix: make order_by_metadata field serde optional in query Response

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -230,6 +230,13 @@ pub struct Response {
     pub work_group: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order_by: Option<OrderBy>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub order_by_metadata: Vec<(String, OrderBy)>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub converted_histogram_query: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_histogram_eligible: Option<bool>,
 }
 
 /// Iterator for Streaming response of search `Response`
@@ -1294,6 +1301,248 @@ mod tests {
         let mut req: Request = json::from_value(req).unwrap();
         req.decode().unwrap();
         assert_eq!(req.query.sql, "select * from test");
+    }
+
+    #[test]
+    fn test_order_by_metadata_serialization_empty() {
+        let mut response = Response::default();
+        response.set_order_by_metadata(vec![]);
+
+        let serialized = serde_json::to_string(&response).unwrap();
+        let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+
+        assert!(deserialized.order_by_metadata.is_empty());
+    }
+
+    #[test]
+    fn test_order_by_metadata_serialization_single_item() {
+        let mut response = Response::default();
+        let metadata = vec![("timestamp".to_string(), OrderBy::Desc)];
+        response.set_order_by_metadata(metadata.clone());
+
+        let serialized = serde_json::to_string(&response).unwrap();
+        let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.order_by_metadata.len(), 1);
+        assert_eq!(deserialized.order_by_metadata[0].0, "timestamp");
+        assert_eq!(deserialized.order_by_metadata[0].1, OrderBy::Desc);
+    }
+
+    #[test]
+    fn test_order_by_metadata_serialization_multiple_items() {
+        let mut response = Response::default();
+        let metadata = vec![
+            ("timestamp".to_string(), OrderBy::Desc),
+            ("level".to_string(), OrderBy::Asc),
+            ("message".to_string(), OrderBy::Desc),
+        ];
+        response.set_order_by_metadata(metadata.clone());
+
+        let serialized = serde_json::to_string(&response).unwrap();
+        let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.order_by_metadata.len(), 3);
+        assert_eq!(deserialized.order_by_metadata[0].0, "timestamp");
+        assert_eq!(deserialized.order_by_metadata[0].1, OrderBy::Desc);
+        assert_eq!(deserialized.order_by_metadata[1].0, "level");
+        assert_eq!(deserialized.order_by_metadata[1].1, OrderBy::Asc);
+        assert_eq!(deserialized.order_by_metadata[2].0, "message");
+        assert_eq!(deserialized.order_by_metadata[2].1, OrderBy::Desc);
+    }
+
+    #[test]
+    fn test_order_by_metadata_serialization_mixed_order() {
+        let mut response = Response::default();
+        let metadata = vec![
+            ("field1".to_string(), OrderBy::Asc),
+            ("field2".to_string(), OrderBy::Desc),
+            ("field3".to_string(), OrderBy::Asc),
+        ];
+        response.set_order_by_metadata(metadata.clone());
+
+        let serialized = serde_json::to_string(&response).unwrap();
+        let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.order_by_metadata.len(), 3);
+        assert_eq!(deserialized.order_by_metadata[0].1, OrderBy::Asc);
+        assert_eq!(deserialized.order_by_metadata[1].1, OrderBy::Desc);
+        assert_eq!(deserialized.order_by_metadata[2].1, OrderBy::Asc);
+    }
+
+    #[test]
+    fn test_order_by_metadata_serialization_special_characters() {
+        let mut response = Response::default();
+        let metadata = vec![
+            ("field_with_underscore".to_string(), OrderBy::Desc),
+            ("field-with-dash".to_string(), OrderBy::Asc),
+            ("field with space".to_string(), OrderBy::Desc),
+            ("field123".to_string(), OrderBy::Asc),
+        ];
+        response.set_order_by_metadata(metadata.clone());
+
+        let serialized = serde_json::to_string(&response).unwrap();
+        let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.order_by_metadata.len(), 4);
+        assert_eq!(deserialized.order_by_metadata[0].0, "field_with_underscore");
+        assert_eq!(deserialized.order_by_metadata[1].0, "field-with-dash");
+        assert_eq!(deserialized.order_by_metadata[2].0, "field with space");
+        assert_eq!(deserialized.order_by_metadata[3].0, "field123");
+    }
+
+    #[test]
+    fn test_order_by_metadata_serialization_empty_string_field() {
+        let mut response = Response::default();
+        let metadata = vec![("".to_string(), OrderBy::Desc)];
+        response.set_order_by_metadata(metadata.clone());
+
+        let serialized = serde_json::to_string(&response).unwrap();
+        let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.order_by_metadata.len(), 1);
+        assert_eq!(deserialized.order_by_metadata[0].0, "");
+        assert_eq!(deserialized.order_by_metadata[0].1, OrderBy::Desc);
+    }
+
+    #[test]
+    fn test_order_by_metadata_serialization_unicode_field() {
+        let mut response = Response::default();
+        let metadata = vec![
+            ("field_中文".to_string(), OrderBy::Asc),
+            ("field_русский".to_string(), OrderBy::Desc),
+            ("field_日本語".to_string(), OrderBy::Asc),
+        ];
+        response.set_order_by_metadata(metadata.clone());
+
+        let serialized = serde_json::to_string(&response).unwrap();
+        let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.order_by_metadata.len(), 3);
+        assert_eq!(deserialized.order_by_metadata[0].0, "field_中文");
+        assert_eq!(deserialized.order_by_metadata[1].0, "field_русский");
+        assert_eq!(deserialized.order_by_metadata[2].0, "field_日本語");
+    }
+
+    #[test]
+    fn test_order_by_metadata_skip_serialization_when_empty() {
+        let response = Response::default();
+        let serialized = serde_json::to_string(&response).unwrap();
+
+        // The order_by_metadata field should not appear in the JSON when empty
+        assert!(!serialized.contains("order_by_metadata"));
+    }
+
+    #[test]
+    fn test_order_by_metadata_include_serialization_when_not_empty() {
+        let mut response = Response::default();
+        let metadata = vec![("timestamp".to_string(), OrderBy::Desc)];
+        response.set_order_by_metadata(metadata);
+
+        let serialized = serde_json::to_string(&response).unwrap();
+
+        // The order_by_metadata field should appear in the JSON when not empty
+        assert!(serialized.contains("order_by_metadata"));
+    }
+
+    #[test]
+    fn test_order_by_metadata_deserialization_from_json() {
+        let json_str = r#"{
+            "took": 100,
+            "total": 10,
+            "from": 0,
+            "size": 10,
+            "cached_ratio": 0,
+            "scan_size": 1024,
+            "idx_scan_size": 512,
+            "scan_records": 100,
+            "result_cache_ratio": 0,
+            "order_by_metadata": [
+                ["timestamp", "desc"],
+                ["level", "asc"]
+            ],
+            "hits": []
+        }"#;
+
+        let deserialized: Response = serde_json::from_str(json_str).unwrap();
+
+        assert_eq!(deserialized.order_by_metadata.len(), 2);
+        assert_eq!(deserialized.order_by_metadata[0].0, "timestamp");
+        assert_eq!(deserialized.order_by_metadata[0].1, OrderBy::Desc);
+        assert_eq!(deserialized.order_by_metadata[1].0, "level");
+        assert_eq!(deserialized.order_by_metadata[1].1, OrderBy::Asc);
+    }
+
+    #[test]
+    fn test_order_by_metadata_deserialization_missing_field() {
+        let json_str = r#"{
+            "took": 100,
+            "total": 10,
+            "from": 0,
+            "size": 10,
+            "cached_ratio": 0,
+            "scan_size": 1024,
+            "idx_scan_size": 512,
+            "scan_records": 100,
+            "result_cache_ratio": 0,
+            "hits": []
+        }"#;
+
+        let deserialized: Response = serde_json::from_str(json_str).unwrap();
+
+        // Should default to empty vector when field is missing
+        assert!(deserialized.order_by_metadata.is_empty());
+    }
+
+    #[test]
+    fn test_order_by_metadata_setter_method() {
+        let mut response = Response::default();
+
+        // Initially should be empty
+        assert!(response.order_by_metadata.is_empty());
+
+        // Set metadata
+        let metadata = vec![
+            ("field1".to_string(), OrderBy::Asc),
+            ("field2".to_string(), OrderBy::Desc),
+        ];
+        response.set_order_by_metadata(metadata.clone());
+
+        // Verify it was set correctly
+        assert_eq!(response.order_by_metadata.len(), 2);
+        assert_eq!(response.order_by_metadata, metadata);
+
+        // Set to empty
+        response.set_order_by_metadata(vec![]);
+        assert!(response.order_by_metadata.is_empty());
+    }
+
+    #[test]
+    fn test_order_by_metadata_round_trip_complex() {
+        let mut response = Response::default();
+        let original_metadata = vec![
+            ("_timestamp".to_string(), OrderBy::Desc),
+            ("log_level".to_string(), OrderBy::Asc),
+            ("service_name".to_string(), OrderBy::Desc),
+            ("request_id".to_string(), OrderBy::Asc),
+            ("user_id".to_string(), OrderBy::Desc),
+        ];
+
+        response.set_order_by_metadata(original_metadata.clone());
+
+        // Serialize to JSON
+        let serialized = serde_json::to_string(&response).unwrap();
+
+        // Deserialize from JSON
+        let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+
+        // Verify round trip
+        assert_eq!(deserialized.order_by_metadata, original_metadata);
+
+        // Verify individual elements
+        for (i, (field, order)) in original_metadata.iter().enumerate() {
+            assert_eq!(deserialized.order_by_metadata[i].0, *field);
+            assert_eq!(deserialized.order_by_metadata[i].1, *order);
+        }
     }
 
     #[test]


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `order_by_metadata` optional vector field

- Added histogram fields `converted_histogram_query` and `is_histogram_eligible`

- Updated serde defaults and skip_serializing_if attributes

- Added tests for metadata serialization


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>search.rs</strong><dd><code>Add optional metadata and histogram fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/search.rs

<ul><li>Add <code>order_by_metadata</code> Vec field<br> <li> Add histogram query and eligibility fields<br> <li> Update serde default and skip_serializing_if<br> <li> Add tests for metadata serialization</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7901/files#diff-373e83a31e5bbc82fba05d7ae274b0dbd624ed748272232cf7eb8b8c3b2f3afc">+249/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

