### PR TITLE
fix: change `updated_at` AI prompts table to bigint

### DIFF
--- a/src/infra/src/table/migration/m20250801_000001_create_system_prompts_table.rs
+++ b/src/infra/src/table/migration/m20250801_000001_create_system_prompts_table.rs
@@ -49,9 +49,9 @@ fn create_system_prompts_table_statement() -> TableCreateStatement {
         .col(ColumnDef::new(SystemPrompts::Content).text().not_null())
         .col(
             ColumnDef::new(SystemPrompts::UpdatedAt)
-                .timestamp()
-                .default(Expr::current_timestamp())
-                .not_null(),
+                .big_integer()
+                .not_null()
+                .default(0),
         )
         .to_owned()
 }
@@ -79,7 +79,7 @@ mod tests {
                 CREATE TABLE IF NOT EXISTS "system_prompts" (
                 "type" varchar(27) NOT NULL PRIMARY KEY,
                 "content" text NOT NULL,
-                "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+                "updated_at" bigint NOT NULL DEFAULT 0
             )"#
         );
     }
@@ -92,7 +92,7 @@ mod tests {
                 CREATE TABLE IF NOT EXISTS `system_prompts` (
                 `type` varchar(27) NOT NULL PRIMARY KEY,
                 `content` text NOT NULL,
-                `updated_at` timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+                `updated_at` bigint NOT NULL DEFAULT 0
             )"#
         );
     }
@@ -105,7 +105,7 @@ mod tests {
                 CREATE TABLE IF NOT EXISTS "system_prompts" (
                 "type" varchar(27) NOT NULL PRIMARY KEY,
                 "content" text NOT NULL,
-                "updated_at" timestamp_text DEFAULT CURRENT_TIMESTAMP NOT NULL
+                "updated_at" bigint NOT NULL DEFAULT 0
             )"#
         );
     }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Change `updated_at` column to bigint

- Update migration tests to expect bigint

- Include `enterprise` in default features

- Add optional `o2_*` dependencies and roaring


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>m20250801_000001_create_system_prompts_table.rs</strong><dd><code>Change `updated_at` column type to bigint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/table/migration/m20250801_000001_create_system_prompts_table.rs

<ul><li>Changed <code>updated_at</code> column to bigint with default 0<br> <li> Removed timestamp default current_timestamp<br> <li> Updated Postgres, MySQL, SQLite tests expectations</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7905/files#diff-72fdc739d614b2a9d909b7681349d8029f4b9a7ce3d3e97da379eeb49d314e67">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update Cargo features and dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<ul><li>Set default features to include <code>enterprise</code><br> <li> Defined <code>enterprise</code> and updated <code>cloud</code> features<br> <li> Added optional <code>o2_*</code> dependencies<br> <li> Added <code>roaring</code> workspace and crate dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7905/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+15/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

