### PR TITLE
fix: fix for equal and other operator used it adds unwanted space. (#…

### DIFF
--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -579,19 +579,16 @@ export function addSpacesToOperators(input: string): string {
   let inSingleQuote = false;
   let inDoubleQuote = false;
   let parenDepth = 0;
-
   while (i < input.length) {
     const char = input[i];
     const nextChar = input[i + 1];
     const prevChar = i > 0 ? input[i - 1] : '';
-
     // Track quote states
     if (char === "'" && !inDoubleQuote) {
       inSingleQuote = !inSingleQuote;
     } else if (char === '"' && !inSingleQuote) {
       inDoubleQuote = !inDoubleQuote;
     }
-
     // Track parentheses depth (for function calls)
     if (!inSingleQuote && !inDoubleQuote) {
       if (char === '(') {
@@ -622,7 +619,6 @@ export function addSpacesToOperators(input: string): string {
           continue;
         }
       }
-
       // Handle special case of "! =" (space between ! and =)
       if (char === '!' && nextChar === ' ' && i + 2 < input.length && input[i + 2] === '=') {
         // Add space before if needed
@@ -637,7 +633,6 @@ export function addSpacesToOperators(input: string): string {
         i += 3;
         continue;
       }
-
       // Handle single-character operators
       if (char === '=' || char === '>' || char === '<') {
         // Add space before if needed
@@ -653,12 +648,10 @@ export function addSpacesToOperators(input: string): string {
         continue;
       }
     }
-
     // Default: just add the character
     result += char;
     i++;
   }
-
   return result;
 }
 


### PR DESCRIPTION
### **User description**
…7639)

https://github.com/openobserve/openobserve/issues/7640


___

### **PR Type**
Other


___

### **Description**
- Remove unnecessary blank lines in addSpacesToOperators

- Improve whitespace consistency in while loop

- No functional changes made


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zincutils.ts</strong><dd><code>Whitespace cleanup in zincutils.ts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/zincutils.ts

<ul><li>Removed extraneous blank lines before and after comment blocks<br> <li> Collapsed spacing within the while loop for readability<br> <li> Preserved existing operator-spacing logic</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7911/files#diff-d3d59688cccdcc6c84ebe88b698c6910030abecc3125f4c0ef81b0df023699ba">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

