### PR TITLE
feat: impl tantivy result cache for rc9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,6 +2534,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest",
+ "roaring",
  "sea-orm",
  "segment",
  "serde",
@@ -6528,6 +6529,7 @@ dependencies = [
  "regex-syntax 0.8.5",
  "report_server",
  "reqwest",
+ "roaring",
  "rust-embed-for-web",
  "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
@@ -8263,6 +8265,16 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "roaring"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f08d6a905edb32d74a5d5737a0c9d7e950c312f3c46cb0ca0a2ca09ea11878a0"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
 
 [[package]]
 name = "roxmltree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ actix-utils = "3.0.1"
 derive_more = { version = "2.0.1", features = ["full"] }
 brotli = "8.0.1"
 tokio-rustls.workspace = true
+roaring.workspace = true
 
 [dev-dependencies]
 async-walkdir.workspace = true
@@ -389,3 +390,4 @@ vector-enrichment = { version = "0.1.0", package = "enrichment", git = "https://
 vrl = { version = "0.22", features = ["value", "compiler", "test"] }
 zip = "3.0.0"
 zstd = "0.13"
+roaring = "0.11.2"

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -76,6 +76,7 @@ tracing-subscriber.workspace = true
 urlencoding.workspace = true
 utoipa.workspace = true
 vrl.workspace = true
+roaring.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1405,7 +1405,7 @@ pub struct Limit {
     pub inverted_index_result_cache_max_entries: usize,
     #[env_config(
         name = "ZO_INVERTED_INDEX_RESULT_CACHE_MAX_ENTRY_SIZE",
-        default = 20 * 1024, // bytes, default is 20KB
+        default = 20480, // bytes, default is 20KB
         help = "Maximum size of a single entry in the inverted index result cache. Higher values increase memory usage but may improve query performance."
     )]
     pub inverted_index_result_cache_max_entry_size: usize,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1411,7 +1411,7 @@ pub struct Limit {
     pub inverted_index_result_cache_max_entry_size: usize,
     #[env_config(
         name = "ZO_INVERTED_INDEX_SKIP_THRESHOLD",
-        default = 0,
+        default = 35,
         help = "If the inverted index returns row_id more than this threshold(%), it will skip the inverted index."
     )]
     pub inverted_index_skip_threshold: usize,

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -937,6 +937,12 @@ pub struct Common {
     )]
     pub inverted_index_enabled: bool,
     #[env_config(
+        name = "ZO_INVERTED_INDEX_RESULT_CACHE_ENABLED",
+        default = false,
+        help = "Toggle tantivy result cache."
+    )]
+    pub inverted_index_result_cache_enabled: bool,
+    #[env_config(
         name = "ZO_INVERTED_INDEX_CACHE_ENABLED",
         default = false,
         help = "Toggle inverted index cache."
@@ -1391,6 +1397,18 @@ pub struct Limit {
         help = "Maximum number of entries in the inverted index cache. Higher values increase memory usage but may improve query performance."
     )]
     pub inverted_index_cache_max_entries: usize,
+    #[env_config(
+        name = "ZO_INVERTED_INDEX_RESULT_CACHE_MAX_ENTRIES",
+        default = 10000,
+        help = "Maximum number of entries in the inverted index result cache. Higher values increase memory usage but may improve query performance."
+    )]
+    pub inverted_index_result_cache_max_entries: usize,
+    #[env_config(
+        name = "ZO_INVERTED_INDEX_RESULT_CACHE_MAX_ENTRY_SIZE",
+        default = 20 * 1024, // bytes, default is 20KB
+        help = "Maximum size of a single entry in the inverted index result cache. Higher values increase memory usage but may improve query performance."
+    )]
+    pub inverted_index_result_cache_max_entry_size: usize,
     #[env_config(
         name = "ZO_INVERTED_INDEX_SKIP_THRESHOLD",
         default = 0,

--- a/src/config/src/meta/inverted_index.rs
+++ b/src/config/src/meta/inverted_index.rs
@@ -24,6 +24,24 @@ pub enum IndexOptimizeMode {
     SimpleDistinct(String, usize, bool),
 }
 
+impl IndexOptimizeMode {
+    pub fn to_rule_string(&self) -> String {
+        match self {
+            IndexOptimizeMode::SimpleSelect(limit, ascend) => format!("s(l:{limit},a:{ascend})"),
+            IndexOptimizeMode::SimpleCount => "c".to_string(),
+            IndexOptimizeMode::SimpleHistogram(min_value, bucket_width, num_buckets) => {
+                format!("h(m:{min_value},b:{bucket_width},n:{num_buckets})")
+            }
+            IndexOptimizeMode::SimpleTopN(field, limit, ascend) => {
+                format!("t(f{field},l:{limit},a:{ascend})")
+            }
+            IndexOptimizeMode::SimpleDistinct(field, limit, ascend) => {
+                format!("d(f:{field},l:{limit},a:{ascend})")
+            }
+        }
+    }
+}
+
 impl std::fmt::Display for IndexOptimizeMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -958,6 +958,59 @@ pub static QUERY_AGGREGATION_CACHE_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+// metrics for tantivy result cache
+pub static TANTIVY_RESULT_CACHE_MEMORY_USAGE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "tantivy_result_cache_memory_usage",
+            "Total memory usage (bytes) of tantivy result cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
+pub static TANTIVY_RESULT_CACHE_GC_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "tantivy_result_cache_gc_total",
+            "Total number of GC of tantivy result cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
+pub static TANTIVY_RESULT_CACHE_REQUESTS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "tantivy_result_cache_requests_total",
+            "Total number of search of tantivy result cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
+pub static TANTIVY_RESULT_CACHE_HITS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "tantivy_result_cache_hits_total",
+            "Total number of hit of tantivy result cache",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
 fn register_metrics(registry: &Registry) {
     // http latency
     registry
@@ -1209,6 +1262,20 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(QUERY_AGGREGATION_CACHE_BYTES.clone()))
+        .expect("Metric registered");
+
+    // metrics for tantivy result cache
+    registry
+        .register(Box::new(TANTIVY_RESULT_CACHE_MEMORY_USAGE.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(TANTIVY_RESULT_CACHE_GC_TOTAL.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(TANTIVY_RESULT_CACHE_REQUESTS_TOTAL.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(TANTIVY_RESULT_CACHE_HITS_TOTAL.clone()))
         .expect("Metric registered");
 }
 

--- a/src/service/search/grpc/mod.rs
+++ b/src/service/search/grpc/mod.rs
@@ -21,6 +21,7 @@ use infra::errors::Result;
 
 pub mod flight;
 pub mod storage;
+pub mod tantivy_result_cache;
 pub(crate) mod utils;
 pub mod wal;
 

--- a/src/service/search/grpc/tantivy_result_cache.rs
+++ b/src/service/search/grpc/tantivy_result_cache.rs
@@ -1,0 +1,453 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+};
+
+use config::{meta::bitvec::BitVec, metrics};
+use dashmap::DashMap;
+use once_cell::sync::Lazy;
+use roaring::RoaringBitmap;
+
+use crate::service::search::grpc::utils::TantivyResult;
+
+pub static TANTIVY_RESULT_CACHE: Lazy<Arc<TantivyResultCache>> =
+    Lazy::new(|| Arc::new(TantivyResultCache::default()));
+
+#[derive(Debug, Clone)]
+pub enum CacheEntry {
+    RowIdsBitVec(usize, BitVec),
+    RowIdsRoaring(usize, RoaringBitmap),
+    Count(usize),              // simple count optimization
+    Histogram(Vec<u64>),       // simple histogram optimization
+    TopN(Vec<(String, u64)>),  // simple top n optimization
+    Distinct(HashSet<String>), // simple distinct optimization
+}
+
+impl From<CacheEntry> for TantivyResult {
+    fn from(entry: CacheEntry) -> Self {
+        match entry {
+            CacheEntry::RowIdsBitVec(num_rows, bitvec) => {
+                TantivyResult::RowIdsBitVec(num_rows, bitvec)
+            }
+            CacheEntry::RowIdsRoaring(num_rows, roaring) => {
+                let mut bitvec = BitVec::repeat(false, roaring.max().unwrap_or(0) as usize + 1);
+                for i in roaring.into_iter() {
+                    bitvec.set(i as usize, true);
+                }
+                TantivyResult::RowIdsBitVec(num_rows, bitvec)
+            }
+            CacheEntry::Count(count) => TantivyResult::Count(count),
+            CacheEntry::Histogram(histogram) => TantivyResult::Histogram(histogram),
+            CacheEntry::TopN(top_n) => TantivyResult::TopN(top_n),
+            CacheEntry::Distinct(distinct) => TantivyResult::Distinct(distinct),
+        }
+    }
+}
+
+impl CacheEntry {
+    pub fn get_memory_size(&self) -> usize {
+        match self {
+            CacheEntry::RowIdsBitVec(_, bitvec) => {
+                bitvec.capacity().div_ceil(8) + std::mem::size_of::<BitVec>()
+            }
+            CacheEntry::RowIdsRoaring(_, roaring) => {
+                roaring.serialized_size() + std::mem::size_of::<RoaringBitmap>()
+            }
+            CacheEntry::Count(_) => std::mem::size_of::<usize>(),
+            CacheEntry::Histogram(histogram) => {
+                histogram.capacity() * std::mem::size_of::<u64>() + std::mem::size_of::<Vec<u64>>()
+            }
+            CacheEntry::TopN(top_n) => {
+                top_n
+                    .iter()
+                    .map(|(s, _)| s.capacity() + std::mem::size_of::<u64>())
+                    .sum::<usize>()
+                    + std::mem::size_of::<Vec<(String, u64)>>()
+            }
+            CacheEntry::Distinct(distinct) => {
+                distinct.iter().map(|s| s.capacity()).sum::<usize>()
+                    + std::mem::size_of::<HashSet<String>>()
+            }
+        }
+    }
+}
+
+/// Cache created for storing the tantivy result
+pub struct TantivyResultCache {
+    readers: DashMap<String, CacheEntry>,
+    cacher: parking_lot::Mutex<VecDeque<String>>,
+    max_entries: usize,
+}
+
+impl TantivyResultCache {
+    pub fn new(max_entries: usize) -> Self {
+        Self {
+            readers: DashMap::new(),
+            cacher: parking_lot::Mutex::new(VecDeque::new()),
+            max_entries,
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<TantivyResult> {
+        let entry = { self.readers.get(key).map(|r| r.value().clone()) };
+
+        entry.map(TantivyResult::from)
+    }
+
+    pub fn put(&self, key: String, value: CacheEntry) -> Option<CacheEntry> {
+        let mut w = self.cacher.lock();
+        if w.len() >= self.max_entries {
+            metrics::TANTIVY_RESULT_CACHE_GC_TOTAL
+                .with_label_values(&[])
+                .inc();
+            let mut memory_usage = 0;
+            // release 10% of the cache
+            for _ in 0..(std::cmp::max(1, self.max_entries / 10)) {
+                if let Some(k) = w.pop_front() {
+                    if let Some((key, entry)) = self.readers.remove(&k) {
+                        memory_usage += entry.get_memory_size() + 2 * key.capacity();
+                    }
+                } else {
+                    break;
+                }
+            }
+            metrics::TANTIVY_RESULT_CACHE_MEMORY_USAGE
+                .with_label_values(&[])
+                .sub(memory_usage as i64);
+        }
+        w.push_back(key.clone());
+        drop(w);
+        // update metrics
+        let memory_usage = value.get_memory_size() + 2 * key.capacity();
+        metrics::TANTIVY_RESULT_CACHE_MEMORY_USAGE
+            .with_label_values(&[])
+            .add(memory_usage as i64);
+        self.readers.insert(key, value)
+    }
+}
+
+impl Default for TantivyResultCache {
+    fn default() -> Self {
+        Self::new(
+            config::get_config()
+                .limit
+                .inverted_index_result_cache_max_entries,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, sync::Arc, time::Duration};
+
+    use config::meta::bitvec::BitVec;
+
+    use super::*;
+
+    fn create_test_tantivy_result() -> CacheEntry {
+        let mut bitvec = BitVec::repeat(false, 100);
+        bitvec.set(10, true);
+        bitvec.set(20, true);
+        bitvec.set(30, true);
+        CacheEntry::RowIdsBitVec(3, bitvec)
+    }
+
+    fn create_test_count_result() -> CacheEntry {
+        CacheEntry::Count(42)
+    }
+
+    fn create_test_histogram_result() -> CacheEntry {
+        CacheEntry::Histogram(vec![10, 20, 30, 40])
+    }
+
+    fn create_test_top_n_result() -> CacheEntry {
+        CacheEntry::TopN(vec![
+            ("key1".to_string(), 100),
+            ("key2".to_string(), 200),
+            ("key3".to_string(), 300),
+        ])
+    }
+
+    fn create_test_distinct_result() -> CacheEntry {
+        let mut distinct = HashSet::new();
+        distinct.insert("value1".to_string());
+        distinct.insert("value2".to_string());
+        distinct.insert("value3".to_string());
+        CacheEntry::Distinct(distinct)
+    }
+
+    fn create_test_bitvec_result() -> CacheEntry {
+        let mut bitvec = BitVec::repeat(false, 100);
+        bitvec.set(10, true);
+        bitvec.set(20, true);
+        bitvec.set(30, true);
+        CacheEntry::RowIdsBitVec(3, bitvec)
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_new() {
+        let cache = TantivyResultCache::new(10);
+        assert_eq!(cache.max_entries, 10);
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_put_and_get() {
+        let cache = TantivyResultCache::new(10);
+        let key = "test_key".to_string();
+        let result = create_test_tantivy_result();
+
+        assert!(cache.get(&key).is_none());
+        cache.put(key.clone(), result.clone());
+        let retrieved = cache.get(&key);
+        assert!(retrieved.is_some());
+        assert!(matches!(
+            retrieved.unwrap(),
+            TantivyResult::RowIdsBitVec(_, _)
+        ));
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_get_nonexistent() {
+        let cache = TantivyResultCache::new(10);
+        let result = cache.get("nonexistent_key");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_multiple_entries() {
+        let cache = TantivyResultCache::new(10);
+
+        cache.put("count_key".to_string(), create_test_count_result());
+        cache.put("histogram_key".to_string(), create_test_histogram_result());
+        cache.put("topn_key".to_string(), create_test_top_n_result());
+        cache.put("distinct_key".to_string(), create_test_distinct_result());
+        cache.put("bitvec_key".to_string(), create_test_bitvec_result());
+
+        assert!(cache.get("count_key").is_some());
+        assert!(cache.get("histogram_key").is_some());
+        assert!(cache.get("topn_key").is_some());
+        assert!(cache.get("distinct_key").is_some());
+        assert!(cache.get("bitvec_key").is_some());
+
+        if let Some(TantivyResult::Count(count)) = cache.get("count_key") {
+            assert_eq!(count, 42);
+        } else {
+            panic!("Expected Count result");
+        }
+
+        if let Some(TantivyResult::Histogram(histogram)) = cache.get("histogram_key") {
+            assert_eq!(histogram, vec![10, 20, 30, 40]);
+        } else {
+            panic!("Expected Histogram result");
+        }
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_eviction() {
+        let cache = TantivyResultCache::new(5);
+
+        for i in 0..10 {
+            let key = format!("key_{i}");
+            let result = create_test_count_result();
+            cache.put(key, result);
+        }
+
+        assert!(cache.get("key_0").is_none());
+        assert!(cache.get("key_9").is_some());
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_overwrite_existing() {
+        let cache = TantivyResultCache::new(10);
+        let key = "test_key".to_string();
+        let result1 = create_test_count_result();
+        let result2 = create_test_histogram_result();
+
+        cache.put(key.clone(), result1.clone());
+        let old_entry = cache.put(key.clone(), result2.clone());
+
+        assert!(old_entry.is_some());
+        if let Some(CacheEntry::Count(count)) = old_entry {
+            assert_eq!(count, 42);
+        } else {
+            panic!("Expected Count result");
+        }
+
+        let retrieved = cache.get(&key).unwrap();
+        if let TantivyResult::Histogram(histogram) = retrieved {
+            assert_eq!(histogram, vec![10, 20, 30, 40]);
+        } else {
+            panic!("Expected Histogram result");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tantivy_result_cache_concurrent_access() {
+        let cache = Arc::new(TantivyResultCache::new(50));
+        let mut handles = vec![];
+
+        for i in 0..10 {
+            let cache_clone = cache.clone();
+            let handle = tokio::spawn(async move {
+                let key = format!("concurrent_key_{i}");
+                let result = create_test_count_result();
+
+                cache_clone.put(key.clone(), result.clone());
+                let retrieved = cache_clone.get(&key);
+                assert!(retrieved.is_some());
+
+                if let Some(TantivyResult::Count(count)) = retrieved {
+                    assert_eq!(count, 42);
+                } else {
+                    panic!("Expected Count result");
+                }
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tantivy_result_cache_concurrent_eviction() {
+        let cache = Arc::new(TantivyResultCache::new(20));
+        let mut handles = vec![];
+
+        for i in 0..30 {
+            let cache_clone = cache.clone();
+            let handle = tokio::spawn(async move {
+                let key = format!("eviction_key_{i}");
+                let result = create_test_count_result();
+                cache_clone.put(key, result);
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert!(cache.get("eviction_key_0").is_none());
+        assert!(cache.get("eviction_key_29").is_some());
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_default() {
+        let cache = TantivyResultCache::default();
+        let key = "test_key".to_string();
+        let result = create_test_count_result();
+        cache.put(key.clone(), result.clone());
+
+        let retrieved = cache.get(&key);
+        assert!(retrieved.is_some());
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_stress_test() {
+        let cache = TantivyResultCache::new(100);
+
+        for i in 0..200 {
+            let key = format!("stress_key_{i}");
+            let result = create_test_count_result();
+            cache.put(key, result);
+        }
+
+        assert!(cache.get("stress_key_0").is_none());
+        assert!(cache.get("stress_key_199").is_some());
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_edge_cases() {
+        let cache = TantivyResultCache::new(1);
+        let result1 = create_test_count_result();
+        let result2 = create_test_histogram_result();
+
+        cache.put("key1".to_string(), result1.clone());
+        cache.put("key2".to_string(), result2.clone());
+
+        assert!(cache.get("key1").is_none());
+        assert!(cache.get("key2").is_some());
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_different_result_types() {
+        let cache = TantivyResultCache::new(10);
+
+        let distinct_result = create_test_distinct_result();
+        cache.put("distinct_key".to_string(), distinct_result.clone());
+
+        if let Some(TantivyResult::Distinct(distinct)) = cache.get("distinct_key") {
+            assert_eq!(distinct.len(), 3);
+            assert!(distinct.contains("value1"));
+            assert!(distinct.contains("value2"));
+            assert!(distinct.contains("value3"));
+        } else {
+            panic!("Expected Distinct result");
+        }
+
+        let topn_result = create_test_top_n_result();
+        cache.put("topn_key".to_string(), topn_result.clone());
+
+        if let Some(TantivyResult::TopN(top_n)) = cache.get("topn_key") {
+            assert_eq!(top_n.len(), 3);
+            assert_eq!(top_n[0].0, "key1");
+            assert_eq!(top_n[0].1, 100);
+        } else {
+            panic!("Expected TopN result");
+        }
+    }
+
+    #[test]
+    fn test_global_cache_accessibility() {
+        let global_cache = &*TANTIVY_RESULT_CACHE;
+
+        let key = "global_test_key".to_string();
+        let result = create_test_count_result();
+        global_cache.put(key.clone(), result.clone());
+
+        let retrieved = global_cache.get(&key);
+        assert!(retrieved.is_some());
+
+        if let Some(TantivyResult::Count(count)) = retrieved {
+            assert_eq!(count, 42);
+        } else {
+            panic!("Expected Count result");
+        }
+    }
+
+    #[test]
+    fn test_tantivy_result_cache_percent_method() {
+        let cache = TantivyResultCache::new(10);
+
+        let mut bitvec = BitVec::repeat(false, 100);
+        bitvec.set(10, true);
+        bitvec.set(20, true);
+        let bitvec_result = CacheEntry::RowIdsBitVec(25, bitvec);
+
+        cache.put("percent_key".to_string(), bitvec_result);
+
+        if let Some(TantivyResult::RowIdsBitVec(percent, _)) = cache.get("percent_key") {
+            assert_eq!(percent, 25);
+        } else {
+            panic!("Expected RowIdsBitVec result");
+        }
+    }
+}

--- a/src/service/search/grpc/utils.rs
+++ b/src/service/search/grpc/utils.rs
@@ -56,6 +56,33 @@ impl TantivyResult {
             _ => 0,
         }
     }
+
+    pub fn get_memory_size(&self) -> usize {
+        match self {
+            Self::RowIds(row_ids) => {
+                row_ids.capacity() * std::mem::size_of::<u32>()
+                    + std::mem::size_of::<HashSet<u32>>()
+            }
+            Self::RowIdsBitVec(_, bitvec) => {
+                bitvec.capacity().div_ceil(8) + std::mem::size_of::<BitVec>()
+            }
+            Self::Count(_) => std::mem::size_of::<usize>(),
+            Self::Histogram(histogram) => {
+                histogram.capacity() * std::mem::size_of::<u64>() + std::mem::size_of::<Vec<u64>>()
+            }
+            Self::TopN(top_n) => {
+                top_n
+                    .iter()
+                    .map(|(s, _)| s.capacity() + std::mem::size_of::<u64>())
+                    .sum::<usize>()
+                    + std::mem::size_of::<Vec<(String, u64)>>()
+            }
+            Self::Distinct(distinct) => {
+                distinct.iter().map(|s| s.capacity()).sum::<usize>()
+                    + std::mem::size_of::<HashSet<String>>()
+            }
+        }
+    }
 }
 
 impl TantivyResult {

--- a/src/service/search/index.rs
+++ b/src/service/search/index.rs
@@ -991,7 +991,9 @@ fn _is_blank_or_alphanumeric(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use sqlparser::ast::{Function, FunctionArgumentList, Ident, ObjectName, ObjectNamePart, Value};
+    use sqlparser::ast::{
+        Function, FunctionArgumentList, Ident, ObjectName, ObjectNamePart, Value,
+    };
 
     use super::*;
 

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -149,8 +149,6 @@ pub async fn search(
         trace_id.to_string()
     };
 
-
-
     #[cfg(not(feature = "enterprise"))]
     let req_regions = vec![];
     #[cfg(not(feature = "enterprise"))]


### PR DESCRIPTION
- [x] tantivy result cache
- [x] enable ZO_INVERTED_INDEX_SKIP_THRESHOLD

## New env
```
ZO_INVERTED_INDEX_RESULT_CACHE_ENABLED = false
ZO_INVERTED_INDEX_RESULT_CACHE_MAX_ENTRIES = 10000
ZO_INVERTED_INDEX_RESULT_CACHE_MAX_ENTRY_SIZE = 20480 // 20KB
```
## design

by default the tantivy result only can cache at mot 10000 entry, and the max entry size is 20KB, it can modify by ZO_INVERTED_INDEX_RESULT_CACHE_MAX_ENTRIES, and ZO_INVERTED_INDEX_RESULT_CACHE_MAX_ENTRY_SIZE.
the cache struct is like below
```rust
#[derive(Debug, Clone)]
pub enum CacheEntry {
    RowIdsBitVec(usize, BitVec),
    RowIdsRoaring(usize, RoaringBitmap),
    Count(usize),              // simple count optimization
    Histogram(Vec<u64>),       // simple histogram optimization
    TopN(Vec<(String, u64)>),  // simple top n optimization
    Distinct(HashSet<String>), // simple distinct optimization
}
```
RowIdsBitVec is for row_ids / total_row_ids > 1%
RowIdsRoaring is for row_ids / total_row_ids < 1%

**if the cache can hit, the index search time can reduce from hundreds of ms to a few ms**