### PR TITLE
feat: improve internal error report

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -91,8 +91,9 @@ pub const ALL_VALUES_COL_NAME: &str = "_all_values";
 pub const DB_SCHEMA_VERSION: u64 = 2;
 pub const DB_SCHEMA_KEY: &str = "/db_schema_version/";
 
-const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 7] =
-    ["log", "message", "msg", "content", "data", "body", "json"];
+const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 9] = [
+    "log", "message", "msg", "content", "data", "body", "json", "error", "errors",
+];
 pub static SQL_FULL_TEXT_SEARCH_FIELDS: Lazy<Vec<String>> = Lazy::new(|| {
     let mut fields = chain(
         _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -882,6 +882,8 @@ pub struct Common {
     pub usage_reporting_url: String,
     #[env_config(name = "ZO_USAGE_REPORTING_CREDS", default = "")]
     pub usage_reporting_creds: String,
+    #[env_config(name = "ZO_USAGE_REPORTING_ERRORS_ENABLED", default = true)]
+    pub usage_reporting_errors_enabled: bool,
     #[env_config(name = "ZO_USAGE_BATCH_SIZE", default = 2000)]
     pub usage_batch_size: usize,
     #[env_config(

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -469,14 +469,11 @@ pub async fn init() -> Result<(), anyhow::Error> {
         if cfg.disk_cache.gc_interval == 0 {
             return;
         }
-        let mut interval =
-            tokio::time::interval(tokio::time::Duration::from_secs(cfg.disk_cache.gc_interval));
-        interval.tick().await; // the first tick is immediate
         loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(cfg.disk_cache.gc_interval)).await;
             if let Err(e) = gc().await {
                 log::error!("disk cache gc error: {}", e);
             }
-            interval.tick().await;
         }
     });
     Ok(())

--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -67,6 +67,15 @@ pub async fn db_init() -> Result<(), anyhow::Error> {
 }
 
 pub async fn init() -> Result<(), anyhow::Error> {
+    if !config::cluster::LOCAL_NODE.is_ingester()
+        && !config::cluster::LOCAL_NODE.is_querier()
+        && !config::cluster::LOCAL_NODE.is_compactor()
+    {
+        return Ok(());
+    }
+
+    println!("infra init");
+
     // if we have skipped db migrations (because version is up-to-date),
     // for non-stateful set components this dir will be absent, so we create it anyways
     std::fs::create_dir_all(&config::get_config().common.data_db_dir)?;

--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -74,8 +74,6 @@ pub async fn init() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    println!("infra init");
-
     // if we have skipped db migrations (because version is up-to-date),
     // for non-stateful set components this dir will be absent, so we create it anyways
     std::fs::create_dir_all(&config::get_config().common.data_db_dir)?;

--- a/src/service/search/index.rs
+++ b/src/service/search/index.rs
@@ -991,7 +991,9 @@ fn _is_blank_or_alphanumeric(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use sqlparser::ast::{Function, FunctionArgumentList, Ident, ObjectName, ObjectNamePart, Value};
+    use sqlparser::ast::{
+        Function, FunctionArgumentList, Ident, ObjectName, ObjectNamePart, Value,
+    };
 
     use super::*;
 

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -149,8 +149,6 @@ pub async fn search(
         trace_id.to_string()
     };
 
-
-
     #[cfg(not(feature = "enterprise"))]
     let req_regions = vec![];
     #[cfg(not(feature = "enterprise"))]


### PR DESCRIPTION
- [x] Add new env to disable error report
- [x] Improve error message to avoid too large error message, we found the `node_errors` over 1MB.
- [x] Add `error` field as default `Full text search` field
- [x] Skip `infra` jobs on router

Add a new ENV and then we can disable error report:
```
ZO_USAGE_REPORTING_ERRORS_ENABLED=true
```
set to `false` will disable error report.

