### PR TITLE
feat: improve internal error report

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -91,8 +91,9 @@ pub const MESSAGE_COL_NAME: &str = "message";
 pub const STREAM_NAME_LABEL: &str = "o2_stream_name";
 pub const DEFAULT_STREAM_NAME: &str = "default";
 
-const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 7] =
-    ["log", "message", "msg", "content", "data", "body", "json"];
+const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 9] = [
+    "log", "message", "msg", "content", "data", "body", "json", "error", "errors",
+];
 pub static SQL_FULL_TEXT_SEARCH_FIELDS: Lazy<Vec<String>> = Lazy::new(|| {
     let mut fields = chain(
         _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS
@@ -874,6 +875,8 @@ pub struct Common {
     pub usage_reporting_url: String,
     #[env_config(name = "ZO_USAGE_REPORTING_CREDS", default = "")]
     pub usage_reporting_creds: String,
+    #[env_config(name = "ZO_USAGE_REPORTING_ERRORS_ENABLED", default = true)]
+    pub usage_reporting_errors_enabled: bool,
     #[env_config(name = "ZO_USAGE_BATCH_SIZE", default = 2000)]
     pub usage_batch_size: usize,
     #[env_config(

--- a/src/config/src/meta/self_reporting/error.rs
+++ b/src/config/src/meta/self_reporting/error.rs
@@ -17,7 +17,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize, ser::SerializeStruct};
 
-use crate::meta::stream::StreamParams;
+use crate::{meta::stream::StreamParams, utils::str::StringExt};
 
 const PIPELINE_ERROR_MAX_SIZE: usize = 1024;
 
@@ -60,21 +60,14 @@ impl Serialize for ErrorSource {
                 state.serialize_field("pipeline_name", &pe.pipeline_name)?;
                 if !pe.node_errors.is_empty() {
                     let node_errors = serde_json::to_string(&pe.node_errors).unwrap_or_default();
-                    if node_errors.len() > PIPELINE_ERROR_MAX_SIZE {
-                        state.serialize_field(
-                            "pipeline_node_errors",
-                            &node_errors[..PIPELINE_ERROR_MAX_SIZE],
-                        )?;
-                    } else {
-                        state.serialize_field("pipeline_node_errors", &node_errors)?;
-                    }
+                    state.serialize_field(
+                        "pipeline_node_errors",
+                        &node_errors.truncate_utf8(PIPELINE_ERROR_MAX_SIZE),
+                    )?;
                 }
                 if let Some(error) = &pe.error {
-                    if error.len() > PIPELINE_ERROR_MAX_SIZE {
-                        state.serialize_field("error", &error[..PIPELINE_ERROR_MAX_SIZE])?;
-                    } else {
-                        state.serialize_field("error", &error)?;
-                    }
+                    state
+                        .serialize_field("error", &error.truncate_utf8(PIPELINE_ERROR_MAX_SIZE))?;
                 }
             }
         }

--- a/src/config/src/meta/self_reporting/error.rs
+++ b/src/config/src/meta/self_reporting/error.rs
@@ -15,11 +15,13 @@
 
 use std::collections::{HashMap, HashSet};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, ser::SerializeStruct};
 
 use crate::meta::stream::StreamParams;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+const PIPELINE_ERROR_MAX_SIZE: usize = 1024;
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ErrorData {
     pub _timestamp: i64,
@@ -29,9 +31,7 @@ pub struct ErrorData {
     pub error_source: ErrorSource,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "error_source")]
-#[serde(rename_all = "snake_case")]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ErrorSource {
     Alert,
     Dashboard,
@@ -41,17 +41,52 @@ pub enum ErrorSource {
     Other,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+impl Serialize for ErrorSource {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("error_source", 4)?;
+        match self {
+            ErrorSource::Alert => state.serialize_field("error_source", &"alert")?,
+            ErrorSource::Dashboard => state.serialize_field("error_source", &"dashboard")?,
+            ErrorSource::Ingestion => state.serialize_field("error_source", &"ingestion")?,
+            ErrorSource::Search => state.serialize_field("error_source", &"search")?,
+            ErrorSource::Other => state.serialize_field("error_source", &"other")?,
+            ErrorSource::Pipeline(pe) => {
+                // limit the size of the pipeline error to 1k characters
+                state.serialize_field("error_source", &"pipeline")?;
+                state.serialize_field("pipeline_id", &pe.pipeline_id)?;
+                state.serialize_field("pipeline_name", &pe.pipeline_name)?;
+                if !pe.node_errors.is_empty() {
+                    let node_errors = serde_json::to_string(&pe.node_errors).unwrap_or_default();
+                    if node_errors.len() > PIPELINE_ERROR_MAX_SIZE {
+                        state.serialize_field(
+                            "pipeline_node_errors",
+                            &node_errors[..PIPELINE_ERROR_MAX_SIZE],
+                        )?;
+                    } else {
+                        state.serialize_field("pipeline_node_errors", &node_errors)?;
+                    }
+                }
+                if let Some(error) = &pe.error {
+                    if error.len() > PIPELINE_ERROR_MAX_SIZE {
+                        state.serialize_field("error", &error[..PIPELINE_ERROR_MAX_SIZE])?;
+                    } else {
+                        state.serialize_field("error", &error)?;
+                    }
+                }
+            }
+        }
+        state.end()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct PipelineError {
     pub pipeline_id: String,
     pub pipeline_name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    #[serde(
-        skip_serializing_if = "HashMap::is_empty",
-        serialize_with = "serialize_values_only"
-    )]
     pub node_errors: HashMap<String, NodeErrors>,
 }
 
@@ -98,22 +133,6 @@ impl NodeErrors {
     }
 }
 
-// Custom serializer for HashMap to serialize values only
-fn serialize_values_only<S>(
-    map: &HashMap<String, NodeErrors>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    use serde::ser::SerializeSeq;
-    let mut seq = serializer.serialize_seq(Some(map.len()))?;
-    for value in map.values() {
-        seq.serialize_element(value)?;
-    }
-    seq.end()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,5 +164,16 @@ mod tests {
         let val_str = json::to_string(&val.unwrap());
         assert!(val_str.is_ok());
         println!("val: {}", val_str.unwrap());
+    }
+
+    #[test]
+    fn test_error_data_serialization() {
+        let error_data = ErrorData {
+            _timestamp: 10,
+            stream_params: StreamParams::default(),
+            error_source: ErrorSource::Pipeline(PipelineError::new("pipeline_id", "pipeline_name")),
+        };
+        let val = json::to_string(&error_data);
+        assert!(val.is_ok());
     }
 }

--- a/src/config/src/utils/str.rs
+++ b/src/config/src/utils/str.rs
@@ -28,6 +28,7 @@ pub fn find(haystack: &str, needle: &str) -> bool {
 pub trait StringExt {
     fn find(&self, needle: &str) -> bool;
     fn optional(&self) -> Option<String>;
+    fn truncate_utf8(&self, max_len: usize) -> String;
 }
 
 impl StringExt for String {
@@ -43,6 +44,26 @@ impl StringExt for String {
             Some(self.clone())
         }
     }
+
+    fn truncate_utf8(&self, max_len: usize) -> String {
+        if self.len() <= max_len {
+            return self.clone();
+        }
+
+        // Find the last valid UTF-8 boundary within max_len
+        // Start from max_len and work backwards until we find a valid boundary
+        let mut end = max_len.min(self.len());
+        while end > 0 && !self.is_char_boundary(end) {
+            end -= 1;
+        }
+
+        // If we couldn't find a valid boundary, return empty string
+        if end == 0 {
+            return String::new();
+        }
+
+        self[..end].to_string()
+    }
 }
 
 #[cfg(test)]
@@ -54,5 +75,231 @@ mod tests {
         let haystack = "This is search-unitTest";
         let needle = "unitTest";
         assert!(find(haystack, needle));
+    }
+
+    #[test]
+    fn test_truncate_ascii() {
+        let s = "Hello, World!".to_string();
+        assert_eq!(s.truncate_utf8(5), "Hello");
+        assert_eq!(
+            "Hello, World!".to_string().truncate_utf8(20),
+            "Hello, World!"
+        );
+        assert_eq!("Hello, World!".to_string().truncate_utf8(0), "");
+    }
+
+    #[test]
+    fn test_truncate_utf8() {
+        // Test with multi-byte UTF-8 characters
+        let s = "Hello, 世界!".to_string(); // "世界" is 6 bytes in UTF-8
+        assert_eq!(s.truncate_utf8(7), "Hello, "); // Truncates before the Chinese characters
+        assert_eq!("Hello, 世界!".to_string().truncate_utf8(8), "Hello, "); // Still truncates before Chinese characters (8 bytes = "Hello, " + start of "世")
+        assert_eq!("Hello, 世界!".to_string().truncate_utf8(9), "Hello, "); // Still truncates before Chinese characters (9 bytes = "Hello, " + start of "世")
+        assert_eq!("Hello, 世界!".to_string().truncate_utf8(10), "Hello, 世"); // Truncates after the first Chinese character
+        assert_eq!("Hello, 世界!".to_string().truncate_utf8(11), "Hello, 世"); // Still before second Chinese character
+        assert_eq!("Hello, 世界!".to_string().truncate_utf8(12), "Hello, 世"); // Still before second Chinese character
+        assert_eq!("Hello, 世界!".to_string().truncate_utf8(13), "Hello, 世界"); // Truncates after both Chinese characters
+        assert_eq!("Hello, 世界!".to_string().truncate_utf8(14), "Hello, 世界!"); // No truncation needed
+    }
+
+    #[test]
+    fn test_truncate_emoji() {
+        // Test with emoji (4 bytes in UTF-8)
+        let s = "Hello 👋 World".to_string();
+        assert_eq!(s.truncate_utf8(6), "Hello "); // Truncates before emoji
+        assert_eq!("Hello 👋 World".to_string().truncate_utf8(7), "Hello "); // Still truncates before emoji (7 bytes = "Hello " + start of emoji)
+        assert_eq!("Hello 👋 World".to_string().truncate_utf8(8), "Hello "); // Still truncates before emoji (8 bytes = "Hello " + start of emoji)
+        assert_eq!("Hello 👋 World".to_string().truncate_utf8(9), "Hello "); // Still truncates before emoji (9 bytes = "Hello " + start of emoji)
+        assert_eq!("Hello 👋 World".to_string().truncate_utf8(10), "Hello 👋"); // Truncates after emoji
+        assert_eq!("Hello 👋 World".to_string().truncate_utf8(11), "Hello 👋 "); // Truncates after emoji and space
+        assert_eq!("Hello 👋 World".to_string().truncate_utf8(12), "Hello 👋 W"); // After emoji, space, and W
+        assert_eq!(
+            "Hello 👋 World".to_string().truncate_utf8(13),
+            "Hello 👋 Wo"
+        ); // After emoji, space, and Wo
+        assert_eq!(
+            "Hello 👋 World".to_string().truncate_utf8(14),
+            "Hello 👋 Wor"
+        ); // After emoji, space, and Wor
+        assert_eq!(
+            "Hello 👋 World".to_string().truncate_utf8(15),
+            "Hello 👋 Worl"
+        ); // After emoji, space, and Worl
+        assert_eq!(
+            "Hello 👋 World".to_string().truncate_utf8(16),
+            "Hello 👋 World"
+        ); // No truncation needed
+    }
+
+    #[test]
+    fn test_truncate_edge_cases() {
+        let s = "Test".to_string();
+        assert_eq!(s.truncate_utf8(0), "");
+        assert_eq!("Test".to_string().truncate_utf8(1), "T");
+        assert_eq!("Test".to_string().truncate_utf8(4), "Test");
+        assert_eq!("Test".to_string().truncate_utf8(5), "Test");
+    }
+
+    #[test]
+    fn test_truncate_empty_string() {
+        let s = "".to_string();
+        assert_eq!(s.truncate_utf8(0), "");
+        assert_eq!("".to_string().truncate_utf8(5), "");
+    }
+
+    #[test]
+    fn test_truncate_single_char() {
+        let s = "A".to_string();
+        assert_eq!(s.truncate_utf8(0), "");
+        assert_eq!("A".to_string().truncate_utf8(1), "A");
+        assert_eq!("A".to_string().truncate_utf8(5), "A");
+    }
+
+    #[test]
+    fn test_truncate_mixed_utf8() {
+        // Test with a mix of ASCII and UTF-8 characters
+        let s = "Hello 世界 👋 Test".to_string();
+        assert_eq!(s.truncate_utf8(5), "Hello");
+        assert_eq!("Hello 世界 👋 Test".to_string().truncate_utf8(6), "Hello ");
+        assert_eq!("Hello 世界 👋 Test".to_string().truncate_utf8(7), "Hello "); // Still before Chinese characters
+        assert_eq!("Hello 世界 👋 Test".to_string().truncate_utf8(8), "Hello "); // Still before Chinese characters
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(9),
+            "Hello 世"
+        ); // After first Chinese character
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(10),
+            "Hello 世"
+        ); // Still before second Chinese character
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(11),
+            "Hello 世"
+        ); // Still before second Chinese character
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(12),
+            "Hello 世界"
+        ); // After both Chinese characters
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(13),
+            "Hello 世界 "
+        ); // After Chinese characters and space
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(14),
+            "Hello 世界 "
+        ); // Still before emoji
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(15),
+            "Hello 世界 "
+        ); // Still before emoji
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(16),
+            "Hello 世界 "
+        ); // Still before emoji
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(17),
+            "Hello 世界 👋"
+        ); // After emoji
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(18),
+            "Hello 世界 👋 "
+        ); // After emoji and space
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(19),
+            "Hello 世界 👋 T"
+        ); // After emoji, space, and T
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(20),
+            "Hello 世界 👋 Te"
+        ); // After emoji, space, and Te
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(21),
+            "Hello 世界 👋 Tes"
+        ); // After emoji, space, and Tes
+        assert_eq!(
+            "Hello 世界 👋 Test".to_string().truncate_utf8(22),
+            "Hello 世界 👋 Test"
+        ); // No truncation needed
+    }
+
+    #[test]
+    fn test_truncate_complex_emoji() {
+        // Test with complex emoji sequences (like family emoji)
+        let s = "Family: 👨‍👩‍👧‍👦".to_string();
+        assert_eq!(s.truncate_utf8(7), "Family:");
+        assert_eq!("Family: 👨‍👩‍👧‍👦".to_string().truncate_utf8(8), "Family: ");
+        assert_eq!("Family: 👨‍👩‍👧‍👦".to_string().truncate_utf8(9), "Family: "); // Still before emoji
+        assert_eq!("Family: 👨‍👩‍👧‍👦".to_string().truncate_utf8(10), "Family: "); // Still before emoji
+        assert_eq!("Family: 👨‍👩‍👧‍👦".to_string().truncate_utf8(11), "Family: "); // Still before emoji
+        assert_eq!("Family: 👨‍👩‍👧‍👦".to_string().truncate_utf8(12), "Family: 👨"); // After first emoji
+        assert_eq!("Family: 👨‍👩‍👧‍👦".to_string().truncate_utf8(13), "Family: 👨"); // Still before second emoji
+        assert_eq!("Family: 👨‍👩‍👧‍👦".to_string().truncate_utf8(14), "Family: 👨"); // Still before second emoji
+        assert_eq!("Family: 👨‍👩‍👧‍👦".to_string().truncate_utf8(15), "Family: 👨‍"); // After first emoji and joiner
+        // The family emoji is a complex sequence, so we test around its boundaries
+    }
+
+    #[test]
+    fn test_truncate_zero_width_characters() {
+        // Test with zero-width characters
+        let s = "Hello\u{200B}World".to_string(); // Zero-width space
+        assert_eq!(s.truncate_utf8(5), "Hello");
+        assert_eq!("Hello\u{200B}World".to_string().truncate_utf8(6), "Hello"); // Still before zero-width character
+        assert_eq!("Hello\u{200B}World".to_string().truncate_utf8(7), "Hello"); // Still before zero-width character
+        assert_eq!(
+            "Hello\u{200B}World".to_string().truncate_utf8(8),
+            "Hello\u{200B}"
+        ); // After zero-width character
+        assert_eq!(
+            "Hello\u{200B}World".to_string().truncate_utf8(9),
+            "Hello\u{200B}W"
+        ); // After zero-width character and W
+        assert_eq!(
+            "Hello\u{200B}World".to_string().truncate_utf8(10),
+            "Hello\u{200B}Wo"
+        ); // After zero-width character and Wo
+        assert_eq!(
+            "Hello\u{200B}World".to_string().truncate_utf8(11),
+            "Hello\u{200B}Wor"
+        ); // After zero-width character and Wor
+        assert_eq!(
+            "Hello\u{200B}World".to_string().truncate_utf8(12),
+            "Hello\u{200B}Worl"
+        ); // After zero-width character and Worl
+        assert_eq!(
+            "Hello\u{200B}World".to_string().truncate_utf8(13),
+            "Hello\u{200B}World"
+        ); // No truncation needed
+    }
+
+    #[test]
+    fn test_truncate_combining_characters() {
+        // Test with combining characters
+        let s = "e\u{0301}".to_string(); // 'e' + combining acute accent = 'é'
+        assert_eq!(s.truncate_utf8(1), "e"); // Should truncate before the combining character
+        assert_eq!("e\u{0301}".to_string().truncate_utf8(2), "e"); // Still before combining character
+        assert_eq!("e\u{0301}".to_string().truncate_utf8(3), "e\u{0301}"); // Should keep the full character
+    }
+
+    #[test]
+    fn test_truncate_boundary_conditions() {
+        // Test boundary conditions around UTF-8 character boundaries
+        let s = "Hello世界".to_string();
+
+        // Test truncation at various byte positions
+        assert_eq!(s.truncate_utf8(5), "Hello");
+        assert_eq!("Hello世界".to_string().truncate_utf8(6), "Hello"); // Still before Chinese characters
+        assert_eq!("Hello世界".to_string().truncate_utf8(7), "Hello"); // Still before Chinese characters
+        assert_eq!("Hello世界".to_string().truncate_utf8(8), "Hello世"); // After first Chinese character
+        assert_eq!("Hello世界".to_string().truncate_utf8(9), "Hello世"); // Still before second Chinese character
+        assert_eq!("Hello世界".to_string().truncate_utf8(10), "Hello世"); // Still before second Chinese character
+        assert_eq!("Hello世界".to_string().truncate_utf8(11), "Hello世界"); // After both Chinese characters
+    }
+
+    #[test]
+    fn test_truncate_ownership() {
+        // Test that the method takes ownership and doesn't clone unnecessarily
+        let s = "Test String".to_string();
+        let truncated = s.truncate_utf8(4);
+        assert_eq!(truncated, "Test");
+        // The original string should be consumed, not cloned
     }
 }

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -469,14 +469,11 @@ pub async fn init() -> Result<(), anyhow::Error> {
         if cfg.disk_cache.gc_interval == 0 {
             return;
         }
-        let mut interval =
-            tokio::time::interval(tokio::time::Duration::from_secs(cfg.disk_cache.gc_interval));
-        interval.tick().await; // the first tick is immediate
         loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(cfg.disk_cache.gc_interval)).await;
             if let Err(e) = gc().await {
                 log::error!("disk cache gc error: {e}");
             }
-            interval.tick().await;
         }
     });
     Ok(())

--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -67,6 +67,13 @@ pub async fn db_init() -> Result<(), anyhow::Error> {
 }
 
 pub async fn init() -> Result<(), anyhow::Error> {
+    if !config::cluster::LOCAL_NODE.is_ingester()
+        && !config::cluster::LOCAL_NODE.is_querier()
+        && !config::cluster::LOCAL_NODE.is_compactor()
+    {
+        return Ok(());
+    }
+
     // if we have skipped db migrations (because version is up-to-date),
     // for non-stateful set components this dir will be absent, so we create it anyways
     std::fs::create_dir_all(&config::get_config().common.data_db_dir)?;

--- a/src/service/self_reporting/queues.rs
+++ b/src/service/self_reporting/queues.rs
@@ -20,7 +20,6 @@ use config::{
     meta::{
         self_reporting::{
             ReportingData, ReportingMessage, ReportingQueue, ReportingRunner,
-            error::ErrorData,
             usage::{ERROR_STREAM, TRIGGERS_USAGE_STREAM, TriggerData},
         },
         stream::{StreamParams, StreamType},
@@ -206,25 +205,10 @@ async fn ingest_buffered_data(thread_id: usize, buffered: Vec<ReportingData>) {
         }
     }
 
-    if !errors.is_empty() {
+    if cfg.common.usage_reporting_errors_enabled && !errors.is_empty() {
         let error_stream = StreamParams::new(META_ORG_ID, ERROR_STREAM, StreamType::Logs);
-        if super::ingestion::ingest_reporting_data(errors.clone(), error_stream)
-            .await
-            .is_err()
-            && &cfg.common.usage_reporting_mode != "both"
-        {
-            // on error in ingesting usage data, push back the data
-            for error_json in errors {
-                let error: ErrorData = json::from_value(error_json).unwrap();
-                if let Err(e) = ERROR_QUEUE
-                    .enqueue(ReportingData::Error(Box::new(error)))
-                    .await
-                {
-                    log::error!(
-                        "[SELF-REPORTING] Error in pushing back un-ingested ErrorData to ErrorQueue: {e}"
-                    );
-                }
-            }
+        if let Err(e) = super::ingestion::ingest_reporting_data(errors, error_stream).await {
+            log::error!("[SELF-REPORTING] Error in ingesting ErrorData: {e}");
         }
     }
 }


### PR DESCRIPTION
### **User description**
- [x] Add new env to disable error report
- [x] Improve error message to avoid too large error message, we found the `node_errors` over 1MB.
- [x] Add `error` field as default `Full text search` field
- [x] Skip `infra` jobs on router

Add a new ENV and then we can disable error report:
```
ZO_USAGE_REPORTING_ERRORS_ENABLED=true
```
set to `false` will disable error report.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add env to toggle error reports

- Truncate oversized pipeline error payloads

- Extend FTS fields with error keys

- Skip infra init for non-core nodes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["Config: new env & FTS fields"] -- controls --> SelfReporting["Self-reporting queues: conditional error ingest"]
  ErrorModel["Error model: custom Serialize + truncation"] -- safe payloads --> SelfReporting
  InfraInit["Infra init: role-gated startup"] -- skip non-core --> InfraServices["Infra services"]
  DiskGC["Disk cache GC: simplified interval"] -- steady sleep loop --> DiskGC
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add error toggle and expand FTS fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<ul><li>Add <code>ZO_USAGE_REPORTING_ERRORS_ENABLED</code> boolean config.<br> <li> Include <code>error</code> and <code>errors</code> in default SQL FTS fields.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7917/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>disk.rs</strong><dd><code>Simplify disk cache GC scheduling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/cache/file_data/disk.rs

<ul><li>Replace interval ticker with sleep-based GC loop.<br> <li> Avoid initial immediate tick.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7917/files#diff-af63f2c5d85313779df0204c9689e50a6c3916e3aadc24e54e23ec640a584fcb">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Role-gated infra initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/lib.rs

- Short-circuit infra init for non-ingester/querier/compactor nodes.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7917/files#diff-58fa06a86b9ed830791b178a164ef47bde3e44138b903c4884681cfe74858675">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>queues.rs</strong><dd><code>Conditional error ingest and simplified retry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/self_reporting/queues.rs

<ul><li>Gate error ingestion by new config flag.<br> <li> Remove pushback-to-queue on ingest failure; log error instead.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7917/files#diff-ed15a56d4d3becc2dfb3d05af2dac7f92962ec3091199728fa953e6aed7ed767">+3/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Safe serialization with size-limited pipeline errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/self_reporting/error.rs

<ul><li>Implement custom Serialize for <code>ErrorSource</code>.<br> <li> Truncate pipeline error and node_errors to 1KB.<br> <li> Remove Deserialize and custom map serializer.<br> <li> Add test for serializing <code>ErrorData</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7917/files#diff-00a00a557343475be7131843f748fbae2d0c1a4041a5c4dddec56c940a03e613">+58/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

