### PR TITLE
test: add failing streaming tests

### DIFF
--- a/tests/api-testing/tests/test_streaming.py
+++ b/tests/api-testing/tests/test_streaming.py
@@ -969,186 +969,186 @@ def test_streaming_histogram(create_session, base_url, test_name, hist_query, ex
         pytest.fail("No hits found in the response.")
 
 # TODO Uncomment the following test cases after the issue (https://github.com/openobserve/openobserve/issues/7858) is fixed
-# @pytest.mark.parametrize("test_name_sql, sql_query, sql_from, sql_size, total_exp", test_data_sql)
-# def test_streaming_sql(create_session, base_url, test_name_sql, sql_query, sql_from, sql_size, total_exp):
-#     """Running an E2E test for sql queries with Parameterized data when websocket is disabled."""
-#
-#     session = create_session
-#     url = base_url
-#     session.auth = HTTPBasicAuth(ZO_ROOT_USER_EMAIL, ZO_ROOT_USER_PASSWORD)
-#     now = datetime.now(timezone.utc)
-#     end_time = int(now.timestamp() * 1000000)
-#     ten_min_ago = int((now - timedelta(minutes=10)).timestamp() * 1000000)
-#     json_data_sql = {
-#         "query": {
-#             "sql": sql_query,
-#             "start_time": ten_min_ago,
-#             "end_time": end_time,
-#             "from": sql_from,
-#             "size": sql_size,
-#             "quick_mode": False
-#         },
-#         "regions": [],
-#         "clusters": []
-#     }
-#
-#     res_sql = session.post(
-#         f"{url}api/{org_id}/_search_stream?type=logs&search_type=UI&use_cache=false", json=json_data_sql, stream=True)
-#
-#     assert (
-#         res_sql.status_code == 200
-#     ), f"SQL mode {test_name_sql} added 200, but got {res_sql.status_code} {res_sql.content}"
-#
-#     print(f"Response {url} SQL False Cache Streaming:", res_sql.status_code)
-#
-#     # Parse the JSON response
-#
-#     res_data_sql = read_response(res_sql)
-#
-#     # Validate the total in the response
-#     total_hits_sql = res_data_sql["results"]["total"]
-#
-#     # Adjust the assertion based on our expectations
-#     expected_hits_sql = total_exp  # what we're expecting
-#     assert total_hits_sql == expected_hits_sql, f"Expected total {test_name_sql} to be {expected_hits_sql}, but got {total_hits_sql}"
-#
-#     # Generate request for cache
-#     res_sql_cache = session.post(
-#         f"{url}api/{org_id}/_search_stream?type=logs&search_type=UI&use_cache=true", json=json_data_sql, stream=True)
-#
-#     assert (
-#         res_sql_cache.status_code == 200
-#     ), f"SQL cache {test_name_sql} mode added 200, but got {res_sql_cache.status_code} {res_sql_cache.content}"
-#
-#     print(f"Response {test_name_sql} Cache True SQL {url} Streaming:",
-#           res_sql_cache.status_code)
-#
-#     # Parse the JSON response
-#
-#     res_data_sql_cache = read_response(res_sql_cache)
-#
-#     # Validate the total in the response
-#     total_hits_sql_cache = res_data_sql_cache["results"]["total"]
-#
-#     # Adjust the assertion based on our expectations
-#     expected_hits_sql_cache = total_exp  # what we're expecting
-#     assert total_hits_sql_cache == expected_hits_sql_cache, f"Expected {test_name_sql} total to be {expected_hits_sql_cache}, but got {total_hits_sql_cache}"
-#
+@pytest.mark.parametrize("test_name_sql, sql_query, sql_from, sql_size, total_exp", test_data_sql)
+def test_streaming_sql(create_session, base_url, test_name_sql, sql_query, sql_from, sql_size, total_exp):
+    """Running an E2E test for sql queries with Parameterized data when websocket is disabled."""
+
+    session = create_session
+    url = base_url
+    session.auth = HTTPBasicAuth(ZO_ROOT_USER_EMAIL, ZO_ROOT_USER_PASSWORD)
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    ten_min_ago = int((now - timedelta(minutes=10)).timestamp() * 1000000)
+    json_data_sql = {
+        "query": {
+            "sql": sql_query,
+            "start_time": ten_min_ago,
+            "end_time": end_time,
+            "from": sql_from,
+            "size": sql_size,
+            "quick_mode": False
+        },
+        "regions": [],
+        "clusters": []
+    }
+
+    res_sql = session.post(
+        f"{url}api/{org_id}/_search_stream?type=logs&search_type=UI&use_cache=false", json=json_data_sql, stream=True)
+
+    assert (
+        res_sql.status_code == 200
+    ), f"SQL mode {test_name_sql} added 200, but got {res_sql.status_code} {res_sql.content}"
+
+    print(f"Response {url} SQL False Cache Streaming:", res_sql.status_code)
+
+    # Parse the JSON response
+
+    res_data_sql = read_response(res_sql)
+
+    # Validate the total in the response
+    total_hits_sql = res_data_sql["results"]["total"]
+
+    # Adjust the assertion based on our expectations
+    expected_hits_sql = total_exp  # what we're expecting
+    assert total_hits_sql == expected_hits_sql, f"Expected total {test_name_sql} to be {expected_hits_sql}, but got {total_hits_sql}"
+
+    # Generate request for cache
+    res_sql_cache = session.post(
+        f"{url}api/{org_id}/_search_stream?type=logs&search_type=UI&use_cache=true", json=json_data_sql, stream=True)
+
+    assert (
+        res_sql_cache.status_code == 200
+    ), f"SQL cache {test_name_sql} mode added 200, but got {res_sql_cache.status_code} {res_sql_cache.content}"
+
+    print(f"Response {test_name_sql} Cache True SQL {url} Streaming:",
+          res_sql_cache.status_code)
+
+    # Parse the JSON response
+
+    res_data_sql_cache = read_response(res_sql_cache)
+
+    # Validate the total in the response
+    total_hits_sql_cache = res_data_sql_cache["results"]["total"]
+
+    # Adjust the assertion based on our expectations
+    expected_hits_sql_cache = total_exp  # what we're expecting
+    assert total_hits_sql_cache == expected_hits_sql_cache, f"Expected {test_name_sql} total to be {expected_hits_sql_cache}, but got {total_hits_sql_cache}"
+
+Define the test function
+
+
+def test_values_streaming_endpoint(create_session, base_url):
+    session = create_session
+    session.auth = HTTPBasicAuth(ZO_ROOT_USER_EMAIL, ZO_ROOT_USER_PASSWORD)
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    ten_min_ago = int((now - timedelta(minutes=10)).timestamp() * 1000000)
+    url = f"{base_url}api/{org_id}/_values_stream"
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Basic {base64.b64encode(f"{ZO_ROOT_USER_EMAIL}:{ZO_ROOT_USER_PASSWORD}".encode()).decode()}'
+    }
+    # Define the JSON payload
+    payload = {
+        "fields": ["kubernetes_container_name"],
+        "size": 10,
+        "no_count": False,
+        "regions": [],
+        "clusters": [],
+        "vrl_fn": "",
+        "start_time": ten_min_ago,
+        "end_time": end_time,
+        "timeout": 30000,
+        "stream_name": f"{stream_name}",
+        "stream_type": "logs",
+        "use_cache": False,
+        "sql": "U0VMRUNUICogRlJPTSAiZGVmYXVsdCIg"
+    }
+    res_values_streaming = session.post(url, headers=headers, json=payload)
+
+    # Assert the response status code
+    assert res_values_streaming.status_code == 200
+
+    # Assert the expected response structure
+    res_data_values_streaming = read_response(res_values_streaming)
+    print(f"Response {url} Values Streaming:", res_data_values_streaming)
+
+    # Check that the response is a dictionary
+    assert isinstance(res_data_values_streaming, dict)
+    assert 'results' in res_data_values_streaming
+    assert isinstance(res_data_values_streaming['results'], dict)
+    assert 'cached_ratio' in res_data_values_streaming['results']
+    assert 'from' in res_data_values_streaming['results']
+    assert 'hits' in res_data_values_streaming['results']
+    assert isinstance(res_data_values_streaming['results']['hits'], list)
+
+    # Additional assertions based on expected values
+    # Total should be non-negative
+    assert res_data_values_streaming['results']['total'] >= 0
+    # Check that hits do not exceed requested size
+    assert len(res_data_values_streaming['results']['hits']) <= 10
+    for hit in res_data_values_streaming['results']['hits']:
+        assert 'field' in hit
+        assert 'values' in hit
+        assert isinstance(hit['values'], list)  # Check that values is a list
+
+
 # Define the test function
+def test_values_streaming_endpoint_cache(create_session, base_url):
+    session = create_session
+    session.auth = HTTPBasicAuth(ZO_ROOT_USER_EMAIL, ZO_ROOT_USER_PASSWORD)
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    ten_min_ago = int((now - timedelta(minutes=10)).timestamp() * 1000000)
+    url = f"{base_url}api/{org_id}/_values_stream"
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Basic {base64.b64encode(f"{ZO_ROOT_USER_EMAIL}:{ZO_ROOT_USER_PASSWORD}".encode()).decode()}'
+    }
+    # Define the JSON payload
+    payload = {
+        "fields": ["kubernetes_container_name"],
+        "size": 10,
+        "no_count": False,
+        "regions": [],
+        "clusters": [],
+        "vrl_fn": "",
+        "start_time": ten_min_ago,
+        "end_time": end_time,
+        "timeout": 30000,
+        "stream_name": f"{stream_name}",
+        "stream_type": "logs",
+        "use_cache": True,
+        "sql": "U0VMRUNUICogRlJPTSAiZGVmYXVsdCIg"
+    }
+    res_values_streaming_cache = session.post(
+        url, headers=headers, json=payload)
 
+    # Assert the response status code
+    assert res_values_streaming_cache.status_code == 200
 
-# def test_values_streaming_endpoint(create_session, base_url):
-#     session = create_session
-#     session.auth = HTTPBasicAuth(ZO_ROOT_USER_EMAIL, ZO_ROOT_USER_PASSWORD)
-#     now = datetime.now(timezone.utc)
-#     end_time = int(now.timestamp() * 1000000)
-#     ten_min_ago = int((now - timedelta(minutes=10)).timestamp() * 1000000)
-#     url = f"{base_url}api/{org_id}/_values_stream"
-#     headers = {
-#         'Content-Type': 'application/json',
-#         'Authorization': f'Basic {base64.b64encode(f"{ZO_ROOT_USER_EMAIL}:{ZO_ROOT_USER_PASSWORD}".encode()).decode()}'
-#     }
-#     # Define the JSON payload
-#     payload = {
-#         "fields": ["kubernetes_container_name"],
-#         "size": 10,
-#         "no_count": False,
-#         "regions": [],
-#         "clusters": [],
-#         "vrl_fn": "",
-#         "start_time": ten_min_ago,
-#         "end_time": end_time,
-#         "timeout": 30000,
-#         "stream_name": f"{stream_name}",
-#         "stream_type": "logs",
-#         "use_cache": False,
-#         "sql": "U0VMRUNUICogRlJPTSAiZGVmYXVsdCIg"
-#     }
-#     res_values_streaming = session.post(url, headers=headers, json=payload)
-#
-#     # Assert the response status code
-#     assert res_values_streaming.status_code == 200
-#
-#     # Assert the expected response structure
-#     res_data_values_streaming = read_response(res_values_streaming)
-#     print(f"Response {url} Values Streaming:", res_data_values_streaming)
-#
-#     # Check that the response is a dictionary
-#     assert isinstance(res_data_values_streaming, dict)
-#     assert 'results' in res_data_values_streaming
-#     assert isinstance(res_data_values_streaming['results'], dict)
-#     assert 'cached_ratio' in res_data_values_streaming['results']
-#     assert 'from' in res_data_values_streaming['results']
-#     assert 'hits' in res_data_values_streaming['results']
-#     assert isinstance(res_data_values_streaming['results']['hits'], list)
-#
-#     # Additional assertions based on expected values
-#     # Total should be non-negative
-#     assert res_data_values_streaming['results']['total'] >= 0
-#     # Check that hits do not exceed requested size
-#     assert len(res_data_values_streaming['results']['hits']) <= 10
-#     for hit in res_data_values_streaming['results']['hits']:
-#         assert 'field' in hit
-#         assert 'values' in hit
-#         assert isinstance(hit['values'], list)  # Check that values is a list
-#
-#
-# # Define the test function
-# def test_values_streaming_endpoint_cache(create_session, base_url):
-#     session = create_session
-#     session.auth = HTTPBasicAuth(ZO_ROOT_USER_EMAIL, ZO_ROOT_USER_PASSWORD)
-#     now = datetime.now(timezone.utc)
-#     end_time = int(now.timestamp() * 1000000)
-#     ten_min_ago = int((now - timedelta(minutes=10)).timestamp() * 1000000)
-#     url = f"{base_url}api/{org_id}/_values_stream"
-#     headers = {
-#         'Content-Type': 'application/json',
-#         'Authorization': f'Basic {base64.b64encode(f"{ZO_ROOT_USER_EMAIL}:{ZO_ROOT_USER_PASSWORD}".encode()).decode()}'
-#     }
-#     # Define the JSON payload
-#     payload = {
-#         "fields": ["kubernetes_container_name"],
-#         "size": 10,
-#         "no_count": False,
-#         "regions": [],
-#         "clusters": [],
-#         "vrl_fn": "",
-#         "start_time": ten_min_ago,
-#         "end_time": end_time,
-#         "timeout": 30000,
-#         "stream_name": f"{stream_name}",
-#         "stream_type": "logs",
-#         "use_cache": True,
-#         "sql": "U0VMRUNUICogRlJPTSAiZGVmYXVsdCIg"
-#     }
-#     res_values_streaming_cache = session.post(
-#         url, headers=headers, json=payload)
-#
-#     # Assert the response status code
-#     assert res_values_streaming_cache.status_code == 200
-#
-#     # Assert the expected response structure
-#     res_data_values_streaming_cache = read_response(res_values_streaming_cache)
-#     print(f"Response {url} Values Streaming:", res_data_values_streaming_cache)
-#
-#     # Check that the response is a dictionary
-#     assert isinstance(res_data_values_streaming_cache, dict)
-#     assert 'results' in res_data_values_streaming_cache
-#     assert isinstance(res_data_values_streaming_cache['results'], dict)
-#     assert 'cached_ratio' in res_data_values_streaming_cache['results']
-#     assert 'from' in res_data_values_streaming_cache['results']
-#     assert 'hits' in res_data_values_streaming_cache['results']
-#     assert isinstance(res_data_values_streaming_cache['results']['hits'], list)
-#
-#     # Additional assertions based on expected values
-#     # Total should be non-negative
-#     assert res_data_values_streaming_cache['results']['total'] >= 0
-#     # Check that hits do not exceed requested size
-#     assert len(res_data_values_streaming_cache['results']['hits']) <= 10
-#     for hit in res_data_values_streaming_cache['results']['hits']:
-#         assert 'field' in hit
-#         assert 'values' in hit
-#         assert isinstance(hit['values'], list)  # Check that values is a list
+    # Assert the expected response structure
+    res_data_values_streaming_cache = read_response(res_values_streaming_cache)
+    print(f"Response {url} Values Streaming:", res_data_values_streaming_cache)
+
+    # Check that the response is a dictionary
+    assert isinstance(res_data_values_streaming_cache, dict)
+    assert 'results' in res_data_values_streaming_cache
+    assert isinstance(res_data_values_streaming_cache['results'], dict)
+    assert 'cached_ratio' in res_data_values_streaming_cache['results']
+    assert 'from' in res_data_values_streaming_cache['results']
+    assert 'hits' in res_data_values_streaming_cache['results']
+    assert isinstance(res_data_values_streaming_cache['results']['hits'], list)
+
+    # Additional assertions based on expected values
+    # Total should be non-negative
+    assert res_data_values_streaming_cache['results']['total'] >= 0
+    # Check that hits do not exceed requested size
+    assert len(res_data_values_streaming_cache['results']['hits']) <= 10
+    for hit in res_data_values_streaming_cache['results']['hits']:
+        assert 'field' in hit
+        assert 'values' in hit
+        assert isinstance(hit['values'], list)  # Check that values is a list
 
 
 def test_streaming_sql_query_range(create_session, base_url):


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
Enable SQL streaming test with parametrization
Add values streaming endpoint test
Add cached values streaming endpoint test
Validate response structure and totals


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["test_streaming_sql"] -- "enable, assert totals & cache" --> B["_search_stream"]
  C["test_values_streaming_endpoint"] -- "POST JSON, validate" --> D["/_values_stream use_cache=false"]
  E["test_values_streaming_endpoint_cache"] -- "POST JSON, validate" --> F["/_values_stream use_cache=true"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_streaming.py</strong><dd><code>Enable SQL and add values streaming tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/api-testing/tests/test_streaming.py

<ul><li>Uncomment and enable <code>test_streaming_sql</code> with parametrization.<br> <li> Add <code>test_values_streaming_endpoint</code> for <code>_values_stream</code> without cache.<br> <li> Add <code>test_values_streaming_endpoint_cache</code> for <code>_values_stream</code> with <br>cache.<br> <li> Validate response status, structure, totals, and hit limits.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7921/files#diff-f15e9b733130f72112380fda658264545435fbf956b08869b0ad5a9435d222f7">+177/-177</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

