### PR TITLE
fix: don't create cache index for alert manager

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -197,7 +197,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
         .expect("syslog settings cache failed");
 
     infra_file_list::create_table_index().await?;
-    infra_file_list::LOCAL_CACHE.create_table_index().await?;
+    if !LOCAL_NODE.is_alert_manager() {
+        infra_file_list::LOCAL_CACHE.create_table_index().await?;
+    }
 
     #[cfg(feature = "enterprise")]
     if !LOCAL_NODE.is_compactor() {


### PR DESCRIPTION
Since, alert manager does not initialize local cache db tables, it panics when try to create indexes on local tables that don't exist.