### PR TITLE
feat: add parquet cache size in status

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -149,6 +149,7 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                 clap::Command::new("offline").about("offline node"),
                 clap::Command::new("online").about("online node"),
                 clap::Command::new("flush").about("flush memtable to disk"),
+                clap::Command::new("status").about("show node status"),
                 clap::Command::new("list").about("list cached nodes").args([
                     clap::Arg::new("metrics")
                         .short('m')
@@ -476,6 +477,9 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                 }
                 Some(("flush", _)) => {
                     super::http::node_flush().await?;
+                }
+                Some(("status", _)) => {
+                    super::http::node_status().await?;
                 }
                 Some(("list", args)) => {
                     let metrics = args.get_flag("metrics");

--- a/src/cli/basic/http.rs
+++ b/src/cli/basic/http.rs
@@ -119,6 +119,29 @@ pub async fn node_flush() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+pub async fn node_status() -> Result<(), anyhow::Error> {
+    let url = "/node/status";
+    let response = request(url, None, reqwest::Method::GET).await?;
+    let Some(body) = response else {
+        return Err(anyhow::anyhow!("node status failed"));
+    };
+    let response: serde_json::Value = serde_json::from_str(&body)?;
+    let response = config::utils::flatten::flatten(response)?;
+
+    // Create header row with all column names
+    let mut table = Table::new();
+    table.add_row(Row::new(vec![Cell::new("KEY"), Cell::new("VALUE")]));
+    for (key, value) in response.as_object().unwrap().iter() {
+        table.add_row(Row::new(vec![
+            Cell::new(key),
+            Cell::new(&value.to_string()),
+        ]));
+    }
+
+    table.printstd();
+    Ok(())
+}
+
 pub async fn node_list() -> Result<(), anyhow::Error> {
     let url = "/node/list";
     let response = request(url, None, reqwest::Method::GET).await?;

--- a/src/config/src/utils/schema_ext.rs
+++ b/src/config/src/utils/schema_ext.rs
@@ -21,8 +21,6 @@ use std::{
 use arrow_schema::{Field, Schema};
 use hashbrown::HashSet;
 
-const HASH_MAP_SIZE: usize = std::mem::size_of::<HashMap<String, String>>();
-
 /// SchemaExt helper...
 pub trait SchemaExt {
     fn to_cloned_fields(&self) -> Vec<Field>;
@@ -82,7 +80,8 @@ impl SchemaExt for Schema {
     }
 
     fn size(&self) -> usize {
-        let mut size = self.fields.iter().fold(0, |acc, field| acc + field.size()) + HASH_MAP_SIZE;
+        let mut size = std::mem::size_of::<&arrow_schema::Fields>();
+        size += self.fields.iter().fold(0, |acc, field| acc + field.size());
         size += std::mem::size_of::<HashMap<String, String>>();
         for (key, val) in self.metadata.iter() {
             size += std::mem::size_of::<String>() * 2;

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -357,8 +357,6 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
     stats.insert("LOCAL_NODE_UUID", json::json!(LOCAL_NODE.uuid.clone()));
     stats.insert("LOCAL_NODE_NAME", json::json!(&cfg.common.instance_name));
     stats.insert("LOCAL_NODE_ROLE", json::json!(&cfg.common.node_role));
-    let nodes = cluster::get_cached_online_nodes().await;
-    stats.insert("NODE_LIST", json::json!(nodes));
 
     let (stream_num, stream_schema_num, mem_size) = get_stream_schema_status().await;
     stats.insert("STREAM_SCHEMA", json::json!({"stream_num": stream_num,"stream_schema_num": stream_schema_num, "mem_size": mem_size}));
@@ -400,7 +398,10 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
     );
     stats.insert(
         "DATAFUSION",
-        json::json!({"file_stat_cache": file_statistics_cache::GLOBAL_CACHE.clone().len()}),
+        json::json!({"file_stat_cache": {
+            "file_num": file_statistics_cache::GLOBAL_CACHE.clone().len(),
+            "mem_size": file_statistics_cache::GLOBAL_CACHE.clone().memory_size()
+        }}),
     );
     stats.insert(
         "INVERTED_INDEX",
@@ -461,14 +462,15 @@ pub async fn config_reload() -> Result<HttpResponse, Error> {
 async fn get_stream_schema_status() -> (usize, usize, usize) {
     let mut stream_num = 0;
     let mut stream_schema_num = 0;
-    let mut mem_size = 0;
+    let mut mem_size = std::mem::size_of::<HashMap<String, Vec<Schema>>>();
     let r = STREAM_SCHEMAS.read().await;
     for (key, val) in r.iter() {
         stream_num += 1;
         mem_size += std::mem::size_of::<Vec<Schema>>();
-        mem_size += key.len();
+        mem_size += std::mem::size_of::<String>() + key.len();
         for schema in val.iter() {
             stream_schema_num += 1;
+            mem_size += std::mem::size_of::<i64>();
             mem_size += schema.1.size();
         }
     }
@@ -477,8 +479,8 @@ async fn get_stream_schema_status() -> (usize, usize, usize) {
     for (key, schema) in r.iter() {
         stream_num += 1;
         stream_schema_num += 1;
-        mem_size += key.len();
-        mem_size += schema.schema().size();
+        mem_size += std::mem::size_of::<String>() + key.len();
+        mem_size += schema.size();
     }
     drop(r);
     (stream_num, stream_schema_num, mem_size)

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -727,6 +727,17 @@ impl SchemaCache {
             .get(field_name)
             .and_then(|i| self.schema.fields().get(*i))
     }
+
+    pub fn size(&self) -> usize {
+        let mut size = std::mem::size_of::<&Schema>() + self.schema.size();
+        size += std::mem::size_of::<&HashMap<String, usize>>();
+        for (key, _val) in self.fields_map.iter() {
+            size += std::mem::size_of::<String>() + key.len();
+            size += std::mem::size_of::<usize>();
+        }
+        size += std::mem::size_of::<String>() + self.hash_key.len();
+        size
+    }
 }
 
 pub fn is_widening_conversion(from: &DataType, to: &DataType) -> bool {

--- a/src/service/enrichment/storage.rs
+++ b/src/service/enrichment/storage.rs
@@ -256,6 +256,9 @@ pub mod remote {
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(merge_interval)).await;
             let org_table_pairs = database::list().await?;
+            if org_table_pairs.is_empty() {
+                continue;
+            }
             log::info!(
                 "[ENRICHMENT::STORAGE] Found {} enrichment tables, {:?}",
                 org_table_pairs.len(),

--- a/src/service/search/datafusion/storage/file_statistics_cache.rs
+++ b/src/service/search/datafusion/storage/file_statistics_cache.rs
@@ -44,6 +44,63 @@ impl FileStatisticsCache {
         self.statistics.len()
     }
 
+    pub fn memory_size(&self) -> usize {
+        let mut total_size = 0;
+
+        // Size of the struct itself
+        total_size += std::mem::size_of::<Self>();
+
+        // Size of DashMap entries
+        for entry in self.statistics.iter() {
+            let (key, (meta, stats)) = entry.pair();
+
+            // Key string
+            total_size += std::mem::size_of::<String>() + key.len();
+
+            // ObjectMeta
+            total_size += std::mem::size_of::<ObjectMeta>();
+            // Path string in ObjectMeta
+            total_size += meta.location.as_ref().len();
+            // Optional e_tag
+            if let Some(ref etag) = meta.e_tag {
+                total_size += std::mem::size_of::<String>() + etag.len();
+            }
+            // Optional version
+            if let Some(ref version) = meta.version {
+                total_size += std::mem::size_of::<String>() + version.len();
+            }
+
+            // Arc<Statistics> - estimate size
+            // Statistics contains num_rows, total_byte_size, and column_statistics
+            total_size += std::mem::size_of::<Statistics>();
+
+            // Column statistics size estimation
+            for _col_stat in &stats.column_statistics {
+                total_size += std::mem::size_of::<datafusion::common::ColumnStatistics>();
+            }
+        }
+
+        // Size of VecDeque<String> in cacher
+        let cacher_guard = self.cacher.lock();
+        total_size += std::mem::size_of::<VecDeque<String>>();
+        for key in cacher_guard.iter() {
+            total_size += std::mem::size_of::<String>() + key.len();
+        }
+        drop(cacher_guard);
+
+        // DashMap overhead (approximate)
+        // DashMap uses sharding internally, estimate based on typical overhead
+        // This is an approximation since we can't access internal shards
+        let estimated_shards = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8)
+            .min(128); // DashMap typically uses CPU count for shards
+        let dashmap_overhead = estimated_shards * std::mem::size_of::<parking_lot::RwLock<()>>();
+        total_size += dashmap_overhead;
+
+        total_size
+    }
+
     fn format_key(&self, k: &Path) -> String {
         if let Some(mut p) = k.as_ref().find("/$$/") {
             if let Some(pp) = k.as_ref()[..p].find("/schema=") {
@@ -195,5 +252,53 @@ mod tests {
         let mut meta2 = meta;
         meta2.location = Path::from("test2");
         assert!(cache.get_with_extra(&meta2.location, &meta2).is_none());
+    }
+
+    #[test]
+    fn test_memory_size_calculation() {
+        let cache = FileStatisticsCache::new(100);
+
+        // Empty cache should have some base size
+        let empty_size = cache.memory_size();
+        assert!(empty_size > 0);
+
+        // Add some entries
+        for i in 0..10 {
+            let meta = ObjectMeta {
+                location: Path::from(format!("test_file_{}", i)),
+                last_modified: DateTime::parse_from_rfc3339("2022-09-27T22:36:00+02:00")
+                    .unwrap()
+                    .into(),
+                size: 1024 * (i + 1),
+                e_tag: Some(format!("etag_{}", i)),
+                version: Some(format!("v{}", i)),
+            };
+
+            let schema = Schema::new(vec![
+                Field::new("column1", DataType::Utf8, false),
+                Field::new("column2", DataType::Int64, true),
+                Field::new(
+                    "column3",
+                    DataType::Timestamp(TimeUnit::Microsecond, None),
+                    false,
+                ),
+            ]);
+
+            cache.put_with_extra(
+                &meta.location,
+                Statistics::new_unknown(&schema).into(),
+                &meta,
+            );
+        }
+
+        // Size should increase after adding entries
+        let filled_size = cache.memory_size();
+        assert!(filled_size > empty_size);
+
+        println!(
+            "Cache with {} entries uses {} bytes",
+            cache.len(),
+            filled_size,
+        );
     }
 }


### PR DESCRIPTION
Add parquet metadata cache size in `/node/status` API, also create one CLI for that:

```
./target/debug/openobserve node status   
+-------------------------------------+-------------------------------+
| KEY                                 | VALUE                         |
+-------------------------------------+-------------------------------+
| cardinality_expired_count           | 0                             |
+-------------------------------------+-------------------------------+
| cardinality_total_count             | 0                             |
+-------------------------------------+-------------------------------+
| compact_file_list_offset            | 0                             |
+-------------------------------------+-------------------------------+
| datafusion_file_stat_cache_file_num | 0                             |
+-------------------------------------+-------------------------------+
| datafusion_file_stat_cache_mem_size | 344                           |
+-------------------------------------+-------------------------------+
| file_data_disk_cache_bytes          | 0                             |
+-------------------------------------+-------------------------------+
| file_data_disk_cache_files          | 0                             |
+-------------------------------------+-------------------------------+
| file_data_disk_cache_limit          | 524288000000                  |
+-------------------------------------+-------------------------------+
| file_data_memory_cache_bytes        | 0                             |
+-------------------------------------+-------------------------------+
| file_data_memory_cache_files        | 0                             |
+-------------------------------------+-------------------------------+
| file_data_memory_cache_limit        | 25769803752                   |
+-------------------------------------+-------------------------------+
| file_data_results_cache_bytes       | 0                             |
+-------------------------------------+-------------------------------+
| file_data_results_cache_files       | 0                             |
+-------------------------------------+-------------------------------+
| file_data_results_cache_limit       | 52428800000                   |
+-------------------------------------+-------------------------------+
| file_list_max_id                    | 0                             |
+-------------------------------------+-------------------------------+
| file_list_num                       | 0                             |
+-------------------------------------+-------------------------------+
| inverted_index_reader_cache         | 0                             |
+-------------------------------------+-------------------------------+
| local_node_name                     | "local-node5080"              |
+-------------------------------------+-------------------------------+
| local_node_role                     | "all"                         |
+-------------------------------------+-------------------------------+
| local_node_uuid                     | "310ct48qp8RRRovK8DR3Aj6cjZC" |
+-------------------------------------+-------------------------------+
| stream_schema_mem_size              | 12842                         |
+-------------------------------------+-------------------------------+
| stream_schema_stream_num            | 4                             |
+-------------------------------------+-------------------------------+
| stream_schema_stream_schema_num     | 4                             |
+-------------------------------------+-------------------------------+
| stream_stats_mem_size               | 0                             |
+-------------------------------------+-------------------------------+
| stream_stats_stream_num             | 0                             |
+-------------------------------------+-------------------------------+
```