### PR TITLE
feat: add parquet cache size in status

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -107,6 +107,7 @@ fn create_cli_app() -> Command {
                 Command::new("offline").about("offline node"),
                 Command::new("online").about("online node"),
                 Command::new("flush").about("flush memtable to disk"),
+                Command::new("status").about("show node status"),
                 Command::new("list").about("list cached nodes").args([
                     arg!("metrics", 'm', "metrics", "show node metrics", false).action(ArgAction::SetTrue),
                 ]),
@@ -340,6 +341,9 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                 }
                 Some(("flush", _)) => {
                     super::http::node_flush().await?;
+                }
+                Some(("status", _)) => {
+                    super::http::node_status().await?;
                 }
                 Some(("list", args)) => {
                     let metrics = args.get_flag("metrics");

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -392,6 +392,32 @@ pub static QUERY_METRICS_CACHE_RATIO: Lazy<HistogramVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+// query parquet metadta cache stats
+pub static QUERY_PARQUET_METADATA_CACHE_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "query_parquet_metadata_cache_files",
+            "Querier parquet metadata cache files.".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_PARQUET_METADATA_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "query_parquet_metadata_cache_used_bytes",
+            "Querier parquet metadata cache used bytes.".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+
 // compactor stats
 pub static COMPACT_USED_TIME: Lazy<CounterVec> = Lazy::new(|| {
     CounterVec::new(
@@ -1096,6 +1122,12 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(QUERY_METRICS_CACHE_RATIO.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_PARQUET_METADATA_CACHE_FILES.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_PARQUET_METADATA_CACHE_USED_BYTES.clone()))
         .expect("Metric registered");
 
     // query manager

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -392,7 +392,7 @@ pub static QUERY_METRICS_CACHE_RATIO: Lazy<HistogramVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
-// query parquet metadta cache stats
+// query parquet metadata cache stats
 pub static QUERY_PARQUET_METADATA_CACHE_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(

--- a/src/config/src/utils/schema_ext.rs
+++ b/src/config/src/utils/schema_ext.rs
@@ -21,8 +21,6 @@ use std::{
 use arrow_schema::{Field, Schema};
 use hashbrown::HashSet;
 
-const HASH_MAP_SIZE: usize = std::mem::size_of::<HashMap<String, String>>();
-
 /// SchemaExt helper...
 pub trait SchemaExt {
     fn to_cloned_fields(&self) -> Vec<Field>;
@@ -82,7 +80,8 @@ impl SchemaExt for Schema {
     }
 
     fn size(&self) -> usize {
-        let mut size = self.fields.iter().fold(0, |acc, field| acc + field.size()) + HASH_MAP_SIZE;
+        let mut size = std::mem::size_of::<arrow_schema::Fields>();
+        size += self.fields.iter().fold(0, |acc, field| acc + field.size());
         size += std::mem::size_of::<HashMap<String, String>>();
         for (key, val) in self.metadata.iter() {
             size += std::mem::size_of::<String>() * 2;

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -356,8 +356,6 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
     stats.insert("LOCAL_NODE_UUID", json::json!(LOCAL_NODE.uuid.clone()));
     stats.insert("LOCAL_NODE_NAME", json::json!(&cfg.common.instance_name));
     stats.insert("LOCAL_NODE_ROLE", json::json!(&cfg.common.node_role));
-    let nodes = cluster::get_cached_online_nodes().await;
-    stats.insert("NODE_LIST", json::json!(nodes));
 
     let (stream_num, stream_schema_num, mem_size) = get_stream_schema_status().await;
     stats.insert("STREAM_SCHEMA", json::json!({"stream_num": stream_num,"stream_schema_num": stream_schema_num, "mem_size": mem_size}));
@@ -401,11 +399,14 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
     );
     stats.insert(
         "DATAFUSION",
-        json::json!({"file_stat_cache": file_statistics_cache::GLOBAL_CACHE.clone().len()}),
+        json::json!({"file_stat_cache": {
+            "file_num": file_statistics_cache::GLOBAL_CACHE.len(),
+            "mem_size": file_statistics_cache::GLOBAL_CACHE.memory_size()
+        }}),
     );
     stats.insert(
         "INVERTED_INDEX",
-        json::json!({"reader_cache": reader_cache::GLOBAL_CACHE.clone().len()}),
+        json::json!({"reader_cache": reader_cache::GLOBAL_CACHE.len()}),
     );
 
     #[cfg(feature = "enterprise")]
@@ -462,14 +463,15 @@ pub async fn config_reload() -> Result<HttpResponse, Error> {
 async fn get_stream_schema_status() -> (usize, usize, usize) {
     let mut stream_num = 0;
     let mut stream_schema_num = 0;
-    let mut mem_size = 0;
+    let mut mem_size = std::mem::size_of::<HashMap<String, Vec<Schema>>>();
     let r = STREAM_SCHEMAS.read().await;
     for (key, val) in r.iter() {
         stream_num += 1;
         mem_size += std::mem::size_of::<Vec<Schema>>();
-        mem_size += key.len();
+        mem_size += std::mem::size_of::<String>() + key.len();
         for schema in val.iter() {
             stream_schema_num += 1;
+            mem_size += std::mem::size_of::<i64>();
             mem_size += schema.1.size();
         }
     }
@@ -478,8 +480,8 @@ async fn get_stream_schema_status() -> (usize, usize, usize) {
     for (key, schema) in r.iter() {
         stream_num += 1;
         stream_schema_num += 1;
-        mem_size += key.len();
-        mem_size += schema.schema().size();
+        mem_size += std::mem::size_of::<String>() + key.len();
+        mem_size += schema.size();
     }
     drop(r);
     (stream_num, stream_schema_num, mem_size)

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -725,8 +725,8 @@ impl SchemaCache {
     }
 
     pub fn size(&self) -> usize {
-        let mut size = std::mem::size_of::<&Schema>() + self.schema.size();
-        size += std::mem::size_of::<&HashMap<String, usize>>();
+        let mut size = std::mem::size_of::<SchemaRef>() + self.schema.size();
+        size += std::mem::size_of::<HashMap<String, usize>>();
         for (key, _val) in self.fields_map.iter() {
             size += std::mem::size_of::<String>() + key.len();
             size += std::mem::size_of::<usize>();

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -723,6 +723,17 @@ impl SchemaCache {
             .get(field_name)
             .and_then(|i| self.schema.fields().get(*i))
     }
+
+    pub fn size(&self) -> usize {
+        let mut size = std::mem::size_of::<&Schema>() + self.schema.size();
+        size += std::mem::size_of::<&HashMap<String, usize>>();
+        for (key, _val) in self.fields_map.iter() {
+            size += std::mem::size_of::<String>() + key.len();
+            size += std::mem::size_of::<usize>();
+        }
+        size += std::mem::size_of::<String>() + self.hash_key.len();
+        size
+    }
 }
 
 pub fn is_widening_conversion(from: &DataType, to: &DataType) -> bool {

--- a/src/job/metrics.rs
+++ b/src/job/metrics.rs
@@ -92,16 +92,17 @@ pub async fn run() -> Result<(), anyhow::Error> {
     }
 
     // update metrics every 60 seconds
-    let mut interval = time::interval(time::Duration::from_secs(60));
-    interval.tick().await; // trigger the first run
     loop {
+        tokio::time::sleep(time::Duration::from_secs(60)).await;
         if let Err(e) = update_metadata_metrics().await {
             log::error!("Error update metadata metrics: {e}");
         }
         if let Err(e) = update_storage_metrics().await {
             log::error!("Error update storage metrics: {e}");
         }
-        interval.tick().await;
+        if let Err(e) = update_parquet_metadata_cache_metrics().await {
+            log::error!("Error update parquet metadata cache metrics: {}", e);
+        }
     }
 }
 
@@ -352,5 +353,19 @@ async fn traces_metrics_collect() -> Result<(), anyhow::Error> {
         );
     }
 
+    Ok(())
+}
+
+async fn update_parquet_metadata_cache_metrics() -> Result<(), anyhow::Error> {
+    let file_num =
+        crate::service::search::datafusion::storage::file_statistics_cache::GLOBAL_CACHE.len();
+    let mem_size = crate::service::search::datafusion::storage::file_statistics_cache::GLOBAL_CACHE
+        .memory_size();
+    metrics::QUERY_PARQUET_METADATA_CACHE_FILES
+        .with_label_values(&[])
+        .set(file_num as i64);
+    metrics::QUERY_PARQUET_METADATA_CACHE_USED_BYTES
+        .with_label_values(&[])
+        .set(mem_size as i64);
     Ok(())
 }

--- a/src/service/enrichment/storage.rs
+++ b/src/service/enrichment/storage.rs
@@ -195,6 +195,9 @@ pub mod remote {
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(merge_interval)).await;
             let org_table_pairs = database::list().await?;
+            if org_table_pairs.is_empty() {
+                continue;
+            }
             log::info!(
                 "[ENRICHMENT::STORAGE] Found {} enrichment tables, {:?}",
                 org_table_pairs.len(),

--- a/src/service/self_reporting/ingestion.rs
+++ b/src/service/self_reporting/ingestion.rs
@@ -213,7 +213,7 @@ pub(super) async fn ingest_reporting_data(
         let req = ingestion::IngestionRequest::Usage(&bytes);
         match service::logs::ingest::ingest(0, &org_id, &stream_name, req, "", None, false).await {
             Ok(resp) if resp.code == 200 => {
-                log::info!(
+                log::debug!(
                     "[SELF-REPORTING] ReportingData successfully ingested to stream {org_id}/{stream_name}"
                 );
                 Ok(())
@@ -246,7 +246,7 @@ pub(super) async fn ingest_reporting_data(
 
         match service::ingestion::ingestion_service::ingest(req).await {
             Ok(resp) if resp.status_code == 200 => {
-                log::info!(
+                log::debug!(
                     "[SELF-REPORTING] ReportingData successfully ingested to stream {org_id}/{stream_name}"
                 );
                 Ok(())


### PR DESCRIPTION
### **User description**
- Add parquet metadata cache in metrics:
  - `zo_query_parquet_metadata_cache_files` and `zo_query_parquet_metadata_cache_used_bytes`
- Add parquet metadata cache size in `/node/status` API, also create one CLI for that:

```
./target/debug/openobserve node status   
+-------------------------------------+-------------------------------+
| KEY                                 | VALUE                         |
+-------------------------------------+-------------------------------+
| cardinality_expired_count           | 0                             |
+-------------------------------------+-------------------------------+
| cardinality_total_count             | 0                             |
+-------------------------------------+-------------------------------+
| compact_file_list_offset            | 0                             |
+-------------------------------------+-------------------------------+
| datafusion_file_stat_cache_file_num | 0                             |
+-------------------------------------+-------------------------------+
| datafusion_file_stat_cache_mem_size | 344                           |
+-------------------------------------+-------------------------------+
| file_data_disk_cache_bytes          | 0                             |
+-------------------------------------+-------------------------------+
| file_data_disk_cache_files          | 0                             |
+-------------------------------------+-------------------------------+
| file_data_disk_cache_limit          | 524288000000                  |
+-------------------------------------+-------------------------------+
| file_data_memory_cache_bytes        | 0                             |
+-------------------------------------+-------------------------------+
| file_data_memory_cache_files        | 0                             |
+-------------------------------------+-------------------------------+
| file_data_memory_cache_limit        | 25769803752                   |
+-------------------------------------+-------------------------------+
| file_data_results_cache_bytes       | 0                             |
+-------------------------------------+-------------------------------+
| file_data_results_cache_files       | 0                             |
+-------------------------------------+-------------------------------+
| file_data_results_cache_limit       | 52428800000                   |
+-------------------------------------+-------------------------------+
| file_list_max_id                    | 0                             |
+-------------------------------------+-------------------------------+
| file_list_num                       | 0                             |
+-------------------------------------+-------------------------------+
| inverted_index_reader_cache         | 0                             |
+-------------------------------------+-------------------------------+
| local_node_name                     | "local-node5080"              |
+-------------------------------------+-------------------------------+
| local_node_role                     | "all"                         |
+-------------------------------------+-------------------------------+
| local_node_uuid                     | "310ct48qp8RRRovK8DR3Aj6cjZC" |
+-------------------------------------+-------------------------------+
| stream_schema_mem_size              | 12842                         |
+-------------------------------------+-------------------------------+
| stream_schema_stream_num            | 4                             |
+-------------------------------------+-------------------------------+
| stream_schema_stream_schema_num     | 4                             |
+-------------------------------------+-------------------------------+
| stream_stats_mem_size               | 0                             |
+-------------------------------------+-------------------------------+
| stream_stats_stream_num             | 0                             |
+-------------------------------------+-------------------------------+
```


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add CLI node status command

- Expose parquet metadata cache metrics

- Report cache sizes in /node/status

- Improve memory size estimations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI: add node status"] -- GET /node/status --> HTTPClient["HTTP client prints table"]
  Metrics["New metrics: parquet metadata cache"] -- register & update --> Registry["Prometheus registry"]
  StatusAPI["/node/status handler"] -- include sizes --> DFCache["DataFusion file stat cache"]
  DFCache -- provide --> SizeAPI["memory_size() calculation"]
  Job["Background metrics job"] -- update every 60s --> Metrics
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>cli.rs</strong><dd><code>Add node status subcommand wiring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7929/files#diff-cb1eb3e74723d891353ccf1e2e5e0d246d2e78a5e69dbe4c73006ea8412d65e0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>http.rs</strong><dd><code>Implement node status HTTP call and table output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7929/files#diff-790b7780a51e8eecd4754b623af8d15ad87baaaf29455ba646e2e410f83f5498">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metrics.rs</strong><dd><code>Add parquet metadata cache gauges and register</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7929/files#diff-950d37bdd77aa533539acd818a3fcdebd90ccb1f09acb5490b9c0f9b51cb2090">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema_ext.rs</strong><dd><code>Refine schema memory size calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7929/files#diff-d499b247ce2f74326444df342a14b2429d0841d02e328bd9f382735bacb75863">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Include cache sizes; adjust stream schema sizing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7929/files#diff-ca09c9c9b020049bdbc3382c466bfcca80daac92e98760d9a9a76172abf34049">+10/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Add size estimator for SchemaCache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7929/files#diff-386fd4fad1e48ab0a90516cab1947b1888b270b2fe912f30d2255cc38e6c519b">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metrics.rs</strong><dd><code>Periodically update parquet cache metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7929/files#diff-ca98d90d1293682c98c33a777a653cf3c1466f6297969ae94a359bb81abca4b1">+18/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>storage.rs</strong><dd><code>Skip merge when no enrichment tables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7929/files#diff-335bb1eea9193dc398da6838c6a6a11dd6f09e984a1ed4a2e611618a427754f0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>file_statistics_cache.rs</strong><dd><code>Add memory size estimator and tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7929/files#diff-5b3f948f2ad04a6babe72c15365b95a284d0533720419fa5dc793aa379783a7d">+105/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ingestion.rs</strong><dd><code>Downgrade reporting success logs to debug</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7929/files#diff-3edd5f4ed1eed0f765b7b450ef0fbf587632e6b22302006a5e397049e297057f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

