### PR TITLE
fix: result cache with func

### DIFF
--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -146,7 +146,14 @@ pub async fn check_cache(
         result_ts_col = Some(TIMESTAMP_COL_NAME.to_string());
     }
 
-    let result_ts_col = result_ts_col.unwrap();
+    // Check ts_col again, if it is still None, return default
+    let Some(result_ts_col) = result_ts_col else {
+        return MultiCachedQueryResponse {
+            order_by,
+            ..Default::default()
+        };
+    };
+
     let mut discard_interval = -1;
     if let Some(interval) = sql.histogram_interval {
         *file_path = format!("{file_path}_{interval}_{result_ts_col}");


### PR DESCRIPTION
### **User description**
fix #7919


___

### **PR Type**
Bug fix


___

### **Description**
Avoid unwrap panic when ts column missing
Return default cache response when None
Preserve order_by in default response
Update result cache key with timestamp


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["check_cache: determine result_ts_col"] -- "was None" --> B["return default MultiCachedQueryResponse"]
  A -- "found ts col" --> C["use result_ts_col for cache key"]
  C -- "set discard_interval, file_path" --> D["proceed with caching logic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cacher.rs</strong><dd><code>Guard missing timestamp column to avoid panic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/cacher.rs

<ul><li>Replace unwrap on <code>result_ts_col</code> with safe <code>else</code> early return.<br> <li> Return default <code>MultiCachedQueryResponse</code> while preserving <code>order_by</code>.<br> <li> Keep existing logic for wildcard and aggregate checks.<br> <li> Ensure cache key includes interval and timestamp when available.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7934/files#diff-8c387b22b2c0a282600ee41ca702b3db60f5a284d507c0feb7418608ff062c6c">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

