### PR TITLE
fix: local cache table for alert manager

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -240,6 +240,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         .expect("ai prompts cache failed");
 
     infra_file_list::create_table_index().await?;
+    infra_file_list::LOCAL_CACHE.create_table().await?;
     infra_file_list::LOCAL_CACHE.create_table_index().await?;
 
     #[cfg(feature = "enterprise")]

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -240,8 +240,9 @@ pub async fn init() -> Result<(), anyhow::Error> {
         .expect("ai prompts cache failed");
 
     infra_file_list::create_table_index().await?;
-    infra_file_list::LOCAL_CACHE.create_table().await?;
-    infra_file_list::LOCAL_CACHE.create_table_index().await?;
+    if !LOCAL_NODE.is_alert_manager() {
+        infra_file_list::LOCAL_CACHE.create_table_index().await?;
+    }
 
     #[cfg(feature = "enterprise")]
     if LOCAL_NODE.is_ingester() || LOCAL_NODE.is_querier() || LOCAL_NODE.is_alert_manager() {


### PR DESCRIPTION
### **User description**
pick from https://github.com/openobserve/openobserve/pull/7925/ for main

Without this the alert manager panics on init


___

### **PR Type**
Bug fix


___

### **Description**
Guard local cache table creation for alert manager
Prevent alert-manager init panics on startup
Create global file index table as before
No behavior change for non-alert nodes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Init["job::init()"] --> CreateGlobal["create_table_index() for infra_file_list"]
  Init --> Cond{"LOCAL_NODE.is_alert_manager()?"}
  Cond -- "No" --> CreateLocal["LOCAL_CACHE.create_table_index()"]
  Cond -- "Yes" --> Skip["Skip local cache table creation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Conditionalize local cache table creation by node role</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/job/mod.rs

<ul><li>Wrap local cache table/index creation in alert-manager guard.<br> <li> Keep global <code>infra_file_list::create_table_index()</code> call unchanged.<br> <li> Prevents panic during alert manager initialization.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7956/files#diff-f2e4c29b8eef22189ec704a832633c4bd135a24444f054864c98064bd0963681">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

