### PR TITLE
fix: commented query with sql mode

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -966,7 +966,10 @@ const useLogs = () => {
           }
         }
 
-        req.query.sql = query;
+        req.query.sql = query.split("\n")
+          .filter((line: string) => !line.trim().startsWith("--"))
+          .join("\n");
+        req.query["sql_mode"] = "full";
         // delete req.aggs;
       } else {
         const parseQuery = [query];

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -4526,9 +4526,7 @@ const useLogs = () => {
     searchObj.meta.quickMode = queryParams.quick_mode == "false" ? false : true;
 
     if (queryParams.stream) {
-      searchObj.data.stream.selectedStream.push(
-        ...queryParams.stream.split(","),
-      );
+      searchObj.data.stream.selectedStream = queryParams.stream.split(",");
     }
 
     if (queryParams.show_histogram) {


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
Strip SQL comment lines before execution
Enable SQL mode by setting `sql_mode` to full
Preserve multiline queries after filtering
Clear hits when rebuilding SQL string


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incoming SQL query"] -- "replace backticks" --> B["Normalized SQL"]
  B -- "split by newline" --> C["Filter out '--' comments"]
  C -- "join back" --> D["Clean SQL"]
  D -- "set sql_mode='full'" --> E["Request query params"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useLogs.ts</strong><dd><code>SQL sanitization and full sql_mode enablement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs.ts

<ul><li>Sanitize SQL by removing '--' comment lines.<br> <li> Set <code>req.query["sql_mode"]</code> to <code>"full"</code>.<br> <li> Preserve multiline SQL via split/filter/join.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/7975/files#diff-1040f61354f92711e0e77ed4e9bfa15586d45a94c7e2ab06cc37372068030e7b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

