### PR TITLE
fix: handle non-empty base-uri in router

### DIFF
--- a/deploy/build/Dockerfile.pr.amd64
+++ b/deploy/build/Dockerfile.pr.amd64
@@ -2,7 +2,7 @@
 
 FROM public.ecr.aws/debian/debian:bookworm-20240513-slim AS runtime
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libatk1.0-0 libnss3 libglib2.0-0/stable ca-certificates curl \
+    apt-get install -y --no-install-recommends libatk1.0-0 libnss3 libglib2.0-0 ca-certificates curl \
     htop iftop nload iptraf ncdu tcpdump sysstat procps lsof net-tools sqlite3 && \
     update-ca-certificates
 COPY ./bin/openobserve /

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -15,6 +15,7 @@
 
 use ::config::{
     get_config,
+    Config,
     meta::{
         cluster::{Role, RoleGroup},
         promql::RequestRangeQuery,
@@ -147,7 +148,8 @@ async fn dispatch(
         .map(|x| x.as_str())
         .unwrap_or("")
         .to_string();
-    let new_url = get_url(&path).await;
+
+    let new_url = get_url(&path, &cfg).await;
     if new_url.is_error {
         log::error!(
             "dispatch: {} to {}, get url details error: {:?}, took: {} ms",
@@ -182,9 +184,16 @@ async fn dispatch(
     default_proxy(req, payload, client, new_url, start).await
 }
 
-async fn get_url(path: &str) -> URLDetails {
+async fn get_url(path: &str, cfg: &Config) -> URLDetails {
     let node_type;
-    let is_querier_path = is_querier_route(path);
+    // all the path handling after this is based on
+    // path starting with /api, so if we have any base_uri
+    // we strip it here
+    let mut api_path = path;
+    if !cfg.common.base_uri.is_empty() {
+        api_path = path.strip_prefix(&cfg.common.base_uri).unwrap_or(path);
+    }
+    let is_querier_path = is_querier_route(api_path);
 
     let nodes = if is_querier_path {
         node_type = Role::Querier;


### PR DESCRIPTION
Currently we do not handle `base_uri` in the router, so if it is set, the path which should go to queriers incorrectly gets sent to ingesters. This fixes it by stripping `base_uri` from path if `base_uri` is non empty and then checking the resulting path.