### PR TITLE
fix: UI getting blocked when rendering roles of deleted entities

### DIFF
--- a/web/src/components/iam/roles/EditRole.vue
+++ b/web/src/components/iam/roles/EditRole.vue
@@ -191,9 +191,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
           </div>
 
-          <div
-            data-test="edit-role-permissions-table-section"
-          >
+          <div data-test="edit-role-permissions-table-section">
             <div v-show="permissionsUiType === 'table'">
               <permissions-table
                 ref="permissionTableRef"
@@ -582,10 +580,14 @@ const setPermission = (resource: any, visited: Set<string>) => {
   }
 
   modifyResourcePermissions(resourcePermission);
-    if (resourcePermission.name === 'org' && store.state.selectedOrganization.identifier !== store.state.zoConfig.meta_org) {
-      return; // Skip adding 'org' resource if the organization is not _meta
-    }
-    permissionsState.permissions.push(resourcePermission as Resource);
+  if (
+    resourcePermission.name === "org" &&
+    store.state.selectedOrganization.identifier !==
+      store.state.zoConfig.meta_org
+  ) {
+    return; // Skip adding 'org' resource if the organization is not _meta
+  }
+  permissionsState.permissions.push(resourcePermission as Resource);
 };
 
 const setDefaultPermissions = () => {
@@ -1337,6 +1339,8 @@ const getPermissionHash = (
  * @param typeOf - Type to assign the new entities that we get from the server
  */
 const getResourceEntities = (resource: Resource | Entity) => {
+  if (!resource) return Promise.resolve(true);
+
   const listEntitiesFnMap: {
     [key: string]: (resource: Resource | Entity) => Promise<any>;
   } = {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
Prevent null resource access in entity fetch
Preserve and gate 'org' permissions correctly
Minor formatting cleanup in template
Ensure permissions list always updated safely


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["EditRole.vue UI"] -- triggers --> getResourceEntities["getResourceEntities(resource)"]
  getResourceEntities -- "guard: if !resource return" --> SafeReturn["Resolve(true)"]
  setPermission["setPermission(...)"] -- "modify + checks" --> permissionsState["permissionsState.permissions"]
  setPermission -- "skip non-meta org 'org' resource" --> GuardedPush["Conditional push"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EditRole.vue</strong><dd><code>Guard missing resources and refine permission push</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/iam/roles/EditRole.vue

<ul><li>Add null-check guard in <code>getResourceEntities</code><br> <li> Keep 'org' permission push with clearer formatting<br> <li> Ensure conditional skip for non-meta org remains<br> <li> Minor template formatting adjustment</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8038/files#diff-263b6bc7d29fdf8358c8437cd637f1350aa3733cc2706eae8ff00028686cc0f5">+11/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

