### PR TITLE
fix: blank chart issue on visualization page

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1579,6 +1579,10 @@ export default defineComponent({
             // emit resize event
             // this will rerender/call resize method of already rendered chart to resize
             window.dispatchEvent(new Event("resize"));
+          } else {
+            // reset dashboard panel data as we will rebuild when user came back to visualize
+            // this fixes blank chart issue when user came back to visualize
+            resetDashboardPanelData()
           }
         } catch (err: any) {
           // this will clear dummy trace id
@@ -1887,8 +1891,8 @@ export default defineComponent({
         let extractedFields;
         
         // Check if we have a cached response for this query
-        if (schemaCache.value && schemaCache.value.key === logsPageQuery) {
-          extractedFields = schemaCache.value.response.data;
+        if (schemaCache?.value && schemaCache?.value?.key === logsPageQuery) {
+          extractedFields = schemaCache?.value?.response?.data;
         } else {
           // Use the refactored getResultSchema function
           extractedFields = await getResultSchema(logsPageQuery, signal, startISOTimestamp, endISOTimestamp);


### PR DESCRIPTION
- #8010 
### **PR Type**
Bug fix


___

### **Description**
Fix blank chart when returning to visualize
Reset dashboard panel state on non-visualize paths
Add safe optional chaining for schema cache
Minor robustness in cached schema access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Load["Logs page load"] -- "Not visualize path" --> Reset["Reset dashboard panel data"]
  Load -- "Visualize path" --> Resize["Dispatch window resize"]
  Query["Build logs query"] -- "Check cache" --> CacheCheck["schemaCache with optional chaining"]
  CacheCheck -- "Hit" --> UseCache["Use cached extracted fields"]
  CacheCheck -- "Miss" --> FetchSchema["getResultSchema()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Fix blank chart and harden schema cache access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/Index.vue

<ul><li>Reset dashboard panel data when not visualizing.<br> <li> Dispatch resize only when charts rendered.<br> <li> Use optional chaining on schema cache access.<br> <li> Improve robustness of cached schema retrieval.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8040/files#diff-0323c3da69b369843c5d72bf4df5b00ca6b5147192a213baf331659ecf92af62">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

