### PR TITLE
feat: dashboard unique colors to the table column automatically.

### DIFF
--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -414,6 +414,7 @@ pub enum Config {
     #[serde(rename = "unique_value_color")]
     #[serde(rename_all = "camelCase")]
     UniqueValueColor {
+        #[serde(default)]
         auto_color: bool,
     },
 }

--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -403,10 +403,18 @@ pub struct Field {
     value: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema, Default)]
-#[serde(default)]
+#[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(untagged, rename_all = "camelCase")]
+pub enum Config {
+    #[serde(rename = "unit")]
+    Unit(UnitConfig),
+    #[serde(rename = "unique_value_color")]
+    UniqueValueColor(UniqueValueColorConfig),
+}
+
+#[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct Config {
+pub struct UnitConfig {
     #[serde(rename = "type")]
     typee: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -419,6 +427,13 @@ pub struct Config {
 pub struct Value {
     unit: String,
     custom_unit: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UniqueValueColorConfig {
+    #[serde(rename = "type")]
+    pub type_field: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     auto_color: Option<bool>,
 }

--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -404,21 +404,18 @@ pub struct Field {
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
-#[serde(untagged, rename_all = "camelCase")]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum Config {
     #[serde(rename = "unit")]
-    Unit(UnitConfig),
+    Unit {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        value: Option<Value>,
+    },
     #[serde(rename = "unique_value_color")]
-    UniqueValueColor(UniqueValueColorConfig),
-}
-
-#[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct UnitConfig {
-    #[serde(rename = "type")]
-    typee: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    value: Option<Value>,
+    UniqueValueColor {
+        #[serde(rename = "autoColor")]
+        auto_color: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema, Default)]
@@ -427,15 +424,6 @@ pub struct UnitConfig {
 pub struct Value {
     unit: String,
     custom_unit: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct UniqueValueColorConfig {
-    #[serde(rename = "type")]
-    pub type_field: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub auto_color: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema, Default)]

--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -435,7 +435,7 @@ pub struct UniqueValueColorConfig {
     #[serde(rename = "type")]
     pub type_field: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    auto_color: Option<bool>,
+    pub auto_color: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema, Default)]

--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -412,6 +412,7 @@ pub enum Config {
         value: Option<Value>,
     },
     #[serde(rename = "unique_value_color")]
+    #[serde(rename_all = "camelCase")]
     UniqueValueColor {
         auto_color: bool,
     },

--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -413,7 +413,6 @@ pub enum Config {
     },
     #[serde(rename = "unique_value_color")]
     UniqueValueColor {
-        #[serde(rename = "autoColor")]
         auto_color: bool,
     },
 }

--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -419,6 +419,8 @@ pub struct Config {
 pub struct Value {
     unit: String,
     custom_unit: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_color: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema, Default)]

--- a/web/src/components/dashboards/OverrideConfigPopup.vue
+++ b/web/src/components/dashboards/OverrideConfigPopup.vue
@@ -59,6 +59,12 @@
           dense
           class="tw-flex-1"
         />
+        <q-checkbox
+          v-model="overrideConfig.config[0].value.autoColor"
+          :label="'Auto color'"
+          :disable="!overrideConfig.field.value"
+          dense
+        />
         <q-input
           v-if="overrideConfig.config[0].value.unit === 'custom'"
           v-model="overrideConfig.config[0].value.customUnit"

--- a/web/src/components/dashboards/OverrideConfigPopup.vue
+++ b/web/src/components/dashboards/OverrideConfigPopup.vue
@@ -22,15 +22,15 @@
     <div
       v-for="(overrideConfig, index) in overrideConfigs"
       :key="index"
-      class="q-mb-md flex items-center tw-w-full tw-flex"
+      class="q-mb-md flex items-start tw-w-full tw-flex"
       style="gap: 15px"
     >
+    <!-- :error="duplicateErrors[index]"
+    :error-message="'This field has already been selected. Please choose a different field.'" -->
       <q-select
         v-model="overrideConfig.field.value"
         :label="'Field'"
         :options="columnsOptions"
-        :error="duplicateErrors[index]"
-        :error-message="'This field has already been selected. Please choose a different field.'"
         style="width: 50%"
         :data-test="`dashboard-addpanel-config-unit-config-select-column-${index}`"
         input-debounce="0"
@@ -379,13 +379,13 @@ export default defineComponent({
 
     const saveOverrides = () => {
       const names = overrideConfigs.value.map((config: any) => config.field.value);
-      duplicateErrors.value = names.map(
-        (name: any, idx: any) => names.indexOf(name) !== idx,
-      );
+      // duplicateErrors.value = names.map(
+      //   (name: any, idx: any) => names.indexOf(name) !== idx,
+      // );
 
-      if (duplicateErrors.value.some((isDuplicate) => isDuplicate)) {
-        return;
-      }
+      // if (duplicateErrors.value.some((isDuplicate) => isDuplicate)) {
+      //   return;
+      // }
 
       // Transform data to match backend expectations
       const transformedConfigs = overrideConfigs.value

--- a/web/src/components/dashboards/OverrideConfigPopup.vue
+++ b/web/src/components/dashboards/OverrideConfigPopup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="padding: 0px 10px; min-width: min(800px, 90vw)">
+  <div style="padding: 0px 10px; min-width: min(1000px, 90vw)">
     <div
       class="flex justify-between items-center q-py-md header"
       style="border-bottom: 2px solid gray; margin-bottom: 5px"
@@ -29,7 +29,7 @@
         v-model="overrideConfig.field.value"
         :label="'Field'"
         :options="columnsOptions"
-        style="width: 50%"
+        style="width: 40%"
         :data-test="`dashboard-addpanel-config-unit-config-select-column-${index}`"
         input-debounce="0"
         filled
@@ -39,13 +39,13 @@
         dense
         class="tw-flex-1"
       />
-      <div class="tw-flex items-center" style="width: 50%; gap: 10px">
+      <div class="tw-flex items-center" style="width: 60%; gap: 10px">
         <q-select
           v-model="overrideConfig.config[0].type"
           :label="'Type'"
           :options="configTypeOptions"
           :disable="!overrideConfig.field.value"
-          style="width: 150px"
+          style="width: 40%"
           :data-test="`dashboard-addpanel-config-type-select-${index}`"
           input-debounce="0"
           filled
@@ -59,14 +59,14 @@
         <div
           v-if="overrideConfig.config[0].type === 'unit'"
           class="tw-flex items-center"
-          style="gap: 10px; flex-grow: 1"
+          style="gap: 10px; flex-grow: 1; width: 60%"
         >
           <q-select
             v-model="overrideConfig.config[0].value.unit"
             :label="'Unit'"
             :options="unitOptions"
             :disable="!overrideConfig.field.value"
-            style="flex-grow: 1"
+            style="flex-grow: 1; width: 50%"
             :data-test="`dashboard-addpanel-config-unit-config-select-unit-${index}`"
             input-debounce="0"
             filled
@@ -87,14 +87,14 @@
             dense
             label-slot
             data-test="dashboard-config-unit"
-            style="width: 150px"
+            style="width: 50%"
           />
         </div>
 
         <div
           v-else-if="overrideConfig.config[0].type === 'unique_value_color'"
           class="tw-flex items-center"
-          style="gap: 10px; flex-grow: 1"
+          style="gap: 10px; flex-grow: 1; width: 60%"
         >
           <q-checkbox
             v-model="overrideConfig.config[0].autoColor"

--- a/web/src/components/dashboards/OverrideConfigPopup.vue
+++ b/web/src/components/dashboards/OverrideConfigPopup.vue
@@ -29,6 +29,7 @@
         v-model="overrideConfig.field.value"
         :label="'Field'"
         :options="columnsOptions"
+        :display-value="getFieldDisplayValue(overrideConfig.field.value)"
         style="width: 40%"
         :data-test="`dashboard-addpanel-config-unit-config-select-column-${index}`"
         input-debounce="0"
@@ -385,6 +386,21 @@ export default defineComponent({
       { deep: true },
     );
 
+    const getFieldDisplayValue = (fieldValue: string) => {
+      if (!fieldValue) return "";
+
+      const option = columnsOptions.value.find(
+        (option) => option.value === fieldValue,
+      );
+
+      if (option) {
+        return option.label;
+      } else {
+        // Field not found, show with error message
+        return `${fieldValue} (Field not found)`;
+      }
+    };
+
     return {
       configTypeOptions,
       unitOptions,
@@ -395,6 +411,7 @@ export default defineComponent({
       removeOverrideConfig,
       saveOverrides,
       onConfigTypeChange,
+      getFieldDisplayValue,
       t,
     };
   },

--- a/web/src/components/dashboards/addPanel/OverrideConfig.vue
+++ b/web/src/components/dashboards/addPanel/OverrideConfig.vue
@@ -32,11 +32,9 @@
     <q-dialog v-model="showOverrideConfigPopup">
       <OverrideConfigPopup
         :columns="columns"
-        :override-config="
-          JSON.parse(
-            JSON.stringify(dashboardPanelData.data.config.override_config),
-          )
-        "
+        :override-config="{
+          overrideConfigs: dashboardPanelData.data.config.override_config || [],
+        }"
         @close="showOverrideConfigPopup = false"
         @save="saveOverrideConfigConfig"
         :class="store.state.theme == 'dark' ? 'dark-mode' : 'bg-white'"

--- a/web/src/components/dashboards/panels/TableRenderer.vue
+++ b/web/src/components/dashboards/panels/TableRenderer.vue
@@ -49,7 +49,7 @@ import { exportFile } from "quasar";
 import { defineComponent, ref } from "vue";
 import { findFirstValidMappedValue } from "@/utils/dashboard/convertDataIntoUnitValue";
 import { useStore } from "vuex";
-import { getColorPalette } from "@/utils/dashboard/colorPalette";
+import { getColorForTable } from "@/utils/dashboard/colorPalette";
 
 export default defineComponent({
   name: "TableRenderer",
@@ -165,7 +165,7 @@ export default defineComponent({
 
       // 1) Priority: override config auto color
       if (rowData?.col?.colorMode === "auto") {
-        const palette = getColorPalette(store?.state?.theme);
+        const palette = getColorForTable;
         const key = String(value);
         // cache on column to keep stable mapping across rows
         const cacheKey = `__autoColorMap_${rowData?.col?.field}`;

--- a/web/src/components/dashboards/panels/TableRenderer.vue
+++ b/web/src/components/dashboards/panels/TableRenderer.vue
@@ -49,6 +49,7 @@ import { exportFile } from "quasar";
 import { defineComponent, ref } from "vue";
 import { findFirstValidMappedValue } from "@/utils/dashboard/convertDataIntoUnitValue";
 import { useStore } from "vuex";
+import { getColorPalette } from "@/utils/dashboard/colorPalette";
 
 export default defineComponent({
   name: "TableRenderer",
@@ -162,7 +163,29 @@ export default defineComponent({
     const getStyle = (rowData: any) => {
       const value = rowData?.row[rowData?.col?.field] ?? rowData?.value;
 
-      // Find the first valid mapping with a valid color
+      // 1) Priority: override config auto color
+      if (rowData?.col?.colorMode === "auto") {
+        const palette = getColorPalette(store?.state?.theme);
+        const key = String(value);
+        // cache on column to keep stable mapping across rows
+        const cacheKey = `__autoColorMap_${rowData?.col?.field}`;
+        // init cache map on column object
+        if (!rowData.col[cacheKey])
+          rowData.col[cacheKey] = new Map<string, string>();
+        const map: Map<string, string> = rowData.col[cacheKey];
+
+        if (!map.has(key)) {
+          const idx = map.size % palette.length;
+          map.set(key, palette[idx]);
+        }
+        const hex = map.get(key) as string;
+        const isDark = isDarkColor(hex);
+        return `background-color: ${hex}; color: ${
+          isDark ? "#ffffff" : "#000000"
+        }`;
+      }
+
+      // 2) Fallback: explicit value-mapping color
       const foundValue = findFirstValidMappedValue(
         value,
         props?.valueMapping,

--- a/web/src/utils/dashboard/colorPalette.ts
+++ b/web/src/utils/dashboard/colorPalette.ts
@@ -439,3 +439,30 @@ export const getSeriesColor = (
     );
   }
 };
+
+export const getColorForTable = [
+  "#FFCDEE",
+  "#FFD2D3",
+  "#C8FCFA",
+  "#B2DAFB",
+  "#C0E9FC",
+  "#FFCDE5",
+  "#C0EFF5",
+  "#FFFDBA",
+  "#FFD2D3",
+  "#F2B9B9",
+  "#A6E8F0",
+  "#C8E5FC",
+  "#E8A3F4",
+  "#C0E5E2",
+  "#C9FFBD",
+  "#F8B1C9",
+  "#BDDFFF",
+  "#D2B9FF",
+  "#D2EBDA",
+  "#C0E3C2",
+  "#C8FCFA",
+  "#FFFDBA",
+  "#FFD2D3",
+  "#F2B9B9",
+];

--- a/web/src/utils/dashboard/colorPalette.ts
+++ b/web/src/utils/dashboard/colorPalette.ts
@@ -398,7 +398,7 @@ export const getSeriesColor = (
   // Check for custom color from colorBySeries mappings first
   if (colorBySeries?.length > 0) {
     const customMapping = colorBySeries.find(
-      (mapping: any) => mapping.value === seriesName && mapping.color
+      (mapping: any) => mapping.value === seriesName && mapping.color,
     );
     if (customMapping) {
       return customMapping.color;
@@ -449,7 +449,7 @@ export const getColorForTable = [
   "#FFCDE5",
   "#C0EFF5",
   "#FFFDBA",
-  "#FFD2D3",
+  "#E6F3FF",
   "#F2B9B9",
   "#A6E8F0",
   "#C8E5FC",
@@ -461,8 +461,8 @@ export const getColorForTable = [
   "#D2B9FF",
   "#D2EBDA",
   "#C0E3C2",
-  "#C8FCFA",
-  "#FFFDBA",
-  "#FFD2D3",
-  "#F2B9B9",
+  "#F0F8E8",
+  "#FFF2CC",
+  "#FFE6E6",
+  "#E8F4FD",
 ];

--- a/web/src/utils/dashboard/convertTableData.ts
+++ b/web/src/utils/dashboard/convertTableData.ts
@@ -74,7 +74,7 @@ export const convertTableData = (
 
       if (alias && config) {
         if (config.type === "unique_value_color") {
-          const autoColor = config.autoColor === true;
+          const autoColor = config.autoColor;
           colorConfigMap[alias] = { autoColor };
         } else if (config.type === "unit") {
           const unit = config.value?.unit;

--- a/web/src/utils/dashboard/convertTableData.ts
+++ b/web/src/utils/dashboard/convertTableData.ts
@@ -64,6 +64,20 @@ export const convertTableData = (
   const histogramFields: string[] = [];
 
   const overrideConfigs = panelSchema.config.override_config || [];
+  const colorConfigMap: Record<string, any> = {};
+  try {
+    // Build a map of field alias -> { autoColor: boolean }
+    overrideConfigs.forEach((o: any) => {
+      const alias = o?.field?.value;
+      // Check for autoColor in the value object (supports both camelCase and snake_case)
+      const autoColor =
+        o?.config?.[0]?.value?.autoColor === true ||
+        o?.config?.[0]?.value?.auto_color === true;
+      if (alias) {
+        colorConfigMap[alias] = { autoColor };
+      }
+    });
+  } catch (e) {}
 
   // use all response keys if tableDynamicColumns is true
   if (panelSchema?.config?.table_dynamic_columns == true) {
@@ -150,6 +164,10 @@ export const convertTableData = (
       obj["label"] = it.label;
       obj["align"] = !isNumber ? "left" : "right";
       obj["sortable"] = true;
+      // pass color mode info for renderer
+      if (colorConfigMap?.[it.alias]?.autoColor) {
+        obj["colorMode"] = "auto";
+      }
 
       obj["format"] = (val: any) => {
         // value mapping
@@ -324,6 +342,10 @@ export const convertTableData = (
         obj["label"] = it;
         obj["align"] = !isNumber ? "left" : "right";
         obj["sortable"] = true;
+        // pass color mode info for renderer
+        if (colorConfigMap?.[it]?.autoColor) {
+          obj["colorMode"] = "auto";
+        }
 
         obj["format"] = (val: any) => {
           // value mapping


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add unique value auto-color for tables

- Introduce typed override config schema

- Update popup UI for new config types

- Pass color mode through table pipeline


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Schema["Dashboard v5 Config enum"]
  Popup["OverrideConfigPopup UI logic"]
  Convert["convertTableData column metadata"]
  Renderer["TableRenderer cell style"]
  Palette["colorPalette getColorForTable"]

  Schema -- "new type 'unique_value_color'" --> Popup
  Popup -- "persist {type, autoColor|value}" --> Convert
  Convert -- "set col.colorMode='auto'" --> Renderer
  Renderer -- "map unique values to colors" --> Palette
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Typed dashboard Config with color variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/dashboards/v5/mod.rs

<ul><li>Replace <code>Config</code> struct with tagged enum.<br> <li> Add variants: <code>Unit{value?}</code> and <code>UniqueValueColor{auto_color}</code>.<br> <li> Adjust serde to use <code>type</code> tag and camelCase.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8051/files#diff-da49585bbcb02bf0f737bb68739ebc248edd15c7ad9427c0e68f7728bb4a8c17">+13/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OverrideConfigPopup.vue</strong><dd><code>Popup supports unit and auto color overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/OverrideConfigPopup.vue

<ul><li>Redesign popup to choose config type.<br> <li> Support unit config and unique value color (auto).<br> <li> Normalize, transform, and save typed configs.<br> <li> UI tweaks: width, layout, and handlers.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8051/files#diff-f1512a15069c23bcc71ac88db5b0ab882031bf6ec9d53a84de2fcd8adb6dec2c">+155/-62</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OverrideConfig.vue</strong><dd><code>Adapt prop shape for typed overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/OverrideConfig.vue

<ul><li>Pass override configs via <code>{ overrideConfigs }</code> shape.<br> <li> Simplify dialog prop wiring.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8051/files#diff-54a6038f5c684ade27b88e3c6a134874b51501904441fa7849a532d10aa7d533">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TableRenderer.vue</strong><dd><code>Table cells auto-colored by unique values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/panels/TableRenderer.vue

<ul><li>Add auto-color rendering path for columns.<br> <li> Use <code>getColorForTable</code> palette and per-column cache.<br> <li> Fallback to value-mapping color.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8051/files#diff-794706ea9da3a70012a0327c0464f9fd16802f78ece26055fe951716c2d73d59">+24/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>colorPalette.ts</strong><dd><code>Add table color palette export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/dashboard/colorPalette.ts

<ul><li>Export <code>getColorForTable</code> palette for tables.<br> <li> Provide light pastel color list.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8051/files#diff-30ac812743f2388c4061647fac5e9f413bfe561f1fc5d4f6f7be82fce73f2840">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>convertTableData.ts</strong><dd><code>Pipe override color/unit configs to table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/dashboard/convertTableData.ts

<ul><li>Parse typed override configs to maps.<br> <li> Set <code>colorMode: 'auto'</code> on columns when enabled.<br> <li> Use unit config map for formatting.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8051/files#diff-a672094c46e697ee7b7a3949a901cc1f7f88ec06cddaf67370474b508d5b0960">+32/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

