### PR TITLE
feat: create data retention by day

### DIFF
--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -668,7 +668,7 @@ async fn delete_stream_data_by_time_range(
     );
 
     // Create a job to delete the data by the time range
-    let key = match crate::service::db::compact::retention::delete_stream(
+    let (key, _created) = match crate::service::db::compact::retention::delete_stream(
         &org_id,
         stream_type,
         &stream_name,

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -111,6 +111,12 @@ pub trait FileList: Sync + Send + 'static {
         limit: i64,
     ) -> Result<Vec<FileListDeleted>>;
     async fn list_deleted(&self) -> Result<Vec<FileListDeleted>>;
+    async fn get_min_date(
+        &self,
+        org_id: &str,
+        stream_type: StreamType,
+        stream_name: &str,
+    ) -> Result<String>;
     // stream stats
     async fn get_min_ts(
         &self,
@@ -354,6 +360,15 @@ pub async fn query_deleted(
 #[inline]
 pub async fn list_deleted() -> Result<Vec<FileListDeleted>> {
     CLIENT.list_deleted().await
+}
+
+#[inline]
+pub async fn get_min_date(
+    org_id: &str,
+    stream_type: StreamType,
+    stream_name: &str,
+) -> Result<String> {
+    CLIENT.get_min_date(org_id, stream_type, stream_name).await
 }
 
 #[inline]

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -405,7 +405,7 @@ SELECT min_ts, max_ts, records, original_size, compressed_size, index_size, flat
             sqlx::query_as::<_, super::FileRecord>(
                 r#"
 SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
-    FROM file_list 
+    FROM file_list
     WHERE stream = $1 AND flattened = $2 LIMIT 1000;
                 "#
                 )
@@ -417,7 +417,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
             let max_ts_upper_bound = super::calculate_max_ts_upper_bound(time_end, stream_type);
             let sql = r#"
 SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
-    FROM file_list 
+    FROM file_list
     WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4;
                 "#;
 
@@ -464,7 +464,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
         let (date_start, date_end) = date_range.unwrap_or(("".to_string(), "".to_string()));
         let sql = r#"
 SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
-    FROM file_list 
+    FROM file_list
     WHERE stream = $1 AND date >= $2 AND date <= $3;
                 "#;
 
@@ -663,7 +663,7 @@ SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, origin
         let max_ts_upper_bound = super::calculate_max_ts_upper_bound(time_end, stream_type);
         let sql = r#"
 SELECT date
-    FROM file_list 
+    FROM file_list
     WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4 AND records < $5
     GROUP BY date HAVING count(*) >= $6;
             "#;
@@ -813,6 +813,25 @@ SELECT date
             .collect())
     }
 
+    async fn get_min_date(
+        &self,
+        org_id: &str,
+        stream_type: StreamType,
+        stream_name: &str,
+    ) -> Result<String> {
+        let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
+        let pool = CLIENT_RO.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "file_list"])
+            .inc();
+        let ret: Option<String> =
+            sqlx::query_scalar(r#"SELECT MIN(date) AS date FROM file_list WHERE stream = $1;"#)
+                .bind(stream_key)
+                .fetch_one(&pool)
+                .await?;
+        Ok(ret.unwrap_or_default())
+    }
+
     async fn get_min_ts(
         &self,
         org_id: &str,
@@ -887,9 +906,9 @@ SELECT date
         let file_list_stream = format!("{org_id}/file_list/");
         let mut sql = format!(
             r#"
-SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS file_num, 
+SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS file_num,
     SUM(records)::BIGINT AS records, SUM(original_size)::BIGINT AS original_size, SUM(compressed_size)::BIGINT AS compressed_size, SUM(index_size)::BIGINT AS index_size
-    FROM file_list 
+    FROM file_list
     WHERE {field} = '{value}' AND stream NOT LIKE '{file_list_stream}%'
             "#
         );
@@ -1003,7 +1022,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS
                 .inc();
             if let Err(e) = sqlx::query(
                 r#"
-INSERT INTO stream_stats 
+INSERT INTO stream_stats
     (org, stream, file_num, min_ts, max_ts, records, original_size, compressed_size, index_size)
     VALUES ($1, $2, 0, 0, 0, 0, 0, 0, 0);
                 "#,
@@ -1034,7 +1053,7 @@ INSERT INTO stream_stats
                 let Err(e) = sqlx
                     ::query(
                         r#"
-UPDATE stream_stats 
+UPDATE stream_stats
     SET file_num = file_num + $1, min_ts = $2, max_ts = $3, records = records + $4, original_size = original_size + $5, compressed_size = compressed_size + $6, index_size = index_size + $7
     WHERE stream = $8;
                 "#
@@ -1271,10 +1290,10 @@ UPDATE stream_stats
         let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(
             r#"
 SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
-    FROM file_list_jobs 
-    WHERE status = $1 
-    GROUP BY stream 
-    ORDER BY num DESC 
+    FROM file_list_jobs
+    WHERE status = $1
+    GROUP BY stream
+    ORDER BY num DESC
     LIMIT $2;"#,
         )
         .bind(super::FileListJobStatus::Pending)

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -659,6 +659,22 @@ SELECT date
             .collect())
     }
 
+    async fn get_min_date(
+        &self,
+        org_id: &str,
+        stream_type: StreamType,
+        stream_name: &str,
+    ) -> Result<String> {
+        let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
+        let pool = CLIENT_RO.clone();
+        let ret: Option<String> =
+            sqlx::query_scalar(r#"SELECT MIN(date) AS date FROM file_list WHERE stream = $1;"#)
+                .bind(stream_key)
+                .fetch_one(&pool)
+                .await?;
+        Ok(ret.unwrap_or_default())
+    }
+
     async fn get_min_ts(
         &self,
         org_id: &str,

--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -82,7 +82,7 @@ pub async fn run_retention() -> Result<(), anyhow::Error> {
 
                 let extended_retention_days = &stream_settings.extended_retention_days;
                 // creates jobs to delete data
-                if let Err(e) = retention::delete_by_stream(
+                if let Err(e) = retention::generate_retention_job(
                     &stream_data_retention_end,
                     &org_id,
                     stream_type,
@@ -92,7 +92,7 @@ pub async fn run_retention() -> Result<(), anyhow::Error> {
                 .await
                 {
                     log::error!(
-                        "[COMPACTOR] lifecycle: delete_by_stream [{org_id}/{stream_type}/{stream_name}] error: {e}"
+                        "[COMPACTOR] lifecycle: generate_retention_job [{org_id}/{stream_type}/{stream_name}] error: {e}"
                     );
                 }
             }

--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -108,8 +108,9 @@ pub async fn run_retention() -> Result<(), anyhow::Error> {
         let stream_name = columns[2];
         let retention = columns[3];
 
-        let Some(node_name) =
-            get_node_from_consistent_hash(stream_name, &Role::Compactor, None).await
+        // here we use job to get the compactor node, so that we can use different compactor for
+        // different job
+        let Some(node_name) = get_node_from_consistent_hash(&job, &Role::Compactor, None).await
         else {
             continue; // no compactor node
         };

--- a/src/service/compact/retention.rs
+++ b/src/service/compact/retention.rs
@@ -139,9 +139,8 @@ fn generate_time_ranges_for_deletion(
     time_ranges_for_deletion
 }
 
-/// Creates delete jobs for the stream based on the stream settings
-/// Returns the number of jobs created
-pub async fn delete_by_stream(
+/// Generate delete jobs for the stream based on the stream settings
+pub async fn generate_retention_job(
     lifecycle_end: &DateTime<Utc>,
     org_id: &str,
     stream_type: StreamType,
@@ -161,7 +160,7 @@ pub async fn delete_by_stream(
     }
 
     log::debug!(
-        "[COMPACTOR] delete_by_stream {}/{}/{}/{},{}",
+        "[COMPACTOR] generate_retention_job {}/{}/{}/{},{}",
         org_id,
         stream_type,
         stream_name,
@@ -225,7 +224,7 @@ pub async fn delete_by_stream(
             .await?;
             if created {
                 log::info!(
-                    "[COMPACTOR] delete_by_stream: generate job for {org_id}/{stream_type}/{stream_name}/{time_range_start},{time_range_end}",
+                    "[COMPACTOR] generate_retention_job: generate job for {org_id}/{stream_type}/{stream_name}/{time_range_start},{time_range_end}",
                 );
             }
         }
@@ -473,7 +472,7 @@ pub async fn delete_from_file_list(
     }
     // generate a new array and sort by key
     let mut hours_files = hours_files.into_iter().collect::<Vec<_>>();
-    hours_files.sort_by(|(k1, _), (k2, _)| k1.cmp(&k2));
+    hours_files.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
 
     // write file list to storage
     write_file_list(org_id, hours_files).await?;
@@ -622,7 +621,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_delete_by_stream() {
+    async fn test_generate_retention_job() {
         infra_file_list::create_table().await.unwrap();
         let org_id = "test";
         let stream_name = "test";
@@ -630,7 +629,8 @@ mod tests {
         let lifecycle_end = DateTime::parse_from_rfc3339("2023-01-01T00:00:00Z")
             .unwrap()
             .to_utc();
-        let res = delete_by_stream(&lifecycle_end, org_id, stream_type, stream_name, &[]).await;
+        let res =
+            generate_retention_job(&lifecycle_end, org_id, stream_type, stream_name, &[]).await;
         assert!(res.is_ok());
     }
 

--- a/src/service/compact/retention.rs
+++ b/src/service/compact/retention.rs
@@ -153,8 +153,9 @@ pub async fn delete_by_stream(
     if min_date.is_empty() {
         return Ok(()); // no data, just skip
     }
+    let min_date = format!("{min_date}/00/00+0000");
     let created_at =
-        DateTime::parse_from_rfc3339(&format!("{}T00:00:00Z", min_date))?.with_timezone(&Utc);
+        DateTime::parse_from_str(&min_date, "%Y/%m/%d/%H/%M/%S%z")?.with_timezone(&Utc);
     if created_at >= *lifecycle_end {
         return Ok(()); // created_at is after lifecycle end, just skip
     }

--- a/src/service/db/compact/retention.rs
+++ b/src/service/db/compact/retention.rs
@@ -42,12 +42,13 @@ pub fn mk_key(
 // delete data from stream
 // if date_range is empty, delete all data
 // date_range is a tuple of (start, end), eg: (2023-01-02, 2023-01-03)
+// return (key, created)
 pub async fn delete_stream(
     org_id: &str,
     stream_type: StreamType,
     stream_name: &str,
     date_range: Option<(&str, &str)>,
-) -> Result<String, anyhow::Error> {
+) -> Result<(String, bool), anyhow::Error> {
     let key = mk_key(org_id, stream_type, stream_name, date_range);
     let db_key = format!("/compact/delete/{key}");
 
@@ -55,12 +56,12 @@ pub async fn delete_stream(
     if let Some(v) = CACHE.get(&key)
         && v.value() + hour_micros(1) > now_micros()
     {
-        return Ok(db_key); // already in cache, don't create same task in one hour
+        return Ok((db_key, false)); // already in cache, don't create same task in one hour
     }
 
     CACHE.insert(key.clone(), now_micros());
     db::put(&db_key, "OK".into(), db::NEED_WATCH, None).await?;
-    Ok(key) // return the key
+    Ok((key, true)) // return the key and true
 }
 
 // set the stream is processing by the node


### PR DESCRIPTION
### **User description**
impl #8055

- [x] Create data retention jobs by day
- [x] Delete the files by hour in order
- [x] Use a sql to get the min date for data retention: select min(date) from file_list where stream='default/logs/default'
- [x] Different job(daily) for same stream can process by different compactor node


___

### **PR Type**
Enhancement


___

### **Description**
- Add daily retention job creation

- Delete by hour within daily jobs

- Query min available date from storage

- Avoid duplicate jobs via cache window


___

### Diagram Walkthrough


```mermaid
flowchart LR
  HTTP["HTTP delete by time range"] -- calls --> DBRet["db.compact.retention.delete_stream (returns key,created)"]
  RetSvc["Retention service delete_by_stream"] -- get min date --> FileList["infra.file_list.get_min_date (MySQL/PG/SQLite)"]
  RetSvc -- generate daily jobs --> DBRet
  DBRet -- cache prevent duplicates --> KV["KV db put(/compact/delete/...)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Adapt delete API to new return signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8058/files#diff-619eafba0f0509d905b021f4a16659010aca23c62cffd9cd3e6c2bbe204ce200">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Add get_min_date to trait and facade</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8058/files#diff-3df833bc826eb12e0819620d1fe316ef1ac352d293c11e57cc3df0da3c031e93">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mysql.rs</strong><dd><code>Implement get_min_date and minor SQL tweaks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8058/files#diff-06d02c738c6a4dc22ff022c16befef8d46aece6cfaa88bb4a5d3d5f92c2e50a1">+28/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>postgres.rs</strong><dd><code>Implement get_min_date and tidy queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8058/files#diff-bb24a30c9c3744eb31fb49e4271a9651d1f9a94a87455ac0074364b879af9651">+31/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sqlite.rs</strong><dd><code>Implement get_min_date for SQLite backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8058/files#diff-85ff00530831fdaa4e13c05cb649f2e20479cce04a4b65ef78d131cdb89b6c71">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>retention.rs</strong><dd><code>Generate per-day retention jobs using min date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8058/files#diff-6abd048f5ef4e7163cffbb51cb4bee10c07fb88b871469d5b3724f7cd04743dc">+39/-35</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>retention.rs</strong><dd><code>Return job key and created flag; de-duplication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8058/files#diff-994630745f4bed3362684c17882afb3a2fac58e4707badafa8538375ebcc8406">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

