### PR TITLE
feat: create data retention by day

### DIFF
--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -623,7 +623,7 @@ async fn delete_stream_data_by_time_range(
     );
 
     // Create a job to delete the data by the time range
-    let key = match crate::service::db::compact::retention::delete_stream(
+    let (key, _created) = match crate::service::db::compact::retention::delete_stream(
         &org_id,
         stream_type,
         &stream_name,

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -110,6 +110,12 @@ pub trait FileList: Sync + Send + 'static {
         limit: i64,
     ) -> Result<Vec<FileListDeleted>>;
     async fn list_deleted(&self) -> Result<Vec<FileListDeleted>>;
+    async fn get_min_date(
+        &self,
+        org_id: &str,
+        stream_type: StreamType,
+        stream_name: &str,
+    ) -> Result<String>;
     // stream stats
     async fn get_min_ts(
         &self,
@@ -338,6 +344,15 @@ pub async fn query_deleted(
 #[inline]
 pub async fn list_deleted() -> Result<Vec<FileListDeleted>> {
     CLIENT.list_deleted().await
+}
+
+#[inline]
+pub async fn get_min_date(
+    org_id: &str,
+    stream_type: StreamType,
+    stream_name: &str,
+) -> Result<String> {
+    CLIENT.get_min_date(org_id, stream_type, stream_name).await
 }
 
 #[inline]

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -582,7 +582,7 @@ SELECT id, stream, date, file, deleted, min_ts, max_ts, records, original_size, 
         let max_ts_upper_bound = super::calculate_max_ts_upper_bound(time_end, stream_type);
         let sql = r#"
 SELECT date
-    FROM file_list 
+    FROM file_list
     WHERE stream = ? AND max_ts >= ? AND max_ts <= ? AND min_ts <= ? AND records < ?
     GROUP BY date HAVING count(*) >= ?;
             "#;
@@ -797,6 +797,25 @@ SELECT date
             .collect())
     }
 
+    async fn get_min_date(
+        &self,
+        org_id: &str,
+        stream_type: StreamType,
+        stream_name: &str,
+    ) -> Result<String> {
+        let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
+        let pool = CLIENT_RO.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "file_list"])
+            .inc();
+        let ret: Option<String> =
+            sqlx::query_scalar(r#"SELECT MIN(date) AS date FROM file_list WHERE stream = ?;"#)
+                .bind(stream_key)
+                .fetch_one(&pool)
+                .await?;
+        Ok(ret.unwrap_or_default())
+    }
+
     async fn get_min_ts(
         &self,
         org_id: &str,
@@ -868,9 +887,9 @@ SELECT date
         };
         let mut sql = format!(
             r#"
-SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SIGNED) AS file_num, 
+SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SIGNED) AS file_num,
     CAST(SUM(records) AS SIGNED) AS records, CAST(SUM(original_size) AS SIGNED) AS original_size, CAST(SUM(compressed_size) AS SIGNED) AS compressed_size, CAST(SUM(index_size) AS SIGNED) AS index_size
-    FROM file_list 
+    FROM file_list
     WHERE {field} = '{value}'
             "#,
         );
@@ -984,7 +1003,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
                 .inc();
             if let Err(e) = sqlx::query(
                 r#"
-INSERT INTO stream_stats 
+INSERT INTO stream_stats
     (org, stream, file_num, min_ts, max_ts, records, original_size, compressed_size, index_size)
     VALUES (?, ?, 0, 0, 0, 0, 0, 0, 0);
                 "#,
@@ -1013,7 +1032,7 @@ INSERT INTO stream_stats
                 .inc();
             if let Err(e) = sqlx::query(
                 r#"
-UPDATE stream_stats 
+UPDATE stream_stats
     SET file_num = file_num + ?, min_ts = ?, max_ts = ?, records = records + ?, original_size = original_size + ?, compressed_size = compressed_size + ?, index_size = index_size + ?
     WHERE stream = ?;
                 "#,
@@ -1280,10 +1299,10 @@ UPDATE stream_stats
         let ret = match sqlx::query_as::<_, super::MergeJobPendingRecord>(
             r#"
 SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
-    FROM file_list_jobs 
-    WHERE status = ? 
-    GROUP BY stream 
-    ORDER BY num DESC 
+    FROM file_list_jobs
+    WHERE status = ?
+    GROUP BY stream
+    ORDER BY num DESC
     LIMIT ?;"#,
         )
         .bind(super::FileListJobStatus::Pending)

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -595,6 +595,22 @@ SELECT date
             .collect())
     }
 
+    async fn get_min_date(
+        &self,
+        org_id: &str,
+        stream_type: StreamType,
+        stream_name: &str,
+    ) -> Result<String> {
+        let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
+        let pool = CLIENT_RO.clone();
+        let ret: Option<String> =
+            sqlx::query_scalar(r#"SELECT MIN(date) AS date FROM file_list WHERE stream = $1;"#)
+                .bind(stream_key)
+                .fetch_one(&pool)
+                .await?;
+        Ok(ret.unwrap_or_default())
+    }
+
     async fn get_min_ts(
         &self,
         org_id: &str,

--- a/src/service/compact/retention.rs
+++ b/src/service/compact/retention.rs
@@ -20,7 +20,7 @@ use config::{
     cluster::LOCAL_NODE,
     get_config, is_local_disk_storage,
     meta::stream::{FileKey, FileListDeleted, PartitionTimeLevel, StreamType, TimeRange},
-    utils::time::{BASE_TIME, hour_micros},
+    utils::time::{BASE_TIME, day_micros, hour_micros},
 };
 use infra::{
     cache, dist_lock, file_list as infra_file_list,
@@ -139,28 +139,28 @@ fn generate_time_ranges_for_deletion(
     time_ranges_for_deletion
 }
 
-/// Creates delete jobs for the stream based on the stream settings
-/// Returns the number of jobs created
-pub async fn delete_by_stream(
+/// Generate delete jobs for the stream based on the stream settings
+pub async fn generate_retention_job(
     lifecycle_end: &DateTime<Utc>,
     org_id: &str,
     stream_type: StreamType,
     stream_name: &str,
     extended_retentions: &[TimeRange],
-) -> Result<u32, anyhow::Error> {
-    // get schema
-    let stats = cache::stats::get_stream_stats(org_id, stream_name, stream_type);
-    let created_at = stats.doc_time_min;
-    if created_at == 0 {
-        return Ok(0); // no data, just skip
+) -> Result<(), anyhow::Error> {
+    // get min date from file_list
+    let min_date = infra::file_list::get_min_date(org_id, stream_type, stream_name).await?;
+    if min_date.is_empty() {
+        return Ok(()); // no data, just skip
     }
-    let created_at: DateTime<Utc> = Utc.timestamp_nanos(created_at * 1000);
+    let min_date = format!("{min_date}/00/00+0000");
+    let created_at =
+        DateTime::parse_from_str(&min_date, "%Y/%m/%d/%H/%M/%S%z")?.with_timezone(&Utc);
     if created_at >= *lifecycle_end {
-        return Ok(0); // created_at is after lifecycle end, just skip
+        return Ok(()); // created_at is after lifecycle end, just skip
     }
 
     log::debug!(
-        "[COMPACTOR] delete_by_stream {}/{}/{}/{},{}",
+        "[COMPACTOR] generate_retention_job {}/{}/{}/{},{}",
         org_id,
         stream_type,
         stream_name,
@@ -169,7 +169,7 @@ pub async fn delete_by_stream(
     );
 
     if created_at.ge(lifecycle_end) {
-        return Ok(0); // created_at is after lifecycle end, just skip
+        return Ok(()); // created_at is after lifecycle end, just skip
     }
 
     // last extended retention time
@@ -198,40 +198,39 @@ pub async fn delete_by_stream(
         ranges
     };
 
-    let job_nos = final_deletion_time_ranges.len();
-
     for time_range in final_deletion_time_ranges {
-        let time_range_start = Utc
-            .timestamp_nanos(time_range.start * 1000)
-            .format("%Y-%m-%d")
-            .to_string();
-        let time_range_end = Utc
-            .timestamp_nanos(time_range.end * 1000)
-            .format("%Y-%m-%d")
-            .to_string();
-        if time_range_start >= time_range_end {
-            continue;
+        // generate jobs by date
+        let mut start = time_range.start;
+        while start < time_range.end {
+            let time_range_start = Utc
+                .timestamp_nanos(start * 1000)
+                .format("%Y-%m-%d")
+                .to_string();
+            start += day_micros(1); // increase one day
+            let time_range_end = Utc
+                .timestamp_nanos(start * 1000)
+                .format("%Y-%m-%d")
+                .to_string();
+            if time_range_start >= time_range_end {
+                continue;
+            }
+
+            let (_key, created) = db::compact::retention::delete_stream(
+                org_id,
+                stream_type,
+                stream_name,
+                Some((time_range_start.as_str(), time_range_end.as_str())),
+            )
+            .await?;
+            if created {
+                log::info!(
+                    "[COMPACTOR] generate_retention_job: generate job for {org_id}/{stream_type}/{stream_name}/{time_range_start},{time_range_end}",
+                );
+            }
         }
-
-        log::info!(
-            "[COMPACTOR] delete_by_stream: generate job for {}/{}/{}/{},{}",
-            org_id,
-            stream_type,
-            stream_name,
-            time_range_start,
-            time_range_end,
-        );
-
-        db::compact::retention::delete_stream(
-            org_id,
-            stream_type,
-            stream_name,
-            Some((time_range_start.as_str(), time_range_end.as_str())),
-        )
-        .await?;
     }
 
-    Ok(job_nos as u32)
+    Ok(())
 }
 
 pub async fn delete_all(
@@ -461,8 +460,12 @@ pub async fn delete_from_file_list(
         entry.push(file);
     }
 
+    // generate a new array and sort by key
+    let mut hours_files = hours_files.into_iter().collect::<Vec<_>>();
+    hours_files.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+
     // write file list to storage
-    write_file_list(org_id, &hours_files).await?;
+    write_file_list(org_id, hours_files).await?;
 
     Ok(())
 }
@@ -470,23 +473,23 @@ pub async fn delete_from_file_list(
 // write file list to db, all the files should be deleted
 async fn write_file_list(
     org_id: &str,
-    hours_files: &HashMap<String, Vec<FileKey>>,
+    hours_files: Vec<(String, Vec<FileKey>)>,
 ) -> Result<(), anyhow::Error> {
     let cfg = get_config();
-    for events in hours_files.values() {
+    for (_, events) in hours_files {
         // set to db, retry 5 times
         let mut success = false;
         let created_at = Utc::now().timestamp_micros();
         for _ in 0..5 {
             // only store the file_list into history, don't delete files
             if cfg.compact.data_retention_history
-                && let Err(e) = infra_file_list::batch_add_history(events).await
+                && let Err(e) = infra_file_list::batch_add_history(&events).await
             {
                 log::error!("[COMPACTOR] file_list batch_add_history failed: {}", e);
                 return Err(e.into());
             }
             // delete from file_list table
-            if let Err(e) = infra_file_list::batch_process(events).await {
+            if let Err(e) = infra_file_list::batch_process(&events).await {
                 log::error!("[COMPACTOR] batch_delete to db failed, retrying: {}", e);
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
                 continue;
@@ -668,7 +671,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_delete_by_stream() {
+    async fn test_generate_retention_job() {
         infra_file_list::create_table().await.unwrap();
         let org_id = "test";
         let stream_name = "test";
@@ -676,7 +679,7 @@ mod tests {
         let lifecycle_end = DateTime::parse_from_rfc3339("2023-01-01T00:00:00Z")
             .unwrap()
             .to_utc();
-        delete_by_stream(&lifecycle_end, org_id, stream_type, stream_name, &[])
+        generate_retention_job(&lifecycle_end, org_id, stream_type, stream_name, &[])
             .await
             .unwrap();
     }


### PR DESCRIPTION

impl #8055

- [x] Create data retention jobs by day
- [x] Delete the files by hour in order
- [x] Use a sql to get the min date for data retention: select min(date) from file_list where stream='default/logs/default'
- [x] Different job(daily) for same stream can process by different compactor node