### PR TITLE
fix: add max bytes for nats stream (#8009)

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1695,6 +1695,12 @@ pub struct Nats {
     pub subscription_capacity: usize,
     #[env_config(name = "ZO_NATS_QUEUE_MAX_AGE", default = 60)] // days
     pub queue_max_age: u64,
+    #[env_config(
+        name = "ZO_NATS_QUEUE_MAX_SIZE",
+        help = "The maximum size of the queue in MB, default is 2048MB",
+        default = 2048
+    )]
+    pub queue_max_size: i64,
 }
 
 #[derive(Debug, EnvConfig)]
@@ -2048,6 +2054,11 @@ pub fn init() -> Config {
     // check pipeline config
     if let Err(e) = check_pipeline_config(&mut cfg) {
         panic!("pipeline config error: {e}");
+    }
+
+    // check nats config
+    if let Err(e) = check_nats_config(&mut cfg) {
+        panic!("nats config error: {e}");
     }
 
     cfg
@@ -2831,6 +2842,14 @@ pub fn get_parquet_compression(compression: &str) -> parquet::basic::Compression
         "zstd" => parquet::basic::Compression::ZSTD(Default::default()),
         _ => parquet::basic::Compression::ZSTD(Default::default()),
     }
+}
+
+fn check_nats_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
+    if cfg.nats.queue_max_size == 0 {
+        cfg.nats.queue_max_size = 2048; // 2GB
+    }
+    cfg.nats.queue_max_size *= 1024 * 1024; // convert to bytes
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/infra/src/queue/nats.rs
+++ b/src/infra/src/queue/nats.rs
@@ -77,6 +77,7 @@ impl super::Queue for NatsQueue {
             retention: jetstream::stream::RetentionPolicy::Limits,
             max_age: Duration::from_secs(60 * 60 * 24 * max(1, cfg.nats.queue_max_age)),
             num_replicas: cfg.nats.replicas,
+            max_bytes: cfg.nats.queue_max_size,
             ..Default::default()
         };
         _ = jetstream.get_or_create_stream(config).await?;


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add NATS queue max size config

- Validate and default NATS size to 2GB

- Convert GB setting to bytes at init

- Apply max_bytes to JetStream stream


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config: Add `queue_max_size` (GB)"] -- "init validation" --> B["`check_nats_config`: default 2GB if 0"]
  B -- "convert to bytes" --> C["Store bytes in cfg.nats.queue_max_size"]
  C -- "use in stream config" --> D["NATS JetStream: set `max_bytes`"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>config.rs</strong><dd><code>Introduce and validate NATS `queue_max_size`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

src/config/src/config.rs

<ul><li>Add <code>queue_max_size</code> env config (GB, default 0)<br> <li> Validate NATS config, default to 2GB if 0<br> <li> Convert size from GB to bytes during init<br> <li> Wire
<code>check_nats_config</code> into global init</ul>


</details>


  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/8009/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>nats.rs</strong><dd><code>Use config to set JetStream max_bytes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/queue/nats.rs

<ul><li>Apply <code>cfg.nats.queue_max_size</code> to JetStream <code>max_bytes</code><br> <li> Enforce retention by size alongside age limits</ul>


</details>


  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/8009/files#diff-b05729b03dff9a5e29eaf536d0f90e94a0c27a27d1a3a41b52f25dc6dc380138">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___