### PR TITLE
fix: improve error msg of nats

### DIFF
--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -90,7 +90,7 @@ async fn get_bucket_by_key<'a>(
     }
     let kv = jetstream.create_key_value(bucket).await.map_err(|e| {
         Error::Message(format!(
-            "[NATS:get_bucket_by_key] create jetstream kv error: {e}"
+            "[NATS:get_bucket_by_key] create jetstream kv {bucket_name} error: {e}"
         ))
     })?;
     Ok((kv, key.trim_start_matches(bucket_name)))

--- a/src/infra/src/queue/nats.rs
+++ b/src/infra/src/queue/nats.rs
@@ -80,7 +80,12 @@ impl super::Queue for NatsQueue {
             max_bytes: cfg.nats.queue_max_size,
             ..Default::default()
         };
-        _ = jetstream.get_or_create_stream(config).await?;
+        _ = jetstream.get_or_create_stream(config).await.map_err(|e| {
+            log::error!("Failed to get_or_create_stream for nats stream {topic_name}: {e}");
+            Error::Message(format!(
+                "Failed to get_or_create_stream for nats stream {topic_name}: {e}"
+            ))
+        })?;
         Ok(())
     }
 
@@ -121,9 +126,11 @@ impl super::Queue for NatsQueue {
                 .get_or_create_consumer(&consumer_name, config)
                 .await
                 .map_err(|e| {
-                    log::error!("Failed to get_or_create nats for stream {stream_name}: {e}");
+                    log::error!(
+                        "Failed to get_or_create_consumer for nats stream {stream_name}: {e}"
+                    );
                     Error::Message(format!(
-                        "Failed to get_or_create nats for stream {stream_name}: {e}"
+                        "Failed to get_or_create_consumer for nats stream {stream_name}: {e}"
                     ))
                 })?;
             // Consume messages from the consumer


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Clarify NATS KV bucket error messages

- Improve stream creation error handling

- Refine consumer creation error logs

- Include bucket and stream names in errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  KV["KV bucket creation"] -- "include bucket_name in error" --> ErrMsg1["More specific error"]
  Stream["Stream get_or_create"] -- "map_err with logging" --> ErrMsg2["Detailed error + log"]
  Consumer["Consumer get_or_create"] -- "refined log and message" --> ErrMsg3["Detailed error + log"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nats.rs</strong><dd><code>More specific KV bucket error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/db/nats.rs

<ul><li>Include <code>bucket_name</code> in KV creation error message<br> <li> Keep existing behavior; improve diagnostics only</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8073/files#diff-2d6809ea34ea04477afb9a6f8287c93cef488b45ef8f0ebeec2241571b93994c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats.rs</strong><dd><code>Better NATS stream and consumer error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/queue/nats.rs

<ul><li>Add map_err with logging for stream creation failures<br> <li> Clarify consumer creation log and error messages<br> <li> Preserve functional behavior; improve observability</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8073/files#diff-b05729b03dff9a5e29eaf536d0f90e94a0c27a27d1a3a41b52f25dc6dc380138">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

