### PR TITLE
fix: return from pipeline batch_execution if batch size is zero

### DIFF
--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -255,6 +255,10 @@ impl ExecutablePipeline {
             batch_size
         );
 
+        if batch_size == 0 {
+            return Ok(HashMap::new());
+        }
+
         // result_channel
         let (result_sender, mut result_receiver) =
             channel::<(usize, StreamParams, Value)>(batch_size);


### PR DESCRIPTION
When the realtime pipeline gets 0 records to process, currently it panics as the mpsc channel uses the number of given records as the buffer size which can not be zero. This pr returns early if the number of records is zero.