### PR TITLE
fix: dashboard stream fields not found

### DIFF
--- a/web/src/components/dashboards/addPanel/FieldList.vue
+++ b/web/src/components/dashboards/addPanel/FieldList.vue
@@ -1106,10 +1106,18 @@ export default defineComponent({
             ) {
               // check for schema exist in the object or not
               // if not pull the schema from server.
-              if (!stream.hasOwnProperty("schema")) {
+              // Also check if schema is an empty array
+              if (
+                !stream.hasOwnProperty("schema") ||
+                (Array.isArray(stream.schema) && stream.schema.length === 0)
+              ) {
                 const streamData: any = await loadStreamFields(stream.name);
                 const streamSchema: any = streamData.schema;
-                if (streamSchema == undefined) {
+                if (
+                  !streamSchema ||
+                  (Array.isArray(streamSchema) && streamSchema.length === 0)
+                ) {
+                  stream.schema = [];
                   return;
                 }
                 stream.settings = streamData.settings;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
Handle missing or empty stream schemas
Fetch schema when absent or zero-length
Default to empty schema to avoid errors
Improve robustness of dashboard field loading


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["FieldList.vue"]
  Check["Check stream.schema present and non-empty"]
  Fetch["Fetch schema via loadStreamFields(name)"]
  Validate["Validate schema not null/empty"]
  Assign["Assign settings and schema"]
  DefaultEmpty["Set stream.schema = [] and return"]

  UI -- "iterate streams" --> Check
  Check -- "missing or empty" --> Fetch
  Fetch --> Validate
  Validate -- "valid schema" --> Assign
  Validate -- "invalid/empty" --> DefaultEmpty
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FieldList.vue</strong><dd><code>Robust schema presence and fallback handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/FieldList.vue

<ul><li>Add check for empty <code>stream.schema</code> arrays<br> <li> Fetch schema when missing or empty<br> <li> Guard against undefined/empty fetched schema<br> <li> Default <code>stream.schema</code> to <code>[]</code> on failure</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8087/files#diff-a071c06e3e26629cb4ae4751450acc39c61fa49b07a1cc4be3711697829668d4">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

