### PR TITLE
fix: config sync on logs to visualization toggle

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -4521,27 +4521,6 @@ const useLogs = () => {
       searchObj.meta.logsVisualizeToggle = queryParams.logs_visualize_toggle;
     }
 
-    // Restore visualization data if available and in visualize mode
-    // Note: Only config and type are restored from URL
-    // The query will always be rebuilt from logs page data
-    if (queryParams.visualization_data && 
-        searchObj.meta.logsVisualizeToggle === "visualize" && 
-        dashboardPanelData) {
-      const restoredData = decodeVisualizationConfig(queryParams.visualization_data);
-      if (restoredData && dashboardPanelData.data) {
-        // Only restore config and type - not the entire data object
-        if (restoredData.config) {
-          dashboardPanelData.data.config = {
-            ...dashboardPanelData.data.config,
-            ...restoredData.config
-          };
-        }
-        if (restoredData.type) {
-          dashboardPanelData.data.type = restoredData.type;
-        }
-      }
-    }
-
     // TODO OK : Replace push with replace and test all scenarios
     router.push({
       query: {

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -582,7 +582,12 @@ const useLogs = () => {
     if (!dashboardPanelData?.data) {
       return null;
     }
-    return dashboardPanelData.data;
+    
+    // Only store config object and chart type, not the entire dashboardPanelData
+    return {
+      config: dashboardPanelData.data.config || {},
+      type: dashboardPanelData.data.type || 'bar',
+    };
   };
 
   const encodeVisualizationConfig = (config: any) => {
@@ -4517,15 +4522,23 @@ const useLogs = () => {
     }
 
     // Restore visualization data if available and in visualize mode
+    // Note: Only config and type are restored from URL
+    // The query will always be rebuilt from logs page data
     if (queryParams.visualization_data && 
         searchObj.meta.logsVisualizeToggle === "visualize" && 
         dashboardPanelData) {
       const restoredData = decodeVisualizationConfig(queryParams.visualization_data);
       if (restoredData && dashboardPanelData.data) {
-        dashboardPanelData.data = {
-          ...dashboardPanelData.data,
-          ...restoredData
-        };
+        // Only restore config and type - not the entire data object
+        if (restoredData.config) {
+          dashboardPanelData.data.config = {
+            ...dashboardPanelData.data.config,
+            ...restoredData.config
+          };
+        }
+        if (restoredData.type) {
+          dashboardPanelData.data.type = restoredData.type;
+        }
       }
     }
 

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -676,14 +676,21 @@ const useLogs = () => {
       query["logs_visualize_toggle"] = searchObj.meta.logsVisualizeToggle;
     }
 
-    // Add visualization data to URL if in visualize mode and dashboardPanelData is provided
+    // Preserve visualization data in URL
+    // - If in visualize mode and panel data is provided, encode the dashboardPanelData
     if (searchObj.meta.logsVisualizeToggle === "visualize" && dashboardPanelData) {
-      const visualizationConfig = getVisualizationConfig(dashboardPanelData);
-      if (visualizationConfig) {
-        const encodedConfig = encodeVisualizationConfig(visualizationConfig);
-        if (encodedConfig) {
-          query["visualization_data"] = encodedConfig;
+      const visualizationData = getVisualizationConfig(dashboardPanelData);
+      if (visualizationData) {
+        const encoded = encodeVisualizationConfig(visualizationData);
+        if (encoded) {
+          query["visualization_data"] = encoded;
         }
+      }
+    } else {
+      // else preserve existing visualization data from the current URL
+      const existingEncodedConfig = router.currentRoute.value?.query?.visualization_data as string | undefined;
+      if (existingEncodedConfig) {
+        query["visualization_data"] = existingEncodedConfig;
       }
     }
 

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1439,68 +1439,68 @@ export default defineComponent({
               dashboardPanelData.layout.currentQueryIndex
             ].customQuery = true;
 
-            // Restore visualization data from URL parameters if available
+            // Apply only visualization config from URL (if present) and rebuild from logs query
             const queryParams = router.currentRoute.value.query;
             if (queryParams.visualization_data) {
               const restoredData = decodeVisualizationConfig(queryParams.visualization_data);
-              if (restoredData && dashboardPanelData.data) {
-                dashboardPanelData.data = {
-                  ...dashboardPanelData.data,
-                  ...restoredData
+              if (restoredData && dashboardPanelData.data && restoredData.config) {
+                dashboardPanelData.data.config = {
+                  ...dashboardPanelData.data.config,
+                  ...restoredData.config,
                 };
               }
-            } else {
+            }
 
-              shouldUseHistogramQuery.value = await extractVisualizationFields(true);
+            // Always rebuild visualization from logs page query and decide feasible chart type
+            shouldUseHistogramQuery.value = await extractVisualizationFields(true);
 
-              // if not able to parse query, do not do anything
-              if (shouldUseHistogramQuery.value === null) {
-                return;
-              }
+            // if not able to parse query, do not do anything
+            if (shouldUseHistogramQuery.value === null) {
+              return;
+            }
 
-              // set logs page data to searchResponseForVisualization
-              if (shouldUseHistogramQuery.value === true) {
+            // set logs page data to searchResponseForVisualization
+            if (shouldUseHistogramQuery.value === true) {
 
-                // only do it if is_histogram_eligible is true on logs page
-                // and showHistogram is true on logs page
-                if (searchObj?.data?.queryResults?.is_histogram_eligible === true && searchObj?.meta?.showHistogram === true) {
+              // only do it if is_histogram_eligible is true on logs page
+              // and showHistogram is true on logs page
+              if (searchObj?.data?.queryResults?.is_histogram_eligible === true && searchObj?.meta?.showHistogram === true) {
 
-                  // replace hits with histogram query data
-                  searchResponseForVisualization.value = {
-                    ...searchObj.data.queryResults,
-                    hits: searchObj.data.queryResults.aggs,
-                    histogram_interval:
-                      searchObj?.data?.queryResults
-                        ?.visualization_histogram_interval,
-                  };
-
-                  // assign converted_histogram_query to dashboardPanelData
-                  if (searchObj.data.queryResults.converted_histogram_query) {
-                    dashboardPanelData.data.queries[
-                      dashboardPanelData.layout.currentQueryIndex
-                    ].query = searchObj.data.queryResults.converted_histogram_query;
-
-                    // assign to visualizeChartData as well
-                    visualizeChartData.value.queries[0].query = dashboardPanelData.data.queries[0].query
-                  }
-                }
-
-              } else {
+                // replace hits with histogram query data
                 searchResponseForVisualization.value = {
                   ...searchObj.data.queryResults,
+                  hits: searchObj.data.queryResults.aggs,
                   histogram_interval:
                     searchObj?.data?.queryResults
                       ?.visualization_histogram_interval,
                 };
 
-                // if hits is empty and filteredHit is present, then set hits to filteredHit
-                if (
-                  searchResponseForVisualization?.value?.hits?.length === 0 &&
-                  searchResponseForVisualization?.value?.filteredHit
-                ) {
-                  searchResponseForVisualization.value.hits =
-                    searchResponseForVisualization?.value?.filteredHit ?? [];
+                // assign converted_histogram_query to dashboardPanelData
+                if (searchObj.data.queryResults.converted_histogram_query) {
+                  dashboardPanelData.data.queries[
+                    dashboardPanelData.layout.currentQueryIndex
+                  ].query = searchObj.data.queryResults.converted_histogram_query;
+
+                  // assign to visualizeChartData as well
+                  visualizeChartData.value.queries[0].query = dashboardPanelData.data.queries[0].query
                 }
+              }
+
+            } else {
+              searchResponseForVisualization.value = {
+                ...searchObj.data.queryResults,
+                histogram_interval:
+                  searchObj?.data?.queryResults
+                    ?.visualization_histogram_interval,
+              };
+
+              // if hits is empty and filteredHit is present, then set hits to filteredHit
+              if (
+                searchResponseForVisualization?.value?.hits?.length === 0 &&
+                searchResponseForVisualization?.value?.filteredHit
+              ) {
+                searchResponseForVisualization.value.hits =
+                  searchResponseForVisualization?.value?.filteredHit ?? [];
               }
             }
 

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1644,7 +1644,6 @@ export default defineComponent({
       async () => {
         // Skip processing if we're currently restoring from URL
         if (isRestoringFromUrl.value) {
-          console.log("Skipping chart type change processing during URL restoration");
           return;
         }
         

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1420,10 +1420,10 @@ export default defineComponent({
             // Enable quick mode automatically when switching to visualization if:
             // 1. SQL mode is disabled OR 
             // 2. Query is "SELECT * FROM some_stream" (simple select all query)
-            const shouldEnableQuickMode = 
-              !searchObj.meta.sqlMode || 
+            const shouldEnableQuickMode =
+              !searchObj.meta.sqlMode ||
               isSimpleSelectAllQuery(searchObj.data.query);
-            
+
             if (shouldEnableQuickMode && !searchObj.meta.quickMode) {
               searchObj.meta.quickMode = true;
 
@@ -1442,111 +1442,57 @@ export default defineComponent({
             // Store current config and chart type to preserve them during rebuild
             const queryParams = router.currentRoute.value.query;
             let preservedConfig = null;
-            let preservedChartType = null;
-            let shouldAutoSelectChartType = true;
-            
+            // let preservedChartType = null;
+            // let shouldAutoSelectChartType = true;
+
             // First, try to restore config from URL if present
             const visualizationDataParam = queryParams.visualization_data;
             if (visualizationDataParam && typeof visualizationDataParam === 'string') {
               try {
                 const restoredData = decodeVisualizationConfig(visualizationDataParam);
-                
+
                 if (restoredData && typeof restoredData === 'object') {
                   // Restore only config and type from URL
                   if (restoredData.config && typeof restoredData.config === 'object') {
                     preservedConfig = { ...restoredData.config };
                   }
-                  
-                  if (restoredData.type && typeof restoredData.type === 'string') {
-                    const validLogsChartTypes = ['area', 'bar', 'h-bar', 'line', 'scatter', 'table'];
-                    if (validLogsChartTypes.includes(restoredData.type)) {
-                      preservedChartType = restoredData.type;
-                      shouldAutoSelectChartType = false;
-                    } else {
-                      console.warn(`Invalid chart type '${restoredData.type}' for logs visualization, using auto-selection`);
-                    }
-                  }
+
+                  // if (restoredData.type && typeof restoredData.type === 'string') {
+                  //   const validLogsChartTypes = ['area', 'bar', 'h-bar', 'line', 'scatter', 'table'];
+                  //   if (validLogsChartTypes.includes(restoredData.type)) {
+                  //     preservedChartType = restoredData.type;
+                  //     shouldAutoSelectChartType = false;
+                  //   } else {
+                  //     console.warn(`Invalid chart type '${restoredData.type}' for logs visualization, using auto-selection`);
+                  //   }
+                  // }
                 }
               } catch (error) {
                 console.warn('Failed to restore visualization config from URL:', error);
               }
             }
 
-            // If no config restored from URL, preserve current dashboard panel config
-            if (!preservedConfig && dashboardPanelData?.data?.config) {
-              preservedConfig = { ...dashboardPanelData.data.config };
-            }
-            
+            // // If no config restored from URL, preserve current dashboard panel config
+            // if (!preservedConfig && dashboardPanelData?.data?.config) {
+            //   preservedConfig = { ...dashboardPanelData.data.config };
+            // }
+
             // If no chart type restored from URL, preserve current dashboard panel chart type
-            if (!preservedChartType) {
-              const currentChartType = dashboardPanelData?.data?.type;
-              const validLogsChartTypes = ['area', 'bar', 'h-bar', 'line', 'scatter', 'table'];
-              
-              if (currentChartType && validLogsChartTypes.includes(currentChartType)) {
-                preservedChartType = currentChartType;
-                shouldAutoSelectChartType = false;
-              }
-            }
+            // if (!preservedChartType) {
+            //   const currentChartType = dashboardPanelData?.data?.type;
+            //   const validLogsChartTypes = ['area', 'bar', 'h-bar', 'line', 'scatter', 'table'];
 
-            // Rebuild visualization from logs page query
-            // Auto-select chart type only if we don't have a valid type from URL or current config
-            shouldUseHistogramQuery.value = await extractVisualizationFields(shouldAutoSelectChartType);
+            //   if (currentChartType && validLogsChartTypes.includes(currentChartType)) {
+            //     preservedChartType = currentChartType;
+            //     shouldAutoSelectChartType = false;
+            //   }
+            // }
 
-            // if not able to parse query, still set up basic chart data so chart can render
+            // always auto select chart type
+            shouldUseHistogramQuery.value = await extractVisualizationFields(true);
+
+            // if not able to parse query, do not do anything
             if (shouldUseHistogramQuery.value === null) {
-              // Set date time for the chart
-              if (searchObj?.data?.customDownloadQueryObj?.query?.end_time && searchObj?.data?.datetime?.startTime) {
-                dashboardPanelData.meta.dateTime = {
-                  start_time: new Date(searchObj.data.customDownloadQueryObj.query.start_time),
-                  end_time: new Date(searchObj.data.customDownloadQueryObj.query.end_time),
-                };
-              } else {
-                const dateTime =
-                  searchObj.data.datetime.type === "relative"
-                    ? getConsumableRelativeTime(
-                      searchObj.data.datetime.relativeTimePeriod,
-                    )
-                    : cloneDeep(searchObj.data.datetime);
-
-                dashboardPanelData.meta.dateTime = {
-                  start_time: new Date(dateTime.startTime),
-                  end_time: new Date(dateTime.endTime),
-                };
-              }
-              
-              // Restore preserved config and chart type even in error case
-              if (preservedConfig) {
-                dashboardPanelData.data.config = {
-                  ...dashboardPanelData.data.config,
-                  ...preservedConfig,
-                };
-              }
-              
-              if (preservedChartType) {
-                dashboardPanelData.data.type = preservedChartType;
-              }
-              
-              // Set basic chart data so chart doesn't fail to render
-              visualizeChartData.value = JSON.parse(
-                JSON.stringify(dashboardPanelData.data),
-              );
-              
-              // Set basic response data from current search results if available
-              if (searchObj.data.queryResults) {
-                searchResponseForVisualization.value = {
-                  ...searchObj.data.queryResults,
-                  histogram_interval:
-                    searchObj?.data?.queryResults
-                      ?.visualization_histogram_interval,
-                };
-              }
-              
-              // Emit resize event for chart rendering
-              window.dispatchEvent(new Event("resize"));
-              
-              // Reset loading state
-              variablesAndPanelsDataLoadingState.fieldsExtractionLoading = false;
-              
               return;
             }
 
@@ -1625,10 +1571,6 @@ export default defineComponent({
                 ...dashboardPanelData.data.config,
                 ...preservedConfig,
               };
-            }
-            
-            if (preservedChartType) {
-              dashboardPanelData.data.type = preservedChartType;
             }
 
             // run query


### PR DESCRIPTION
### Config sync from logs to visualization toggle

Steps:
1. Go to logs page.
2. Select stream and render logs.
3. Toggle to visualization
4. modify chart type or chart configs.
5. Go back to logs page.
6. Again switch to visualization.(config should be synced and default chart type will be automatically selected).

- Share visualization will always sync config and chart type both.