### PR TITLE
feat: dashboard unique colors to the table column automatically. (#8051)

### DIFF
--- a/src/config/src/meta/dashboards/v5/mod.rs
+++ b/src/config/src/meta/dashboards/v5/mod.rs
@@ -399,12 +399,19 @@ pub struct Field {
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct Config {
-    #[serde(rename = "type")]
-    typee: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    value: Option<Value>,
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum Config {
+    #[serde(rename = "unit")]
+    Unit {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        value: Option<Value>,
+    },
+    #[serde(rename = "unique_value_color")]
+    #[serde(rename_all = "camelCase")]
+    UniqueValueColor {
+        #[serde(default)]
+        auto_color: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]

--- a/web/src/components/dashboards/OverrideConfigPopup.vue
+++ b/web/src/components/dashboards/OverrideConfigPopup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="padding: 0px 10px; min-width: min(800px, 90vw)">
+  <div style="padding: 0px 10px; min-width: min(1000px, 90vw)">
     <div
       class="flex justify-between items-center q-py-md header"
       style="border-bottom: 2px solid gray; margin-bottom: 5px"
@@ -22,16 +22,15 @@
     <div
       v-for="(overrideConfig, index) in overrideConfigs"
       :key="index"
-      class="q-mb-md flex items-center tw-w-full tw-flex"
+      class="q-mb-md flex items-start tw-w-full tw-flex"
       style="gap: 15px"
     >
       <q-select
         v-model="overrideConfig.field.value"
         :label="'Field'"
         :options="columnsOptions"
-        :error="duplicateErrors[index]"
-        :error-message="'This field has already been selected. Please choose a different field.'"
-        style="width: 50%"
+        :display-value="getFieldDisplayValue(overrideConfig.field.value)"
+        style="width: 40%"
         :data-test="`dashboard-addpanel-config-unit-config-select-column-${index}`"
         input-debounce="0"
         filled
@@ -41,36 +40,71 @@
         dense
         class="tw-flex-1"
       />
-      <div class="tw-flex items-center" style="width: 50%; gap: 10px">
+      <div class="tw-flex items-center" style="width: 60%; gap: 10px">
         <q-select
-          v-model="overrideConfig.config[0].value.unit"
-          :label="'Unit'"
-          :error="duplicateErrors[index]"
-          :error-message="'This field has already been selected. Please choose a different field.'"
-          :options="filteredUnitOptions(index)"
+          v-model="overrideConfig.config[0].type"
+          :label="'Type'"
+          :options="configTypeOptions"
           :disable="!overrideConfig.field.value"
-          style="flex-grow: 1"
-          :data-test="`dashboard-addpanel-config-unit-config-select-unit-${index}`"
+          style="width: 40%"
+          :data-test="`dashboard-addpanel-config-type-select-${index}`"
           input-debounce="0"
           filled
           emit-value
           map-options
           borderless
           dense
-          class="tw-flex-1"
+          @update:model-value="onConfigTypeChange(index)"
         />
-        <q-input
-          v-if="overrideConfig.config[0].value.unit === 'custom'"
-          v-model="overrideConfig.config[0].value.customUnit"
-          :label="t('dashboard.customunitLabel')"
-          color="input-border"
-          bg-color="input-bg"
-          stack-label
-          filled
-          dense
-          label-slot
-          data-test="dashboard-config-unit"
-        />
+
+        <div
+          v-if="overrideConfig.config[0].type === 'unit'"
+          class="tw-flex items-center"
+          style="gap: 10px; flex-grow: 1; width: 60%"
+        >
+          <q-select
+            v-model="overrideConfig.config[0].value.unit"
+            :label="'Unit'"
+            :options="unitOptions"
+            :disable="!overrideConfig.field.value"
+            style="flex-grow: 1; width: 50%"
+            :data-test="`dashboard-addpanel-config-unit-config-select-unit-${index}`"
+            input-debounce="0"
+            filled
+            emit-value
+            map-options
+            borderless
+            dense
+            class="tw-flex-1"
+          />
+          <q-input
+            v-if="overrideConfig.config[0].value.unit === 'custom'"
+            v-model="overrideConfig.config[0].value.customUnit"
+            :label="t('dashboard.customunitLabel')"
+            color="input-border"
+            bg-color="input-bg"
+            stack-label
+            filled
+            dense
+            label-slot
+            data-test="dashboard-config-unit"
+            style="width: 50%"
+          />
+        </div>
+
+        <div
+          v-else-if="overrideConfig.config[0].type === 'unique_value_color'"
+          class="tw-flex items-center"
+          style="gap: 10px; flex-grow: 1; width: 60%"
+        >
+          <q-checkbox
+            v-model="overrideConfig.config[0].autoColor"
+            :label="'Unique Value Color'"
+            :disable="!overrideConfig.field.value"
+            dense
+          />
+        </div>
+
         <q-btn
           @click="removeOverrideConfig(index)"
           icon="close"
@@ -114,7 +148,11 @@ export default defineComponent({
       type: Object as PropType<{
         overrideConfigs?: Array<{
           field: { matchBy: string; value: string };
-          config: Array<{ type: string; value: { unit: string; customUnit: string } }>;
+          config: Array<{
+            type: string;
+            value?: { unit: string; customUnit: string };
+            autoColor?: boolean;
+          }>;
         }>;
       }>,
       required: true
@@ -123,9 +161,17 @@ export default defineComponent({
   emits: ["close", "save"],
   setup(props: any, { emit }) {
     const { t } = useI18n();
-    const duplicateErrors = ref<Array<boolean>>(
-      props.overrideConfig.overrideConfigs?.map(() => false) || [],
-    );
+
+    const configTypeOptions = [
+      {
+        label: "Unit",
+        value: "unit",
+      },
+      {
+        label: "Unique Value Color",
+        value: "unique_value_color",
+      },
+    ];
 
     const unitOptions = [
       {
@@ -210,15 +256,37 @@ export default defineComponent({
     const overrideConfigs = ref(
       JSON.parse(
         JSON.stringify(
-          props.overrideConfig || [
-            {
-              field: { matchBy: "name", value: "" },
-              config: [{ type: "unit", value: { unit: "", customUnit: "" } }],
-            },
-          ],
+          normalizeOverrideConfigs(props.overrideConfig.overrideConfigs || []),
         ),
       ),
     );
+
+    function normalizeOverrideConfigs(configs: any[]) {
+      if (configs.length === 0) {
+        return [];
+      }
+
+      return configs.map((config) => ({
+        field: {
+          matchBy: config.field?.matchBy || "name",
+          value: config.field?.value || "",
+        },
+        config: [
+          config.config?.[0]?.type === "unique_value_color"
+            ? {
+                type: "unique_value_color",
+                autoColor: Boolean(config.config[0].autoColor),
+              }
+            : {
+                type: "unit",
+                value: {
+                  unit: config.config?.[0]?.value?.unit || "",
+                  customUnit: config.config?.[0]?.value?.customUnit || "",
+                },
+              },
+        ],
+      }));
+    }
 
     const columnsOptions = computed(() =>
       props.columns.map((column: any) => ({
@@ -231,7 +299,6 @@ export default defineComponent({
       overrideConfigs.value = JSON.parse(
         JSON.stringify(originalOverrideConfigs.value),
       );
-      duplicateErrors.value.fill(false);
       emit("close");
     };
 
@@ -240,33 +307,51 @@ export default defineComponent({
         field: { matchBy: "name", value: "" },
         config: [{ type: "unit", value: { unit: "", customUnit: "" } }],
       });
-      duplicateErrors.value.push(false);
+    };
+
+    const onConfigTypeChange = (index: number) => {
+      const config = overrideConfigs.value[index].config[0];
+      if (config.type === "unit") {
+        // Initialize unit config
+        config.value = { unit: "", customUnit: "" };
+        delete config.autoColor;
+      } else if (config.type === "unique_value_color") {
+        // Initialize color config
+        config.autoColor = Boolean(config.autoColor ?? false);
+        delete config.value;
+      }
     };
 
     const removeOverrideConfig = (index: number) => {
       overrideConfigs.value.splice(index, 1);
-      duplicateErrors.value.splice(index, 1);
-    };
-
-    const filteredUnitOptions = (index: number) => {
-      return unitOptions;
     };
 
     const saveOverrides = () => {
-      const names = overrideConfigs.value.map((config: any) => config.field.value);
-      duplicateErrors.value = names.map(
-        (name: any, idx: any) => names.indexOf(name) !== idx,
-      );
+      const transformedConfigs = overrideConfigs.value
+        .filter((config: any) => config.field.value) // Only include configs with field values
+        .map((config: any) => ({
+          field: {
+            matchBy: config.field.matchBy,
+            value: config.field.value,
+          },
+          config: [
+            config.config[0].type === "unit"
+              ? {
+                  type: "unit",
+                  value: {
+                    unit: config.config[0].value?.unit || "",
+                    customUnit: config.config[0].value?.customUnit || "",
+                  },
+                }
+              : {
+                  type: "unique_value_color",
+                  autoColor: config.config[0].autoColor === true,
+                },
+          ],
+        }));
 
-      if (duplicateErrors.value.some((isDuplicate) => isDuplicate)) {
-        return;
-      }
-
-      originalOverrideConfigs.value = JSON.parse(
-        JSON.stringify(overrideConfigs.value),
-      );
-      props.overrideConfig.overrideConfigs = overrideConfigs.value;
-      emit("save", overrideConfigs.value);
+      props.overrideConfig.overrideConfigs = transformedConfigs;
+      emit("save", transformedConfigs);
       emit("close");
     };
 
@@ -279,29 +364,54 @@ export default defineComponent({
 
     watch(
       () =>
-        overrideConfigs.value.map(
-          (config: any) => config.config[0].value.unit,
+        overrideConfigs.value.map((config: any) =>
+          config.config[0].type === "unit"
+            ? config.config[0].value?.unit
+            : null,
         ),
       (newUnits, oldUnits) => {
         newUnits.forEach((newUnit: any, index: any) => {
-          if (newUnit !== "custom" && oldUnits[index] === "custom") {
-            overrideConfigs.value[index].config[0].value.customUnit = "";
+          const config = overrideConfigs.value[index].config[0];
+          if (
+            config.type === "unit" &&
+            newUnit !== "custom" &&
+            oldUnits[index] === "custom"
+          ) {
+            if (config.value) {
+              config.value.customUnit = "";
+            }
           }
         });
       },
       { deep: true },
     );
 
+    const getFieldDisplayValue = (fieldValue: string) => {
+      if (!fieldValue) return "";
+
+      const option = columnsOptions.value.find(
+        (option) => option.value === fieldValue,
+      );
+
+      if (option) {
+        return option.label;
+      } else {
+        // Field not found, show with error message
+        return `${fieldValue} (Field not found)`;
+      }
+    };
+
     return {
+      configTypeOptions,
       unitOptions,
       columnsOptions,
       overrideConfigs,
       closePopup,
       addOverrideConfig,
       removeOverrideConfig,
-      filteredUnitOptions,
       saveOverrides,
-      duplicateErrors,
+      onConfigTypeChange,
+      getFieldDisplayValue,
       t,
     };
   },

--- a/web/src/components/dashboards/addPanel/OverrideConfig.vue
+++ b/web/src/components/dashboards/addPanel/OverrideConfig.vue
@@ -32,11 +32,9 @@
     <q-dialog v-model="showOverrideConfigPopup">
       <OverrideConfigPopup
         :columns="columns"
-        :override-config="
-          JSON.parse(
-            JSON.stringify(dashboardPanelData.data.config.override_config),
-          )
-        "
+        :override-config="{
+          overrideConfigs: dashboardPanelData.data.config.override_config || [],
+        }"
         @close="showOverrideConfigPopup = false"
         @save="saveOverrideConfigConfig"
         :class="store.state.theme == 'dark' ? 'dark-mode' : 'bg-white'"

--- a/web/src/utils/dashboard/colorPalette.ts
+++ b/web/src/utils/dashboard/colorPalette.ts
@@ -398,7 +398,7 @@ export const getSeriesColor = (
   // Check for custom color from colorBySeries mappings first
   if (colorBySeries?.length > 0) {
     const customMapping = colorBySeries.find(
-      (mapping: any) => mapping.value === seriesName && mapping.color
+      (mapping: any) => mapping.value === seriesName && mapping.color,
     );
     if (customMapping) {
       return customMapping.color;
@@ -439,3 +439,30 @@ export const getSeriesColor = (
     );
   }
 };
+
+export const getColorForTable = [
+  "#FFCDEE",
+  "#FFD2D3",
+  "#C8FCFA",
+  "#B2DAFB",
+  "#C0E9FC",
+  "#FFCDE5",
+  "#C0EFF5",
+  "#FFFDBA",
+  "#E6F3FF",
+  "#F2B9B9",
+  "#A6E8F0",
+  "#C8E5FC",
+  "#E8A3F4",
+  "#C0E5E2",
+  "#C9FFBD",
+  "#F8B1C9",
+  "#BDDFFF",
+  "#D2B9FF",
+  "#D2EBDA",
+  "#C0E3C2",
+  "#F0F8E8",
+  "#FFF2CC",
+  "#FFE6E6",
+  "#E8F4FD",
+];


### PR DESCRIPTION
Enhancement

___
- Add unique value auto-color for tables

- Introduce typed override config schema

- Update popup UI for new config types

- Pass color mode through table pipeline

___

```mermaid
flowchart LR
  Schema["Dashboard v5 Config enum"]
  Popup["OverrideConfigPopup UI logic"]
  Convert["convertTableData column metadata"]
  Renderer["TableRenderer cell style"]
  Palette["colorPalette getColorForTable"]

  Schema -- "new type 'unique_value_color'" --> Popup
  Popup -- "persist {type, autoColor|value}" --> Convert
  Convert -- "set col.colorMode='auto'" --> Renderer
  Renderer -- "map unique values to colors" --> Palette
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>mod.rs</strong><dd><code>Typed dashboard Config with color variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/dashboards/v5/mod.rs

<ul><li>Replace <code>Config</code> struct with tagged enum.<br> <li> Add variants: <code>Unit{value?}</code> and
<code>UniqueValueColor{auto_color}</code>.<br> <li> Adjust serde to use <code>type</code> tag and camelCase.</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/8051/files#diff-da49585bbcb02bf0f737bb68739ebc248edd15c7ad9427c0e68f7728bb4a8c17">+13/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>OverrideConfigPopup.vue</strong><dd><code>Popup supports unit and auto color overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/OverrideConfigPopup.vue

<ul><li>Redesign popup to choose config type.<br> <li> Support unit config and unique value color (auto).<br> <li> Normalize, transform, and save typed configs.<br> <li> UI tweaks: width, layout, and handlers.</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/8051/files#diff-f1512a15069c23bcc71ac88db5b0ab882031bf6ec9d53a84de2fcd8adb6dec2c">+155/-62</a></td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>OverrideConfig.vue</strong><dd><code>Adapt prop shape for typed overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

web/src/components/dashboards/addPanel/OverrideConfig.vue

<ul><li>Pass override configs via <code>{ overrideConfigs }</code> shape.<br> <li> Simplify dialog prop wiring.</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/8051/files#diff-54a6038f5c684ade27b88e3c6a134874b51501904441fa7849a532d10aa7d533">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>TableRenderer.vue</strong><dd><code>Table cells auto-colored by unique values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/panels/TableRenderer.vue

<ul><li>Add auto-color rendering path for columns.<br> <li> Use <code>getColorForTable</code> palette and per-column cache.<br> <li> Fallback to value-mapping color.</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/8051/files#diff-794706ea9da3a70012a0327c0464f9fd16802f78ece26055fe951716c2d73d59">+24/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>colorPalette.ts</strong><dd><code>Add table color palette export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/dashboard/colorPalette.ts

<ul><li>Export <code>getColorForTable</code> palette for tables.<br> <li> Provide light pastel color list.</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/8051/files#diff-30ac812743f2388c4061647fac5e9f413bfe561f1fc5d4f6f7be82fce73f2840">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>convertTableData.ts</strong><dd><code>Pipe override color/unit configs to table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/dashboard/convertTableData.ts

<ul><li>Parse typed override configs to maps.<br> <li> Set <code>colorMode: 'auto'</code> on columns when enabled.<br> <li> Use unit config map for formatting.</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/8051/files#diff-a672094c46e697ee7b7a3949a901cc1f7f88ec06cddaf67370474b508d5b0960">+32/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

---------