### PR TITLE
fix: config sync on logs to visualization toggle main

### DIFF
--- a/web/src/composables/useLogs.spec.ts
+++ b/web/src/composables/useLogs.spec.ts
@@ -1424,18 +1424,20 @@ describe("Use Logs Composable", () => {
         
         const dashboardPanelData = {
           data: {
-            chart_type: "line",
-            x_axis: "timestamp",
-            y_axis: "count"
+            config: {
+              decimals: 2,
+            },
+            type: "table"
           }
         };
 
         const config = wrapper.vm.getVisualizationConfig(dashboardPanelData);
         
         expect(config).toEqual({
-          chart_type: "line",
-          x_axis: "timestamp",
-          y_axis: "count"
+          config: {
+            decimals: 2,
+          },
+          type: "table"
         });
       });
 

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1452,6 +1452,12 @@ export default defineComponent({
     const searchResponseForVisualization = ref({});
 
     const shouldUseHistogramQuery = ref(false);
+    
+    // Flag to prevent unnecessary chart type changes during URL restoration
+    const isRestoringFromUrl = ref(false);
+    
+    // Flag to track if this is the first time switching to visualization mode
+    const isFirstVisualizationToggle = ref(true);
 
     watch(
       () => [searchObj?.meta?.logsVisualizeToggle],
@@ -1480,83 +1486,100 @@ export default defineComponent({
               dashboardPanelData.layout.currentQueryIndex
             ].customQuery = true;
 
-            // Restore visualization data from URL parameters if available
+            // Store current config and chart type to preserve them during rebuild
             const queryParams = router.currentRoute.value.query;
-            if (queryParams.visualization_data) {
-              const restoredData = decodeVisualizationConfig(
-                queryParams.visualization_data,
-              );
-              if (restoredData && dashboardPanelData.data) {
-                dashboardPanelData.data = {
-                  ...dashboardPanelData.data,
-                  ...restoredData,
-                };
-              }
-            } else {
-              shouldUseHistogramQuery.value =
-                await extractVisualizationFields(true);
+            let preservedConfig = null;
+            let shouldAutoSelectChartType = true;
+            // Always try to restore config from URL if present
+            const visualizationDataParam = queryParams.visualization_data;
+            if (visualizationDataParam && typeof visualizationDataParam === 'string') {
+              try {
+                const restoredData = decodeVisualizationConfig(visualizationDataParam);
 
-              // if not able to parse query, do not do anything
-              if (shouldUseHistogramQuery.value === null) {
-                return;
-              }
+                if (restoredData && typeof restoredData === 'object') {
+                  // Always restore config from URL on every toggle
+                  if (restoredData.config && typeof restoredData.config === 'object') {
+                    preservedConfig = { ...restoredData.config };
+                  }
 
-              // set logs page data to searchResponseForVisualization
-              if (shouldUseHistogramQuery.value === true) {
-                // only do it if is_histogram_eligible is true on logs page
-                // and showHistogram is true on logs page
-                if (
-                  searchObj?.data?.queryResults?.is_histogram_eligible ===
-                    true &&
-                  searchObj?.meta?.showHistogram === true
-                ) {
-                  // replace hits with histogram query data
-                  searchResponseForVisualization.value = {
-                    ...searchObj.data.queryResults,
-                    hits: searchObj.data.queryResults.aggs,
-                    histogram_interval:
-                      searchObj?.data?.queryResults
-                        ?.visualization_histogram_interval,
-                  };
-
-                  // assign converted_histogram_query to dashboardPanelData
-                  if (searchObj.data.queryResults.converted_histogram_query) {
-                    dashboardPanelData.data.queries[
-                      dashboardPanelData.layout.currentQueryIndex
-                    ].query =
-                      searchObj.data.queryResults.converted_histogram_query;
-
-                    // assign to visualizeChartData as well
-                    visualizeChartData.value.queries[0].query =
-                      dashboardPanelData.data.queries[0].query;
+                  // Only check for chart type from URL on first visualization toggle
+                  if (isFirstVisualizationToggle.value && restoredData.type && typeof restoredData.type === 'string') {
+                    const validLogsChartTypes = ['area', 'bar', 'h-bar', 'line', 'scatter', 'table'];
+                    if (validLogsChartTypes.includes(restoredData.type)) {
+                      // Valid chart type found in URL - set it and disable auto-selection
+                      dashboardPanelData.data.type = restoredData.type;
+                      shouldAutoSelectChartType = false;
+                    }
                   }
                 }
-              } else {
+              } catch (error) {
+                console.warn('Failed to restore visualization config from URL:', error);
+              }
+            }
+
+            // Mark that we've processed the first toggle
+            if (isFirstVisualizationToggle.value) {
+              isFirstVisualizationToggle.value = false;
+            }
+
+            // Use conditional auto-selection based on first toggle and URL chart type
+            isRestoringFromUrl.value = true;
+            shouldUseHistogramQuery.value = await extractVisualizationFields(shouldAutoSelectChartType);
+
+            // if not able to parse query, do not do anything
+            if (shouldUseHistogramQuery.value === null) {
+              return;
+            }
+
+            // set logs page data to searchResponseForVisualization
+            if (shouldUseHistogramQuery.value === true) {
+
+              // only do it if is_histogram_eligible is true on logs page
+              // and showHistogram is true on logs page
+              if (searchObj?.data?.queryResults?.is_histogram_eligible === true && searchObj?.meta?.showHistogram === true) {
+
+                // replace hits with histogram query data
                 searchResponseForVisualization.value = {
                   ...searchObj.data.queryResults,
+                  hits: searchObj.data.queryResults.aggs,
                   histogram_interval:
                     searchObj?.data?.queryResults
                       ?.visualization_histogram_interval,
                 };
 
-                // if hits is empty and filteredHit is present, then set hits to filteredHit
-                if (
-                  searchResponseForVisualization?.value?.hits?.length === 0 &&
-                  searchResponseForVisualization?.value?.filteredHit
-                ) {
-                  searchResponseForVisualization.value.hits =
-                    searchResponseForVisualization?.value?.filteredHit ?? [];
+                // assign converted_histogram_query to dashboardPanelData
+                if (searchObj.data.queryResults.converted_histogram_query) {
+                  dashboardPanelData.data.queries[
+                    dashboardPanelData.layout.currentQueryIndex
+                  ].query = searchObj.data.queryResults.converted_histogram_query;
+
+                  // assign to visualizeChartData as well
+                  visualizeChartData.value.queries[0].query = dashboardPanelData.data.queries[0].query
                 }
+              }
+
+            } else {
+              searchResponseForVisualization.value = {
+                ...searchObj.data.queryResults,
+                histogram_interval:
+                  searchObj?.data?.queryResults
+                    ?.visualization_histogram_interval,
+              };
+
+              // if hits is empty and filteredHit is present, then set hits to filteredHit
+              if (
+                searchResponseForVisualization?.value?.hits?.length === 0 &&
+                searchResponseForVisualization?.value?.filteredHit
+              ) {
+                searchResponseForVisualization.value.hits =
+                  searchResponseForVisualization?.value?.filteredHit ?? [];
               }
             }
 
             // reset old rendered chart
             visualizeChartData.value = {};
 
-            if (
-              searchObj?.data?.customDownloadQueryObj?.query?.end_time &&
-              searchObj?.data?.datetime?.startTime
-            ) {
+            if (searchObj?.data?.customDownloadQueryObj?.query?.start_time && searchObj?.data?.customDownloadQueryObj?.query?.end_time) {
               dashboardPanelData.meta.dateTime = {
                 start_time: new Date(
                   searchObj.data.customDownloadQueryObj.query.start_time,
@@ -1580,10 +1603,22 @@ export default defineComponent({
               };
             }
 
+            // Always restore preserved config after field extraction
+            if (preservedConfig) {
+              dashboardPanelData.data.config = {
+                ...dashboardPanelData.data.config,
+                ...preservedConfig,
+              };
+            }
+
             // run query
             visualizeChartData.value = JSON.parse(
               JSON.stringify(dashboardPanelData.data),
             );
+
+            // Clear the restoration flag after all operations are complete
+            await nextTick();
+            isRestoringFromUrl.value = false;
 
             // set fields extraction loading to false
             variablesAndPanelsDataLoadingState.fieldsExtractionLoading = false;
@@ -1591,10 +1626,16 @@ export default defineComponent({
             // emit resize event
             // this will rerender/call resize method of already rendered chart to resize
             window.dispatchEvent(new Event("resize"));
+
+            // Sync visualization data to URL parameters when chart type changes
+            if (searchObj.meta.logsVisualizeToggle === "visualize") {
+              updateUrlQueryParams(dashboardPanelData);
+            }
+
           } else {
             // reset dashboard panel data as we will rebuild when user came back to visualize
             // this fixes blank chart issue when user came back to visualize
-            resetDashboardPanelData()
+            resetDashboardPanelData();
           }
         } catch (err: any) {
           // this will clear dummy trace id
@@ -1646,6 +1687,11 @@ export default defineComponent({
     watch(
       () => dashboardPanelData.data.type,
       async () => {
+        // Skip processing if we're currently restoring from URL
+        if (isRestoringFromUrl.value) {
+          return;
+        }
+        
         const currentQuery =
           dashboardPanelData.data.queries[
             dashboardPanelData.layout.currentQueryIndex


### PR DESCRIPTION
### **User description**
Steps:
1. Go to logs page.
2. Select stream and render logs.
3. Toggle to visualization
4. modify chart type or chart configs.
5. Go back to logs page.
6. Again switch to visualization.(config should be synced and default chart type will be automatically selected).

- Share visualization will always sync config and chart type both.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Restore visualization config from URL reliably

- Preserve chart type on first toggle

- Prevent re-trigger during URL restoration

- Persist visualization_data across routes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  LogsPage["Logs page toggle"] -- "to visualize" --> RestoreURL["Restore config from URL"]
  RestoreURL -- "preserve config + maybe type" --> ExtractFields["Extract fields (auto-select?)"]
  ExtractFields -- "build data" --> VizData["visualizeChartData"]
  VizData -- "update" --> URLSync["updateUrlQueryParams"]
  URLSync -- "persist visualization_data" --> RouterQuery["Router query params"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Robust restore, preserve, and sync visualization state</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/Index.vue

<ul><li>Add flags <code>isRestoringFromUrl</code>, <code>isFirstVisualizationToggle</code>.<br> <li> Always decode URL <code>visualization_data</code>; preserve config and first-toggle <br>type.<br> <li> Conditional auto-chart selection via <code>extractVisualizationFields</code>.<br> <li> Build histogram/queries safely; fix dateTime assignment condition.<br> <li> Restore preserved config post-extraction; update URL after switch.<br> <li> Skip type watcher while restoring; minor refactors and safety checks.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8115/files#diff-0323c3da69b369843c5d72bf4df5b00ca6b5147192a213baf331659ecf92af62">+106/-60</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useLogs.ts</strong><dd><code>URL persistence and scoped visualization config encoding</code>&nbsp; </dd></summary>
<hr>

web/src/composables/useLogs.ts

<ul><li>Narrow <code>getVisualizationConfig</code> to <code>config</code> and <code>type</code>.<br> <li> Persist <code>visualization_data</code> in URL across modes.<br> <li> Encode/decode flow refined; remove eager restore on init.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8115/files#diff-1040f61354f92711e0e77ed4e9bfa15586d45a94c7e2ab06cc37372068030e7b">+19/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

