### PR TITLE
fix: parse cte query to extract stream name (#8102)

### DIFF
--- a/web/src/components/dashboards/addPanel/FieldList.vue
+++ b/web/src/components/dashboards/addPanel/FieldList.vue
@@ -783,9 +783,11 @@ export default defineComponent({
     // watch the stream type and load the stream list
     watch(
       () =>
-        dashboardPanelData.data.queries[
-          dashboardPanelData.layout.currentQueryIndex
-        ].fields.stream_type,
+        [
+          dashboardPanelData.data.queries[
+            dashboardPanelData.layout.currentQueryIndex
+          ].fields.stream_type,
+        ],
       async () => {
         loadStreamsListBasedOnType();
       },

--- a/web/src/composables/useDashboardPanel.ts
+++ b/web/src/composables/useDashboardPanel.ts
@@ -2079,7 +2079,7 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
     parser = await sqlParser();
 
     // do not allow to modify custom query fields for logs page
-    updateQueryValue(pageKey == "logs" ? true : falsepageKey == "logs" ? true : false);
+    updateQueryValue(pageKey == "logs" ? true : false);
   };
 
   /**

--- a/web/src/composables/useDashboardPanel.ts
+++ b/web/src/composables/useDashboardPanel.ts
@@ -23,7 +23,7 @@ import {
   b64EncodeUnicode,
   isStreamingEnabled,
 } from "@/utils/zincutils";
-import { extractFields } from "@/utils/query/sqlUtils";
+import { extractFields, getStreamNameFromQuery } from "@/utils/query/sqlUtils";
 import { validatePanel } from "@/utils/dashboard/convertDataIntoUnitValue";
 import useValuesWebSocket from "./dashboard/useValuesWebSocket";
 import queryService from "@/services/search";
@@ -2079,7 +2079,7 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
     parser = await sqlParser();
 
     // do not allow to modify custom query fields for logs page
-    updateQueryValue(pageKey == "logs" ? true : false);
+    updateQueryValue(pageKey == "logs" ? true : falsepageKey == "logs" ? true : false);
   };
 
   /**
@@ -3054,7 +3054,7 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
   }
 
   // This function parses the custom query and generates the errors and custom fields
-  const updateQueryValue = (shouldSkipCustomQueryFields: boolean = false) => {
+  const updateQueryValue = async (shouldSkipCustomQueryFields: boolean = false) => {
     // store the query in the dashboard panel data
     // dashboardPanelData.meta.editorValue = value;
     // dashboardPanelData.data.query = value;
@@ -3155,22 +3155,22 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
 
         // update the existing x and y axis fields
         updateXYFieldsOnCustomQueryChange(oldCustomQueryFields);
-      } else {
+      } else if (!shouldSkipCustomQueryFields) {
         dashboardPanelData.meta.errors.queryErrors.push("Invalid Columns");
       }
 
-      if (dashboardPanelData.meta.parsedQuery.from?.length > 0) {
+      const currentQuery =
+      dashboardPanelData.data.queries[
+        dashboardPanelData.layout.currentQueryIndex
+      ];
+
+      const tableName = await getStreamNameFromQuery(currentQuery?.query ?? "");
+
+      if (tableName) {
         const streamFound = dashboardPanelData.meta.stream.streamResults.find(
           (it: any) =>
-            it.name == dashboardPanelData.meta.parsedQuery.from[0].table,
+            it.name == tableName,
         );
-
-        const currentQuery =
-          dashboardPanelData.data.queries[
-            dashboardPanelData.layout.currentQueryIndex
-          ];
-
-        const tableName = dashboardPanelData.meta.parsedQuery.from?.[0]?.table;
 
         if (streamFound) {
           if (currentQuery.fields.stream != streamFound.name) {
@@ -3178,14 +3178,6 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
           }
         } else if (isDummyStreamName(tableName)) {
           // nothing to do as the stream is dummy
-        } else {
-          let parsedQuery;
-          try {
-            parsedQuery = parser.astify(currentQuery?.query);
-          } catch (e) {
-            // exit if not able to parse query
-            return;
-          }
         }
       }
     }
@@ -3201,7 +3193,7 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
       ].customQuery, // Only watch for custom query mode changes
       selectedStreamFieldsBasedOnUserDefinedSchema.value,
     ],
-    (newVal, oldVal) => {
+    async (newVal, oldVal) => {
 
       // if pageKey is logs, then return
       // because custom query fields will be extracted from the query using the result schema api
@@ -3223,7 +3215,7 @@ const useDashboardPanelData = (pageKey: string = "dashboard") => {
       ) {
         // Call the updateQueryValue function
         // will skip custom query fields extraction for logs page
-        if (parser) updateQueryValue(pageKey == "logs" ? true : false);
+        if (parser) await updateQueryValue(pageKey == "logs" ? true : false);
       } else if (customQueryChanged) {
         // Only clear lists when switching modes
         // auto query mode selected

--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -774,3 +774,79 @@ export const convertQueryIntoSingleLine = async (query: any) => {
     return query;
   }
 };
+
+
+export const getStreamNameFromQuery = async (query: any) => {
+  let streamName = null;
+  try {
+    await importSqlParser();
+    try {
+      if(query && query != ""){
+        const parsedQuery = parser?.astify(query);
+        if (parsedQuery?.with) {
+            let withObj = parsedQuery.with;
+            withObj.forEach((obj: any) => {
+              // Recursively extract table names from the WITH statement with depth protection
+              const MAX_RECURSION_DEPTH = 50; // Prevent stack overflow
+              const visitedNodes = new WeakSet(); // Prevent circular references - more efficient for objects
+              
+              const extractTablesFromNode = (node: any, depth: number = 0) => {
+                if (!node || depth > MAX_RECURSION_DEPTH) {
+                  if (depth > MAX_RECURSION_DEPTH) {
+                    console.warn("Maximum recursion depth reached while parsing SQL query");
+                  }
+                  return;
+                }
+                
+                // Use WeakSet for efficient circular reference detection
+                if (typeof node === 'object' && node !== null) {
+                  if (visitedNodes.has(node)) {
+                    return; // Skip already visited nodes
+                  }
+                  visitedNodes.add(node);
+                }
+                
+                // Check if current node has a from clause
+                if (node.from && Array.isArray(node.from)) {
+                  node.from.forEach((stream: any) => {
+                    if (stream.table) {
+                      streamName = stream.table;
+                    }
+                    // Handle subquery in FROM clause
+                    if (stream.expr && stream.expr.ast) {
+                      extractTablesFromNode(stream.expr.ast, depth + 1);
+                    }
+                  });
+                }
+                
+                // Check for nested subqueries in WHERE clause
+                if (node.where && node.where.right && node.where.right.ast) {
+                  extractTablesFromNode(node.where.right.ast, depth + 1);
+                }
+                
+                // Check for nested subqueries in SELECT expressions
+                if (node.columns && Array.isArray(node.columns)) {
+                  node.columns.forEach((col: any) => {
+                    if (col.expr && col.expr.ast) {
+                      extractTablesFromNode(col.expr.ast, depth + 1);
+                    }
+                  });
+                }
+              };
+              
+              // Start extraction from the WITH statement
+              extractTablesFromNode(obj?.stmt);
+            });
+          }
+          else{
+            streamName = parsedQuery?.from[0]?.table;
+          }
+      }
+    } catch (error) {
+      console.log(error,'error parsing sql query');
+    }
+    return streamName;
+  } catch (error) {
+    return null;
+  }
+};


### PR DESCRIPTION
### **User description**
- #8080
- #8098


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix stream selection for CTE queries

- Add robust stream extraction utility

- Make query updates async-aware

- Adjust watchers to trigger reliably


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SQL["SQL query (incl. CTE)"] -- parse --> Extract["getStreamNameFromQuery()"]
  Extract -- returns stream --> Panel["useDashboardPanel: updateQueryValue()"]
  Panel -- set --> StreamField["currentQuery.fields.stream"]
  Watcher["Vue watch hooks"] -- trigger on changes --> Panel
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FieldList.vue</strong><dd><code>Stabilize watcher for stream type changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/FieldList.vue

<ul><li>Change watcher source to array form.<br> <li> Ensure stream list reloads on type changes.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8116/files#diff-a071c06e3e26629cb4ae4751450acc39c61fa49b07a1cc4be3711697829668d4">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sqlUtils.ts</strong><dd><code>Add robust stream extractor for SQL/CTE queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/query/sqlUtils.ts

<ul><li>Add <code>getStreamNameFromQuery</code> to parse SQL/CTE.<br> <li> Safeguard recursion and circular refs with WeakSet.<br> <li> Handle FROM, WHERE, SELECT subqueries.<br> <li> Gracefully handle parser errors.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8116/files#diff-dde40e8fcb5c37b06c011ede08922c44a3c025682fbc341aee97ba046b73a0e3">+76/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useDashboardPanel.ts</strong><dd><code>Async query parsing and CTE-aware stream resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useDashboardPanel.ts

<ul><li>Import <code>getStreamNameFromQuery</code>.<br> <li> Make <code>updateQueryValue</code> async and await in watcher.<br> <li> Use stream name from parser for selection, including CTE.<br> <li> Remove redundant parsing branch; minor bug introduced in logs flag.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8116/files#diff-fbba1700750053b9eaf38ddd30dab84531bc44131c795ebb713811e4930cd7cb">+15/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

