### PR TITLE
fix: remove environment option from list

### DIFF
--- a/web/src/components/logstream/schema.vue
+++ b/web/src/components/logstream/schema.vue
@@ -442,7 +442,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       "
                       :disable="isEnvironmentSettings(props.row)"
                       v-model="props.row.index_type"
-                      :options="streamIndexType"
+                      :options="isEnvironmentSettings(props.row) ? streamIndexTypeEnv : streamIndexType"
                       :popup-content-style="{ textTransform: 'capitalize' }"
                       color="input-border"
                       bg-color="input-bg"
@@ -888,11 +888,14 @@ export default defineComponent({
       return "Other Fields";
     });
 
+    const streamIndexTypeEnv = [
+      { label: "Full text search (Environment setting)", value: "fullTextSearchKeyEnv" },
+      { label: "Secondary index (Environment setting)", value: "secondaryIndexKeyEnv" },
+    ];
+
     const streamIndexType = [
       { label: "Full text search", value: "fullTextSearchKey" },
       { label: "Secondary index", value: "secondaryIndexKey" },
-      { label: "Full text search (Environment setting)", value: "fullTextSearchKeyEnv" },
-      { label: "Secondary index (Environment setting)", value: "secondaryIndexKeyEnv" },
       { label: "Bloom filter", value: "bloomFilterKey" },
       { label: "KeyValue partition", value: "keyPartition" },
       { label: "Prefix partition", value: "prefixPartition" },
@@ -1807,6 +1810,7 @@ export default defineComponent({
       markFormDirty,
       formDirtyFlag,
       streamIndexType,
+      streamIndexTypeEnv,
       disableOptions,
       loadingState,
       filterFieldFn,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Split index options for environment fields

- Remove env options from default list

- Conditionally render options based on row settings

- Expose new env options in component state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Schema Index Select (QSelect)"]
  RowCheck["isEnvironmentSettings(row)"]
  DefaultOpts["streamIndexType"]
  EnvOpts["streamIndexTypeEnv"]
  State["Component exports"]

  UI -- evaluates --> RowCheck
  RowCheck -- true --> EnvOpts
  RowCheck -- false --> DefaultOpts
  EnvOpts -- provided as :options --> UI
  DefaultOpts -- provided as :options --> UI
  EnvOpts -- added to --> State
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.vue</strong><dd><code>Split and conditionally apply environment index options</code>&nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/logstream/schema.vue

<ul><li>Add <code>streamIndexTypeEnv</code> with environment-only options.<br> <li> Remove environment options from <code>streamIndexType</code>.<br> <li> Conditionally set QSelect <code>:options</code> based on <br><code>isEnvironmentSettings(row)</code>.<br> <li> Expose <code>streamIndexTypeEnv</code> from setup return.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8141/files#diff-9196be2ccae4054a00b0b1aa9d1e87b366c10920d6eaf9ef8c6e6293d50bcf46">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

