### PR TITLE
fix: added spacing between box

### DIFF
--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -110,7 +110,7 @@ flat
         </div>
       </div>
 
-      <div align="center" class="q-w-sm my-card card-container">
+      <div align="center" class="q-w-sm my-card card-container q-mr-lg">
         <div align="center" flat
 bordered class="q-w-sm my-card q-py-md">
           <div class="text-subtitle1">{{ t("home.pipelineTitle") }}</div>
@@ -145,7 +145,7 @@ flat
         </div>
       </div>
 
-      <div class="q-w-sm my-card card-container">
+      <div class="q-w-sm my-card card-container q-mr-lg">
         <div align="center" flat
 bordered class="q-w-sm my-card q-py-md">
           <div class="text-subtitle1">{{ t("home.alertTitle") }}</div>
@@ -180,7 +180,7 @@ flat
         </div>
       </div>
 
-      <div class="q-w-sm my-card card-container">
+      <div class="q-w-sm my-card card-container q-mr-lg">
         <div align="center" flat
 bordered class="q-w-sm my-card q-py-md">
           <div class="row justify-center">


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add right margin to home cards

- Improve spacing between dashboard boxes

- Visual polish on HomeView layout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HomeView.vue"] -- "add q-mr-lg" --> B["Card containers"]
  B -- "improved spacing" --> C["Home page layout"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HomeView.vue</strong><dd><code>Add right margin to HomeView card containers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/HomeView.vue

<ul><li>Add <code>q-mr-lg</code> to three <code>.card-container</code> divs.<br> <li> Improves horizontal spacing between home page cards.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8149/files#diff-9af441af191d3254ef5f9db603dca75486de7638cda41a3c050e7b3c33d68280">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

