### PR TITLE
fix: ingester writer channel closed

### DIFF
--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -116,10 +116,26 @@ pub async fn get_writer(
             start.elapsed().as_millis()
         );
     }
+    let mut is_exixting_writer_channel_closed = false;
     if let Some(w) = data {
-        return w.clone();
+        if !w.is_channel_closed() {
+            return w.clone();
+        }
+        is_exixting_writer_channel_closed = true;
     }
     drop(r);
+
+    if is_exixting_writer_channel_closed {
+        log::warn!(
+            "[INGESTER:MEM:{}] Writer channel closed for {}/{}, removing from cache",
+            idx,
+            org_id,
+            stream_type
+        );
+        let mut w = WRITERS[idx].write().await;
+        w.remove(&key);
+        drop(w);
+    }
 
     // slow path
     let start = std::time::Instant::now();
@@ -182,7 +198,7 @@ pub async fn check_ttl() -> Result<()> {
                 .send((WriterSignal::Rotate, vec![], false))
                 .await
             {
-                log::error!("[INGESTER:MEM] writer queue rotate error: {}", e);
+                log::error!("[INGESTER:MEM:{}] writer queue rotate error: {}", r.idx, e);
             }
         }
     }
@@ -284,6 +300,10 @@ impl Writer {
 
     pub fn get_key_str(&self) -> String {
         format!("{}/{}", self.key.org_id, self.key.stream_type)
+    }
+
+    pub fn is_channel_closed(&self) -> bool {
+        self.write_queue.is_closed()
     }
 
     // check_ttl is used to check if the memtable has expired


### PR DESCRIPTION
- During ingestion there are instances where the writer channel is closed. And this will need an app restart. 
- So instead when we do `get_writer` check if channel is closed and if it is creates a new writer 