### PR TITLE
fix: ingester writer channel closed

### DIFF
--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -127,10 +127,7 @@ pub async fn get_writer(
 
     if is_existing_writer_channel_closed {
         log::warn!(
-            "[INGESTER:MEM:{}] Writer channel closed for {}/{}, removing from cache",
-            idx,
-            org_id,
-            stream_type
+            "[INGESTER:MEM:{idx}] Writer channel closed for {org_id}/{stream_type}, removing from cache",
         );
         let mut w = WRITERS[idx].write().await;
         w.remove(&key);


### PR DESCRIPTION
### **User description**
- During ingestion there are instances where the writer channel is closed. And this will need an app restart.
- So instead when we do get_writer check if channel is closed and if it is creates a new writer


___

### **PR Type**
Bug fix


___

### **Description**
- Detect closed writer channels and refresh

- Remove stale writers from cache on close

- Add channel-closed helper on Writer

- Improve rotate error log with writer index


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GW["get_writer()"] -- "cache hit + channel open" --> RET["return cached Writer"]
  GW -- "cache hit but channel closed" --> RM["remove from cache"]
  RM -- "proceed to slow path" --> CREATE["create new Writer"]
  GW -- "cache miss" --> CREATE
  W["Writer"] -- "is_channel_closed()" --> GW
  TTL["check_ttl()"] -- "log with idx on error" --> LOG["enhanced error log"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>writer.rs</strong><dd><code>Handle closed writer channels and improve logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ingester/src/writer.rs

<ul><li>Check cached writer channel state before returning.<br> <li> Remove closed-channel writers from cache and recreate.<br> <li> Add Writer::is_channel_closed helper method.<br> <li> Enhance rotate error log to include writer index.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8155/files#diff-d1a9b1542cc2758afe4fa67abd454dd818718f4e1c7570303519af5a58d6301f">+22/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

