### PR TITLE
fix: enhance machine id check

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -399,6 +399,14 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
         "parse-id" => {
             let id = command.get_one::<String>("id").unwrap();
             println!("id: {id}");
+            // Snowflake IDs are expected to be 19 digits. If the input ID is longer,
+            // we truncate to the first 19 digits to ensure correct parsing; any extra digits are
+            // ignored.
+            let id = if id.len() > 19 {
+                id[..19].to_string()
+            } else {
+                id.to_string()
+            };
             let id = id.parse::<i64>().unwrap();
             let ts = config::ider::to_timestamp_millis(id);
             println!("timestamp: {ts}");

--- a/src/common/infra/cluster/etcd.rs
+++ b/src/common/infra/cluster/etcd.rs
@@ -110,23 +110,9 @@ async fn register() -> Result<()> {
     }
     drop(w);
 
-    node_ids.sort();
-    node_ids.dedup();
-    log::debug!("node_ids: {node_ids:?}");
-
-    let mut new_node_id = 1;
-    for id in node_ids {
-        if id == new_node_id {
-            new_node_id += 1;
-        } else {
-            break;
-        }
-    }
-    log::debug!("new_node_id: {new_node_id:?}");
+    let new_node_id = super::generate_node_id(node_ids);
     // update local id
-    unsafe {
-        LOCAL_NODE_ID = new_node_id;
-    }
+    LOCAL_NODE_ID.store(new_node_id, Ordering::Relaxed);
 
     // 4. join the cluster
     let key = format!("{}nodes/{}", &cfg.etcd.prefix, LOCAL_NODE.uuid);
@@ -223,7 +209,7 @@ pub(crate) async fn set_status(status: NodeStatus, new_lease_id: bool) -> Result
             val
         }
         None => Node {
-            id: unsafe { LOCAL_NODE_ID },
+            id: LOCAL_NODE_ID.load(Ordering::Relaxed),
             uuid: LOCAL_NODE.uuid.clone(),
             name: cfg.common.instance_name.clone(),
             http_addr: format!(

--- a/src/common/infra/cluster/mod.rs
+++ b/src/common/infra/cluster/mod.rs
@@ -636,6 +636,23 @@ async fn set_node_status_metrics(node: &Node) {
     }
 }
 
+fn generate_node_id(mut ids: Vec<i32>) -> i32 {
+    ids.sort();
+    ids.dedup();
+    log::debug!("node_ids: {:?}", ids);
+
+    let mut new_node_id = 1;
+    for id in ids {
+        if id == new_node_id {
+            new_node_id += 1;
+        } else {
+            break;
+        }
+    }
+    log::debug!("new_node_id: {:?}", new_node_id);
+    new_node_id
+}
+
 async fn update_node_status_metrics() -> NodeMetrics {
     let node_status = get_node_metrics();
 

--- a/src/common/infra/cluster/nats.rs
+++ b/src/common/infra/cluster/nats.rs
@@ -129,23 +129,9 @@ async fn register() -> Result<()> {
     }
     drop(w);
 
-    node_ids.sort();
-    node_ids.dedup();
-    log::debug!("node_ids: {node_ids:?}");
-
-    let mut new_node_id = 1;
-    for id in node_ids {
-        if id == new_node_id {
-            new_node_id += 1;
-        } else {
-            break;
-        }
-    }
-    log::debug!("new_node_id: {new_node_id:?}");
+    let new_node_id = super::generate_node_id(node_ids);
     // update local id
-    unsafe {
-        LOCAL_NODE_ID = new_node_id;
-    }
+    LOCAL_NODE_ID.store(new_node_id, Ordering::Relaxed);
 
     // 5. join the cluster
     let key = format!("/nodes/{}", LOCAL_NODE.uuid);
@@ -232,7 +218,7 @@ pub(crate) async fn set_status(status: NodeStatus) -> Result<()> {
             val
         }
         None => Node {
-            id: unsafe { LOCAL_NODE_ID },
+            id: LOCAL_NODE_ID.load(Ordering::Relaxed),
             uuid: LOCAL_NODE.uuid.clone(),
             name: cfg.common.instance_name.clone(),
             http_addr: format!(
@@ -257,6 +243,23 @@ pub(crate) async fn set_status(status: NodeStatus) -> Result<()> {
             version: config::VERSION.to_string(),
         },
     };
+
+    // check node id if it is duplicated in the node list
+    let r = super::NODES.read().await;
+    let node_ids = r.values().map(|n| n.id).collect::<Vec<_>>();
+    drop(r);
+    if node_ids.iter().filter(|&v| *v == node.id).count() > 1 {
+        let new_node_id = super::generate_node_id(node_ids);
+        node.id = new_node_id;
+        log::warn!(
+            "[CLUSTER] node id is duplicated, generate new node id: {}",
+            new_node_id
+        );
+        // update local id
+        LOCAL_NODE_ID.store(new_node_id, Ordering::Relaxed);
+        // reset snowflake id generator
+        config::ider::reload_machine_id();
+    }
 
     // update node status metrics
     node.metrics = super::update_node_status_metrics().await;

--- a/src/config/src/cluster.rs
+++ b/src/config/src/cluster.rs
@@ -15,7 +15,7 @@
 
 use std::{
     net::IpAddr,
-    sync::atomic::{AtomicU32, Ordering},
+    sync::atomic::{AtomicI32, Ordering},
 };
 
 use once_cell::sync::Lazy;
@@ -25,9 +25,9 @@ use crate::{
     meta::cluster::{Node, NodeStatus, Role, RoleGroup},
 };
 
-pub static mut LOCAL_NODE_ID: i32 = 0;
+pub static LOCAL_NODE_ID: AtomicI32 = AtomicI32::new(0);
 pub static mut LOCAL_NODE_KEY_LEASE_ID: i64 = 0;
-pub static LOCAL_NODE_STATUS: AtomicU32 = AtomicU32::new(NodeStatus::Prepare as _);
+pub static LOCAL_NODE_STATUS: AtomicI32 = AtomicI32::new(NodeStatus::Prepare as _);
 pub static LOCAL_NODE: Lazy<Node> = Lazy::new(load_local_node);
 
 pub fn load_local_node() -> Node {

--- a/src/config/src/ider.rs
+++ b/src/config/src/ider.rs
@@ -15,7 +15,7 @@
 
 use std::{
     hint::spin_loop,
-    sync::LazyLock,
+    sync::{LazyLock, atomic::Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -24,13 +24,21 @@ use rand::Rng;
 use svix_ksuid::{Ksuid, KsuidLike};
 
 static IDER: LazyLock<Mutex<SnowflakeIdGenerator>> = LazyLock::new(|| {
-    let machine_id = unsafe { super::cluster::LOCAL_NODE_ID };
+    let machine_id = super::cluster::LOCAL_NODE_ID.load(Ordering::Relaxed);
     log::info!("init ider with machine_id: {machine_id}");
     Mutex::new(SnowflakeIdGenerator::new(machine_id))
 });
 
 pub fn init() {
     _ = generate();
+}
+
+pub fn reload_machine_id() {
+    let machine_id = super::cluster::LOCAL_NODE_ID.load(Ordering::Relaxed);
+    log::info!("init ider with machine_id: {}", machine_id);
+    let new_ider = SnowflakeIdGenerator::new(machine_id);
+    let mut w = IDER.lock();
+    _ = std::mem::replace(&mut *w, new_ider);
 }
 
 /// Generate a distributed unique id with snowflake.

--- a/src/config/src/meta/cluster.rs
+++ b/src/config/src/meta/cluster.rs
@@ -80,7 +80,8 @@ impl Node {
     }
 
     pub fn is_same(&self, other: &Node) -> bool {
-        self.uuid == other.uuid
+        self.id == other.id
+            && self.uuid == other.uuid
             && self.name == other.name
             && self.http_addr == other.http_addr
             && self.grpc_addr == other.grpc_addr
@@ -179,8 +180,8 @@ pub enum NodeStatus {
     Offline = 3,
 }
 
-impl From<u32> for NodeStatus {
-    fn from(value: u32) -> Self {
+impl From<i32> for NodeStatus {
+    fn from(value: i32) -> Self {
         match value {
             1 => NodeStatus::Prepare,
             2 => NodeStatus::Online,

--- a/src/job/files/mod.rs
+++ b/src/job/files/mod.rs
@@ -77,5 +77,6 @@ pub fn generate_storage_file_name(
     } else {
         format!("{}/{}", &file_name[..file_name_pos], id)
     };
-    format!("files/{stream_key}/{file_date}/{file_name}{FILE_EXT_PARQUET}")
+    let rand_str = format!("{:04x}", rand::random::<u16>());
+    format!("files/{stream_key}/{file_date}/{file_name}{rand_str}{FILE_EXT_PARQUET}")
 }

--- a/src/service/db/schema.rs
+++ b/src/service/db/schema.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::sync::{Arc, atomic::Ordering};
 
 use arrow_schema::{Field, Schema};
 use bytes::Bytes;
@@ -363,7 +363,9 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                     && let dashmap::Entry::Vacant(entry) =
                         STREAM_RECORD_ID_GENERATOR.entry(item_key.to_string())
                 {
-                    entry.insert(SnowflakeIdGenerator::new(unsafe { LOCAL_NODE_ID }));
+                    entry.insert(SnowflakeIdGenerator::new(
+                        LOCAL_NODE_ID.load(Ordering::Relaxed),
+                    ));
                 }
                 let mut w = STREAM_SETTINGS.write().await;
                 w.insert(item_key.to_string(), settings);
@@ -520,7 +522,9 @@ pub async fn cache() -> Result<(), anyhow::Error> {
             && let dashmap::Entry::Vacant(entry) =
                 STREAM_RECORD_ID_GENERATOR.entry(item_key.to_string())
         {
-            entry.insert(SnowflakeIdGenerator::new(unsafe { LOCAL_NODE_ID }));
+            entry.insert(SnowflakeIdGenerator::new(
+                LOCAL_NODE_ID.load(Ordering::Relaxed),
+            ));
         }
         let mut w = STREAM_SETTINGS.write().await;
         w.insert(item_key.to_string(), settings);

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -15,7 +15,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    sync::Arc,
+    sync::{Arc, atomic::Ordering},
 };
 
 use chrono::{Duration, TimeZone, Utc};
@@ -568,7 +568,7 @@ pub fn generate_record_id(org_id: &str, stream_name: &str, stream_type: &StreamT
     let key = format!("{org_id}/{stream_type}/{stream_name}");
     STREAM_RECORD_ID_GENERATOR
         .entry(key)
-        .or_insert_with(|| SnowflakeIdGenerator::new(unsafe { LOCAL_NODE_ID }))
+        .or_insert_with(|| SnowflakeIdGenerator::new(LOCAL_NODE_ID.load(Ordering::Relaxed)))
         .generate()
 }
 

--- a/src/service/schema.rs
+++ b/src/service/schema.rs
@@ -13,7 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, atomic::Ordering},
+};
 
 use anyhow::Result;
 use config::{
@@ -432,7 +435,9 @@ async fn handle_diff_schema(
     if (need_original || index_original_data)
         && let dashmap::Entry::Vacant(entry) = STREAM_RECORD_ID_GENERATOR.entry(cache_key.clone())
     {
-        entry.insert(SnowflakeIdGenerator::new(unsafe { LOCAL_NODE_ID }));
+        entry.insert(SnowflakeIdGenerator::new(
+            LOCAL_NODE_ID.load(Ordering::Relaxed),
+        ));
     }
     let mut w = STREAM_SETTINGS.write().await;
     w.insert(cache_key.clone(), stream_setting);


### PR DESCRIPTION
### **User description**
- Add duplicated machine id check
- Add 4 random chars for generate parquet filename
- Use Atomic replace unsafe code


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Centralize node ID generation logic

- Replace unsafe globals with atomics

- Detect and resolve duplicate node IDs

- Truncate long Snowflake IDs when parsing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cluster register (etcd/nats)"] -- "collect node ids" --> B["generate_node_id()"]
  B -- "new id" --> C["LOCAL_NODE_ID (AtomicI32)"]
  C -- "reload if changed" --> D["Snowflake ID generator"]
  E["set_status()"] -- "detect duplicate id" --> B
  F["CLI parse-id"] -- "truncate to 19 digits" --> G["parse i64"]
  H["Parquet filename"] -- "append 4-hex random" --> I["unique file path"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>cli.rs</strong><dd><code>Truncate IDs longer than 19 digits before parse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-cb1eb3e74723d891353ccf1e2e5e0d246d2e78a5e69dbe4c73006ea8412d65e0">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>etcd.rs</strong><dd><code>Use centralized node-id generation and atomics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-37c2c2803d1c12ebb4ef9299bc79c9e6740fc5f19f7f4d84e7cfbb610b9561a9">+3/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Add reusable generate_node_id utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-d15434a27e2b8406811f5a707b605203b603dad4a262c0642326be860bd2b568">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nats.rs</strong><dd><code>Centralize id generation; detect duplicates; reload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-901773980aa255942e7865b977fe63811f31511ac40bc512d6bbb14dbb54bece">+20/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cluster.rs</strong><dd><code>Replace unsafe globals with AtomicI32</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-68d7195ab7cccf22579c4944a37c8a2f592392c30371ce907fadf62fca6f97dd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ider.rs</strong><dd><code>Read machine id atomically; support reload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-6ea42b8eab8ba0708f93f9a8b44056d9a9e6ac42517ffba12f81420d6b0bd2b0">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cluster.rs</strong><dd><code>Node equality includes id; NodeStatus i32</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-a2667c1be522ce095796a7066e02631a7e01acc85a46573e1e3a157d2aefb7c3">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Add 4-hex random suffix to filenames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-30f42c3685037c219f0033617f032b23a7f74624ba4ae6c4e3687af401304591">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.rs</strong><dd><code>Initialize generators using atomic node id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-4696a44abde2df4ac48fed716f930bfdcc01759bdfcfd8d802821c6dd857bff9">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Generate record ids using atomic node id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-7c7b5bca85f0ced652965cae66540c96f56dfcca4f4c16b77bf7b45aac203d1b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.rs</strong><dd><code>Use atomic node id for stream generators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8160/files#diff-d9596182a0c7a46a6a7ff5cee822554cdae05ceec312f86c93b538db9f73bbfd">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

