### PR TITLE
refactor: stream stats

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -46,7 +46,7 @@ pub type RwAHashSet<K> = tokio::sync::RwLock<HashSet<K>>;
 pub type RwBTreeMap<K, V> = tokio::sync::RwLock<BTreeMap<K, V>>;
 
 // for DDL commands and migrations
-pub const DB_SCHEMA_VERSION: u64 = 7;
+pub const DB_SCHEMA_VERSION: u64 = 8;
 pub const DB_SCHEMA_KEY: &str = "/db_schema_version/";
 
 // global version variables

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1289,7 +1289,7 @@ pub struct Limit {
     pub job_runtime_shutdown_timeout: u64,
     #[env_config(name = "ZO_CALCULATE_STATS_INTERVAL", default = 60)] // seconds
     pub calculate_stats_interval: u64,
-    #[env_config(name = "ZO_CALCULATE_STATS_STEP_LIMIT", default = 1000000)] // records
+    #[env_config(name = "ZO_CALCULATE_STATS_STEP_LIMIT", default = 600)] // seconds
     pub calculate_stats_step_limit: i64,
     #[env_config(name = "ZO_ACTIX_REQ_TIMEOUT", default = 5)] // seconds
     pub http_request_timeout: u64,
@@ -2240,7 +2240,10 @@ fn check_limit_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
 
     // check for calculate stats
     if cfg.limit.calculate_stats_step_limit < 1 {
-        cfg.limit.calculate_stats_step_limit = 1000000;
+        cfg.limit.calculate_stats_step_limit = 600;
+    }
+    if cfg.limit.calculate_stats_step_limit > 86400 {
+        cfg.limit.calculate_stats_step_limit = 86400;
     }
 
     Ok(())

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -388,10 +388,12 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
     );
 
     let file_list_num = file_list::len().await;
-    let file_list_max_id = file_list::get_max_pk_value().await.unwrap_or_default();
+    let file_list_last_update_at = file_list::get_max_update_at().await.unwrap_or_default();
+    let (last_run_stats_at, _) = db::compact::stats::get_offset().await;
+
     stats.insert(
         "FILE_LIST",
-        json::json!({"num":file_list_num,"max_id": file_list_max_id}),
+        json::json!({"num":file_list_num,"last_update_at": file_list_last_update_at, "last_run_stats_at": last_run_stats_at}),
     );
 
     let last_file_list_offset = db::compact::file_list::get_offset().await.unwrap();

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -389,11 +389,15 @@ pub async fn cache_status() -> Result<HttpResponse, Error> {
 
     let file_list_num = file_list::len().await;
     let file_list_last_update_at = file_list::get_max_update_at().await.unwrap_or_default();
-    let (last_run_stats_at, _) = db::compact::stats::get_offset().await;
+    let (last_check_updated_at, _) = db::compact::stats::get_offset().await;
 
     stats.insert(
         "FILE_LIST",
-        json::json!({"num":file_list_num,"last_update_at": file_list_last_update_at, "last_run_stats_at": last_run_stats_at}),
+        json::json!({
+            "num":file_list_num,
+            "last_update_at": file_list_last_update_at,
+            "last_check_updated_at": last_check_updated_at,
+        }),
     );
 
     let last_file_list_offset = db::compact::file_list::get_offset().await.unwrap();

--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -433,9 +433,7 @@ impl FileData {
 pub async fn init() -> Result<(), anyhow::Error> {
     let cfg = get_config();
     // clean the tmp dir
-    if let Err(e) = std::fs::remove_dir_all(&cfg.common.data_tmp_dir) {
-        log::warn!("clean tmp dir error: {}", e);
-    }
+    _ = std::fs::remove_dir_all(&cfg.common.data_tmp_dir);
     std::fs::create_dir_all(&cfg.common.data_tmp_dir).expect("create tmp dir success");
 
     for file in FILES.iter() {

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -178,7 +178,7 @@ pub trait FileList: Sync + Send + 'static {
         stream: Option<&str>,
         start_time: i64,
         end_time: i64,
-        min_id: Option<i64>,
+        min_updated_at: Option<i64>,
     ) -> Result<Vec<FileRecord>>;
     async fn get_pending_dump_jobs(&self) -> Result<Vec<(i64, String, String, i64)>>;
     async fn set_job_dumped_status(&self, id: i64, dumped: bool) -> Result<()>;
@@ -496,10 +496,10 @@ pub async fn get_entries_in_range(
     stream: Option<&str>,
     start_time: i64,
     end_time: i64,
-    min_id: Option<i64>,
+    min_updated_at: Option<i64>,
 ) -> Result<Vec<FileRecord>> {
     CLIENT
-        .get_entries_in_range(org, stream, start_time, end_time, min_id)
+        .get_entries_in_range(org, stream, start_time, end_time, min_updated_at)
         .await
 }
 
@@ -589,6 +589,10 @@ pub struct FileRecord {
     pub index_size: i64,
     #[sqlx(default)]
     pub flattened: bool,
+    #[sqlx(default)]
+    pub created_at: i64,
+    #[sqlx(default)]
+    pub updated_at: i64,
 }
 
 impl From<&FileRecord> for FileKey {

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -925,18 +925,6 @@ SELECT date
         Ok(ret.unwrap_or_default())
     }
 
-    async fn get_max_update_at(&self) -> Result<i64> {
-        let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list"])
-            .inc();
-        let ret: Option<i64> =
-            sqlx::query_scalar(r#"SELECT MAX(updated_at) AS num FROM file_list;"#)
-                .fetch_one(&pool)
-                .await?;
-        Ok(ret.unwrap_or_default())
-    }
-
     async fn get_min_update_at(&self) -> Result<i64> {
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS
@@ -949,58 +937,36 @@ SELECT date
         Ok(ret.unwrap_or_default())
     }
 
+    async fn get_max_update_at(&self) -> Result<i64> {
+        let pool = CLIENT_RO.clone();
+        DB_QUERY_NUMS
+            .with_label_values(&["select", "file_list"])
+            .inc();
+        let ret: Option<i64> =
+            sqlx::query_scalar(r#"SELECT MAX(updated_at) AS num FROM file_list;"#)
+                .fetch_one(&pool)
+                .await?;
+        Ok(ret.unwrap_or_default())
+    }
+
     async fn clean_by_min_update_at(&self, _val: i64) -> Result<()> {
         Ok(()) // do nothing
     }
 
-    async fn stats(
-        &self,
-        org_id: &str,
-        stream_type: Option<StreamType>,
-        stream_name: Option<&str>,
-        pk_value: Option<(i64, i64)>,
-        deleted: bool,
-    ) -> Result<Vec<(String, StreamStats)>> {
-        let (field, value) = if stream_type.is_some() && stream_name.is_some() {
-            (
-                "stream",
-                format!(
-                    "{}/{}/{}",
-                    org_id,
-                    stream_type.unwrap(),
-                    stream_name.unwrap()
-                ),
-            )
-        } else {
-            ("org", org_id.to_string())
-        };
-        let file_list_stream = format!("{org_id}/file_list/");
-        let mut sql = format!(
+    async fn stats(&self, time_range: (i64, i64)) -> Result<Vec<(String, StreamStats)>> {
+        let (min, max) = time_range;
+        let sql = format!(
             r#"
 SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SIGNED) AS file_num,
     CAST(SUM(records) AS SIGNED) AS records, CAST(SUM(original_size) AS SIGNED) AS original_size, CAST(SUM(compressed_size) AS SIGNED) AS compressed_size, CAST(SUM(index_size) AS SIGNED) AS index_size
     FROM file_list
-    WHERE {field} = '{value}' AND stream NOT LIKE '{file_list_stream}%'
+    WHERE updated_at >= {min} AND updated_at < {max}
+    GROUP BY stream
             "#,
         );
-        if deleted {
-            sql = format!("{sql} AND deleted IS TRUE");
-        }
-        let sql = match pk_value {
-            None => format!("{sql} GROUP BY stream"),
-            Some((0, 0)) => format!("{sql} GROUP BY stream"),
-            Some((min, max)) => {
-                if deleted {
-                    format!("{sql} AND id <= {max} GROUP BY stream")
-                } else {
-                    format!("{sql} AND id > {min} AND id <= {max} GROUP BY stream")
-                }
-            }
-        };
         let pool = CLIENT_RO.clone();
-        let op_name = if deleted { "stats_deleted" } else { "stats" };
         DB_QUERY_NUMS
-            .with_label_values(&[op_name, "file_list"])
+            .with_label_values(&["stats", "file_list"])
             .inc();
         let start = std::time::Instant::now();
         let ret = sqlx::query_as::<_, super::StatsRecord>(&sql)
@@ -1008,7 +974,7 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
             .await?;
         let time = start.elapsed().as_secs_f64();
         DB_QUERY_TIME
-            .with_label_values(&[op_name, "file_list"])
+            .with_label_values(&["stats", "file_list"])
             .observe(time);
         Ok(ret
             .iter()
@@ -1063,30 +1029,29 @@ SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SI
 
     async fn set_stream_stats(
         &self,
-        org_id: &str,
         streams: &[(String, StreamStats)],
-        pk_value: Option<(i64, i64)>,
+        time_range: (i64, i64),
     ) -> Result<()> {
         let pool = CLIENT.clone();
-        let old_stats = self.get_stream_stats(org_id, None, None).await?;
-        let old_stats = old_stats.into_iter().collect::<HashMap<_, _>>();
-        let mut new_streams = Vec::new();
-        let mut update_streams = Vec::with_capacity(streams.len());
-        for (stream_key, item) in streams {
-            let mut stats = match old_stats.get(stream_key) {
-                Some(s) => s.to_owned(),
-                None => {
-                    new_streams.push(stream_key);
-                    StreamStats::default()
-                }
-            };
-            stats.format_by(item); // format stats
-            update_streams.push((stream_key, stats));
-        }
-
+        // check if stream stats exist
         let mut tx = pool.begin().await?;
-        for stream_key in new_streams {
-            let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
+        for (stream_key, _) in streams {
+            if crate::schema::STREAM_STATS_EXISTS.contains(stream_key) {
+                continue;
+            }
+            // stream stats not exist, check from stream_stats table again
+            let Some((org_id, stream_type, stream_name)) = super::parse_stream_key(stream_key)
+            else {
+                return Err(Error::Message(format!("invalid stream key: {stream_key}")));
+            };
+            let ret = self
+                .get_stream_stats(&org_id, Some(stream_type), Some(&stream_name))
+                .await?;
+            if !ret.is_empty() {
+                crate::schema::STREAM_STATS_EXISTS.insert(stream_key.clone());
+                continue;
+            }
+            // stream stats not exist, insert a new one
             DB_QUERY_NUMS
                 .with_label_values(&["insert", "stream_stats"])
                 .inc();
@@ -1109,13 +1074,13 @@ INSERT INTO stream_stats
             }
         }
         if let Err(e) = tx.commit().await {
-            log::error!("[MYSQL] commit set stream stats error: {e}");
+            log::error!("[MYSQL] commit insert stream stats error: {e}");
             return Err(e.into());
         }
 
-        let mut tx = pool.begin().await?;
         // update stats
-        for (stream_key, stats) in update_streams {
+        let mut tx = pool.begin().await?;
+        for (stream_key, stats) in streams {
             DB_QUERY_NUMS
                 .with_label_values(&["update", "stream_stats"])
                 .inc();
@@ -1144,28 +1109,18 @@ UPDATE stream_stats
             }
         }
         // delete files which already marked deleted
-        if let Some((_min_id, max_id)) = pk_value {
-            DB_QUERY_NUMS
-                .with_label_values(&["clean_deleted", "file_list"])
-                .inc();
+        let (min_ts, max_ts) = time_range;
+        DB_QUERY_NUMS
+            .with_label_values(&["clean_deleted", "file_list"])
+            .inc();
+        let start = std::time::Instant::now();
+        loop {
             let start = std::time::Instant::now();
-            let limit = config::get_config().limit.calculate_stats_step_limit;
-            loop {
-                let start = std::time::Instant::now();
-                match sqlx::query(
-                    r#"DELETE f
-                                  FROM file_list f
-                                  JOIN (
-                                      SELECT id
-                                      FROM file_list
-                                      WHERE org = ? AND deleted IS TRUE AND id <= ?
-                                      LIMIT ?
-                                  ) AS sub
-                                  ON f.id = sub.id;"#,
+            match sqlx::query(
+                    r#"DELETE FROM file_list WHERE deleted IS TRUE AND updated_at >= ? AND updated_at < ?"#,
                 )
-                .bind(org_id)
-                .bind(max_id)
-                .bind(limit)
+                .bind(min_ts)
+                .bind(max_ts)
                 .execute(&mut *tx)
                 .await
                 {
@@ -1188,12 +1143,11 @@ UPDATE stream_stats
                         return Err(e.into());
                     }
                 }
-            }
-            let time = start.elapsed().as_secs_f64();
-            DB_QUERY_TIME
-                .with_label_values(&["clean_deleted", "file_list"])
-                .observe(time);
         }
+        let time = start.elapsed().as_secs_f64();
+        DB_QUERY_TIME
+            .with_label_values(&["clean_deleted", "file_list"])
+            .observe(time);
 
         // commit
         if let Err(e) = tx.commit().await {

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -1636,7 +1636,7 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
         stream: Option<&str>,
         time_start: i64,
         time_end: i64,
-        min_id: Option<i64>,
+        min_updated_at: Option<i64>,
     ) -> Result<Vec<super::FileRecord>> {
         if time_start == 0 && time_end == 0 {
             return Ok(Vec::new());
@@ -1667,8 +1667,8 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
                 Some(stream) => format!("{sql} AND stream = '{stream}'"),
                 None => sql.to_string(),
             };
-            let sql = match min_id {
-                Some(id) => format!("{sql} AND id >= {id}"),
+            let sql = match min_updated_at {
+                Some(updated_at) => format!("{sql} AND updated_at >= {updated_at}"),
                 None => sql,
             };
             tasks.push(tokio::task::spawn(async move {

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -960,7 +960,7 @@ SELECT date
 SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, CAST(COUNT(*) AS SIGNED) AS file_num,
     CAST(SUM(records) AS SIGNED) AS records, CAST(SUM(original_size) AS SIGNED) AS original_size, CAST(SUM(compressed_size) AS SIGNED) AS compressed_size, CAST(SUM(index_size) AS SIGNED) AS index_size
     FROM file_list
-    WHERE updated_at >= {min} AND updated_at < {max}
+    WHERE updated_at > {min} AND updated_at <= {max}
     GROUP BY stream
             "#,
         );
@@ -1117,7 +1117,7 @@ UPDATE stream_stats
         loop {
             let start = std::time::Instant::now();
             match sqlx::query(
-                    r#"DELETE FROM file_list WHERE deleted IS TRUE AND updated_at >= ? AND updated_at < ?"#,
+                    r#"DELETE FROM file_list WHERE deleted IS TRUE AND updated_at > ? AND updated_at <= ?"#,
                 )
                 .bind(min_ts)
                 .bind(max_ts)

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -2058,7 +2058,11 @@ CREATE TABLE IF NOT EXISTS stream_stats
     )
     .await?;
 
-    // create column updated_at for version >= 0.14.7
+    // create column created_at and updated_at for version >= 0.14.7
+    let column = "created_at";
+    let data_type = "BIGINT default 0 not null";
+    add_column("file_list", column, data_type).await?;
+    add_column("file_list_history", column, data_type).await?;
     let column = "updated_at";
     let data_type = "BIGINT default 0 not null";
     add_column("file_list", column, data_type).await?;

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -903,7 +903,7 @@ SELECT date
 SELECT stream, MIN(min_ts) AS min_ts, MAX(max_ts) AS max_ts, COUNT(*)::BIGINT AS file_num,
     SUM(records)::BIGINT AS records, SUM(original_size)::BIGINT AS original_size, SUM(compressed_size)::BIGINT AS compressed_size, SUM(index_size)::BIGINT AS index_size
     FROM file_list
-    WHERE updated_at >= {min} AND updated_at < {max}
+    WHERE updated_at > {min} AND updated_at <= {max}
     GROUP BY stream
             "#
         );
@@ -1061,7 +1061,7 @@ UPDATE stream_stats
         loop {
             let start = std::time::Instant::now();
             match sqlx::query(
-                    r#"DELETE FROM file_list WHERE deleted IS TRUE AND updated_at >= $1 AND updated_at < $2"#,
+                    r#"DELETE FROM file_list WHERE deleted IS TRUE AND updated_at > $1 AND updated_at <= $2"#,
                 )
                 .bind(min_ts)
                 .bind(max_ts)

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1948,7 +1948,11 @@ CREATE TABLE IF NOT EXISTS stream_stats
     )
     .await?;
 
-    // create column updated_at for version >= 0.14.7
+    // create column created_at and updated_at for version >= 0.14.7
+    let column = "created_at";
+    let data_type = "BIGINT default 0 not null";
+    add_column("file_list", column, data_type).await?;
+    add_column("file_list_history", column, data_type).await?;
     let column = "updated_at";
     let data_type = "BIGINT default 0 not null";
     add_column("file_list", column, data_type).await?;

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1520,7 +1520,7 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         stream: Option<&str>,
         time_start: i64,
         time_end: i64,
-        min_id: Option<i64>,
+        min_updated_at: Option<i64>,
     ) -> Result<Vec<super::FileRecord>> {
         if time_start == 0 && time_end == 0 {
             return Ok(Vec::new());
@@ -1551,8 +1551,8 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
                 Some(stream) => format!("{sql} AND stream = '{stream}'"),
                 None => sql.to_string(),
             };
-            let sql = match min_id {
-                Some(id) => format!("{sql} AND id >= {id}"),
+            let sql = match min_updated_at {
+                Some(updated_at) => format!("{sql} AND updated_at >= {updated_at}"),
                 None => sql,
             };
             tasks.push(tokio::task::spawn(async move {

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1814,7 +1814,8 @@ CREATE TABLE IF NOT EXISTS file_list
     records   BIGINT not null,
     original_size   BIGINT not null,
     compressed_size BIGINT not null,
-    index_size      BIGINT not null
+    index_size      BIGINT not null,
+    updated_at      BIGINT not null
 );
         "#,
     )
@@ -1838,7 +1839,8 @@ CREATE TABLE IF NOT EXISTS file_list_history
     records   BIGINT not null,
     original_size   BIGINT not null,
     compressed_size BIGINT not null,
-    index_size      BIGINT not null
+    index_size      BIGINT not null,
+    updated_at      BIGINT not null
 );
         "#,
     )
@@ -1942,6 +1944,12 @@ CREATE TABLE IF NOT EXISTS stream_stats
     )
     .await?;
 
+    // create column updated_at for version >= 0.14.7
+    let column = "updated_at";
+    let data_type = "BIGINT default 0 not null";
+    add_column("file_list", column, data_type).await?;
+    add_column("file_list_history", column, data_type).await?;
+
     Ok(())
 }
 
@@ -1961,9 +1969,9 @@ pub async fn create_table_index() -> Result<()> {
             &["stream", "date"],
         ),
         (
-            "file_list_org_deleted_stream_idx",
+            "file_list_updated_at_deleted_idx",
             "file_list",
-            &["org", "deleted", "stream"],
+            &["updated_at", "deleted"],
         ),
         ("file_list_history_org_idx", "file_list_history", &["org"]),
         (

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -1561,7 +1561,8 @@ CREATE TABLE IF NOT EXISTS file_list
     records   BIGINT not null,
     original_size   BIGINT not null,
     compressed_size BIGINT not null,
-    index_size      BIGINT not null
+    index_size      BIGINT not null,
+    updated_at      BIGINT not null
 );
         "#,
     )
@@ -1585,7 +1586,8 @@ CREATE TABLE IF NOT EXISTS file_list_history
     records   BIGINT not null,
     original_size   BIGINT not null,
     compressed_size BIGINT not null,
-    index_size      BIGINT not null
+    index_size      BIGINT not null,
+    updated_at      BIGINT not null
 );
         "#,
     )
@@ -1703,6 +1705,12 @@ CREATE TABLE IF NOT EXISTS stream_stats
     )
     .await?;
 
+    // create column updated_at for version >= 0.14.7
+    let column = "updated_at";
+    let data_type = "BIGINT default 0 not null";
+    add_column(&client, "file_list", column, data_type).await?;
+    add_column(&client, "file_list_history", column, data_type).await?;
+
     Ok(())
 }
 
@@ -1720,9 +1728,9 @@ pub async fn create_table_index() -> Result<()> {
             &["stream", "date"],
         ),
         (
-            "file_list_org_deleted_stream_idx",
+            "file_list_updated_at_deleted_idx",
             "file_list",
-            &["org", "deleted", "stream"],
+            &["updated_at", "deleted"],
         ),
         ("file_list_history_org_idx", "file_list_history", &["org"]),
         (

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -1280,7 +1280,7 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         stream: Option<&str>,
         time_start: i64,
         time_end: i64,
-        min_id: Option<i64>,
+        min_updated_at: Option<i64>,
     ) -> Result<Vec<super::FileRecord>> {
         if time_start == 0 && time_end == 0 {
             return Ok(Vec::new());
@@ -1311,8 +1311,8 @@ SELECT stream, max(id) as id, COUNT(*) AS num
                 Some(stream) => format!("{sql} AND stream = '{stream}'"),
                 None => sql.to_string(),
             };
-            let sql = match min_id {
-                Some(id) => format!("{sql} AND id >= {id}"),
+            let sql = match min_updated_at {
+                Some(updated_at) => format!("{sql} AND updated_at >= {updated_at}"),
                 None => sql,
             };
             tasks.push(tokio::task::spawn(async move {

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -1714,7 +1714,11 @@ CREATE TABLE IF NOT EXISTS stream_stats
     )
     .await?;
 
-    // create column updated_at for version >= 0.14.7
+    // create column created_at and updated_at for version >= 0.14.7
+    let column = "created_at";
+    let data_type = "BIGINT default 0 not null";
+    add_column(&client, "file_list", column, data_type).await?;
+    add_column(&client, "file_list_history", column, data_type).await?;
     let column = "updated_at";
     let data_type = "BIGINT default 0 not null";
     add_column(&client, "file_list", column, data_type).await?;

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -742,7 +742,7 @@ SELECT date
             r#"
 SELECT stream, MIN(min_ts) as min_ts, MAX(max_ts) as max_ts, COUNT(*) as file_num, SUM(records) as records, SUM(original_size) as original_size, SUM(compressed_size) as compressed_size, SUM(index_size) as index_size
     FROM file_list
-    WHERE updated_at >= {min} AND updated_at < {max}
+    WHERE updated_at > {min} AND updated_at <= {max}
     GROUP BY stream
             "#,
         );
@@ -877,7 +877,7 @@ UPDATE stream_stats
         loop {
             let start = std::time::Instant::now();
             match sqlx::query(
-                    r#"DELETE FROM file_list WHERE deleted IS TRUE AND updated_at >= $1 AND updated_at < $2"#,
+                    r#"DELETE FROM file_list WHERE deleted IS TRUE AND updated_at > $1 AND updated_at <= $2"#,
                 )
                 .bind(min_ts)
                 .bind(max_ts)

--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -19,7 +19,8 @@ use arc_swap::ArcSwap;
 use chrono::Utc;
 use config::{
     ALL_VALUES_COL_NAME, BLOOM_FILTER_DEFAULT_FIELDS, ORIGINAL_DATA_COL_NAME, RwAHashMap,
-    RwHashMap, SQL_FULL_TEXT_SEARCH_FIELDS, SQL_SECONDARY_INDEX_SEARCH_FIELDS, get_config,
+    RwHashMap, RwHashSet, SQL_FULL_TEXT_SEARCH_FIELDS, SQL_SECONDARY_INDEX_SEARCH_FIELDS,
+    get_config,
     ider::SnowflakeIdGenerator,
     meta::stream::{PartitionTimeLevel, StreamSettings, StreamType},
     utils::{json, schema_ext::SchemaExt},
@@ -45,6 +46,8 @@ pub static STREAM_SETTINGS: Lazy<RwAHashMap<String, StreamSettings>> = Lazy::new
 /// SnowflakeIdGenerator::generate() requires a &mut
 pub static STREAM_RECORD_ID_GENERATOR: Lazy<RwHashMap<String, SnowflakeIdGenerator>> =
     Lazy::new(Default::default);
+/// Cache if the stream stats is exists, used for calculate stats
+pub static STREAM_STATS_EXISTS: Lazy<RwHashSet<String>> = Lazy::new(Default::default);
 
 // atomic version of cache
 type StreamSettingsCache = hashbrown::HashMap<String, StreamSettings>;

--- a/src/infra/src/table/migration/README.md
+++ b/src/infra/src/table/migration/README.md
@@ -1,0 +1,19 @@
+# Creating Migration Entity
+
+cargo install sea-orm-cli@1.1.0
+
+sea-orm-cli migrate generate NAME_OF_MIGRATION
+
+For example:
+
+```
+sea-orm-cli migrate generate create_new_table
+```
+
+It will generate the new job
+
+```
+Generating new migration...
+Creating migration file `./migration/m20250822_093713_create_new_table.rs`
+Adding migration `m20250822_093713_create_new_table` to `./migration/mod.rs`
+```

--- a/src/infra/src/table/migration/m20250213_000001_add_dashboard_updated_at.rs
+++ b/src/infra/src/table/migration/m20250213_000001_add_dashboard_updated_at.rs
@@ -33,7 +33,7 @@ impl MigrationTrait for Migration {
     }
 }
 
-// Removes the old created_at column.
+// Add the updated_at column to the dashboards table.
 async fn add_updated_at_column(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
     if matches!(manager.get_database_backend(), sea_orm::DbBackend::MySql) {
         manager

--- a/src/infra/src/table/migration/m20250520_000001_add_trial_end_col.rs
+++ b/src/infra/src/table/migration/m20250520_000001_add_trial_end_col.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#[cfg(feature = "cloud")]
 use config::utils::time::day_micros;
 use sea_orm_migration::prelude::*;
 
@@ -21,8 +22,9 @@ pub struct Migration;
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
-    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        add_updated_at_column(manager).await?;
+    async fn up(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        #[cfg(feature = "cloud")]
+        add_updated_at_column(_manager).await?;
         Ok(())
     }
 
@@ -32,6 +34,7 @@ impl MigrationTrait for Migration {
     }
 }
 
+#[cfg(feature = "cloud")]
 async fn add_updated_at_column(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
     let end = chrono::Utc::now().timestamp_micros() + day_micros(14);
     if matches!(manager.get_database_backend(), sea_orm::DbBackend::MySql) {
@@ -69,6 +72,7 @@ async fn add_updated_at_column(manager: &SchemaManager<'_>) -> Result<(), DbErr>
 
 /// Identifiers used in queries on the folders table.
 #[derive(DeriveIden)]
+#[cfg(feature = "cloud")]
 pub(super) enum Organizations {
     Table,
     TrialEndsAt,

--- a/src/infra/src/table/migration/m20250611_000003_populate_reports_scheduled_jobs.rs
+++ b/src/infra/src/table/migration/m20250611_000003_populate_reports_scheduled_jobs.rs
@@ -74,7 +74,7 @@ async fn update_scheduled_triggers(manager: &SchemaManager<'_>) -> Result<(), Db
         sea_orm::DatabaseBackend::Sqlite => select_query.build(SqliteQueryBuilder),
     };
     let statement = Statement::from_sql_and_values(backend, sql, values);
-    log::info!("[SCHEDULED_TRIGGERS_MIGRATION] select_query: {statement}");
+    log::debug!("[SCHEDULED_TRIGGERS_MIGRATION] select_query: {statement}");
 
     // 1. Get all alert triggers from the scheduled jobs table
     let triggers_result = db
@@ -82,7 +82,7 @@ async fn update_scheduled_triggers(manager: &SchemaManager<'_>) -> Result<(), Db
         .await
         .map_err(|e| DbErr::Custom(format!("Failed to query scheduled jobs: {e}")))?;
 
-    log::info!(
+    log::debug!(
         "[SCHEDULED_TRIGGERS_MIGRATION] triggers_result length: {}",
         triggers_result.len()
     );
@@ -111,12 +111,12 @@ async fn update_scheduled_triggers(manager: &SchemaManager<'_>) -> Result<(), Db
             sea_orm::DatabaseBackend::Sqlite => report_query.build(SqliteQueryBuilder),
         };
         let statement = Statement::from_sql_and_values(backend, sql, values);
-        log::info!("[SCHEDULED_TRIGGERS_MIGRATION] report_query to get id: {statement}");
+        log::debug!("[SCHEDULED_TRIGGERS_MIGRATION] report_query to get id: {statement}");
         let report_result = db
             .query_one(statement)
             .await
             .map_err(|e| DbErr::Custom(format!("Failed to query report: {e}")))?;
-        log::info!(
+        log::debug!(
             "[SCHEDULED_TRIGGERS_MIGRATION] report_result is found: {}",
             report_result.is_some()
         );
@@ -127,7 +127,7 @@ async fn update_scheduled_triggers(manager: &SchemaManager<'_>) -> Result<(), Db
                 .try_get::<String>("", "id")
                 .map_err(|e| DbErr::Custom(format!("Failed to get report ID: {e}")))?;
 
-            log::info!("[SCHEDULED_TRIGGERS_MIGRATION] report_id to upgrade: {report_id}");
+            log::debug!("[SCHEDULED_TRIGGERS_MIGRATION] report_id to upgrade: {report_id}");
             // Update the trigger module_key
             let update_query = Query::update()
                 .table(ScheduledJobs::Table)
@@ -142,7 +142,7 @@ async fn update_scheduled_triggers(manager: &SchemaManager<'_>) -> Result<(), Db
                 sea_orm::DatabaseBackend::Sqlite => update_query.build(SqliteQueryBuilder),
             };
             let statement = Statement::from_sql_and_values(backend, sql, values);
-            log::info!(
+            log::debug!(
                 "[SCHEDULED_TRIGGERS_MIGRATION] update_query report scheduled job statement: {statement}"
             );
             db.execute(statement)

--- a/src/infra/src/table/migration/m20250822_093713_add_updated_at_for_file_list_table.rs
+++ b/src/infra/src/table/migration/m20250822_093713_add_updated_at_for_file_list_table.rs
@@ -1,0 +1,109 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use sea_orm::Statement;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const UPDATED_AT_DELETED_IDX: &str = "file_list_updated_at_deleted_idx";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // create field first
+        manager.alter_table(add_updated_at_column_stmnt()).await?;
+        // create index first
+        manager.create_index(create_updated_at_idx_stmnt()).await?;
+        // set default value for existing rows
+        set_updated_at_for_existing_rows(manager).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(Index::drop().name(UPDATED_AT_DELETED_IDX).to_owned())
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(FileList::Table)
+                    .drop_column(FileList::UpdatedAt)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+/// Statement to add updated_at column to the file_list table.
+fn add_updated_at_column_stmnt() -> TableAlterStatement {
+    Table::alter()
+        .table(FileList::Table)
+        .add_column(
+            ColumnDef::new(FileList::UpdatedAt)
+                .big_integer()
+                .not_null()
+                .default(0),
+        )
+        .to_owned()
+}
+
+/// Statement to create index on the updated_at and deleted columns of the file_list table.
+fn create_updated_at_idx_stmnt() -> IndexCreateStatement {
+    sea_query::Index::create()
+        .if_not_exists()
+        .name(UPDATED_AT_DELETED_IDX)
+        .table(FileList::Table)
+        .col(FileList::UpdatedAt)
+        .col(FileList::Deleted)
+        .to_owned()
+}
+
+/// Set updated_at for existing rows. use the value of min_ts field to set the updated_at field.
+async fn set_updated_at_for_existing_rows(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    // Update existing rows with updated_at = min_ts where updated_at = 0
+    let db = manager.get_connection();
+    let backend = db.get_database_backend();
+
+    log::info!("[FILE_LIST_MIGRATION] db backend: {backend:?}");
+
+    let update_query = Query::update()
+        .table(FileList::Table)
+        .value(FileList::UpdatedAt, Expr::col(FileList::MinTs))
+        .and_where(Expr::col(FileList::UpdatedAt).eq(0))
+        .to_owned();
+
+    let (sql, values) = match backend {
+        sea_orm::DatabaseBackend::MySql => update_query.build(MysqlQueryBuilder),
+        sea_orm::DatabaseBackend::Postgres => update_query.build(PostgresQueryBuilder),
+        sea_orm::DatabaseBackend::Sqlite => update_query.build(SqliteQueryBuilder),
+    };
+    let statement = Statement::from_sql_and_values(backend, sql, values);
+    let ret = db.execute(statement).await?;
+    log::info!("[FILE_LIST_MIGRATION] updated {} rows", ret.rows_affected());
+
+    Ok(())
+}
+
+/// Identifiers used in queries on the alerts table.
+#[derive(DeriveIden)]
+enum FileList {
+    Table,
+    UpdatedAt,
+    Deleted,
+    MinTs,
+}

--- a/src/infra/src/table/migration/m20250822_093713_add_updated_at_for_file_list_table.rs
+++ b/src/infra/src/table/migration/m20250822_093713_add_updated_at_for_file_list_table.rs
@@ -36,7 +36,8 @@ impl MigrationTrait for Migration {
     }
 }
 
-/// Set created_at and updated_at for existing rows. use the value of min_ts field to set both fields.
+/// Set created_at and updated_at for existing rows. use the value of min_ts field to set both
+/// fields.
 async fn set_updated_at_for_existing_rows(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
     // Update existing rows with created_at = min_ts and updated_at = min_ts where updated_at = 0
     let db = manager.get_connection();
@@ -78,7 +79,10 @@ async fn truncate_stream_stats_table(manager: &SchemaManager<'_>) -> Result<(), 
 
     let statement = Statement::from_string(backend, truncate_query);
     let ret = db.execute(statement).await?;
-    log::debug!("[FILE_LIST_MIGRATION] Truncated stream_stats table, affected rows: {}", ret.rows_affected());
+    log::debug!(
+        "[FILE_LIST_MIGRATION] Truncated stream_stats table, affected rows: {}",
+        ret.rows_affected()
+    );
 
     Ok(())
 }
@@ -90,11 +94,15 @@ async fn clean_compactor_offset(manager: &SchemaManager<'_>) -> Result<(), DbErr
 
     log::debug!("[FILE_LIST_MIGRATION] Cleaning compactor offset");
 
-    let delete_query = "DELETE FROM meta WHERE module='compact' AND key1='stream_stats' AND key2='offset'";
+    let delete_query =
+        "DELETE FROM meta WHERE module='compact' AND key1='stream_stats' AND key2='offset'";
 
     let statement = Statement::from_string(backend, delete_query.to_string());
     let ret = db.execute(statement).await?;
-    log::debug!("[FILE_LIST_MIGRATION] Cleaned compactor offset, affected rows: {}", ret.rows_affected());
+    log::debug!(
+        "[FILE_LIST_MIGRATION] Cleaned compactor offset, affected rows: {}",
+        ret.rows_affected()
+    );
 
     Ok(())
 }

--- a/src/infra/src/table/migration/mod.rs
+++ b/src/infra/src/table/migration/mod.rs
@@ -54,7 +54,6 @@ mod m20250213_000001_add_dashboard_updated_at;
 mod m20250217_115548_ratelimit_table;
 mod m20250320_000001_remove_alert_name_unique_constraint;
 mod m20250422_000001_add_alert_align_time;
-#[cfg(feature = "cloud")]
 mod m20250520_000001_add_trial_end_col;
 mod m20250611_000001_create_reports_table;
 mod m20250611_000002_populate_reports_table;
@@ -64,6 +63,7 @@ mod m20250612_000002_create_re_pattern_stream_map_table;
 mod m20250716_000001_create_enrichment_table;
 mod m20250731_000001_create_compactor_manual_jobs;
 mod m20250801_000001_create_system_prompts_table;
+mod m20250822_093713_add_updated_at_for_file_list_table;
 
 pub struct Migrator;
 
@@ -91,8 +91,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20241227_000200_create_users_table::Migration),
             Box::new(m20241227_000300_create_org_users_table::Migration),
             Box::new(m20241227_000400_populate_users_table::Migration),
-            // TODO: Include this in a future pr
-            // Box::new(m20241227_000500_delete_meta_users_table::Migration),
+            Box::new(m20241227_000500_delete_meta_users_table::Migration),
             Box::new(m20250107_160900_delete_bad_dashboards::Migration),
             Box::new(m20250109_092400_recreate_tables_with_ksuids::Migration),
             Box::new(m20250113_144600_create_unique_folder_name_idx::Migration),
@@ -100,17 +99,16 @@ impl MigratorTrait for Migrator {
             Box::new(m20250122_000001_create_table_action_scripts::Migration),
             Box::new(m20250124_000001_create_timed_annotations_table::Migration),
             Box::new(m20250124_000002_create_timed_annotation_panels_table::Migration),
+            Box::new(m20250125_102300_create_destinations_table::Migration),
             Box::new(m20250125_115400_create_templates_table::Migration),
             Box::new(m20250125_132500_populate_templates_table::Migration),
-            Box::new(m20250125_172300_delete_metas_templates::Migration),
-            Box::new(m20250125_102300_create_destinations_table::Migration),
             Box::new(m20250125_133700_populate_destinations_table::Migration),
             Box::new(m20250125_153005_delete_metas_destinations::Migration),
+            Box::new(m20250125_172300_delete_metas_templates::Migration),
             Box::new(m20250213_000001_add_dashboard_updated_at::Migration),
             Box::new(m20250217_115548_ratelimit_table::Migration),
             Box::new(m20250320_000001_remove_alert_name_unique_constraint::Migration),
             Box::new(m20250422_000001_add_alert_align_time::Migration),
-            #[cfg(feature = "cloud")]
             Box::new(m20250520_000001_add_trial_end_col::Migration),
             Box::new(m20250611_000001_create_reports_table::Migration),
             Box::new(m20250611_000002_populate_reports_table::Migration),
@@ -120,6 +118,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250716_000001_create_enrichment_table::Migration),
             Box::new(m20250731_000001_create_compactor_manual_jobs::Migration),
             Box::new(m20250801_000001_create_system_prompts_table::Migration),
+            Box::new(m20250822_093713_add_updated_at_for_file_list_table::Migration),
         ]
     }
 }

--- a/src/job/file_list_dump.rs
+++ b/src/job/file_list_dump.rs
@@ -61,6 +61,8 @@ pub static FILE_LIST_SCHEMA: Lazy<Arc<Schema>> = Lazy::new(|| {
         Field::new("original_size", arrow_schema::DataType::Int64, false),
         Field::new("compressed_size", arrow_schema::DataType::Int64, false),
         Field::new("index_size", arrow_schema::DataType::Int64, true),
+        Field::new("created_at", arrow_schema::DataType::Int64, false),
+        Field::new("updated_at", arrow_schema::DataType::Int64, false),
     ]))
 });
 
@@ -328,6 +330,8 @@ fn create_record_batch(files: Vec<FileRecord>) -> Result<RecordBatch, anyhow::Er
     let mut field_compressed_size = Int64Builder::with_capacity(batch_size);
     let mut field_index_size = Int64Builder::with_capacity(batch_size);
     let mut field_flattened = BooleanBuilder::with_capacity(batch_size);
+    let mut field_created_at = Int64Builder::with_capacity(batch_size);
+    let mut field_updated_at = Int64Builder::with_capacity(batch_size);
 
     for file in files {
         field_id.append_value(file.id);
@@ -344,6 +348,8 @@ fn create_record_batch(files: Vec<FileRecord>) -> Result<RecordBatch, anyhow::Er
         field_compressed_size.append_value(file.compressed_size);
         field_index_size.append_value(file.index_size);
         field_flattened.append_value(file.flattened);
+        field_created_at.append_value(file.created_at);
+        field_updated_at.append_value(file.updated_at);
     }
 
     let batch = RecordBatch::try_new(
@@ -363,6 +369,8 @@ fn create_record_batch(files: Vec<FileRecord>) -> Result<RecordBatch, anyhow::Er
             Arc::new(field_original_size.finish()),
             Arc::new(field_compressed_size.finish()),
             Arc::new(field_index_size.finish()),
+            Arc::new(field_created_at.finish()),
+            Arc::new(field_updated_at.finish()),
         ],
     )?;
     Ok(batch)

--- a/src/wal/src/reader.rs
+++ b/src/wal/src/reader.rs
@@ -225,7 +225,7 @@ where
         // Log timing breakdown if slow
         if total_duration.as_millis() > 100 {
             log::warn!(
-                "[WAL Reader] SLOW _read_entry: {}ms total (checksum_read: {}μs, length_read: {}μs, data_setup: {}μs, decompress: {}ms, crc_verify: {}μs, validation: {}μs) - data_len: {}, compressed_len: {}",
+                "[WAL Reader] SLOW _read_entry: {}ms (checksum_read: {}μs, length_read: {}μs, data_setup: {}μs, decompress: {}ms, crc_verify: {}μs, validation: {}μs), data_len: {}, compressed_len: {}",
                 total_duration.as_millis(),
                 checksum_read_duration.as_micros(),
                 length_read_duration.as_micros(),


### PR DESCRIPTION
impl #8069 

The final solution is:

We add two fields for `file_list` table. `created_at` and `updated_at`. then we calculate stats by a single SQL with a step `10` minutes.

## Ingest data

set `created_at` and `updated_at` both to `NOW`

## Compact data

set `updated_at=NOW AND deleted=TRUE` for merged files.

## Stream stats

- Write last checked updated_at as offset. 
- Next round we only get the files `updated_at > last_check_time`.
- To avoid too many records per batch, we using `ZO_CALCULATE_STATS_STEP_LIMIT=600`, 10m as a step. every batch we only calculate the data in 10 minutes.
- No longer calculate by org, so the query can avoid multiple scan.
- Use single query to get the stats of all the streams.
- Update stream stats and delete files which marked as `deleted is TRUE` in one transcation.

```sql
SELECT 
    stream,
    MIN(CASE WHEN deleted IS FALSE THEN min_ts END) AS min_ts,
    MAX(CASE WHEN deleted IS FALSE THEN max_ts END) AS max_ts,
    SUM(CASE 
        WHEN deleted IS TRUE AND created_at <= {min} THEN -1
        WHEN deleted IS FALSE THEN 1
        ELSE 0
    END)::BIGINT AS file_num,
    SUM(CASE 
        WHEN deleted IS TRUE AND created_at <= {min} THEN -records
        WHEN deleted IS FALSE THEN records
        ELSE 0
    END)::BIGINT AS records,
    SUM(CASE 
        WHEN deleted IS TRUE AND created_at <= {min} THEN -original_size
        WHEN deleted IS FALSE THEN original_size
        ELSE 0
    END)::BIGINT AS original_size,
    SUM(CASE 
        WHEN deleted IS TRUE AND created_at <= {min} THEN -compressed_size
        WHEN deleted IS FALSE THEN compressed_size
        ELSE 0
    END)::BIGINT AS compressed_size,
    SUM(CASE 
        WHEN deleted IS TRUE AND created_at <= {min} THEN -index_size
        WHEN deleted IS FALSE THEN index_size
        ELSE 0
    END)::BIGINT AS index_size
FROM file_list
WHERE updated_at > {min} AND updated_at <= {max}
GROUP BY stream
```