### PR TITLE
fix: sql generation for quick alerts

### DIFF
--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -743,7 +743,7 @@ async fn build_sql(
         && !group.is_empty()
     {
         sql = format!(
-            "SELECT {}, {} AS alert_agg_value, MIN({}) as zo_sql_min_time, MAX({}) AS zo_sql_max_time FROM \"{}\" {} GROUP BY {} HAVING {}",
+            "SELECT {}, {} AS alert_agg_value, MIN({}) as zo_sql_min_time, MAX({}) AS zo_sql_max_time FROM \"{}\"  WHERE {} GROUP BY {} HAVING {}",
             group.join(", "),
             func_expr,
             TIMESTAMP_COL_NAME,
@@ -756,7 +756,7 @@ async fn build_sql(
     }
     if sql.is_empty() {
         sql = format!(
-            "SELECT {func_expr} AS alert_agg_value, MIN({TIMESTAMP_COL_NAME}) as zo_sql_min_time, MAX({TIMESTAMP_COL_NAME}) AS zo_sql_max_time FROM \"{stream_name}\" {where_sql} HAVING {having_expr}"
+            "SELECT {func_expr} AS alert_agg_value, MIN({TIMESTAMP_COL_NAME}) as zo_sql_min_time, MAX({TIMESTAMP_COL_NAME}) AS zo_sql_max_time FROM \"{stream_name}\"  {where_sql} HAVING {having_expr}"
         );
     }
     Ok(sql)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix WHERE placement in grouped alert SQL

- Ensure filter applied before GROUP BY/HAVING

- Minor spacing cleanup in non-grouped query


___

### Diagram Walkthrough


```mermaid
flowchart LR
  buildSQL["build_sql in alerts/mod.rs"]
  groupCase["Grouped query path"]
  noGroupCase["Non-grouped query path"]
  bug["WHERE placed after FROM"]
  fix["Move WHERE before GROUP BY/HAVING"]

  buildSQL -- "when group_by present" --> groupCase
  groupCase -- "was" --> bug
  bug -- "now" --> fix

  buildSQL -- "when no group_by" --> noGroupCase
  noGroupCase -- "retain WHERE placement" --> fix
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Correct SQL clause ordering for grouped alert queries</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/alerts/mod.rs

<ul><li>In grouped path, insert WHERE before GROUP BY/HAVING.<br> <li> Replace extraneous space and ensure proper clause order.<br> <li> Keep WHERE inclusion in non-grouped path; minor spacing tweak.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8169/files#diff-ba9b65130898444f7815fd6068bdb0dc590612f74cc893f79d91b0afc44cc851">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

