### PR TITLE
fix: unify cache delay secs across result cache, aggs cache and metrics

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1046,12 +1046,6 @@ pub struct Common {
     )]
     pub result_cache_selection_strategy: String,
     #[env_config(
-        name = "ZO_RESULT_CACHE_DISCARD_DURATION",
-        default = 60,
-        help = "Discard data of last n seconds from cached results"
-    )]
-    pub result_cache_discard_duration: i64,
-    #[env_config(
         name = "ZO_METRICS_CACHE_ENABLED",
         default = true,
         help = "Enable result cache for PromQL metrics queries"
@@ -1446,6 +1440,8 @@ pub struct Limit {
         default = true
     )]
     pub histogram_enabled: bool,
+    #[env_config(name = "ZO_CACHE_DELAY_SECS", default = 300)] // seconds
+    pub cache_delay_secs: i64,
 }
 
 #[derive(EnvConfig)]
@@ -1592,12 +1588,6 @@ pub struct DiskCache {
     pub multi_dir: String,
     #[env_config(name = "ZO_DISK_AGGREGATION_CACHE_MAX_SIZE", default = 0)]
     pub aggregation_max_size: usize,
-    #[env_config(
-        name = "ZO_DISK_CACHE_DELAY_WINDOW_MINS",
-        default = 10,
-        help = "Delay window indicates the time range from now to skip caching to disk, default is 10 minutes"
-    )]
-    pub delay_window_mins: i64,
 }
 
 #[derive(EnvConfig)]

--- a/src/service/promql/search/cache/mod.rs
+++ b/src/service/promql/search/cache/mod.rs
@@ -225,7 +225,7 @@ pub async fn set(
 ) -> Result<()> {
     // check time range, if over ZO_MAX_FILE_RETENTION_TIME, return
     let cfg = get_config();
-    let max_ts = now_micros() - second_micros(cfg.limit.max_file_retention_time as i64);
+    let max_ts = now_micros() - second_micros(cfg.limit.cache_delay_secs as i64);
     let new_end = if end > max_ts { max_ts } else { end };
     if range_values.is_empty() || start >= max_ts || new_end <= start + step {
         // all of the data in retention time, no need to store
@@ -521,7 +521,7 @@ mod tests {
             exemplars: None,
             time_window: None,
         }];
-        let max_ts = end - second_micros(get_config().limit.max_file_retention_time as i64);
+        let max_ts = end - second_micros(get_config().limit.cache_delay_secs as i64);
         let mut valid_max_ts = 0;
         for i in 0..((end - start + step) / step) {
             let ts = start + step * i;

--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -18,7 +18,11 @@ use chrono::Utc;
 use config::{
     TIMESTAMP_COL_NAME, get_config,
     meta::{search::Response, sql::OrderBy, stream::StreamType},
-    utils::{file::scan_files, json, time::now_micros},
+    utils::{
+        file::scan_files,
+        json,
+        time::{now_micros, second_micros},
+    },
 };
 use infra::cache::{
     file_data::disk::{self, QUERY_RESULT_CACHE},
@@ -413,7 +417,7 @@ pub async fn get_cached_results(
                 let mut matching_cache_meta = matching_meta.clone();
                 // calculate delta time range to fetch the delta data using search query
                 let cfg = get_config();
-                let discard_duration = cfg.common.result_cache_discard_duration * 1000 * 1000;
+                let discard_duration = second_micros(cfg.limit.cache_delay_secs);
 
                 let cache_duration = matching_cache_meta.end_time - matching_cache_meta.start_time;
                 // return None if cache duration is less than 2 * discard_duration

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -33,7 +33,7 @@ use config::{
         hash::Sum64,
         json,
         sql::{is_aggregate_query, is_eligible_for_histogram},
-        time::format_duration,
+        time::{format_duration, second_micros},
     },
 };
 use infra::{
@@ -752,7 +752,7 @@ pub async fn _write_results(
     let first_rec_ts = get_ts_value(ts_column, local_resp.hits.first().unwrap());
 
     let smallest_ts = std::cmp::min(first_rec_ts, last_rec_ts);
-    let discard_duration = get_config().common.result_cache_discard_duration * 1000 * 1000;
+    let discard_duration = second_micros(get_config().limit.cache_delay_secs);
 
     if (last_rec_ts - first_rec_ts).abs() < discard_duration
         && smallest_ts > Utc::now().timestamp_micros() - discard_duration
@@ -910,7 +910,7 @@ pub async fn write_results_v2(
     let first_rec_ts = get_ts_value(ts_column, local_resp.hits.first().unwrap());
 
     let smallest_ts = std::cmp::min(first_rec_ts, last_rec_ts);
-    let discard_duration = get_config().common.result_cache_discard_duration * 1000 * 1000;
+    let discard_duration = second_micros(get_config().limit.cache_delay_secs);
 
     if (last_rec_ts - first_rec_ts).abs() < discard_duration
         && smallest_ts > Utc::now().timestamp_micros() - discard_duration

--- a/src/service/search/cache/multi.rs
+++ b/src/service/search/cache/multi.rs
@@ -17,7 +17,11 @@ use std::str::FromStr;
 
 use async_recursion::async_recursion;
 use chrono::Utc;
-use config::{get_config, meta::search::Response, utils::json};
+use config::{
+    get_config,
+    meta::search::Response,
+    utils::{json, time::second_micros},
+};
 use infra::cache::{file_data::disk::QUERY_RESULT_CACHE, meta::ResultCacheMeta};
 
 use super::{cacher::get_results, sort_response};
@@ -142,7 +146,7 @@ async fn recursive_process_multiple_metas(
 
         // Calculate delta time range to fetch the delta data using search query
         let cfg = get_config();
-        let discard_duration = cfg.common.result_cache_discard_duration * 1000 * 1000;
+        let discard_duration = second_micros(cfg.limit.cache_delay_secs);
 
         let cache_duration = matching_cache_meta.end_time - matching_cache_meta.start_time;
         if


### PR DESCRIPTION
## New Env:

- `ZO_CACHE_DELAY_SECS` default 300 secs (5mins)