### PR TITLE
fix: visualization sync for saved views (#8168)

### DIFF
--- a/web/src/components/dashboards/addPanel/PanelSidebar.vue
+++ b/web/src/components/dashboards/addPanel/PanelSidebar.vue
@@ -35,7 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         data-test="dashboard-sidebar-collapse-btn"
       />
     </div>
-    <q-separator style="margin-top: -1px" />
+    <q-separator style="margin-top: -1px; flex-shrink: 0;" />
     <div class="sidebar-content scroll" v-if="isOpen">
       <slot></slot>
     </div>
@@ -85,6 +85,9 @@ export default defineComponent({
   position: relative;
   width: 50px;
   height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar.open {
@@ -108,6 +111,7 @@ export default defineComponent({
   justify-content: space-between;
   height: 60px;
   padding: 0 10px;
+  flex-shrink: 0;
 }
 
 .collapsed-icon {
@@ -133,7 +137,8 @@ export default defineComponent({
 
 .sidebar-content {
   padding: 0px 10px;
-  height: calc(100vh - 176px);
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 </style>

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -2018,7 +2018,7 @@ export default defineComponent({
         const allFieldsHaveAlias = allSelectionFieldsHaveAlias(finalQuery);
         if (!allFieldsHaveAlias) {
           showAliasErrorForVisualization(
-            "All fields must have alias to visualize, please add alias to all fields",
+            "Fields using aggregation functions must have aliases to visualize.",
           );
           variablesAndPanelsDataLoadingState.fieldsExtractionLoading = false;
           return null;

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -1663,6 +1663,8 @@ export default defineComponent({
       getJobData,
       routeToSearchSchedule,
       isActionsEnabled,
+      getVisualizationConfig,
+      encodeVisualizationConfig,
     } = useLogs();
 
     const { isStreamExists, isStreamFetched } = useStreams();
@@ -2543,6 +2545,34 @@ export default defineComponent({
       savedViewDropdownModel.value = false;
     };
 
+    // Common function to restore visualization data and sync to URL
+    const restoreVisualizationData = async (visualizationData) => {
+      if (!visualizationData) return;
+
+      // Restore visualization config to dashboardPanelData
+      if (visualizationData.config) {
+        dashboardPanelData.data.config = visualizationData.config;
+      }
+      if (visualizationData.type) {
+        dashboardPanelData.data.type = visualizationData.type;
+      }
+
+      // Sync visualization data to URL
+      const currentVisualizationData = getVisualizationConfig(dashboardPanelData);
+      if (currentVisualizationData) {
+        const encoded = encodeVisualizationConfig(currentVisualizationData);
+        if (encoded) {
+          const currentQuery = { ...router.currentRoute.value.query };
+          currentQuery.visualization_data = encoded;
+
+          await router.replace({
+            name: router.currentRoute.value.name,
+            query: currentQuery
+          });
+        }
+      }
+    };
+
     const applySavedView = async (item) => {
       await cancelQuery();
       searchObj.shouldIgnoreWatcher = true;
@@ -2650,6 +2680,11 @@ export default defineComponent({
               extractedObj.meta.scrollInfo = {};
               mergeDeep(searchObj, extractedObj);
               searchObj.shouldIgnoreWatcher = true;
+
+              // Restore visualization data if available
+              if (extractedObj.data.visualizationData) {
+                await restoreVisualizationData(extractedObj.data.visualizationData);
+              }
               // await nextTick();
               if (extractedObj.data.tempFunctionContent != "") {
                 populateFunctionImplementation(
@@ -2735,6 +2770,11 @@ export default defineComponent({
 
               mergeDeep(searchObj, extractedObj);
               searchObj.data.streamResults = {};
+
+              // Restore visualization data if available
+              if (extractedObj.data.visualizationData) {
+                await restoreVisualizationData(extractedObj.data.visualizationData);
+              }
 
               const streamData = await getStreams(
                 searchObj.data.stream.streamType,
@@ -2990,6 +3030,14 @@ export default defineComponent({
 
         if (savedSearchObj.data.parsedQuery) {
           delete savedSearchObj.data.parsedQuery;
+        }
+
+        // Include visualization data if in visualization mode
+        if (searchObj.meta.logsVisualizeToggle === "visualize" && dashboardPanelData) {
+          const visualizationData = getVisualizationConfig(dashboardPanelData);
+          if (visualizationData) {
+            savedSearchObj.data.visualizationData = visualizationData;
+          }
         }
 
         return savedSearchObj;
@@ -3498,7 +3546,7 @@ export default defineComponent({
         // validate sql query that all fields have alias
         if (!allSelectionFieldsHaveAlias(logsPageQuery)) {
           showErrorNotification(
-            "All fields must have alias in query to visualize",
+            "Fields using aggregation functions must have aliases to visualize.",
           );
           return;
         }

--- a/web/src/plugins/logs/VisualizeLogsQuery.vue
+++ b/web/src/plugins/logs/VisualizeLogsQuery.vue
@@ -197,7 +197,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </div>
               <q-separator vertical />
-              <div class="col-auto">
+              <div class="col-auto" style="height: 100%;">
                 <PanelSidebar
                   :title="t('dashboard.configLabel')"
                   v-model="dashboardPanelData.layout.isConfigPanelOpen"
@@ -354,7 +354,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </div>
               <q-separator vertical />
-              <div class="col-auto">
+              <div class="col-auto" style="height: 100%;">
                 <PanelSidebar
                   :title="t('dashboard.configLabel')"
                   v-model="dashboardPanelData.layout.isConfigPanelOpen"

--- a/web/src/views/Dashboards/addPanel/AddPanel.vue
+++ b/web/src/views/Dashboards/addPanel/AddPanel.vue
@@ -276,7 +276,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </div>
               <q-separator vertical />
-              <div class="col-auto">
+              <div class="col-auto" style="height: 100%;">
                 <PanelSidebar
                   :title="t('dashboard.configLabel')"
                   v-model="dashboardPanelData.layout.isConfigPanelOpen"
@@ -457,7 +457,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </div>
               <q-separator vertical />
-              <div class="col-auto">
+              <div class="col-auto" style="height: 100%;">
                 <PanelSidebar
                   :title="t('dashboard.configLabel')"
                   v-model="dashboardPanelData.layout.isConfigPanelOpen"


### PR DESCRIPTION
### **User description**
- Save visualization which contains Dashboard configs as a Saved view.
- CSS issue for config on visualization page.
- `All fields must have alias to visualize` Error msg refactor.

**Note:** On the Logs to Visualize, we use the default chart type(line
or table chart). If a saved visualization view is applied from the Logs
page, it will switch to the Visualization page and select the default
chart type. However, applying a saved visualization view while already
on the Visualization page will work as expected.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Persist visualization config in saved views

- Sync visualization config to URL on apply

- Improve alias validation error messaging

- Fix sidebar layout and overflow behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SV["Saved View apply"] -- "merge extractedObj" --> SO["searchObj"]
  SO -- "has visualizationData?" --> RD["restoreVisualizationData()"]
  RD -- "set type/config" --> DPD["dashboardPanelData"]
  DPD -- "getVisualizationConfig()" --> VC["visualizationData"]
  VC -- "encode & push" --> URL["router.replace(query.visualization_data)"]

  Save["Save View action"] -- "collect visualizationData" --> SVObj["savedSearchObj.data.visualizationData"]

  UI1["PanelSidebar.vue"] -- "flex layout & shrink fixes" --> UX["Stable sidebar height/scroll"]
  UI2["VisualizeLogsQuery/AddPanel"] -- "full height sidebar container" --> UX
  Valid["Alias validation"] -- "refined messages" --> UX
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PanelSidebar.vue</strong><dd><code>Make sidebar flex-based with stable scrolling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/PanelSidebar.vue

<ul><li>Prevent separator shrinking via flex-shrink.<br> <li> Sidebar becomes flex column with min-height fixes.<br> <li> Header marked non-shrinking.<br> <li> Content uses flex:1 with proper overflow.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8176/files#diff-8e63f9f02875ae5308688ef83d5a8d12383dd32b298475e85a210d6c7334af79">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SearchBar.vue</strong><dd><code>Persist and restore visualization config for saved views</code>&nbsp; </dd></summary>
<hr>

web/src/plugins/logs/SearchBar.vue

<ul><li>Import helpers to get/encode visualization config.<br> <li> Add restoreVisualizationData to set config/type and sync URL.<br> <li> Apply restoration when loading saved views.<br> <li> Include visualizationData when saving views in visualize mode.<br> <li> Refine alias validation error message.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8176/files#diff-81893de4edf186b0556f610acb280c87baa2ffe67d3b48a60a866094c7635baf">+49/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>VisualizeLogsQuery.vue</strong><dd><code>Full-height container for config sidebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/VisualizeLogsQuery.vue

- Ensure config sidebar container takes full height (two places).


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8176/files#diff-979b01d943d58c5d70faeeac5948b7f02f0b2392a12b84ef07ba7f7393ab0261">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AddPanel.vue</strong><dd><code>Full-height PanelSidebar in add panel views</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/Dashboards/addPanel/AddPanel.vue

- Ensure PanelSidebar container takes full height in both layouts.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8176/files#diff-c9632db1ad95af95aba10161bcbc7c5608318919f228637bdafae3f3a31267e8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Clarify alias requirement error text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/Index.vue

- Refine alias validation error message.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8176/files#diff-0323c3da69b369843c5d72bf4df5b00ca6b5147192a213baf331659ecf92af62">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

