### PR TITLE
fix: visualization sync for saved views (#8168)

### DIFF
--- a/web/src/components/dashboards/addPanel/PanelSidebar.vue
+++ b/web/src/components/dashboards/addPanel/PanelSidebar.vue
@@ -35,7 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         data-test="dashboard-sidebar-collapse-btn"
       />
     </div>
-    <q-separator style="margin-top: -1px" />
+    <q-separator style="margin-top: -1px; flex-shrink: 0;" />
     <div class="sidebar-content scroll" v-if="isOpen">
       <slot></slot>
     </div>
@@ -85,6 +85,9 @@ export default defineComponent({
   position: relative;
   width: 50px;
   height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar.open {
@@ -108,6 +111,7 @@ export default defineComponent({
   justify-content: space-between;
   height: 60px;
   padding: 0 10px;
+  flex-shrink: 0;
 }
 
 .collapsed-icon {
@@ -133,7 +137,8 @@ export default defineComponent({
 
 .sidebar-content {
   padding: 0px 10px;
-  height: calc(100vh - 176px);
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 </style>

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -2012,7 +2012,7 @@ export default defineComponent({
         const allFieldsHaveAlias = allSelectionFieldsHaveAlias(finalQuery);
         if (!allFieldsHaveAlias) {
           showAliasErrorForVisualization(
-            "All fields must have alias to visualize, please add alias to all fields",
+            "Fields using aggregation functions must have aliases to visualize.",
           );
           variablesAndPanelsDataLoadingState.fieldsExtractionLoading = false;
           return null;

--- a/web/src/plugins/logs/VisualizeLogsQuery.vue
+++ b/web/src/plugins/logs/VisualizeLogsQuery.vue
@@ -197,7 +197,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </div>
               <q-separator vertical />
-              <div class="col-auto">
+              <div class="col-auto" style="height: 100%;">
                 <PanelSidebar
                   :title="t('dashboard.configLabel')"
                   v-model="dashboardPanelData.layout.isConfigPanelOpen"
@@ -354,7 +354,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </div>
               <q-separator vertical />
-              <div class="col-auto">
+              <div class="col-auto" style="height: 100%;">
                 <PanelSidebar
                   :title="t('dashboard.configLabel')"
                   v-model="dashboardPanelData.layout.isConfigPanelOpen"

--- a/web/src/views/Dashboards/addPanel/AddPanel.vue
+++ b/web/src/views/Dashboards/addPanel/AddPanel.vue
@@ -276,7 +276,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </div>
               <q-separator vertical />
-              <div class="col-auto">
+              <div class="col-auto" style="height: 100%;">
                 <PanelSidebar
                   :title="t('dashboard.configLabel')"
                   v-model="dashboardPanelData.layout.isConfigPanelOpen"
@@ -457,7 +457,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </div>
               <q-separator vertical />
-              <div class="col-auto">
+              <div class="col-auto" style="height: 100%;">
                 <PanelSidebar
                   :title="t('dashboard.configLabel')"
                   v-model="dashboardPanelData.layout.isConfigPanelOpen"


### PR DESCRIPTION
### **User description**
- Save visualization which contains Dashboard configs as a Saved view.
- CSS issue for config on visualization page.
- `All fields must have alias to visualize` Error msg refactor.

**Note:** On the Logs to Visualize, we use the default chart type(line
or table chart). If a saved visualization view is applied from the Logs
page, it will switch to the Visualization page and select the default
chart type. However, applying a saved visualization view while already
on the Visualization page will work as expected.