### PR TITLE
fix: skip alert evaluation when stream not found

### DIFF
--- a/src/infra/src/schema/mod.rs
+++ b/src/infra/src/schema/mod.rs
@@ -64,6 +64,20 @@ pub fn set_stream_settings_atomic(settings: StreamSettingsCache) {
     STREAM_SETTINGS_ATOMIC.store(Arc::new(settings));
 }
 
+pub async fn get_stream_schema_from_cache(
+    org_id: &str,
+    stream_name: &str,
+    stream_type: StreamType,
+) -> Option<Schema> {
+    let key = mk_key(org_id, stream_type, stream_name);
+    let cache_key = key.strip_prefix("/schema/").unwrap();
+    STREAM_SCHEMAS_LATEST
+        .read()
+        .await
+        .get(cache_key)
+        .map(|schema| schema.schema().as_ref().clone())
+}
+
 pub fn mk_key(org_id: &str, stream_type: StreamType, stream_name: &str) -> String {
     format!("/schema/{org_id}/{stream_type}/{stream_name}")
 }

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -221,8 +221,9 @@ impl QueryConditionExt for QueryCondition {
         // SQL may contain multiple stream names, check for each stream
         // if the query period is greater than the max query range
         for stream in stream_names.iter() {
-            if let None =
-                infra::schema::get_stream_schema_from_cache(org_id, stream, stream_type).await
+            if infra::schema::get_stream_schema_from_cache(org_id, stream, stream_type)
+                .await
+                .is_none()
             {
                 return Err(anyhow::anyhow!(
                     "Stream \"{stream}\" not found in schema, skipping alert evaluation"

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -221,6 +221,14 @@ impl QueryConditionExt for QueryCondition {
         // SQL may contain multiple stream names, check for each stream
         // if the query period is greater than the max query range
         for stream in stream_names.iter() {
+            if let None =
+                infra::schema::get_stream_schema_from_cache(org_id, stream, stream_type).await
+            {
+                return Err(anyhow::anyhow!(
+                    "Stream \"{stream}\" not found in schema, skipping alert evaluation"
+                ));
+            };
+
             if let Some(settings) = infra::schema::get_settings(org_id, stream, stream_type).await {
                 let max_query_range = settings.max_query_range;
                 if max_query_range > 0 && trigger_condition.period > max_query_range * 60 {


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add schema cache lookup helper

- Skip alert evaluation if stream missing

- Improve error message for missing stream


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Alert evaluation"] -- "resolve stream names" --> B["Per-stream checks"]
  B -- "schema missing" --> C["Return error: skip evaluation"]
  B -- "schema exists" --> D["Fetch settings & validate period"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Introduce schema cache lookup utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/schema/mod.rs

<ul><li>Add <code>get_stream_schema_from_cache</code> async helper.<br> <li> Build cache key via <code>mk_key</code> prefix strip.<br> <li> Return cloned <code>Schema</code> from <code>STREAM_SCHEMAS_LATEST</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8179/files#diff-386fd4fad1e48ab0a90516cab1947b1888b270b2fe912f30d2255cc38e6c519b">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Skip alerts when referenced stream missing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/alerts/mod.rs

<ul><li>Validate each referenced stream exists in schema cache.<br> <li> Short-circuit with clear error to skip evaluation.<br> <li> Keep existing max query range validation.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8179/files#diff-ba9b65130898444f7815fd6068bdb0dc590612f74cc893f79d91b0afc44cc851">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

