### PR TITLE
fix: dashboard config height issue

### DIFF
--- a/web/src/components/dashboards/addPanel/PanelSidebar.vue
+++ b/web/src/components/dashboards/addPanel/PanelSidebar.vue
@@ -137,8 +137,7 @@ export default defineComponent({
 
 .sidebar-content {
   padding: 0px 10px;
-  flex: 1;
-  min-height: 0;
+  height: calc(100vh - 176px);
   overflow-y: auto;
 }
 </style>

--- a/web/src/views/Dashboards/addPanel/AddPanel.vue
+++ b/web/src/views/Dashboards/addPanel/AddPanel.vue
@@ -276,7 +276,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </div>
               <q-separator vertical />
-              <div class="col-auto" style="height: 100%;">
+              <div class="col-auto">
                 <PanelSidebar
                   :title="t('dashboard.configLabel')"
                   v-model="dashboardPanelData.layout.isConfigPanelOpen"
@@ -457,7 +457,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </div>
               <q-separator vertical />
-              <div class="col-auto" style="height: 100%;">
+              <div class="col-auto">
                 <PanelSidebar
                   :title="t('dashboard.configLabel')"
                   v-model="dashboardPanelData.layout.isConfigPanelOpen"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix sidebar height overflow in panel sidebar

- Remove redundant inline height on right column

- Ensure viewport-based sizing for config panel


___

### Diagram Walkthrough


```mermaid
flowchart LR
  View["AddPanel.vue layout"] -- "drop inline height" --> Column["Right column .col-auto"]
  Column -- "hosts" --> Sidebar["PanelSidebar.vue .sidebar-content"]
  Sidebar -- "set viewport height" --> CSS["height: calc(100vh - 176px)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PanelSidebar.vue</strong><dd><code>Use viewport-based height for sidebar content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/PanelSidebar.vue

<ul><li>Replace flex/min-height with fixed viewport-based height<br> <li> Keep vertical scroll via overflow-y: auto</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8201/files#diff-8e63f9f02875ae5308688ef83d5a8d12383dd32b298475e85a210d6c7334af79">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AddPanel.vue</strong><dd><code>Clean inline height to prevent overflow issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/Dashboards/addPanel/AddPanel.vue

<ul><li>Remove inline style height: 100% on right column<br> <li> Simplify layout to rely on CSS sizing</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8201/files#diff-c9632db1ad95af95aba10161bcbc7c5608318919f228637bdafae3f3a31267e8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

