### PR TITLE
fix: manually clear the input using updateInputValue function

### DIFF
--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   >
     <div>
       <q-select
+        ref="streamSelect"
         data-test="log-search-index-list-select-stream"
         v-model="searchObj.data.stream.selectedStream"
         :options="streamOptions"
@@ -814,6 +815,16 @@ export default defineComponent({
   emits: ["setInterestingFieldInSQLQuery"],
   methods: {
     handleMultiStreamSelection() {
+      // Clear the filter input when streams change
+      //we will first check if qselect is there or not and then call the method
+      //we will use the quasar next tick to ensure that the dom is updated before we call the method
+      //we will also us the quasar's updateInputValue method to clear the input value
+      this.$nextTick(() => {
+        const indexListSelectField = this.$refs.streamSelect;
+        if (indexListSelectField && indexListSelectField.updateInputValue) {
+          indexListSelectField.updateInputValue("");
+        }
+      });
       this.onStreamChange("");
     },
     handleSingleStreamSelect(opt: any) {
@@ -821,6 +832,16 @@ export default defineComponent({
         this.searchObj.data.stream.selectedFields = [];
       }
       this.searchObj.data.stream.selectedStream = [opt.value];
+      // Clear the filter input when single stream is selected
+      //we will first check if qselect is there or not and then call the method
+      //we will use the quasar next tick to ensure that the dom is updated before we call the method
+      //we will also us the quasar's updateInputValue method to clear the input value
+      this.$nextTick(() => {
+        const indexListSelectField = this.$refs.streamSelect;
+        if (indexListSelectField && indexListSelectField.updateInputValue) {
+          indexListSelectField.updateInputValue("");
+        }
+      });
       this.onStreamChange("");
     },
   },


### PR DESCRIPTION
### **User description**
1. in index list that is there in logs page when user adds any filter and clicks on the row instead of toggle , then the filter stays there it should be cleared


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Clear index filter after stream selection

- Add ref to stream select component

- Use Quasar updateInputValue via nextTick


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["IndexList.vue QSelect (stream)"] -- "ref=streamSelect" --> Ref["Access component ref"]
  Ref -- "nextTick" --> Safe["DOM ready"]
  Safe -- "updateInputValue('')" --> Clear["Clear filter input"]
  Clear -- "then" --> Change["Trigger onStreamChange(\"\")"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IndexList.vue</strong><dd><code>Clear QSelect input on stream selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/IndexList.vue

<ul><li>Add ref <code>streamSelect</code> to QSelect.<br> <li> Clear QSelect input on multi-stream change using nextTick + <br>updateInputValue.<br> <li> Clear QSelect input on single-stream select using nextTick + <br>updateInputValue.<br> <li> Keep existing stream change handling intact.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8203/files#diff-08f058f883b659e713e606991a7ea37ae1ff016b7cccef970489ab5840dc3d09">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

