### PR TITLE
fix: improve write flush logic

### DIFF
--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -206,15 +206,15 @@ pub async fn check_ttl() -> Result<()> {
 }
 
 pub async fn flush_all() -> Result<()> {
+    log::info!("[INGESTER:MEM] start flush all writers");
     for w in WRITERS.iter() {
         let mut w = w.write().await;
         let keys = w.keys().cloned().collect::<Vec<_>>();
-        for r in w.values() {
-            r.close().await?; // close writer
-            metrics::INGEST_MEMTABLE_FILES.with_label_values(&[]).dec();
-        }
         for key in keys {
-            w.remove(&key);
+            if let Some(r) = w.remove(&key) {
+                r.flush().await?; // close writer
+                metrics::INGEST_MEMTABLE_FILES.with_label_values(&[]).dec();
+            }
         }
     }
     Ok(())
@@ -487,7 +487,7 @@ impl Writer {
         Ok(())
     }
 
-    pub async fn close(&self) -> Result<()> {
+    pub async fn flush(&self) -> Result<()> {
         // wait for all messages to be processed
         if let Err(e) = self
             .write_queue
@@ -497,6 +497,7 @@ impl Writer {
             log::error!("[INGESTER:MEM:{}] close writer error: {}", self.idx, e);
         }
         self.write_queue.closed().await;
+        log::info!("[INGESTER:MEM:{}] writer queue closed", self.idx);
 
         // rotation wal
         let mut wal = self.wal.write().await;


### PR DESCRIPTION
The old logic will close write first then remove from WRITERS, but if close got problem, it never remove from WRITERS, then check ttl will get the writer and try to flush it, at the end, got error:
```
[INGESTER:MEM] writer queue rotate error: channel closed
```