### PR TITLE
fix: check if cache latest files enabled for cache local file

### DIFF
--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -796,7 +796,10 @@ async fn merge_files(
 
     // upload file
     let buf = Bytes::from(buf);
-    if cfg.cache_latest_files.cache_parquet && cfg.cache_latest_files.download_from_node {
+    if cfg.cache_latest_files.enabled
+        && cfg.cache_latest_files.cache_parquet
+        && cfg.cache_latest_files.download_from_node
+    {
         infra::cache::file_data::disk::set(&new_file_key, buf.clone()).await?;
         log::debug!("merge_files {new_file_key} file_data::disk::set success");
     }

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -931,7 +931,10 @@ pub async fn merge_files(
 
             // upload file to storage
             let buf = Bytes::from(buf);
-            if cfg.cache_latest_files.cache_parquet && cfg.cache_latest_files.download_from_node {
+            if cfg.cache_latest_files.enabled
+                && cfg.cache_latest_files.cache_parquet
+                && cfg.cache_latest_files.download_from_node
+            {
                 infra::cache::file_data::disk::set(&new_file_key, buf.clone()).await?;
                 log::debug!("merge_files {new_file_key} file_data::disk::set success");
             }
@@ -968,7 +971,9 @@ pub async fn merge_files(
 
                 // upload file to storage
                 let buf = Bytes::from(buf);
-                if cfg.cache_latest_files.cache_parquet && cfg.cache_latest_files.download_from_node
+                if cfg.cache_latest_files.enabled
+                    && cfg.cache_latest_files.cache_parquet
+                    && cfg.cache_latest_files.download_from_node
                 {
                     infra::cache::file_data::disk::set(&new_file_key, buf.clone()).await?;
                     log::debug!("merge_files {new_file_key} file_data::disk::set success");

--- a/src/service/tantivy/mod.rs
+++ b/src/service/tantivy/mod.rs
@@ -67,8 +67,10 @@ pub(crate) async fn create_tantivy_index(
         return Ok(0);
     };
 
-    if get_config().cache_latest_files.cache_index
-        && get_config().cache_latest_files.download_from_node
+    let cfg = get_config();
+    if cfg.cache_latest_files.enabled
+        && cfg.cache_latest_files.cache_index
+        && cfg.cache_latest_files.download_from_node
     {
         infra::cache::file_data::disk::set(&idx_file_name, Bytes::from(puffin_bytes.clone()))
             .await?;


### PR DESCRIPTION
### **User description**
We also should check if cache latest files enabled when we try to cache local file to disk cache.


___

### **PR Type**
Bug fix


___

### **Description**
- Guard caching with `enabled` flag

- Apply to parquet merge paths

- Apply to Tantivy index caching

- Prevent unintended disk writes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CFG["Config: cache_latest_files.enabled"]
  P1["parquet.rs merge_files"]
  M1["compact/merge.rs merge_files (path 1)"]
  M2["compact/merge.rs merge_files (path 2)"]
  T1["tantivy create_tantivy_index"]
  DISK["disk cache set(...)"]

  CFG -- "enabled && cache_* && download_from_node" --> P1
  CFG -- "enabled && cache_* && download_from_node" --> M1
  CFG -- "enabled && cache_* && download_from_node" --> M2
  CFG -- "enabled && cache_* && download_from_node" --> T1

  P1 -- "conditional write" --> DISK
  M1 -- "conditional write" --> DISK
  M2 -- "conditional write" --> DISK
  T1 -- "conditional write" --> DISK
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parquet.rs</strong><dd><code>Guard parquet caching with global enable flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/job/files/parquet.rs

<ul><li>Add <code>cfg.cache_latest_files.enabled</code> to condition<br> <li> Gate parquet disk caching on enabled flag</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8219/files#diff-27f710981cfe1b938aeeb53abaed05961596c32e2edf3b8a2a59d3e72b2f542b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>merge.rs</strong><dd><code>Enforce enabled flag in merge caching paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/compact/merge.rs

<ul><li>Add <code>enabled</code> check to first merge upload path<br> <li> Add <code>enabled</code> check to secondary merge upload path<br> <li> Prevent cache write when caching disabled</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8219/files#diff-0ab016dbd5129c9c285c9c459bf78928147bce97dc92a03aa754da3da71168d7">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Respect enabled flag for Tantivy index caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/tantivy/mod.rs

<ul><li>Store <code>get_config()</code> in <code>cfg</code><br> <li> Add <code>enabled</code> check to index caching condition</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8219/files#diff-68837d2f393b453002ec2d95f6882cfcaf70d9ef6547be2c9a890e8b0fc3c559">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

