### PR TITLE
fix: scan_stats for each node info

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2593,6 +2593,11 @@ fn check_disk_cache_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     let cache_dir = cache_dir.to_str().unwrap();
 
     // disable disk cache for local disk storage
+    if cfg.common.is_local_storage
+        && !cfg.common.result_cache_enabled
+        && !cfg.common.metrics_cache_enabled
+        && !cfg.common.feature_query_streaming_aggs
+    {
     if cfg.common.is_local_storage {
         cfg.disk_cache.enabled = false;
     }

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2593,11 +2593,7 @@ fn check_disk_cache_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     let cache_dir = cache_dir.to_str().unwrap();
 
     // disable disk cache for local disk storage
-    if cfg.common.is_local_storage
-        && !cfg.common.result_cache_enabled
-        && !cfg.common.metrics_cache_enabled
-        && !cfg.common.feature_query_streaming_aggs
-    {
+    if cfg.common.is_local_storage {
         cfg.disk_cache.enabled = false;
     }
 

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2598,7 +2598,6 @@ fn check_disk_cache_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         && !cfg.common.metrics_cache_enabled
         && !cfg.common.feature_query_streaming_aggs
     {
-    if cfg.common.is_local_storage {
         cfg.disk_cache.enabled = false;
     }
 


### PR DESCRIPTION
The currently printed scan_stats are accumulated as the node returns, but the scan_stats of a node itself should be output
this change only affect log output