### PR TITLE
fix: Add field to table in logs

### DIFF
--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -517,6 +517,9 @@ watch(
   () => {
     emits("update:columnOrder", columnOrder.value, props.columns);
   },
+  {
+    immediate: true,
+  },
 );
 
 let table: any = useVueTable({


### PR DESCRIPTION
#8249 
When a logs short URL is created and opened, trying to add a column to the table using the eye icon does not add the column.