### PR TITLE
fix: quick mode by default check explore 15

### DIFF
--- a/web/src/views/LogStream.vue
+++ b/web/src/views/LogStream.vue
@@ -874,6 +874,7 @@ export default defineComponent({
           refresh: "0",
           query: "",
           type: "stream_explorer",
+          quick_mode: store.state.zoConfig.quick_mode_enabled ? "true" : "false",
           org_identifier: store.state.selectedOrganization.identifier,
           ...dateTime,
         },


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Pass quick mode flag in log stream redirect

- Preserve org and datetime query params

- Ensure compatibility with stream explorer navigation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  LogStream["LogStream.vue redirect"] -- "router.push with query" --> Logs["Logs view"]
  Store["Store zoConfig.quick_mode_enabled"] -- "evaluate true/false" --> LogStream
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LogStream.vue</strong><dd><code>Add quick_mode to logs redirect query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/LogStream.vue

<ul><li>Add <code>quick_mode</code> query param when routing to <code>logs</code>.<br> <li> Value derived from <code>store.state.zoConfig.quick_mode_enabled</code>.<br> <li> Maintains existing query params for stream navigation.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8258/files#diff-56f4223b74568c10bc305741cc9fc3a8830184a251b4eaa6a2649033bc6200e3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

