### PR TITLE
feat: use uuid v7 for internal trace ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,6 +2556,7 @@ dependencies = [
  "tracing-subscriber",
  "urlencoding",
  "utoipa",
+ "uuid",
  "vrl",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,7 +387,7 @@ url = "2.5"
 urlencoding = "2.1"
 utoipa = { version = "5", features = ["actix_extras", "openapi_extensions"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
-uuid = { version = "1.17", features = ["v7"] }
+uuid = { version = "1.18.1", features = ["v7"] }
 vector-enrichment = { version = "0.1.0", package = "enrichment", git = "https://github.com/openobserve/vector", rev = "063cabbbf4bc6f75794fa0ccd3b0bd5c074f0e35" }
 vrl = { version = "0.22", features = ["value", "compiler", "test"] }
 zip = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,6 +387,7 @@ url = "2.5"
 urlencoding = "2.1"
 utoipa = { version = "5", features = ["actix_extras", "openapi_extensions"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
+uuid = { version = "1.17", features = ["v7"] }
 vector-enrichment = { version = "0.1.0", package = "enrichment", git = "https://github.com/openobserve/vector", rev = "063cabbbf4bc6f75794fa0ccd3b0bd5c074f0e35" }
 vrl = { version = "0.22", features = ["value", "compiler", "test"] }
 zip = "3.0.0"

--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,7 @@ git-fetch-with-cli = true
 
 exceptions = [
     # We should probably NOT bundle CA certs but use the OS ones.
-    { name = "webpki-roots", allow = ["MPL-2.0"] },
+    { name = "webpki-roots", allow = ["MPL-2.0","CDLA-Permissive-2.0"] },
     { name = "openobserve", allow = ["AGPL-3.0"] },
     { name = "config", allow = ["AGPL-3.0"] },
     { name = "infra", allow = ["AGPL-3.0"] },

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -77,6 +77,7 @@ tracing-log.workspace = true
 tracing-subscriber.workspace = true
 urlencoding.workspace = true
 utoipa.workspace = true
+uuid.workspace = true
 vrl.workspace = true
 roaring.workspace = true
 

--- a/src/config/src/ider.rs
+++ b/src/config/src/ider.rs
@@ -22,6 +22,7 @@ use std::{
 use parking_lot::Mutex;
 use rand::Rng;
 use svix_ksuid::{Ksuid, KsuidLike};
+use uuid::Uuid;
 
 static IDER: LazyLock<Mutex<SnowflakeIdGenerator>> = LazyLock::new(|| {
     let machine_id = super::cluster::LOCAL_NODE_ID.load(Ordering::Relaxed);
@@ -51,11 +52,51 @@ pub fn uuid() -> String {
     Ksuid::new(None, None).to_string()
 }
 
-/// Generate a new trace_id.
+/// Generate a new trace_id using UUID v7.
 pub fn generate_trace_id() -> String {
-    let trace_id = crate::utils::rand::get_rand_u128()
-        .unwrap_or_else(|| crate::utils::time::now_micros() as u128);
+    // Generate UUID v7 (time-ordered UUID)
+    let uuid_v7 = Uuid::now_v7();
+
+    // Convert UUID to 128-bit integer and then to OpenTelemetry TraceId
+    let trace_id = uuid_v7.as_u128();
     opentelemetry::trace::TraceId::from(trace_id).to_string()
+}
+
+/// Extract timestamp from UUID v7 trace ID
+/// Returns the timestamp in microseconds since Unix epoch, or None if parsing fails
+pub fn get_start_time_from_trace_id(trace_id: &str) -> Option<i64> {
+    // First, convert the hex string back to UUID format if needed
+    let uuid_str = if trace_id.len() == 32 {
+        // Convert from hex format (32 chars) to UUID format (with hyphens)
+        format!(
+            "{}-{}-{}-{}-{}",
+            &trace_id[0..8],
+            &trace_id[8..12],
+            &trace_id[12..16],
+            &trace_id[16..20],
+            &trace_id[20..32]
+        )
+    } else {
+        trace_id.to_string()
+    };
+
+    // Parse the UUID and extract timestamp
+    if let Ok(uuid) = Uuid::parse_str(&uuid_str) {
+        // Check if it's actually a UUID v7
+        if uuid.get_version() == Some(uuid::Version::SortRand) {
+            if let Some(timestamp) = uuid.get_timestamp() {
+                // Convert to microseconds: seconds * 1_000_000 + nanoseconds / 1_000
+                let (seconds, nanoseconds) = timestamp.to_unix();
+                Some((seconds * 1_000_000 + nanoseconds as u64 / 1_000) as i64)
+            } else {
+                None // No timestamp available
+            }
+        } else {
+            None // Not a UUID v7
+        }
+    } else {
+        None // Failed to parse as UUID
+    }
 }
 
 /// Generate a new span_id.
@@ -249,21 +290,212 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_generate_trace_id() {
+    fn test_generate_trace_id_basic() {
         let trace_id = generate_trace_id();
-        println!("trace_id: {}", trace_id);
-        let trace_id1 = format!("{}-{}", trace_id, "0");
-        let trace_id2 = format!("{}-{}", trace_id1, "abcd");
 
-        let new_id = trace_id
-            .split('-')
-            .next()
-            .and_then(|id| opentelemetry::trace::TraceId::from_hex(id).ok());
-        assert!(new_id.is_some());
-        let new_id = new_id.unwrap();
-        let new_id1 = format!("{}-{}", new_id, "0");
-        let new_id2 = format!("{}-{}", new_id1, "abcd");
-        assert_eq!(new_id2, trace_id2);
+        // Basic format validation
+        assert_eq!(trace_id.len(), 32, "Trace ID should be 32 characters long");
+        assert!(
+            trace_id.chars().all(|c| c.is_ascii_hexdigit()),
+            "Trace ID should contain only hex characters"
+        );
+        assert_ne!(
+            trace_id, "00000000000000000000000000000000",
+            "Trace ID should not be all zeros"
+        );
+
+        // Should be parseable as OpenTelemetry TraceId
+        assert!(
+            opentelemetry::trace::TraceId::from_hex(&trace_id).is_ok(),
+            "Should be valid OpenTelemetry TraceId"
+        );
+    }
+
+    #[test]
+    fn test_generate_trace_id_uuid_v7() {
+        let trace_id1 = generate_trace_id();
+        let trace_id2 = generate_trace_id();
+
+        // Trace IDs should be unique
+        assert_ne!(trace_id1, trace_id2, "Generated trace IDs should be unique");
+
+        // Trace IDs should be 32 characters long (16 bytes in hex)
+        assert_eq!(trace_id1.len(), 32, "Trace ID should be 32 characters long");
+        assert_eq!(trace_id2.len(), 32, "Trace ID should be 32 characters long");
+
+        // Trace IDs should be valid hex
+        assert!(
+            trace_id1.chars().all(|c| c.is_ascii_hexdigit()),
+            "Trace ID should contain only hex characters"
+        );
+        assert!(
+            trace_id2.chars().all(|c| c.is_ascii_hexdigit()),
+            "Trace ID should contain only hex characters"
+        );
+
+        // Trace IDs should not be all zeros
+        assert_ne!(
+            trace_id1, "00000000000000000000000000000000",
+            "Trace ID should not be all zeros"
+        );
+        assert_ne!(
+            trace_id2, "00000000000000000000000000000000",
+            "Trace ID should not be all zeros"
+        );
+
+        // Verify they can be parsed as OpenTelemetry TraceIds
+        assert!(
+            opentelemetry::trace::TraceId::from_hex(&trace_id1).is_ok(),
+            "Should be valid OpenTelemetry TraceId"
+        );
+        assert!(
+            opentelemetry::trace::TraceId::from_hex(&trace_id2).is_ok(),
+            "Should be valid OpenTelemetry TraceId"
+        );
+
+        // Verify they are actually UUID v7 by converting back to UUID format and checking version
+        let uuid_str1 = format!(
+            "{}-{}-{}-{}-{}",
+            &trace_id1[0..8],
+            &trace_id1[8..12],
+            &trace_id1[12..16],
+            &trace_id1[16..20],
+            &trace_id1[20..32]
+        );
+        let uuid_str2 = format!(
+            "{}-{}-{}-{}-{}",
+            &trace_id2[0..8],
+            &trace_id2[8..12],
+            &trace_id2[12..16],
+            &trace_id2[16..20],
+            &trace_id2[20..32]
+        );
+
+        let uuid1 = Uuid::parse_str(&uuid_str1).unwrap();
+        let uuid2 = Uuid::parse_str(&uuid_str2).unwrap();
+
+        assert_eq!(
+            uuid1.get_version(),
+            Some(uuid::Version::SortRand),
+            "Should be UUID v7"
+        );
+        assert_eq!(
+            uuid2.get_version(),
+            Some(uuid::Version::SortRand),
+            "Should be UUID v7"
+        );
+    }
+
+    #[test]
+    fn test_get_start_time_from_trace_id_valid_cases() {
+        // Test with a generated UUID v7 trace ID (hex format)
+        let trace_id = generate_trace_id();
+        let timestamp = get_start_time_from_trace_id(&trace_id);
+
+        // Should successfully extract timestamp
+        assert!(
+            timestamp.is_some(),
+            "Should extract timestamp from valid UUID v7"
+        );
+        let timestamp = timestamp.unwrap();
+
+        // Timestamp should be reasonable (not too far in past or future)
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as i64;
+
+        // Allow for some tolerance (within last hour and next hour)
+        assert!(
+            timestamp >= now - 3600_000_000,
+            "Timestamp should not be too far in past"
+        );
+        assert!(
+            timestamp <= now + 3600_000_000,
+            "Timestamp should not be too far in future"
+        );
+
+        // Test with UUID v7 in standard format (with hyphens)
+        let uuid_v7_standard = Uuid::now_v7().to_string();
+        let standard_result = get_start_time_from_trace_id(&uuid_v7_standard);
+        assert!(
+            standard_result.is_some(),
+            "Should extract timestamp from standard UUID v7 format"
+        );
+
+        // Verify both formats give reasonable timestamps
+        let standard_timestamp = standard_result.unwrap();
+        assert!(standard_timestamp >= now - 3600_000_000);
+        assert!(standard_timestamp <= now + 3600_000_000);
+    }
+
+    #[test]
+    fn test_get_start_time_from_trace_id_invalid_cases() {
+        // Test with invalid UUID string
+        let invalid_result = get_start_time_from_trace_id("invalid-uuid");
+        assert!(
+            invalid_result.is_none(),
+            "Should return None for invalid UUID string"
+        );
+
+        // Test with empty string
+        let empty_result = get_start_time_from_trace_id("");
+        assert!(
+            empty_result.is_none(),
+            "Should return None for empty string"
+        );
+
+        // Test with too short string
+        let short_result = get_start_time_from_trace_id("123");
+        assert!(
+            short_result.is_none(),
+            "Should return None for too short string"
+        );
+
+        // Test with too long string
+        let long_result = get_start_time_from_trace_id("1234567890123456789012345678901234567890");
+        assert!(
+            long_result.is_none(),
+            "Should return None for too long string"
+        );
+
+        // Test with UUID v4 (should return None)
+        let uuid_v4 = Uuid::new_v4().to_string().replace('-', "");
+        let v4_result = get_start_time_from_trace_id(&uuid_v4);
+        assert!(v4_result.is_none(), "Should return None for UUID v4");
+
+        // Test with UUID v1 (should return None) - using a known v1 UUID
+        let uuid_v1_str = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"; // Known UUID v1
+        let v1_result = get_start_time_from_trace_id(&uuid_v1_str.replace('-', ""));
+        assert!(v1_result.is_none(), "Should return None for UUID v1");
+
+        // Test with non-hex characters
+        let non_hex_result = get_start_time_from_trace_id("gggggggggggggggggggggggggggggggg");
+        assert!(
+            non_hex_result.is_none(),
+            "Should return None for non-hex characters"
+        );
+    }
+
+    #[test]
+    fn test_get_start_time_from_trace_id_time_ordering() {
+        // Generate two UUID v7s with a small delay to ensure different timestamps
+        let trace_id1 = generate_trace_id();
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        let trace_id2 = generate_trace_id();
+
+        let timestamp1 = get_start_time_from_trace_id(&trace_id1).unwrap();
+        let timestamp2 = get_start_time_from_trace_id(&trace_id2).unwrap();
+
+        // Timestamp2 should be greater than timestamp1 (time ordering)
+        assert!(
+            timestamp2 > timestamp1,
+            "UUID v7 timestamps should be time-ordered"
+        );
+
+        // The difference should be reasonable (at least 1ms = 1000 microseconds)
+        let diff = timestamp2 - timestamp1;
+        assert!(diff >= 1000, "Time difference should be at least 1ms");
     }
 
     #[test]
@@ -303,16 +535,36 @@ mod tests {
     fn test_generate_span_id() {
         let span_id1 = generate_span_id();
         let span_id2 = generate_span_id();
+
+        // Uniqueness
         assert_ne!(span_id1, span_id2, "Generated span IDs should be unique");
+
+        // Format validation
         assert_eq!(
             span_id1.len(),
             16,
             "Span ID should be 16 characters long (8 bytes in hex)"
         );
+        assert!(
+            span_id1.chars().all(|c| c.is_ascii_hexdigit()),
+            "Span ID should contain only hex characters"
+        );
+
+        // Should not be all zeros (this is tested in the function itself with recursion)
         assert_ne!(
             span_id1, "0000000000000000",
             "Span ID should not be all zeros"
         );
+
+        // Test multiple generations to ensure no all-zero IDs slip through
+        for _ in 0..100 {
+            let span_id = generate_span_id();
+            assert_ne!(
+                span_id, "0000000000000000",
+                "Span ID should never be all zeros"
+            );
+            assert_eq!(span_id.len(), 16, "All span IDs should be 16 characters");
+        }
     }
 
     #[test]
@@ -320,11 +572,21 @@ mod tests {
         let mut generator = SnowflakeIdGenerator::new(1);
         let id1 = generator.real_time_generate();
         let id2 = generator.real_time_generate();
+
+        // Uniqueness
         assert_ne!(id1, id2, "Generated snowflake IDs should be unique");
 
         // Test timestamp extraction
         let timestamp = to_timestamp_millis(id1);
         assert!(timestamp > 0, "Timestamp should be positive");
+
+        // Test that IDs are monotonically increasing (time-ordered)
+        assert!(id2 > id1, "Snowflake IDs should be time-ordered");
+
+        // Test with different machine IDs
+        let mut generator2 = SnowflakeIdGenerator::new(2);
+        let id3 = generator2.real_time_generate();
+        assert_ne!(id1, id3, "IDs from different machines should be different");
     }
 
     #[test]

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -101,6 +101,8 @@ async fn handle_req(
 }
 
 /// GetLatestTraces
+///
+/// #{"ratelimit_module":"Traces", "ratelimit_module_operation":"list"}#
 #[utoipa::path(
     context_path = "/api",
     tag = "Traces",
@@ -137,9 +139,6 @@ async fn handle_req(
         })),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
-    ),
-    extensions(
-        ("x-o2-ratelimit" = json!({"module": "Traces", "operation": "list"}))
     )
 )]
 #[get("/{org_id}/{stream_name}/traces/latest")]
@@ -263,7 +262,7 @@ pub async fn get_latest_traces(
     };
 
     if start_time_from_trace_id > 0 {
-        start_time = start_time_from_trace_id - 30 * 1_000_000; //30 seconds eariler
+        start_time = start_time_from_trace_id - 60 * 1_000_000; //60 seconds earlier
         end_time = start_time_from_trace_id + 3600 * 1_000_000; //1 hour later
     }
 

--- a/web/src/plugins/traces/TraceBlock.spec.ts
+++ b/web/src/plugins/traces/TraceBlock.spec.ts
@@ -366,7 +366,11 @@ describe("TraceBlock", () => {
       await flushPromises();
       await flushPromises();
 
-      const oldTimestamp = (Date.now() * 1000) - ((86400 * 5) * 1000000);
+      // Create a timestamp 5 days ago in microseconds
+      // Date.now() returns milliseconds, so we multiply by 1000 to get microseconds
+      // Then subtract 5 days worth of microseconds (5 * 24 * 60 * 60 * 1000000)
+      const fiveDaysAgoMs = Date.now() - (5 * 24 * 60 * 60 * 1000); // 5 days ago in milliseconds
+      const oldTimestamp = fiveDaysAgoMs * 1000; // Convert to microseconds
 
       await wrapper.setProps({
         item: { ...wrapper.props("item"), trace_start_time: oldTimestamp },

--- a/web/src/utils/zincutils.spec.ts
+++ b/web/src/utils/zincutils.spec.ts
@@ -34,6 +34,7 @@ import {
   convertToUtcTimestamp,
   mergeDeep,
   getUUID,
+  getUUIDv7,
   maskText,
   queryIndexSplit,
   convertToCamelCase,
@@ -475,6 +476,32 @@ describe("zincutils", () => {
       });
     });
 
+    describe("getUUIDv7", () => {
+      it("should generate valid UUID v7", () => {
+        const uuid = getUUIDv7();
+        expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+      });
+
+      it("should generate unique UUID v7s", () => {
+        const uuid1 = getUUIDv7();
+        const uuid2 = getUUIDv7();
+        expect(uuid1).not.toBe(uuid2);
+      });
+
+      it("should generate time-ordered UUID v7s", () => {
+        const uuid1 = getUUIDv7();
+        // Small delay to ensure different timestamps
+        const start = Date.now();
+        while (Date.now() - start < 1) {
+          // Wait for at least 1ms
+        }
+        const uuid2 = getUUIDv7();
+        
+        // UUID v7 should be lexicographically sortable by time
+        expect(uuid1 < uuid2).toBe(true);
+      });
+    });
+
     describe("generateTraceContext", () => {
       it("should generate valid trace context", () => {
         const context = generateTraceContext();
@@ -482,6 +509,24 @@ describe("zincutils", () => {
         expect(context).toHaveProperty("traceId");
         expect(context).toHaveProperty("spanId");
         expect(context.traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/);
+      });
+
+      it("should use UUID v7 for trace ID", () => {
+        const context = generateTraceContext();
+        // Trace ID should be 32 characters (UUID without hyphens)
+        expect(context.traceId).toHaveLength(32);
+        expect(context.traceId).toMatch(/^[0-9a-f]{32}$/i);
+        
+        // Convert back to UUID format to verify it's v7
+        const uuidFormat = context.traceId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
+        expect(uuidFormat).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+      });
+
+      it("should generate unique trace contexts", () => {
+        const context1 = generateTraceContext();
+        const context2 = generateTraceContext();
+        expect(context1.traceId).not.toBe(context2.traceId);
+        expect(context1.spanId).not.toBe(context2.spanId);
       });
     });
   });

--- a/web/src/utils/zincutils.spec.ts
+++ b/web/src/utils/zincutils.spec.ts
@@ -488,13 +488,10 @@ describe("zincutils", () => {
         expect(uuid1).not.toBe(uuid2);
       });
 
-      it("should generate time-ordered UUID v7s", () => {
+      it("should generate time-ordered UUID v7s", async () => {
         const uuid1 = getUUIDv7();
-        // Small delay to ensure different timestamps
-        const start = Date.now();
-        while (Date.now() - start < 1) {
-          // Wait for at least 1ms
-        }
+        // Use a proper delay instead of busy-waiting
+        await new Promise(resolve => setTimeout(resolve, 2));
         const uuid2 = getUUIDv7();
         
         // UUID v7 should be lexicographically sortable by time

--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -16,7 +16,7 @@
 import config from "../aws-exports";
 import { ref } from "vue";
 import { DateTime } from "luxon";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4, v7 as uuidv7 } from "uuid";
 import { useQuasar, date } from "quasar";
 import { useStore } from "vuex";
 import useStreams from "@/composables/useStreams";
@@ -777,6 +777,10 @@ export function getUUID() {
   return uuidv4();
 }
 
+export function getUUIDv7() {
+  return uuidv7();
+}
+
 export const maskText = (text: string) => {
   // Disabled masking as it was not great usefully
   // const visibleChars = 4; // Number of characters to keep visible at the beginning and end
@@ -850,7 +854,9 @@ export const getFunctionErrorMessage = (
 };
 
 export const generateTraceContext = () => {
-  const traceId = getUUID().replace(/-/g, "");
+  // Use UUID v7 for trace ID (time-ordered)
+  const traceId = getUUIDv7().replace(/-/g, "");
+  // Use UUID v4 for span ID (random)
   const spanId = getUUID().replace(/-/g, "").slice(0, 16);
 
   return {


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Switch trace IDs to UUID v7

- Add timestamp extraction from trace ID

- Improve HTTP header parsing robustness

- Add frontend UUID v7 utils and tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  RustGen["Rust: generate_trace_id uses UUID v7"] -- "u128 -> OTel TraceId" --> OTel["OpenTelemetry TraceId"]
  RustExtract["Rust: get_start_time_from_trace_id"] -- "parse v7 timestamp" --> QueryTime["Adjust query time window"]
  HTTP["HTTP traces handler"] -- "robust headers + trace_id param" --> RustExtract
  WebUtil["Web utils: getUUIDv7 + generateTraceContext"] -- "v7 traceId, v4 spanId" --> BrowserTraces["Browser trace context"]
  TestsRust["Rust tests"] -- "validate v7, ordering, parsing" --> RustGen
  TestsWeb["Web tests"] -- "validate v7, ordering, context" --> WebUtil
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ider.rs</strong><dd><code>Switch to UUID v7 and add timestamp extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/ider.rs

<ul><li>Generate trace IDs using <code>Uuid::now_v7()</code>.<br> <li> Add <code>get_start_time_from_trace_id</code> to extract microsecond timestamp.<br> <li> Expand tests for v7 validity, ordering, and parsing.<br> <li> Strengthen span ID and snowflake generator tests.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8261/files#diff-6ea42b8eab8ba0708f93f9a8b44056d9a9e6ac42517ffba12f81420d6b0bd2b0">+279/-17</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Robust headers and time-window from trace_id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/traces/mod.rs

<ul><li>Make Content-Type/header parsing tolerant to errors.<br> <li> Allow <code>trace_id</code> param or filter to set time window.<br> <li> Derive query window from UUID v7 timestamp.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8261/files#diff-64694c886c809b6efe449e6eba9fbb33d31ce5a3c49cea1a30006fc1d9522665">+37/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zincutils.ts</strong><dd><code>Frontend UUID v7 support and trace context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/zincutils.ts

<ul><li>Import and expose <code>getUUIDv7</code>.<br> <li> Use UUID v7 for traceId in trace context.<br> <li> Keep spanId generation via UUID v4.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8261/files#diff-d3d59688cccdcc6c84ebe88b698c6910030abecc3125f4c0ef81b0df023699ba">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zincutils.spec.ts</strong><dd><code>Tests for UUID v7 and trace context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/zincutils.spec.ts

<ul><li>Add tests for <code>getUUIDv7</code> validity, uniqueness, ordering.<br> <li> Validate trace context uses v7 traceId.<br> <li> Ensure uniqueness of trace and span IDs.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8261/files#diff-225d7ad1afe0a7e6f522c267bfd9ac4928cb5c23047fc6c02a287519a34aacb7">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add uuid v7 dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Add `uuid` crate with v7 feature.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8261/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add uuid to config crate dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/Cargo.toml

- Wire `uuid` crate via workspace dependency.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8261/files#diff-a70836e42ee2ff2af5068df047dd443758a0edc910d8ec5a01780396a69c9a9e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

