### PR TITLE
chore: default disable utf8view for main

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1107,7 +1107,7 @@ pub struct Common {
     pub aggregation_topk_enabled: bool,
     #[env_config(name = "ZO_SEARCH_INSPECTOR_ENABLED", default = false)]
     pub search_inspector_enabled: bool,
-    #[env_config(name = "ZO_UTF8_VIEW_ENABLED", default = true)]
+    #[env_config(name = "ZO_UTF8_VIEW_ENABLED", default = false)]
     pub utf8_view_enabled: bool,
     #[env_config(
         name = "ZO_DASHBOARD_SHOW_SYMBOL_ENABLED",


### PR DESCRIPTION
related to https://github.com/openobserve/openobserve/issues/8280
in some case, the utf8view will result in large memory usage, and slow down performance, so current make it default disable