### PR TITLE
fix: cloud pricing related changes

### DIFF
--- a/web/src/enterprise/components/billings/enterprisePlan.vue
+++ b/web/src/enterprise/components/billings/enterprisePlan.vue
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <q-separator spaced />
 
-    <div class="q-px-md q-pt-sm" style="margin-bottom: 30px;">
+    <div class="q-px-md q-pt-sm" style="margin-bottom: 58px;">
       <div class="o2-page-subtitle1">{{ t("billing.features") }}</div>
       <div class="o2-page-subtitle2 q-mb-md q-mt-xs">{{ t("billing.included") }}</div>
 

--- a/web/src/enterprise/components/billings/proPlan.vue
+++ b/web/src/enterprise/components/billings/proPlan.vue
@@ -98,15 +98,16 @@ export default defineComponent({
       { name: 'Ingestion (Logs, Metrics, Traces)', price: '$0.30/GB' , is_parent: true},
       { name: 'Query Volume', price: '$0.01/GB' , is_parent: true},
       { name: 'Pipelines', price: '' , is_parent: true},
-      { name: 'Data Processed', price: '$0.10/ GB' , is_parent: false},
+      { name: 'Data Processed', price: '$0.20/ GB' , is_parent: false},
       { name: 'Each additional destination', price: '$0.30/ GB' , is_parent: false},
+      { name: 'Each remote destination', price: '$0.45/ GB' , is_parent: false},
       { name: 'RUM & Session Replay', price: '$1/ 1K sessions' , is_parent: true},
       { name: 'Error Tracking', price: '$0.15/ 1K events' , is_parent: true},
       { name: 'Action Script', price: '$1/ 1K runs' , is_parent: true},
       { name: 'Unlimited Users', price: '' , is_parent: true},
       { name: 'Role-Based Access Control (RBAC)', price: '' , is_parent: true},
-      { name: 'API Access', price: '' , is_parent: true},
       { name: '15-Days Retention', price: '' , is_parent: true},
+      { name: '30 days additional retention', price: '$0.10/GB' , is_parent: true},
     ];
 
     const cancelSubscription = () => {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update Pro plan pricing details

- Add remote destination pricing tier

- Introduce optional 30-day retention add-on

- Adjust enterprise layout spacing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PricingVue["Pro plan pricing config"] -- "updated rates + new items" --> BillingUI["Billing features list"]
  BillingUI -- "renders revised pricing" --> Users["End-users"]
  EnterpriseVue["Enterprise plan layout"] -- "increase bottom margin" --> UISpacing["Visual spacing adjustment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enterprisePlan.vue</strong><dd><code>Adjust enterprise plan section spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/enterprise/components/billings/enterprisePlan.vue

<ul><li>Increase bottom margin from 30px to 58px<br> <li> Maintain features section structure</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8284/files#diff-f7fa88084375d33ceff7ec4816843de2705f2ed393590b9d1d993a67ff8ac29b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proPlan.vue</strong><dd><code>Revise Pro plan pricing and features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/enterprise/components/billings/proPlan.vue

<ul><li>Update 'Data Processed' to $0.20/GB<br> <li> Add 'Each remote destination' at $0.45/GB<br> <li> Remove 'API Access' line item<br> <li> Add '30 days additional retention' at $0.10/GB</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8284/files#diff-b5678b2763909484d6475adf5af690b3d382d8438520adcfc1428b66cf7ad7d5">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

