### PR TITLE
fix: default value for enable_distinct_fields

### DIFF
--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -776,23 +776,23 @@ impl TimeRange {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, ToSchema, PartialEq)]
+#[derive(Clone, Debug, Deserialize, ToSchema, PartialEq)]
 pub struct StreamSettings {
-    #[serde(skip_serializing_if = "Option::None")]
+    #[serde(default)]
     pub partition_time_level: Option<PartitionTimeLevel>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(default)]
     pub partition_keys: Vec<StreamPartition>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(default)]
     pub full_text_search_keys: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(default)]
     pub index_fields: Vec<String>,
     #[serde(default)]
     pub bloom_filter_fields: Vec<String>,
     #[serde(default)]
     pub data_retention: i64,
-    #[serde(skip_serializing_if = "Option::None")]
+    #[serde(default)]
     pub flatten_level: Option<i64>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(default)]
     pub defined_schema_fields: Vec<String>,
     #[serde(default)]
     pub max_query_range: i64, // hours
@@ -800,7 +800,7 @@ pub struct StreamSettings {
     pub store_original_data: bool,
     #[serde(default)]
     pub approx_partition: bool,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(default)]
     pub distinct_value_fields: Vec<DistinctField>,
     #[serde(default)]
     pub index_updated_at: i64,
@@ -812,6 +812,30 @@ pub struct StreamSettings {
     pub index_all_values: bool,
     #[serde(default)]
     pub enable_distinct_fields: bool,
+}
+
+impl Default for StreamSettings {
+    fn default() -> Self {
+        Self {
+            partition_time_level: None,
+            partition_keys: Vec::new(),
+            full_text_search_keys: Vec::new(),
+            index_fields: Vec::new(),
+            bloom_filter_fields: Vec::new(),
+            data_retention: 0,
+            flatten_level: None,
+            defined_schema_fields: Vec::new(),
+            max_query_range: 0,
+            store_original_data: false,
+            approx_partition: false,
+            distinct_value_fields: Vec::new(),
+            index_updated_at: 0,
+            extended_retention_days: Vec::new(),
+            index_original_data: false,
+            index_all_values: false,
+            enable_distinct_fields: true,
+        }
+    }
 }
 
 impl Serialize for StreamSettings {
@@ -841,7 +865,7 @@ impl Serialize for StreamSettings {
         state.serialize_field("extended_retention_days", &self.extended_retention_days)?;
         state.serialize_field("index_original_data", &self.index_original_data)?;
         state.serialize_field("index_all_values", &self.index_all_values)?;
-        state.serialize_field("disable_distinct_fields", &self.enable_distinct_fields)?;
+        state.serialize_field("enable_distinct_fields", &self.enable_distinct_fields)?;
 
         if !self.defined_schema_fields.is_empty() {
             let mut fields = self.defined_schema_fields.clone();


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement

close #8264

___

### **Description**
- Add Default for `StreamSettings`

- Set `enable_distinct_fields` default to true

- Fix serialization key for distinct fields flag

- Use serde defaults for optional fields


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["StreamSettings struct"] -- "add Default impl" --> B["enable_distinct_fields defaults to true"]
  A -- "serde default on fields" --> C["robust deserialization"]
  A -- "Serialize impl update" --> D["serialize 'enable_distinct_fields' key"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stream.rs</strong><dd><code>StreamSettings defaults and serialization corrected</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/stream.rs

<ul><li>Remove derive(Default); implement explicit Default.<br> <li> Default <code>enable_distinct_fields</code> to true.<br> <li> Swap serde skips to <code>#[serde(default)]</code> on many fields.<br> <li> Fix serialization key from <code>disable_distinct_fields</code> to <br><code>enable_distinct_fields</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8288/files#diff-2438d04c3fe97bc5452e5b74a303163b8723d93455cda32c95f0525435ad46bd">+33/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

