### PR TITLE
fix: add default length filter for tantivy token

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1419,6 +1419,18 @@ pub struct Limit {
     )]
     pub inverted_index_skip_threshold: usize,
     #[env_config(
+        name = "ZO_INVERTED_INDEX_MIN_TOKEN_LENGTH",
+        default = 1,
+        help = "Minimum length of a token in the inverted index."
+    )]
+    pub inverted_index_min_token_length: usize,
+    #[env_config(
+        name = "ZO_INVERTED_INDEX_MAX_TOKEN_LENGTH",
+        default = 64,
+        help = "Maximum length of a token in the inverted index."
+    )]
+    pub inverted_index_max_token_length: usize,
+    #[env_config(
         name = "ZO_DEFAULT_MAX_QUERY_RANGE_DAYS",
         default = 0,
         help = "unit: Days. Global default max query range for all streams. If set to a value > 0, this will be used as the default max query range. Can be overridden by stream settings."
@@ -2054,6 +2066,11 @@ pub fn init() -> Config {
     // check nats config
     if let Err(e) = check_nats_config(&mut cfg) {
         panic!("nats config error: {e}");
+    }
+
+    // check inverted index config
+    if let Err(e) = check_inverted_index_config(&mut cfg) {
+        panic!("inverted index config error: {e}");
     }
 
     cfg
@@ -2798,6 +2815,19 @@ fn check_health_check_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
     if cfg.health_check.failed_times == 0 {
         cfg.health_check.failed_times = 3;
+    }
+    Ok(())
+}
+
+fn check_inverted_index_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
+    if cfg.limit.inverted_index_cache_max_entries == 0 {
+        cfg.limit.inverted_index_cache_max_entries = 100000;
+    }
+    if cfg.limit.inverted_index_min_token_length == 0 {
+        cfg.limit.inverted_index_min_token_length = 1;
+    }
+    if cfg.limit.inverted_index_max_token_length == 0 {
+        cfg.limit.inverted_index_max_token_length = 64;
     }
     Ok(())
 }

--- a/src/config/src/ider.rs
+++ b/src/config/src/ider.rs
@@ -52,6 +52,13 @@ pub fn uuid() -> String {
     Ksuid::new(None, None).to_string()
 }
 
+/// Generate a unique id like uuid for file name.
+pub fn generate_file_name() -> String {
+    let id = generate();
+    let rand_str = format!("{:04x}", rand::random::<u16>());
+    id + rand_str.as_str()
+}
+
 /// Generate a new trace_id.
 pub fn generate_trace_id() -> String {
     let trace_id = crate::utils::rand::get_rand_u128()

--- a/src/config/src/utils/tantivy/tokenizer/mod.rs
+++ b/src/config/src/utils/tantivy/tokenizer/mod.rs
@@ -14,26 +14,37 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 mod o2_tokenizer;
+mod remove_short;
 
 pub use o2_tokenizer::O2Tokenizer;
 use tantivy::tokenizer::{SimpleTokenizer, TextAnalyzer, Token};
 
-use crate::get_config;
+use crate::{get_config, utils::tantivy::tokenizer::remove_short::RemoveShortFilter};
 
 pub const O2_TOKENIZER: &str = "o2";
+const MIN_TOKEN_LENGTH: usize = 1;
+const MAX_TOKEN_LENGTH: usize = 64;
 
 pub fn o2_tokenizer_build() -> TextAnalyzer {
-    if get_config()
-        .common
-        .inverted_index_camel_case_tokenizer_disabled
-    {
+    let cfg = get_config();
+    let min_token_length =
+        std::cmp::max(cfg.limit.inverted_index_min_token_length, MIN_TOKEN_LENGTH);
+    let max_token_length =
+        std::cmp::max(cfg.limit.inverted_index_max_token_length, MAX_TOKEN_LENGTH);
+    if cfg.common.inverted_index_camel_case_tokenizer_disabled {
         tantivy::tokenizer::TextAnalyzer::builder(SimpleTokenizer::default())
-            .filter(tantivy::tokenizer::RemoveLongFilter::limit(64))
+            .filter(RemoveShortFilter::limit(min_token_length))
+            .filter(tantivy::tokenizer::RemoveLongFilter::limit(
+                max_token_length,
+            ))
             .filter(tantivy::tokenizer::LowerCaser)
             .build()
     } else {
         tantivy::tokenizer::TextAnalyzer::builder(O2Tokenizer::default())
-            .filter(tantivy::tokenizer::RemoveLongFilter::limit(64))
+            .filter(RemoveShortFilter::limit(min_token_length))
+            .filter(tantivy::tokenizer::RemoveLongFilter::limit(
+                max_token_length,
+            ))
             .filter(tantivy::tokenizer::LowerCaser)
             .build()
     }

--- a/src/config/src/utils/tantivy/tokenizer/o2_tokenizer.rs
+++ b/src/config/src/utils/tantivy/tokenizer/o2_tokenizer.rs
@@ -152,7 +152,7 @@ fn looks_like_base64(s: &str) -> bool {
     // Base64 characteristics:
     // 1. Only contains [A-Za-z0-9], the tokenizer will remove all non-alphanumeric characters
     // 2. Should be reasonably long (to avoid false positives)
-    const MIN_BASE64_LENGTH: usize = 1024; // Adjust this threshold as needed
+    const MIN_BASE64_LENGTH: usize = super::MAX_TOKEN_LENGTH + 1; // Adjust this threshold as needed
 
     if s.len() < MIN_BASE64_LENGTH {
         return false;
@@ -230,9 +230,9 @@ mod tests {
 
     #[test]
     fn test_o2_tokenizer_camel_case_with_base64() {
-        let body = "2025-03-13 INFO Current Users : Ly8gQWRkIHRoaXMgaGVscGVyIGZ1bmN0aW9uIHRvIGRldGVjdCBiYXNlNjQtbGlrZSBzdHJpbmdzCmZuIGxvb2tzX2xpa2VfYmFzZTY0KHM6ICZzdHIpIC0xIGJvb2wgewogICAgLy8gQmFzZTY0IGNoYXJhY3RlcmlzdGljczoKICAgIC8vIDEuIExlbmd0aCBzaG91bGQgYmUgbXVsdGlwbGUgb2YgNCAoZXhjZXB0IGZvciBwYWRkZWQgc3RyaW5ncykKICAgIC8vIDIuIE9ubHkgY29udGFpbnMgW0EtWmEtejAtOSsvPV0KICAgIC8vIDMuIFNob3VsZCBiZSByZWFzb25hYmx5IGxvbmcgKHRvIGF2b2lkIGZhbHNlIHBvc2l0aXZlcykKICAgIGNvbnN0IE1JTl9CQVNFNjRfTEVOR1RIOiB1c2l6ZSA9IDE2OyAvLyBBZGp1c3QgdGhpcyB0aHJlc2hvbGQgYXMgbmVlZGVkCiAgICAKICAgIGlmIHMubGVuKCkgPCBNSU5fQkFTRTY0X0xFTkdUSCB7c3NzCiAgICAgICAgcmV0dXJuIGZhbHNlO3gKICAgIH0KICAgIC8vIEFkZCB0aGlzIGhlbHBlciBmdW5jdGlvbiB0byBkZXRlY3QgYmFzZTY0LWxpa2Ugc3RyaW5ncwpmbiBsb29rc19saWtlX2Jhc2U2NChzOiAmc3RyKSAtPiBib29sIHsKICAgIC8vIEJhc2U2NCBjaGFyYWN0ZXJpc3RpY3M6CiAgICAvLyAxLiBMZW5ndGggc2hvdWxkIGJlIG11bHRpcGxlIG9mIDQgKGV4Y2VwdCBmb3IgcGFkZGVkIHN0cmluZ3MpCiAgICAvLyAyLiBPbmx5IGNvbnRhaW5zIFtBLVphLXowLTkrLz1dCiAgICAvLyAzLiBTaG91bGQgYmUgcmVhc29uYWJseSBsb25nICh0byBhdm9pZCBmYWxzZSBwb3NpdGl2ZXMpCiAgICBjb25zdCBNSU5fQkFTRTY0X0xFTkdUSDogdXNpemUgPSAxNjsgLy8gQWRqdXN0IHRoaXMgdGhyZXNob2xkIGFzIG5lZWRlZAogICAgCiAgICBpZiBzLmxlbigpIDwgTUlOX0JBU0U2NF9MRU5HVEggewogICAgICAgIHJldHVybiBmYWxzZTsKICAgIH0KICAgIA==";
+        let body = "2025-03-13 INFO Current Users : Ly8gQWRkIHRoaXMgaGVscGVyIGZ1bmN0aW9uIHRvIGRldGVjd+O2gQWRkIHRoaXMgaGVscGVyIGZ1bmN0aW9uIHRvIGRldGVjdCBiYXNlNjQtbGlrZSBzdHJpbmdzCmZuIGxvb2tzX2xpa2VfYmFzZTY0KHM6ICZzdHIpIC0xIGJvb2wgewogICAgLy8gQmFzZTY0IGNoYXJhY3RlcmlzdGljczoKICAgIC8vIDEuIExlbmd0aCBzaG91bGQgYmUgbXVsdGlwbGUgb2YgNCAoZXhjZXB0IGZvciBwYWRkZWQgc3RyaW5ncykKICAgIC8vIDIuIE9ubHkgY29udGFpbnMgW0EtWmEtejAtOSsvPV0KICAgIC8vIDMuIFNob3VsZCBiZSByZWFzb25hYmx5IGxvbmcgKHRvIGF2b2lkIGZhbHNlIHBvc2l0aXZlcykKICAgIGNvbnN0IE1JTl9CQVNFNjRfTEVOR1RIOiB1c2l6ZSA9IgPCBNSU5fQkFTRTY0X0xF==";
         let tokens = token_stream_helper(body);
-        assert_eq!(tokens.len(), 7);
+        assert_eq!(tokens.len(), 27);
         assert_token(&tokens[0], 0, "2025", 0, 4);
         assert_token(&tokens[1], 1, "03", 5, 7);
         assert_token(&tokens[2], 2, "13", 8, 10);

--- a/src/config/src/utils/tantivy/tokenizer/remove_short.rs
+++ b/src/config/src/utils/tantivy/tokenizer/remove_short.rs
@@ -1,0 +1,119 @@
+use tantivy::tokenizer::{Token, TokenFilter, TokenStream, Tokenizer};
+
+/// `RemoveLongFilter` removes tokens that are longer
+/// than a given number of bytes (in UTF-8 representation).
+///
+/// It is especially useful when indexing unconstrained content.
+/// e.g. Mail containing base-64 encoded pictures etc.
+#[derive(Clone)]
+pub struct RemoveShortFilter {
+    length_limit: usize,
+}
+
+impl RemoveShortFilter {
+    /// Creates a `RemoveLongFilter` given a limit in bytes of the UTF-8 representation.
+    pub fn limit(length_limit: usize) -> RemoveShortFilter {
+        RemoveShortFilter { length_limit }
+    }
+}
+
+impl<T> RemoveShortFilterStream<T> {
+    fn predicate(&self, token: &Token) -> bool {
+        token.text.len() > self.token_length_limit
+    }
+}
+
+impl TokenFilter for RemoveShortFilter {
+    type Tokenizer<T: Tokenizer> = RemoveShortFilterWrapper<T>;
+
+    fn transform<T: Tokenizer>(self, tokenizer: T) -> RemoveShortFilterWrapper<T> {
+        RemoveShortFilterWrapper {
+            length_limit: self.length_limit,
+            inner: tokenizer,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RemoveShortFilterWrapper<T: Tokenizer> {
+    length_limit: usize,
+    inner: T,
+}
+
+impl<T: Tokenizer> Tokenizer for RemoveShortFilterWrapper<T> {
+    type TokenStream<'a> = RemoveShortFilterStream<T::TokenStream<'a>>;
+
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+        RemoveShortFilterStream {
+            token_length_limit: self.length_limit,
+            tail: self.inner.token_stream(text),
+        }
+    }
+}
+
+pub struct RemoveShortFilterStream<T> {
+    token_length_limit: usize,
+    tail: T,
+}
+
+impl<T: TokenStream> TokenStream for RemoveShortFilterStream<T> {
+    fn advance(&mut self) -> bool {
+        while self.tail.advance() {
+            if self.predicate(self.tail.token()) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn token(&self) -> &Token {
+        self.tail.token()
+    }
+
+    fn token_mut(&mut self) -> &mut Token {
+        self.tail.token_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tantivy::tokenizer::{SimpleTokenizer, TextAnalyzer, Token};
+
+    use super::*;
+
+    fn assert_token(token: &Token, position: usize, text: &str, from: usize, to: usize) {
+        assert_eq!(
+            token.position, position,
+            "expected position {position} but {token:?}"
+        );
+        assert_eq!(token.text, text, "expected text {text} but {token:?}");
+        assert_eq!(
+            token.offset_from, from,
+            "expected offset_from {from} but {token:?}"
+        );
+        assert_eq!(token.offset_to, to, "expected offset_to {to} but {token:?}");
+    }
+
+    fn token_stream_helper(text: &str) -> Vec<Token> {
+        let mut a = TextAnalyzer::builder(SimpleTokenizer::default())
+            .filter(RemoveShortFilter::limit(2))
+            .build();
+        let mut token_stream = a.token_stream(text);
+        let mut tokens: Vec<Token> = vec![];
+        let mut add_token = |token: &Token| {
+            tokens.push(token.clone());
+        };
+        token_stream.process(&mut add_token);
+        tokens
+    }
+
+    #[test]
+    fn test_remove_short() {
+        let tokens = token_stream_helper("i am a hello tantivy, happy searching!");
+        assert_eq!(tokens.len(), 4);
+        assert_token(&tokens[0], 3, "hello", 7, 12);
+        assert_token(&tokens[1], 4, "tantivy", 13, 20);
+        assert_token(&tokens[2],5, "happy", 22, 27);
+        assert_token(&tokens[3], 6, "searching", 28, 37);
+    }
+}

--- a/src/job/files/mod.rs
+++ b/src/job/files/mod.rs
@@ -72,12 +72,11 @@ pub fn generate_storage_file_name(
     // let hash_id = file_columns[5].to_string();
     let file_name = file_columns.last().unwrap().to_string();
     let file_name_pos = file_name.rfind('/').unwrap_or_default();
-    let id = ider::generate();
+    let id = ider::generate_file_name();
     let file_name = if file_name_pos == 0 {
         id
     } else {
         format!("{}/{}", &file_name[..file_name_pos], id)
     };
-    let rand_str = format!("{:04x}", rand::random::<u16>());
-    format!("files/{stream_key}/{file_date}/{file_name}{rand_str}{FILE_EXT_PARQUET}")
+    format!("files/{stream_key}/{file_date}/{file_name}{FILE_EXT_PARQUET}")
 }

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -846,7 +846,7 @@ pub async fn merge_files(
 
     // generate datafusion tables
     let mut tables = Vec::new();
-    let trace_id = ider::generate();
+    let trace_id = ider::generate_file_name();
     for (schema_key, files) in file_groups {
         if files.is_empty() {
             continue;


### PR DESCRIPTION
Add two new ENV:
```
ZO_INVERTED_INDEX_MIN_TOKEN_LENGTH=1
ZO_INVERTED_INDEX_MAX_TOKEN_LENGTH=64
```
Default we only remove the tokens longer than `64`, didn't remove the small tokens. 

Now, we support both remove mini token and huge token.

Why we got error like this:
```
thread 'job_runtime' panicked at /index.crates.io-1949cf8c6b5b557f/tantivy-stacker-0.3.0/src/memory_arena.rs:205:9:
```
Because Tantivy use int32 for memory address, it can't generate data page large than 4GB, and we only generate one segment file for one parquet file in OpenObserve, it caused one problem, if the parquet is very large that will generate a lot of tokens, at the end, the Tantivy segment will exceeds the limit then paniced.

This PR improved the token generated, will auto remove the single char token, and large than 64 chars. with these changes we can succeeded generate `5GB` parquet file and the tantivy file.