### PR TITLE
fix: redodotdev identify call should be after redirection

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -22,9 +22,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import config from "@/aws-exports";
+import { useReo } from "@/services/reodotdev_analytics";
+import { b64DecodeStandard } from "./utils/zincutils";
 export default {
   setup() {
     const store = useStore();
+    const { identify } = useReo();
     // if (
     //   config.isCloud == "false" &&
     //   window.location.origin != "http://localhost:8081"
@@ -40,6 +43,15 @@ export default {
     // }
     const router = useRouter();
     const creds = localStorage.getItem("creds");
+    const userLoggedIn = localStorage.getItem("userInfo");
+    if (userLoggedIn && localStorage.getItem("sendIdentify") === "true") {
+      const userInfo = JSON.parse(b64DecodeStandard(userLoggedIn));
+      identify({
+            username: userInfo.email,
+            type: "email"
+          });      
+      localStorage.setItem("sendIdentify", "false");
+    }
     if (creds) {
       // const credsInfo = JSON.parse(creds);
       // store.dispatch("login", credsInfo);

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -176,15 +176,9 @@ export default defineComponent({
           ) {
             localStorage.setItem("isFirstTimeLogin", "true");
           }
-          //this will identify the user for reo.dev
-          identify({
-            username: store.state.userInfo.email,
-            type: "email"
-          });
+          localStorage.setItem("sendIdentify", "true");
           // Check for pending invites
-          setTimeout(() => {
             redirectUser();
-          }, 800);
 
         })
         .catch((e: any) => {


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Defer analytics identify until post-redirect

- Add identify trigger via localStorage flag

- Decode user info before identifying

- Simplify login redirect flow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Login["Login.vue: set sendIdentify flag"] --> App["App.vue: on load check flag"]
  App --> Decode["Decode userInfo (base64)"]
  Decode --> Identify["Call identify(username/email)"]
  Identify --> ResetFlag["Reset sendIdentify=false"]
  Login --> Redirect["Redirect user to destination"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.vue</strong><dd><code>Post-redirect identify handling in App bootstrap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/App.vue

<ul><li>Import <code>useReo</code> and <code>b64DecodeStandard</code>.<br> <li> On load, check <code>sendIdentify</code> and <code>userInfo</code>.<br> <li> Decode <code>userInfo</code> and call <code>identify</code> with email.<br> <li> Reset <code>sendIdentify</code> flag after identifying.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8312/files#diff-7322e6842f92edbe4a6e810d63f066ec95e64806d64a02b52e2b9bef2a73db91">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Login.vue</strong><dd><code>Defer identify and streamline login redirect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/Login.vue

<ul><li>Remove immediate <code>identify</code> call on login.<br> <li> Set <code>sendIdentify</code> flag in localStorage.<br> <li> Simplify redirect by removing timeout.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8312/files#diff-a135c379ef6ac8f92199ea5f7ff19a227971a9b0a87ccccf87c0268740522c2c">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

