### PR TITLE
fix: add indices to file_list_jobs

### DIFF
--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -2102,6 +2102,12 @@ pub async fn create_table_index() -> Result<()> {
             "file_list_deleted",
             &["org", "created_at"],
         ),
+        ("file_list_jobs_status_idx", "file_list_jobs", &["status"]),
+        (
+            "file_list_jobs_status_stream_idx",
+            "file_list_jobs",
+            &["status", "stream"],
+        ),
         (
             "file_list_deleted_stream_date_file_idx",
             "file_list_deleted",

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1992,6 +1992,12 @@ pub async fn create_table_index() -> Result<()> {
             "file_list_deleted",
             &["org", "created_at"],
         ),
+        ("file_list_jobs_status_idx", "file_list_jobs", &["status"]),
+        (
+            "file_list_jobs_status_stream_idx",
+            "file_list_jobs",
+            &["status", "stream"],
+        ),
         (
             "file_list_deleted_stream_date_file_idx",
             "file_list_deleted",

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -1756,13 +1756,14 @@ pub async fn create_table_index() -> Result<()> {
             "file_list_deleted",
             &["org", "created_at"],
         ),
+        ("file_list_jobs_status_idx", "file_list_jobs", &["status"]),
         (
             "file_list_deleted_stream_date_file_idx",
             "file_list_deleted",
             &["stream", "date", "file"],
         ),
         (
-            "file_list_jobs_stream_status_idx",
+            "file_list_jobs_status_stream_idx",
             "file_list_jobs",
             &["status", "stream"],
         ),


### PR DESCRIPTION
### **User description**
File list jobs queries are having higher latencies in prod and dev env , adding indices to speed up queries


___

### **PR Type**
Enhancement


___

### **Description**
- Add indexes for file_list_jobs status

- Add composite status,stream index

- Align index naming across backends

- Improve query latency for job listings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  code["Index definitions in Rust"] -- "add status index" --> mysql["MySQL backend"]
  code -- "add status,stream index" --> mysql
  code -- "add status index" --> pg["Postgres backend"]
  code -- "add status,stream index" --> pg
  code -- "add status index" --> sqlite["SQLite backend"]
  code -- "rename composite index" --> sqlite
  mysql -- "faster status queries" --> perf["Lower latency"]
  pg -- "faster status queries" --> perf
  sqlite -- "consistent naming & performance" --> perf
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mysql.rs</strong><dd><code>Add status and composite indexes for MySQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/file_list/mysql.rs

<ul><li>Add <code>file_list_jobs_status_idx</code> on <code>status</code>.<br> <li> Add <code>file_list_jobs_status_stream_idx</code> on <code>status, stream</code>.<br> <li> Extend index list in <code>create_table_index</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8316/files#diff-06d02c738c6a4dc22ff022c16befef8d46aece6cfaa88bb4a5d3d5f92c2e50a1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>postgres.rs</strong><dd><code>Add status and composite indexes for Postgres</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/file_list/postgres.rs

<ul><li>Add <code>file_list_jobs_status_idx</code> on <code>status</code>.<br> <li> Add <code>file_list_jobs_status_stream_idx</code> on <code>status, stream</code>.<br> <li> Update <code>create_table_index</code> to include new indexes.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8316/files#diff-bb24a30c9c3744eb31fb49e4271a9651d1f9a94a87455ac0074364b879af9651">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sqlite.rs</strong><dd><code>Add and rename job indexes for SQLite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/file_list/sqlite.rs

<ul><li>Add <code>file_list_jobs_status_idx</code> on <code>status</code>.<br> <li> Rename composite index to <code>file_list_jobs_status_stream_idx</code>.<br> <li> Keep composite on <code>status, stream</code> for consistency.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8316/files#diff-85ff00530831fdaa4e13c05cb649f2e20479cce04a4b65ef78d131cdb89b6c71">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

