### PR TITLE
fix: disable ident normalization

### DIFF
--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -405,6 +405,10 @@ pub fn create_session_config(
         .options_mut()
         .execution
         .listing_table_ignore_subdirectory = false;
+    // enable_ident_normalization will lower case idents, such as alias name unless they are quoted
+    // TEST->test "TEST"->TEST . We want to keep whatever user has provided, as otherwise
+    // it breaks existing behavior, so we disable it.
+    config.options_mut().sql_parser.enable_ident_normalization = false;
     config.options_mut().sql_parser.dialect = "PostgreSQL".to_string();
 
     // based on data distributing, it only works for the data on a few records


### PR DESCRIPTION
Disables the ident normalization from df config. This allows retaining the alias names as provided by the user instead of getting normalized to lowercase

https://github.com/apache/datafusion/blob/main/datafusion/common/src/config.rs#L251