### PR TITLE
chore: shutdown ddl pool

### DIFF
--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -92,6 +92,10 @@ async fn cache_indices() -> HashSet<DBIndex> {
     }
 }
 
+pub async fn shutdown_ddl_pool() -> Result<()> {
+    CLIENT_DDL.close().await;
+    Ok(())
+}
 pub struct MysqlDb {}
 
 impl MysqlDb {

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -82,6 +82,11 @@ async fn cache_indices() -> HashSet<DBIndex> {
         Err(_) => HashSet::new(),
     }
 }
+
+pub async fn shutdown_ddl_pool() -> Result<()> {
+    CLIENT_DDL.close().await;
+    Ok(())
+}
 pub struct PostgresDb {}
 
 impl PostgresDb {

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -121,5 +121,22 @@ pub async fn init_db() -> std::result::Result<(), anyhow::Error> {
     #[cfg(feature = "cloud")]
     o2_enterprise::enterprise::cloud::migrate().await?;
 
+    log::info!("Shutting down DDL connection pool");
+    // Shutdown DDL connection pool after all migrations are complete
+    let cfg = config::get_config();
+    match cfg.common.meta_store.as_str() {
+        "postgres" => {
+            if let Err(e) = infra::db::postgres::shutdown_ddl_pool().await {
+                log::warn!("Failed to shutdown PostgreSQL DDL connection pool: {}", e);
+            }
+        }
+        "mysql" => {
+            if let Err(e) = infra::db::mysql::shutdown_ddl_pool().await {
+                log::warn!("Failed to shutdown MySQL DDL connection pool: {}", e);
+            }
+        }
+        _ => {} // SQLite doesn't have separate DDL pool
+    }
+
     Ok(())
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add DDL pool shutdown helpers

- Invoke shutdown after migrations complete

- Handle MySQL and PostgreSQL cases

- Log outcomes and warnings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MIG["Migrations complete"] -- "meta_store=postgres" --> P["Call postgres::shutdown_ddl_pool()"]
  MIG -- "meta_store=mysql" --> M["Call mysql::shutdown_ddl_pool()"]
  MIG -- "meta_store=sqlite/other" --> S["No-op"]
  P -- "close CLIENT_DDL" --> PDONE["Postgres DDL pool closed"]
  M -- "close CLIENT_DDL" --> MDONE["MySQL DDL pool closed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mysql.rs</strong><dd><code>MySQL DDL pool shutdown helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/db/mysql.rs

<ul><li>Add <code>shutdown_ddl_pool()</code> async function.<br> <li> Close <code>CLIENT_DDL</code> and return <code>Ok(())</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8330/files#diff-412dc407af348f4b54b7d98de6a928876b0333ea501792498a0568850f83d7b7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>postgres.rs</strong><dd><code>PostgreSQL DDL pool shutdown helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/db/postgres.rs

<ul><li>Add <code>shutdown_ddl_pool()</code> async function.<br> <li> Close <code>CLIENT_DDL</code> and return <code>Ok(())</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8330/files#diff-1554e69f6d6c29812af88f0dcf093240b24ff85f9e292322c71cb19b0dda808d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Trigger DDL pool shutdown post-migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/migration/mod.rs

<ul><li>Log intent to shutdown DDL pool.<br> <li> Conditionally call MySQL/Postgres shutdown after migrations.<br> <li> Handle errors with warnings; SQLite no-op.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8330/files#diff-eb855be0fa22d1a540379f6142cc4a473d49f89c3e0fe16cfd5078d5a69f9a3b">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

