### PR TITLE
fix: disallow _timestamp as alias

### DIFF
--- a/src/service/search/sql/mod.rs
+++ b/src/service/search/sql/mod.rs
@@ -157,6 +157,11 @@ impl Sql {
             .collect::<Vec<_>>();
         let group_by = column_visitor.group_by;
         let mut order_by = column_visitor.order_by;
+        if aliases.iter().any(|(_, alias)| alias == TIMESTAMP_COL_NAME) {
+            return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(
+                "Using _timestamp as alias is not supported".to_string(),
+            )));
+        }
 
         // check if need sort by time
         if order_by.is_empty()


### PR DESCRIPTION
### **User description**
fixed #8349


___

### **PR Type**
Enhancement


___

### **Description**
- Reject `_timestamp` column aliases

- Add SQL validation with clear error


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SQL parse and visit columns"] -- "collect aliases" --> B["Check alias equals `_timestamp`"]
  B -- "true" --> C["Return SearchSQLNotValid error"]
  B -- "false" --> D["Continue order/group processing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add validation to block `_timestamp` alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/sql/mod.rs

<ul><li>Validate collected aliases against <code>TIMESTAMP_COL_NAME</code>.<br> <li> Return <code>SearchSQLNotValid</code> when alias is <code>_timestamp</code>.<br> <li> Prevents misuse of reserved timestamp identifier.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8350/files#diff-dc0ab53d0ff551cf3cd12027c73d0da5e66680c0bf2d1830778639a33bac3464">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

