### PR TITLE
fix: user update mode for enterprise

### DIFF
--- a/src/handler/http/auth/jwt.rs
+++ b/src/handler/http/auth/jwt.rs
@@ -246,7 +246,7 @@ pub async fn process_token(
                 match users::update_user(
                     &org.name,
                     &user_email,
-                    false,
+                    crate::common::meta::user::UserUpdateMode::OtherUpdate,
                     &get_config().auth.root_user_email,
                     crate::common::meta::user::UpdateUser {
                         role: Some(crate::common::meta::user::UserRoleRequest {

--- a/src/service/users.rs
+++ b/src/service/users.rs
@@ -259,6 +259,7 @@ pub async fn update_user(
         )));
     }
     let is_email_root = is_root_user(email);
+
     #[cfg(not(feature = "enterprise"))]
     if is_email_root {
         user.role = Some(crate::common::meta::user::UserRoleRequest {
@@ -266,6 +267,7 @@ pub async fn update_user(
             custom: None,
         });
     }
+    user.role = user.role.clone();
 
     // Only root user can update root user
     if is_email_root && !update_mode.is_self_update() && !update_mode.is_cli_update() {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Use explicit UserUpdateMode in JWT flow

- Preserve role assignment after validation

- Ensure EE/root handling respects update mode


___

### Diagram Walkthrough


```mermaid
flowchart LR
  JWT["JWT processing"] -- "update_user call" --> UsersSvc["users::update_user"]
  UsersSvc -- "uses UpdateMode.OtherUpdate" --> ModeCheck["Update mode checks"]
  UsersSvc -- "role handling" --> RoleAssign["Preserve/adjust user.role"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jwt.rs</strong><dd><code>Use explicit update mode in JWT user updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/auth/jwt.rs

<ul><li>Pass explicit <code>UserUpdateMode::OtherUpdate</code> to <code>update_user</code>.<br> <li> Replace boolean flag with semantic update mode enum.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8363/files#diff-232cab74f4cbf135af424744272e17732fbda8ac005d33c0acb4597e65479d02">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>users.rs</strong><dd><code>Preserve role state after root role enforcement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/users.rs

<ul><li>Add <code>user.role = user.role.clone();</code> after root role guard.<br> <li> Minor formatting; keep root user role enforcement for non-EE.<br> <li> Preserve role object post-validation path.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8363/files#diff-98da2588a28d62bb2e301d989836125f89f89b76272cd7f75e08ec4deeea5f38">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

