### PR TITLE
chore: Update canonnicalization step for scan_files_filtered to be more async

### DIFF
--- a/src/config/src/utils/async_file.rs
+++ b/src/config/src/utils/async_file.rs
@@ -21,6 +21,7 @@ use std::{
 };
 
 use async_walkdir::WalkDir;
+use chrono::{DateTime, Datelike, TimeZone, Timelike, Utc};
 use futures::StreamExt;
 use tokio::{
     fs::{File, metadata, read_dir, remove_dir},
@@ -143,6 +144,109 @@ pub async fn clean_empty_dirs(
     Ok(())
 }
 
+/// Creates a closure that filters file paths based on a datetime range extracted
+/// from the directory structure.
+///
+/// This function is designed to work with a directory hierarchy where dates are
+/// embedded in the path, such as `/skippable/base/path/YYYY/MM/DD/HH/`. It constructs
+/// a filter that checks if the date derived from a path falls within the
+/// specified `start_time` and `end_time`.
+///
+/// The filter also ensures that if the path points to a file, its extension
+/// matches the provided `extension_pattern`.
+///
+/// # Arguments
+///
+/// * `start_time` - The inclusive start of the datetime range for the filter.
+/// * `end_time` - The inclusive end of the datetime range for the filter.
+/// * `extension_pattern` - The file extension to match (e.g., "json").
+/// * `skip_count` - The number of initial path components to skip before starting to parse the date
+///   parts (year, month, etc.). This is not guaranteed to be the same as
+///   "$WAL_ROOT/files/<org_id>/<stream_type>/<stream_name>/" as there can be more skippable
+///   segments after <stream_name> which may only be decided by the use of the API.
+///
+/// # Returns
+///
+/// A closure that takes a `PathBuf` and returns `true` if the path matches the
+/// criteria, and `false` otherwise. This closure is `Send`, `Clone`, and
+/// `'static`.
+pub fn create_wal_dir_datetime_filter(
+    start_time: DateTime<Utc>,
+    end_time: DateTime<Utc>,
+    extension_pattern: String,
+    skip_count: usize,
+) -> impl Fn(PathBuf) -> bool + Send + Clone + 'static {
+    let extension_pattern = extension_pattern.to_lowercase();
+    move |path: PathBuf| {
+        let mut components = path
+            .components()
+            .skip(skip_count)
+            .map(|c| c.as_os_str())
+            .filter_map(|osc| osc.to_str());
+
+        let year = match components.next().map(|c| c.parse::<i32>()) {
+            Some(Ok(y @ 1901..=9999)) => y, // A plausible year
+            Some(_) => return false,        // Parsed, but not a plausible year
+            None => return true,            /* Not present or failed to parse, could be a
+                                              * skippable path */
+        };
+
+        let month = match components.next().map(|c| c.parse::<u32>()) {
+            Some(Ok(m @ 1..=12)) => m,
+            Some(_) => return false,    // Parsed, but invalid month number
+            None => start_time.month(), // Not present or failed to parse
+        };
+
+        let month_days = [31u32, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+        let days = month_days[month as usize] + if month == 2 && year % 4 == 0 { 1 } else { 0 };
+        let day = match components.next().map(|c| c.parse::<u32>()) {
+            Some(Ok(day)) => {
+                if 1 <= day && day <= days {
+                    day
+                } else {
+                    return false;
+                }
+            }
+            Some(_) => return false,
+            None => start_time.day(),
+        };
+
+        let hour = match components.next().map(|c| c.parse::<u32>()) {
+            Some(Ok(hour @ 0..24)) => hour,
+            Some(_) => return false,
+            None => start_time.hour(),
+        };
+
+        let date_range_check = if let Some(datetime) = Utc
+            .with_ymd_and_hms(
+                year,
+                month,
+                day,
+                hour,
+                start_time.minute(),
+                start_time.second(),
+            )
+            .single()
+            .and_then(|dt| dt.with_nanosecond(start_time.timestamp_subsec_nanos()))
+        {
+            datetime >= start_time && datetime <= end_time
+        } else {
+            false
+        };
+
+        date_range_check
+            && (!path.is_file()
+                || path
+                    .extension()
+                    .and_then(|extension| {
+                        extension
+                            .to_str()
+                            .map(|s| s.to_lowercase() == extension_pattern)
+                    })
+                    .unwrap_or_default())
+    }
+}
+
 /// Asynchronously scans a directory tree and returns a vector of canonicalized file paths
 /// that match a given filter.
 ///
@@ -210,13 +314,16 @@ where
         walker.collect().await
     };
 
-    let files =
-        futures::future::join_all(uncanonicalized_paths.iter().map(tokio::fs::canonicalize))
-            .await
+    let files = futures::future::join_all(
+        uncanonicalized_paths
             .into_iter()
-            .map(Result::ok)
-            .filter_map(|path| path.and_then(|pbuf| pbuf.to_str().map(String::from)))
-            .collect();
+            .map(tokio::fs::canonicalize),
+    )
+    .await
+    .into_iter()
+    .map(Result::ok)
+    .filter_map(|path| path.and_then(|pbuf| pbuf.to_str().map(String::from)))
+    .collect();
 
     Ok(files)
 }
@@ -250,7 +357,6 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::*;
-    use crate::utils::file::wal_dir_datetime_filter_builder;
 
     #[tokio::test]
     async fn test_get_file_contents_with_range() {
@@ -336,7 +442,7 @@ mod tests {
         let start_time = Utc.with_ymd_and_hms(2025, 9, 10, 2, 0, 0).single().unwrap();
         let end_time = Utc.with_ymd_and_hms(2025, 9, 10, 4, 0, 0).single().unwrap();
         // 3 hours (2, 3, 4 - inclusive matching) - 4 parquet files per hour -> 12 files in total
-        let filter = wal_dir_datetime_filter_builder(
+        let filter = create_wal_dir_datetime_filter(
             start_time,
             end_time,
             "parquet".to_string(),

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -26,8 +26,8 @@ use config::{
         stream::{FileKey, StreamParams, StreamPartition},
     },
     utils::{
-        async_file::scan_files_filtered,
-        file::{is_exists, wal_dir_datetime_filter_builder},
+        async_file::{create_wal_dir_datetime_filter, scan_files_filtered},
+        file::is_exists,
         parquet::{parse_time_range_from_filename, read_metadata_from_file},
         record_batch_ext::concat_batches,
         size::bytes_to_human_readable,
@@ -584,12 +584,8 @@ async fn get_file_list_inner(
         let extension_pattern = file_ext.to_string();
         // Skip count is the number of segments in the cannonicalised path before
         // <YY>/<MM>/<DD>/<HH>/<file> appear
-        let filter = wal_dir_datetime_filter_builder(
-            start_time,
-            end_time,
-            extension_pattern,
-            skip_count + 1,
-        );
+        let filter =
+            create_wal_dir_datetime_filter(start_time, end_time, extension_pattern, skip_count + 1);
 
         scan_files_filtered(&pattern, filter, None).await?
     } else {


### PR DESCRIPTION
### **User description**
# PR type
Chore / Code improvement

# Description
We are addressing Greptile's complaint about Path::canonnicalize negating the async benefits and suggested tokio::fs::cannonicalize. Now all path canonnicalizations are performed asynchronously.

create_wal_dir_datetime_filter is now refactored into async_file.rs where its companion function scan_file_filtered() exists.


___

### **PR Type**
Enhancement


___

### **Description**
- Switch to async canonicalization with Tokio

- Defer canonicalization after filtering files

- Batch resolve paths via join_all

- Preserve limit before async canonicalization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dir entries stream"] -- "filter files" --> B["PathBuf list (uncanonicalized)"]
  B -- "apply limit (optional)" --> C["Bounded list"]
  C -- "tokio::fs::canonicalize (join_all)" --> D["Canonical paths (String)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>async_file.rs</strong><dd><code>Replace blocking canonicalize with async batched canonicalize</code></dd></summary>
<hr>

src/config/src/utils/async_file.rs

<ul><li>Remove blocking <code>PathBuf::canonicalize</code> in walker.<br> <li> Collect uncanonicalized files, then async canonicalize.<br> <li> Use <code>futures::future::join_all</code> with <code>tokio::fs::canonicalize</code>.<br> <li> Preserve string conversion and error filtering.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8364/files#diff-8275f369cab85b5e9a97ed11d236de3364850b6989698936f19e70a0144e6a0d">+10/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

