### PR TITLE
fix: restrict select * query for visualization

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -383,7 +383,7 @@ import useDashboardPanelData from "@/composables/useDashboardPanel";
 import { reactive } from "vue";
 import { getConsumableRelativeTime } from "@/utils/date";
 import { cloneDeep, debounce } from "lodash-es";
-import { buildSqlQuery, getFieldsFromQuery } from "@/utils/query/sqlUtils";
+import { buildSqlQuery, getFieldsFromQuery, isSimpleSelectAllQuery } from "@/utils/query/sqlUtils";
 import useNotifications from "@/composables/useNotifications";
 import SearchBar from "@/plugins/logs/SearchBar.vue";
 import SearchHistory from "@/plugins/logs/SearchHistory.vue";
@@ -1372,19 +1372,6 @@ export default defineComponent({
       return parsedSQL;
     };
 
-    // Helper function to check if the query is a simple "SELECT * FROM....." query
-    const isSimpleSelectAllQuery = (query: string): boolean => {
-      if (!query || typeof query !== "string") return false;
-
-      // Normalize the query by removing extra whitespace
-      const normalizedQuery = query.trim().replace(/\s+/g, " ");
-
-      // Pattern to match: SELECT * FROM followed by anything (case insensitive)
-      const selectAllPattern = /^select\s+\*\s+from\s+/i;
-
-      return selectAllPattern.test(normalizedQuery);
-    };
-
     const handleQuickModeChange = () => {
       if (searchObj.meta.quickMode == true) {
         let field_list: string = "*";
@@ -1481,14 +1468,21 @@ export default defineComponent({
             // Enable quick mode automatically when switching to visualization if:
             // 1. SQL mode is disabled OR
             // 2. Query is "SELECT * FROM some_stream" (simple select all query)
+            // 3. Default quick mode config is true
             const shouldEnableQuickMode =
               !searchObj.meta.sqlMode ||
               isSimpleSelectAllQuery(searchObj.data.query);
 
-            if (shouldEnableQuickMode && !searchObj.meta.quickMode) {
-              searchObj.meta.quickMode = true;
+            const isQuickModeDisabled = !searchObj.meta.quickMode;
+            const isQuickModeConfigEnabled =
+              store.state.zoConfig.quick_mode_enabled === true;
 
-              // handle quick mode change
+            if (
+              shouldEnableQuickMode &&
+              isQuickModeDisabled &&
+              isQuickModeConfigEnabled
+            ) {
+              searchObj.meta.quickMode = true;
               handleQuickModeChange();
             }
 
@@ -1759,6 +1753,27 @@ export default defineComponent({
       if (searchObj.meta.logsVisualizeToggle == "visualize") {
         // wait to extract fields if its ongoing; if promise rejects due to abort just return silently
         try {
+          let logsPageQuery = "";
+          
+          // handle sql mode
+          if(!searchObj.meta.sqlMode){
+            const queryBuild = buildSearch();
+            logsPageQuery = queryBuild?.query?.sql ?? "";
+          } else {
+            logsPageQuery = searchObj.data.query;
+          }
+          
+          // Check if query is SELECT * which is not supported for visualization
+          if (
+            store.state.zoConfig.quick_mode_enabled === true &&
+            isSimpleSelectAllQuery(logsPageQuery)
+          ) {
+            showErrorNotification(
+              "Select * query is not supported for visualization",
+            );
+            return;
+          }
+
           const success = await updateVisualization(false);
           if (!success) {
             return;

--- a/web/src/plugins/logs/VisualizeLogsQuery.vue
+++ b/web/src/plugins/logs/VisualizeLogsQuery.vue
@@ -37,8 +37,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             'scatter',
             'table',
           ]"
-          v-model:selectedChartType="dashboardPanelData.data.type"
-          @update:selected-chart-type="resetAggregationFunction"
+          :selectedChartType="dashboardPanelData.data.type"
+          @update:selected-chart-type="handleChartTypeChange"
         />
       </div>
       <q-separator vertical />
@@ -404,6 +404,8 @@ import { isEqual } from "lodash-es";
 import { onActivated } from "vue";
 import useNotifications from "@/composables/useNotifications";
 import CustomChartEditor from "@/components/dashboards/addPanel/CustomChartEditor.vue";
+import useLogs from "@/composables/useLogs";
+import { isSimpleSelectAllQuery } from "@/utils/query/sqlUtils";
 
 const ConfigPanel = defineAsyncComponent(() => {
   return import("@/components/dashboards/addPanel/ConfigPanel.vue");
@@ -476,6 +478,8 @@ export default defineComponent({
       metaData.value = metadata;
     };
     const { showErrorNotification } = useNotifications();
+    
+    const { searchObj, buildSearch } = useLogs();
 
     const { visualizeChartData, is_ui_histogram }: any = toRefs(props);
     const chartData = ref(visualizeChartData.value);
@@ -511,6 +515,36 @@ export default defineComponent({
         window.dispatchEvent(new Event("resize"));
       },
     );
+
+    // Handle chart type change with validation
+    const handleChartTypeChange = (newType: string) => {
+      // Get the actual logs page query, handling SQL mode
+      let logsPageQuery = "";
+      
+      // Handle sql mode - same as in Index.vue
+      if(!searchObj.meta.sqlMode){
+        const queryBuild = buildSearch();
+        logsPageQuery = queryBuild?.query?.sql ?? "";
+      } else {
+        logsPageQuery = searchObj.data.query;
+      }
+      
+      // Check if query is SELECT * and trying to switch chart type
+      if (
+        store.state.zoConfig.quick_mode_enabled === true &&
+        isSimpleSelectAllQuery(logsPageQuery)
+      ) {
+        showErrorNotification(
+          "Select * query is not supported for visualization.",
+        );
+        // Prevent the change by not updating the type
+        return;
+      }
+
+      // If validation passes, proceed with the change
+      dashboardPanelData.data.type = newType;
+      resetAggregationFunction();
+    };
 
     // resize the chart when query editor is opened and closed
     watch(
@@ -800,6 +834,8 @@ export default defineComponent({
       collapseFieldList,
       is_ui_histogram,
       onResultMetadataUpdate,
+      isSimpleSelectAllQuery,
+      handleChartTypeChange,
     };
   },
 });

--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -3,6 +3,23 @@ import { splitQuotedString, escapeSingleQuotes } from "@/utils/zincutils";
 let parser: any;
 let parserInitialized = false;
 
+/**
+ * Helper function to check if the query is a simple "SELECT * FROM....." query
+ * @param query The SQL query string to check
+ * @returns true if the query is a SELECT * query, false otherwise
+ */
+export const isSimpleSelectAllQuery = (query: string): boolean => {
+  if (!query || typeof query !== 'string') return false;
+  
+  // Normalize the query by removing extra whitespace
+  const normalizedQuery = query.trim().replace(/\s+/g, ' ');
+  
+  // Pattern to match: SELECT * FROM followed by anything (case insensitive)
+  const selectAllPattern = /^select\s+\*\s+from\s+/i;
+  
+  return selectAllPattern.test(normalizedQuery);
+};
+
 const importSqlParser = async () => {
   if (!parserInitialized) {
     const useSqlParser: any = await import("@/composables/useParser");


### PR DESCRIPTION
- #8338

Resolved Issues:
- Implemented a check for `ZO_QUICK_MODE_ENABLED` before enabling quick
mode on logs for visualization toggle.
1. If `ZO_QUICK_MODE_ENABLED=true`, quick mode is enabled when the query
is `select *`.
2. Otherwise, `select *` query is always permitted in visualization
mode.
- Restricted the use of `SELECT *` queries in visualization mode.
- As API call triggered on changing the chart type, such changes are now
disallowed for `SELECT *` queries.