### PR TITLE
feat: add tokio runtime metrics collection

### DIFF
--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -1050,6 +1050,75 @@ pub static QUERY_AGGREGATION_CACHE_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+// Runtime metrics - consolidated into fewer metrics with different labels
+pub static RUNTIME_TASKS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "runtime_tasks",
+            "Runtime task statistics",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["runtime", "metric_type"],
+    )
+    .expect("Metric created")
+});
+
+pub static RUNTIME_TASKS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "runtime_tasks_total",
+            "Total runtime task counters",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["runtime", "metric_type"],
+    )
+    .expect("Metric created")
+});
+
+pub static RUNTIME_WORKER_METRICS: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "runtime_worker_metrics_total",
+            "Runtime worker metrics",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["runtime", "worker", "metric_type"],
+    )
+    .expect("Metric created")
+});
+
+pub static RUNTIME_WORKER_DURATION_SECONDS: Lazy<CounterVec> = Lazy::new(|| {
+    CounterVec::new(
+        Opts::new(
+            "runtime_worker_duration_seconds_total",
+            "Runtime worker duration metrics in seconds",
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &["runtime", "worker"],
+    )
+    .expect("Metric created")
+});
+
+pub static RUNTIME_WORKER_POLL_TIME_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
+            "runtime_worker_poll_time_seconds",
+            "Runtime worker poll time distribution in seconds",
+        )
+        .namespace(NAMESPACE)
+        .buckets(vec![
+            0.000001, 0.000005, 0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0,
+        ])
+        .const_labels(create_const_labels()),
+        &["runtime", "worker"],
+    )
+    .expect("Metric created")
+});
+
 fn register_metrics(registry: &Registry) {
     // http latency
     registry
@@ -1324,6 +1393,23 @@ fn register_metrics(registry: &Registry) {
         .expect("Metric registered");
     registry
         .register(Box::new(TANTIVY_RESULT_CACHE_HITS_TOTAL.clone()))
+        .expect("Metric registered");
+
+    // runtime metrics
+    registry
+        .register(Box::new(RUNTIME_TASKS.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(RUNTIME_TASKS_TOTAL.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(RUNTIME_WORKER_METRICS.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(RUNTIME_WORKER_DURATION_SECONDS.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(RUNTIME_WORKER_POLL_TIME_SECONDS.clone()))
         .expect("Metric registered");
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,6 +283,11 @@ async fn main() -> Result<(), anyhow::Error> {
                 panic!("meter provider init failed");
             };
 
+            // Register job runtime for metrics collection
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                openobserve::service::runtime_metrics::register_runtime("job".to_string(), handle);
+            }
+
             job_init_tx.send(true).ok();
             job_shutdown_rx.await.ok();
             job_stopped_tx.send(()).ok();
@@ -327,6 +332,10 @@ async fn main() -> Result<(), anyhow::Error> {
             .max_blocking_threads(cfg.limit.grpc_runtime_blocking_worker_num)
             .build()
             .expect("grpc runtime init failed");
+            
+        // Register gRPC runtime for metrics collection
+        openobserve::service::runtime_metrics::register_runtime("grpc".to_string(), rt.handle().clone());
+        
         let _guard = rt.enter();
         rt.block_on(async move {
             let ret = if config::cluster::LOCAL_NODE.is_router() {
@@ -343,6 +352,14 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // wait for gRPC init
     grpc_init_rx.await.ok();
+
+    // Register main HTTP runtime for metrics collection
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        openobserve::service::runtime_metrics::register_runtime("http".to_string(), handle);
+    }
+
+    // Start runtime metrics collector
+    openobserve::service::runtime_metrics::start_metrics_collector().await;
 
     // let node online
     let _ = cluster::set_online(false).await;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -43,6 +43,7 @@ pub mod pipeline;
 pub mod promql;
 #[cfg(feature = "enterprise")]
 pub mod ratelimit;
+pub mod runtime_metrics;
 pub mod schema;
 pub mod search;
 pub mod tantivy;

--- a/src/service/runtime_metrics.rs
+++ b/src/service/runtime_metrics.rs
@@ -1,0 +1,161 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    sync::Mutex,
+    time::Duration,
+};
+
+use config::metrics::RUNTIME_TASKS;
+#[cfg(tokio_unstable)]
+use config::metrics::{
+    RUNTIME_TASKS_TOTAL, RUNTIME_WORKER_DURATION_SECONDS,
+    RUNTIME_WORKER_METRICS, RUNTIME_WORKER_POLL_TIME_SECONDS,
+};
+use tokio::runtime::Handle;
+
+static RUNTIME_HANDLES: Mutex<Vec<(String, Handle)>> = Mutex::new(Vec::new());
+
+pub fn register_runtime(name: String, handle: Handle) {
+    log::info!("Registered runtime '{}' for metrics collection", &name);
+    let mut handles = RUNTIME_HANDLES.lock().unwrap();
+    handles.push((name, handle));
+}
+
+pub async fn collect_runtime_metrics() {
+    let handles = {
+        let handles = RUNTIME_HANDLES.lock().unwrap();
+        handles.clone()
+    };
+
+    for (runtime_name, handle) in handles {
+        // Try to get runtime metrics if tokio_unstable is available
+        #[cfg(tokio_unstable)]
+        {
+            let metrics = handle.metrics();
+            update_runtime_metrics(&runtime_name, &metrics).await;
+        }
+        
+        #[cfg(not(tokio_unstable))]
+        {
+            // For stable tokio, we can only collect basic information
+            update_basic_runtime_info(&runtime_name).await;
+            let _ = handle; // Suppress unused variable warning
+        }
+    }
+}
+
+#[cfg(tokio_unstable)]
+async fn update_runtime_metrics(runtime_name: &str, metrics: &tokio::runtime::RuntimeMetrics) {
+    // Basic runtime task metrics using consolidated metrics with labels
+    RUNTIME_TASKS
+        .with_label_values(&[runtime_name, "workers"])
+        .set(metrics.num_workers() as i64);
+
+    RUNTIME_TASKS
+        .with_label_values(&[runtime_name, "alive_tasks"])
+        .set(metrics.num_alive_tasks() as i64);
+
+    RUNTIME_TASKS
+        .with_label_values(&[runtime_name, "global_queue_depth"])
+        .set(metrics.global_queue_depth() as i64);
+
+    RUNTIME_TASKS
+        .with_label_values(&[runtime_name, "blocking_queue_depth"])
+        .set(metrics.blocking_queue_depth() as i64);
+
+    RUNTIME_TASKS
+        .with_label_values(&[runtime_name, "io_driver_fd_registered"])
+        .set(metrics.io_driver_fd_registered_count() as i64);
+
+    // Total counters using consolidated metrics
+    RUNTIME_TASKS_TOTAL
+        .with_label_values(&[runtime_name, "spawned_tasks"])
+        .inc_by(metrics.spawned_tasks_count() as u64);
+
+    RUNTIME_TASKS_TOTAL
+        .with_label_values(&[runtime_name, "remote_schedule"])
+        .inc_by(metrics.remote_schedule_count() as u64);
+
+    RUNTIME_TASKS_TOTAL
+        .with_label_values(&[runtime_name, "io_driver_ready"])
+        .inc_by(metrics.io_driver_ready_count() as u64);
+
+    // Worker-specific metrics using consolidated metrics
+    for worker_id in 0..metrics.num_workers() {
+        let worker_id_str = worker_id.to_string();
+
+        // Worker counters
+        RUNTIME_WORKER_METRICS
+            .with_label_values(&[runtime_name, &worker_id_str, "poll_count"])
+            .inc_by(metrics.worker_poll_count(worker_id) as u64);
+
+        RUNTIME_WORKER_METRICS
+            .with_label_values(&[runtime_name, &worker_id_str, "steal_count"])
+            .inc_by(metrics.worker_steal_count(worker_id) as u64);
+
+        RUNTIME_WORKER_METRICS
+            .with_label_values(&[runtime_name, &worker_id_str, "park_count"])
+            .inc_by(metrics.worker_park_count(worker_id) as u64);
+
+        RUNTIME_WORKER_METRICS
+            .with_label_values(&[runtime_name, &worker_id_str, "local_queue_depth"])
+            .inc_by(metrics.worker_local_queue_depth(worker_id) as u64);
+
+        RUNTIME_WORKER_METRICS
+            .with_label_values(&[runtime_name, &worker_id_str, "local_schedule_count"])
+            .inc_by(metrics.worker_local_schedule_count(worker_id) as u64);
+
+        // Duration metrics (converted from Duration to seconds)
+        let busy_duration = metrics.worker_total_busy_duration(worker_id);
+        RUNTIME_WORKER_DURATION_SECONDS
+            .with_label_values(&[runtime_name, &worker_id_str])
+            .inc_by(busy_duration.as_secs_f64());
+
+        // Poll time as histogram
+        let mean_poll_time = metrics.worker_mean_poll_time(worker_id);
+        RUNTIME_WORKER_POLL_TIME_SECONDS
+            .with_label_values(&[runtime_name, &worker_id_str])
+            .observe(mean_poll_time.as_secs_f64());
+    }
+}
+
+#[cfg(not(tokio_unstable))]
+async fn update_basic_runtime_info(runtime_name: &str) {
+    // For stable tokio, we can only set basic information
+    // Set workers to -1 to indicate unknown when tokio_unstable is not available
+    RUNTIME_TASKS
+        .with_label_values(&[runtime_name, "workers"])
+        .set(-1);
+    
+    // Log that detailed metrics require tokio_unstable
+    log::debug!("Runtime '{}' metrics available only with tokio_unstable feature", runtime_name);
+}
+
+pub async fn start_metrics_collector() {
+    #[cfg(tokio_unstable)]
+    log::info!("Starting runtime metrics collector with full tokio_unstable metrics support");
+    
+    #[cfg(not(tokio_unstable))]
+    log::info!("Starting runtime metrics collector (basic mode - compile with --cfg tokio_unstable for detailed metrics)");
+    
+    tokio::spawn(async {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        loop {
+            interval.tick().await;
+            collect_runtime_metrics().await;
+        }
+    });
+}


### PR DESCRIPTION
## Summary
Implement comprehensive runtime metrics collection for OpenObserve's three Tokio runtimes to help debug performance and slowness issues.

- ✅ Added runtime metrics collection for HTTP, gRPC, and job runtimes
- ✅ Consolidated metrics with labels to reduce Prometheus metric count  
- ✅ Support for both stable and tokio_unstable configurations
- ✅ Automatic runtime registration and periodic collection (30s interval)

## Key Features

### Runtime Identification
- **HTTP runtime**: Main application runtime (actix-web server)
- **gRPC runtime**: Dedicated runtime for gRPC services  
- **Job runtime**: Background job processing runtime

### Metrics Collection
- **Basic metrics** (stable tokio): Runtime identification with `workers = -1` indicator
- **Detailed metrics** (tokio_unstable): Full runtime statistics including:
  - Task counts (alive, spawned total)
  - Queue depths (global, blocking, per-worker local)
  - Worker statistics (poll/steal/park counts, busy duration)  
  - I/O driver metrics (file descriptors, ready events)
  - Timing histograms (poll time distribution)

### Prometheus Metrics
All metrics are exposed under the `zo` namespace with labels:
- `runtime`: "http", "grpc", "job"
- `metric_type`: varies by specific metric  
- `worker`: worker ID for per-worker metrics

Examples:
```
zo_runtime_tasks{runtime="http",metric_type="workers"} 8
zo_runtime_tasks{runtime="grpc",metric_type="alive_tasks"} 42
zo_runtime_worker_metrics_total{runtime="job",worker="0",metric_type="poll_count"} 1234
```

## Usage

### Standard Build (Stable Tokio)
```bash
cargo build --release
```
Shows basic runtime identification metrics.

### Full Metrics Build (Tokio Unstable)  
```bash
RUSTFLAGS="--cfg tokio_unstable" cargo build --release
```
Enables detailed runtime performance metrics.

## Test Plan
- [x] Verify compilation with stable tokio (basic mode)
- [x] Verify conditional compilation with tokio_unstable 
- [x] Runtime registration works for all three runtimes
- [ ] Manual verification of metrics in Prometheus endpoint
- [ ] Performance impact assessment during load testing

## Implementation Details

The implementation uses a consolidated approach with fewer metrics and more labels per the feedback to reduce metric proliferation. All runtime handles are registered at startup and metrics are collected every 30 seconds.

Resolves #8354

🤖 Generated with [Claude Code](https://claude.ai/code)