### PR TITLE
fix: In logs append results if partition results are chunked

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -328,7 +328,13 @@ const {
   fetchQueryDataWithHttpStream,
 } = useStreamingSearch();
 
-const searchPartitionMap = reactive<{ [key: string]: number }>({});
+
+type SearchPartition = {
+  partition: number;
+  chunks: Record<number, number>;
+};
+
+const searchPartitionMap = reactive<Record<string, SearchPartition>>({});
 
 const useLogs = () => {
   const store = useStore();
@@ -6011,7 +6017,7 @@ const useLogs = () => {
     // Scan-size and took time in histogram title
     // For the initial request, we get histogram and logs data. So, we need to sum the scan_size and took time of both the requests.
     // For the pagination request, we only get logs data. So, we need to consider scan_size and took time of only logs request.
-    if((isPagination && searchPartitionMap[payload.traceId] === 1) || !appendResult){
+    if((isPagination && searchPartitionMap[payload.traceId].partition === 1) || !appendResult){
       searchObj.data.queryResults.hits = response.content.results.hits;
     } else if (appendResult) {
       searchObj.data.queryResults.hits.push(
@@ -6319,25 +6325,33 @@ const useLogs = () => {
     if(payload.type === "search" && response?.type === "search_response_hits") {
       const isStreamingAggs = response.content?.streaming_aggs || searchObj.data.queryResults.streaming_aggs;
       const shouldAppendStreamingResults = isStreamingAggs ? !response.content?.results?.hits?.length : true;
+      searchPartitionMap[payload.traceId].chunks[searchPartitionMap[payload.traceId].partition]++;
+      // If single partition has more than 1 chunk, then we need to append the results
+      const isChunkedHits = searchPartitionMap[payload.traceId].chunks[searchPartitionMap[payload.traceId].partition] > 1;
 
-      handleStreamingHits(payload, response, payload.isPagination, (shouldAppendStreamingResults && searchPartitionMap[payload.traceId] > 1));
+      handleStreamingHits(payload, response, payload.isPagination, (shouldAppendStreamingResults && (searchPartitionMap[payload.traceId].partition > 1 || isChunkedHits)));
       return;
     }
 
     if(payload.type === "search" && response?.type === "search_response_metadata") {
       searchPartitionMap[payload.traceId] = searchPartitionMap[payload.traceId]
       ? searchPartitionMap[payload.traceId]
-      : 0;
-      searchPartitionMap[payload.traceId]++;
+      : {
+        partition: 0,
+        chunks: {},
+      };
 
       const isStreamingAggs = response.content?.streaming_aggs;
       const shouldAppendStreamingResults = isStreamingAggs ? !response.content?.results?.hits?.length : true;
 
-      handleStreamingMetadata(payload, response, payload.isPagination, (shouldAppendStreamingResults && searchPartitionMap[payload.traceId] > 1));
+      searchPartitionMap[payload.traceId].partition++;
+      searchPartitionMap[payload.traceId].chunks[searchPartitionMap[payload.traceId].partition] = 0;
+
+      handleStreamingMetadata(payload, response, payload.isPagination, (shouldAppendStreamingResults && searchPartitionMap[payload.traceId].partition > 1));
       return;
     }
 
-    if(payload.type === "histogram" && response?.type === "search_response_hits") {
+    if(payload.type === "histogram" && response?.type === "search_response_hits") {      
       handleHistogramStreamingHits(payload, response, payload.isPagination);
       return;
     }
@@ -6361,8 +6375,11 @@ const useLogs = () => {
     if (response.type === "search_response") {
       searchPartitionMap[payload.traceId] = searchPartitionMap[payload.traceId]
       ? searchPartitionMap[payload.traceId]
-      : 0;
-      searchPartitionMap[payload.traceId]++;
+      : {
+        partition: 0,
+        chunks: {},
+      };
+      searchPartitionMap[payload.traceId].partition++;
 
       if (payload.type === "search") {
         handleLogsResponse(
@@ -6371,7 +6388,7 @@ const useLogs = () => {
           payload.traceId,
           response,
           !response.content?.streaming_aggs &&
-            searchPartitionMap[payload.traceId] > 1, // In aggregation query, we need to replace the results instead of appending
+            searchPartitionMap[payload.traceId].partition > 1, // In aggregation query, we need to replace the results instead of appending
         );
       }
 


### PR DESCRIPTION
### **User description**
If we receive chunked hits of a single partition, then append the hits.


___

### **PR Type**
Bug fix


___

### **Description**
- Track chunks per partition for hits

- Append hits when partition is chunked

- Replace hits only on first partition

- Refactor partition map to structured object


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebSocket search responses"] -- "metadata" --> B["Init/Increment partition"]
  B -- "set chunks[partition]=0" --> C["Track chunks per partition"]
  A -- "hits" --> D["Increment chunk count"]
  D -- "is chunked or partition>1?" --> E["Append hits"]
  D -- "else" --> F["Replace hits"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useLogs.ts</strong><dd><code>Chunk-aware partition tracking and hit appending</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs.ts

<ul><li>Introduce <code>SearchPartition</code> with <code>partition</code> and <code>chunks</code>.<br> <li> Track chunk counts per partition per <code>traceId</code>.<br> <li> Append hits when single partition has multiple chunks.<br> <li> Update conditions to use <code>partition</code> field instead of number map.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8385/files#diff-1040f61354f92711e0e77ed4e9bfa15586d45a94c7e2ab06cc37372068030e7b">+29/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

