### PR TITLE
fix: removed the check for show add destination button

### DIFF
--- a/web/src/components/alerts/PipelinesDestinationList.vue
+++ b/web/src/components/alerts/PipelinesDestinationList.vue
@@ -42,7 +42,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :class="store.state.theme === 'dark' ? 'o2-primary-button-dark' : 'o2-primary-button-light'"
             no-caps
             flat
-            :disable="!templates.length"
             :label="t(`alert_destinations.add`)"
             @click="editDestination(null)"
           />


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Enable Add Destination button always

- Remove templates-length disable condition


___

### Diagram Walkthrough


```mermaid
flowchart LR
  BTN["Add Destination Button"] -- remove disable binding --> ENABLED["Always enabled"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PipelinesDestinationList.vue</strong><dd><code>Remove conditional disable on Add button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/PipelinesDestinationList.vue

<ul><li>Removed <code>:disable="!templates.length"</code> from Add button.<br> <li> Button now clickable regardless of templates array.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8402/files#diff-088c66f5a34e73a5350a794a772e5d905262277337c937dd36f4295072203ebf">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

