### PR TITLE
fix: axisvalue issue on go to logs page drilldown #8404

### DIFF
--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -1427,6 +1427,9 @@ export default defineComponent({
                       drilldownParams[0].value.length - 1
                     ]
                   : drilldownParams[0].value,
+                __axisValue:
+                  drilldownParams?.[0]?.value?.[0] ??
+                  drilldownParams?.[0]?.name,
               };
             }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add `__axisValue` to drilldown payload

- Fallback to name when value missing

- Improve logs page drilldown accuracy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Drilldown event params"] --> B["Extract value/name"]
  B --> C["Set __axisValue from value[0]"]
  B --> D["Fallback to name if missing"]
  C --> E["Build drilldown payload"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PanelSchemaRenderer.vue</strong><dd><code>Add robust axis value to drilldown data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/PanelSchemaRenderer.vue

<ul><li>Add <code>__axisValue</code> to the drilldown data object.<br> <li> Use first element of <code>value</code> array when available.<br> <li> Fallback to <code>name</code> when <code>value[0]</code> is absent.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8405/files#diff-e5376e7e77bf3aaf6590c2522d8c2dbffcc95a8006ae0d6dc0040a37825367d6">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

