### PR TITLE
fix: trace id added for values api

### DIFF
--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -1347,6 +1347,7 @@ export default defineComponent({
                     searchObj.meta.clusters.length > 0
                       ? searchObj.meta.clusters.join(",")
                       : "",
+                  traceparent: generateTraceContext().traceId,
                 });
 
                 if (res.data.hits.length) {

--- a/web/src/services/stream.ts
+++ b/web/src/services/stream.ts
@@ -104,6 +104,7 @@ const stream = {
     clusters,
     no_count,
     action_id,
+    traceparent,
   }: any) => {
     const fieldsString = fields.join(",");
     let url = `/api/${org_identifier}/${stream_name}/_values?fields=${fieldsString}&size=${size}&start_time=${start_time}&end_time=${end_time}`;
@@ -114,7 +115,14 @@ const stream = {
     if (type) url += "&type=" + type;
     if (regions) url += "&regions=" + regions;
     if (clusters) url += "&clusters=" + clusters;
-    return http().get(url);
+
+    let headers = {};
+    if (traceparent) {
+      headers = { traceparent };
+    }
+    return http({
+      headers,
+    }).get(url);
   },
 
   // Thia API is just used for service_name and operation_name fields


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add optional trace header to values API

- Propagate generated trace id from UI

- Use http client with custom headers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Logs IndexList.vue: generate trace id"] -- "pass traceparent" --> Service["stream.values() accepts traceparent"]
  Service -- "set headers if present" --> HTTP["http({ headers }).get(url)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stream.ts</strong><dd><code>Support optional traceparent header in service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/services/stream.ts

<ul><li>Accept new <code>traceparent</code> param in <code>values</code> method.<br> <li> Build optional headers with <code>traceparent</code>.<br> <li> Switch to <code>http({ headers }).get(url)</code> to send header.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8408/files#diff-021a378afe6f62526991974cd72b045a5be00aa5233281218cadce6d3d1c6abf">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IndexList.vue</strong><dd><code>Propagate trace id from UI to service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/IndexList.vue

<ul><li>Generate trace context in UI.<br> <li> Pass <code>traceparent</code> (traceId) to values API call.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8408/files#diff-08f058f883b659e713e606991a7ea37ae1ff016b7cccef970489ab5840dc3d09">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

