### PR TITLE
fix: missing timestamp column on switch between streams

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -4136,6 +4136,9 @@ const useLogs = () => {
         }
       } else {
         if (
+          searchObj.data.queryResults.hits?.some((item) =>
+            item.hasOwnProperty(store.state.zoConfig.timestamp_column),
+          ) ||
           searchObj.data.hasSearchDataTimestampField ||
           selectedFields.includes(store.state.zoConfig.timestamp_column)
         ) {


### PR DESCRIPTION
### **PR Type**
- Bug fix



___

### **Description**
- Preserve timestamp column when switching streams

- Check hits for timestamp field presence

- Prevent duplicate column insertion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Search results (hits)"] -- "check for timestamp field" --> B["Timestamp present?"]
  B -- "yes" --> C["Prepend timestamp column"]
  B -- "no" --> D["Fallback checks (hasSearchDataTimestampField or selectedFields)"]
  D -- "true" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useLogs.ts</strong><dd><code>Add hits-aware timestamp column detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs.ts

<ul><li>Add hits-based check for <code>timestamp_column</code>.<br> <li> Short-circuit with optional chaining to avoid errors.<br> <li> Ensure timestamp column added when any hit includes it.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8420/files#diff-1040f61354f92711e0e77ed4e9bfa15586d45a94c7e2ab06cc37372068030e7b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

