### PR TITLE
fix: improve stream stats reset

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -223,6 +223,19 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                     db::functions::reset().await?;
                 }
                 "stream-stats" => {
+                    if cfg.limit.calculate_stats_step_limit_secs < 3600 {
+                        println!(
+                            r#"
+------------------------------------------------------------------------------
+Warning: !!! 
+calculate_stats_step_limit_secs good to be at least 3600 for stats reset,
+suggested to run again with:
+
+ZO_CALCULATE_STATS_STEP_LIMIT_SECS=3600 ./openobserve reset -c stream-stats
+------------------------------------------------------------------------------
+"#
+                        );
+                    }
                     // reset stream stats update offset
                     db::compact::stats::set_offset(0, None).await?;
                     // reset stream stats table data

--- a/src/infra/src/queue/nats.rs
+++ b/src/infra/src/queue/nats.rs
@@ -37,10 +37,9 @@ pub struct NatsQueue {
 impl NatsQueue {
     pub fn new(prefix: &str) -> Self {
         let prefix = prefix.trim_end_matches('/');
-        let consumer_name = get_config().common.instance_name.to_string();
         Self {
             prefix: prefix.to_string(),
-            consumer_name,
+            consumer_name: format_key(&get_config().common.instance_name),
             is_durable: false,
         }
     }
@@ -52,7 +51,7 @@ impl NatsQueue {
     pub fn with_consumer_name(&self, consumer_name: String, is_durable: bool) -> Self {
         Self {
             prefix: self.prefix.clone(),
-            consumer_name,
+            consumer_name: format_key(&consumer_name),
             is_durable,
         }
     }
@@ -88,7 +87,7 @@ impl super::Queue for NatsQueue {
         let cfg = config::get_config();
         let client = get_nats_client().await.clone();
         let jetstream = jetstream::new(client);
-        let topic_name = format!("{}{}", self.prefix, topic);
+        let topic_name = format!("{}{}", self.prefix, format_key(topic));
         let config = jetstream::stream::Config {
             name: topic_name.to_string(),
             subjects: vec![topic_name.to_string(), format!("{}.*", topic_name)],
@@ -112,7 +111,7 @@ impl super::Queue for NatsQueue {
         let client = get_nats_client().await.clone();
         let jetstream = jetstream::new(client);
         // Publish a message to the stream
-        let topic_name = format!("{}{}", self.prefix, topic);
+        let topic_name = format!("{}{}", self.prefix, format_key(topic));
         let ack = jetstream.publish(topic_name, value).await?;
         ack.await?;
         Ok(())
@@ -120,7 +119,7 @@ impl super::Queue for NatsQueue {
 
     async fn consume(&self, topic: &str) -> Result<Arc<mpsc::Receiver<super::Message>>> {
         let (tx, rx) = mpsc::channel(1024);
-        let stream_name = format!("{}{}", self.prefix, topic);
+        let stream_name = format!("{}{}", self.prefix, format_key(topic));
         let consumer_name = self.consumer_name.clone();
         let is_durable = self.is_durable;
         let _task: JoinHandle<Result<()>> = tokio::task::spawn(async move {
@@ -201,5 +200,54 @@ fn get_deliver_policy() -> DeliverPolicy {
         "last" | "deliverlast" | "deliver_last" => DeliverPolicy::Last,
         "new" | "delivernew" | "deliver_new" => DeliverPolicy::New,
         _ => DeliverPolicy::All,
+    }
+}
+
+// format the key to be a valid nats key
+// refer to: https://docs.nats.io/nats-concepts/subjects#characters-allowed-and-recommended-for-subject-names
+fn format_key(key: &str) -> String {
+    let mut result = String::new();
+
+    for ch in key.chars() {
+        match ch {
+            // Keep recommended characters as-is
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => result.push(ch),
+            // Replace other characters with underscore for safety
+            _ => result.push('_'),
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_key;
+
+    #[test]
+    fn test_queue_nats_format_key() {
+        // Test basic functionality
+        assert_eq!(format_key("test"), "test");
+        assert_eq!(format_key("test123"), "test123");
+        assert_eq!(format_key("test-key"), "test-key");
+        assert_eq!(format_key("test_key"), "test_key");
+
+        // Test forbidden characters
+        assert_eq!(format_key("test.key"), "test_key");
+        assert_eq!(format_key("test*key"), "test_key");
+        assert_eq!(format_key("test>key"), "test_key");
+        assert_eq!(format_key("test key"), "test_key");
+        assert_eq!(format_key("test\0key"), "test_key");
+
+        // Test empty string
+        assert_eq!(format_key(""), "");
+
+        // Test mixed characters
+        assert_eq!(format_key("test@#$%^&*()key"), "test_________key");
+        assert_eq!(format_key("test.key*value>data"), "test_key_value_data");
+
+        // Test unicode characters (should be replaced with _)
+        assert_eq!(format_key("test中文key"), "test__key");
+        assert_eq!(format_key("test🚀key"), "test_key");
     }
 }


### PR DESCRIPTION
### **User description**
Add some tips:
```
Warning: !!!
calculate_stats_step_limit_secs good to be greater than 3600 for stats reset,
suggested to run again with:

ZO_CALCULATE_STATS_STEP_LIMIT_SECS=3600 ./openobserve reset -c stream-stats
```


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add warning for low stats step limit

- Guide to rerun with recommended env var

- Improve stream-stats reset safety messaging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI reset command"]
  Check["Check calculate_stats_step_limit_secs"]
  Warn["Print warning and rerun tip"]
  ResetOffset["Reset stats update offset"]
  ResetData["Reset stream stats table"]

  CLI -- "reset -c stream-stats" --> Check
  Check -- "< 3600" --> Warn
  Check -- "any value" --> ResetOffset
  ResetOffset --> ResetData
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.rs</strong><dd><code>Warn and guide when stats step limit too low</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/basic/cli.rs

<ul><li>Add threshold check for <code>calculate_stats_step_limit_secs</code>.<br> <li> Print multi-line warning with rerun recommendation.<br> <li> Keep existing reset of offset and stats data.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8426/files#diff-cb1eb3e74723d891353ccf1e2e5e0d246d2e78a5e69dbe4c73006ea8412d65e0">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

