### PR TITLE
fix: sql query editor rapidly increases

### DIFF
--- a/web/src/components/alerts/ScheduledAlert.vue
+++ b/web/src/components/alerts/ScheduledAlert.vue
@@ -1294,12 +1294,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       :class="[
                         query === '' && queryEditorPlaceholderFlag ? 'empty-query' : '',
                         store.state.theme === 'dark' ? 'dark-mode dark-mode-editor' : 'light-mode light-mode-editor',
-                        !!sqlQueryErrorMsg ? 'tw-h-[calc(100%-100px)]' : 'tw-h-[calc(100%-62px)]'
                       ]"
                       @update:query="updateQueryValue"
                       @focus="queryEditorPlaceholderFlag = false"
                       @blur="onBlurQueryEditor"
-                      style="min-height: 10rem;"
+                      style="min-height: 18rem;"
+                      :style="{
+                            height: !!sqlQueryErrorMsg ? 'calc(100% - 150px)' : 'calc(100% - 80px)'
+                      }"
                     />
 
                     <div style="height: 50px; overflow: auto;" v-show="!!sqlQueryErrorMsg && tab === 'sql'" class="text-negative q-py-sm invalid-sql-error">


### PR DESCRIPTION
### **User description**
This PR fixes the issue in #8433


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent SQL editor height growth

- Set minimum height to 18rem

- Compute height via inline style binding

- Adjust for error message presence


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Alert Form UI"] -- contains --> Editor["SQL Query Editor"]
  ErrorState["SQL Error State"] -- toggles --> EditorHeight["Dynamic Height Style"]
  Editor -- renders with --> EditorHeight
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ScheduledAlert.vue</strong><dd><code>Stabilize SQL editor height with dynamic styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/ScheduledAlert.vue

<ul><li>Remove class-based height toggling.<br> <li> Add inline dynamic height style based on error state.<br> <li> Increase minimum editor height to 18rem.<br> <li> Use calc values: 100%-150px or 100%-80px.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8435/files#diff-5e143a17ab0fa5d7817f6d9301667fb5597236f27184248c7a71728e85b8d999">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

