### PR TITLE
feat: add env to bypass collect scan size

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -789,6 +789,12 @@ pub struct Common {
         help = "Skip WAL for query"
     )]
     pub feature_query_skip_wal: bool,
+    #[env_config(
+        name = "ZO_FEATURE_QUERY_SKIP_COLLECT_STATS",
+        default = false,
+        help = "Skip collect stats for query"
+    )]
+    pub feature_query_skip_collect_stats: bool,
     #[env_config(name = "ZO_UI_ENABLED", default = true)]
     pub ui_enabled: bool,
     #[env_config(name = "ZO_UI_SQL_BASE64_ENABLED", default = false)]

--- a/src/service/search/super_cluster/leader.rs
+++ b/src/service/search/super_cluster/leader.rs
@@ -199,9 +199,11 @@ pub async fn search(
         }
     };
 
-    let main_trace_id = trace_id.split("-").next().unwrap();
-    let stats = super::super::utils::collect_scan_stats(&nodes, main_trace_id, true).await;
-    scan_stats.add(&stats);
+    if !cfg.common.feature_query_skip_collect_stats {
+        let main_trace_id = trace_id.split("-").next().unwrap();
+        let stats = super::super::utils::collect_scan_stats(&nodes, main_trace_id, true).await;
+        scan_stats.add(&stats);
+    }
 
     log::info!("[trace_id {trace_id}] super cluster leader: search finished");
 

--- a/src/service/search/utils.rs
+++ b/src/service/search/utils.rs
@@ -185,6 +185,9 @@ pub async fn collect_scan_stats(
     trace_id: &str,
     is_leader: bool,
 ) -> ScanStats {
+    let start = std::time::Instant::now();
+    log::info!("[trace_id {trace_id}] collecting scan stats start");
+
     let mut scan_stats = ScanStats::default();
     for node in nodes {
         let mut scan_stats_request = tonic::Request::new(proto::cluster_rpc::GetScanStatsRequest {
@@ -209,5 +212,10 @@ pub async fn collect_scan_stats(
         let stats = stats.into_inner().stats.unwrap_or_default();
         scan_stats.add(&(&stats).into());
     }
+
+    log::info!(
+        "[trace_id {trace_id}] collecting scan stats end: took {} ms",
+        start.elapsed().as_millis()
+    );
     scan_stats
 }


### PR DESCRIPTION
New env set to `true` can bypass collect scan size for super cluster.

```
ZO_FEATURE_QUERY_SKIP_COLLECT_STATS=false
```