### PR TITLE
chore: vrl error logging (#8445)

### DIFF
--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -139,7 +139,7 @@ pub fn apply_vrl_fn(
                 let err_msg = format!(
                     "{org_id}/{stream_name:?} vrl failed at processing result {err:?} on record {row:?}. Returning original row.",
                 );
-                log::warn!("{err_msg}");
+                log::warn!("{}", err_msg.get(0..250).unwrap_or(&err_msg));
                 (row, Some(err_msg))
             }
         },
@@ -155,7 +155,7 @@ pub fn apply_vrl_fn(
             let err_msg = format!(
                 "{org_id}/{stream_name:?} vrl runtime failed at getting result {err:?} on record {row:?}. Returning original row.",
             );
-            log::warn!("{err_msg}");
+            log::warn!("{}", err_msg.get(0..250).unwrap_or(&err_msg));
             (row, Some(err_msg))
         }
     }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Truncate VRL warning logs to 250 chars

- Preserve full error message for return value

- Avoid potential format string misuse in logs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  applyVRL["apply_vrl_fn"] -- "on VRL error" --> buildMsg["build err_msg string"]
  buildMsg -- "log truncated (<=250 chars)" --> warnLog["log::warn"]
  buildMsg -- "return full message" --> returnPath["(row, Some(err_msg))"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Truncate VRL error warning logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/ingestion/mod.rs

<ul><li>Replace direct warn of full message with truncated version<br> <li> Use substring get(0..250) with fallback to full message<br> <li> Apply change for both processing and runtime error branches</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8447/files#diff-7c7b5bca85f0ced652965cae66540c96f56dfcca4f4c16b77bf7b45aac203d1b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

