### PR TITLE
fix: contains search for match_all

### DIFF
--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -862,7 +862,7 @@ impl AlertExt for Alert {
                 self.org_id, self.stream_type, self.stream_name, self.name
             )));
             search_event_ctx.alert_name = Some(self.name.clone());
-            
+
             self.query_condition
                 .evaluate_scheduled(
                     &self.org_id,

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -1060,6 +1060,10 @@ async fn search_tantivy_index(
             let row_ids_percent = row_ids.len() as f64 / parquet_file.meta.records as f64 * 100.0;
             if skip_threshold > 0 && row_ids_percent > skip_threshold as f64 {
                 // return empty file name means we need to add filter back and skip tantivy search
+                log::info!(
+                    "search->tantivy: file: {}, result percent {row_ids_percent}% is too large, back to datafusion",
+                    parquet_file.key
+                );
                 return Ok((
                     "".to_string(),
                     TantivyResult::RowIdsBitVec(row_ids_percent as usize, BitVec::EMPTY),

--- a/src/service/search/index.rs
+++ b/src/service/search/index.rs
@@ -488,6 +488,11 @@ impl Condition {
                 })?;
                 if value.is_empty() || value == "*" {
                     Box::new(AllQuery {})
+                } else if value.starts_with("*") && value.ends_with("*") {
+                    Box::new(ContainsQuery::new_case_insensitive(
+                        value.trim_matches('*'),
+                        default_field,
+                    )?)
                 } else {
                     let mut tokens = o2_collect_tokens(value);
                     let first_prefix = if value.starts_with("*") && !tokens.is_empty() {
@@ -508,10 +513,8 @@ impl Condition {
                         })
                         .collect();
                     if let Some(value) = first_prefix {
-                        terms.push(Box::new(PhrasePrefixQuery::new_with_offset(vec![(
-                            0,
-                            Term::from_field_text(default_field, &value),
-                        )])));
+                        let value = format!(".*{value}");
+                        terms.push(Box::new(RegexQuery::from_pattern(&value, default_field)?));
                     }
                     if let Some(value) = last_prefix {
                         terms.push(Box::new(PhrasePrefixQuery::new_with_offset(vec![(


### PR DESCRIPTION
Now match_all support:

- term search: `match_all('keyword')`
- contains search: `match_all('*wor*')`
- prefix search: `match_all('keyw*')`
- suffix search: `match_all('*word')`
