### PR TITLE
fix: contains search for match_all

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -13,10 +13,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::path::PathBuf;
+
 use chrono::TimeZone;
 use config::utils::file::set_permission;
 use infra::{file_list as infra_file_list, table};
-use std::path::PathBuf;
 
 use crate::{
     cli::data::{

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -330,7 +330,7 @@ pub fn load_config() -> Result<(), anyhow::Error> {
             }
         }
     }
-    
+
     Ok(())
 }
 static CHROME_LAUNCHER_OPTIONS: tokio::sync::OnceCell<Option<BrowserConfig>> =

--- a/src/config/src/config_path_manager.rs
+++ b/src/config/src/config_path_manager.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{path::PathBuf, sync::RwLock};
+
 use once_cell::sync::Lazy;
 
 // Config file path management
@@ -23,28 +24,30 @@ pub struct ConfigManager {
     last_hash: Option<String>,
 }
 
-static CONFIG_MANAGER: Lazy<RwLock<ConfigManager>> = Lazy::new(|| {
-    RwLock::new(ConfigManager::default())
-});
+static CONFIG_MANAGER: Lazy<RwLock<ConfigManager>> =
+    Lazy::new(|| RwLock::new(ConfigManager::default()));
 
 // Config manager interface functions
 pub fn set_config_file_path(path: PathBuf) -> Result<(), anyhow::Error> {
     // CLI validation: file MUST exist when provided via CLI
     if !path.exists() {
-        return Err(anyhow::anyhow!("Config file does not exist: {}", path.display()));
+        return Err(anyhow::anyhow!(
+            "Config file does not exist: {}",
+            path.display()
+        ));
     }
-    
+
     let hash = super::calculate_config_file_hash(&path)?;
-    
+
     // Update the config manager
     {
         let mut manager = CONFIG_MANAGER.write().unwrap();
         manager.file_path = Some(path.clone());
         manager.last_hash = Some(hash); // Reset hash when path changes
     }
-    
+
     log::info!("Config manager: Set CLI config file path to {:?}", path);
-    
+
     Ok(())
 }
 

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -15,12 +15,12 @@
 
 pub mod cluster;
 pub mod config;
+pub mod config_path_manager;
 pub mod ider;
 pub mod meta;
 pub mod metrics;
 pub mod router;
 pub mod utils;
-pub mod config_path_manager;
 
 pub use config::*;
 

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -89,7 +89,7 @@ pub struct HealthzResponse {
     status: String,
 }
 
-#[cfg( feature = "enterprise")]
+#[cfg(feature = "enterprise")]
 pub fn reload_enterprise_config() -> Result<(), anyhow::Error> {
     refresh_o2_config()
         .and_then(|_| refresh_dex_config())
@@ -422,8 +422,7 @@ pub async fn config_reload() -> Result<HttpResponse, Error> {
         );
     }
     #[cfg(feature = "enterprise")]
-    if let Err(e) = reload_enterprise_config()
-    {
+    if let Err(e) = reload_enterprise_config() {
         return Ok(
             HttpResponse::InternalServerError().json(serde_json::json!({"status": e.to_string()}))
         );

--- a/src/job/config_watcher.rs
+++ b/src/job/config_watcher.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::path::PathBuf;
+
 use config::spawn_pausable_job;
 
 /// This function will start the config file watcher and load the global config


### PR DESCRIPTION
Now match_all support:

- term search: `match_all('keyword')`
- contains search: `match_all('*wor*')`
- prefix search: `match_all('keyw*')`
- suffix search: `match_all('*word')`
