### PR TITLE
feat: add custom env file path support (#8365)

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -16,6 +16,7 @@
 use chrono::TimeZone;
 use config::utils::file::set_permission;
 use infra::{file_list as infra_file_list, table};
+use std::path::PathBuf;
 
 use crate::{
     cli::data::{
@@ -32,6 +33,13 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
     let app = clap::Command::new("openobserve")
         .version(config::VERSION)
         .about(clap::crate_description!())
+        .arg(
+            clap::Arg::new("config")
+                .short('c')
+                .long("config")
+                .value_name("FILE")
+                .help("Path to config file to load and watch for changes")
+        )
         .subcommands(&[
             clap::Command::new("reset")
                 .about("reset openobserve data")
@@ -270,6 +278,18 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                 ])
         ])
         .get_matches();
+
+    // Handle config file argument
+    if let Some(config_file_path) = app.get_one::<String>("config") {
+        let path = PathBuf::from(config_file_path);
+        config::config_path_manager::set_config_file_path(path.clone())
+            .and_then(|_| crate::job::config_watcher::reload_config(&path))
+            .map_err(|e|
+                anyhow::anyhow!(
+                    "set config from file path {config_file_path} failed with {e}, stopping boot up... ",
+                )
+            )?;
+    }
 
     if app.subcommand().is_none() {
         return Ok(false);

--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -13,10 +13,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::path::PathBuf;
+
 use chrono::TimeZone;
 use config::utils::file::set_permission;
 use infra::{file_list as infra_file_list, table};
-use std::path::PathBuf;
 
 use crate::{
     cli::data::{

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -13,14 +13,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{cmp::max, collections::BTreeMap, path::Path, sync::Arc, time::Duration};
+use std::{
+    cmp::max,
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use aes_siv::{KeyInit, siv::Aes256Siv};
 use arc_swap::ArcSwap;
 use base64::{Engine, prelude::BASE64_STANDARD};
 use chromiumoxide::{browser::BrowserConfig, handler::viewport::Viewport};
 use dotenv_config::EnvConfig;
-use dotenvy::dotenv_override;
 use hashbrown::{HashMap, HashSet};
 use itertools::chain;
 use lettre::{
@@ -31,6 +36,7 @@ use lettre::{
     },
 };
 use once_cell::sync::Lazy;
+use sha256::digest;
 
 use crate::{
     meta::cluster,
@@ -299,6 +305,35 @@ pub fn get_instance_id() -> String {
     }
 }
 
+pub fn calculate_config_file_hash(path: &PathBuf) -> Result<String, anyhow::Error> {
+    let content = std::fs::read_to_string(path)?;
+    Ok(digest(content))
+}
+
+pub fn load_config() -> Result<(), anyhow::Error> {
+    match crate::config_path_manager::get_config_file_path() {
+        Some(path) => {
+            log::info!("Loading config file from path: {:?}", path);
+            if dotenvy::from_path_override(path).is_ok() {
+                log::info!("Config loaded successfully from file");
+            } else {
+                log::error!("Config loading from file failed");
+            }
+        }
+        None => {
+            // Perform default .env discovery and set it in the config manager
+            if let Ok(env_path) = dotenvy::dotenv_override() {
+                log::debug!("Config init: Found .env file at {:?} during boot", env_path);
+                // Set the default path in config manager
+                crate::config_path_manager::set_config_file_path(env_path)?;
+            } else {
+                log::debug!("Config init: No .env file found during default discovery");
+            }
+        }
+    }
+    
+    Ok(())
+}
 static CHROME_LAUNCHER_OPTIONS: tokio::sync::OnceCell<Option<BrowserConfig>> =
     tokio::sync::OnceCell::const_new();
 
@@ -1097,6 +1132,12 @@ pub struct Common {
         help = "Enable to use large partition for index. This will apply for all streams"
     )]
     pub align_partitions_for_index: bool,
+    #[env_config(
+        name = "ZO_CONFIG_WATCHER_INTERVAL",
+        default = 30,
+        help = "Config file watcher interval in seconds. Set to 0 to disable"
+    )]
+    pub env_watcher_interval: u64,
 }
 
 #[derive(EnvConfig)]
@@ -1993,7 +2034,7 @@ pub struct EnrichmentTable {
 }
 
 pub fn init() -> Config {
-    dotenv_override().ok();
+    let _ = load_config();
     let mut cfg = Config::init().expect("config init error");
 
     // set local mode

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -331,7 +331,7 @@ pub fn load_config() -> Result<(), anyhow::Error> {
             }
         }
     }
-    
+
     Ok(())
 }
 static CHROME_LAUNCHER_OPTIONS: tokio::sync::OnceCell<Option<BrowserConfig>> =

--- a/src/config/src/config_path_manager.rs
+++ b/src/config/src/config_path_manager.rs
@@ -1,0 +1,64 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{path::PathBuf, sync::RwLock};
+use once_cell::sync::Lazy;
+
+// Config file path management
+#[derive(Debug, Clone, Default)]
+pub struct ConfigManager {
+    file_path: Option<PathBuf>,
+    last_hash: Option<String>,
+}
+
+static CONFIG_MANAGER: Lazy<RwLock<ConfigManager>> = Lazy::new(|| {
+    RwLock::new(ConfigManager::default())
+});
+
+// Config manager interface functions
+pub fn set_config_file_path(path: PathBuf) -> Result<(), anyhow::Error> {
+    // CLI validation: file MUST exist when provided via CLI
+    if !path.exists() {
+        return Err(anyhow::anyhow!("Config file does not exist: {}", path.display()));
+    }
+    
+    let hash = super::calculate_config_file_hash(&path)?;
+    
+    // Update the config manager
+    {
+        let mut manager = CONFIG_MANAGER.write().unwrap();
+        manager.file_path = Some(path.clone());
+        manager.last_hash = Some(hash); // Reset hash when path changes
+    }
+    
+    log::info!("Config manager: Set CLI config file path to {:?}", path);
+    
+    Ok(())
+}
+
+pub fn get_config_file_path() -> Option<PathBuf> {
+    let manager = CONFIG_MANAGER.read().unwrap();
+    manager.file_path.clone()
+}
+
+pub fn get_config_file_last_hash() -> Option<String> {
+    let manager = CONFIG_MANAGER.read().unwrap();
+    manager.last_hash.clone()
+}
+
+pub fn update_config_file_last_hash(hash: String) {
+    let mut manager = CONFIG_MANAGER.write().unwrap();
+    manager.last_hash = Some(hash);
+}

--- a/src/config/src/config_path_manager.rs
+++ b/src/config/src/config_path_manager.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{path::PathBuf, sync::RwLock};
+
 use once_cell::sync::Lazy;
 
 // Config file path management
@@ -23,28 +24,30 @@ pub struct ConfigManager {
     last_hash: Option<String>,
 }
 
-static CONFIG_MANAGER: Lazy<RwLock<ConfigManager>> = Lazy::new(|| {
-    RwLock::new(ConfigManager::default())
-});
+static CONFIG_MANAGER: Lazy<RwLock<ConfigManager>> =
+    Lazy::new(|| RwLock::new(ConfigManager::default()));
 
 // Config manager interface functions
 pub fn set_config_file_path(path: PathBuf) -> Result<(), anyhow::Error> {
     // CLI validation: file MUST exist when provided via CLI
     if !path.exists() {
-        return Err(anyhow::anyhow!("Config file does not exist: {}", path.display()));
+        return Err(anyhow::anyhow!(
+            "Config file does not exist: {}",
+            path.display()
+        ));
     }
-    
+
     let hash = super::calculate_config_file_hash(&path)?;
-    
+
     // Update the config manager
     {
         let mut manager = CONFIG_MANAGER.write().unwrap();
         manager.file_path = Some(path.clone());
         manager.last_hash = Some(hash); // Reset hash when path changes
     }
-    
+
     log::info!("Config manager: Set CLI config file path to {:?}", path);
-    
+
     Ok(())
 }
 

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -15,12 +15,12 @@
 
 pub mod cluster;
 pub mod config;
+pub mod config_path_manager;
 pub mod ider;
 pub mod meta;
 pub mod metrics;
 pub mod router;
 pub mod utils;
-pub mod config_path_manager;
 
 pub use config::*;
 

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -20,6 +20,7 @@ pub mod meta;
 pub mod metrics;
 pub mod router;
 pub mod utils;
+pub mod config_path_manager;
 
 pub use config::*;
 

--- a/src/config/src/utils/pausable_job.rs
+++ b/src/config/src/utils/pausable_job.rs
@@ -16,11 +16,11 @@
 /// Duration in seconds to sleep when a job is paused
 pub const PAUSE_SLEEP_DURATION: u64 = 60;
 
-/// Macro for spawning pausable jobs with flexible configuration
+/// Macro for spawning pausable jobs with flexible configuration.
 /// Prefer using this macro for jobs that need to execute at some interval as its
-/// reactive to the changes in the configuration
+/// reactive to the changes in the configuration.
 ///
-/// This macro standardizes the pattern used across multiple jobs where:
+/// Note:
 /// 1. A job gets an interval from config and checks if it should be paused
 /// 2. If paused (interval <= 0 by default), it sleeps for 60 seconds and checks again
 /// 3. If not paused, it sleeps for the interval and executes the job logic

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -91,7 +91,7 @@ pub struct HealthzResponse {
     status: String,
 }
 
-#[cfg( feature = "enterprise")]
+#[cfg(feature = "enterprise")]
 pub fn reload_enterprise_config() -> Result<(), anyhow::Error> {
     refresh_o2_config()
         .and_then(|_| refresh_dex_config())
@@ -440,8 +440,7 @@ pub async fn config_reload() -> Result<HttpResponse, Error> {
         );
     }
     #[cfg(feature = "enterprise")]
-    if let Err(e) = reload_enterprise_config()
-    {
+    if let Err(e) = reload_enterprise_config() {
         return Ok(
             HttpResponse::InternalServerError().json(serde_json::json!({"status": e.to_string()}))
         );

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -91,6 +91,13 @@ pub struct HealthzResponse {
     status: String,
 }
 
+#[cfg( feature = "enterprise")]
+pub fn reload_enterprise_config() -> Result<(), anyhow::Error> {
+    refresh_o2_config()
+        .and_then(|_| refresh_dex_config())
+        .and_then(|_| refresh_openfga_config())
+}
+
 #[derive(Serialize)]
 struct ConfigResponse<'a> {
     version: String,
@@ -433,9 +440,7 @@ pub async fn config_reload() -> Result<HttpResponse, Error> {
         );
     }
     #[cfg(feature = "enterprise")]
-    if let Err(e) = refresh_o2_config()
-        .and_then(|_| refresh_dex_config())
-        .and_then(|_| refresh_openfga_config())
+    if let Err(e) = reload_enterprise_config()
     {
         return Ok(
             HttpResponse::InternalServerError().json(serde_json::json!({"status": e.to_string()}))

--- a/src/job/config_watcher.rs
+++ b/src/job/config_watcher.rs
@@ -1,0 +1,94 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::path::PathBuf;
+use config::spawn_pausable_job;
+
+/// This function will start the config file watcher and load the global config
+/// this is because it uses the interval from config to determine the frequency
+pub fn run() -> Option<tokio::task::JoinHandle<()>> {
+    // Only start if config file path is set
+    if config::config_path_manager::get_config_file_path().is_none() {
+        log::debug!("[CONFIG_WATCHER] No config file specified, watcher not started");
+        return None;
+    }
+
+    Some(config::spawn_pausable_job!(
+        "config_watcher",
+        config::get_config().common.env_watcher_interval,
+        {
+            if let Err(e) = check_and_reload_config_file() {
+                log::error!("[CONFIG_WATCHER] Error checking config file: {}", e);
+            }
+        }
+    ))
+}
+
+fn check_and_reload_config_file() -> Result<(), anyhow::Error> {
+    let path = match config::config_path_manager::get_config_file_path() {
+        Some(path) => path,
+        None => return Ok(()), // No config file to watch
+    };
+
+    // Check if file exists
+    if !path.exists() {
+        log::warn!("[CONFIG_WATCHER] Config file does not exist: {path:?}");
+        return Ok(());
+    }
+
+    // Calculate current hash
+    let current_hash = config::calculate_config_file_hash(&path)?;
+    let last_hash = config::config_path_manager::get_config_file_last_hash();
+
+    // Compare hashes
+    if Some(&current_hash) != last_hash.as_ref() {
+        if last_hash.is_none() {
+            log::info!("[CONFIG_WATCHER] Initial config file hash stored");
+        } else {
+            log::info!("[CONFIG_WATCHER] Config file hash changed, reloading config...");
+        }
+
+        if let Err(e) = reload_config(&path) {
+            log::error!("[CONFIG_WATCHER] Failed to reload config file: {}", e);
+        } else {
+            // Update stored hash only on successful reload
+            config::config_path_manager::update_config_file_last_hash(current_hash);
+            log::info!("[CONFIG_WATCHER] Config file and config reloaded successfully");
+        }
+    }
+
+    Ok(())
+}
+
+pub fn reload_config(path: &PathBuf) -> Result<(), anyhow::Error> {
+    log::info!("[CONFIG_WATCHER] Reloading config file: {:?}", path);
+
+    // Refresh config - this will read from the updated config file
+    config::config::refresh_config()?;
+
+    #[cfg(feature = "enterprise")]
+    {
+        use o2_dex::config::refresh_config as refresh_dex_config;
+        use o2_enterprise::enterprise::common::infra::config::refresh_config as refresh_o2_config;
+        use o2_openfga::config::refresh_config as refresh_openfga_config;
+
+        refresh_o2_config()
+            .and_then(|_| refresh_dex_config())
+            .and_then(|_| refresh_openfga_config())?;
+    }
+
+    log::info!("Config file and config reloaded successfully");
+    Ok(())
+}

--- a/src/job/config_watcher.rs
+++ b/src/job/config_watcher.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::path::PathBuf;
+
 use config::spawn_pausable_job;
 
 /// This function will start the config file watcher and load the global config

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -31,6 +31,7 @@ mod alert_manager;
 #[cfg(feature = "enterprise")]
 mod cipher;
 mod compactor;
+pub mod config_watcher;
 mod file_downloader;
 pub(crate) mod files;
 mod flatten_compactor;
@@ -225,6 +226,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         }
     }
 
+    config_watcher::run();
     tokio::task::spawn(async move { files::run().await });
     tokio::task::spawn(async move { stats::run().await });
     tokio::task::spawn(async move { compactor::run().await });

--- a/src/job/stats.rs
+++ b/src/job/stats.rs
@@ -25,7 +25,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
         log::debug!("[STATS] job not started as not a compactor");
     }
 
-    if cache_stream_stats().is_none() {
+    if cache_stream_stats().await.is_none() {
         log::debug!("[STATS] job not started as not a compactor");
     }
 
@@ -61,8 +61,8 @@ fn file_list_update_stats() -> Option<tokio::task::JoinHandle<()>> {
     ))
 }
 
-fn cache_stream_stats() -> Option<tokio::task::JoinHandle<()>> {
-    if !LOCAL_NODE.is_querier() && !LOCAL_NODE.is_compactor() {
+async fn cache_stream_stats() -> Option<tokio::task::JoinHandle<()>> {
+    if !LOCAL_NODE.is_ingester() && !LOCAL_NODE.is_querier() && !LOCAL_NODE.is_compactor() {
         return None;
     }
 
@@ -74,19 +74,19 @@ fn cache_stream_stats() -> Option<tokio::task::JoinHandle<()>> {
     #[cfg(not(feature = "enterprise"))]
     let need_wait_one_around = false;
 
+    // wait one around to make sure the dependent models are ready
+    if need_wait_one_around {
+        tokio::time::sleep(time::Duration::from_secs(std::cmp::max(
+            60,
+            get_config().limit.calculate_stats_interval,
+        )))
+        .await;
+    }
+
     Some(spawn_pausable_job!(
         "cache_stream_stats",
         std::cmp::max(60, get_config().limit.calculate_stats_interval),
         {
-            // wait one around to make sure the dependent models are ready
-            if need_wait_one_around {
-                tokio::time::sleep(time::Duration::from_secs(std::cmp::max(
-                    60,
-                    get_config().limit.calculate_stats_interval,
-                )))
-                .await;
-            }
-
             if let Err(e) = db::file_list::cache_stats().await {
                 log::error!("[STATS] run cached stream stats error: {}", e);
             } else {


### PR DESCRIPTION
This feature adds a new cli argument to openobserve binary, i.e. `-c` which allows user to pass in path to a config file, adding flexibility to load env variables from different files. Earlier versions strictly looked for `.env` file in the current directory.
If this flag is not specified when running o2, the default file path (`.env`) from current directory will be used to load the config files.

This feature also adds a job to watch the config file. By default this job will run every `30` seconds, and can be configured via `ZO_CONFIG_WATCHER_INTERVAL` env variable. The watcher will watch the config file and reload the config if any changes are detected. By default the watcher watches `.env` file if no other file is configured using `-c` flag.