### PR TITLE
feat: impl multiple storage accounts

### DIFF
--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-05-20
+          toolchain: nightly-2025-07-20
 
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-fork-pr-image.yml
+++ b/.github/workflows/build-fork-pr-image.yml
@@ -53,7 +53,7 @@ jobs:
         - name: Setup Rust Toolchain
           uses: dtolnay/rust-toolchain@master
           with:
-            toolchain: nightly-2025-05-20
+            toolchain: nightly-2025-07-20
             
         - uses: Swatinem/rust-cache@v2
           with:

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -36,7 +36,7 @@ jobs:
         - name: Setup Rust Toolchain
           uses: dtolnay/rust-toolchain@master
           with:
-            toolchain: nightly-2025-05-20
+            toolchain: nightly-2025-07-20
             
         - uses: Swatinem/rust-cache@v2
           with:
@@ -123,7 +123,7 @@ jobs:
         - name: Setup Rust Toolchain
           uses: dtolnay/rust-toolchain@master
           with:
-            toolchain: nightly-2025-05-20
+            toolchain: nightly-2025-07-20
             
         - uses: Swatinem/rust-cache@v2
           with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-05-20
+          toolchain: nightly-2025-07-20
           targets: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
       - "v*.*.*"
 name: Release
 env:
-  RUST_TOOLCHAIN: nightly-2025-05-20
+  RUST_TOOLCHAIN: nightly-2025-07-20
 jobs:
   build:
     name: Build binary

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-05-20
+          toolchain: nightly-2025-07-20
           targets: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5172,6 +5172,7 @@ dependencies = [
  "sha1",
  "sqlx",
  "svix-ksuid",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",

--- a/deploy/build/Dockerfile
+++ b/deploy/build/Dockerfile
@@ -8,8 +8,8 @@ RUN NODE_OPTIONS="--max-old-space-size=8192" npm run build
 
 FROM public.ecr.aws/zinclabs/rust:bookworm-sccache AS builder
 
-# RUN rustup toolchain install nightly-2025-05-20
-# RUN rustup default nightly-2025-05-20
+# RUN rustup toolchain install nightly-2025-07-20
+# RUN rustup default nightly-2025-07-20
 # RUN rustup target add x86_64-unknown-linux-gnu
 # RUN diff -u <(rustc --print cfg) <(rustc -C target-cpu=native --print cfg)
 RUN rustc --version && sccache --version

--- a/deploy/build/Dockerfile.sccache.aarch64
+++ b/deploy/build/Dockerfile.sccache.aarch64
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/docker/library/rust:bookworm
 
-RUN rustup toolchain install nightly-2025-05-20
-RUN rustup default nightly-2025-05-20
+RUN rustup toolchain install nightly-2025-07-20
+RUN rustup default nightly-2025-07-20
 RUN rustup target add aarch64-unknown-linux-gnu
 RUN rustup component add rustfmt clippy llvm-tools
 RUN cargo install --locked sccache

--- a/deploy/build/Dockerfile.sccache.amd64
+++ b/deploy/build/Dockerfile.sccache.amd64
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/docker/library/rust:bookworm
 
-RUN rustup toolchain install nightly-2025-05-20
-RUN rustup default nightly-2025-05-20
+RUN rustup toolchain install nightly-2025-07-20
+RUN rustup default nightly-2025-07-20
 RUN rustup target add x86_64-unknown-linux-gnu
 RUN rustup component add rustfmt clippy llvm-tools
 RUN cargo install --locked sccache

--- a/deploy/build/Dockerfile.tag-debug.aarch64
+++ b/deploy/build/Dockerfile.tag-debug.aarch64
@@ -11,8 +11,8 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache AS builder
 # RUN apt-get install -y protobuf-compiler
 # RUN apt-get install -y cmake curl
 
-# RUN rustup toolchain install nightly-2025-05-20
-# RUN rustup default nightly-2025-05-20
+# RUN rustup toolchain install nightly-2025-07-20
+# RUN rustup default nightly-2025-07-20
 # RUN rustup target add aarch64-unknown-linux-gnu
 
 WORKDIR /openobserve

--- a/deploy/build/Dockerfile.tag-debug.amd64
+++ b/deploy/build/Dockerfile.tag-debug.amd64
@@ -11,8 +11,8 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache AS builder
 # RUN apt-get install -y protobuf-compiler
 # RUN apt-get install -y cmake curl
 
-# RUN rustup toolchain install nightly-2025-05-20
-# RUN rustup default nightly-2025-05-20
+# RUN rustup toolchain install nightly-2025-07-20
+# RUN rustup default nightly-2025-07-20
 # RUN rustup target add x86_64-unknown-linux-gnu
 
 WORKDIR /openobserve

--- a/deploy/build/Dockerfile.tag-simd.amd64
+++ b/deploy/build/Dockerfile.tag-simd.amd64
@@ -11,8 +11,8 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache AS builder
 # RUN apt-get install -y protobuf-compiler
 # RUN apt-get install -y cmake curl
 
-# RUN rustup toolchain install nightly-2025-05-20
-# RUN rustup default nightly-2025-05-20
+# RUN rustup toolchain install nightly-2025-07-20
+# RUN rustup default nightly-2025-07-20
 # RUN rustup target add x86_64-unknown-linux-gnu
 
 WORKDIR /openobserve

--- a/deploy/build/Dockerfile.tag.aarch64
+++ b/deploy/build/Dockerfile.tag.aarch64
@@ -11,8 +11,8 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache AS builder
 # RUN apt-get install -y protobuf-compiler
 # RUN apt-get install -y cmake curl
 
-# RUN rustup toolchain install nightly-2025-05-20
-# RUN rustup default nightly-2025-05-20
+# RUN rustup toolchain install nightly-2025-07-20
+# RUN rustup default nightly-2025-07-20
 # RUN rustup target add aarch64-unknown-linux-gnu
 
 WORKDIR /openobserve

--- a/deploy/build/Dockerfile.tag.amd64
+++ b/deploy/build/Dockerfile.tag.amd64
@@ -11,7 +11,7 @@ FROM public.ecr.aws/zinclabs/rust:bookworm-sccache AS builder
 # RUN apt-get install -y protobuf-compiler
 # RUN apt-get install -y cmake curl
 
-# RUN rustup toolchain install nightly-2025-05-20
+# RUN rustup toolchain install nightly-2025-07-20
 # RUN rustup default nightly-2024-07-07
 # RUN rustup target add x86_64-unknown-linux-gnu
 

--- a/deploy/build/buildspec-test.yml
+++ b/deploy/build/buildspec-test.yml
@@ -10,9 +10,9 @@ phases:
       - unzip protoc-21.12-linux-x86_64.zip -d protoc && cp protoc/bin/protoc /usr/local/bin/ && cp -r protoc/include/google /usr/local/include/
       - curl https://sh.rustup.rs -sSf | sh -s -- -y
       - . "$HOME/.cargo/env"
-      - rustup toolchain install nightly-2025-05-20
+      - rustup toolchain install nightly-2025-07-20
       - rustup toolchain list
-      - rustup default nightly-2025-05-20  
+      - rustup default nightly-2025-07-20  
       - rustup component add clippy llvm-tools
       - export RUSTFLAGS='-C target-cpu=native'
       - rm -rf ~/.cargo/registry

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-05-20"
+channel = "nightly-2025-07-20"
 components = ["rustfmt", "clippy", "llvm-tools"]

--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -112,13 +112,19 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                 ),
             clap::Command::new("delete-parquet")
                 .about("delete parquet files from s3 and file_list")
-                .arg(
+                .args([
+                    clap::Arg::new("account")
+                        .short('a')
+                        .long("account")
+                        .required(false)
+                        .value_name("account")
+                        .help("the account name"),
                     clap::Arg::new("file")
                         .short('f')
                         .long("file")
                         .value_name("file")
                         .help("the parquet file name"),
-                ),
+                ]),
             clap::Command::new("migrate-schemas").about("migrate from single row to row per schema version"),
             clap::Command::new("seaorm-rollback").about("rollback SeaORM migration steps")
                 .subcommand(
@@ -130,21 +136,28 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                     .about("rollback last N SeaORM migration steps")
                     .arg(clap::Arg::new("N").help("number of migration steps to rollback (default is 1)").value_parser(clap::value_parser!(u32)))
                 ),
-            clap::Command::new("recover-file-list").about("recover file list from s3").args([
-                clap::Arg::new("prefix")
-                    .short('p')
-                    .long("prefix")
-                    .value_name("prefix")
-                    .required(true)
-                    .help("only migrate specified prefix"),
-                clap::Arg::new("insert")
-                    .short('i')
-                    .long("insert")
-                    .value_name("insert")
-                    .required(false)
-                    .action(clap::ArgAction::SetTrue)
-                    .help("insert file list into db"),
-            ]),
+                clap::Command::new("recover-file-list").about("recover file list from s3")
+                .args([
+                    clap::Arg::new("account")
+                        .short('a')
+                        .long("account")
+                        .value_name("account")
+                        .required(true)
+                        .help("the account name"),
+                    clap::Arg::new("prefix")
+                        .short('p')
+                        .long("prefix")
+                        .value_name("prefix")
+                        .required(true)
+                        .help("only migrate specified prefix"),
+                    clap::Arg::new("insert")
+                        .short('i')
+                        .long("insert")
+                        .value_name("insert")
+                        .required(false)
+                        .action(clap::ArgAction::SetTrue)
+                        .help("insert file list into db"),
+                ]),
             clap::Command::new("node").about("node command").subcommands([
                 clap::Command::new("offline").about("offline node"),
                 clap::Command::new("online").about("online node"),
@@ -416,8 +429,12 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
             migration::pipeline_func::run(drop_table).await?;
         }
         "delete-parquet" => {
+            let account = command
+                .get_one::<String>("account")
+                .map(|s| s.to_string())
+                .unwrap_or_default();
             let file = command.get_one::<String>("file").unwrap();
-            match file_list::delete_parquet_file(file, true).await {
+            match file_list::delete_parquet_file(&account, file, true).await {
                 Ok(_) => {
                     println!("delete parquet file {file} successfully");
                 }
@@ -462,9 +479,13 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
             }
         },
         "recover-file-list" => {
+            let account = command
+                .get_one::<String>("account")
+                .map(|s| s.to_string())
+                .unwrap_or_default();
             let prefix = command.get_one::<String>("prefix").unwrap();
             let insert = command.get_flag("insert");
-            super::load::load_file_list_from_s3(prefix, insert).await?;
+            super::load::load_file_list_from_s3(&account, prefix, insert).await?;
         }
         "node" => {
             let command = command.subcommand();

--- a/src/cli/basic/load.rs
+++ b/src/cli/basic/load.rs
@@ -16,16 +16,21 @@
 use config::utils::parquet::parse_file_key_columns;
 
 /// Read parquet file from object storage and generate file_list information
-pub async fn load_file_list_from_s3(prefix: &str, insert: bool) -> Result<(), anyhow::Error> {
+pub async fn load_file_list_from_s3(
+    account: &str,
+    prefix: &str,
+    insert: bool,
+) -> Result<(), anyhow::Error> {
     if prefix.is_empty() {
         return Err(anyhow::anyhow!(
             "prefix is required, eg: files/default/logs/default/2025/"
         ));
     }
+    println!("account: {account}");
     println!("prefix: {prefix}");
 
     println!("Listing files...");
-    let files = infra::storage::list(prefix).await?;
+    let files = infra::storage::list(account, prefix).await?;
     println!("get files: {}", files.len());
 
     println!("Processing files...");
@@ -33,14 +38,15 @@ pub async fn load_file_list_from_s3(prefix: &str, insert: bool) -> Result<(), an
         println!("{i} {file}");
         let (stream_key, date, file_name) = parse_file_key_columns(file)?;
         let (org, stream) = stream_key.split_once('/').unwrap();
-        let file_meta = infra::storage::get_file_meta(file).await?;
+        let file_meta = infra::storage::get_file_meta(account, file).await?;
         if insert {
-            if let Err(e) = infra::file_list::add(file, &file_meta).await {
+            if let Err(e) = infra::file_list::add(account, file, &file_meta).await {
                 println!("insert to db with file {file} error: {e}");
             }
         } else {
             println!(
-                "INSERT INTO file_list (org, stream, date, file, deleted, flattened, min_ts, max_ts, records, original_size, compressed_size, index_size) VALUES ('{}', '{}/{}', '{}', '{}', FALSE, FALSE, {}, {}, {}, {}, {}, 0);",
+                "INSERT INTO file_list (account, org, stream, date, file, deleted, flattened, min_ts, max_ts, records, original_size, compressed_size, index_size) VALUES ('{}', '{}', '{}/{}', '{}', '{}', FALSE, FALSE, {}, {}, {}, {}, {}, 0);",
+                account,
                 org,
                 org,
                 stream,

--- a/src/common/meta/user.rs
+++ b/src/common/meta/user.rs
@@ -327,6 +327,12 @@ pub struct TokenValidationResponseBuilder {
     pub response: TokenValidationResponse,
 }
 
+impl Default for TokenValidationResponseBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Builder for creating a `TokenValidationResponse` from a `DBUser`.
 impl TokenValidationResponseBuilder {
     /// Creates a new `TokenValidationResponseBuilder` from a `DBUser`.

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -45,6 +45,10 @@ pub type RwAHashMap<K, V> = tokio::sync::RwLock<HashMap<K, V>>;
 pub type RwAHashSet<K> = tokio::sync::RwLock<HashSet<K>>;
 pub type RwBTreeMap<K, V> = tokio::sync::RwLock<BTreeMap<K, V>>;
 
+// for DDL commands and migrations
+pub const DB_SCHEMA_VERSION: u64 = 3;
+pub const DB_SCHEMA_KEY: &str = "/db_schema_version/";
+
 // global version variables
 pub static VERSION: &str = env!("GIT_VERSION");
 pub static COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");
@@ -86,10 +90,6 @@ pub const TIMESTAMP_COL_NAME: &str = "_timestamp";
 pub const ID_COL_NAME: &str = "_o2_id";
 pub const ORIGINAL_DATA_COL_NAME: &str = "_original";
 pub const ALL_VALUES_COL_NAME: &str = "_all_values";
-
-// for DDL commands and migrations
-pub const DB_SCHEMA_VERSION: u64 = 2;
-pub const DB_SCHEMA_KEY: &str = "/db_schema_version/";
 
 const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 9] = [
     "log", "message", "msg", "content", "data", "body", "json", "error", "errors",
@@ -1486,7 +1486,7 @@ pub struct Compact {
     pub file_list_deleted_mode: String,
     #[env_config(
         name = "ZO_COMPACT_BATCH_SIZE",
-        default = 500,
+        default = 0,
         help = "Batch size for compact get pending jobs"
     )]
     pub batch_size: i64,
@@ -1522,11 +1522,8 @@ pub struct CacheLatestFiles {
     pub delete_merge_files: bool,
     #[env_config(name = "ZO_CACHE_LATEST_FILES_DOWNLOAD_FROM_NODE", default = false)]
     pub download_from_node: bool,
-    #[env_config(
-        name = "ZO_CACHE_LATEST_FILES_DOWNLOAD_FROM_NODE_MAX_SIZE",
-        default = 250
-    )]
-    pub download_from_node_max_size: usize,
+    #[env_config(name = "ZO_CACHE_LATEST_FILES_DOWNLOAD_NODE_SIZE", default = 100)] // MB
+    pub download_node_size: i64,
 }
 
 #[derive(EnvConfig)]
@@ -1711,8 +1708,20 @@ pub struct Nats {
     pub v211_support: bool,
 }
 
-#[derive(Debug, EnvConfig)]
+#[derive(Debug, Default, EnvConfig)]
 pub struct S3 {
+    #[env_config(
+        name = "ZO_S3_ACCOUNTS",
+        default = "",
+        help = "comma separated list of accounts"
+    )]
+    pub accounts: String,
+    #[env_config(
+        name = "ZO_S3_STREAM_STRATEGY",
+        default = "",
+        help = "stream strategy, default is: empty, only use default account, other value is: file_hash, stream_hash, stream1:account1,stream2:account2"
+    )]
+    pub stream_strategy: String,
     #[env_config(name = "ZO_S3_PROVIDER", default = "")]
     pub provider: String,
     #[env_config(name = "ZO_S3_SERVER_URL", default = "")]
@@ -2684,7 +2693,7 @@ fn check_compact_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     }
 
     if cfg.compact.batch_size < 1 {
-        cfg.compact.batch_size = 100;
+        cfg.compact.batch_size = cfg.limit.cpu_num as i64;
     }
     if cfg.compact.pending_jobs_metric_interval == 0 {
         cfg.compact.pending_jobs_metric_interval = 300;

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -169,6 +169,7 @@ pub struct ListStreamParams {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct FileKey {
     pub id: i64,
+    pub account: String,
     pub key: String,
     pub meta: FileMeta,
     pub deleted: bool,
@@ -176,9 +177,10 @@ pub struct FileKey {
 }
 
 impl FileKey {
-    pub fn new(id: i64, key: String, meta: FileMeta, deleted: bool) -> Self {
+    pub fn new(id: i64, account: String, key: String, meta: FileMeta, deleted: bool) -> Self {
         Self {
             id,
+            account,
             key,
             meta,
             deleted,
@@ -189,6 +191,7 @@ impl FileKey {
     pub fn from_file_name(file: &str) -> Self {
         Self {
             id: 0,
+            account: String::default(),
             key: file.to_string(),
             meta: FileMeta::default(),
             deleted: false,
@@ -240,6 +243,7 @@ impl From<&[parquet::file::metadata::KeyValue]> for FileMeta {
 #[derive(Clone, Debug, Default)]
 pub struct FileListDeleted {
     pub id: i64,
+    pub account: String,
     pub file: String,
     pub index_file: bool,
     pub flattened: bool,
@@ -454,6 +458,7 @@ impl From<&FileKey> for cluster_rpc::FileKey {
     fn from(req: &FileKey) -> Self {
         cluster_rpc::FileKey {
             id: req.id,
+            account: req.account.clone(),
             key: req.key.clone(),
             meta: Some(cluster_rpc::FileMeta::from(&req.meta)),
             deleted: req.deleted,
@@ -466,6 +471,7 @@ impl From<&cluster_rpc::FileKey> for FileKey {
     fn from(req: &cluster_rpc::FileKey) -> Self {
         FileKey {
             id: req.id,
+            account: req.account.clone(),
             key: req.key.clone(),
             meta: FileMeta::from(req.meta.as_ref().unwrap()),
             deleted: req.deleted,

--- a/src/handler/http/auth/validator.rs
+++ b/src/handler/http/auth/validator.rs
@@ -426,8 +426,7 @@ async fn validate_user_from_db(
                     password_ext_salt,
                 );
                 if hashed_pass.eq(&user_password) {
-                    let resp = TokenValidationResponseBuilder::from_db_user(&user).build();
-                    return Ok(resp);
+                    Ok(TokenValidationResponseBuilder::from_db_user(&user).build())
                 } else {
                     Err(ErrorForbidden("Not allowed"))
                 }

--- a/src/infra/Cargo.toml
+++ b/src/infra/Cargo.toml
@@ -27,6 +27,7 @@ object_store.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 parquet.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
@@ -35,11 +36,11 @@ svix-ksuid.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
-zstd.workspace = true
+tempfile.workspace = true
 tracing.workspace = true
 sea-orm.workspace = true
 sea-orm-migration.workspace = true
-reqwest.workspace = true
+zstd.workspace = true
 
 [dev-dependencies]
 collapse.workspace = true

--- a/src/infra/src/cache/file_data/delete.rs
+++ b/src/infra/src/cache/file_data/delete.rs
@@ -28,10 +28,8 @@ impl Queue {
         tokio::task::spawn(async move {
             while let Some(files) = rx.recv().await {
                 for file in files {
-                    if let Err(e) =
-                        super::disk::remove(super::TRACE_ID_FOR_CACHE_LATEST_FILE, &file).await
-                    {
-                        log::error!("[CACHE:FILE_DATA] Failed to delete file: {}", e);
+                    if let Err(e) = super::disk::remove(&file).await {
+                        log::error!("[CACHE:FILE_DATA] Failed to delete file: {e}");
                     }
                     tokio::task::consume_budget().await;
                 }
@@ -42,10 +40,7 @@ impl Queue {
 
     fn add(&self, files: Vec<String>) {
         if let Err(e) = self.tx.try_send(files) {
-            log::error!(
-                "[CACHE:FILE_DATA] Failed to send files to pending delete channel: {:?}",
-                e
-            );
+            log::error!("[CACHE:FILE_DATA] Failed to send files to pending delete channel: {e}");
         }
     }
 }

--- a/src/infra/src/cache/file_data/memory.rs
+++ b/src/infra/src/cache/file_data/memory.rs
@@ -20,7 +20,7 @@ use std::{
 
 use bytes::Bytes;
 use config::{
-    RwHashMap, get_config, metrics, spawn_pausable_job,
+    RwHashMap, get_config, is_local_disk_storage, metrics, spawn_pausable_job,
     utils::hash::{Sum64, gxhash},
 };
 use once_cell::sync::Lazy;
@@ -94,19 +94,16 @@ impl FileData {
         Some(data.value().len())
     }
 
-    async fn set(&mut self, trace_id: &str, file: &str, data: Bytes) -> Result<(), anyhow::Error> {
+    async fn set(&mut self, file: &str, data: Bytes) -> Result<(), anyhow::Error> {
         let data_size = file.len() + data.len();
         if self.cur_size + data_size >= self.max_size {
-            log::info!(
-                "[trace_id {trace_id}] File memory cache is full, can't cache extra {} bytes",
-                data_size
-            );
+            log::info!("File memory cache is full, can't cache extra {data_size} bytes");
             // cache is full, need release some space
             let need_release_size = min(
                 self.cur_size,
                 max(get_config().memory_cache.release_size, data_size * 100),
             );
-            self.gc(trace_id, need_release_size).await?;
+            self.gc(need_release_size).await?;
         }
 
         self.cur_size += data_size;
@@ -127,9 +124,9 @@ impl FileData {
         Ok(())
     }
 
-    async fn gc(&mut self, trace_id: &str, need_release_size: usize) -> Result<(), anyhow::Error> {
+    async fn gc(&mut self, need_release_size: usize) -> Result<(), anyhow::Error> {
         log::info!(
-            "[trace_id {trace_id}] File memory cache start gc {}/{}, need to release {} bytes",
+            "File memory cache start gc {}/{}, need to release {} bytes",
             self.cur_size,
             self.max_size,
             need_release_size
@@ -138,16 +135,16 @@ impl FileData {
         loop {
             let item = self.data.remove();
             if item.is_none() {
-                log::warn!(
-                    "[trace_id {trace_id}] File memory cache is corrupt, it shouldn't be none"
-                );
+                log::warn!("File memory cache is corrupt, it shouldn't be none");
                 break;
             }
             let (key, data_size) = item.unwrap();
             // move the file from memory to disk cache
             let idx = get_bucket_idx(&key);
-            if let Some((key, data)) = DATA[idx].remove(&key) {
-                _ = super::disk::set(trace_id, &key, data).await;
+            if let Some((key, data)) = DATA[idx].remove(&key)
+                && !is_local_disk_storage()
+            {
+                _ = super::disk::set(&key, data).await;
             }
             // metrics
             let columns = key.split('/').collect::<Vec<&str>>();
@@ -166,18 +163,12 @@ impl FileData {
         }
         self.cur_size -= release_size;
         let _ = DATA.iter().map(|c| c.shrink_to_fit()).collect::<Vec<_>>();
-        log::info!(
-            "[trace_id {trace_id}] File memory cache gc done, released {} bytes",
-            release_size
-        );
+        log::info!("File memory cache gc done, released {release_size} bytes");
         Ok(())
     }
 
-    async fn remove(&mut self, trace_id: &str, file: &str) -> Result<(), anyhow::Error> {
-        log::debug!(
-            "[trace_id {trace_id}] File memory cache remove file {}",
-            file
-        );
+    async fn remove(&mut self, file: &str) -> Result<(), anyhow::Error> {
+        log::debug!("File memory cache remove file {file}");
 
         let Some((key, data_size)) = self.data.remove_key(file) else {
             return Ok(());
@@ -222,7 +213,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
     spawn_pausable_job!("memory_cache_gc", get_config().memory_cache.gc_interval, {
         if let Err(e) = gc().await {
-            log::error!("memory cache gc error: {}", e);
+            log::error!("memory cache gc error: {e}");
         }
     });
     Ok(())
@@ -259,7 +250,7 @@ pub async fn exist(file: &str) -> bool {
 }
 
 #[inline]
-pub async fn set(trace_id: &str, file: &str, data: Bytes) -> Result<(), anyhow::Error> {
+pub async fn set(file: &str, data: Bytes) -> Result<(), anyhow::Error> {
     if !get_config().memory_cache.enabled {
         return Ok(());
     }
@@ -268,17 +259,17 @@ pub async fn set(trace_id: &str, file: &str, data: Bytes) -> Result<(), anyhow::
     if files.exist(file).await {
         return Ok(());
     }
-    files.set(trace_id, file, data).await
+    files.set(file, data).await
 }
 
 #[inline]
-pub async fn remove(trace_id: &str, file: &str) -> Result<(), anyhow::Error> {
+pub async fn remove(file: &str) -> Result<(), anyhow::Error> {
     if !get_config().memory_cache.enabled {
         return Ok(());
     }
     let idx = get_bucket_idx(file);
     let mut files = FILES[idx].write().await;
-    files.remove(trace_id, file).await
+    files.remove(file).await
 }
 
 async fn gc() -> Result<(), anyhow::Error> {
@@ -294,7 +285,7 @@ async fn gc() -> Result<(), anyhow::Error> {
         }
         drop(r);
         let mut w = file.write().await;
-        w.gc("global", cfg.memory_cache.gc_size).await?;
+        w.gc(cfg.memory_cache.gc_size).await?;
         drop(w);
     }
 
@@ -336,12 +327,12 @@ pub async fn is_empty() -> bool {
 }
 
 pub async fn download(
-    trace_id: &str,
+    account: &str,
     file: &str,
     size: Option<usize>,
 ) -> Result<usize, anyhow::Error> {
-    let (data_len, data_bytes) = super::download_from_storage(file, size).await?;
-    if let Err(e) = set(trace_id, file, data_bytes).await {
+    let (data_len, data_bytes) = super::download_from_storage(account, file, size).await?;
+    if let Err(e) = set(file, data_bytes).await {
         return Err(anyhow::anyhow!(
             "set file {} to memory cache failed: {}",
             file,
@@ -367,7 +358,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_lru_cache_set_file() {
-        let trace_id = "session_1";
         let mut file_data = FileData::with_capacity_and_cache_strategy(1024, "lru");
         let content = Bytes::from("Some text Need to store in cache");
         for i in 0..50 {
@@ -375,29 +365,22 @@ mod tests {
                 "files/default/logs/memory/2022/10/03/10/6982652937134804993_1_{}.parquet",
                 i
             );
-            let resp = file_data.set(trace_id, &file_key, content.clone()).await;
+            let resp = file_data.set(&file_key, content.clone()).await;
             assert!(resp.is_ok());
         }
     }
 
     #[tokio::test]
     async fn test_lru_cache_get_file() {
-        let trace_id = "session_2";
         let mut file_data =
             FileData::with_capacity_and_cache_strategy(get_config().memory_cache.max_size, "lru");
         let file_key = "files/default/logs/memory/2022/10/03/10/6982652937134804993_2_1.parquet";
         let content = Bytes::from("Some text");
 
-        file_data
-            .set(trace_id, file_key, content.clone())
-            .await
-            .unwrap();
+        file_data.set(file_key, content.clone()).await.unwrap();
         assert_eq!(file_data.get(file_key, None).await.unwrap(), content);
 
-        file_data
-            .set(trace_id, file_key, content.clone())
-            .await
-            .unwrap();
+        file_data.set(file_key, content.clone()).await.unwrap();
         assert!(file_data.exist(file_key).await);
         assert_eq!(file_data.get(file_key, None).await.unwrap(), content);
         assert!(file_data.size().0 > 0);
@@ -405,22 +388,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_lru_cache_miss() {
-        let trace_id = "session_3";
         let mut file_data = FileData::with_capacity_and_cache_strategy(100, "lru");
         let file_key1 = "files/default/logs/memory/2022/10/03/10/6982652937134804993_3_1.parquet";
         let file_key2 = "files/default/logs/memory/2022/10/03/10/6982652937134804993_3_2.parquet";
         let content = Bytes::from("Some text");
         // set one key
-        file_data
-            .set(trace_id, file_key1, content.clone())
-            .await
-            .unwrap();
+        file_data.set(file_key1, content.clone()).await.unwrap();
         assert_eq!(file_data.get(file_key1, None).await.unwrap(), content);
         // set another key, will release first key
-        file_data
-            .set(trace_id, file_key2, content.clone())
-            .await
-            .unwrap();
+        file_data.set(file_key2, content.clone()).await.unwrap();
         assert_eq!(file_data.get(file_key2, None).await.unwrap(), content);
         // get first key, should get error
         assert!(file_data.get(file_key1, None).await.is_none());
@@ -428,7 +404,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_fifo_cache_set_file() {
-        let trace_id = "session_4";
         let mut file_data = FileData::with_capacity_and_cache_strategy(1024, "fifo");
         let content = Bytes::from("Some text Need to store in cache");
         for i in 0..50 {
@@ -436,29 +411,22 @@ mod tests {
                 "files/default/logs/memory/2022/10/03/10/6982652937134804993_4_{}.parquet",
                 i
             );
-            let resp = file_data.set(trace_id, &file_key, content.clone()).await;
+            let resp = file_data.set(&file_key, content.clone()).await;
             assert!(resp.is_ok());
         }
     }
 
     #[tokio::test]
     async fn test_fifo_cache_get_file() {
-        let trace_id = "session_5";
         let mut file_data =
             FileData::with_capacity_and_cache_strategy(get_config().memory_cache.max_size, "fifo");
         let file_key = "files/default/logs/memory/2022/10/03/10/6982652937134804993_5_1.parquet";
         let content = Bytes::from("Some text");
 
-        file_data
-            .set(trace_id, file_key, content.clone())
-            .await
-            .unwrap();
+        file_data.set(file_key, content.clone()).await.unwrap();
         assert_eq!(file_data.get(file_key, None).await.unwrap(), content);
 
-        file_data
-            .set(trace_id, file_key, content.clone())
-            .await
-            .unwrap();
+        file_data.set(file_key, content.clone()).await.unwrap();
         assert!(file_data.exist(file_key).await);
         assert_eq!(file_data.get(file_key, None).await.unwrap(), content);
         assert!(file_data.size().0 > 0);
@@ -466,22 +434,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_fifo_cache_miss() {
-        let trace_id = "session_6";
         let mut file_data = FileData::with_capacity_and_cache_strategy(100, "fifo");
         let file_key1 = "files/default/logs/memory/2022/10/03/10/6982652937134804993_6_1.parquet";
         let file_key2 = "files/default/logs/memory/2022/10/03/10/6982652937134804993_6_2.parquet";
         let content = Bytes::from("Some text");
         // set one key
-        file_data
-            .set(trace_id, file_key1, content.clone())
-            .await
-            .unwrap();
+        file_data.set(file_key1, content.clone()).await.unwrap();
         assert_eq!(file_data.get(file_key1, None).await.unwrap(), content);
         // set another key, will release first key
-        file_data
-            .set(trace_id, file_key2, content.clone())
-            .await
-            .unwrap();
+        file_data.set(file_key2, content.clone()).await.unwrap();
         assert_eq!(file_data.get(file_key2, None).await.unwrap(), content);
         // get first key, should get error
         assert!(file_data.get(file_key1, None).await.is_none());

--- a/src/infra/src/cache/storage.rs
+++ b/src/infra/src/cache/storage.rs
@@ -21,18 +21,21 @@ use config::utils::time::BASE_TIME;
 use futures::{StreamExt, stream::BoxStream};
 use object_store::{
     Attributes, Error, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload,
-    OBJECT_STORE_COALESCE_DEFAULT, ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions,
-    PutPayload, PutResult, Result, coalesce_ranges, path::Path,
+    OBJECT_STORE_COALESCE_DEFAULT, ObjectMeta, PutMultipartOptions, PutOptions, PutPayload,
+    PutResult, Result, coalesce_ranges, path::Path,
 };
 use once_cell::sync::Lazy;
 
-use crate::{cache::file_data, storage};
+use crate::{
+    cache::file_data,
+    storage::{self, ObjectStoreExt},
+};
 
 /// File system with cache
 #[derive(Debug, Default)]
 pub struct CacheFS {}
 
-pub static DEFAULT: Lazy<Box<dyn ObjectStore>> = Lazy::new(CacheFS::new_store);
+static DEFAULT: Lazy<Box<dyn ObjectStoreExt>> = Lazy::new(CacheFS::new_store);
 
 impl std::fmt::Display for CacheFS {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -41,16 +44,56 @@ impl std::fmt::Display for CacheFS {
 }
 
 impl CacheFS {
-    pub fn new_store() -> Box<dyn ObjectStore> {
+    pub fn new_store() -> Box<dyn ObjectStoreExt> {
         Box::new(Self {})
     }
 }
 
 #[async_trait]
-impl ObjectStore for CacheFS {
-    async fn get(&self, location: &Path) -> Result<GetResult> {
+impl ObjectStoreExt for CacheFS {
+    fn get_account(&self, file: &str) -> Option<String> {
+        storage::get_account(file)
+    }
+
+    async fn put(
+        &self,
+        _account: &str,
+        _location: &Path,
+        _payload: PutPayload,
+    ) -> Result<PutResult> {
+        Err(Error::NotImplemented)
+    }
+
+    async fn put_opts(
+        &self,
+        _account: &str,
+        _location: &Path,
+        _payload: PutPayload,
+        _opts: PutOptions,
+    ) -> Result<PutResult> {
+        Err(Error::NotImplemented)
+    }
+
+    async fn put_multipart(
+        &self,
+        _account: &str,
+        _location: &Path,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        Err(Error::NotImplemented)
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        _account: &str,
+        _location: &Path,
+        _opts: PutMultipartOptions,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        Err(Error::NotImplemented)
+    }
+
+    async fn get(&self, account: &str, location: &Path) -> Result<GetResult> {
         let path = location.to_string();
-        if let Ok(data) = file_data::get_opts(&path, None, false).await {
+        if let Ok(data) = file_data::get_opts(account, &path, None, false).await {
             let meta = ObjectMeta {
                 location: location.clone(),
                 last_modified: *BASE_TIME,
@@ -72,12 +115,17 @@ impl ObjectStore for CacheFS {
             });
         }
         // default to storage
-        storage::DEFAULT.get(location).await
+        storage::get(account, &path).await
     }
 
-    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+    async fn get_opts(
+        &self,
+        account: &str,
+        location: &Path,
+        options: GetOptions,
+    ) -> Result<GetResult> {
         let path = location.to_string();
-        if let Ok(data) = file_data::get_opts(&path, None, false).await {
+        if let Ok(data) = file_data::get_opts(account, &path, None, false).await {
             let meta = ObjectMeta {
                 location: location.clone(),
                 last_modified: *BASE_TIME,
@@ -104,30 +152,35 @@ impl ObjectStore for CacheFS {
             });
         }
         // default to storage
-        storage::DEFAULT.get_opts(location, options).await
+        storage::get_opts(account, &path, options).await
     }
 
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
+    async fn get_range(&self, account: &str, location: &Path, range: Range<u64>) -> Result<Bytes> {
         if range.start > range.end {
             return Err(crate::storage::Error::BadRange(location.to_string()).into());
         }
         let path = location.to_string();
-        let data = file_data::get_opts(&path, Some(range), true).await?;
+        let data = file_data::get_opts(account, &path, Some(range), true).await?;
         Ok(data)
     }
 
-    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+    async fn get_ranges(
+        &self,
+        account: &str,
+        location: &Path,
+        ranges: &[Range<u64>],
+    ) -> Result<Vec<Bytes>> {
         coalesce_ranges(
             ranges,
-            |range| self.get_range(location, range),
+            |range| self.get_range(account, location, range),
             OBJECT_STORE_COALESCE_DEFAULT,
         )
         .await
     }
 
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+    async fn head(&self, account: &str, location: &Path) -> Result<ObjectMeta> {
         let path = location.to_string();
-        if let Ok(size) = file_data::get_size_opts(&path, false).await {
+        if let Ok(size) = file_data::get_size_opts(account, &path, false).await {
             return Ok(ObjectMeta {
                 location: location.clone(),
                 last_modified: *BASE_TIME,
@@ -137,87 +190,351 @@ impl ObjectStore for CacheFS {
             });
         }
         // default
-        storage::DEFAULT.head(location).await
+        storage::head(account, &path).await
     }
 
-    async fn delete(&self, _location: &Path) -> Result<()> {
+    async fn delete(&self, _account: &str, _location: &Path) -> Result<()> {
         Err(Error::NotImplemented)
     }
 
     fn delete_stream<'a>(
         &'a self,
+        _account: &str,
         _locations: BoxStream<'a, Result<Path>>,
     ) -> BoxStream<'a, Result<Path>> {
         futures::stream::once(async { Err(object_store::Error::NotImplemented {}) }).boxed()
     }
 
-    fn list(&self, _prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+    fn list(
+        &self,
+        _account: &str,
+        _prefix: Option<&Path>,
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
         futures::stream::once(async { Err(object_store::Error::NotImplemented {}) }).boxed()
     }
 
     fn list_with_offset(
         &self,
+        _account: &str,
         _prefix: Option<&Path>,
         _offset: &Path,
     ) -> BoxStream<'static, Result<ObjectMeta>> {
         futures::stream::once(async { Err(object_store::Error::NotImplemented {}) }).boxed()
     }
 
-    async fn list_with_delimiter(&self, _prefix: Option<&Path>) -> Result<ListResult> {
-        Err(Error::NotImplemented)
-    }
-
-    async fn put_opts(
+    async fn list_with_delimiter(
         &self,
-        location: &Path,
-        _payload: PutPayload,
-        _opts: PutOptions,
-    ) -> Result<PutResult> {
-        log::error!("NotImplemented put_opts: {}", location);
-        Err(object_store::Error::NotImplemented {})
-    }
-
-    async fn put_multipart(&self, _location: &Path) -> Result<Box<dyn MultipartUpload>> {
-        Err(object_store::Error::NotImplemented)
-    }
-
-    async fn put_multipart_opts(
-        &self,
-        _location: &Path,
-        _opts: PutMultipartOptions,
-    ) -> Result<Box<dyn MultipartUpload>> {
-        Err(object_store::Error::NotImplemented)
-    }
-
-    async fn copy(&self, _from: &Path, _to: &Path) -> Result<()> {
+        _account: &str,
+        _prefix: Option<&Path>,
+    ) -> Result<ListResult> {
         Err(Error::NotImplemented)
     }
 
-    async fn rename(&self, _from: &Path, _to: &Path) -> Result<()> {
+    async fn copy(&self, _account: &str, _from: &Path, _to: &Path) -> Result<()> {
         Err(Error::NotImplemented)
     }
 
-    async fn copy_if_not_exists(&self, _from: &Path, _to: &Path) -> Result<()> {
+    async fn rename(&self, _account: &str, _from: &Path, _to: &Path) -> Result<()> {
         Err(Error::NotImplemented)
     }
 
-    async fn rename_if_not_exists(&self, _from: &Path, _to: &Path) -> Result<()> {
+    async fn copy_if_not_exists(&self, _account: &str, _from: &Path, _to: &Path) -> Result<()> {
+        Err(Error::NotImplemented)
+    }
+
+    async fn rename_if_not_exists(&self, _account: &str, _from: &Path, _to: &Path) -> Result<()> {
         Err(Error::NotImplemented)
     }
 }
 
-pub async fn get(path: &Path) -> Result<GetResult> {
-    DEFAULT.get(path).await
+pub async fn get(account: &str, path: &Path) -> Result<GetResult> {
+    DEFAULT.get(account, path).await
 }
 
-pub async fn get_opts(path: &Path, options: GetOptions) -> Result<GetResult> {
-    DEFAULT.get_opts(path, options).await
+pub async fn get_opts(account: &str, path: &Path, options: GetOptions) -> Result<GetResult> {
+    DEFAULT.get_opts(account, path, options).await
 }
 
-pub async fn get_range(location: &Path, range: Range<u64>) -> Result<bytes::Bytes> {
-    DEFAULT.get_range(location, range).await
+pub async fn get_range(account: &str, location: &Path, range: Range<u64>) -> Result<bytes::Bytes> {
+    DEFAULT.get_range(account, location, range).await
 }
 
-pub async fn head(location: &Path) -> Result<ObjectMeta> {
-    DEFAULT.head(location).await
+pub async fn head(account: &str, location: &Path) -> Result<ObjectMeta> {
+    DEFAULT.head(account, location).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+
+    use bytes::Bytes;
+
+    use super::*;
+
+    #[test]
+    fn test_cache_fs_display() {
+        let cache_fs = CacheFS {};
+        assert_eq!(cache_fs.to_string(), "CacheFS");
+    }
+
+    #[test]
+    fn test_cache_fs_new_store() {
+        let store = CacheFS::new_store();
+        assert_eq!(store.to_string(), "CacheFS");
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_put() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+        let payload = PutPayload::from(Bytes::from("test data"));
+
+        let result = cache_fs.put("default", &location, payload).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::NotImplemented));
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_put_opts() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+        let payload = PutPayload::from(Bytes::from("test data"));
+        let opts = PutOptions::default();
+
+        let result = cache_fs.put_opts("default", &location, payload, opts).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::NotImplemented));
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_put_multipart() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+
+        let result = cache_fs.put_multipart("default", &location).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::NotImplemented));
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_put_multipart_opts() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+        let opts = PutMultipartOptions::default();
+
+        let result = cache_fs
+            .put_multipart_opts("default", &location, opts)
+            .await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::NotImplemented));
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_get_with_cache_hit() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+
+        // This test would require setting up cache data first
+        // For now, we test the basic structure
+        let result = cache_fs.get("default", &location).await;
+        // The result depends on whether the file exists in cache or storage
+        // This is a basic test to ensure the function doesn't panic
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_get_opts_with_cache_hit() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+        let options = GetOptions::default();
+
+        let result = cache_fs.get_opts("default", &location, options).await;
+        // The result depends on whether the file exists in cache or storage
+        // This is a basic test to ensure the function doesn't panic
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_get_range_invalid() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+        let range = Range { start: 10, end: 5 }; // Invalid range
+
+        let result = cache_fs.get_range("default", &location, range).await;
+        assert!(result.is_err());
+        // Should return a BadRange error
+        assert!(matches!(result.unwrap_err(), Error::Generic { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_get_ranges() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+        let ranges = vec![Range { start: 0, end: 10 }, Range { start: 10, end: 20 }];
+
+        let result = cache_fs.get_ranges("default", &location, &ranges).await;
+        // The result depends on whether the file exists in cache
+        // This is a basic test to ensure the function doesn't panic
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_head_with_cache_hit() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+
+        let result = cache_fs.head("default", &location).await;
+        // The result depends on whether the file exists in cache or storage
+        // This is a basic test to ensure the function doesn't panic
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_delete() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+
+        let result = cache_fs.delete("default", &location).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::NotImplemented));
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_delete_stream() {
+        let cache_fs = CacheFS {};
+        let locations = futures::stream::once(async { Ok(Path::from("test/file.txt")) }).boxed();
+
+        let mut result_stream = cache_fs.delete_stream("default", locations);
+        let result = result_stream.next().await;
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::NotImplemented { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_copy() {
+        let cache_fs = CacheFS {};
+        let from = Path::from("test/from.txt");
+        let to = Path::from("test/to.txt");
+
+        let result = cache_fs.copy("default", &from, &to).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::NotImplemented));
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_rename() {
+        let cache_fs = CacheFS {};
+        let from = Path::from("test/from.txt");
+        let to = Path::from("test/to.txt");
+
+        let result = cache_fs.rename("default", &from, &to).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::NotImplemented));
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_copy_if_not_exists() {
+        let cache_fs = CacheFS {};
+        let from = Path::from("test/from.txt");
+        let to = Path::from("test/to.txt");
+
+        let result = cache_fs.copy_if_not_exists("default", &from, &to).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::NotImplemented));
+    }
+
+    #[tokio::test]
+    async fn test_cache_fs_rename_if_not_exists() {
+        let cache_fs = CacheFS {};
+        let from = Path::from("test/from.txt");
+        let to = Path::from("test/to.txt");
+
+        let result = cache_fs.rename_if_not_exists("default", &from, &to).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::NotImplemented));
+    }
+
+    // Test the public functions that use the DEFAULT instance
+    #[tokio::test]
+    async fn test_get_function() {
+        let path = Path::from("test/file.txt");
+        let result = get("default", &path).await;
+        // The result depends on whether the file exists in cache or storage
+        // This is a basic test to ensure the function doesn't panic
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_opts_function() {
+        let path = Path::from("test/file.txt");
+        let options = GetOptions::default();
+        let result = get_opts("default", &path, options).await;
+        // The result depends on whether the file exists in cache or storage
+        // This is a basic test to ensure the function doesn't panic
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_range_function() {
+        let location = Path::from("test/file.txt");
+        let range = Range { start: 0, end: 10 };
+        let result = get_range("default", &location, range).await;
+        // The result depends on whether the file exists in cache
+        // This is a basic test to ensure the function doesn't panic
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_head_function() {
+        let location = Path::from("test/file.txt");
+        let result = head("default", &location).await;
+        // The result depends on whether the file exists in cache or storage
+        // This is a basic test to ensure the function doesn't panic
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    // Integration test for cache behavior
+    #[tokio::test]
+    async fn test_cache_fs_integration() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("integration/test.txt");
+
+        // Test that the cache FS properly delegates to underlying storage
+        // when cache is not available
+        let get_result = cache_fs.get("default", &location).await;
+        let head_result = cache_fs.head("default", &location).await;
+
+        // Both should either succeed (if file exists in storage) or fail appropriately
+        // This tests the integration between cache and storage layers
+        assert!(get_result.is_ok() || get_result.is_err());
+        assert!(head_result.is_ok() || head_result.is_err());
+    }
+
+    // Test error handling for malformed paths
+    #[tokio::test]
+    async fn test_cache_fs_malformed_path() {
+        let cache_fs = CacheFS {};
+        let location = Path::from(""); // Empty path
+
+        let result = cache_fs.get("default", &location).await;
+        // Should handle empty paths gracefully
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    // Test with different account names
+    #[tokio::test]
+    async fn test_cache_fs_different_accounts() {
+        let cache_fs = CacheFS {};
+        let location = Path::from("test/file.txt");
+
+        // Test with different account names
+        let result1 = cache_fs.get("account1", &location).await;
+        let result2 = cache_fs.get("account2", &location).await;
+
+        // Both should handle different accounts appropriately
+        assert!(result1.is_ok() || result1.is_err());
+        assert!(result2.is_ok() || result2.is_err());
+    }
 }

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -52,8 +52,8 @@ pub fn connect_local_cache() -> Box<dyn FileList> {
 pub trait FileList: Sync + Send + 'static {
     async fn create_table(&self) -> Result<()>;
     async fn create_table_index(&self) -> Result<()>;
-    async fn add(&self, file: &str, meta: &FileMeta) -> Result<i64>;
-    async fn add_history(&self, file: &str, meta: &FileMeta) -> Result<i64>;
+    async fn add(&self, account: &str, file: &str, meta: &FileMeta) -> Result<i64>;
+    async fn add_history(&self, account: &str, file: &str, meta: &FileMeta) -> Result<i64>;
     async fn remove(&self, file: &str) -> Result<()>;
     async fn batch_add(&self, files: &[FileKey]) -> Result<()>;
     async fn batch_add_with_id(&self, files: &[FileKey]) -> Result<()>;
@@ -189,13 +189,13 @@ pub async fn create_table_index() -> Result<()> {
 }
 
 #[inline]
-pub async fn add(file: &str, meta: &FileMeta) -> Result<i64> {
-    CLIENT.add(file, meta).await
+pub async fn add(account: &str, file: &str, meta: &FileMeta) -> Result<i64> {
+    CLIENT.add(account, file, meta).await
 }
 
 #[inline]
-pub async fn add_history(file: &str, meta: &FileMeta) -> Result<i64> {
-    CLIENT.add_history(file, meta).await
+pub async fn add_history(account: &str, file: &str, meta: &FileMeta) -> Result<i64> {
+    CLIENT.add_history(account, file, meta).await
 }
 
 #[inline]
@@ -539,6 +539,8 @@ pub struct FileRecord {
     #[sqlx(default)]
     pub id: i64,
     #[sqlx(default)]
+    pub account: String,
+    #[sqlx(default)]
     pub stream: String,
     pub date: String,
     pub file: String,
@@ -559,6 +561,7 @@ impl From<&FileRecord> for FileKey {
     fn from(r: &FileRecord) -> Self {
         Self {
             id: r.id,
+            account: r.account.clone(),
             key: "files/".to_string() + &r.stream + "/" + &r.date + "/" + &r.file,
             meta: r.into(),
             deleted: r.deleted,
@@ -612,6 +615,8 @@ impl From<&StatsRecord> for StreamStats {
 pub struct FileDeletedRecord {
     #[sqlx(default)]
     pub id: i64,
+    #[sqlx(default)]
+    pub account: String,
     pub stream: String,
     pub date: String,
     pub file: String,

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -63,12 +63,13 @@ impl super::FileList for MysqlFileList {
         create_table_index().await
     }
 
-    async fn add(&self, file: &str, meta: &FileMeta) -> Result<i64> {
-        self.inner_add("file_list", file, meta).await
+    async fn add(&self, account: &str, file: &str, meta: &FileMeta) -> Result<i64> {
+        self.inner_add("file_list", account, file, meta).await
     }
 
-    async fn add_history(&self, file: &str, meta: &FileMeta) -> Result<i64> {
-        self.inner_add("file_list_history", file, meta).await
+    async fn add_history(&self, account: &str, file: &str, meta: &FileMeta) -> Result<i64> {
+        self.inner_add("file_list_history", account, file, meta)
+            .await
     }
 
     async fn remove(&self, file: &str) -> Result<()> {
@@ -119,12 +120,13 @@ impl super::FileList for MysqlFileList {
         for files in chunks {
             let mut tx = pool.begin().await?;
             let mut query_builder: QueryBuilder<MySql> = QueryBuilder::new(
-                "INSERT INTO file_list_deleted (org, stream, date, file, index_file, flattened, created_at)",
+                "INSERT INTO file_list_deleted (account, org, stream, date, file, index_file, flattened, created_at)",
             );
             query_builder.push_values(files, |mut b, item| {
                 let (stream_key, date_key, file_name) =
                     parse_file_key_columns(&item.file).expect("parse file key failed");
-                b.push_bind(org_id)
+                b.push_bind(&item.account)
+                    .push_bind(org_id)
                     .push_bind(stream_key)
                     .push_bind(date_key)
                     .push_bind(file_name)
@@ -214,7 +216,7 @@ impl super::FileList for MysqlFileList {
         let start = std::time::Instant::now();
         let ret = sqlx::query_as::<_, super::FileRecord>(
             r#"
-SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
+SELECT account, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
     FROM file_list WHERE stream = ? AND date = ? AND file = ?;
             "#,
         )
@@ -323,7 +325,7 @@ SELECT stream, date, file, deleted, min_ts, max_ts, records, original_size, comp
         let ret = if flattened.is_some() {
             sqlx::query_as::<_, super::FileRecord>(
                 r#"
-SELECT id, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
+SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
     FROM file_list
     WHERE stream = ? AND flattened = ? LIMIT 1000;
                 "#,
@@ -337,7 +339,7 @@ SELECT id, stream, date, file, deleted, min_ts, max_ts, records, original_size, 
             let max_ts_upper_bound = super::calculate_max_ts_upper_bound(time_end, stream_type);
             sqlx::query_as::<_, super::FileRecord>(
                 r#"
-SELECT id, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
+SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
     FROM file_list
     WHERE stream = ? AND max_ts >= ? AND max_ts <= ? AND min_ts <= ?;
                 "#,
@@ -383,7 +385,7 @@ SELECT id, stream, date, file, deleted, min_ts, max_ts, records, original_size, 
         let (date_start, date_end) = date_range.unwrap_or(("".to_string(), "".to_string()));
         let ret = sqlx::query_as::<_, super::FileRecord>(
                 r#"
-SELECT id, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
+SELECT id, account, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
     FROM file_list
     WHERE stream = ? AND date >= ? AND date <= ?;
                 "#,
@@ -420,7 +422,7 @@ SELECT id, stream, date, file, deleted, min_ts, max_ts, records, original_size, 
                 .collect::<Vec<String>>()
                 .join(",");
             let query_str = format!(
-                "SELECT id, stream, date, file, min_ts, max_ts, records, original_size, compressed_size, index_size FROM file_list WHERE id IN ({ids})"
+                "SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, compressed_size, index_size FROM file_list WHERE id IN ({ids})"
             );
             DB_QUERY_NUMS
                 .with_label_values(&["query_by_ids", "file_list"])
@@ -669,7 +671,7 @@ SELECT date
             .with_label_values(&["select", "file_list_deleted"])
             .inc();
         let items: Vec<FileListDeleted> = match sqlx::query_as::<_, super::FileDeletedRecord>(
-            r#"SELECT id, stream, date, file, index_file, flattened FROM file_list_deleted WHERE org = ? AND created_at < ? ORDER BY created_at ASC LIMIT ?;"#,
+            r#"SELECT id, account, stream, date, file, index_file, flattened FROM file_list_deleted WHERE org = ? AND created_at < ? ORDER BY created_at ASC LIMIT ?;"#,
         )
         .bind(org_id)
         .bind(time_max)
@@ -680,6 +682,7 @@ SELECT date
             .iter()
             .map(|r| FileListDeleted {
                 id: r.id,
+                account: r.account.to_string(),
                 file: format!("files/{}/{}/{}", r.stream, r.date, r.file),
                 index_file: r.index_file,
                 flattened: r.flattened,
@@ -782,7 +785,7 @@ SELECT date
             .with_label_values(&["select", "file_list_deleted"])
             .inc();
         let ret = sqlx::query_as::<_, super::FileDeletedRecord>(
-            r#"SELECT id, stream, date, file, index_file, flattened FROM file_list_deleted;"#,
+            r#"SELECT id, account, stream, date, file, index_file, flattened FROM file_list_deleted;"#,
         )
         .fetch_all(&pool)
         .await?;
@@ -790,6 +793,7 @@ SELECT date
             .iter()
             .map(|r| FileListDeleted {
                 id: r.id,
+                account: r.account.to_string(),
                 file: format!("files/{}/{}/{}", r.stream, r.date, r.file),
                 index_file: r.index_file,
                 flattened: r.flattened,
@@ -1555,7 +1559,13 @@ SELECT stream, max(id) as id, CAST(COUNT(*) AS SIGNED) AS num
 }
 
 impl MysqlFileList {
-    async fn inner_add(&self, table: &str, file: &str, meta: &FileMeta) -> Result<i64> {
+    async fn inner_add(
+        &self,
+        table: &str,
+        account: &str,
+        file: &str,
+        meta: &FileMeta,
+    ) -> Result<i64> {
         let pool = CLIENT.clone();
         let (stream_key, date_key, file_name) =
             parse_file_key_columns(file).map_err(|e| Error::Message(e.to_string()))?;
@@ -1563,10 +1573,11 @@ impl MysqlFileList {
         DB_QUERY_NUMS.with_label_values(&["insert", table]).inc();
         match  sqlx::query(
             format!(r#"
-INSERT IGNORE INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT IGNORE INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
             "#).as_str(),
         )
+        .bind(account)
         .bind(org_id)
         .bind(stream_key)
         .bind(date_key)
@@ -1604,13 +1615,14 @@ INSERT IGNORE INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, re
             let chunks = add_items.chunks(100);
             for files in chunks {
                 let mut query_builder: QueryBuilder<MySql> = QueryBuilder::new(
-                format!("INSERT INTO {table} (org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened)").as_str(),
+                format!("INSERT INTO {table} (account, org, stream, date, file, deleted, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened)").as_str(),
                 );
                 query_builder.push_values(files, |mut b, item| {
                     let (stream_key, date_key, file_name) =
                         parse_file_key_columns(&item.key).expect("parse file key failed");
                     let org_id = stream_key[..stream_key.find('/').unwrap()].to_string();
-                    b.push_bind(org_id)
+                    b.push_bind(&item.account)
+                        .push_bind(org_id)
                         .push_bind(stream_key)
                         .push_bind(date_key)
                         .push_bind(file_name)
@@ -1723,6 +1735,7 @@ pub async fn create_table() -> Result<()> {
 CREATE TABLE IF NOT EXISTS file_list
 (
     id        BIGINT not null primary key AUTO_INCREMENT,
+    account   VARCHAR(32)  not null,
     org       VARCHAR(100) not null,
     stream    VARCHAR(256) not null,
     date      VARCHAR(16)  not null,
@@ -1746,6 +1759,7 @@ CREATE TABLE IF NOT EXISTS file_list
 CREATE TABLE IF NOT EXISTS file_list_history
 (
     id        BIGINT not null primary key AUTO_INCREMENT,
+    account   VARCHAR(32)  not null,
     org       VARCHAR(100) not null,
     stream    VARCHAR(256) not null,
     date      VARCHAR(16)  not null,
@@ -1769,6 +1783,7 @@ CREATE TABLE IF NOT EXISTS file_list_history
 CREATE TABLE IF NOT EXISTS file_list_deleted
 (
     id         BIGINT not null primary key AUTO_INCREMENT,
+    account   VARCHAR(32)  not null,
     org        VARCHAR(100) not null,
     stream     VARCHAR(256) not null,
     date       VARCHAR(16)  not null,
@@ -1841,6 +1856,21 @@ CREATE TABLE IF NOT EXISTS stream_stats
     let column = "index_file";
     let data_type = "BOOLEAN default false not null";
     add_column("file_list_deleted", column, data_type).await?;
+
+    // create col account for multiple object storage account support, version >= 0.14.6
+    add_column("file_list", "account", "VARCHAR(32) default '' not null").await?;
+    add_column(
+        "file_list_history",
+        "account",
+        "VARCHAR(32) default '' not null",
+    )
+    .await?;
+    add_column(
+        "file_list_deleted",
+        "account",
+        "VARCHAR(32) default '' not null",
+    )
+    .await?;
 
     Ok(())
 }
@@ -1937,7 +1967,7 @@ pub async fn create_table_index() -> Result<()> {
             .bind(file)
             .execute(&pool)
             .await?;
-            if i % 1000 == 0 {
+            if i.is_multiple_of(1000) {
                 log::warn!("[MYSQL] delete duplicate records: {}/{}", i, ret.len());
             }
         }

--- a/src/infra/src/lib.rs
+++ b/src/infra/src/lib.rs
@@ -81,7 +81,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     file_list::LOCAL_CACHE.create_table().await?;
     file_list::local_cache_gc().await?;
     if !config::is_local_disk_storage() {
-        storage::remote::test_config().await?;
+        storage::test_remote_config().await?;
     }
     // because of asynchronous, we need to wait for a while
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;

--- a/src/infra/src/storage/accounts.rs
+++ b/src/infra/src/storage/accounts.rs
@@ -1,0 +1,539 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::ops::Range;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use config::{get_config, is_local_disk_storage, utils::hash::Sum64};
+use futures::stream::BoxStream;
+use hashbrown::{HashMap, HashSet};
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result, path::Path,
+};
+
+use crate::storage::{ObjectStoreExt, get_stream_from_file, remote::StorageConfig};
+
+const DEFAULT_ACCOUNT: &str = "default";
+
+pub struct StorageClientFactory {
+    accounts: HashMap<String, Box<dyn ObjectStore>>,
+    stream_strategy: StreamStrategy,
+    only_default: bool,
+}
+
+impl Default for StorageClientFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Returns the default object store based on the configuration.
+/// It creates a remote object store with multiple accounts.
+pub(crate) fn default() -> Box<dyn ObjectStoreExt> {
+    Box::<StorageClientFactory>::default()
+}
+
+/// StorageClientFactory is a factory for creating storage clients.
+/// It is used to manage multiple storage clients for different accounts.
+impl StorageClientFactory {
+    pub fn new() -> Self {
+        let config = get_config();
+        Self::new_with_config(&config.s3, is_local_disk_storage())
+    }
+
+    pub fn new_with_config(config: &config::S3, local_mode: bool) -> Self {
+        let (stream_strategy, accounts) = parse_storage_config(config);
+        let mut storage = Self {
+            accounts: HashMap::with_capacity(accounts.len()),
+            only_default: accounts.len() == 1,
+            stream_strategy,
+        };
+
+        if local_mode {
+            std::fs::create_dir_all(&get_config().common.data_stream_dir)
+                .expect("create stream data dir success");
+            storage.accounts.insert(
+                DEFAULT_ACCOUNT.to_string(),
+                Box::<super::local::Local>::default(),
+            );
+            // local storage only has one account
+            storage.only_default = true;
+        } else {
+            for (name, config) in accounts {
+                storage
+                    .accounts
+                    .insert(name, Box::new(super::remote::Remote::new(config)));
+            }
+        }
+        storage
+    }
+
+    /// Get the account name for the path by the given strategy.
+    pub fn get_name_by_path(&self, path: &Path) -> Option<String> {
+        if self.only_default {
+            return None;
+        }
+        match &self.stream_strategy {
+            StreamStrategy::Default => None,
+            StreamStrategy::FileHash(account_names) => {
+                let file = path.to_string();
+                let mut h = config::utils::hash::gxhash::new();
+                let v = h.sum64(&file);
+                let account_name = account_names[v as usize % account_names.len()].clone();
+                Some(account_name)
+            }
+            StreamStrategy::StreamHash(account_names) => get_stream_from_file(path).map(|stream| {
+                let mut h = config::utils::hash::gxhash::new();
+                let v = h.sum64(&stream);
+                account_names[v as usize % account_names.len()].clone()
+            }),
+            StreamStrategy::Stream(stream_map) => get_stream_from_file(path)
+                .and_then(|stream| stream_map.get(&stream).map(|s| s.to_string())),
+        }
+    }
+
+    /// Get the client for the given name.
+    /// If the name is not found, return the default client.
+    pub fn get_client_by_name(&self, name: &str) -> &dyn ObjectStore {
+        if !name.is_empty()
+            && let Some(client) = self.accounts.get(name)
+        {
+            return client;
+        }
+        self.accounts
+            .get(DEFAULT_ACCOUNT)
+            .expect("default object store account not found")
+    }
+}
+
+pub fn parse_storage_config(
+    config: &config::S3,
+) -> (StreamStrategy, HashMap<String, StorageConfig>) {
+    // check account based on ZO_S3_ACCOUNTS
+    let account_names = config
+        .accounts
+        .split(",")
+        .map(|s| s.trim().to_string())
+        .collect::<Vec<String>>();
+    let account_num = account_names.len();
+    let mut accounts = HashMap::with_capacity(account_num);
+
+    // check multi accounts config
+    let providers = config.provider.split(",").collect::<Vec<&str>>();
+    let server_urls = config.server_url.split(",").collect::<Vec<&str>>();
+    let region_names = config.region_name.split(",").collect::<Vec<&str>>();
+    let access_keys = config.access_key.split(",").collect::<Vec<&str>>();
+    let secret_keys = config.secret_key.split(",").collect::<Vec<&str>>();
+    let bucket_names = config.bucket_name.split(",").collect::<Vec<&str>>();
+    let bucket_prefixes = config.bucket_prefix.split(",").collect::<Vec<&str>>();
+    if (!config.provider.is_empty() && providers.len() != account_num)
+        || (!config.server_url.is_empty() && server_urls.len() != account_num)
+        || (!config.region_name.is_empty() && region_names.len() != account_num)
+        || (!config.access_key.is_empty() && access_keys.len() != account_num)
+        || (!config.secret_key.is_empty() && secret_keys.len() != account_num)
+        || (!config.bucket_name.is_empty() && bucket_names.len() != account_num)
+        || (!config.bucket_prefix.is_empty() && bucket_prefixes.len() != account_num)
+    {
+        panic!("Invalid multi object store accounts config");
+    }
+
+    // add accounts
+    for (i, name) in account_names.iter().enumerate() {
+        if i == 0 {
+            // the first we will use as default account
+            accounts.insert(
+                DEFAULT_ACCOUNT.to_string(),
+                StorageConfig {
+                    name: DEFAULT_ACCOUNT.to_string(),
+                    provider: get_value_by_idx(&providers, i),
+                    server_url: get_value_by_idx(&server_urls, i),
+                    region_name: get_value_by_idx(&region_names, i),
+                    access_key: get_value_by_idx(&access_keys, i),
+                    secret_key: get_value_by_idx(&secret_keys, i),
+                    bucket_name: get_value_by_idx(&bucket_names, i),
+                    bucket_prefix: get_value_by_idx(&bucket_prefixes, i),
+                },
+            );
+        }
+        accounts.insert(
+            name.to_string(),
+            StorageConfig {
+                name: name.to_string(),
+                provider: get_value_by_idx(&providers, i),
+                server_url: get_value_by_idx(&server_urls, i),
+                region_name: get_value_by_idx(&region_names, i),
+                access_key: get_value_by_idx(&access_keys, i),
+                secret_key: get_value_by_idx(&secret_keys, i),
+                bucket_name: get_value_by_idx(&bucket_names, i),
+                bucket_prefix: get_value_by_idx(&bucket_prefixes, i),
+            },
+        );
+    }
+
+    // parse stream strategy
+    let stream_strategy = StreamStrategy::new(&config.stream_strategy, account_names);
+
+    (stream_strategy, accounts)
+}
+
+impl std::fmt::Debug for StorageClientFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("storage for StorageClientFactory")
+    }
+}
+
+impl std::fmt::Display for StorageClientFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("storage for StorageClientFactory")
+    }
+}
+
+fn get_value_by_idx(values: &[&str], index: usize) -> String {
+    if values.is_empty() || index >= values.len() {
+        "".to_string()
+    } else {
+        values[index].to_string()
+    }
+}
+
+#[derive(Debug)]
+pub enum StreamStrategy {
+    Default,
+    FileHash(Vec<String>),           // account name list
+    StreamHash(Vec<String>),         // account name list
+    Stream(HashMap<String, String>), // stream name -> account name
+}
+
+impl StreamStrategy {
+    pub fn new(strategy: &str, account_names: Vec<String>) -> Self {
+        match strategy.to_lowercase().as_str() {
+            "" => Self::Default,
+            "file_hash" => Self::FileHash(account_names),
+            "stream_hash" => Self::StreamHash(account_names),
+            _ => {
+                let account_set = account_names.iter().collect::<HashSet<&String>>();
+                let mut stream_map = HashMap::new();
+                for part in strategy.split(",") {
+                    let pos = part
+                        .rfind(":")
+                        .expect("invalid value of ZO_S3_STREAM_STRATEGY");
+                    if pos == 0 || part.len() <= pos + 1 {
+                        panic!("invalid value of ZO_S3_STREAM_STRATEGY");
+                    }
+                    let stream_name = part[0..pos].to_string();
+                    let account_name = part[pos + 1..].to_string();
+                    if !account_set.contains(&account_name) {
+                        panic!("invalid value of ZO_S3_STREAM_STRATEGY");
+                    }
+                    stream_map.insert(stream_name, account_name);
+                }
+                Self::Stream(stream_map)
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStoreExt for StorageClientFactory {
+    fn get_account(&self, file: &str) -> Option<String> {
+        self.get_name_by_path(&file.into())
+    }
+
+    async fn put(&self, account: &str, location: &Path, payload: PutPayload) -> Result<PutResult> {
+        self.get_client_by_name(account)
+            .put(location, payload)
+            .await
+    }
+
+    async fn put_opts(
+        &self,
+        account: &str,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        self.get_client_by_name(account)
+            .put_opts(location, payload, opts)
+            .await
+    }
+
+    async fn put_multipart(
+        &self,
+        account: &str,
+        location: &Path,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        self.get_client_by_name(account)
+            .put_multipart(location)
+            .await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        account: &str,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        self.get_client_by_name(account)
+            .put_multipart_opts(location, opts)
+            .await
+    }
+
+    async fn get(&self, account: &str, location: &Path) -> Result<GetResult> {
+        self.get_client_by_name(account).get(location).await
+    }
+
+    async fn get_opts(
+        &self,
+        account: &str,
+        location: &Path,
+        options: GetOptions,
+    ) -> Result<GetResult> {
+        self.get_client_by_name(account)
+            .get_opts(location, options)
+            .await
+    }
+
+    async fn get_range(&self, account: &str, location: &Path, range: Range<u64>) -> Result<Bytes> {
+        self.get_client_by_name(account)
+            .get_range(location, range)
+            .await
+    }
+
+    async fn get_ranges(
+        &self,
+        account: &str,
+        location: &Path,
+        ranges: &[Range<u64>],
+    ) -> Result<Vec<Bytes>> {
+        self.get_client_by_name(account)
+            .get_ranges(location, ranges)
+            .await
+    }
+
+    async fn head(&self, account: &str, location: &Path) -> Result<ObjectMeta> {
+        self.get_client_by_name(account).head(location).await
+    }
+
+    async fn delete(&self, account: &str, location: &Path) -> Result<()> {
+        self.get_client_by_name(account).delete(location).await
+    }
+
+    fn delete_stream<'a>(
+        &'a self,
+        account: &str,
+        locations: BoxStream<'a, Result<Path>>,
+    ) -> BoxStream<'a, Result<Path>> {
+        self.get_client_by_name(account).delete_stream(locations)
+    }
+
+    fn list(&self, account: &str, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+        self.get_client_by_name(account).list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        account: &str,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
+        self.get_client_by_name(account)
+            .list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        account: &str,
+        prefix: Option<&Path>,
+    ) -> Result<ListResult> {
+        self.get_client_by_name(account)
+            .list_with_delimiter(prefix)
+            .await
+    }
+
+    async fn copy(&self, account: &str, from: &Path, to: &Path) -> Result<()> {
+        self.get_client_by_name(account).copy(from, to).await
+    }
+
+    async fn rename(&self, account: &str, from: &Path, to: &Path) -> Result<()> {
+        self.get_client_by_name(account).rename(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, account: &str, from: &Path, to: &Path) -> Result<()> {
+        self.get_client_by_name(account)
+            .copy_if_not_exists(from, to)
+            .await
+    }
+
+    async fn rename_if_not_exists(&self, account: &str, from: &Path, to: &Path) -> Result<()> {
+        self.get_client_by_name(account)
+            .rename_if_not_exists(from, to)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use config::S3;
+
+    use super::*;
+
+    fn base_s3_config() -> S3 {
+        S3 {
+            accounts: "default".to_string(),
+            provider: "aws".to_string(),
+            server_url: "https://s3.amazonaws.com".to_string(),
+            region_name: "us-east-1".to_string(),
+            access_key: "AKIA...".to_string(),
+            secret_key: "SECRET".to_string(),
+            bucket_name: "mybucket".to_string(),
+            bucket_prefix: "".to_string(),
+            stream_strategy: "".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_storage_client_factory_local_mode_default() {
+        let config = base_s3_config();
+        let factory = StorageClientFactory::new_with_config(&config, true);
+        assert!(factory.only_default);
+        assert_eq!(factory.accounts.len(), 1);
+        assert!(factory.accounts.contains_key("default"));
+        assert!(matches!(factory.stream_strategy, StreamStrategy::Default));
+    }
+
+    #[test]
+    fn test_storage_client_factory_multiple_account_local_mode_strategy() {
+        let mut config = base_s3_config();
+        config.accounts = "acc1,acc2".to_string();
+        config.provider = "aws,aws".to_string();
+        config.server_url = "url1,url2".to_string();
+        config.region_name = "r1,r2".to_string();
+        config.access_key = "k1,k2".to_string();
+        config.secret_key = "s1,s2".to_string();
+        config.bucket_name = "b1,b2".to_string();
+        config.bucket_prefix = "p1,p2".to_string();
+
+        let factory = StorageClientFactory::new_with_config(&config, true);
+        assert!(factory.only_default);
+        assert_eq!(factory.accounts.len(), 1); // includes "default" 
+    }
+
+    #[test]
+    fn test_storage_client_factory_single_account_default() {
+        let config = base_s3_config();
+        let factory = StorageClientFactory::new_with_config(&config, false);
+        assert!(factory.only_default);
+        assert_eq!(factory.accounts.len(), 1);
+        assert!(factory.accounts.contains_key("default"));
+        assert!(matches!(factory.stream_strategy, StreamStrategy::Default));
+    }
+
+    #[test]
+    fn test_storage_client_factory_multiple_accounts_file_hash_strategy() {
+        let mut config = base_s3_config();
+        config.accounts = "acc1,acc2".to_string();
+        config.provider = "aws,aws".to_string();
+        config.server_url = "url1,url2".to_string();
+        config.region_name = "r1,r2".to_string();
+        config.access_key = "k1,k2".to_string();
+        config.secret_key = "s1,s2".to_string();
+        config.bucket_name = "b1,b2".to_string();
+        config.bucket_prefix = "p1,p2".to_string();
+        config.stream_strategy = "file_hash".to_string();
+
+        let factory = StorageClientFactory::new_with_config(&config, false);
+        assert!(!factory.only_default);
+        assert_eq!(factory.accounts.len(), 3); // includes "default"
+        assert!(matches!(
+            factory.stream_strategy,
+            StreamStrategy::FileHash(_)
+        ));
+    }
+
+    #[test]
+    fn test_storage_client_factory_multiple_accounts_stream_hash_strategy() {
+        let mut config = base_s3_config();
+        config.accounts = "acc1,acc2".to_string();
+        config.provider = "aws,aws".to_string();
+        config.server_url = "url1,url2".to_string();
+        config.region_name = "r1,r2".to_string();
+        config.access_key = "k1,k2".to_string();
+        config.secret_key = "s1,s2".to_string();
+        config.bucket_name = "b1,b2".to_string();
+        config.bucket_prefix = "p1,p2".to_string();
+        config.stream_strategy = "stream_hash".to_string();
+
+        let factory = StorageClientFactory::new_with_config(&config, false);
+        assert!(!factory.only_default);
+        assert_eq!(factory.accounts.len(), 3); // includes "default"
+        assert!(matches!(
+            factory.stream_strategy,
+            StreamStrategy::StreamHash(_)
+        ));
+    }
+
+    #[test]
+    fn test_storage_client_factory_multiple_accounts_stream_strategy() {
+        let mut config = base_s3_config();
+        config.accounts = "acc1,acc2".to_string();
+        config.provider = "aws,aws".to_string();
+        config.server_url = "url1,url2".to_string();
+        config.region_name = "r1,r2".to_string();
+        config.access_key = "k1,k2".to_string();
+        config.secret_key = "s1,s2".to_string();
+        config.bucket_name = "b1,b2".to_string();
+        config.bucket_prefix = "p1,p2".to_string();
+        config.stream_strategy = "stream1:acc1,stream2:acc2".to_string();
+
+        let factory = StorageClientFactory::new_with_config(&config, false);
+        assert!(!factory.only_default);
+        assert_eq!(factory.accounts.len(), 3); // includes "default"
+        match &factory.stream_strategy {
+            StreamStrategy::Stream(map) => {
+                assert_eq!(map.get("stream1").unwrap(), "acc1");
+                assert_eq!(map.get("stream2").unwrap(), "acc2");
+            }
+            _ => panic!("Expected StreamStrategy::Stream"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid multi object store accounts config")]
+    fn test_storage_client_factory_invalid_multi_account_config() {
+        let mut config = base_s3_config();
+        config.accounts = "acc1,acc2".to_string();
+        config.provider = "aws".to_string(); // Only one provider, should panic
+        StorageClientFactory::new_with_config(&config, false);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid value of ZO_S3_STREAM_STRATEGY")]
+    fn test_storage_client_factory_invalid_stream_strategy() {
+        let mut config = base_s3_config();
+        config.accounts = "acc1,acc2".to_string();
+        config.provider = "aws,aws".to_string();
+        config.server_url = "url1,url2".to_string();
+        config.region_name = "r1,r2".to_string();
+        config.access_key = "k1,k2".to_string();
+        config.secret_key = "s1,s2".to_string();
+        config.bucket_name = "b1,b2".to_string();
+        config.bucket_prefix = "p1,p2".to_string();
+        config.stream_strategy = "stream1:acc3".to_string(); // acc3 does not exist
+        StorageClientFactory::new_with_config(&config, false);
+    }
+}

--- a/src/infra/src/storage/local.rs
+++ b/src/infra/src/storage/local.rs
@@ -96,7 +96,7 @@ impl ObjectStore for Local {
                 })
             }
             Err(err) => {
-                log::error!("disk File upload error: {:?}", err);
+                log::error!("disk File upload error: {err:?}");
                 Err(err)
             }
         }
@@ -129,7 +129,7 @@ impl ObjectStore for Local {
             .get(&(format_key(&file, self.with_prefix).into()))
             .await
             .map_err(|e| {
-                log::error!("[STORAGE] get local file: {}, error: {:?}", file, e);
+                log::error!("[STORAGE] get local file: {file}, error: {e:?}");
                 e
             })?;
 
@@ -160,7 +160,7 @@ impl ObjectStore for Local {
             .get_opts(&(format_key(&file, self.with_prefix).into()), options)
             .await
             .map_err(|e| {
-                log::error!("[STORAGE] get_opts local file: {}, error: {:?}", file, e);
+                log::error!("[STORAGE] get_opts local file: {file}, error: {e:?}");
                 e
             })?;
 
@@ -192,10 +192,7 @@ impl ObjectStore for Local {
             .await
             .map_err(|e| {
                 log::error!(
-                    "[STORAGE] get_range local file: {}, range: {:?}, error: {:?}",
-                    file,
-                    range,
-                    e
+                    "[STORAGE] get_range local file: {file}, range: {range:?}, error: {e:?}"
                 );
                 e
             })?;

--- a/src/infra/src/storage/mod.rs
+++ b/src/infra/src/storage/mod.rs
@@ -13,54 +13,94 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{ops::Range, sync::Arc};
+use std::{fmt::Debug, ops::Range, sync::Arc};
 
-use bytes::buf::Buf;
+use async_trait::async_trait;
+use bytes::{Bytes, buf::Buf};
 use config::{get_config, is_local_disk_storage, meta::stream::FileMeta, metrics};
 use datafusion::parquet::{data_type::AsBytes, file::metadata::ParquetMetaData};
-use futures::{StreamExt, TryStreamExt};
-use object_store::{GetResult, ObjectMeta, ObjectStore, WriteMultipart, path::Path};
+use futures::{StreamExt, TryStreamExt, stream::BoxStream};
+use hashbrown::HashMap;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, PutMultipartOptions,
+    PutOptions, PutPayload, PutResult, Result, WriteMultipart, path::Path,
+};
 use once_cell::sync::Lazy;
 use parquet::file::metadata::ParquetMetaDataReader;
 
-pub mod local;
-pub mod remote;
+pub mod accounts;
+mod local;
+mod remote;
+pub mod wal;
+
+pub use remote::test_config as test_remote_config;
 
 pub const CONCURRENT_REQUESTS: usize = 1000;
 
-pub static DEFAULT: Lazy<Box<dyn ObjectStore>> = Lazy::new(default);
-pub static LOCAL_WAL: Lazy<Box<dyn ObjectStore>> = Lazy::new(local_wal);
+static MULTI_ACCOUNTS: Lazy<Box<dyn ObjectStoreExt>> = Lazy::new(accounts::default);
 
-/// Returns the default object store based on the configuration.
-/// If the local disk storage is enabled, it creates a local object store.
-/// Otherwise, it creates a remote object store.
-///
-/// # Examples
-///
-/// ```
-/// use infra::storage::default;
-///
-/// let object_store = default();
-/// ```
-fn default() -> Box<dyn ObjectStore> {
-    if is_local_disk_storage() {
-        std::fs::create_dir_all(&get_config().common.data_stream_dir)
-            .expect("create stream data dir success");
-        Box::<local::Local>::default()
-    } else {
-        Box::<remote::Remote>::default()
-    }
+// Create a wrapper trait that extends ObjectStore
+#[async_trait]
+pub trait ObjectStoreExt: std::fmt::Display + Send + Sync + Debug + 'static {
+    fn get_account(&self, file: &str) -> Option<String>;
+    async fn put(&self, account: &str, location: &Path, payload: PutPayload) -> Result<PutResult>;
+    async fn put_opts(
+        &self,
+        account: &str,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult>;
+    async fn put_multipart(
+        &self,
+        account: &str,
+        location: &Path,
+    ) -> Result<Box<dyn MultipartUpload>>;
+    async fn put_multipart_opts(
+        &self,
+        account: &str,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<Box<dyn MultipartUpload>>;
+    async fn get(&self, account: &str, location: &Path) -> Result<GetResult>;
+    async fn get_opts(
+        &self,
+        account: &str,
+        location: &Path,
+        options: GetOptions,
+    ) -> Result<GetResult>;
+    async fn get_range(&self, account: &str, location: &Path, range: Range<u64>) -> Result<Bytes>;
+    async fn get_ranges(
+        &self,
+        account: &str,
+        location: &Path,
+        ranges: &[Range<u64>],
+    ) -> Result<Vec<Bytes>>;
+    async fn head(&self, account: &str, location: &Path) -> Result<ObjectMeta>;
+    async fn delete(&self, account: &str, location: &Path) -> Result<()>;
+    fn delete_stream<'a>(
+        &'a self,
+        account: &str,
+        locations: BoxStream<'a, Result<Path>>,
+    ) -> BoxStream<'a, Result<Path>>;
+    fn list(&self, account: &str, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>>;
+    fn list_with_offset(
+        &self,
+        account: &str,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, Result<ObjectMeta>>;
+    async fn list_with_delimiter(&self, account: &str, prefix: Option<&Path>)
+    -> Result<ListResult>;
+    async fn copy(&self, account: &str, from: &Path, to: &Path) -> Result<()>;
+    async fn rename(&self, account: &str, from: &Path, to: &Path) -> Result<()>;
+    async fn copy_if_not_exists(&self, account: &str, from: &Path, to: &Path) -> Result<()>;
+    async fn rename_if_not_exists(&self, account: &str, from: &Path, to: &Path) -> Result<()>;
 }
 
-fn local_wal() -> Box<dyn ObjectStore> {
-    let cfg = get_config();
-    std::fs::create_dir_all(&cfg.common.data_wal_dir).expect("create wal dir success");
-    Box::new(local::Local::new(&cfg.common.data_wal_dir, false))
-}
-
-pub async fn list(prefix: &str) -> object_store::Result<Vec<String>> {
-    let files = DEFAULT
-        .list(Some(&prefix.into()))
+pub async fn list(account: &str, prefix: &str) -> Result<Vec<String>> {
+    let files = MULTI_ACCOUNTS
+        .list(account, Some(&prefix.into()))
         .map_ok(|meta| meta.location.to_string())
         .try_collect::<Vec<String>>()
         .await
@@ -68,80 +108,121 @@ pub async fn list(prefix: &str) -> object_store::Result<Vec<String>> {
     Ok(files)
 }
 
-pub async fn get(file: &str) -> object_store::Result<GetResult> {
-    DEFAULT.get(&file.into()).await
+pub fn get_account(file: &str) -> Option<String> {
+    MULTI_ACCOUNTS.get_account(file)
 }
 
-pub async fn get_range(file: &str, range: Range<u64>) -> object_store::Result<bytes::Bytes> {
-    DEFAULT.get_range(&file.into(), range).await
+pub async fn get(account: &str, file: &str) -> Result<GetResult> {
+    MULTI_ACCOUNTS.get(account, &file.into()).await
 }
 
-pub async fn head(file: &str) -> object_store::Result<ObjectMeta> {
-    DEFAULT.head(&file.into()).await
+pub async fn get_opts(account: &str, file: &str, options: GetOptions) -> Result<GetResult> {
+    MULTI_ACCOUNTS
+        .get_opts(account, &file.into(), options)
+        .await
 }
 
-pub async fn put(file: &str, data: bytes::Bytes) -> object_store::Result<()> {
+pub async fn get_range(account: &str, file: &str, range: Range<u64>) -> Result<bytes::Bytes> {
+    MULTI_ACCOUNTS.get_range(account, &file.into(), range).await
+}
+
+pub async fn head(account: &str, file: &str) -> Result<ObjectMeta> {
+    MULTI_ACCOUNTS.head(account, &file.into()).await
+}
+
+pub async fn get_bytes(account: &str, file: &str) -> Result<bytes::Bytes> {
+    let data = get(account, file).await?;
+    data.bytes().await
+}
+
+pub async fn get_opts_bytes(
+    account: &str,
+    file: &str,
+    options: GetOptions,
+) -> Result<bytes::Bytes> {
+    let data = get_opts(account, file, options).await?;
+    data.bytes().await
+}
+
+pub async fn put(account: &str, file: &str, data: bytes::Bytes) -> Result<()> {
     let multi_part_upload_size = get_config().s3.multi_part_upload_size;
     if multi_part_upload_size > 0 && multi_part_upload_size < bytes_size_in_mb(&data) as usize {
-        put_multipart(file, data).await?;
+        put_multipart(account, file, data).await?;
     } else {
-        DEFAULT.put(&file.into(), data.into()).await?;
+        MULTI_ACCOUNTS
+            .put(account, &file.into(), data.into())
+            .await?;
     }
     Ok(())
 }
 
-pub async fn put_multipart(file: &str, data: bytes::Bytes) -> object_store::Result<()> {
+pub async fn put_multipart(account: &str, file: &str, data: bytes::Bytes) -> Result<()> {
     let path = Path::from(file);
-    let upload = DEFAULT.put_multipart(&path).await?;
+    let upload = MULTI_ACCOUNTS.put_multipart(account, &path).await?;
     let mut write = WriteMultipart::new(upload);
     write.write(data.as_bytes());
     write.finish().await?;
     Ok(())
 }
 
-pub async fn del(files: &[&str]) -> object_store::Result<()> {
+/// Delete files from the object store.
+/// params: account, file
+pub async fn del(files: Vec<(&str, &str)>) -> Result<()> {
     if files.is_empty() {
         return Ok(());
     }
 
     let start = std::time::Instant::now();
-    let columns = files[0].split('/').collect::<Vec<&str>>();
-    let files = files
-        .iter()
-        .map(|file| file.to_string())
-        .collect::<Vec<_>>();
+    let columns = files[0].1.split('/').collect::<Vec<&str>>();
 
     if !is_local_disk_storage() && get_config().s3.feature_bulk_delete {
-        let files_stream = futures::stream::iter(files)
-            .map(|file| Ok(Path::from(file)))
-            .boxed();
-        match DEFAULT
-            .delete_stream(files_stream)
-            .try_collect::<Vec<Path>>()
-            .await
-        {
-            Ok(files) => {
-                log::debug!("Deleted objects: {:?}", files);
-            }
-            Err(e) => {
-                log::error!("Failed to delete objects: {:?}", e);
+        // group the files by account
+        let mut file_groups = HashMap::new();
+        for (account, file) in files {
+            file_groups
+                .entry(account)
+                .or_insert_with(Vec::new)
+                .push(file);
+        }
+        for (account, files) in file_groups {
+            let files = futures::stream::iter(files)
+                .map(|file| Ok(Path::from(file)))
+                .boxed();
+            match MULTI_ACCOUNTS
+                .delete_stream(account, files)
+                .try_collect::<Vec<Path>>()
+                .await
+            {
+                Ok(files) => {
+                    log::debug!("Deleted objects: {files:?}");
+                }
+                Err(e) => {
+                    log::error!("Failed to delete objects: {e}");
+                }
             }
         }
     } else {
-        let files_stream = futures::stream::iter(files);
-        files_stream
-            .for_each_concurrent(get_config().limit.cpu_num, |file| async move {
-                match DEFAULT.delete(&(file.as_str().into())).await {
+        let files = files
+            .into_iter()
+            .map(|(account, file)| (account, file.to_string()))
+            .collect::<Vec<_>>();
+        let files = futures::stream::iter(files);
+        files
+            .for_each_concurrent(get_config().limit.cpu_num, |(account, file)| async move {
+                match MULTI_ACCOUNTS
+                    .delete(account, &Path::from(file.as_str()))
+                    .await
+                {
                     Ok(_) => {
-                        log::debug!("Deleted object: {}", file);
+                        log::debug!("Deleted object: {file}");
                     }
                     Err(e) => {
                         // TODO: need a better solution for identifying the error
                         if file.ends_with(".result.json") {
                             // ignore search job file deletion error
-                            log::debug!("Failed to delete object: {}, error: {:?}", file, e);
+                            log::debug!("Failed to delete object: {file}, error: {e:?}");
                         } else if !is_local_disk_storage() {
-                            log::error!("Failed to delete object: {:?}", e);
+                            log::error!("Failed to delete object: {e}");
                         }
                     }
                 }
@@ -159,9 +240,9 @@ pub async fn del(files: &[&str]) -> object_store::Result<()> {
     Ok(())
 }
 
-pub async fn get_file_meta(file: &str) -> Result<FileMeta, anyhow::Error> {
+pub async fn get_file_meta(account: &str, file: &str) -> Result<FileMeta, anyhow::Error> {
     let mut file_meta = FileMeta::default();
-    let (file_size, parquet_meta) = get_parquet_metadata(file).await?;
+    let (file_size, parquet_meta) = get_parquet_metadata(account, file).await?;
     if let Some(metadata) = parquet_meta.file_metadata().key_value_metadata() {
         file_meta = metadata.as_slice().into();
     }
@@ -169,32 +250,37 @@ pub async fn get_file_meta(file: &str) -> Result<FileMeta, anyhow::Error> {
     Ok(file_meta)
 }
 
-async fn get_parquet_metadata(file: &str) -> Result<(u64, Arc<ParquetMetaData>), anyhow::Error> {
+async fn get_parquet_metadata(
+    account: &str,
+    file: &str,
+) -> Result<(usize, Arc<ParquetMetaData>), anyhow::Error> {
     // get file info
-    let info = head(file).await?;
+    let info = head(account, file).await?;
     let file_size = info.size;
 
     // read metadata len
     let mut data = get_range(
+        account,
         file,
         (file_size - parquet::file::FOOTER_SIZE as u64)..file_size,
     )
     .await?;
     let mut buf = [0_u8; parquet::file::FOOTER_SIZE];
     data.copy_to_slice(&mut buf);
-    let footer_tail = ParquetMetaDataReader::decode_footer_tail(&buf)?;
-    let metadata_len = footer_tail.metadata_length() as u64;
+    let metadata_len =
+        ParquetMetaDataReader::decode_footer_tail(&buf).map(|f| f.metadata_length())?;
 
     // read metadata
     let data = get_range(
+        account,
         file,
-        (file_size - parquet::file::FOOTER_SIZE as u64 - metadata_len)
+        (file_size - parquet::file::FOOTER_SIZE as u64 - metadata_len as u64)
             ..(file_size - parquet::file::FOOTER_SIZE as u64),
     )
     .await?;
 
     Ok((
-        file_size,
+        file_size as usize,
         Arc::new(ParquetMetaDataReader::decode_metadata(&data)?),
     ))
 }
@@ -210,6 +296,20 @@ pub fn format_key(key: &str, with_prefix: bool) -> String {
     } else {
         key.to_string()
     }
+}
+
+pub fn get_stream_from_file(file: &Path) -> Option<String> {
+    // eg: files/default/logs/olympics/2023/08/21/08/a.parquet
+    // eg: files/default/traces/default/2023/09/04/05/default/service_name=ingester/
+    let parts = file.parts().collect::<Vec<_>>();
+    if parts.len() < 9 || parts[0] != "files".into() {
+        return None;
+    }
+    // 0 files
+    // 1 org_id
+    // 2 stream_type
+    // 3 stream_name
+    Some(parts[3].as_ref().to_string())
 }
 
 fn bytes_size_in_mb(b: &bytes::Bytes) -> f64 {

--- a/src/infra/src/storage/remote.rs
+++ b/src/infra/src/storage/remote.rs
@@ -29,14 +29,26 @@ use crate::storage::{CONCURRENT_REQUESTS, format_key};
 // test only
 const TEST_FILE: &str = "o2_test/check.txt";
 
+#[derive(Debug)]
+pub struct StorageConfig {
+    pub name: String,          // ZO_S3_ACCOUNTS
+    pub provider: String,      // ZO_S3_PROVIDER
+    pub server_url: String,    // ZO_S3_SERVER_URL
+    pub region_name: String,   // ZO_S3_REGION_NAME
+    pub access_key: String,    // ZO_S3_ACCESS_KEY
+    pub secret_key: String,    // ZO_S3_SECRET_KEY
+    pub bucket_name: String,   // ZO_S3_BUCKET_NAME
+    pub bucket_prefix: String, // ZO_S3_BUCKET_PREFIX
+}
+
 pub struct Remote {
     client: LimitStore<Box<dyn object_store::ObjectStore>>,
 }
 
-impl Default for Remote {
-    fn default() -> Self {
+impl Remote {
+    pub fn new(config: StorageConfig) -> Self {
         Self {
-            client: LimitStore::new(init_client(), CONCURRENT_REQUESTS),
+            client: LimitStore::new(init_client(config), CONCURRENT_REQUESTS),
         }
     }
 }
@@ -90,7 +102,7 @@ impl ObjectStore for Remote {
                 })
             }
             Err(err) => {
-                log::error!("[STORAGE] put_opts remote file: {}, error: {:?}", file, err);
+                log::error!("[STORAGE] put_opts remote file: {file}, error: {err:?}");
                 Err(err)
             }
         }
@@ -109,11 +121,7 @@ impl ObjectStore for Remote {
         {
             Ok(r) => Ok(r),
             Err(err) => {
-                log::error!(
-                    "[STORAGE] put_multipart_opts remote file: {}, error: {:?}",
-                    file,
-                    err
-                );
+                log::error!("[STORAGE] put_multipart_opts remote file: {file}, error: {err:?}");
                 Err(err)
             }
         }
@@ -128,7 +136,7 @@ impl ObjectStore for Remote {
             .await
             .map_err(|e| {
                 if file.ne(TEST_FILE) {
-                    log::error!("[STORAGE] get remote file: {}, error: {:?}", file, e);
+                    log::error!("[STORAGE] get remote file: {file}, error: {e:?}");
                 }
                 e
             })?;
@@ -148,7 +156,7 @@ impl ObjectStore for Remote {
                 .with_label_values(&[columns[1], columns[2], "get", "remote"])
                 .inc_by(time);
         }
-        log::debug!("[STORAGE] get remote file: {}", file);
+        log::debug!("[STORAGE] get remote file: {file}");
 
         Ok(result)
     }
@@ -161,7 +169,7 @@ impl ObjectStore for Remote {
             .get_opts(&(format_key(&file, true).into()), options)
             .await
             .map_err(|e| {
-                log::error!("[STORAGE] get_opts remote file: {}, error: {:?}", file, e);
+                log::error!("[STORAGE] get_opts remote file: {file}, error: {e:?}");
                 e
             })?;
 
@@ -193,10 +201,7 @@ impl ObjectStore for Remote {
             .await
             .map_err(|e| {
                 log::error!(
-                    "[STORAGE] get_range remote file: {}, range: {:?}, error: {:?}",
-                    file,
-                    range,
-                    e
+                    "[STORAGE] get_range remote file: {file}, range: {range:?}, error: {e:?}"
                 );
                 e
             })?;
@@ -259,7 +264,7 @@ impl ObjectStore for Remote {
     }
 }
 
-fn init_aws_config() -> object_store::Result<object_store::aws::AmazonS3> {
+fn init_aws_config(config: StorageConfig) -> object_store::Result<object_store::aws::AmazonS3> {
     let cfg = get_config();
     let mut opts = object_store::ClientOptions::default()
         .with_connect_timeout(std::time::Duration::from_secs(cfg.s3.connect_timeout))
@@ -286,25 +291,27 @@ fn init_aws_config() -> object_store::Result<object_store::aws::AmazonS3> {
     };
     let mut builder = object_store::aws::AmazonS3Builder::from_env()
         .with_client_options(opts)
-        .with_bucket_name(&cfg.s3.bucket_name)
+        .with_bucket_name(&config.bucket_name)
         .with_retry(retry_config)
         .with_virtual_hosted_style_request(force_hosted_style);
-    if !cfg.s3.server_url.is_empty() {
-        builder = builder.with_endpoint(&cfg.s3.server_url);
+    if !config.server_url.is_empty() {
+        builder = builder.with_endpoint(&config.server_url);
     }
-    if !cfg.s3.region_name.is_empty() {
-        builder = builder.with_region(&cfg.s3.region_name);
+    if !config.region_name.is_empty() {
+        builder = builder.with_region(&config.region_name);
     }
-    if !cfg.s3.access_key.is_empty() {
-        builder = builder.with_access_key_id(&cfg.s3.access_key);
+    if !config.access_key.is_empty() {
+        builder = builder.with_access_key_id(&config.access_key);
     }
-    if !cfg.s3.secret_key.is_empty() {
-        builder = builder.with_secret_access_key(&cfg.s3.secret_key);
+    if !config.secret_key.is_empty() {
+        builder = builder.with_secret_access_key(&config.secret_key);
     }
     builder.build()
 }
 
-fn init_azure_config() -> object_store::Result<object_store::azure::MicrosoftAzure> {
+fn init_azure_config(
+    config: StorageConfig,
+) -> object_store::Result<object_store::azure::MicrosoftAzure> {
     let cfg = get_config();
     let mut builder = object_store::azure::MicrosoftAzureBuilder::from_env()
         .with_client_options(
@@ -313,17 +320,19 @@ fn init_azure_config() -> object_store::Result<object_store::azure::MicrosoftAzu
                 .with_timeout(std::time::Duration::from_secs(cfg.s3.request_timeout))
                 .with_allow_invalid_certificates(cfg.s3.allow_invalid_certificates),
         )
-        .with_container_name(&cfg.s3.bucket_name);
-    if !cfg.s3.access_key.is_empty() {
-        builder = builder.with_account(&cfg.s3.access_key);
+        .with_container_name(&config.bucket_name);
+    if !config.access_key.is_empty() {
+        builder = builder.with_account(&config.access_key);
     }
-    if !cfg.s3.secret_key.is_empty() {
-        builder = builder.with_access_key(&cfg.s3.secret_key);
+    if !config.secret_key.is_empty() {
+        builder = builder.with_access_key(&config.secret_key);
     }
     builder.build()
 }
 
-fn init_gcp_config() -> object_store::Result<object_store::gcp::GoogleCloudStorage> {
+fn init_gcp_config(
+    config: StorageConfig,
+) -> object_store::Result<object_store::gcp::GoogleCloudStorage> {
     let cfg = get_config();
     let mut builder = object_store::gcp::GoogleCloudStorageBuilder::from_env()
         .with_client_options(
@@ -332,42 +341,42 @@ fn init_gcp_config() -> object_store::Result<object_store::gcp::GoogleCloudStora
                 .with_timeout(std::time::Duration::from_secs(cfg.s3.request_timeout))
                 .with_allow_invalid_certificates(cfg.s3.allow_invalid_certificates),
         )
-        .with_bucket_name(&cfg.s3.bucket_name);
-    if !cfg.s3.access_key.is_empty() {
-        builder = builder.with_service_account_path(&cfg.s3.access_key);
+        .with_bucket_name(&config.bucket_name);
+    if !config.access_key.is_empty() {
+        builder = builder.with_service_account_path(&config.access_key);
     }
     builder.build()
 }
 
-fn init_client() -> Box<dyn object_store::ObjectStore> {
-    let cfg = get_config();
-    if cfg.common.print_key_config {
-        log::info!("s3 init config: {:?}", cfg.s3);
+fn init_client(config: StorageConfig) -> Box<dyn object_store::ObjectStore> {
+    if get_config().common.print_key_config {
+        log::info!("s3 init config: {config:?}");
     }
 
-    match cfg.s3.provider.as_str() {
-        "aws" | "s3" => match init_aws_config() {
+    let provider = config.provider.to_string();
+    match provider.as_str() {
+        "aws" | "s3" => match init_aws_config(config) {
             Ok(client) => Box::new(client),
             Err(e) => {
-                panic!("s3 init config error: {e:?}");
+                panic!("s3 init config error: {e}");
             }
         },
-        "azure" => match init_azure_config() {
+        "azure" => match init_azure_config(config) {
             Ok(client) => Box::new(client),
             Err(e) => {
-                panic!("azure init config error: {e:?}");
+                panic!("azure init config error: {e}");
             }
         },
-        "gcs" | "gcp" => match init_gcp_config() {
+        "gcs" | "gcp" => match init_gcp_config(config) {
             Ok(client) => Box::new(client),
             Err(e) => {
-                panic!("gcp init config error: {e:?}");
+                panic!("gcp init config error: {e}");
             }
         },
-        _ => match init_aws_config() {
+        _ => match init_aws_config(config) {
             Ok(client) => Box::new(client),
             Err(e) => {
-                panic!("{} init config error: {:?}", cfg.s3.provider, e);
+                panic!("{provider} init config error: {e:?}");
             }
         },
     }
@@ -375,17 +384,24 @@ fn init_client() -> Box<dyn object_store::ObjectStore> {
 
 pub async fn test_config() -> Result<(), anyhow::Error> {
     // Test download
-    if let Err(e) = super::get(TEST_FILE).await {
-        if matches!(e, object_store::Error::NotFound { .. }) {
-            let test_content = Bytes::from("Hello, S3!");
-            // Test upload
-            if let Err(e) = super::put(TEST_FILE, test_content).await {
-                return Err(anyhow::anyhow!("S3 upload test failed: {:?}", e));
-            }
-        } else {
-            return Err(anyhow::anyhow!("S3 download test failed: {:?}", e));
+    match super::get("", TEST_FILE).await {
+        Ok(_) => {
+            return Ok(());
         }
-    }
+        Err(e) => match e {
+            object_store::Error::NotFound { .. } => {}
+            object_store::Error::PermissionDenied { path: _, source }
+                if source.to_string().contains("ListBucket") => {}
+            _ => {
+                return Err(anyhow::anyhow!("S3 download test failed: {e}"));
+            }
+        },
+    };
 
+    // Test upload
+    let data = Bytes::from("Hello, OpenObserve!");
+    if let Err(e) = super::put("", TEST_FILE, data).await {
+        return Err(anyhow::anyhow!("S3 upload test failed: {e}"));
+    }
     Ok(())
 }

--- a/src/infra/src/storage/wal.rs
+++ b/src/infra/src/storage/wal.rs
@@ -1,0 +1,290 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::ops::Range;
+
+use config::get_config;
+use object_store::{GetOptions, GetResult, ObjectMeta, ObjectStore, Result, path::Path};
+use once_cell::sync::Lazy;
+
+static DEFAULT: Lazy<Box<dyn ObjectStore>> = Lazy::new(default);
+
+fn default() -> Box<dyn ObjectStore> {
+    let cfg = get_config();
+    std::fs::create_dir_all(&cfg.common.data_wal_dir).expect("create wal dir success");
+    Box::new(super::local::Local::new(&cfg.common.data_wal_dir, false))
+}
+
+pub async fn get(path: &Path) -> Result<GetResult> {
+    DEFAULT.get(path).await
+}
+
+pub async fn get_opts(path: &Path, options: GetOptions) -> Result<GetResult> {
+    DEFAULT.get_opts(path, options).await
+}
+
+pub async fn get_range(path: &Path, range: Range<u64>) -> Result<bytes::Bytes> {
+    DEFAULT.get_range(path, range).await
+}
+
+pub async fn head(path: &Path) -> Result<ObjectMeta> {
+    DEFAULT.head(path).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+
+    use object_store::GetOptions;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    // Helper function to create a temporary WAL directory for testing
+    fn create_temp_wal_dir() -> TempDir {
+        tempfile::tempdir().expect("Failed to create temp directory")
+    }
+
+    // Helper function to set up test environment with custom WAL dir
+    async fn setup_test_environment() -> (TempDir, String) {
+        let temp_dir = create_temp_wal_dir();
+        let wal_path = temp_dir.path().join("wal");
+        std::fs::create_dir_all(&wal_path).expect("Failed to create WAL directory");
+
+        // Override the config temporarily for testing
+        // Note: In a real test environment, you might want to mock the config
+        (temp_dir, wal_path.to_string_lossy().to_string())
+    }
+
+    #[tokio::test]
+    async fn test_get_function() {
+        let (_temp_dir, _wal_path) = setup_test_environment().await;
+        let path = Path::from("test/file.txt");
+
+        // Test with a non-existent file
+        let result = get(&path).await;
+        assert!(result.is_err());
+
+        // Verify the error is appropriate for a non-existent file
+        if let Err(e) = result {
+            assert!(matches!(e, object_store::Error::NotFound { .. }));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_opts_function() {
+        let (_temp_dir, _wal_path) = setup_test_environment().await;
+        let path = Path::from("test/file.txt");
+        let options = GetOptions::default();
+
+        // Test with a non-existent file
+        let result = get_opts(&path, options).await;
+        assert!(result.is_err());
+
+        // Verify the error is appropriate for a non-existent file
+        if let Err(e) = result {
+            assert!(matches!(e, object_store::Error::NotFound { .. }));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_range_function() {
+        let (_temp_dir, _wal_path) = setup_test_environment().await;
+        let path = Path::from("test/file.txt");
+        let range = Range { start: 0, end: 10 };
+
+        // Test with a non-existent file
+        let result = get_range(&path, range).await;
+        assert!(result.is_err());
+
+        // Verify the error is appropriate for a non-existent file
+        if let Err(e) = result {
+            assert!(matches!(e, object_store::Error::NotFound { .. }));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_head_function() {
+        let (_temp_dir, _wal_path) = setup_test_environment().await;
+        let path = Path::from("test/file.txt");
+
+        // Test with a non-existent file
+        let result = head(&path).await;
+        assert!(result.is_err());
+
+        // Verify the error is NotImplemented (as implemented in local storage)
+        if let Err(e) = result {
+            assert!(matches!(e, object_store::Error::NotImplemented));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_different_path_formats() {
+        let (_temp_dir, _wal_path) = setup_test_environment().await;
+        let test_paths = [
+            Path::from("simple.txt"),
+            Path::from("/absolute/path/file.txt"),
+            Path::from("nested/directory/file.txt"),
+            Path::from("file with spaces.txt"),
+            Path::from("file-with-special-chars@#$%.txt"),
+            Path::from("very/deeply/nested/path/to/file.log"),
+        ];
+
+        for path in &test_paths {
+            let result = get(path).await;
+            assert!(result.is_err(), "Should fail for path: {}", path);
+
+            let head_result = head(path).await;
+            assert!(head_result.is_err(), "Should fail for path: {}", path);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_range_with_different_ranges() {
+        let (_temp_dir, _wal_path) = setup_test_environment().await;
+        let path = Path::from("test/file.txt");
+        let test_ranges = [
+            Range { start: 0, end: 10 },
+            Range { start: 10, end: 20 },
+            Range { start: 0, end: 0 }, // Empty range
+            Range {
+                start: 100,
+                end: 200,
+            },
+            Range { start: 0, end: 1 }, // Single byte range
+        ];
+
+        for range in &test_ranges {
+            let result = get_range(&path, range.clone()).await;
+            assert!(result.is_err(), "Should fail for range: {:?}", range);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_opts_with_different_options() {
+        let (_temp_dir, _wal_path) = setup_test_environment().await;
+        let path = Path::from("test/file.txt");
+
+        // Test with default options
+        let default_options = GetOptions::default();
+        let result = get_opts(&path, default_options).await;
+        assert!(result.is_err());
+
+        // Test with custom options (if any specific options are available)
+        let custom_options = GetOptions::default();
+        // Note: GetOptions might not have many configurable options in the current version
+        let result = get_opts(&path, custom_options).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_operations() {
+        let (_temp_dir, _wal_path) = setup_test_environment().await;
+        let path = Path::from("test/concurrent.txt");
+
+        // Test multiple concurrent operations of the same type
+        let get_futures = [get(&path), get(&path), get(&path)];
+
+        let get_range_futures = [
+            get_range(&path, Range { start: 0, end: 10 }),
+            get_range(&path, Range { start: 10, end: 20 }),
+            get_range(&path, Range { start: 20, end: 30 }),
+        ];
+
+        let head_futures = [head(&path), head(&path), head(&path)];
+
+        let get_results = futures::future::join_all(get_futures).await;
+        let get_range_results = futures::future::join_all(get_range_futures).await;
+        let head_results = futures::future::join_all(head_futures).await;
+
+        // All operations should fail with errors
+        for result in get_results {
+            assert!(result.is_err());
+        }
+        for result in get_range_results {
+            assert!(result.is_err());
+        }
+        for result in head_results {
+            assert!(result.is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_empty_and_edge_case_paths() {
+        let (_temp_dir, _wal_path) = setup_test_environment().await;
+        let edge_case_paths = [
+            Path::from(""),        // Empty path
+            Path::from("."),       // Current directory
+            Path::from(".."),      // Parent directory
+            Path::from("/"),       // Root
+            Path::from("////"),    // Multiple slashes
+            Path::from("file"),    // No extension
+            Path::from(".hidden"), // Hidden file
+            Path::from("dir/"),    // Directory with trailing slash
+        ];
+
+        for path in &edge_case_paths {
+            let result = get(path).await;
+            assert!(
+                result.is_err(),
+                "Should fail for edge case path: '{}'",
+                path
+            );
+        }
+    }
+
+    #[test]
+    fn test_default_function_creates_directory() {
+        // This test verifies that the default function creates the WAL directory
+        // Note: This is a bit tricky to test without mocking the config
+        // In a real scenario, you might want to use a test configuration
+
+        // For now, we'll just test that the function doesn't panic
+        // and that the DEFAULT static is properly initialized
+        let _default_store = &*DEFAULT;
+        // If we get here, the DEFAULT was successfully initialized
+    }
+
+    #[tokio::test]
+    async fn test_error_consistency() {
+        let (_temp_dir, _wal_path) = setup_test_environment().await;
+        let path = Path::from("test/consistency.txt");
+
+        // Test that all functions return consistent error types for the same non-existent file
+        let get_result = get(&path).await;
+        let get_opts_result = get_opts(&path, GetOptions::default()).await;
+        let get_range_result = get_range(&path, Range { start: 0, end: 10 }).await;
+        let head_result = head(&path).await;
+
+        // get, get_opts, and get_range should return NotFound errors
+        // head returns NotImplemented as per local storage implementation
+        assert!(matches!(
+            get_result,
+            Err(object_store::Error::NotFound { .. })
+        ));
+        assert!(matches!(
+            get_opts_result,
+            Err(object_store::Error::NotFound { .. })
+        ));
+        assert!(matches!(
+            get_range_result,
+            Err(object_store::Error::NotFound { .. })
+        ));
+        assert!(matches!(
+            head_result,
+            Err(object_store::Error::NotImplemented)
+        ));
+    }
+}

--- a/src/infra/src/table/migration/m20250125_133700_populate_destinations_table.rs
+++ b/src/infra/src/table/migration/m20250125_133700_populate_destinations_table.rs
@@ -240,28 +240,6 @@ mod destinations {
 
     impl ActiveModelBehavior for ActiveModel {}
 
-    #[derive(Clone, Debug, Serialize, Deserialize)]
-    #[serde(rename_all = "snake_case")]
-    pub struct Destination {
-        pub id: String,
-        pub org_id: String,
-        pub name: String,
-        pub module: Module,
-    }
-
-    #[derive(Serialize, Debug, Deserialize, Clone)]
-    #[serde(rename_all = "snake_case")]
-    pub enum Module {
-        Alert {
-            template_id: String,
-            destination_type: DestinationType,
-        },
-        Pipeline {
-            pipeline_id: String,
-            endpoint: Endpoint,
-        },
-    }
-
     #[derive(Serialize, Debug, Deserialize, Clone)]
     #[serde(tag = "type")]
     #[serde(rename_all = "snake_case")]

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -284,7 +284,7 @@ impl Writer {
                     },
                 }
                 total += 1;
-                if total % 1000 == 0 {
+                if total.is_multiple_of(1000) {
                     log::info!(
                         "[INGESTER:MEM:{idx}] writer queue consuming, total: {}, in queue: {}",
                         total,

--- a/src/job/file_downloader.rs
+++ b/src/job/file_downloader.rs
@@ -15,15 +15,28 @@
 
 use std::{collections::VecDeque, sync::Arc};
 
-use config::{get_config, metrics, utils::time::now_micros};
+use config::{
+    cluster::LOCAL_NODE,
+    get_config,
+    meta::cluster::{Role, RoleGroup, get_internal_grpc_token},
+    metrics,
+    utils::time::now_micros,
+};
+use futures_util::StreamExt;
+use hashbrown::{HashMap, HashSet};
 use infra::cache::file_data;
 use once_cell::sync::Lazy;
+use proto::cluster_rpc::{SimpleFileList, event_client::EventClient};
 use tokio::sync::{
     Mutex,
     mpsc::{Receiver, Sender},
 };
+use tonic::{codec::CompressionEncoding, metadata::MetadataValue};
 
-type FileInfo = (String, String, usize, file_data::CacheType);
+use crate::common::infra::cluster;
+
+/// (trace_id, file_id, account, file, size, cache_type)
+type FileInfo = (String, i64, String, String, usize, file_data::CacheType);
 
 mod processing_files {
     use hashbrown::HashSet;
@@ -104,15 +117,14 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 let ret = rx.lock().await.recv().await;
                 match ret {
                     None => {
-                        log::debug!("[FILE_CACHE_DOWNLOAD:JOB] Receiving channel is closed");
+                        log::debug!("[FILE_CACHE_DOWNLOAD:JOB:NORMAL] Receiving channel is closed");
                         break;
                     }
-                    Some((trace_id, file, file_size, cache)) => {
+                    Some((trace_id, id, account, file, file_size, cache)) => {
                         // check if the file is already being downloaded
                         if processing_files::is_processing(&file) {
                             log::warn!(
-                                "[trace_id {trace_id}] [thread {thread}] search->storage: file {} is already being downloaded, will skip it",
-                                file
+                                "[trace_id {trace_id}] [thread {thread}] search->storage: file {file} is already being downloaded, will skip it"
                             );
                             // update metrics
                             metrics::FILE_DOWNLOADER_NORMAL_QUEUE_SIZE
@@ -125,23 +137,21 @@ pub async fn run() -> Result<(), anyhow::Error> {
                         processing_files::add(&file);
 
                         // download the file
-                        match download_file(thread, &trace_id, &file, file_size, cache).await {
+                        match download_file(
+                            thread, &trace_id, id, &account, &file, file_size, cache,
+                        )
+                        .await
+                        {
                             Ok(data_len) => {
                                 if data_len > 0 && data_len != file_size {
                                     log::warn!(
-                                        "[trace_id {trace_id}] search->storage: download file {} found size mismatch, expected: {}, actual: {}, will skip it",
-                                        file,
-                                        file_size,
-                                        data_len,
+                                        "[FILE_CACHE_DOWNLOAD:JOB:NORMAL] download file {file} found size mismatch, expected: {file_size}, actual: {data_len}, will skip it",
                                     );
                                 }
                             }
                             Err(e) => {
                                 log::error!(
-                                    "[trace_id {trace_id}] search->storage: download file {} to cache {:?} err: {}",
-                                    file,
-                                    cache,
-                                    e,
+                                    "[FILE_CACHE_DOWNLOAD:JOB:NORMAL] download file {file} to cache {cache:?} err: {e}",
                                 );
                             }
                         }
@@ -168,19 +178,17 @@ pub async fn run() -> Result<(), anyhow::Error> {
             let ret = rx.lock().await.recv().await;
             match ret {
                 None => {
-                    log::debug!(
-                        "[FILE_CACHE_DOWNLOAD:PRIORITY_QUEUE:JOB] Receiving channel is closed"
-                    );
+                    log::debug!("[FILE_CACHE_DOWNLOAD:JOB:PRIORITY] Receiving channel is closed");
                     if shutdown_tx.send(true).is_err() {
                         log::error!(
-                            "[FILE_CACHE_DOWNLOAD:PRIORITY_QUEUE:JOB] Failed to send disconnect signal"
+                            "[FILE_CACHE_DOWNLOAD:JOB:PRIORITY] Failed to send disconnect signal"
                         );
                     }
                     break;
                 }
-                Some((trace_id, file, file_size, cache)) => {
+                Some((trace_id, id, account, file, file_size, cache)) => {
                     PRIORITY_FILE_DOWNLOAD_CHANNEL
-                        .push((trace_id, file, file_size, cache))
+                        .push((trace_id, id, account, file, file_size, cache))
                         .await;
                 }
             }
@@ -195,19 +203,18 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 tokio::select! {
                     _ = shutdown_rx.changed() => {
                         log::warn!(
-                            "[FILE_CACHE_DOWNLOAD:PRIORITY_QUEUE:JOB] Received shutdown signal, exiting"
+                            "[FILE_CACHE_DOWNLOAD:JOB:PRIORITY] Received shutdown signal, exiting"
                         );
                         break;
                     }
                     _ = async {
                         let file_info = PRIORITY_FILE_DOWNLOAD_CHANNEL.pop().await;
                         match file_info {
-                            Some((trace_id, file, file_size, cache)) => {
+                            Some((trace_id, id, account, file, file_size, cache)) => {
                                  // check if the file is already being downloaded
                                 if processing_files::is_processing(&file) {
                                     log::warn!(
-                                        "[trace_id {trace_id}] [thread {thread}] search->storage: file {} is already being downloaded, will skip it",
-                                        file
+                                        "[trace_id {trace_id}] [thread {thread}] search->storage: file {file} is already being downloaded, will skip it"
                                     );
                                     // update metrics
                                     metrics::FILE_DOWNLOADER_PRIORITY_QUEUE_SIZE
@@ -220,25 +227,17 @@ pub async fn run() -> Result<(), anyhow::Error> {
                                 processing_files::add(&file);
 
                                 // download the file
-                                match download_file(thread, &trace_id, &file, file_size, cache).await {
+                                match download_file(thread, &trace_id, id, &account, &file, file_size, cache).await {
                                     Ok(data_len) => {
                                         if data_len > 0 && data_len != file_size {
                                             log::warn!(
-                                                "[trace_id {}] priority queue download file {} found size mismatch, expected: {}, actual: {}, will skip it",
-                                                trace_id,
-                                                file,
-                                                file_size,
-                                                data_len
+                                                "[FILE_CACHE_DOWNLOAD:JOB:PRIORITY] download file {file} found size mismatch, expected: {file_size}, actual: {data_len}, will skip it",
                                             );
                                         }
                                     }
                                     Err(e) => {
                                         log::error!(
-                                            "[trace_id {}] priority queue download file {} to cache {:?} err: {}",
-                                            trace_id,
-                                            file,
-                                            cache,
-                                            e
+                                            "[FILE_CACHE_DOWNLOAD:JOB:PRIORITY] download file {file} to cache {cache:?} err: {e}",
                                         );
                                     }
                                 }
@@ -266,11 +265,24 @@ pub async fn run() -> Result<(), anyhow::Error> {
 async fn download_file(
     thread: usize,
     trace_id: &str,
+    file_id: i64,
+    account: &str,
     file_name: &str,
     file_size: usize,
     cache_type: file_data::CacheType,
 ) -> Result<usize, anyhow::Error> {
     let cfg = get_config();
+
+    // download file from node
+    if cfg.cache_latest_files.download_from_node
+        && let Ok(ok) =
+            download_file_with_consistent_hash(file_id, account, file_name, file_size).await
+        && ok
+    {
+        return Ok(file_size);
+    }
+
+    // download from object store
     let size = if file_size > 0 { Some(file_size) } else { None };
     let start = std::time::Instant::now();
     let ret = match cache_type {
@@ -278,18 +290,17 @@ async fn download_file(
             let mut disk_exists = false;
             let mem_exists = file_data::memory::exist(file_name).await;
             if !mem_exists && !cfg.memory_cache.skip_disk_check {
-                // when skip_disk_check = false, need to check disk cache
                 disk_exists = file_data::disk::exist(file_name).await;
             }
             if !mem_exists && (cfg.memory_cache.skip_disk_check || !disk_exists) {
-                file_data::memory::download(trace_id, file_name, size).await
+                file_data::memory::download(account, file_name, size).await
             } else {
                 Ok(0)
             }
         }
         file_data::CacheType::Disk => {
             if !file_data::disk::exist(file_name).await {
-                file_data::disk::download(trace_id, file_name, size).await
+                file_data::disk::download(account, file_name, size).await
             } else {
                 Ok(0)
             }
@@ -297,35 +308,199 @@ async fn download_file(
         _ => Ok(0),
     };
     log::debug!(
-        "[FILE_CACHE_DOWNLOAD:JOB:{thread}] [trace_id {trace_id}] download_file: {file_name}, ret: {:?}, took: {} ms",
+        "[FILE_CACHE_DOWNLOAD:JOB:{thread}] [trace_id {trace_id}] download file: {file_name}, ret: {:?}, took: {} ms",
         ret,
         start.elapsed().as_millis()
     );
     ret
 }
 
+async fn download_file_with_consistent_hash(
+    file_id: i64,
+    account: &str,
+    file_name: &str,
+    file_size: usize,
+) -> Result<bool, anyhow::Error> {
+    let role_group = if LOCAL_NODE.is_interactive_querier() {
+        RoleGroup::Interactive
+    } else {
+        RoleGroup::Background
+    };
+    let Some(node_name) = cluster::get_node_from_consistent_hash(
+        &file_id.to_string(),
+        &Role::Querier,
+        Some(role_group),
+    )
+    .await
+    else {
+        return Ok(false);
+    };
+    // get node by file_id
+    let Some(node) = cluster::get_cached_node_by_name(&node_name).await else {
+        return Ok(false);
+    };
+    // download file from node
+    let Ok(failed) = download_from_node(
+        &node.grpc_addr,
+        &[(
+            file_id,
+            account.to_string(),
+            file_name.to_string(),
+            file_size as i64,
+            0,
+        )],
+    )
+    .await
+    else {
+        return Ok(false);
+    };
+    // failed is empty means download success
+    Ok(failed.is_empty())
+}
+
+// download files from node and return download failed files
+// file: (account, file, size, ts)
+pub async fn download_from_node(
+    addr: &str,
+    files: &[(i64, String, String, i64, i64)],
+) -> Result<Vec<(i64, String, String, i64, i64)>, anyhow::Error> {
+    let start = std::time::Instant::now();
+    let cfg = get_config();
+    log::debug!(
+        "[FILE_CACHE_DOWNLOAD:gRPC] Download files from node start, files: {:?}",
+        files.len()
+    );
+
+    let token: MetadataValue<_> = get_internal_grpc_token()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid token"))?;
+
+    let channel = crate::service::grpc::get_cached_channel(addr).await?;
+    let client = EventClient::with_interceptor(channel, move |mut req: tonic::Request<()>| {
+        req.metadata_mut().insert("authorization", token.clone());
+        Ok(req)
+    });
+
+    let file_size_map = files
+        .iter()
+        .filter_map(|(_, _, f, s, _)| {
+            if *s > cfg.cache_latest_files.download_node_size * 1024 * 1024 {
+                None
+            } else {
+                Some((f, *s as usize))
+            }
+        })
+        .collect::<HashMap<_, _>>();
+    if file_size_map.is_empty() {
+        return Ok(files.to_vec());
+    }
+    let request = tonic::Request::new(SimpleFileList {
+        files: files.iter().map(|(_, _, f, ..)| f.to_string()).collect(),
+    });
+
+    let resp = client
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .max_decoding_message_size(cfg.grpc.max_message_size * 1024 * 1024)
+        .max_encoding_message_size(cfg.grpc.max_message_size * 1024 * 1024)
+        .get_files(request)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to get files from {addr}, {e}"))?;
+
+    let mut file_contents = HashMap::new();
+    let mut downloaded_files = HashSet::new();
+    let mut resp_stream = resp.into_inner();
+    while let Some(resp) = resp_stream.next().await {
+        let resp = match resp {
+            Ok(resp) => resp,
+            Err(err) => {
+                if err.code() == tonic::Code::NotFound {
+                    log::debug!(
+                        "[FILE_CACHE_DOWNLOAD:gRPC] Failed to download file {} from {}: file not found",
+                        err.message(),
+                        addr
+                    );
+                    continue;
+                }
+                return Err(anyhow::anyhow!(
+                    "Failed to download file from {addr}, {err}"
+                ));
+            }
+        };
+        for content in resp.entries {
+            let entry = file_contents
+                .entry(content.filename.clone())
+                .or_insert(bytes::BytesMut::new());
+            entry.extend_from_slice(&content.content);
+            downloaded_files.insert(content.filename);
+        }
+    }
+
+    log::debug!(
+        "[FILE_CACHE_DOWNLOAD:gRPC] Successfully retrieved {} files from {} in {} ms",
+        downloaded_files.len(),
+        addr,
+        start.elapsed().as_millis()
+    );
+
+    // Cache the file contents
+    for (file, content) in file_contents {
+        let data = content.freeze();
+        if let Some(size) = file_size_map.get(&file)
+            && *size != data.len()
+        {
+            log::warn!(
+                "[FILE_CACHE_DOWNLOAD:gRPC] Failed to download file {} from {}: size mismatch, expected {} but got {}",
+                file,
+                addr,
+                size,
+                data.len()
+            );
+            downloaded_files.remove(&file);
+            continue;
+        }
+        if let Err(e) = infra::cache::file_data::set(&file, data).await {
+            log::error!("[FILE_CACHE_DOWNLOAD:gRPC] Failed to cache file {file}: {e}");
+            downloaded_files.remove(&file);
+        }
+    }
+
+    // Return list of failed files
+    let failed_files: Vec<_> = files
+        .iter()
+        .filter(|(_, f, ..)| !downloaded_files.contains(f))
+        .cloned()
+        .collect();
+
+    log::debug!(
+        "[FILE_CACHE_DOWNLOAD:gRPC] Failed to retrieve {} files from {} in {} ms",
+        failed_files.len(),
+        addr,
+        start.elapsed().as_millis()
+    );
+
+    Ok(failed_files)
+}
+
 pub async fn queue_download(
-    trace_id: &str,
-    file: &str,
+    trace_id: String,
+    id: i64,
+    account: String,
+    file: String,
     size: i64,
-    max_ts: i64,
+    ts: i64,
     cache_type: file_data::CacheType,
 ) -> Result<(), anyhow::Error> {
     log::debug!(
-        "[FILE_CACHE_DOWNLOAD:JOB] [trace_id {trace_id}] queue_background_download: {file}, size: {size}, ts: {max_ts}"
+        "[FILE_CACHE_DOWNLOAD:JOB] [trace_id {trace_id}] enqueue file: {file}, size: {size}, ts: {ts}"
     );
     let cfg = get_config();
     if cfg.limit.file_download_enable_priority_queue
-        && should_prioritize_file(max_ts, cfg.limit.file_download_priority_queue_window_secs)
+        && should_prioritize_file(ts, cfg.limit.file_download_priority_queue_window_secs)
     {
         PRIORITY_FILE_DOWNLOAD_CHANNEL
             .sender
-            .send((
-                trace_id.to_owned(),
-                file.to_owned(),
-                size as usize,
-                cache_type,
-            ))
+            .send((trace_id, id, account, file, size as usize, cache_type))
             .await?;
 
         // update metrics
@@ -336,7 +511,9 @@ pub async fn queue_download(
         FILE_DOWNLOAD_CHANNEL
             .sender
             .send((
-                trace_id.to_owned(),
+                trace_id,
+                id,
+                account,
                 file.to_owned(),
                 size as usize,
                 cache_type,

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -43,7 +43,7 @@ mod promql_self_consume;
 mod stats;
 pub(crate) mod syslog_server;
 
-pub use file_downloader::queue_download;
+pub use file_downloader::{download_from_node, queue_download};
 pub use mmdb_downloader::MMDB_INIT_NOTIFIER;
 
 pub async fn init() -> Result<(), anyhow::Error> {

--- a/src/proto/proto/cluster/common.proto
+++ b/src/proto/proto/cluster/common.proto
@@ -51,6 +51,7 @@ message FileKey {
     FileMeta       meta        = 3;
     bool           deleted     = 4;
     optional bytes segment_ids = 5;
+    string         account     = 6;
 }
 
 message IdxFileName {
@@ -68,5 +69,5 @@ message FileContent {
 }
 
 message SimpleFileList {
-    repeated string paths = 1;
+    repeated string files = 1;
 }

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -99,6 +99,8 @@ pub struct FileKey {
     pub deleted: bool,
     #[prost(bytes = "vec", optional, tag = "5")]
     pub segment_ids: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(string, tag = "6")]
+    pub account: ::prost::alloc::string::String,
 }
 #[derive(Eq)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -129,7 +131,7 @@ pub struct FileContent {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SimpleFileList {
     #[prost(string, repeated, tag = "1")]
-    pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub files: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Generated client implementations.
 pub mod event_client {

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -862,7 +862,7 @@ impl AlertExt for Alert {
                 self.org_id, self.stream_type, self.stream_name, self.name
             )));
             search_event_ctx.alert_name = Some(self.name.clone());
-            
+
             self.query_condition
                 .evaluate_scheduled(
                     &self.org_id,

--- a/src/service/compact/flatten.rs
+++ b/src/service/compact/flatten.rs
@@ -156,8 +156,7 @@ pub async fn generate_file(file: &FileKey) -> Result<(), anyhow::Error> {
     let start = std::time::Instant::now();
     log::debug!("[FLATTEN_COMPACTOR] generate flatten file for {}", file.key);
 
-    let res = storage::get(&file.key).await?;
-    let data = res.bytes().await?;
+    let data = storage::get_bytes(&file.account, &file.key).await?;
     let (_, batches) = read_recordbatch_from_bytes(&data)
         .await
         .map_err(|e| anyhow::anyhow!("read_recordbatch_from_bytes error: {}", e))?;
@@ -165,7 +164,7 @@ pub async fn generate_file(file: &FileKey) -> Result<(), anyhow::Error> {
         .map_err(|e| anyhow::anyhow!("generate_vertical_partition_recordbatch error: {}", e))?;
 
     if new_batches.is_empty() {
-        storage::del(&[&file.key]).await?;
+        storage::del(vec![(&file.account, &file.key)]).await?;
         return Ok(());
     }
     let columns = file.key.splitn(9, '/').collect::<Vec<&str>>();
@@ -193,7 +192,7 @@ pub async fn generate_file(file: &FileKey) -> Result<(), anyhow::Error> {
             .await
             .map_err(|e| anyhow::anyhow!("write_recordbatch_to_parquet error: {}", e))?;
     // upload filee
-    storage::put(&new_file, new_data.into()).await?;
+    storage::put(&file.account, &new_file, new_data.into()).await?;
     // delete from queue
     PROCESSING_FILES.write().remove(&file.key);
     log::info!(

--- a/src/service/compact/retention.rs
+++ b/src/service/compact/retention.rs
@@ -532,6 +532,7 @@ async fn write_file_list(
                     .iter()
                     .map(|v| FileListDeleted {
                         id: 0,
+                        account: v.account.clone(),
                         file: v.key.clone(),
                         index_file: v.meta.index_size > 0,
                         flattened: v.meta.flattened,

--- a/src/service/db/file_list/local.rs
+++ b/src/service/db/file_list/local.rs
@@ -28,7 +28,7 @@ pub async fn exist_pending_delete(file: &str) -> bool {
     PENDING_DELETE_FILES.read().await.contains(file)
 }
 
-pub async fn add_pending_delete(org_id: &str, file: &str) -> Result<()> {
+pub async fn add_pending_delete(account: &str, org_id: &str, file: &str) -> Result<()> {
     // add to local db for persistence
     let ts = config::utils::time::now_micros();
     infra::file_list::LOCAL_CACHE
@@ -37,6 +37,7 @@ pub async fn add_pending_delete(org_id: &str, file: &str) -> Result<()> {
             ts,
             &[FileListDeleted {
                 id: 0,
+                account: account.to_string(),
                 file: file.to_string(),
                 index_file: false,
                 flattened: false,

--- a/src/service/db/schema.rs
+++ b/src/service/db/schema.rs
@@ -475,7 +475,7 @@ pub async fn cache() -> Result<(), anyhow::Error> {
         let start_dt: i64 = columns[3].parse().unwrap();
         let entry = schemas.entry(item_key).or_insert(Vec::new());
         entry.push((start_dt, val));
-        if i % 1000 == 0 {
+        if i.is_multiple_of(1000) {
             log::info!("Cache schema progress: {}/{}", i, items_num);
         }
     }
@@ -532,7 +532,7 @@ pub async fn cache() -> Result<(), anyhow::Error> {
         let mut w = STREAM_SCHEMAS.write().await;
         w.insert(item_key.to_string(), schema_versions);
         drop(w);
-        if i % 1000 == 0 {
+        if i.is_multiple_of(1000) {
             log::info!("Stream schemas Cached progress: {}/{}", i, keys.len());
         }
     }

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -230,13 +230,20 @@ pub fn calculate_local_files_size(files: &[String]) -> Result<u64> {
 }
 
 // Delete one parquet file and update the file list
-pub async fn delete_parquet_file(key: &str, file_list_only: bool) -> Result<()> {
+pub async fn delete_parquet_file(account: &str, key: &str, file_list_only: bool) -> Result<()> {
     // delete from file list in metastore
-    file_list::batch_process(&[FileKey::new(0, key.to_string(), Default::default(), true)]).await?;
+    file_list::batch_process(&[FileKey::new(
+        0,
+        account.to_string(),
+        key.to_string(),
+        Default::default(),
+        true,
+    )])
+    .await?;
 
     // delete the parquet whaterever the file is exists or not
     if !file_list_only {
-        _ = storage::del(&[key]).await;
+        _ = storage::del(vec![(account, key)]).await;
     }
     Ok(())
 }

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -561,7 +561,7 @@ pub fn generate_record_id(org_id: &str, stream_name: &str, stream_type: &StreamT
 pub fn create_log_ingestion_req(
     ingestion_type: i32,
     data: &bytes::Bytes,
-) -> Result<IngestionRequest> {
+) -> Result<IngestionRequest<'_>> {
     match IngestionType::try_from(ingestion_type) {
         Ok(IngestionType::Json) => Ok(IngestionRequest::JSON(data)),
         Ok(IngestionType::Multi) => Ok(IngestionRequest::Multi(data)),

--- a/src/service/promql/search/cache/mod.rs
+++ b/src/service/promql/search/cache/mod.rs
@@ -331,7 +331,7 @@ pub async fn set(
 
     // store the series to disk cache
     let cache_key = get_cache_item_key(&key, org, start, new_end);
-    infra::cache::file_data::disk::set(trace_id, &cache_key, bytes_data.into())
+    infra::cache::file_data::disk::set(&cache_key, bytes_data.into())
         .await
         .map_err(|e| Error::Message(e.to_string()))?;
 

--- a/src/service/promql/search/grpc/storage.rs
+++ b/src/service/promql/search/grpc/storage.rs
@@ -150,7 +150,15 @@ pub(crate) async fn create_context(
         trace_id,
         &files
             .iter()
-            .map(|f| (f.key.as_str(), f.meta.compressed_size, f.meta.max_ts))
+            .map(|f| {
+                (
+                    f.id,
+                    &f.account,
+                    &f.key,
+                    f.meta.compressed_size,
+                    f.meta.max_ts,
+                )
+            })
             .collect_vec(),
         &mut scan_stats,
         "parquet",

--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -587,13 +587,12 @@ pub fn calculate_deltas_v1(
 }
 
 pub async fn cache_results_to_disk(
-    trace_id: &str,
     file_path: &str,
     file_name: &str,
     data: String,
 ) -> std::io::Result<()> {
     let file = format!("results/{file_path}/{file_name}");
-    match disk::set(trace_id, &file, Bytes::from(data)).await {
+    match disk::set(&file, Bytes::from(data)).await {
         Ok(_) => (),
         Err(e) => {
             log::error!("Error caching results to disk: {:?}", e);
@@ -692,7 +691,7 @@ pub async fn delete_cache(path: &str, delete_ts: i64) -> std::io::Result<bool> {
                 }
             }
         }
-        match disk::remove("", file.strip_prefix(&prefix).unwrap()).await {
+        match disk::remove(file.strip_prefix(&prefix).unwrap()).await {
             Ok(_) => remove_files.push(file),
             Err(e) => {
                 log::error!("Error deleting cache: {:?}", e);
@@ -757,7 +756,7 @@ pub fn handle_histogram(
         Some(v) => v
             .as_str()
             .split(',')
-            .map(|v| v.trim().trim_matches(|v| (v == '\'' || v == '"')))
+            .map(|v| v.trim().trim_matches(|v| v == '\'' || v == '"'))
             .collect::<Vec<&str>>(),
         None => return,
     };

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -789,7 +789,6 @@ pub async fn _write_results(
         let file_path_local = file_path.clone();
 
         match SearchService::cache::cacher::cache_results_to_disk(
-            &trace_id,
             &file_path_local,
             &file_name,
             res_cache,
@@ -942,12 +941,10 @@ pub async fn write_results_v2(
 
     let res_cache = json::to_string(&local_resp).unwrap();
     let query_key = file_path.replace('/', "_");
-    let trace_id = trace_id.to_string();
     tokio::spawn(async move {
         let file_path_local = file_path.clone();
 
         match SearchService::cache::cacher::cache_results_to_disk(
-            &trace_id,
             &file_path_local,
             &file_name,
             res_cache,

--- a/src/service/search/datafusion/storage/file_list.rs
+++ b/src/service/search/datafusion/storage/file_list.rs
@@ -20,6 +20,8 @@ use object_store::ObjectMeta;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 
+use super::{ACCOUNT_SEPARATOR, TRACE_ID_SEPARATOR};
+
 type SegmentData = HashMap<String, BitVec>;
 
 static FILES: Lazy<RwLock<HashMap<String, Vec<ObjectMeta>>>> = Lazy::new(Default::default);
@@ -39,7 +41,14 @@ pub async fn set(trace_id: &str, schema_key: &str, files: &[FileKey]) {
     let mut segment_data = HashMap::new();
     for file in files {
         let modified = Utc.timestamp_nanos(file.meta.max_ts * 1000);
-        let file_name = format!("/{}/$$/{}", key, file.key);
+        let file_name = if file.account.is_empty() {
+            format!("/{}/{}/{}", key, TRACE_ID_SEPARATOR, file.key)
+        } else {
+            format!(
+                "/{}/{}/{}/{}/{}",
+                key, TRACE_ID_SEPARATOR, file.account, ACCOUNT_SEPARATOR, file.key
+            )
+        };
         values.push(ObjectMeta {
             location: file_name.into(),
             last_modified: modified,

--- a/src/service/search/datafusion/storage/file_statistics_cache.rs
+++ b/src/service/search/datafusion/storage/file_statistics_cache.rs
@@ -20,6 +20,8 @@ use datafusion::{common::Statistics, execution::cache::CacheAccessor};
 use object_store::{ObjectMeta, path::Path};
 use once_cell::sync::Lazy;
 
+use super::TRACE_ID_SEPARATOR;
+
 pub static GLOBAL_CACHE: Lazy<Arc<FileStatisticsCache>> =
     Lazy::new(|| Arc::new(FileStatisticsCache::default()));
 
@@ -106,7 +108,7 @@ impl FileStatisticsCache {
     }
 
     fn format_key(&self, k: &Path) -> String {
-        if let Some(mut p) = k.as_ref().find("/$$/") {
+        if let Some(mut p) = k.as_ref().find(TRACE_ID_SEPARATOR) {
             if let Some(pp) = k.as_ref()[..p].find("/schema=") {
                 p = pp;
             }
@@ -269,13 +271,13 @@ mod tests {
         // Add some entries
         for i in 0..10 {
             let meta = ObjectMeta {
-                location: Path::from(format!("test_file_{}", i)),
+                location: Path::from(format!("test_file_{i}")),
                 last_modified: DateTime::parse_from_rfc3339("2022-09-27T22:36:00+02:00")
                     .unwrap()
                     .into(),
                 size: 1024 * (i + 1),
-                e_tag: Some(format!("etag_{}", i)),
-                version: Some(format!("v{}", i)),
+                e_tag: Some(format!("etag_{i}")),
+                version: Some(format!("v{i}")),
             };
 
             let schema = Schema::new(vec![

--- a/src/service/search/datafusion/storage/memory.rs
+++ b/src/service/search/datafusion/storage/memory.rs
@@ -23,6 +23,8 @@ use object_store::{
     PutMultipartOptions, PutOptions, PutPayload, PutResult, Result, path::Path,
 };
 
+use super::format_location;
+
 /// File system with memory cache
 #[derive(Debug, Default)]
 pub struct FS {}
@@ -31,14 +33,6 @@ impl FS {
     /// Create new memory storage.
     pub fn new() -> Self {
         Self::default()
-    }
-
-    fn format_location(&self, location: &Path) -> Path {
-        let mut path = location.to_string();
-        if let Some(p) = path.find("/$$/") {
-            path = path[p + 4..].to_string();
-        }
-        path.into()
     }
 }
 
@@ -51,36 +45,37 @@ impl std::fmt::Display for FS {
 #[async_trait]
 impl ObjectStore for FS {
     async fn get(&self, location: &Path) -> Result<GetResult> {
-        let location = self.format_location(location);
-        infra::cache::storage::DEFAULT.get(&location).await
+        let (account, location) = format_location(location);
+        infra::cache::storage::get(&account, &location).await
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
-        let location = self.format_location(location);
-        infra::cache::storage::DEFAULT
-            .get_opts(&location, options)
-            .await
+        let (account, location) = format_location(location);
+        infra::cache::storage::get_opts(&account, &location, options).await
     }
 
     async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
-        let location = self.format_location(location);
-        infra::cache::storage::DEFAULT
-            .get_range(&location, range)
-            .await
+        let (account, location) = format_location(location);
+        infra::cache::storage::get_range(&account, &location, range).await
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let location = self.format_location(location);
-        infra::cache::storage::DEFAULT.head(&location).await
+        let (account, location) = format_location(location);
+        infra::cache::storage::head(&account, &location).await
     }
 
-    #[tracing::instrument(name = "datafusion::storage::memory::list", skip_all)]
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
-        let key = prefix.unwrap().to_string();
+        let key = match prefix {
+            Some(p) => p.to_string(),
+            None => {
+                // Return empty stream when prefix is None
+                return futures::stream::empty().boxed();
+            }
+        };
         let objects = match super::file_list::get(&key) {
             Ok(objects) => objects,
             Err(e) => {
-                log::error!("Error getting file list for memory storage: {}", e);
+                log::error!("Error getting file list for memory storage: {e}");
                 vec![]
             }
         };
@@ -92,7 +87,7 @@ impl ObjectStore for FS {
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
-        log::error!("NotImplemented list_with_delimiter: {:?}", prefix);
+        log::error!("NotImplemented list_with_delimiter: {prefix:?}");
         Err(object_store::Error::NotImplemented {})
     }
 
@@ -102,12 +97,12 @@ impl ObjectStore for FS {
         _payload: PutPayload,
         _opts: PutOptions,
     ) -> Result<PutResult> {
-        log::error!("NotImplemented put_opts: {}", location);
+        log::error!("NotImplemented put_opts: {location}");
         Err(object_store::Error::NotImplemented {})
     }
 
     async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
-        log::error!("NotImplemented put_multipart: {}", location);
+        log::error!("NotImplemented put_multipart: {location}");
         Err(object_store::Error::NotImplemented)
     }
 
@@ -116,22 +111,211 @@ impl ObjectStore for FS {
         location: &Path,
         _opts: PutMultipartOptions,
     ) -> Result<Box<dyn MultipartUpload>> {
-        log::error!("NotImplemented put_multipart_opts: {}", location);
+        log::error!("NotImplemented put_multipart_opts: {location}");
         Err(object_store::Error::NotImplemented)
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {
-        log::error!("NotImplemented delete: {}", location);
+        log::error!("NotImplemented delete: {location}");
         Err(object_store::Error::NotImplemented {})
     }
 
     async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
-        log::error!("NotImplemented copy: from {} to {}", from, to);
+        log::error!("NotImplemented copy: from {from} to {to}");
         Err(object_store::Error::NotImplemented {})
     }
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        log::error!("NotImplemented copy_if_not_exists: from {} to {}", from, to);
+        log::error!("NotImplemented copy_if_not_exists: from {from} to {to}");
         Err(object_store::Error::NotImplemented {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+
+    use bytes::Bytes;
+    use object_store::{GetOptions, PutOptions, PutPayload};
+
+    use super::*;
+
+    #[test]
+    fn test_fs_constructors_and_traits() {
+        // Test constructors and trait implementations
+        let fs_new = FS::new();
+        let fs_default = FS::default();
+        let fs_direct = FS {};
+
+        // All should display as "Memory"
+        assert_eq!(fs_new.to_string(), "Memory");
+        assert_eq!(fs_default.to_string(), "Memory");
+        assert_eq!(fs_direct.to_string(), "Memory");
+
+        // Debug should show "FS"
+        assert_eq!(format!("{fs_direct:?}"), "FS");
+    }
+
+    #[tokio::test]
+    async fn test_read_operations() {
+        let fs = FS::new();
+        let location = Path::from("test/file.txt");
+        let range = Range { start: 0, end: 100 };
+        let options = GetOptions::default();
+
+        // Test all read operations with non-existent files
+        let get_result = fs.get(&location).await;
+        let get_opts_result = fs.get_opts(&location, options).await;
+        let get_range_result = fs.get_range(&location, range).await;
+        let head_result = fs.head(&location).await;
+
+        assert!(get_result.is_err());
+        assert!(get_opts_result.is_err());
+        assert!(get_range_result.is_err());
+        assert!(head_result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_operations() {
+        let fs = FS::new();
+
+        // Test list with valid prefix
+        let prefix = Some(Path::from("test/"));
+        let stream = fs.list(prefix.as_ref());
+        let results: Vec<Result<ObjectMeta>> = stream.collect().await;
+        assert!(results.is_empty());
+
+        // Test list with None prefix
+        let prefix_none: Option<&Path> = None;
+        let stream_none = fs.list(prefix_none);
+        let results_none: Vec<Result<ObjectMeta>> = stream_none.collect().await;
+        assert!(results_none.is_empty());
+
+        // Test list with invalid prefix (error handling)
+        let prefix_invalid = Some(Path::from("invalid_prefix_that_will_cause_error"));
+        let stream_invalid = fs.list(prefix_invalid.as_ref());
+        let results_invalid: Vec<Result<ObjectMeta>> = stream_invalid.collect().await;
+        assert!(results_invalid.is_empty());
+
+        // Test list_with_delimiter
+        let delimiter_result = fs.list_with_delimiter(prefix.as_ref()).await;
+        assert!(delimiter_result.is_err());
+        assert!(matches!(
+            delimiter_result.unwrap_err(),
+            object_store::Error::NotImplemented
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_unimplemented_operations() {
+        let fs = FS::new();
+        let location = Path::from("test/file.txt");
+        let from = Path::from("test/from.txt");
+        let to = Path::from("test/to.txt");
+        let payload = PutPayload::from(Bytes::from("test data"));
+        let opts = PutOptions::default();
+        let multipart_opts = PutMultipartOptions::default();
+
+        // Test all operations that return NotImplemented
+        let put_opts_result = fs.put_opts(&location, payload, opts).await;
+        let put_multipart_result = fs.put_multipart(&location).await;
+        let put_multipart_opts_result = fs.put_multipart_opts(&location, multipart_opts).await;
+        let delete_result = fs.delete(&location).await;
+        let copy_result = fs.copy(&from, &to).await;
+        let copy_if_not_exists_result = fs.copy_if_not_exists(&from, &to).await;
+
+        // All should return NotImplemented error
+        assert!(matches!(
+            put_opts_result.unwrap_err(),
+            object_store::Error::NotImplemented
+        ));
+        assert!(matches!(
+            put_multipart_result.unwrap_err(),
+            object_store::Error::NotImplemented
+        ));
+        assert!(matches!(
+            put_multipart_opts_result.unwrap_err(),
+            object_store::Error::NotImplemented
+        ));
+        assert!(matches!(
+            delete_result.unwrap_err(),
+            object_store::Error::NotImplemented
+        ));
+        assert!(matches!(
+            copy_result.unwrap_err(),
+            object_store::Error::NotImplemented
+        ));
+        assert!(matches!(
+            copy_if_not_exists_result.unwrap_err(),
+            object_store::Error::NotImplemented
+        ));
+    }
+
+    #[test]
+    fn test_format_location() {
+        // Test the format_location function from the parent module
+        let test_cases = [
+            (
+                "/test/$$/file.txt",
+                ("".to_string(), Path::from("file.txt")),
+            ),
+            (
+                "/test/account/::/file.txt",
+                ("test/account".to_string(), Path::from("file.txt")),
+            ),
+            ("::/file.txt", ("".to_string(), Path::from("file.txt"))),
+            (
+                "/test/file.txt",
+                ("".to_string(), Path::from("/test/file.txt")),
+            ),
+        ];
+
+        for (input, expected) in &test_cases {
+            let path = Path::from(*input);
+            let result = super::format_location(&path);
+            assert_eq!(result, *expected, "Failed for input: {input}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_operations() {
+        let fs = FS::new();
+        let location = Path::from("test/concurrent.txt");
+
+        // Test multiple concurrent operations of the same type
+        let get_futures = [fs.get(&location), fs.get(&location)];
+
+        let get_range_futures = [
+            fs.get_range(&location, Range { start: 0, end: 10 }),
+            fs.get_range(&location, Range { start: 10, end: 20 }),
+        ];
+
+        let get_results = futures::future::join_all(get_futures).await;
+        let get_range_results = futures::future::join_all(get_range_futures).await;
+
+        // All operations should fail with errors
+        for result in get_results {
+            assert!(result.is_err());
+        }
+        for result in get_range_results {
+            assert!(result.is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_different_path_formats() {
+        let fs = FS::new();
+        let test_paths = [
+            Path::from("simple.txt"),
+            Path::from("/absolute/path/file.txt"),
+            Path::from("nested/directory/file.txt"),
+            Path::from("file with spaces.txt"),
+            Path::from("file-with-special-chars@#$%.txt"),
+        ];
+
+        for path in &test_paths {
+            let result = fs.get(path).await;
+            assert!(result.is_err(), "Should fail for path: {path}");
+        }
     }
 }

--- a/src/service/search/datafusion/storage/mod.rs
+++ b/src/service/search/datafusion/storage/mod.rs
@@ -13,7 +13,29 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use object_store::path::Path;
+
 pub mod file_list;
 pub mod file_statistics_cache;
 pub mod memory;
 pub mod wal;
+
+const TRACE_ID_SEPARATOR: &str = "$$";
+const ACCOUNT_SEPARATOR: &str = "::";
+
+fn format_location(location: &Path) -> (String, Path) {
+    let mut path = location.to_string();
+    if let Some(p) = path.find("/$$/") {
+        path = path[p + 4..].to_string();
+    }
+    let mut account = String::new();
+    if path.starts_with("::/") {
+        // the `//` was format to `/`, so we can't find `/::/`, need to check `::/`
+        // account is empty, and we need to remove the `::/` as path
+        path = path[3..].to_string();
+    } else if let Some(p) = path.find("/::/") {
+        account = path[..p].to_string();
+        path = path[p + 4..].to_string();
+    }
+    (account.to_string(), path.into())
+}

--- a/src/service/search/datafusion/table_provider/mod.rs
+++ b/src/service/search/datafusion/table_provider/mod.rs
@@ -546,7 +546,7 @@ fn repartition_sorted_groups(
         let mut even_group = Vec::with_capacity(group_cap);
 
         for (idx, file) in max_group.into_inner().into_iter().enumerate() {
-            if idx % 2 == 0 {
+            if idx.is_multiple_of(2) {
                 even_group.push(file);
             } else {
                 odd_group.push(file);

--- a/src/service/tantivy/puffin/reader.rs
+++ b/src/service/tantivy/puffin/reader.rs
@@ -22,13 +22,15 @@ use super::*;
 
 #[derive(Debug)]
 pub struct PuffinBytesReader {
+    account: String,
     source: Arc<object_store::ObjectMeta>,
     metadata: Option<PuffinMeta>,
 }
 
 impl PuffinBytesReader {
-    pub fn new(source: object_store::ObjectMeta) -> Self {
+    pub fn new(account: String, source: object_store::ObjectMeta) -> Self {
         Self {
+            account,
             source: Arc::new(source),
             metadata: None,
         }
@@ -42,6 +44,7 @@ impl PuffinBytesReader {
         range: Option<core::ops::Range<u64>>,
     ) -> Result<bytes::Bytes> {
         let raw_data = infra::cache::storage::get_range(
+            &self.account,
             &self.source.location,
             blob_metadata.get_offset(range),
         )
@@ -79,10 +82,12 @@ impl PuffinBytesReader {
         }
 
         // check MAGIC
-        let magic = infra::cache::storage::get_range(&self.source.location, 0..MAGIC_SIZE).await?;
+        let magic =
+            infra::cache::storage::get_range(&self.account, &self.source.location, 0..MAGIC_SIZE)
+                .await?;
         ensure!(magic.to_vec() == MAGIC, anyhow!("Header MAGIC mismatch"));
 
-        let puffin_meta = PuffinFooterBytesReader::new(self.source.clone())
+        let puffin_meta = PuffinFooterBytesReader::new(self.account.clone(), self.source.clone())
             .parse()
             .await?;
         self.metadata = Some(puffin_meta);
@@ -93,6 +98,7 @@ impl PuffinBytesReader {
 /// Footer layout: HeadMagic Payload PayloadSize Flags FootMagic
 ///                [4]       [?]     [4]         [4]   [4]
 struct PuffinFooterBytesReader {
+    account: String,
     source: Arc<object_store::ObjectMeta>,
     flags: PuffinFooterFlags,
     payload_size: u64,
@@ -100,8 +106,9 @@ struct PuffinFooterBytesReader {
 }
 
 impl PuffinFooterBytesReader {
-    fn new(source: Arc<object_store::ObjectMeta>) -> Self {
+    fn new(account: String, source: Arc<object_store::ObjectMeta>) -> Self {
         Self {
+            account,
             source,
             flags: PuffinFooterFlags::empty(),
             payload_size: 0,
@@ -121,6 +128,7 @@ impl PuffinFooterBytesReader {
             ));
         }
         let footer = infra::cache::storage::get_range(
+            &self.account,
             &self.source.location,
             (self.source.size - FOOTER_SIZE)..self.source.size,
         )
@@ -162,6 +170,7 @@ impl PuffinFooterBytesReader {
             ));
         }
         let payload = infra::cache::storage::get_range(
+            &self.account,
             &self.source.location,
             (self.source.size - FOOTER_SIZE - self.payload_size - MAGIC_SIZE)
                 ..(self.source.size - FOOTER_SIZE),

--- a/src/service/tantivy/puffin_directory/reader.rs
+++ b/src/service/tantivy/puffin_directory/reader.rs
@@ -42,8 +42,8 @@ pub struct PuffinDirReader {
 }
 
 impl PuffinDirReader {
-    pub async fn from_path(source: object_store::ObjectMeta) -> io::Result<Self> {
-        let mut source = PuffinBytesReader::new(source);
+    pub async fn from_path(account: String, source: object_store::ObjectMeta) -> io::Result<Self> {
+        let mut source = PuffinBytesReader::new(account, source);
         let Some(metadata) = source.get_metadata().await.map_err(|e| {
             io::Error::other(format!("Error reading metadata from puffin file: {e:?}"))
         })?


### PR DESCRIPTION
Impl multiple storage accounts

## New ENV
```
ZO_S3_ACCOUNTS=""
ZO_S3_STREAM_STRATEGY=""
```

Default is empty, it will use only one default account. if you want to use multiple account, you can config like this:


```
ZO_S3_ACCOUNTS="acc1,acc2"
ZO_S3_PROVIDER="aws,aws"
ZO_S3_SERVER_URL=""
ZO_S3_REGION_NAME="us-east2,us-west2"
ZO_S3_ACCESS_KEY="app1,app2"
ZO_S3_SECRET_KEY="key1,key2"
ZO_S3_BUCKET_NAME="buk1,buk2"
ZO_S3_BUCKET_PREFIX=""
```

We support these 7 S3 ENVs for multiple accounts, other S3 ENV will be shared. each ENV can be empty or config to same number of accounts values.

> We always use the first account as default account. so we should configure the old account as the first one.

The stream strategy can config like this:

```
ZO_S3_STREAM_STRATEGY=""
```

Default is empty, it means we always use default account.

```
ZO_S3_STREAM_STRATEGY="file_hash"
```
Will use hashing of the file name to choose bucket.

```
ZO_S3_STREAM_STRATEGY="stream_hash"
```
Will use hashing of the stream name to choose bucket.

```
ZO_S3_STREAM_STRATEGY="stream1:acc1,stream2:acc2,stream3:acc3"
```
use a static mapping rule for stream and account.

