### PR TITLE
test: Added wildcard search tests

### DIFF
--- a/tests/api-testing/tests/test_search.py
+++ b/tests/api-testing/tests/test_search.py
@@ -1115,7 +1115,113 @@ def test_e2e_match_all_validation(create_session, base_url):
     print(f"level='info' query executed in {took_time}ms and found {total_hits} total matching records")
 
 
+def test_e2e_matchall_prefix_wildcard(create_session, base_url):
+    """Running an E2E test for match_all with prefix wildcard '*s' - finds words ending with 's'."""
 
+    session = create_session
+    url = base_url
+    org_id = "org_pytest_data"
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
+    json_data = {
+        "query": {
+            "sql": "SELECT * FROM \"stream_pytest_data\" WHERE match_all('*s')",
+            "start_time": one_min_ago,
+            "end_time": end_time,
+            "from": 0,
+            "size": 100,
+            "quick_mode": False,
+            "sql_mode": "full"
+        }
+    }
+    resp_get_inquery = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+    assert (
+        resp_get_inquery.status_code == 200
+    ), f"Expected status code 200, but got {resp_get_inquery.status_code} {resp_get_inquery.content}"
+    response_data = resp_get_inquery.json()
+
+    # Validate that returned data contains words ending with 's'
+    hits = response_data.get('hits', [])
+    if hits:  # Only validate if there are results
+        for hit in hits:
+            log_content = hit.get('_all', hit.get('log', ''))  # Try _all first, fallback to log
+            # Check if any word in the log ends with 's'
+            words = log_content.split()
+            assert any(word.lower().endswith('s') for word in words), f"No word ending with 's' found in log: {log_content[:200]}..."
+
+
+def test_e2e_matchall_suffix_wildcard(create_session, base_url):
+    """Running an E2E test for match_all with suffix wildcard 'm*'."""
+
+    session = create_session
+    url = base_url
+    org_id = "org_pytest_data"
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
+    json_data = {
+        "query": {
+            "sql": "SELECT * FROM \"stream_pytest_data\" WHERE match_all('m*')",
+            "start_time": one_min_ago,
+            "end_time": end_time,
+            "from": 0,
+            "size": 100,
+            "quick_mode": False,
+            "sql_mode": "full"
+        }
+    }
+    resp_get_inquery = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+    assert (
+        resp_get_inquery.status_code == 200
+    ), f"Expected status code 200, but got {resp_get_inquery.status_code} {resp_get_inquery.content}"
+    response_data = resp_get_inquery.json()
+
+    # Validate that returned data contains words starting with 'm'
+    hits = response_data.get('hits', [])
+    if hits:  # Only validate if there are results
+        for hit in hits:
+            log_content = hit.get('log', '')
+            # Check if any word in the log starts with 'm'
+            words = log_content.split()
+            assert any(word.lower().startswith('m') for word in words), f"No word starting with 'm' found in log: {log_content}"
+
+
+def test_e2e_matchall_both_wildcards(create_session, base_url):
+    """Running an E2E test for match_all with both prefix and suffix wildcard '*m*'."""
+
+    session = create_session
+    url = base_url
+    org_id = "org_pytest_data"
+    now = datetime.now(timezone.utc)
+    end_time = int(now.timestamp() * 1000000)
+    one_min_ago = int((now - timedelta(minutes=1)).timestamp() * 1000000)
+    json_data = {
+        "query": {
+            "sql": "SELECT * FROM \"stream_pytest_data\" WHERE match_all('*m*')",
+            "start_time": one_min_ago,
+            "end_time": end_time,
+            "from": 0,
+            "size": 100,
+            "quick_mode": False,
+            "sql_mode": "full"
+        }
+    }
+    resp_get_inquery = session.post(f"{url}api/{org_id}/_search?type=logs", json=json_data)
+    assert (
+        resp_get_inquery.status_code == 200
+    ), f"Expected status code 200, but got {resp_get_inquery.status_code} {resp_get_inquery.content}"
+    response_data = resp_get_inquery.json()
+
+    # Validate that returned data contains words with 'm' anywhere in them
+    hits = response_data.get('hits', [])
+    if hits:  # Only validate if there are results
+        for hit in hits:
+            log_content = hit.get('log', '')
+            # Check if any word in the log contains 'm'
+            words = log_content.split()
+            assert any('m' in word.lower() for word in words), f"No word containing 'm' found in log: {log_content}"
+            
 def test_e2e_timestamp_ordering_validation(create_session, base_url):
     """Test ORDER BY timestamp and validate proper ordering."""
 


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Add wildcard match_all E2E tests

- Validate prefix, suffix, both wildcards

- Assert word presence in returned hits

- Ensure search endpoint returns 200


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New E2E tests"] -- "prefix '*s'" --> B["match_all prefix wildcard"]
  A -- "suffix 'm*'" --> C["match_all suffix wildcard"]
  A -- "both '*m*'" --> D["match_all contains wildcard"]
  B --> E["POST /api/{org}/_search"]
  C --> E
  D --> E
  E --> F["Validate 200 and word checks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_search.py</strong><dd><code>Add E2E wildcard match_all tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/api-testing/tests/test_search.py

<ul><li>Add test for match_all('*s') suffix matching<br> <li> Add test for match_all('m*') prefix matching<br> <li> Add test for match_all('*m*') contains matching<br> <li> Validate 200 status and content assertions on hits</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8470/files#diff-f3776a5bc02e67c163ed707f86b2192f47b73c641dde04b83523b95a74518141">+106/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

