### PR TITLE
fix: added additional match_all pattern to the syntax guide

### DIFF
--- a/web/src/plugins/logs/SyntaxGuide.vue
+++ b/web/src/plugins/logs/SyntaxGuide.vue
@@ -52,11 +52,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   to find phrases starting with 'error code'.
                 </li>
                 <li>
-                  For regex search use
-                  <span class="bg-highlight">match_all('*code 40*')</span>
-                  to match patterns using regular expressions.
-                </li>
-                <li>
                   For case sensitive search use
                   <span class="bg-highlight">match_all('traceHits')</span>
                   with exact case matching.
@@ -138,13 +133,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     >SELECT * FROM <b>stream</b> WHERE match_all('error code*')</span
                   >
                   to find phrases starting with 'error code'.
-                </li>
-                <li>
-                  For regex search use
-                  <span class="bg-highlight"
-                    >SELECT * FROM <b>stream</b> WHERE match_all('*code 40*')</span
-                  >
-                  to match patterns using regular expressions.
                 </li>
                 <li>
                   For case sensitive search use


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Expand syntax guide with match_all examples

- Add prefix, phrase prefix, regex usage

- Document case-sensitive and postfix searches

- Mirror examples for query editor and SQL


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Guide["Syntax guide (logs)"]
  MatchAll["match_all examples"]
  Prefix["Prefix & postfix"]
  Phrase["Phrase prefix"]
  Regex["Regex patterns"]
  Case["Case-sensitive usage"]

  Guide -- "adds" --> MatchAll
  MatchAll -- "includes" --> Prefix
  MatchAll -- "includes" --> Phrase
  MatchAll -- "includes" --> Regex
  MatchAll -- "includes" --> Case
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SyntaxGuide.vue</strong><dd><code>Extend logs syntax guide with match_all patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/SyntaxGuide.vue

<ul><li>Add match_all prefix example ('error*')<br> <li> Add phrase prefix example ('error code*')<br> <li> Add regex-like example ('*code 40*')<br> <li> Add case-sensitive and postfix examples ('traceHits', '*failed')</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8475/files#diff-c6e8bb651fadd2b15b5b97f5b6069a57813fb97cc3d06eef983af4def33e8806">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

