### PR TITLE
fix: interesting field config

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1120,6 +1120,12 @@ pub struct Common {
         help = "Enable to use large partition for index. This will apply for all streams"
     )]
     pub align_partitions_for_index: bool,
+    #[env_config(
+        name = "ZO_LOG_PAGE_DEFAULT_FIELD_LIST",
+        default = "uds",
+        help = "Which fields to show by default in logs search page. Valid values - all,uds,interesting"
+    )]
+    pub log_page_default_field_list: String,
 }
 
 #[derive(EnvConfig, Default)]
@@ -2332,6 +2338,14 @@ fn check_common_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
 
     if cfg.common.default_hec_stream.is_empty() {
         cfg.common.default_hec_stream = "_hec".to_string();
+    }
+
+    cfg.common.log_page_default_field_list = cfg.common.log_page_default_field_list.to_lowercase();
+    if !matches!(
+        cfg.common.log_page_default_field_list.as_str(),
+        "uds" | "all" | "interesting"
+    ) {
+        cfg.common.log_page_default_field_list = "uds".to_string();
     }
 
     Ok(())

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -138,6 +138,7 @@ struct ConfigResponse<'a> {
     dashboard_placeholder: String,
     dashboard_show_symbol_enabled: bool,
     ingest_flatten_level: u32,
+    log_page_default_field_list: String,
 }
 
 #[derive(Serialize, serde::Deserialize)]
@@ -358,6 +359,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         dashboard_placeholder: cfg.common.dashboard_placeholder.to_string(),
         dashboard_show_symbol_enabled: cfg.common.dashboard_show_symbol_enabled,
         ingest_flatten_level: cfg.limit.ingest_flatten_level,
+        log_page_default_field_list: cfg.common.log_page_default_field_list.clone(),
     }))
 }
 

--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -990,8 +990,8 @@ export default defineComponent({
               slot: "interesting_fields_slot",
             });
           }
-          searchObj.meta.useUserDefinedSchemas = "interesting_fields";
-          showOnlyInterestingFields.value = true;
+
+          setDefaultFieldTab();
         } else {
           userDefinedSchemaBtnGroupOption.value =
             userDefinedSchemaBtnGroupOption.value.filter(
@@ -1031,6 +1031,15 @@ export default defineComponent({
       },
     );
 
+    /**
+     * Added this watcher to set default field tab when user defined schema toggle is changed
+     * As when user selects stream defineSchema flag is set and there is no any event to identify that
+     * so we are using this watcher to set default field tab as per the stream settings
+     */
+    watch(showUserDefinedSchemaToggle, () => {
+      setDefaultFieldTab();
+    });
+
     const filterStreamFn = (val: string, update: any) => {
       update(() => {
         streamOptions.value = streamList.value;
@@ -1042,6 +1051,19 @@ export default defineComponent({
     };
 
     const selectedStream = ref("");
+
+    // if interesting field is enabled, then set default tab as interesting fields
+    // otherwise set default tab as user defined schema
+    // store.state.zoConfig.interesting_field_enabled was set as interesting fields was getting set by default with _timestamp field
+    function setDefaultFieldTab() {
+      if (store.state.zoConfig.log_page_default_field_list === "uds") {
+        searchObj.meta.useUserDefinedSchemas = "user_defined_schema";
+        showOnlyInterestingFields.value = false;
+      } else {
+        searchObj.meta.useUserDefinedSchemas = "interesting_fields";
+        showOnlyInterestingFields.value = true;
+      }
+    }
 
     const filterFieldFn = (rows: any, terms: any) => {
       var filtered = [];


### PR DESCRIPTION
### **User description**
This provides the default tab for logs ui sidebar via config api and env config


___

### **PR Type**
Enhancement


___

### **Description**
- Add env to set default fields tab

- Validate and expose config via status API

- Set frontend default tab based on config

- Add watcher to apply tab on toggle


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Env var ZO_LOG_PAGE_DEFAULT_FIELD_LIST"] --> B["Backend Config (Common.log_page_default_field_list)"]
  B --> C["Config validation (uds|all|interesting)"]
  C --> D["/api/config response (zo_config)"]
  D --> E["Frontend store.state.zoConfig.log_page_default_field_list"]
  E --> F["Logs UI sets default tab via setDefaultFieldTab()"]
  F --> G["Watch toggle to re-apply default"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Introduce and validate default field list config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<ul><li>Add <code>log_page_default_field_list</code> env-config option.<br> <li> Default to <code>uds</code>; document valid values.<br> <li> Normalize to lowercase and validate allowed values.<br> <li> Fallback to <code>uds</code> on invalid input.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8480/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Expose default field list in status/config API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/status/mod.rs

<ul><li>Extend <code>ConfigResponse</code> with <code>log_page_default_field_list</code>.<br> <li> Populate response from common config.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8480/files#diff-ca09c9c9b020049bdbc3382c466bfcca80daac92e98760d9a9a76172abf34049">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IndexList.vue</strong><dd><code>Use config to set Logs UI default fields tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/IndexList.vue

<ul><li>Add <code>setDefaultFieldTab()</code> to pick initial tab.<br> <li> Use backend config to select UDS vs Interesting.<br> <li> Watch user-defined schema toggle to re-apply default.<br> <li> Remove hardcoded default to Interesting fields.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8480/files#diff-08f058f883b659e713e606991a7ea37ae1ff016b7cccef970489ab5840dc3d09">+24/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

