### PR TITLE
refactor: replace feature_per_thread_lock with mem_table_bucket_num

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -742,8 +742,6 @@ pub struct Common {
         help = "Disable timestamp field compression"
     )]
     pub timestamp_compression_disabled: bool,
-    #[env_config(name = "ZO_FEATURE_PER_THREAD_LOCK", default = false)]
-    pub feature_per_thread_lock: bool,
     #[env_config(name = "ZO_FEATURE_INGESTER_NONE_COMPRESSION", default = false)]
     pub feature_ingester_none_compression: bool,
     #[env_config(name = "ZO_FEATURE_FULLTEXT_EXTRA_FIELDS", default = "")]

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -159,7 +159,7 @@ pub async fn read_from_memtable(
     let cfg = get_config();
     let key = WriterKey::new(org_id, stream_type);
     // fast past
-    if !cfg.common.feature_per_thread_lock {
+    if cfg.limit.mem_table_bucket_num <= 1 {
         let idx = get_table_idx(0, stream_name);
         let w = WRITERS[idx].read().await;
         return match w.get(&key) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -683,7 +683,7 @@ async fn init_http_server() -> Result<(), anyhow::Error> {
     let server = HttpServer::new(move || {
         let cfg = get_config();
         let local_id = thread_id.load(Ordering::SeqCst) as usize;
-        if cfg.common.feature_per_thread_lock {
+        if cfg.limit.mem_table_bucket_num > 1 {
             thread_id.fetch_add(1, Ordering::SeqCst);
         }
         let scheme = if cfg.http.tls_enabled {
@@ -788,7 +788,7 @@ async fn init_http_server_without_tracing() -> Result<(), anyhow::Error> {
     let server = HttpServer::new(move || {
         let cfg = get_config();
         let local_id = thread_id.load(Ordering::SeqCst) as usize;
-        if cfg.common.feature_per_thread_lock {
+        if cfg.limit.mem_table_bucket_num > 1 {
             thread_id.fetch_add(1, Ordering::SeqCst);
         }
 
@@ -1073,7 +1073,7 @@ async fn init_script_server() -> Result<(), anyhow::Error> {
     let server = HttpServer::new(move || {
         let cfg = get_config();
         let local_id = thread_id.load(Ordering::SeqCst) as usize;
-        if cfg.common.feature_per_thread_lock {
+        if cfg.limit.mem_table_bucket_num > 1 {
             thread_id.fetch_add(1, Ordering::SeqCst);
         }
         let scheme = if cfg.http.tls_enabled {


### PR DESCRIPTION
### **User description**
close #8478


___

### **PR Type**
Enhancement


___

### **Description**
- Remove `ZO_FEATURE_PER_THREAD_LOCK` config

- Gate behavior by `mem_table_bucket_num`

- Update memtable read fast-path logic

- Adjust thread-id increment conditions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CFG["Config: remove `feature_per_thread_lock`"] -- "cleanup" --> ING["Ingester: fast-path uses `mem_table_bucket_num`"]
  CFG -- "single source of truth" --> MAIN["Servers: thread id increments when bucket_num > 1"]
  MAIN -- "consistent thread sharding" --> ING
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Remove per-thread lock config from Common</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<ul><li>Remove <code>ZO_FEATURE_PER_THREAD_LOCK</code> env config.<br> <li> Delete <code>feature_per_thread_lock</code> field from <code>Common</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8484/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>writer.rs</strong><dd><code>Fast-path keyed by mem_table bucket count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ingester/src/writer.rs

<ul><li>Replace flag check with <code>mem_table_bucket_num <= 1</code>.<br> <li> Use bucket count to decide single-bucket fast path.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8484/files#diff-d1a9b1542cc2758afe4fa67abd454dd818718f4e1c7570303519af5a58d6301f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Thread sharding tied to mem_table buckets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.rs

<ul><li>Thread id increment only when <code>mem_table_bucket_num > 1</code>.<br> <li> Update across HTTP and script servers.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8484/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

