### PR TITLE
refactor: fix OpenAPI schemas and improvements

### DIFF
--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -12,6 +12,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#![feature(macro_metavar_expr_concat)]
 
 pub mod cluster;
 pub mod config;

--- a/src/config/src/meta/dashboards/mod.rs
+++ b/src/config/src/meta/dashboards/mod.rs
@@ -43,157 +43,46 @@ pub struct Dashboard {
     pub updated_at: i64,
 }
 
-impl Dashboard {
-    pub fn dashboard_id(&self) -> Option<&str> {
-        match self.version {
-            1 => self.v1.as_ref().map(|inner| inner.dashboard_id.as_str()),
-            2 => self.v2.as_ref().map(|inner| inner.dashboard_id.as_str()),
-            3 => self.v3.as_ref().map(|inner| inner.dashboard_id.as_str()),
-            4 => self.v4.as_ref().map(|inner| inner.dashboard_id.as_str()),
-            5 => self.v5.as_ref().map(|inner| inner.dashboard_id.as_str()),
-            _ => None,
+/// Generate elegant setter methods for `Dashboard` fields.
+macro_rules! make_setter {
+    ($field:ident; $($ver:literal $vx:ident),+) => {
+        #[doc = concat!("Set the ", stringify!($field), " field for the dashboard.")]
+        pub fn ${concat(set_, $field)}(&mut self, $field: String) {
+            match self {
+                $(Self { version: $ver, $vx: Some(inner), .. } => {inner.$field = $field;})+
+                _ => {}
+            }
         }
-    }
+    };
+}
 
-    pub fn set_dashboard_id(&mut self, dashboard_id: String) {
-        match self {
-            Self {
-                version: 1,
-                v1: Some(inner),
-                ..
-            } => inner.dashboard_id = dashboard_id,
-            Self {
-                version: 2,
-                v2: Some(inner),
-                ..
-            } => inner.dashboard_id = dashboard_id,
-            Self {
-                version: 3,
-                v3: Some(inner),
-                ..
-            } => inner.dashboard_id = dashboard_id,
-            Self {
-                version: 4,
-                v4: Some(inner),
-                ..
-            } => inner.dashboard_id = dashboard_id,
-            Self {
-                version: 5,
-                v5: Some(inner),
-                ..
-            } => inner.dashboard_id = dashboard_id,
-            _ => {}
-        };
-    }
+macro_rules! make_getter {
+    ($field:ident; $($ver:literal $vx:ident),+) => {
+        #[doc = concat!("Get the ", stringify!($field), " field for the dashboard.")]
+        pub fn $field(&self) -> Option<&str> {
+            match self.version {
+                $($ver => self.$vx.as_ref().map(|inner| inner.$field.as_str()),)+
+                _ => None,
+            }
+        }
+    };
+}
+
+impl Dashboard {
+    make_getter!(dashboard_id; 1 v1, 2 v2, 3 v3, 4 v4, 5 v5);
+    make_setter!(dashboard_id; 1 v1, 2 v2, 3 v3, 4 v4, 5 v5);
+
+    make_getter!(owner; 1 v1, 2 v2, 3 v3, 4 v4, 5 v5);
+    make_setter!(owner; 1 v1, 2 v2, 3 v3, 4 v4, 5 v5);
+
+    make_getter!(title; 1 v1, 2 v2, 3 v3, 4 v4, 5 v5);
+    make_setter!(title; 1 v1, 2 v2, 3 v3, 4 v4, 5 v5);
+
+    make_getter!(description; 1 v1, 2 v2, 3 v3, 4 v4, 5 v5);
+    make_getter!(role; 1 v1, 2 v2, 3 v3, 4 v4, 5 v5);
 
     pub fn set_updated_at(&mut self) {
         self.updated_at = Utc::now().timestamp_micros();
-    }
-
-    pub fn owner(&self) -> Option<&str> {
-        match self.version {
-            1 => self.v1.as_ref().map(|inner| inner.owner.as_str()),
-            2 => self.v2.as_ref().map(|inner| inner.owner.as_str()),
-            3 => self.v3.as_ref().map(|inner| inner.owner.as_str()),
-            4 => self.v4.as_ref().map(|inner| inner.owner.as_str()),
-            5 => self.v5.as_ref().map(|inner| inner.owner.as_str()),
-            _ => None,
-        }
-    }
-
-    pub fn set_owner(&mut self, owner: String) {
-        match self {
-            Self {
-                version: 1,
-                v1: Some(inner),
-                ..
-            } => inner.owner = owner,
-            Self {
-                version: 2,
-                v2: Some(inner),
-                ..
-            } => inner.owner = owner,
-            Self {
-                version: 3,
-                v3: Some(inner),
-                ..
-            } => inner.owner = owner,
-            Self {
-                version: 4,
-                v4: Some(inner),
-                ..
-            } => inner.owner = owner,
-            Self {
-                version: 5,
-                v5: Some(inner),
-                ..
-            } => inner.owner = owner,
-            _ => {}
-        };
-    }
-
-    pub fn title(&self) -> Option<&str> {
-        match self.version {
-            1 => self.v1.as_ref().map(|inner| inner.title.as_str()),
-            2 => self.v2.as_ref().map(|inner| inner.title.as_str()),
-            3 => self.v3.as_ref().map(|inner| inner.title.as_str()),
-            4 => self.v4.as_ref().map(|inner| inner.title.as_str()),
-            5 => self.v5.as_ref().map(|inner| inner.title.as_str()),
-            _ => None,
-        }
-    }
-
-    pub fn set_title(&mut self, title: String) {
-        match self {
-            Self {
-                version: 1,
-                v1: Some(inner),
-                ..
-            } => inner.title = title,
-            Self {
-                version: 2,
-                v2: Some(inner),
-                ..
-            } => inner.title = title,
-            Self {
-                version: 3,
-                v3: Some(inner),
-                ..
-            } => inner.title = title,
-            Self {
-                version: 4,
-                v4: Some(inner),
-                ..
-            } => inner.title = title,
-            Self {
-                version: 5,
-                v5: Some(inner),
-                ..
-            } => inner.title = title,
-            _ => {}
-        };
-    }
-
-    pub fn description(&self) -> Option<&str> {
-        match self.version {
-            1 => self.v1.as_ref().map(|inner| inner.description.as_str()),
-            2 => self.v2.as_ref().map(|inner| inner.description.as_str()),
-            3 => self.v3.as_ref().map(|inner| inner.description.as_str()),
-            4 => self.v4.as_ref().map(|inner| inner.description.as_str()),
-            5 => self.v5.as_ref().map(|inner| inner.description.as_str()),
-            _ => None,
-        }
-    }
-
-    pub fn role(&self) -> Option<&str> {
-        match self.version {
-            1 => self.v1.as_ref().map(|inner| inner.role.as_str()),
-            2 => self.v2.as_ref().map(|inner| inner.role.as_str()),
-            3 => self.v3.as_ref().map(|inner| inner.role.as_str()),
-            4 => self.v4.as_ref().map(|inner| inner.role.as_str()),
-            5 => self.v5.as_ref().map(|inner| inner.role.as_str()),
-            _ => None,
-        }
     }
 
     /// Returns the timestamp with timezone of the time at which the dashboard
@@ -307,6 +196,87 @@ mod tests {
     }
 
     #[test]
+    fn test_set_dashboard_id_v1() {
+        let mut dashboard = Dashboard {
+            version: 1,
+            v1: Some(v1::Dashboard {
+                dashboard_id: "old_id".to_string(),
+                title: "Test".to_string(),
+                description: "Test desc".to_string(),
+                role: String::new(),
+                owner: String::new(),
+                created: datetime_now(),
+                panels: Vec::new(),
+                layouts: None,
+                variables: None,
+                updated_at: 0,
+            }),
+            ..Default::default()
+        };
+
+        dashboard.set_dashboard_id("new_dashboard_id".to_string());
+
+        assert_eq!(dashboard.dashboard_id(), Some("new_dashboard_id"));
+        assert_eq!(
+            dashboard.v1.as_ref().unwrap().dashboard_id,
+            "new_dashboard_id"
+        );
+    }
+
+    #[test]
+    fn test_set_dashboard_id_multiple_versions() {
+        // Test that setter works for v1
+        let v1_dashboard = v1::Dashboard {
+            dashboard_id: "old_id_v1".to_string(),
+            title: "Test V1".to_string(),
+            description: "Test desc V1".to_string(),
+            role: String::new(),
+            owner: String::new(),
+            created: datetime_now(),
+            panels: Vec::new(),
+            layouts: None,
+            variables: None,
+            updated_at: 0,
+        };
+        let mut dashboard = Dashboard::from(v1_dashboard);
+
+        dashboard.set_dashboard_id("new_id_v1".to_string());
+
+        assert_eq!(dashboard.dashboard_id(), Some("new_id_v1"));
+        assert_eq!(dashboard.v1.as_ref().unwrap().dashboard_id, "new_id_v1");
+
+        // Test with empty string
+        dashboard.set_dashboard_id("".to_string());
+        assert_eq!(dashboard.dashboard_id(), Some(""));
+        assert_eq!(dashboard.v1.as_ref().unwrap().dashboard_id, "");
+    }
+
+    #[test]
+    fn test_set_dashboard_id_no_inner_dashboard() {
+        let mut dashboard = Dashboard {
+            version: 1,
+            v1: None,
+            ..Default::default()
+        };
+
+        dashboard.set_dashboard_id("should_not_set".to_string());
+
+        assert_eq!(dashboard.dashboard_id(), None);
+    }
+
+    #[test]
+    fn test_set_dashboard_id_unsupported_version() {
+        let mut dashboard = Dashboard {
+            version: 99,
+            ..Default::default()
+        };
+
+        dashboard.set_dashboard_id("should_not_set".to_string());
+
+        assert_eq!(dashboard.dashboard_id(), None);
+    }
+
+    #[test]
     fn test_set_updated_at() {
         let mut dashboard = Dashboard::default();
         let before = Utc::now().timestamp_micros();
@@ -326,6 +296,112 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(dashboard.owner(), None);
+    }
+
+    #[test]
+    fn test_set_owner_v1() {
+        let mut dashboard = Dashboard {
+            version: 1,
+            v1: Some(v1::Dashboard {
+                dashboard_id: "test_id".to_string(),
+                title: "Test".to_string(),
+                description: "Test desc".to_string(),
+                role: String::new(),
+                owner: "old_owner@example.com".to_string(),
+                created: datetime_now(),
+                panels: Vec::new(),
+                layouts: None,
+                variables: None,
+                updated_at: 0,
+            }),
+            ..Default::default()
+        };
+
+        dashboard.set_owner("new_owner@example.com".to_string());
+
+        assert_eq!(dashboard.owner(), Some("new_owner@example.com"));
+        assert_eq!(
+            dashboard.v1.as_ref().unwrap().owner,
+            "new_owner@example.com"
+        );
+    }
+
+    #[test]
+    fn test_set_owner_multiple_versions() {
+        // Test that setter works for v1
+        let v1_dashboard = v1::Dashboard {
+            dashboard_id: "test_id_v1".to_string(),
+            title: "Test V1".to_string(),
+            description: "Test desc V1".to_string(),
+            role: String::new(),
+            owner: "old_owner_v1@example.com".to_string(),
+            created: datetime_now(),
+            panels: Vec::new(),
+            layouts: None,
+            variables: None,
+            updated_at: 0,
+        };
+        let mut dashboard = Dashboard::from(v1_dashboard);
+
+        dashboard.set_owner("new_owner_v1@example.com".to_string());
+
+        assert_eq!(dashboard.owner(), Some("new_owner_v1@example.com"));
+        assert_eq!(
+            dashboard.v1.as_ref().unwrap().owner,
+            "new_owner_v1@example.com"
+        );
+
+        // Test with empty string
+        dashboard.set_owner("".to_string());
+        assert_eq!(dashboard.owner(), Some(""));
+        assert_eq!(dashboard.v1.as_ref().unwrap().owner, "");
+    }
+
+    #[test]
+    fn test_set_owner_no_inner_dashboard() {
+        let mut dashboard = Dashboard {
+            version: 1,
+            v1: None,
+            ..Default::default()
+        };
+
+        dashboard.set_owner("should_not_set@example.com".to_string());
+
+        assert_eq!(dashboard.owner(), None);
+    }
+
+    #[test]
+    fn test_set_owner_unsupported_version() {
+        let mut dashboard = Dashboard {
+            version: 99,
+            ..Default::default()
+        };
+
+        dashboard.set_owner("should_not_set@example.com".to_string());
+
+        assert_eq!(dashboard.owner(), None);
+    }
+
+    #[test]
+    fn test_set_owner_empty_string() {
+        let v1_dashboard = v1::Dashboard {
+            dashboard_id: "test_id".to_string(),
+            title: "Test".to_string(),
+            description: "Test desc".to_string(),
+            role: String::new(),
+            owner: "existing_owner@example.com".to_string(),
+            created: datetime_now(),
+            panels: Vec::new(),
+            layouts: None,
+            variables: None,
+            updated_at: 0,
+        };
+        let mut dashboard = Dashboard::from(v1_dashboard);
+
+        dashboard.set_owner("".to_string());
+
+        assert_eq!(dashboard.owner(), Some(""));
+        assert_eq!(dashboard.v1.as_ref().unwrap().owner, "");
     }
 
     #[test]

--- a/src/config/src/meta/pipeline/mod.rs
+++ b/src/config/src/meta/pipeline/mod.rs
@@ -40,7 +40,7 @@ pub type PipelineExecDFS = (
     HashMap<String, VRLResultResolver>,
 );
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct Pipeline {
     #[serde(rename = "pipeline_id", default)]
     pub id: String,

--- a/src/handler/http/request/actions/action.rs
+++ b/src/handler/http/request/actions/action.rs
@@ -123,7 +123,6 @@ pub async fn delete_action(path: web::Path<(String, Ksuid)>) -> Result<HttpRespo
         ("org_id" = String, Path, description = "Organization name"),
         ("ksuid" = String, Path, description = "Action ID"),
     ),
-    request_body(content = Template, description = "Template data", content_type ="application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/zip", body = String),
         (status = 400, description = "Error",   content_type = "application/json",body = ()),
@@ -253,7 +252,6 @@ pub async fn update_action_details(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = Template, description = "Template data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error", content_type = "application/json", body = ()),

--- a/src/handler/http/request/ai/prompt.rs
+++ b/src/handler/http/request/ai/prompt.rs
@@ -116,7 +116,7 @@ pub async fn get_prompt(path: web::Path<(String, PromptType)>) -> Result<HttpRes
         ("org_id" = String, Path, description = "Organization name")
     ),
     request_body(
-        content = Object,
+        content = UpdatePromptRequest,
         description = "Prompt details", 
         example = json!({
             "content": "Write a SQL query to get the top 10 users by response time in the default stream"

--- a/src/handler/http/request/alerts/deprecated.rs
+++ b/src/handler/http/request/alerts/deprecated.rs
@@ -98,7 +98,7 @@ pub async fn save_alert(
 #[utoipa::path(
     context_path = "/api",
     tag = "Alerts",
-    operation_id = "UpdateAlert",
+    operation_id = "UpdateAlertDeprecated",
     summary = "Update alert (deprecated)",
     description = "Updates an existing alert with new configuration settings. This endpoint is deprecated; please use \
                    the newer alert management endpoints for improved functionality and better error handling.",
@@ -203,7 +203,7 @@ async fn list_stream_alerts(path: web::Path<(String, String)>, req: HttpRequest)
 #[utoipa::path(
     context_path = "/api",
     tag = "Alerts",
-    operation_id = "ListAlerts",
+    operation_id = "ListAlertsDeprecated",
     summary = "List all alerts (deprecated)",
     description = "Retrieves all alerts in the organization across all streams. Supports filtering by owner, enabled \
                    status, stream type, and stream name. This endpoint is deprecated; please use the newer alert \
@@ -314,7 +314,7 @@ async fn list_alerts(path: web::Path<String>, req: HttpRequest) -> HttpResponse 
 #[utoipa::path(
     context_path = "/api",
     tag = "Alerts",
-    operation_id = "GetAlert",
+    operation_id = "GetAlertDeprecated",
     summary = "Get alert details (deprecated)",
     description = "Retrieves detailed information about a specific alert including its configuration, trigger conditions, \
                    and execution status. This endpoint is deprecated; please use the newer alert management endpoints \
@@ -370,7 +370,7 @@ async fn get_alert(path: web::Path<(String, String, String)>, req: HttpRequest) 
 #[utoipa::path(
     context_path = "/api",
     tag = "Alerts",
-    operation_id = "DeleteAlert",
+    operation_id = "DeleteAlertDeprecated",
     summary = "Delete alert (deprecated)",
     description = "Permanently removes an alert and stops its monitoring and notification functionality. This endpoint is \
                    deprecated; please use the newer alert management endpoints for better error handling and \
@@ -408,7 +408,7 @@ async fn delete_alert(path: web::Path<(String, String, String)>, req: HttpReques
 #[utoipa::path(
     context_path = "/api",
     tag = "Alerts",
-    operation_id = "EnableAlert",
+    operation_id = "EnableAlertDeprecated",
     summary = "Enable/disable alert (deprecated)",
     description = "Enables or disables an alert's monitoring and notification functionality. When disabled, the alert \
                    will not trigger or send notifications. This endpoint is deprecated; please use the newer alert \
@@ -453,7 +453,7 @@ async fn enable_alert(path: web::Path<(String, String, String)>, req: HttpReques
 #[utoipa::path(
     context_path = "/api",
     tag = "Alerts",
-    operation_id = "TriggerAlert",
+    operation_id = "TriggerAlertDeprecated",
     summary = "Manually trigger alert (deprecated)",
     description = "Manually triggers an alert to test its notification functionality and validate the configured \
                    destinations. This is useful for testing alert configurations without waiting for actual \

--- a/src/handler/http/request/authz/fga.rs
+++ b/src/handler/http/request/authz/fga.rs
@@ -280,7 +280,7 @@ pub async fn get_roles(
         ("org_id" = String, Path, description = "Organization name"),
         ("role_id" = String, Path, description = "Role Id"),
     ),
-    request_body(content = Object, description = "RoleRequest", content_type = "application/json"),
+    request_body(content = RoleRequest, description = "RoleRequest", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),

--- a/src/handler/http/request/dashboards/mod.rs
+++ b/src/handler/http/request/dashboards/mod.rs
@@ -14,6 +14,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use actix_web::{HttpRequest, HttpResponse, Responder, delete, get, http, patch, post, put, web};
+use config::meta::dashboards::{
+    Dashboard, v1::Dashboard as DashboardV1, v2::Dashboard as DashboardV2,
+    v3::Dashboard as DashboardV3, v4::Dashboard as DashboardV4, v5::Dashboard as DashboardV5,
+};
 use hashbrown::HashMap;
 
 use crate::{
@@ -82,7 +86,7 @@ impl From<DashboardError> for HttpResponse {
         ("org_id" = String, Path, description = "Organization name"),
     ),
     request_body(
-        content = CreateDashboardRequestBody,
+        content((DashboardV1), (DashboardV2), (DashboardV3), (DashboardV4), (DashboardV5)),
         description = "Dashboard details",
         example = json!({
             "title": "Network Traffic Overview",
@@ -106,8 +110,7 @@ pub async fn create_dashboard(
 ) -> impl Responder {
     let org_id = path.into_inner();
     let folder = get_folder(req.query_string());
-    let mut dashboard: config::meta::dashboards::Dashboard = match req_body.into_inner().try_into()
-    {
+    let mut dashboard: Dashboard = match req_body.into_inner().try_into() {
         Ok(dashboard) => dashboard,
         Err(_) => return MetaHttpResponse::bad_request("Error parsing request body"),
     };
@@ -137,7 +140,7 @@ pub async fn create_dashboard(
         ("dashboard_id" = String, Path, description = "Dashboard ID"),
     ),
     request_body(
-        content = UpdateDashboardRequestBody,
+        content((DashboardV1), (DashboardV2), (DashboardV3), (DashboardV4), (DashboardV5)),
         description = "Dashboard details",
     ),
     responses(
@@ -161,8 +164,7 @@ async fn update_dashboard(
     let folder = crate::common::utils::http::get_folder(&query);
     let hash = query.get("hash").map(|h| h.as_str());
 
-    let mut dashboard: config::meta::dashboards::Dashboard = match req_body.into_inner().try_into()
-    {
+    let mut dashboard: Dashboard = match req_body.into_inner().try_into() {
         Ok(dashboard) => dashboard,
         Err(_) => return MetaHttpResponse::bad_request("Error parsing request body"),
     };

--- a/src/handler/http/request/pipeline.rs
+++ b/src/handler/http/request/pipeline.rs
@@ -54,7 +54,7 @@ impl From<PipelineError> for HttpResponse {
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = Object, description = "Pipeline data", content_type = "application/json"),
+    request_body(content = Pipeline, description = "Pipeline data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
@@ -238,7 +238,7 @@ async fn delete_pipeline(path: web::Path<(String, String)>) -> Result<HttpRespon
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = Object, description = "Pipeline data", content_type = "application/json"),
+    request_body(content = Pipeline, description = "Pipeline data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),

--- a/src/handler/http/request/rum/ingest.rs
+++ b/src/handler/http/request/rum/ingest.rs
@@ -20,6 +20,7 @@ use actix_web::{HttpResponse, post, web};
 use config::utils::json;
 use flate2::read::ZlibDecoder;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::{
     common::meta::{
@@ -34,9 +35,11 @@ pub const RUM_SESSION_REPLAY_STREAM: &str = "_sessionreplay";
 pub const RUM_DATA_STREAM: &str = "_rumdata";
 
 /// Multipart form data being ingested in the form of session-replay
-#[derive(MultipartForm)]
+#[derive(MultipartForm, ToSchema)]
 pub struct SegmentEvent {
+    #[schema(value_type = String, format = Binary)]
     pub segment: Bytes,
+    #[schema(value_type = String, format = Binary)]
     pub event: Bytes,
 }
 
@@ -200,7 +203,9 @@ pub async fn log(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = Object, description = "Multipart form data containing compressed session replay segment and event metadata", content_type = "multipart/form-data"),
+    request_body(
+        content = SegmentEvent, content_type = "multipart/form-data",
+        description = "Multipart form data containing compressed session replay segment and event metadata"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", 
             body = Object, example = json!({"code": 200,"status": [{"name": "olympics","successful": 3,"failed": 0}]}),

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -1327,7 +1327,7 @@ async fn values_v1(
         ("enable_align_histogram" = bool, Query, description = "Enable align histogram"),
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = Object, description = "Search query", content_type = "application/json", example = json!({
+    request_body(content = config::meta::search::SearchPartitionRequest, description = "Search query", content_type = "application/json", example = json!({
         "sql": "select * from k8s ",
         "start_time": 1675182660872049i64,
         "end_time": 1675185660872049i64
@@ -1469,7 +1469,7 @@ pub async fn search_partition(
         ("org_id" = String, Path, description = "Organization ID"),
     ),
     request_body(
-        content = Object,
+        content = config::meta::search::SearchHistoryRequest,
         description = "Search history request parameters",
         content_type = "application/json",
         example = json!({
@@ -1673,7 +1673,7 @@ pub async fn search_history(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = Object, description = "Search query", content_type = "application/json", example = json!({
+    request_body(content = config::meta::search::Request, description = "Search query", content_type = "application/json", example = json!({
         "query": {
             "sql": "select k8s_namespace_name as ns, histogram(_timestamp) from k8s group by k8s_namespace_name, histogram(_timestamp)",
             "start_time": 1675182660872049i64,

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -58,12 +58,12 @@ use crate::{
 #[utoipa::path(
     context_path = "/api",
     tag = "Search",
-    operation_id = "SearchSQL",
+    operation_id = "SearchSQLMultiStream",
     summary = "Search across multiple streams",
     description = "Executes SQL queries that can span across multiple data streams within the organization. This enables cross-stream analytics, joins, and aggregations to analyze data relationships and patterns across different log streams, metrics, or traces. The query engine automatically handles data from different streams and returns unified results.",
     params(("org_id" = String, Path, description = "Organization name")),
     request_body(
-        content = Object,
+        content = search::MultiStreamRequest,
         description = "Search query",
         content_type = "application/json",
         example = json!({
@@ -654,7 +654,7 @@ pub async fn search_multi(
         ("enable_align_histogram" = bool, Query, description = "Enable align histogram"),
     ),
     request_body(
-        content = Object,
+        content = search::MultiSearchPartitionRequest,
         description = "Search query",
         content_type = "application/json",
         example = json!({

--- a/src/handler/http/request/search/search_job.rs
+++ b/src/handler/http/request/search/search_job.rs
@@ -58,7 +58,7 @@ use crate::service::organization::is_org_in_free_trial_period;
 #[utoipa::path(
     context_path = "/api",
     tag = "Search Jobs",
-    operation_id = "SearchSQL",
+    operation_id = "SubmitSearchJob",
     summary = "Submit search job",
     description = "Submits a new asynchronous search job for execution. Search jobs are useful for long-running queries that \
                    might exceed normal timeout limits or for scheduling queries to run in the background. The job is \
@@ -69,7 +69,7 @@ use crate::service::organization::is_org_in_free_trial_period;
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = Object, description = "Search query", content_type = "application/json", example = json!({
+    request_body(content = config::meta::search::Request, description = "Search query", content_type = "application/json", example = json!({
         "query": {
             "sql": "select * from k8s ",
             "start_time": 1675182660872049i64,

--- a/src/handler/http/request/service_accounts/mod.rs
+++ b/src/handler/http/request/service_accounts/mod.rs
@@ -282,7 +282,6 @@ pub async fn delete(
     ),
     params(
         ("org_id" = String, Path, description = "Organization name"),
-        ("org_id" = String, Path, description = "Organization name"),
         ("email_id" = String, Path, description = "Service Account email id"),
       ),
     responses(

--- a/src/handler/http/request/short_url/mod.rs
+++ b/src/handler/http/request/short_url/mod.rs
@@ -16,7 +16,7 @@
 use std::io::Error;
 
 use actix_web::{HttpRequest, HttpResponse, get, post, web};
-use config::meta::short_url::ShortenUrlResponse;
+use config::meta::short_url::{ShortenUrlRequest, ShortenUrlResponse};
 use serde::Deserialize;
 
 use crate::{
@@ -32,10 +32,11 @@ use crate::{
 #[utoipa::path(
     post,
     context_path = "/api",
+    operation_id = "createShortUrl",
     summary = "Create short URL",
     description = "Generates a shortened URL from a longer original URL. This is useful for creating more manageable links for dashboards, reports, or search queries that can be easily shared via email, chat, or documentation. The short URL remains valid and can be used to redirect back to the original destination.",
     request_body(
-        content = Object,
+        content = ShortenUrlRequest,
         description = "The original URL to shorten",
         content_type = "application/json",
         example = json!({
@@ -61,7 +62,7 @@ use crate::{
 )]
 #[post("/{org_id}/short")]
 pub async fn shorten(org_id: web::Path<String>, body: web::Bytes) -> Result<HttpResponse, Error> {
-    let req: config::meta::short_url::ShortenUrlRequest = match serde_json::from_slice(&body) {
+    let req: ShortenUrlRequest = match serde_json::from_slice(&body) {
         Ok(v) => v,
         Err(e) => return Ok(MetaHttpResponse::bad_request(e)),
     };
@@ -91,6 +92,7 @@ pub struct RetrieveQuery {
 #[utoipa::path(
     get,
     context_path = "/short",
+    operation_id = "resolveShortUrl",
     summary = "Resolve short URL",
     description = "Resolves a shortened URL back to its original destination. By default, this endpoint redirects the user to the original URL. When the 'type=ui' query parameter is provided, it returns the original URL as JSON instead of performing a redirect. This is useful for applications that need to inspect or validate URLs before navigation.",
     params(

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -240,7 +240,6 @@ use crate::{common::meta, handler::http::request};
             config::meta::timed_annotations::TimedAnnotationDelete,
             config::meta::timed_annotations::TimedAnnotationUpdate,
             // Dashboards
-            crate::handler::http::models::dashboards::CreateDashboardRequestBody,
             crate::handler::http::models::dashboards::CreateDashboardResponseBody,
             crate::handler::http::models::dashboards::GetDashboardResponseBody,
             crate::handler::http::models::dashboards::UpdateDashboardRequestBody,

--- a/src/service/search/datafusion/optimizer/physical_optimizer/distribute_analyze.rs
+++ b/src/service/search/datafusion/optimizer/physical_optimizer/distribute_analyze.rs
@@ -102,6 +102,6 @@ mod tests {
         let mut rewriter = AnalyzeRewrite::new();
         let plan = plan.rewrite(&mut rewriter).unwrap().data;
         let remote_scan = plan.as_any().downcast_ref::<RemoteScanExec>().unwrap();
-        assert_eq!(remote_scan.analyze(), true);
+        assert!(remote_scan.analyze());
     }
 }

--- a/src/service/tantivy/mod.rs
+++ b/src/service/tantivy/mod.rs
@@ -362,7 +362,7 @@ mod tests {
             fields.push(Field::new("status", DataType::Utf8, false));
             let status: Vec<String> = (0..num_rows)
                 .map(|i| {
-                    if i % 2 == 0 {
+                    if i.is_multiple_of(2) {
                         "success".to_string()
                     } else {
                         "error".to_string()


### PR DESCRIPTION
### **User description**
- **OpenAPI schema fixes**: Replace generic `Object` content types with proper typed schemas
    - `ai/prompt.rs`: Use `UpdatePromptRequest` instead of `Object`
    - `authz/fga.rs`: Use `RoleRequest` for role operations
    - `keys/mod.rs`: Use `KeyAddRequest` for cipher key operations
    - `dashboards/mod.rs`: Use versioned dashboard schemas for create/update endpoints
    - `actions/action.rs`: Remove incorrect request_body specifications

  - **Deprecated endpoint disambiguation**: Add "Deprecated" suffix to alert operation IDs to prevent OpenAPI conflicts

- **Dashboard macro refactoring**: Replace repetitive getter/setter methods with declarative macros
    - `make_getter!` macro generates type-safe field accessors across all dashboard versions (v1-v5)
    - `make_setter!` macro generates unified field mutators with version-specific matching
    - Add comprehensive unit tests covering edge cases (empty values, unsupported versions, missing inner objects)

  - **Pipeline schema**: Add `ToSchema` derive to Pipeline struct for API documentation

  - **Enterprise feature gating**: Properly gate cipher key endpoints with conditional compilation


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace OpenAPI Object with typed schemas

- Introduce dashboard getter/setter macros

- Gate cipher key endpoints by feature

- Add ToSchema for Pipeline and multipart


___

### Diagram Walkthrough


```mermaid
flowchart LR
  OpenAPI["OpenAPI annotations"] -- "use typed schemas" --> Handlers["HTTP handlers"]
  DashModel["Dashboard struct"] -- "generate getters/setters" --> Macros["make_getter!/make_setter!"]
  Pipeline["Pipeline model"] -- "derive ToSchema" --> Docs["API Docs"]
  Keys["Cipher key endpoints"] -- "cfg(feature=enterprise)" --> Gated["Enterprise-only"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Enable macro metavariable concat feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-c1f72c148113548ea854a05d09e3576632fcd7367279563bf3f42f0aef5454e2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Add getter/setter macros and unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-5bf716db7e1d91dfbd427a2e320ce407c4f0c92d55d68f8e636daed1b02abd56">+219/-143</a></td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Gate endpoints and use KeyAddRequest parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-043222e433d1e5825a4b7bfc2c7feedba417f2630f0082fa67aff64976736396">+137/-138</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Derive ToSchema for Pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-c4bd542e4e07ed7706b0643086f5a7d4edbb3647c7ceedbe4bea516c5274d8bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>action.rs</strong><dd><code>Remove incorrect request_body annotations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-616df3014c553f763ea57e925f1bff7bb47f9467c632940d93a45b7b1e4c3a07">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prompt.rs</strong><dd><code>Use UpdatePromptRequest in OpenAPI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-4435a6dbd41255db8c334941643b22ef4eb401004370566cc56394d2e74bab6b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>deprecated.rs</strong><dd><code>Disambiguate deprecated alert operation IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-3a5d80eac45bff881716e2cf099f90130659576eca017ad238a61781d3341b7e">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fga.rs</strong><dd><code>Use RoleRequest schema for roles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-e7c99f37f3abbb5e0507d2760bbf67df010d9218704b38dce84c5477acecd22e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Switch dashboard request bodies to versioned schemas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-1b3c257e1d174c826718499faa4a1d4e93465dd56cb2b7b273b690ff7e3223fd">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pipeline.rs</strong><dd><code>Use Pipeline schema in OpenAPI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-c69f4f94eee97ce226caddc497b2adf89e26869f2d72b0d0206dc31ab2714daf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingest.rs</strong><dd><code>Add ToSchema and schema for multipart fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-40fa0a7da7845799e5bed864e8ccc8111330a3d76fcc8e50af0b76251d566b45">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Replace Object with concrete search request schemas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-96630a0dbb6dd7b2b0248fa325c7c7041ce31340c32826675a4a70772e9d29f6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>multi_streams.rs</strong><dd><code>Rename operation IDs and use typed requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-c3233cdf1e68cb2455f91457719b9c2f477e735ee16546fdfe111e76768bd054">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>search_job.rs</strong><dd><code>Rename operation ID and type request body</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-d848b311eae318d198558c29a007c8973afb5f8867a31ec056f4e037dcd1b854">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Remove duplicate org_id param in OpenAPI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-095d70f65b6e69bf7de0180fcbcddcd7c89c4cf00095d7b06f039a07e73916bb">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Use typed request and set operation IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-c10dd7b4ea20ffe5840c93a6ae4298aec0c32c8ba1b114192fda6c2bac1c41d1">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>openapi.rs</strong><dd><code>Remove unused CreateDashboardRequestBody schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-edb8ce232c0cd08366879f642788a75d99f6bab64b4c0e77391281fdb9241e90">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>distribute_analyze.rs</strong><dd><code>Simplify test assertion with assert!</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-79a2bd6eedd7766e9aaf85c580022139ea164c419a6c86068adcd46a8cb80a99">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Use is_multiple_of in test status selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8505/files#diff-68837d2f393b453002ec2d95f6882cfcaf70d9ef6547be2c9a890e8b0fc3c559">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

