### PR TITLE
fix: should add include search term before group by clause

### DIFF
--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -4097,7 +4097,19 @@ export default defineComponent({
                     filter +
                     " order by" +
                     afterOrderBy;
-                } else if (query.toLowerCase().includes("limit")) {
+                } else if (query.toLowerCase().includes("group by")) {
+                  const [beforeGroupBy, afterGroupBy] = queryIndexSplit(
+                    query,
+                    "group by",
+                  );
+                  query =
+                    beforeGroupBy.trim() +
+                    " AND " +
+                    filter +
+                    " group by" +
+                    afterGroupBy;
+                } 
+                else if (query.toLowerCase().includes("limit")) {
                   const [beforeLimit, afterLimit] = queryIndexSplit(
                     query,
                     "limit",
@@ -4123,7 +4135,19 @@ export default defineComponent({
                     filter +
                     " order by" +
                     afterOrderBy;
-                } else if (query.toLowerCase().includes("limit")) {
+                } else if (query.toLowerCase().includes("group by")) {
+                  const [beforeGroupBy, afterGroupBy] = queryIndexSplit(
+                    query,
+                    "group by",
+                  );
+                  query =
+                    beforeGroupBy.trim() +
+                    " where " +
+                    filter +
+                    " group by" +
+                    afterGroupBy;
+                }
+                 else if (query.toLowerCase().includes("limit")) {
                   const [beforeLimit, afterLimit] = queryIndexSplit(
                     query,
                     "limit",


### PR DESCRIPTION
### **User description**
This PR fixes the #8510


___

### **PR Type**
Bug fix


___

### **Description**
- Insert filters before GROUP BY clause

- Handle both include and exclude terms

- Preserve ORDER BY and LIMIT positions

- Align query splitting via group-by branch


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Query["Incoming query"] --> CheckOB["Has ORDER BY?"]
  CheckOB -- Yes --> InsertBeforeOB["Insert filter before ORDER BY"]
  CheckOB -- No --> CheckGB["Has GROUP BY?"]
  CheckGB -- Yes --> InsertBeforeGB["Insert filter before GROUP BY"]
  CheckGB -- No --> CheckLimit["Has LIMIT?"]
  CheckLimit -- Yes --> InsertBeforeLimit["Insert filter before LIMIT"]
  CheckLimit -- No --> AppendFilter["Append filter at end/with WHERE"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SearchBar.vue</strong><dd><code>Add group-by-aware filter insertion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/SearchBar.vue

<ul><li>Add GROUP BY branch when adding filters.<br> <li> Insert "AND"/"where" filter before GROUP BY.<br> <li> Maintain existing ORDER BY and LIMIT handling.<br> <li> Minor formatting of conditional branches.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8515/files#diff-81893de4edf186b0556f610acb280c87baa2ffe67d3b48a60a866094c7635baf">+26/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

