### PR TITLE
fix: No data found was displayed on refresh as loading was not set

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -911,6 +911,7 @@ export default defineComponent({
             await getRegionInfo();
           }
 
+          searchObj.loading = true;
           loadLogsData();
 
           store.dispatch("logs/setIsInitialized", true);


### PR DESCRIPTION
When we refresh the logs page or open short url, "No data found for histogram." was displayed for some time till the logs data loads as loading was not set during first load.