### PR TITLE
fix: correct ent repo path

### DIFF
--- a/src/job/config_watcher.rs
+++ b/src/job/config_watcher.rs
@@ -82,7 +82,7 @@ pub fn reload_config(path: &PathBuf) -> Result<(), anyhow::Error> {
     #[cfg(feature = "enterprise")]
     {
         use o2_dex::config::refresh_config as refresh_dex_config;
-        use o2_enterprise::enterprise::common::infra::config::refresh_config as refresh_o2_config;
+        use o2_enterprise::enterprise::common::config::refresh_config as refresh_o2_config;
         use o2_openfga::config::refresh_config as refresh_openfga_config;
 
         refresh_o2_config()


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix enterprise config path import

- Ensure enterprise config reload compiles


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Watcher["Config watcher reload_config"] -- "imports enterprise refresh" --> Import["o2_enterprise::enterprise::common::config::refresh_config"]
  Import -- "used in" --> Reload["refresh_o2_config() chain"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_watcher.rs</strong><dd><code>Correct enterprise config import path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/job/config_watcher.rs

<ul><li>Update enterprise config import path.<br> <li> Use <code>common::config::refresh_config</code> instead of <code>common::infra::config</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8544/files#diff-598ec79e0686bf314514227cf1f0b1dc560770b0e056761d6a214289d2eeb7f2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

