### PR TITLE
fix: check for lower case select as well in middle of the query

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1098,7 +1098,7 @@ export default defineComponent({
             (currentQuery.toLowerCase() === "select" ||
               currentQuery.toLowerCase().indexOf("select ") == 0);
           //check if user try to applied saved views in which sql mode is enabled.
-          if (currentQuery.indexOf("SELECT") >= 0) {
+          if (currentQuery.toLowerCase().indexOf("select") >= 0) {
             return;
           }
 


### PR DESCRIPTION
### **User description**
This PR fixes the issue mentioned in #8541


___

### **PR Type**
Bug fix


___

### **Description**
- Handle lowercase SELECT in saved views

- Prevent applying views to SQL queries

- Use case-insensitive SELECT detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  InputQuery["User query input"] -- toLowerCase check --> SelectDetector["Detect 'select' anywhere"]
  SelectDetector -- true --> EarlyReturn["Skip applying saved views"]
  SelectDetector -- false --> ContinueFlow["Proceed with view application"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Case-insensitive SQL detection in saved views</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/Index.vue

<ul><li>Make SELECT detection case-insensitive.<br> <li> Detect 'select' anywhere in the query string.<br> <li> Prevent applying saved views when SQL mode detected.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8545/files#diff-0323c3da69b369843c5d72bf4df5b00ca6b5147192a213baf331659ecf92af62">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

