### PR TITLE
fix: No data found displayed until logs are fetched on refresh

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -864,6 +864,7 @@ export default defineComponent({
         }
 
         if (isLogsTab()) {
+          searchObj.loading = true;
           loadLogsData();
         } else {
           loadVisualizeData();


### PR DESCRIPTION
When we refresh the logs page or open a short URL, "No data found for histogram" is displayed for some time till the logs data loads, as loading was not set during the first load.