### PR TITLE
fix: move config at top to init from custom config file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,16 @@ use tracing_subscriber::{
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
+    // CLI provides the path to the config file (if any)
+    // In case a custom path is provided, the file will be read first
+    // and config variables will be loaded.
+    // This has to happen as the foremost step as any call to
+    // get_config without this would be loaded from local `.env`
+    // or environment itself.
+    if cli::cli().await? {
+        return Ok(());
+    }
+
     let cfg = get_config();
 
     #[cfg(feature = "tokio-console")]
@@ -165,11 +175,6 @@ async fn main() -> Result<(), anyhow::Error> {
     } else {
         None
     };
-
-    // cli mode
-    if cli::cli().await? {
-        return Ok(());
-    }
 
     let mut tracer_provider = None;
 


### PR DESCRIPTION
path