### PR TITLE
fix: search parquet for wal

### DIFF
--- a/src/config/src/utils/async_file.rs
+++ b/src/config/src/utils/async_file.rs
@@ -216,18 +216,17 @@ pub fn create_wal_dir_datetime_filter(
             Some(_) => return false,
             None => start_time.hour(),
         };
-
+   
         let date_range_check = if let Some(datetime) = Utc
             .with_ymd_and_hms(
                 year,
                 month,
                 day,
                 hour,
-                start_time.minute(),
-                start_time.second(),
+                0,
+                0,
             )
             .single()
-            .and_then(|dt| dt.with_nanosecond(start_time.timestamp_subsec_nanos()))
         {
             datetime >= start_time && datetime <= end_time
         } else {

--- a/src/config/src/utils/async_file.rs
+++ b/src/config/src/utils/async_file.rs
@@ -216,22 +216,13 @@ pub fn create_wal_dir_datetime_filter(
             Some(_) => return false,
             None => start_time.hour(),
         };
-   
-        let date_range_check = if let Some(datetime) = Utc
-            .with_ymd_and_hms(
-                year,
-                month,
-                day,
-                hour,
-                0,
-                0,
-            )
-            .single()
-        {
-            datetime >= start_time && datetime <= end_time
-        } else {
-            false
-        };
+
+        let date_range_check =
+            if let Some(datetime) = Utc.with_ymd_and_hms(year, month, day, hour, 0, 0).single() {
+                datetime >= start_time && datetime <= end_time
+            } else {
+                false
+            };
 
         date_range_check
             && (!path.is_file()

--- a/src/config/src/utils/time.rs
+++ b/src/config/src/utils/time.rs
@@ -24,6 +24,7 @@ pub static BASE_TIME: Lazy<DateTime<Utc>> =
     Lazy::new(|| Utc.with_ymd_and_hms(1971, 1, 1, 0, 0, 0).unwrap());
 
 pub static DAY_MICRO_SECS: i64 = 24 * 3600 * 1_000_000;
+pub static HOUR_MICRO_SECS: i64 = 3600 * 1_000_000;
 
 // check format: 1s, 1m, 1h, 1d, 1w, 1y, 1h10m30s
 static TIME_UNITS: [(char, u64); 7] = [

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -30,7 +30,8 @@ use config::{
         file::is_exists,
         parquet::{parse_time_range_from_filename, read_metadata_from_file},
         record_batch_ext::concat_batches,
-        size::bytes_to_human_readable, time::HOUR_MICRO_SECS,
+        size::bytes_to_human_readable,
+        time::HOUR_MICRO_SECS,
     },
 };
 use datafusion::{

--- a/src/service/search/grpc/wal.rs
+++ b/src/service/search/grpc/wal.rs
@@ -30,7 +30,7 @@ use config::{
         file::is_exists,
         parquet::{parse_time_range_from_filename, read_metadata_from_file},
         record_batch_ext::concat_batches,
-        size::bytes_to_human_readable,
+        size::bytes_to_human_readable, time::HOUR_MICRO_SECS,
     },
 };
 use datafusion::{
@@ -578,6 +578,8 @@ async fn get_file_list_inner(
         wal_dir, query.org_id, query.stream_type, query.stream_name
     );
     let files = if let Some((start_time, end_time)) = query.time_range.and_then(|(s, e)| {
+        let s = s - s % HOUR_MICRO_SECS;
+        let e = e - e % HOUR_MICRO_SECS;
         DateTime::from_timestamp_micros(s).zip(DateTime::from_timestamp_micros(e))
     }) {
         let skip_count = AsRef::<Path>::as_ref(&pattern).components().count();


### PR DESCRIPTION
### **User description**
This PR fixed in some edge case we missing records on ingester but it will appear again after a while.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix WAL datetime filter to hour precision

- Align search range to hour boundaries

- Add HOUR_MICRO_SECS constant


___

### Diagram Walkthrough


```mermaid
flowchart LR
  query["Query time range (microseconds)"] -- "align to hour (floor)" --> aligned["Aligned start/end (hour)"]
  aligned -- "scan WAL parquet dirs" --> filter["Hour-based datetime filter"]
  filter -- "list matching files" --> results["File list for search"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>async_file.rs</strong><dd><code>Hour-level WAL directory datetime filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/utils/async_file.rs

<ul><li>Normalize constructed datetime to top of hour.<br> <li> Remove minute/second/nanosecond dependence.<br> <li> Keep range check using start/end bounds.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8558/files#diff-8275f369cab85b5e9a97ed11d236de3364850b6989698936f19e70a0144e6a0d">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wal.rs</strong><dd><code>Align WAL search time range to hour</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/grpc/wal.rs

<ul><li>Import HOUR_MICRO_SECS for range alignment.<br> <li> Floor start/end times to hour before scanning.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8558/files#diff-48aea52fd870678e577e03f29fc9769920b7f74761b1447242835dbf1b8ac8df">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>time.rs</strong><dd><code>Add microsecond hour constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/utils/time.rs

<ul><li>Introduce HOUR_MICRO_SECS constant.<br> <li> Keep existing BASE_TIME and DAY_MICRO_SECS.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8558/files#diff-7b7e5972c321c99c5147af56a71afc1136a7c75844b8442e207de60bc86b7ddf">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

