### PR TITLE
fix: remove drilldown and compare against config on visualization rc7(#8534)

### DIFF
--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -1425,7 +1425,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         v-if="
           !['html', 'markdown', 'geomap', 'maps'].includes(
             dashboardPanelData.data.type,
-          )
+          ) && dashboardPanelDataPageKey !== 'logs'
         "
         :variablesData="variablesData"
       />
@@ -1461,7 +1461,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           'scatter',
           'area-stacked',
           'stacked',
-        ].includes(dashboardPanelData.data.type) && !promqlMode
+        ].includes(dashboardPanelData.data.type) &&
+        !promqlMode &&
+        dashboardPanelDataPageKey !== 'logs'
       "
     >
       <div class="flex items-center q-mr-sm">
@@ -2136,6 +2138,7 @@ export default defineComponent({
       showTrellisConfig,
       isBreakdownFieldEmpty,
       hasTimeShifts,
+      dashboardPanelDataPageKey,
     };
   },
 });


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Disable drilldown on Logs page

- Guard chart compare against Logs context

- Expose page key to template


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ConfigPanel["ConfigPanel.vue"]
  DrilldownGuard["Add 'pageKey !== logs' guard"]
  CompareGuard["Guard compare UI for logs"]
  ExposeKey["Return dashboardPanelDataPageKey from setup()"]

  ConfigPanel -- "update Drilldown v-if" --> DrilldownGuard
  ConfigPanel -- "update compare v-if" --> CompareGuard
  ConfigPanel -- "export key to template" --> ExposeKey
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConfigPanel.vue</strong><dd><code>Disable drilldown/compare when page key is logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/ConfigPanel.vue

<ul><li>Add <code>dashboardPanelDataPageKey !== 'logs'</code> to Drilldown v-if.<br> <li> Add same guard to compare/series options v-if with <code>!promqlMode</code>.<br> <li> Return <code>dashboardPanelDataPageKey</code> from setup exports.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8562/files#diff-c3a6e64dff02b58bb7cdc3f0668990b41ff41544b4c5e991bbcd989ad4bba3f8">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

