### PR TITLE
fix: dashboard toLowercase issue (#8538)

### DIFF
--- a/web/src/utils/dashboard/aliasUtils.ts
+++ b/web/src/utils/dashboard/aliasUtils.ts
@@ -14,5 +14,5 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 export const getDataValue = (obj: any, alias: string): any => {
-  return obj?.[alias] || obj?.[alias?.toLowerCase()];
+  return obj?.[alias] || obj?.[alias?.toString()?.toLowerCase()];
 };


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix alias lowercase conversion with non-strings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  getDataValue["getDataValue in aliasUtils.ts"]
  aliasInput["alias input (any type)"]
  toStringLower["toString() then toLowerCase()"]
  propertyAccess["Safe property access on obj"]

  aliasInput -- "fallback path" --> toStringLower
  toStringLower -- "compute lowercase key" --> propertyAccess
  propertyAccess -- "return value" --> getDataValue
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aliasUtils.ts</strong><dd><code>Safe lowercase conversion for alias keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/dashboard/aliasUtils.ts

<ul><li>Add toString() before toLowerCase().<br> <li> Prevent errors when alias isn't a string.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8563/files#diff-5edee3a79266ff067f9767615a887375f369c6006c4c02bb46a9b6006969e284">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

