### PR TITLE
fix: update quick_mode parameter handling in logs URL based on configuration for drilldown and go to logs in dashboard

### DIFF
--- a/web/src/components/dashboards/PanelContainer.vue
+++ b/web/src/components/dashboards/PanelContainer.vue
@@ -611,7 +611,6 @@ export default defineComponent({
         "org_identifier",
         store.state.selectedOrganization.identifier,
       );
-      // if store.state.zoConfig.quick_mode_enabled is true then only set quick_mode to true else set quick_mode to false
       if (store.state.zoConfig.quick_mode_enabled) {
         logsUrl.searchParams.set("quick_mode", "true");
       } else {
@@ -622,11 +621,6 @@ export default defineComponent({
     };
 
     const onLogPanel = async () => {
-      console.log(
-        "Navigating to logs page with query details:",
-        store.state.zoConfig.quick_mode_enabled,
-      );
-
       const showNotification = showPositiveNotification(
         "Redirecting to logs page",
         {

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -1283,7 +1283,6 @@ export default defineComponent({
         "org_identifier",
         store.state.selectedOrganization.identifier,
       );
-      // if store.state.zoConfig.quick_mode_enabled is true then only set quick_mode to true else set quick_mode to false
       if (store.state.zoConfig.quick_mode_enabled) {
         logsUrl.searchParams.set("quick_mode", "true");
       } else {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Respect `quick_mode_enabled` in logs URL

- Apply to drilldown and go-to-logs flows

- Minor watch formatting cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["zoConfig.quick_mode_enabled"]
  Builder1["PanelContainer: build logs URL"]
  Builder2["PanelSchemaRenderer: build logs URL"]
  URLParam["Set quick_mode=true/false"]
  Format["Refactor watch() formatting"]

  Config -- controls --> Builder1
  Config -- controls --> Builder2
  Builder1 -- sets --> URLParam
  Builder2 -- sets --> URLParam
  PanelSchemaRenderer --> Format
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PanelContainer.vue</strong><dd><code>Conditional quick_mode in logs URL construction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/PanelContainer.vue

<ul><li>Set <code>quick_mode</code> based on <code>zoConfig.quick_mode_enabled</code>.<br> <li> Remove unconditional <code>quick_mode=false</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8586/files#diff-414737cba6064461f7026e0b016afcb9620bd5bb29c4708fc170dee789dbcd4d">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PanelSchemaRenderer.vue</strong><dd><code>Apply config-driven quick_mode and tidy watchers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/PanelSchemaRenderer.vue

<ul><li>Set <code>quick_mode</code> based on <code>zoConfig.quick_mode_enabled</code>.<br> <li> Keep histogram hidden; preserve other params.<br> <li> Reformat watch() for readability.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8586/files#diff-e5376e7e77bf3aaf6590c2522d8c2dbffcc95a8006ae0d6dc0040a37825367d6">+12/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

