### PR TITLE
fix: import issue due to refactoring on visualization

### DIFF
--- a/web/src/plugins/logs/VisualizeLogsQuery.vue
+++ b/web/src/plugins/logs/VisualizeLogsQuery.vue
@@ -405,8 +405,9 @@ import { onActivated } from "vue";
 import useNotifications from "@/composables/useNotifications";
 import CustomChartEditor from "@/components/dashboards/addPanel/CustomChartEditor.vue";
 import { checkIfConfigChangeRequiredApiCallOrNot } from "@/utils/dashboard/checkConfigChangeApiCall";
-import useLogs from "@/composables/useLogs";
 import { isSimpleSelectAllQuery } from "@/utils/query/sqlUtils";
+import { useSearchStream } from "@/composables/useLogs/useSearchStream";
+import { searchState } from "@/composables/useLogs/searchState";
 
 const ConfigPanel = defineAsyncComponent(() => {
   return import("@/components/dashboards/addPanel/ConfigPanel.vue");
@@ -481,7 +482,8 @@ export default defineComponent({
     };
     const { showErrorNotification } = useNotifications();
     
-    const { searchObj, buildSearch } = useLogs();
+    const { searchObj } = searchState();
+    const { buildSearch } = useSearchStream();
 
     const { visualizeChartData, is_ui_histogram }: any = toRefs(props);
     const chartData = ref(visualizeChartData.value);


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace deprecated logs composable imports

- Switch to `useSearchStream` and `searchState`

- Update imports to new module paths

- Adjust usage to new APIs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VisualizeLogsQuery.vue"] --> B["Remove useLogs import"]
  A --> C["Import useSearchStream"]
  A --> D["Import searchState"]
  A --> E["Use searchState().searchObj"]
  A --> F["Use useSearchStream().buildSearch"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VisualizeLogsQuery.vue</strong><dd><code>Migrate logs search to new composables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/VisualizeLogsQuery.vue

<ul><li>Remove <code>useLogs</code> import and usage.<br> <li> Import <code>useSearchStream</code> for <code>buildSearch</code>.<br> <li> Import <code>searchState</code> to access <code>searchObj</code>.<br> <li> Update variable initializations to new composables.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8591/files#diff-979b01d943d58c5d70faeeac5948b7f02f0b2392a12b84ef07ba7f7393ab0261">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

