### PR TITLE
chore: bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
  "derive_more 2.0.1",
  "encoding_rs",
  "flate2",
- "foldhash",
+ "foldhash 0.1.4",
  "futures-core",
  "h2 0.3.26",
  "http 0.2.12",
@@ -65,7 +65,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.1",
+ "rand 0.9.2",
  "sha1",
  "smallvec",
  "tokio",
@@ -229,7 +229,7 @@ dependencies = [
  "cookie",
  "derive_more 2.0.1",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.4",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -686,7 +686,7 @@ dependencies = [
  "arrow-schema",
  "base64 0.22.1",
  "bytes",
- "futures",
+ "futures 0.3.31",
  "prost 0.13.4",
  "prost-types 0.13.4",
  "tonic 0.13.1",
@@ -946,7 +946,7 @@ checksum = "08f6da6d49a956424ca4e28fe93656f790d748b469eaccbc7488fec545315180"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures",
+ "futures 0.3.31",
  "memchr",
  "nkeys",
  "nuid",
@@ -1559,12 +1559,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -2071,7 +2065,7 @@ dependencies = [
  "chromiumoxide_types",
  "dunce",
  "fnv",
- "futures",
+ "futures 0.3.31",
  "futures-timer",
  "pin-project-lite",
  "reqwest",
@@ -2293,24 +2287,24 @@ dependencies = [
 
 [[package]]
 name = "cloudevents-sdk"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801713078518ab05d7c78508c14cf55173a14a1a6659421d3352c2576a6167bf"
+checksum = "9d48721bdd20fbaa008c5180469dc76363776cb68ace437064e916044dd2d92a"
 dependencies = [
  "actix-http",
  "actix-web",
  "async-trait",
- "base64 0.12.3",
- "bitflags 1.3.2",
+ "base64 0.22.1",
+ "bitflags 2.9.0",
  "bytes",
  "chrono",
  "delegate-attr",
- "futures",
- "hostname 0.3.1",
+ "futures 0.3.31",
+ "hostname",
  "http 0.2.12",
  "serde",
  "serde_json",
- "snafu 0.6.10",
+ "snafu 0.8.5",
  "url",
  "uuid",
  "web-sys",
@@ -2365,8 +2359,8 @@ version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
 dependencies = [
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "unicode-width 0.2.0",
 ]
 
@@ -2423,14 +2417,13 @@ dependencies = [
  "dotenvy",
  "expect-test",
  "faststr",
- "futures",
+ "futures 0.3.31",
  "get_if_addrs",
- "getrandom 0.2.15",
  "gxhash",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.0",
  "hex",
  "indexmap 2.11.3",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lettre",
  "log",
  "md5",
@@ -2438,12 +2431,12 @@ dependencies = [
  "murmur3",
  "once_cell",
  "opentelemetry 0.30.0",
- "ordered-float 4.6.0",
+ "ordered-float 5.0.0",
  "parking_lot",
  "parquet",
  "prometheus",
  "proto",
- "rand 0.8.5",
+ "rand 0.9.2",
  "regex",
  "reqwest",
  "roaring",
@@ -2454,7 +2447,7 @@ dependencies = [
  "sha256",
  "sqlparser",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "svix-ksuid",
  "sysinfo",
  "tantivy",
@@ -2625,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -2953,13 +2946,13 @@ dependencies = [
  "datafusion-session",
  "datafusion-sql",
  "flate2",
- "futures",
+ "futures 0.3.31",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
  "sqlparser",
  "tempfile",
@@ -2988,7 +2981,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "datafusion-sql",
- "futures",
+ "futures 0.3.31",
  "itertools 0.14.0",
  "log",
  "object_store",
@@ -3013,7 +3006,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
- "futures",
+ "futures 0.3.31",
  "log",
  "object_store",
  "tokio",
@@ -3050,7 +3043,7 @@ version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a1d1bc69aaaadb8008b65329ed890b33e845dc063225c190f77b20328fbe1d"
 dependencies = [
- "futures",
+ "futures 0.3.31",
  "log",
  "tokio",
 ]
@@ -3077,13 +3070,13 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "flate2",
- "futures",
+ "futures 0.3.31",
  "glob",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parquet",
- "rand 0.9.1",
+ "rand 0.9.2",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -3111,7 +3104,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
- "futures",
+ "futures 0.3.31",
  "object_store",
  "regex",
  "tokio",
@@ -3136,7 +3129,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
- "futures",
+ "futures 0.3.31",
  "object_store",
  "serde_json",
  "tokio",
@@ -3165,13 +3158,13 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-pruning",
  "datafusion-session",
- "futures",
+ "futures 0.3.31",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.1",
+ "rand 0.9.2",
  "tokio",
 ]
 
@@ -3192,11 +3185,11 @@ dependencies = [
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
- "futures",
+ "futures 0.3.31",
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "tempfile",
  "url",
 ]
@@ -3258,7 +3251,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "md-5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
  "sha2",
  "unicode-segmentation",
@@ -3500,7 +3493,7 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "futures",
+ "futures 0.3.31",
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.11.3",
@@ -3572,7 +3565,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "datafusion-sql",
- "futures",
+ "futures 0.3.31",
  "itertools 0.14.0",
  "log",
  "object_store",
@@ -3623,13 +3616,13 @@ checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "delegate-attr"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7e7ea0dba407429d816e8e38dda1a467cd74737722f2ccc8eae60429a1a3ab"
+checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3947,6 +3940,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3958,15 +3961,15 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
- "humantime",
- "is-terminal",
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
  "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -4179,7 +4182,7 @@ dependencies = [
  "config",
  "datafusion",
  "flatbuffers",
- "futures",
+ "futures 0.3.31",
  "parking_lot",
  "serde",
  "serde_json",
@@ -4220,6 +4223,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,6 +4252,12 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -4351,6 +4366,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -4426,16 +4442,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4558,7 +4572,18 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.4",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
  "serde",
 ]
 
@@ -4633,17 +4658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5117,10 +5131,10 @@ dependencies = [
  "collapse",
  "config",
  "datafusion",
- "futures",
- "hashbrown 0.15.2",
+ "futures 0.3.31",
+ "hashbrown 0.16.0",
  "hashlink",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "object_store",
  "once_cell",
@@ -5158,11 +5172,11 @@ dependencies = [
  "chrono",
  "config",
  "datafusion",
- "futures",
- "hashbrown 0.15.2",
+ "futures 0.3.31",
+ "hashbrown 0.16.0",
  "indexmap 2.11.3",
  "infra",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "once_cell",
  "parquet",
@@ -5290,6 +5304,30 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "jiter"
@@ -5431,7 +5469,7 @@ dependencies = [
  "fastrand",
  "futures-io",
  "futures-util",
- "hostname 0.4.0",
+ "hostname",
  "httpdate",
  "idna",
  "mime",
@@ -5732,13 +5770,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-rs"
-version = "0.3.0"
+name = "lzma-rust2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
 dependencies = [
- "byteorder",
  "crc",
+ "sha2",
 ]
 
 [[package]]
@@ -5751,12 +5789,6 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -5803,9 +5835,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "measure_time"
@@ -6225,6 +6257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6240,6 +6281,16 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -6262,7 +6313,7 @@ dependencies = [
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures 0.3.31",
  "http 1.2.0",
  "http-body-util",
  "httparse",
@@ -6273,7 +6324,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.0",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reqwest",
  "ring",
  "rustls-pemfile 2.2.0",
@@ -6412,23 +6463,22 @@ dependencies = [
  "datafusion-proto",
  "derive_more 2.0.1",
  "enrichment",
- "env_logger 0.10.2",
+ "env_logger 0.11.8",
  "expect-test",
  "faststr",
  "flate2",
  "flight",
  "float-cmp",
- "futures",
+ "futures 0.3.31",
  "futures-core",
  "futures-util",
- "getrandom 0.2.15",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.0",
  "hashlink",
  "hex",
  "http-auth-basic",
  "infra",
  "ingester",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "jsonwebtoken",
  "lettre",
  "log",
@@ -6454,7 +6504,7 @@ dependencies = [
  "proto",
  "pyroscope",
  "pyroscope_pprofrs",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rayon",
  "rcgen",
  "regex",
@@ -6473,7 +6523,7 @@ dependencies = [
  "snafu 0.7.5",
  "snap",
  "sqlparser",
- "strum",
+ "strum 0.27.2",
  "svix-ksuid",
  "tantivy",
  "tantivy-fst",
@@ -6499,7 +6549,7 @@ dependencies = [
  "vrl",
  "wal",
  "x509-parser",
- "zip 3.0.0",
+ "zip 5.1.1",
  "zstd",
 ]
 
@@ -6603,7 +6653,7 @@ dependencies = [
  "futures-util",
  "opentelemetry 0.30.0",
  "percent-encoding",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.11",
  "tokio",
@@ -6639,6 +6689,15 @@ name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -6768,7 +6827,7 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
- "futures",
+ "futures 0.3.31",
  "half",
  "hashbrown 0.15.2",
  "lz4_flex",
@@ -7080,10 +7139,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c834641d8ad1b348c9ee86dec3b9840d805acd5f24daa5f90c788951a52ff59b"
 
 [[package]]
 name = "pprof"
@@ -7223,9 +7297,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -7819,9 +7893,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -7863,7 +7937,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -8017,8 +8091,8 @@ dependencies = [
  "chromiumoxide",
  "chrono",
  "config",
- "env_logger 0.10.2",
- "futures",
+ "env_logger 0.11.8",
+ "futures 0.3.31",
  "lettre",
  "log",
  "once_cell",
@@ -8563,7 +8637,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "time",
  "tracing",
@@ -8671,7 +8745,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aab1592d17860a9a8584d9b549aebcd06f7bdc3ff615f71752486ba0b05b1e6e"
 dependencies = [
- "futures",
+ "futures 0.3.31",
  "sea-query",
  "sea-schema-derive",
 ]
@@ -9022,16 +9096,6 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
-dependencies = [
- "doc-comment",
- "snafu-derive 0.6.10",
-]
-
-[[package]]
-name = "snafu"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
@@ -9047,17 +9111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
 dependencies = [
  "snafu-derive 0.8.5",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -9448,8 +9501,14 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -9462,6 +9521,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.106",
 ]
 
@@ -9551,16 +9622,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "07cec4dc2d2e357ca1e610cfb07de2fa7a10fc3e9fe89f72545f3d244ea87753"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
- "windows 0.57.0",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -10329,7 +10400,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9f0a709784e86923586cff0d872dba54cd2d2e116b3bc57587d15737cfce9d"
 dependencies = [
- "futures",
+ "futures 0.3.31",
  "pin-project-lite",
  "tokio",
 ]
@@ -10611,7 +10682,7 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -10706,7 +10777,7 @@ dependencies = [
  "grok",
  "hex",
  "hmac",
- "hostname 0.4.0",
+ "hostname",
  "iana-time-zone",
  "idna",
  "indexmap 2.11.3",
@@ -11049,12 +11120,24 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -11068,21 +11151,33 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-link",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11091,9 +11186,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.57.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11107,22 +11202,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result 0.2.0",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -11136,6 +11232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11143,6 +11248,15 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -11225,6 +11339,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -11444,9 +11567,9 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+checksum = "eb3e137310115a65136898d2079f003ce33331a6c4b0d51f1531d1be082b6425"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -11615,22 +11738,36 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.11.3",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f852905151ac8d4d06fdca66520a661c09730a74c6d4e2b0f27b436b382e532"
+dependencies = [
  "aes",
  "arbitrary",
- "bzip2 0.5.2",
+ "bzip2 0.6.0",
  "constant_time_eq",
  "crc32fast",
  "deflate64",
  "flate2",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "hmac",
  "indexmap 2.11.3",
- "lzma-rs",
+ "lzma-rust2",
  "memchr",
  "pbkdf2",
+ "ppmd-rust",
  "sha1",
  "time",
- "xz2",
  "zeroize",
  "zopfli",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ clap = { version = "4.1", default-features = false, features = [
     "suggestions",
     "cargo",
 ] }
-cloudevents-sdk = { version = "0.7.0", features = ["actix"] }
+cloudevents-sdk = { version = "0.8.0", features = ["actix"] }
 cron.workspace = true
 csv = "1.3"
 dashmap.workspace = true
@@ -122,7 +122,6 @@ prettytable-rs = "0.10.0"
 pyroscope = { version = "0.5.8", optional = true }
 pyroscope_pprofrs = { version = "0.2.8", optional = true }
 rand.workspace = true
-getrandom.workspace = true
 rayon.workspace = true
 regex.workspace = true
 regex-syntax.workspace = true
@@ -157,7 +156,7 @@ utoipa.workspace = true
 utoipa-swagger-ui.workspace = true
 version-compare = "0.2.0"
 vector-enrichment.workspace = true
-x509-parser = "0.17.0"
+x509-parser = "0.18.0"
 vrl.workspace = true
 zstd.workspace = true
 config.workspace = true
@@ -268,17 +267,16 @@ object_store = { version = "0.12.3", features = ["aws", "azure", "gcp"] }
 sqlparser = { version = "0.58.0", features = ["serde", "visitor"] }
 dotenv_config = "0.2.2"
 dotenvy = "0.15.7"
-env_logger = "0.10"
+env_logger = "0.11.8"
 faststr = { version = "0.2", features = ["serde"] }
 flate2 = { version = "1.0", features = ["zlib"] }
 futures = "0.3"
 get_if_addrs = "0.5"
-getrandom = "0.2.15"
 hashlink = "0.10"
-hashbrown = { version = "0.15", features = ["serde"] }
+hashbrown = { version = "0.16.0", features = ["serde"] }
 hex = "0.4"
 indexmap = { version = "2.7", features = ["serde"] }
-itertools = "0.13"
+itertools = "0.14"
 lettre = { version = "0.11", default-features = false, features = [
     "builder",
     "hostname",
@@ -288,11 +286,11 @@ lettre = { version = "0.11", default-features = false, features = [
     "tokio1-rustls-tls",
 ] }
 log = "0.4"
-md5 = "0.7.0"
+md5 = "0.8.0"
 memchr = "2.7"
 murmur3 = "0.5"
 once_cell = "1.20"
-ordered-float = { version = "4.5.0", features = ["serde"] }
+ordered-float = { version = "5.0.0", features = ["serde"] }
 opentelemetry = "0.30"
 opentelemetry_sdk = { version = "0.30", features = [
     "experimental_trace_batch_span_processor_with_async_runtime",
@@ -320,7 +318,7 @@ parking_lot = "0.12"
 prometheus = { version = "0.13", features = ["process"] }
 prost = "0.13.1"
 prost-wkt-types = "0.6"
-rand = "0.8"
+rand = "0.9.2"
 rayon = "1.10"
 regex = "1.11"
 regex-syntax = "0.8"
@@ -359,9 +357,9 @@ sqlx = { version = "0.8.3", features = [
     "sqlite",
     "chrono",
 ] }
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 svix-ksuid = { version = "0.8", features = ["serde"] }
-sysinfo = "0.33"
+sysinfo = "0.37"
 tantivy = { version = "0.24", features = ["quickwit"] }
 tantivy-fst = "0.5"
 tempfile = "3"
@@ -391,5 +389,5 @@ utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 uuid = { version = "1.18.1", features = ["v7"] }
 vector-enrichment = { version = "0.1.0", package = "enrichment", git = "https://github.com/openobserve/vector", rev = "063cabbbf4bc6f75794fa0ccd3b0bd5c074f0e35" }
 vrl = { version = "0.22", features = ["value", "compiler", "test"] }
-zip = "3.0.0"
+zip = "5.1.1"
 zstd = "0.13"

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -36,7 +36,6 @@ dotenvy.workspace = true
 faststr.workspace = true
 futures.workspace = true
 get_if_addrs.workspace = true
-getrandom.workspace = true
 gxhash = { version = "~3.4.1", optional = true }
 hashbrown.workspace = true
 hex.workspace = true

--- a/src/config/src/ider.rs
+++ b/src/config/src/ider.rs
@@ -108,7 +108,7 @@ pub fn get_start_time_from_trace_id(trace_id: &str) -> Option<i64> {
 
 /// Generate a new span_id.
 pub fn generate_span_id() -> String {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut bytes = [0u8; 8];
     rng.fill(&mut bytes);
 

--- a/src/config/src/utils/sysinfo/cpu.rs
+++ b/src/config/src/utils/sysinfo/cpu.rs
@@ -65,7 +65,12 @@ mod tests {
 
     #[test]
     fn test_sysinfo_get_cpu_usage() {
-        assert!(get_cpu_usage() > 0.0);
+        let usage = get_cpu_usage();
+        assert!(
+            usage >= 0.0 && usage <= 100.0,
+            "CPU usage should be between 0 and 100, got {}",
+            usage
+        );
     }
 
     #[test]

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -1762,7 +1762,7 @@ mod tests {
 
         // Test with very long names
         let long_name = "a".repeat(1000);
-        let module_key = format!("logs/org123/{}/pipeline_id", long_name);
+        let module_key = format!("logs/org123/{long_name}/pipeline_id");
         let result = get_pipeline_info_from_module_key(&module_key);
 
         assert!(result.is_ok());

--- a/src/service/search/datafusion/distributed_plan/remote_scan.rs
+++ b/src/service/search/datafusion/distributed_plan/remote_scan.rs
@@ -86,7 +86,7 @@ impl RemoteScanExec {
             .filter_map(|(idx, n)| if n.is_querier() { Some(idx) } else { None })
             .collect::<Vec<_>>();
         // random shuffle the node ids
-        node_ids.shuffle(&mut rand::thread_rng());
+        node_ids.shuffle(&mut rand::rng());
         let enrich_mode_node_idx = node_ids.pop().unwrap_or_default();
 
         Ok(RemoteScanExec {

--- a/src/service/search/datafusion/optimizer/physical_optimizer/index_optimizer/mod.rs
+++ b/src/service/search/datafusion/optimizer/physical_optimizer/index_optimizer/mod.rs
@@ -329,12 +329,12 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
         let plan: Arc<dyn ExecutionPlan> = Arc::new(NewEmptyExec::new(
             "my_table",
-            schema.clone().into(),
+            schema.clone(),
             None,
             &[],
             None,
             false,
-            schema.clone().into(),
+            schema.clone(),
         ));
 
         let mut visitor = TableNameVisitor::new();
@@ -352,12 +352,12 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
         let child: Arc<dyn ExecutionPlan> = Arc::new(NewEmptyExec::new(
             "child",
-            schema.clone().into(),
+            schema.clone(),
             None,
             &[],
             None,
             false,
-            schema.clone().into(),
+            schema.clone(),
         ));
 
         let remote_node =

--- a/src/service/search/grpc_search.rs
+++ b/src/service/search/grpc_search.rs
@@ -23,7 +23,7 @@ use infra::{
     client::grpc::make_grpc_search_client,
     errors::{Error, ErrorCodes},
 };
-use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
+use rand::{SeedableRng, rngs::StdRng, seq::IndexedRandom};
 use tracing::{Instrument, info_span};
 
 use crate::{common::infra::cluster as infra_cluster, service::search::server_internal_error};
@@ -48,7 +48,7 @@ pub async fn grpc_search(
         return Err(server_internal_error("no querier node online"));
     }
 
-    let mut rng = StdRng::from_entropy();
+    let mut rng = StdRng::seed_from_u64(rand::random());
     let node = nodes.choose(&mut rng).unwrap().clone();
 
     // make cluster request
@@ -120,7 +120,7 @@ pub async fn grpc_search_multi(
         return Err(server_internal_error("no querier node online"));
     }
 
-    let mut rng = StdRng::from_entropy();
+    let mut rng = StdRng::seed_from_u64(rand::random());
     let node = nodes.choose(&mut rng).unwrap().clone();
 
     // make cluster request
@@ -172,8 +172,6 @@ pub async fn grpc_search_multi(
     Ok(response)
 }
 
-// Not sure why it's generating a warning, no time to debug right now
-#[allow(dead_code)]
 #[tracing::instrument(name = "service:search:grpc_search_partition", skip_all)]
 pub async fn grpc_search_partition(
     trace_id: &str,
@@ -194,7 +192,7 @@ pub async fn grpc_search_partition(
         return Err(server_internal_error("no querier node online"));
     }
 
-    let mut rng = StdRng::from_entropy();
+    let mut rng = StdRng::seed_from_u64(rand::random());
     let node = nodes.choose(&mut rng).unwrap().clone();
 
     // make cluster request


### PR DESCRIPTION
### **User description**
- `cloudevents-sdk`: v0.7.0 -> v0.8.0
- `env_logger`: v0.10 -> v0.11.8
- `hashbrown`: v0.15 -> v0.16.0
- `itertools`: v0.13 -> v0.14
- `md5`: v0.7.0 -> v0.8.0
- `ordered-float`: v4.5.0 -> v5.0.0
- `rand`: v0.8 -> v0.9.2
- `strum`: v0.26 -> v0.27
- `sysinfo`: v0.33 -> v0.37
- `x509-parser`: v0.17.0 -> v0.18.0

Also remove `getrandom` from dependencies


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Upgrade multiple crate dependencies

- Migrate to rand 0.9 APIs

- Remove direct getrandom usage

- Adjust imports for API changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  deps["Dependency versions updated"] -- "rand 0.9" --> randapi["Migrate RNG APIs"]
  randapi -- "thread_rng -> rng()" --> code1["generate_span_id"]
  randapi -- "getrandom removed" --> code2["utils::rand helpers"]
  randapi -- "SliceRandom -> IndexedRandom" --> code3["grpc_search node selection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ider.rs</strong><dd><code>Update span ID generation to rand 0.9</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/ider.rs

<ul><li>Use <code>rand::rng()</code> instead of <code>thread_rng()</code><br> <li> Fill span-id bytes via new RNG API</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8593/files#diff-6ea42b8eab8ba0708f93f9a8b44056d9a9e6ac42517ffba12f81420d6b0bd2b0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rand.rs</strong><dd><code>Refactor random utilities for rand 0.9</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/utils/rand.rs

<ul><li>Switch to <code>rand::rng()</code> and <code>Rng::fill</code><br> <li> Replace <code>getrandom</code> calls with <code>rand</code> RNG<br> <li> Update imports to <code>distr::Alphanumeric</code>, <code>SampleString</code><br> <li> Use <code>sample_string</code> with new RNG API</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8593/files#diff-0d3428b49ff2b4ccd88510d8f7ca07672e20cfe8aae3a05a093b39409b45f1cc">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>remote_scan.rs</strong><dd><code>Migrate node shuffle to rand 0.9</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/datafusion/distributed_plan/remote_scan.rs

- Use `rand::rng()` for shuffling nodes


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8593/files#diff-bedf6eb5852c3d7f49b8a7aad163acd5eaef2c2a5f73961020c7822cedab3fef">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>grpc_search.rs</strong><dd><code>Update RNG usage and imports in gRPC search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/grpc_search.rs

<ul><li>Replace <code>SliceRandom</code> with <code>IndexedRandom</code><br> <li> Seed <code>StdRng</code> via <code>seed_from_u64(rand::random())</code><br> <li> Remove unnecessary dead_code allow</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8593/files#diff-017a31d3b88229bd95098e93ae249b34647b3919b8c49be06ba482b8787423ba">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Dependency upgrades and cleanup in workspace manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<ul><li>Bump multiple dependency versions<br> <li> Upgrade <code>rand</code> to 0.9.2<br> <li> Remove <code>getrandom</code> dependency<br> <li> Update <code>env_logger</code>, <code>x509-parser</code>, <code>zip</code>, others</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8593/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+11/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Remove getrandom from config crate deps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/Cargo.toml

- Remove `getrandom` from workspace members


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8593/files#diff-a70836e42ee2ff2af5068df047dd443758a0edc910d8ec5a01780396a69c9a9e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

