### PR TITLE
fix: consider all fts fields to ignore for distinct values

### DIFF
--- a/src/migration/dashboards.rs
+++ b/src/migration/dashboards.rs
@@ -24,7 +24,7 @@ use config::{
 use hashbrown::HashMap;
 use infra::{
     db as infra_db,
-    schema::{get_settings, get_stream_setting_fts_fields},
+    schema::get_settings,
     table::{
         dashboards,
         distinct_values::{self, DistinctFieldRecord, OriginType},

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use config::{
-    SQL_FULL_TEXT_SEARCH_FIELDS, TIMESTAMP_COL_NAME, ider,
+    TIMESTAMP_COL_NAME, ider,
     meta::{
         dashboards::{Dashboard, ListDashboardsParams},
         folder::{DEFAULT_FOLDER, Folder, FolderType},
@@ -195,7 +195,7 @@ async fn update_distinct_variables(
                 .unwrap_or_default();
             let mut _new_added = false;
 
-            let _fts = get_stream_setting_fts_fields(&Some(stream_settings));
+            let _fts = get_stream_setting_fts_fields(&Some(stream_settings.clone()));
             for f in fields.iter() {
                 // we ignore full text search no matter what
                 if _fts.contains(f) {

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -646,7 +646,7 @@ pub async fn update_stream_settings(
             .retain(|range| !new_settings.extended_retention_days.remove.contains(range));
     }
 
-    let _fts = get_stream_setting_fts_fields(&Some(settings));
+    let _fts = get_stream_setting_fts_fields(&Some(settings.clone()));
 
     if !new_settings.distinct_value_fields.add.is_empty() {
         for f in &new_settings.distinct_value_fields.add {


### PR DESCRIPTION
### **User description**
Consider all fts fields including env specified fts fields for ignoring in distinct field setup


___

### **PR Type**
Bug fix


___

### **Description**
- Exclude all FTS fields from distinct setup

- Use global and per-stream FTS sources

- Add config constant checks for FTS fields

- Centralize FTS retrieval via schema helper


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CFG["SQL_FULL_TEXT_SEARCH_FIELDS (config)"]
  SCH["get_stream_setting_fts_fields (schema)"]
  MIG["migration/dashboards.rs"]
  SVCDB["service/dashboards/mod.rs"]
  SVCSTR["service/stream.rs"]

  CFG -- "global FTS list" --> MIG
  SCH -- "resolve stream FTS" --> MIG
  SCH -- "resolve stream FTS" --> SVCDB
  SCH -- "resolve stream FTS" --> SVCSTR

  MIG -- "skip FTS in distinct" --> Distinct["Distinct setup"]
  SVCDB -- "skip FTS in distinct" --> Distinct
  SVCSTR -- "skip FTS in distinct" --> Distinct
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboards.rs</strong><dd><code>Ignore global and stream FTS in migration distincts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/migration/dashboards.rs

<ul><li>Import <code>SQL_FULL_TEXT_SEARCH_FIELDS</code> and <code>get_stream_setting_fts_fields</code><br> <li> Skip adding distinct fields if in global or stream FTS<br> <li> Preserve existing reserved field checks</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8601/files#diff-eba7ddaafafa0efbc35474fd19af320f0cce754dc6048bf4ce3d9ff3f22358b1">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Use unified FTS set when updating dashboard distincts</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/dashboards/mod.rs

<ul><li>Import <code>SQL_FULL_TEXT_SEARCH_FIELDS</code> and schema FTS helper<br> <li> Use <code>get_stream_setting_fts_fields</code> to filter FTS<br> <li> Continue ignoring reserved fields like timestamp and count</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8601/files#diff-6ae9e22ced40c50675dde5348b8d696f6559655bbbded915d7e6e88bf64b71a6">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stream.rs</strong><dd><code>Centralize FTS filtering in stream settings update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/stream.rs

<ul><li>Import <code>get_stream_setting_fts_fields</code><br> <li> Precompute FTS set from settings<br> <li> Skip distinct additions if in FTS or newly added FTS</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8601/files#diff-41452a7fb29b4634437174fd6aecf6a9050dbfdef41b9077a21d59af3d79e9ed">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

