### PR TITLE
fix: should not show checkbox before loading columns

### DIFF
--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -308,7 +308,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <template v-slot:header="props">
             <q-tr :props="props">
               <!-- Adding this block to render the select-all checkbox -->
-              <q-th auto-width>
+              <q-th v-if="columns.length > 0">
                 <q-checkbox
                   v-model="props.selected"
                   size="sm"


### PR DESCRIPTION
### **User description**
This PR fixes the issue in https://github.com/openobserve/openobserve/issues/8615


___

### **PR Type**
Bug fix


___

### **Description**
- Hide select-all checkbox until columns load

- Prevent checkbox misalignment on initial render

- Apply conditional header cell rendering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["PipelinesList header render"] -- "columns.length == 0" --> Hidden["Do not render q-th/checkbox"]
  UI -- "columns.length > 0" --> Visible["Render q-th with select-all checkbox"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PipelinesList.vue</strong><dd><code>Conditionally render select-all checkbox based on columns</code></dd></summary>
<hr>

web/src/components/pipeline/PipelinesList.vue

<ul><li>Gate header checkbox rendering on columns length<br> <li> Replace unconditional q-th with v-if="columns.length > 0"<br> <li> Prevents checkbox appearing before columns load</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8618/files#diff-85e3ef322f3eea0fc6d74d89431ba338a1153cb82ee06bef0f7c5f439c04267d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

