### PR TITLE
fix: Add CC0-1.0 license to allow list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -50,6 +50,7 @@ allow = [
     "Unicode-3.0", # OSI
     "ISC", # OSI + fsf free
     "BSL-1.0",
+    "CC0-1.0"
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
### **User description**
# PR Type
Fix

# Description
cargo builds were failing on the license checking. Reason being the zip crate needed a sub dependency `ppmd-rust` which is CC0-1.0 which wasn't explicitly listed in the allowed licenses. This broke builds. We are adding it back ti fix this.


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Allow CC0-1.0 in license policy

- Unblocks cargo license checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  deny["deny.toml license allowlist"] -- "add" --> cc0["CC0-1.0"]
  cc0 -- "permits" --> cargo["Cargo license check passes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deny.toml</strong><dd><code>Add CC0-1.0 to allowed licenses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deny.toml

<ul><li>Added <code>CC0-1.0</code> to <code>allow</code> licenses list.<br> <li> Keeps existing allowed licenses unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8626/files#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3de">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

