### PR TITLE
fix: distinct values has no _timestamp

### DIFF
--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -112,7 +112,7 @@ impl DistinctValues {
             get_config().limit.distinct_values_interval,
             {
                 if let Err(e) = INSTANCE.flush().await {
-                    log::error!("[DISTINCT_VALUES] error flush data to wal: {}", e);
+                    log::error!("[DISTINCT_VALUES] error flush data to wal: {e}");
                 }
             }
         );
@@ -219,7 +219,7 @@ impl Metadata for DistinctValues {
                 infra::schema::get_cache(&org_id, &distinct_stream_name, StreamType::Metadata)
                     .await?;
             let mut is_new = false;
-            if db_schema.fields_map().is_empty() {
+            if !db_schema.fields_map().contains_key(TIMESTAMP_COL_NAME) {
                 is_new = true;
                 let schema = default_schema.as_ref().clone();
                 if let Err(e) = db::schema::merge(

--- a/src/service/metadata/distinct_values.rs
+++ b/src/service/metadata/distinct_values.rs
@@ -137,7 +137,7 @@ fn handle_channel() -> Arc<mpsc::Sender<DvEvent>> {
             };
             if let DvEventType::Shutudown = event.ev_type {
                 if let Err(e) = INSTANCE.flush().await {
-                    log::error!("[DISTINCT_VALUES] flush error: {}", e);
+                    log::error!("[DISTINCT_VALUES] flush error: {e}");
                 }
                 INSTANCE.shutdown.store(true, Ordering::Release);
                 break;
@@ -231,7 +231,7 @@ impl Metadata for DistinctValues {
                 )
                 .await
                 {
-                    log::error!("[DISTINCT_VALUES] error while setting schema: {}", e);
+                    log::error!("[DISTINCT_VALUES] error while setting schema: {e}");
                     return Err(Error::Message(e.to_string()));
                 }
             }


### PR DESCRIPTION
There is no `_timestamp` field in schema but the schema has other fields in some edge case. for example we lost some events for super cluster.