### PR TITLE
fix: stream stats merge

### DIFF
--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -411,14 +411,17 @@ impl StreamStats {
     pub fn add_file_meta(&mut self, meta: &FileMeta) {
         self.file_num += 1;
         self.doc_num = max(0, self.doc_num + meta.records);
-        self.doc_time_min = self.doc_time_min.min(meta.min_ts);
+        self.doc_time_min = if self.doc_time_min == 0 {
+            meta.min_ts
+        } else if meta.min_ts == 0 {
+            self.doc_time_min
+        } else {
+            self.doc_time_min.min(meta.min_ts)
+        };
         self.doc_time_max = self.doc_time_max.max(meta.max_ts);
         self.storage_size += meta.original_size as f64;
         self.compressed_size += meta.compressed_size as f64;
         self.index_size += meta.index_size as f64;
-        if self.doc_time_min == 0 {
-            self.doc_time_min = meta.min_ts;
-        }
         if self.storage_size < 0.0 {
             self.storage_size = 0.0;
         }
@@ -436,16 +439,25 @@ impl StreamStats {
         self.storage_size = stats.storage_size;
         self.compressed_size = stats.compressed_size;
         self.index_size = stats.index_size;
-        self.doc_time_min = self.doc_time_min.min(stats.doc_time_min);
+        self.doc_time_min = if self.doc_time_min == 0 {
+            stats.doc_time_min
+        } else if stats.doc_time_min == 0 {
+            self.doc_time_min
+        } else {
+            self.doc_time_min.min(stats.doc_time_min)
+        };
         self.doc_time_max = self.doc_time_max.max(stats.doc_time_max);
-        if self.doc_time_min == 0 {
-            self.doc_time_min = stats.doc_time_min;
-        }
     }
 
     pub fn merge(&mut self, other: &StreamStats) {
         self.created_at = self.created_at.min(other.created_at);
-        self.doc_time_min = self.doc_time_min.min(other.doc_time_min);
+        self.doc_time_min = if self.doc_time_min == 0 {
+            other.doc_time_min
+        } else if other.doc_time_min == 0 {
+            self.doc_time_min
+        } else {
+            self.doc_time_min.min(other.doc_time_min)
+        };
         self.doc_time_max = self.doc_time_max.max(other.doc_time_max);
         self.doc_num += other.doc_num;
         self.file_num += other.file_num;


### PR DESCRIPTION
### **User description**
The `doc_time_min` become `zero` when we merge stream stats in super cluster.


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent zero timestamp overriding min time

- Correct doc_time_min handling in merges

- Align add/format/merge zero-check logic

- Preserve existing min when incoming is zero


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AddFileMeta["add_file_meta: robust min selection"] -- uses --> ZeroCheck["zero-aware min logic"]
  FormatBy["format_by: adopt zero-aware min"] -- uses --> ZeroCheck
  Merge["merge: zero-safe min merge"] -- uses --> ZeroCheck
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stream.rs</strong><dd><code>Zero-safe min timestamp across stats operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/stream.rs

<ul><li>Make <code>doc_time_min</code> selection zero-aware.<br> <li> Update add_file_meta, format_by, merge logic.<br> <li> Remove redundant post-check assignments.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8648/files#diff-2438d04c3fe97bc5452e5b74a303163b8723d93455cda32c95f0525435ad46bd">+21/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

