### PR TITLE
fix: redirect to login page on unauthorised error with http2 streaming

### DIFF
--- a/web/src/composables/useStreamingSearch.ts
+++ b/web/src/composables/useStreamingSearch.ts
@@ -357,6 +357,11 @@ const useHttpStreaming = () => {
     } catch (error) {
       if ((error as any).name === 'AbortError') {
        // console.error('Stream was canceled');
+      } else if((error as any).status === 401) {
+        store.dispatch("logout");
+        localStorage.clear();
+        sessionStorage.clear();
+        window.location.reload();
       } else {
         onError(traceId, error);
       }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Handle 401 during HTTP2 streaming

- Trigger logout and clear storages

- Reload app to force auth flow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP2 streaming request"] -- "error caught" --> B["Check error type"]
  B -- "AbortError" --> C["Ignore silently"]
  B -- "status === 401" --> D["Dispatch logout"]
  D -- "then" --> E["Clear localStorage/sessionStorage"]
  E -- "then" --> F["window.location.reload()"]
  B -- "other errors" --> G["onError(traceId, error)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useStreamingSearch.ts</strong><dd><code>Add unauthorized handling in streaming error catch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useStreamingSearch.ts

<ul><li>Add 401 error handling branch.<br> <li> Dispatch <code>logout</code> on unauthorized error.<br> <li> Clear local and session storage.<br> <li> Reload page to restart auth flow.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8656/files#diff-8fce3e25a161cd458e734bd9b1f98aadefe3482da7b6529a5b1f4fa20ec115e2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

