### PR TITLE
fix: update tooltip text for JSON editor in pipeline component #8537

### DIFF
--- a/web/src/components/pipeline/PipelineEditor.vue
+++ b/web/src/components/pipeline/PipelineEditor.vue
@@ -56,7 +56,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           data-test="pipeline-json-edit-btn"
           @click="openJsonEditor"
         >
-              <q-tooltip>{{ t("dashboard.editJson") }}</q-tooltip>
+              <q-tooltip>{{ t("pipeline.editJson") }}</q-tooltip>
             </q-btn>
       <q-btn
         data-test="add-pipeline-cancel-btn"

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -527,7 +527,8 @@
     "edit": "Edit",
     "delete": "Delete",
     "view": "View",
-    "delay": "Delay"
+    "delay": "Delay",
+    "editJson": "Edit Pipeline JSON"
   },
   "function": {
     "header": "Functions",


### PR DESCRIPTION
 ## Summary
   - Fixed tooltip text in pipeline JSON editor to show "Edit Pipeline JSON" instead of "Edit Dashboard JSON"
   - Closes #8537

   ## Changes Made
   - Added `pipeline.editJson` translation key to English translations
   - Updated PipelineEditor.vue to use correct translation key `t("pipeline.editJson")`

   ## Test Plan
   - [x] Verified tooltip now displays correct text for pipeline JSON editor
   - [x] Confirmed dashboard tooltips remain unaffected
