### PR TITLE
fix: optimize cache metadata

### DIFF
--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -248,7 +248,7 @@ pub async fn check_cache(
         }
 
         // Only consider it a full cache hit if we have enough records AND no time gaps
-        let deltas = if total_hits == (sql.limit as usize) && deltas.is_empty() {
+        let deltas = if total_hits >= (sql.limit as usize) && deltas.is_empty() {
             *should_exec_query = false;
             vec![]
         } else {

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -137,10 +137,14 @@ pub async fn search(
             delta_end_time: req.query.end_time,
         });
     } else if use_cache {
-        log::info!(
-            "[trace_id {trace_id}] Query deltas are: {:?}",
-            c_resp.deltas
-        );
+        if c_resp.deltas.is_empty() {
+            log::info!("[trace_id {trace_id}] Query hit full cache");
+        } else {
+            log::info!(
+                "[trace_id {trace_id}] Query deltas are: {:?}",
+                c_resp.deltas
+            );
+        }
     }
 
     let search_role = "cache".to_string();
@@ -807,17 +811,24 @@ pub async fn write_results(
     // 1. alignment time range for incomplete records for histogram
     let mut accept_start_time = req_query_start_time;
     let mut accept_end_time = req_query_end_time;
+    let mut need_adjust_end_time = false;
     if is_aggregate && let Some(interval) = res.histogram_interval {
         let interval = interval * 1000 * 1000; // convert to microseconds
         // next interval of start_time
-        accept_start_time = accept_start_time - (accept_start_time % interval) + interval;
+        if (accept_start_time % interval) != 0 {
+            accept_start_time = accept_start_time - (accept_start_time % interval) + interval;
+        }
         // previous interval of end_time
-        accept_end_time = accept_end_time - (accept_end_time % interval) - interval;
+        if (accept_end_time % interval) != 0 {
+            need_adjust_end_time = true;
+            accept_end_time = accept_end_time - (accept_end_time % interval) - interval;
+        }
     }
 
     // 2. get the data time range, check if need to remove records with discard_duration
     let delay_ts = second_micros(get_config().limit.cache_delay_secs);
-    let accept_end_time = std::cmp::min(Utc::now().timestamp_micros() - delay_ts, accept_end_time);
+    let mut accept_end_time =
+        std::cmp::min(Utc::now().timestamp_micros() - delay_ts, accept_end_time);
     let last_rec_ts = get_ts_value(ts_column, res.hits.last().unwrap());
     let first_rec_ts = get_ts_value(ts_column, res.hits.first().unwrap());
     let data_start_time = std::cmp::min(first_rec_ts, last_rec_ts);
@@ -845,25 +856,24 @@ pub async fn write_results(
     }
 
     // 4. check if the time range is less than discard_duration
-    let last_rec_ts = get_ts_value(ts_column, res.hits.last().unwrap());
-    let first_rec_ts = get_ts_value(ts_column, res.hits.first().unwrap());
-    let cache_start_time = std::cmp::min(first_rec_ts, last_rec_ts);
-    let mut cache_end_time = std::cmp::max(first_rec_ts, last_rec_ts);
-    if (cache_end_time - cache_start_time) < delay_ts {
+    if (accept_end_time - accept_start_time) < delay_ts {
         log::info!("[trace_id {trace_id}] Time range is too short for caching, skipping caching");
         return;
     }
 
     // 5. adjust the cache time range
-    if is_aggregate && let Some(interval) = res.histogram_interval {
-        cache_end_time += interval * 1000 * 1000;
+    if need_adjust_end_time
+        && is_aggregate
+        && let Some(interval) = res.histogram_interval
+    {
+        accept_end_time += interval * 1000 * 1000;
     }
 
     // 6. cache to disk
     let file_name = format!(
         "{}_{}_{}_{}.json",
-        cache_start_time,
-        cache_end_time,
+        accept_start_time,
+        accept_end_time,
         if is_aggregate { 1 } else { 0 },
         if is_descending { 1 } else { 0 }
     );
@@ -883,8 +893,8 @@ pub async fn write_results(
                         .entry(query_key)
                         .or_insert_with(Vec::new)
                         .push(ResultCacheMeta {
-                            start_time: cache_start_time,
-                            end_time: cache_end_time,
+                            start_time: accept_start_time,
+                            end_time: accept_end_time,
                             is_aggregate,
                             is_descending,
                         });

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -136,15 +136,8 @@ pub async fn search(
             delta_start_time: req.query.start_time,
             delta_end_time: req.query.end_time,
         });
-    } else if use_cache {
-        if c_resp.deltas.is_empty() {
-            log::info!("[trace_id {trace_id}] Query hit full cache");
-        } else {
-            log::info!(
-                "[trace_id {trace_id}] Query deltas are: {:?}",
-                c_resp.deltas
-            );
-        }
+    } else if use_cache && c_resp.deltas.is_empty() {
+        log::info!("[trace_id {trace_id}] Query hit full cache");
     }
 
     let search_role = "cache".to_string();

--- a/tests/api-testing/tests/test_streaming.py
+++ b/tests/api-testing/tests/test_streaming.py
@@ -1219,7 +1219,7 @@ def test_streaming_sql_query_range(create_session, base_url):
     sixtyone_min_ago = int((now - timedelta(minutes=61)).timestamp() * 1000000)
     json_sql_query_range = {
         "query": {
-            "sql": f'SELECT * FROM "{stream_name}"',
+            "sql": f'SELECT count(*) AS _max_query_range FROM "{stream_name}"',
             "start_time": sixtyone_min_ago,
             "end_time": end_time,
             "from": 0,


### PR DESCRIPTION
### **User description**
- [x] cache metadata should use query time range
- [x] histogram should only fix when it need adjustment


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improve full cache hit detection

- Align histogram time bounds precisely

- Respect cache delay in end time

- Refine cache metadata time range


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cached responses"] -- "calculate_deltas_multi" --> B["Deltas & adjusted start/end"]
  B -- "no gaps + enough hits" --> C["Full cache hit"]
  B -- "gaps or not enough" --> D["Query deltas logged"]
  E["Write results"] -- "align histogram bounds" --> F["Adjusted accept_start/end"]
  F -- "apply cache delay & interval" --> G["Final cache time range"]
  G -- "persist" --> H["Cache file + metadata"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cacher.rs</strong><dd><code>Robust full cache hit logic with deltas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/cacher.rs

<ul><li>Compute deltas before full-hit check<br> <li> Update request start time from deltas<br> <li> Track total cache duration<br> <li> Require no gaps for full cache hit</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8671/files#diff-8c387b22b2c0a282600ee41ca702b3db60f5a284d507c0feb7418608ff062c6c">+13/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Precise histogram alignment and cache metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/mod.rs

<ul><li>Log full cache hit vs deltas<br> <li> Align histogram start/end only if misaligned<br> <li> Enforce cache delay on accepted end time<br> <li> Use aligned times for cache filename/metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8671/files#diff-f07bfacc0501b9c234e64b16c1dd8eb0ae8fcbe231f90c81fed72bcc94946f74">+28/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

