### PR TITLE
fix: remove select all placeholder for metrics

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1225,7 +1225,7 @@ pub struct Limit {
         help = "Maximum number of fields allowed in user-defined schema"
     )]
     pub user_defined_schema_max_fields: usize,
-    // MB, total data size in memory, default is 50% of system memory
+    // MB, total data size of memtable in memory
     #[env_config(name = "ZO_MEM_TABLE_MAX_SIZE", default = 0)]
     pub mem_table_max_size: usize,
     #[env_config(

--- a/src/service/promql/mod.rs
+++ b/src/service/promql/mod.rs
@@ -33,6 +33,7 @@ mod engine;
 mod exec;
 mod functions;
 pub mod name_visitor;
+mod rewrite;
 pub mod search;
 pub mod selector_visitor;
 mod utils;

--- a/src/service/promql/rewrite.rs
+++ b/src/service/promql/rewrite.rs
@@ -32,8 +32,8 @@ fn match_placeholder(matcher: &Matcher, placeholder: &str) -> bool {
     match &matcher.op {
         MatchOp::Equal => matcher.value == placeholder,
         MatchOp::NotEqual => matcher.value == placeholder,
-        MatchOp::Re(pattern) => pattern.to_string() == placeholder,
-        MatchOp::NotRe(pattern) => pattern.to_string() == placeholder,
+        MatchOp::Re(pattern) => pattern.is_match(placeholder),
+        MatchOp::NotRe(pattern) => pattern.is_match(placeholder),
     }
 }
 

--- a/src/service/promql/rewrite.rs
+++ b/src/service/promql/rewrite.rs
@@ -1,3 +1,18 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use promql_parser::{
     label::{MatchOp, Matcher},
     parser::VectorSelector,

--- a/src/service/promql/rewrite.rs
+++ b/src/service/promql/rewrite.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use config::get_config;
 use promql_parser::{
     label::{MatchOp, Matcher},
     parser::VectorSelector,
@@ -28,10 +29,7 @@ impl RemoveFilterAllRewriter {
 
 impl RemoveFilterAllRewriter {
     pub fn rewrite(&self, vs: &mut VectorSelector) {
-        let placeholder = config::get_config()
-            .common
-            .dashboard_placeholder
-            .to_string();
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
 
         vs.matchers
             .matchers
@@ -90,54 +88,55 @@ mod tests {
 
     #[test]
     fn test_match_placeholder_equal_op() {
-        let placeholder = "_o2_all_";
-        let matcher = create_test_matcher("label", MatchOp::Equal, placeholder);
-        assert!(match_placeholder(&matcher, placeholder));
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let matcher = create_test_matcher("label", MatchOp::Equal, &placeholder);
+        assert!(match_placeholder(&matcher, &placeholder));
 
         let non_matching_matcher = create_test_matcher("label", MatchOp::Equal, "other_value");
-        assert!(!match_placeholder(&non_matching_matcher, placeholder));
+        assert!(!match_placeholder(&non_matching_matcher, &placeholder));
     }
 
     #[test]
     fn test_match_placeholder_not_equal_op() {
-        let placeholder = "_o2_all_";
-        let matcher = create_test_matcher("label", MatchOp::NotEqual, placeholder);
-        assert!(match_placeholder(&matcher, placeholder));
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let matcher = create_test_matcher("label", MatchOp::NotEqual, &placeholder);
+        assert!(match_placeholder(&matcher, &placeholder));
 
         let non_matching_matcher = create_test_matcher("label", MatchOp::NotEqual, "other_value");
-        assert!(!match_placeholder(&non_matching_matcher, placeholder));
+        assert!(!match_placeholder(&non_matching_matcher, &placeholder));
     }
 
     #[test]
     fn test_match_placeholder_regex_op() {
-        let placeholder = "_o2_all_";
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
         let matcher =
-            create_test_matcher("label", MatchOp::Re(Regex::new("").unwrap()), placeholder);
-        assert!(match_placeholder(&matcher, placeholder));
+            create_test_matcher("label", MatchOp::Re(Regex::new("").unwrap()), &placeholder);
+        assert!(match_placeholder(&matcher, &placeholder));
 
         let non_matching_matcher =
             create_test_matcher("label", MatchOp::Re(Regex::new("").unwrap()), "other.*");
-        assert!(!match_placeholder(&non_matching_matcher, placeholder));
+        assert!(!match_placeholder(&non_matching_matcher, &placeholder));
     }
 
     #[test]
     fn test_match_placeholder_not_regex_op() {
-        let placeholder = "_o2_all_";
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
         let matcher = create_test_matcher(
             "label",
             MatchOp::NotRe(Regex::new("").unwrap()),
-            placeholder,
+            &placeholder,
         );
-        assert!(match_placeholder(&matcher, placeholder));
+        assert!(match_placeholder(&matcher, &placeholder));
 
         let non_matching_matcher =
             create_test_matcher("label", MatchOp::NotRe(Regex::new("").unwrap()), "other.*");
-        assert!(!match_placeholder(&non_matching_matcher, placeholder));
+        assert!(!match_placeholder(&non_matching_matcher, &placeholder));
     }
 
     #[test]
     fn test_remove_filter_all_removes_placeholder_matchers() {
-        let placeholder_matcher = create_test_matcher("env", MatchOp::Equal, "_o2_all_");
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let placeholder_matcher = create_test_matcher("env", MatchOp::Equal, &placeholder);
         let normal_matcher = create_test_matcher("service", MatchOp::Equal, "web");
 
         let mut vs =
@@ -152,10 +151,14 @@ mod tests {
 
     #[test]
     fn test_remove_filter_all_removes_all_placeholder_matchers() {
-        let placeholder_matcher1 = create_test_matcher("env", MatchOp::Equal, "_o2_all_");
-        let placeholder_matcher2 = create_test_matcher("region", MatchOp::NotEqual, "_o2_all_");
-        let placeholder_matcher3 =
-            create_test_matcher("cluster", MatchOp::Re(Regex::new("").unwrap()), "_o2_all_");
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let placeholder_matcher1 = create_test_matcher("env", MatchOp::Equal, &placeholder);
+        let placeholder_matcher2 = create_test_matcher("region", MatchOp::NotEqual, &placeholder);
+        let placeholder_matcher3 = create_test_matcher(
+            "cluster",
+            MatchOp::Re(Regex::new("").unwrap()),
+            &placeholder,
+        );
 
         let mut vs = create_vector_selector_with_matchers(vec![
             placeholder_matcher1,
@@ -191,7 +194,8 @@ mod tests {
 
     #[test]
     fn test_remove_filter_all_handles_or_matchers() {
-        let placeholder_matcher = create_test_matcher("env", MatchOp::Equal, "_o2_all_");
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let placeholder_matcher = create_test_matcher("env", MatchOp::Equal, &placeholder);
         let normal_matcher = create_test_matcher("service", MatchOp::Equal, "web");
 
         let mut vs = VectorSelector {

--- a/src/service/promql/rewrite.rs
+++ b/src/service/promql/rewrite.rs
@@ -1,0 +1,213 @@
+use promql_parser::{
+    label::{MatchOp, Matcher},
+    parser::VectorSelector,
+};
+
+struct RemoveFilterAllRewriter {}
+
+impl RemoveFilterAllRewriter {
+    pub fn new() -> Self {
+        RemoveFilterAllRewriter {}
+    }
+}
+
+impl RemoveFilterAllRewriter {
+    pub fn rewrite(&self, vs: &mut VectorSelector) {
+        let placeholder = config::get_config()
+            .common
+            .dashboard_placeholder
+            .to_string();
+
+        vs.matchers
+            .matchers
+            .retain(|m| !match_placeholder(m, &placeholder));
+        vs.matchers
+            .or_matchers
+            .iter_mut()
+            .for_each(|vs| vs.retain(|m| !match_placeholder(m, &placeholder)));
+    }
+}
+
+fn match_placeholder(matcher: &Matcher, placeholder: &str) -> bool {
+    match &matcher.op {
+        MatchOp::Equal => matcher.value == placeholder,
+        MatchOp::NotEqual => matcher.value == placeholder,
+        MatchOp::Re(pattern) => pattern.to_string() == placeholder,
+        MatchOp::NotRe(pattern) => pattern.to_string() == placeholder,
+    }
+}
+
+pub fn remove_filter_all(vs: &mut VectorSelector) {
+    RemoveFilterAllRewriter::new().rewrite(vs);
+}
+
+#[cfg(test)]
+mod tests {
+    use promql_parser::label::Matchers;
+    use regex::Regex;
+
+    use super::*;
+
+    fn create_test_matcher(name: &str, op: MatchOp, value: &str) -> Matcher {
+        Matcher {
+            name: name.to_string(),
+            op: match op {
+                MatchOp::Equal => MatchOp::Equal,
+                MatchOp::NotEqual => MatchOp::NotEqual,
+                MatchOp::Re(_) => MatchOp::Re(Regex::new(value).unwrap()),
+                MatchOp::NotRe(_) => MatchOp::NotRe(Regex::new(value).unwrap()),
+            },
+            value: value.to_string(),
+        }
+    }
+
+    fn create_vector_selector_with_matchers(matchers: Vec<Matcher>) -> VectorSelector {
+        VectorSelector {
+            name: Some("test_metric".to_string()),
+            matchers: Matchers {
+                matchers,
+                or_matchers: vec![],
+            },
+            offset: None,
+            at: None,
+        }
+    }
+
+    #[test]
+    fn test_match_placeholder_equal_op() {
+        let placeholder = "_o2_all_";
+        let matcher = create_test_matcher("label", MatchOp::Equal, placeholder);
+        assert!(match_placeholder(&matcher, placeholder));
+
+        let non_matching_matcher = create_test_matcher("label", MatchOp::Equal, "other_value");
+        assert!(!match_placeholder(&non_matching_matcher, placeholder));
+    }
+
+    #[test]
+    fn test_match_placeholder_not_equal_op() {
+        let placeholder = "_o2_all_";
+        let matcher = create_test_matcher("label", MatchOp::NotEqual, placeholder);
+        assert!(match_placeholder(&matcher, placeholder));
+
+        let non_matching_matcher = create_test_matcher("label", MatchOp::NotEqual, "other_value");
+        assert!(!match_placeholder(&non_matching_matcher, placeholder));
+    }
+
+    #[test]
+    fn test_match_placeholder_regex_op() {
+        let placeholder = "_o2_all_";
+        let matcher =
+            create_test_matcher("label", MatchOp::Re(Regex::new("").unwrap()), placeholder);
+        assert!(match_placeholder(&matcher, placeholder));
+
+        let non_matching_matcher =
+            create_test_matcher("label", MatchOp::Re(Regex::new("").unwrap()), "other.*");
+        assert!(!match_placeholder(&non_matching_matcher, placeholder));
+    }
+
+    #[test]
+    fn test_match_placeholder_not_regex_op() {
+        let placeholder = "_o2_all_";
+        let matcher = create_test_matcher(
+            "label",
+            MatchOp::NotRe(Regex::new("").unwrap()),
+            placeholder,
+        );
+        assert!(match_placeholder(&matcher, placeholder));
+
+        let non_matching_matcher =
+            create_test_matcher("label", MatchOp::NotRe(Regex::new("").unwrap()), "other.*");
+        assert!(!match_placeholder(&non_matching_matcher, placeholder));
+    }
+
+    #[test]
+    fn test_remove_filter_all_removes_placeholder_matchers() {
+        let placeholder_matcher = create_test_matcher("env", MatchOp::Equal, "_o2_all_");
+        let normal_matcher = create_test_matcher("service", MatchOp::Equal, "web");
+
+        let mut vs =
+            create_vector_selector_with_matchers(vec![placeholder_matcher, normal_matcher.clone()]);
+
+        remove_filter_all(&mut vs);
+
+        assert_eq!(vs.matchers.matchers.len(), 1);
+        assert_eq!(vs.matchers.matchers[0].name, "service");
+        assert_eq!(vs.matchers.matchers[0].value, "web");
+    }
+
+    #[test]
+    fn test_remove_filter_all_removes_all_placeholder_matchers() {
+        let placeholder_matcher1 = create_test_matcher("env", MatchOp::Equal, "_o2_all_");
+        let placeholder_matcher2 = create_test_matcher("region", MatchOp::NotEqual, "_o2_all_");
+        let placeholder_matcher3 =
+            create_test_matcher("cluster", MatchOp::Re(Regex::new("").unwrap()), "_o2_all_");
+
+        let mut vs = create_vector_selector_with_matchers(vec![
+            placeholder_matcher1,
+            placeholder_matcher2,
+            placeholder_matcher3,
+        ]);
+
+        remove_filter_all(&mut vs);
+
+        assert_eq!(vs.matchers.matchers.len(), 0);
+    }
+
+    #[test]
+    fn test_remove_filter_all_preserves_non_placeholder_matchers() {
+        let normal_matcher1 = create_test_matcher("service", MatchOp::Equal, "web");
+        let normal_matcher2 = create_test_matcher("env", MatchOp::NotEqual, "dev");
+        let normal_matcher3 =
+            create_test_matcher("version", MatchOp::Re(Regex::new("").unwrap()), "v1.*");
+
+        let mut vs = create_vector_selector_with_matchers(vec![
+            normal_matcher1,
+            normal_matcher2,
+            normal_matcher3,
+        ]);
+
+        remove_filter_all(&mut vs);
+
+        assert_eq!(vs.matchers.matchers.len(), 3);
+        assert_eq!(vs.matchers.matchers[0].name, "service");
+        assert_eq!(vs.matchers.matchers[1].name, "env");
+        assert_eq!(vs.matchers.matchers[2].name, "version");
+    }
+
+    #[test]
+    fn test_remove_filter_all_handles_or_matchers() {
+        let placeholder_matcher = create_test_matcher("env", MatchOp::Equal, "_o2_all_");
+        let normal_matcher = create_test_matcher("service", MatchOp::Equal, "web");
+
+        let mut vs = VectorSelector {
+            name: Some("test_metric".to_string()),
+            matchers: Matchers {
+                matchers: vec![normal_matcher.clone()],
+                or_matchers: vec![
+                    vec![placeholder_matcher.clone(), normal_matcher.clone()],
+                    vec![normal_matcher.clone()],
+                ],
+            },
+            offset: None,
+            at: None,
+        };
+
+        remove_filter_all(&mut vs);
+
+        assert_eq!(vs.matchers.matchers.len(), 1);
+        assert_eq!(vs.matchers.or_matchers.len(), 2);
+        assert_eq!(vs.matchers.or_matchers[0].len(), 1); // placeholder removed
+        assert_eq!(vs.matchers.or_matchers[1].len(), 1); // unchanged
+        assert_eq!(vs.matchers.or_matchers[0][0].name, "service");
+    }
+
+    #[test]
+    fn test_remove_filter_all_with_empty_matchers() {
+        let mut vs = create_vector_selector_with_matchers(vec![]);
+
+        remove_filter_all(&mut vs);
+
+        assert_eq!(vs.matchers.matchers.len(), 0);
+        assert_eq!(vs.matchers.or_matchers.len(), 0);
+    }
+}

--- a/src/service/search/sql/rewriter/remove_dashboard_placeholder.rs
+++ b/src/service/search/sql/rewriter/remove_dashboard_placeholder.rs
@@ -169,8 +169,9 @@ mod tests {
 
     #[test]
     fn test_remove_dashboard_all_visitor() {
-        let sql = "select * from t where field1 = '_o2_all_'";
-        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let sql = format!("select * from t where field1 = '{}'", placeholder);
+        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, &sql)
             .unwrap()
             .pop()
             .unwrap();
@@ -182,8 +183,9 @@ mod tests {
 
     #[test]
     fn test_remove_dashboard_all_visitor_with_in_list() {
-        let sql = "select * from t where field1 in ('_o2_all_')";
-        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let sql = format!("select * from t where field1 in ('{}')", placeholder);
+        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, &sql)
             .unwrap()
             .pop()
             .unwrap();
@@ -195,8 +197,9 @@ mod tests {
 
     #[test]
     fn test_remove_dashboard_all_visitor_with_in_list_and_negated() {
-        let sql = "select * from t where field1 not in ('_o2_all_')";
-        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let sql = format!("select * from t where field1 not in ('{}')", placeholder);
+        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, &sql)
             .unwrap()
             .pop()
             .unwrap();
@@ -208,8 +211,12 @@ mod tests {
 
     #[test]
     fn test_remove_dashboard_all_visitor_with_in_list_and_negated_and_other_filter() {
-        let sql = "select * from t where field1 not in ('_o2_all_') and field2 = 'value2'";
-        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let sql = format!(
+            "select * from t where field1 not in ('{}') and field2 = 'value2'",
+            placeholder
+        );
+        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, &sql)
             .unwrap()
             .pop()
             .unwrap();
@@ -222,8 +229,12 @@ mod tests {
     // test multi and/or with _o2_all_
     #[test]
     fn test_remove_dashboard_all_visitor_with_multi_and_or_with_o2_all() {
-        let sql = "select * from t where field1 = '_o2_all_' and (field2 = '_o2_all_' or field3 = '_o2_all_')";
-        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let sql = format!(
+            "select * from t where field1 = '{}' and (field2 = '{}' or field3 = '{}')",
+            placeholder, placeholder, placeholder
+        );
+        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, &sql)
             .unwrap()
             .pop()
             .unwrap();
@@ -236,8 +247,12 @@ mod tests {
     // test _o2_all_ with like and not like
     #[test]
     fn test_remove_dashboard_all_visitor_with_like_and_not_like() {
-        let sql = "select * from t where field1 like '_o2_all_' and field2 not like '_o2_all_'";
-        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let sql = format!(
+            "select * from t where field1 like '{}' and field2 not like '{}'",
+            placeholder, placeholder
+        );
+        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, &sql)
             .unwrap()
             .pop()
             .unwrap();
@@ -250,8 +265,12 @@ mod tests {
     // test _o2_all_ with like and not like
     #[test]
     fn test_remove_dashboard_all_visitor_with_like_and_not_like_and_other_filter() {
-        let sql = "select * from t where field1 like '_o2_all_' and field2 not like '_o2_all_' and field3 = 'value3'";
-        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let sql = format!(
+            "select * from t where field1 like '{}' and field2 not like '{}' and field3 = 'value3'",
+            placeholder, placeholder
+        );
+        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, &sql)
             .unwrap()
             .pop()
             .unwrap();
@@ -263,8 +282,12 @@ mod tests {
 
     #[test]
     fn test_remove_dashboard_all_visitor_with_str_match_and_other_filter() {
-        let sql = "select * from t where str_match(field1, '_o2_all_') and field2 = 'value2'";
-        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let sql = format!(
+            "select * from t where str_match(field1, '{}') and field2 = 'value2'",
+            placeholder
+        );
+        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, &sql)
             .unwrap()
             .pop()
             .unwrap();
@@ -276,8 +299,12 @@ mod tests {
 
     #[test]
     fn test_remove_dashboard_all_visitor_with_match_field_and_other_filter() {
-        let sql = "select * from t where match_field(field1, '_o2_all_') and field2 = 'value2'";
-        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+        let placeholder = get_config().common.dashboard_placeholder.to_string();
+        let sql = format!(
+            "select * from t where match_field(field1, '{}') and field2 = 'value2'",
+            placeholder
+        );
+        let mut statement = sqlparser::parser::Parser::parse_sql(&GenericDialect {}, &sql)
             .unwrap()
             .pop()
             .unwrap();


### PR DESCRIPTION
### **User description**
fixed #8427


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Strip "_o2_all_" placeholder from PromQL

- Add rewriter to clean vector/matrix selectors

- Integrate rewrite in engine evaluation

- Unit tests for placeholder handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  placeholder["_o2_all_ placeholder in matchers"]
  rewriter["RemoveFilterAll rewriter"]
  engineVS["Engine: VectorSelector eval"]
  engineMS["Engine: MatrixSelector eval"]
  cleanVS["Cleaned matchers"]
  result["Correct PromQL execution"]

  placeholder -- detected by --> rewriter
  rewriter -- rewrite --> cleanVS
  cleanVS -- used by --> engineVS
  cleanVS -- used by --> engineMS
  engineVS -- yields --> result
  engineMS -- yields --> result
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>engine.rs</strong><dd><code>Apply placeholder-removal before selector evaluation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/promql/engine.rs

<ul><li>Import <code>rewrite::remove_filter_all</code>.<br> <li> Clone and rewrite <code>VectorSelector</code> before eval.<br> <li> Clone and rewrite <code>MatrixSelector.vs</code> before eval.<br> <li> Return unchanged semantics for empty results.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8675/files#diff-a98ac5b55a4c9440c09c4e2dfa3b6f7f24f9e58fcb6bf8b10577a0b4f123ed41">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Expose rewrite module in promql namespace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/promql/mod.rs

- Add new `rewrite` module export.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8675/files#diff-4dc51fd2f42be1f409f8e44d15dbb4d27acc4430fb65dbdf290718b892dd9aad">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rewrite.rs</strong><dd><code>Rewriter to strip "_o2_all_" placeholder matchers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/promql/rewrite.rs

<ul><li>Implement <code>RemoveFilterAllRewriter</code> for <code>VectorSelector</code>.<br> <li> Remove matchers matching dashboard placeholder across ops.<br> <li> Provide <code>remove_filter_all</code> API.<br> <li> Add comprehensive unit tests for matcher removal.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8675/files#diff-a90f52b713785fe494069e5de718fe46cf7f23b587e350dea868e23adcef5071">+213/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

