### PR TITLE
fix: rename regex patterns to sensitive data redaction

### DIFF
--- a/web/src/components/logstream/schema.vue
+++ b/web/src/components/logstream/schema.vue
@@ -423,7 +423,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         <span class="tw-pl-7" v-else-if="col.name === 'patterns'">
                           {{ col.label }}
                           <q-tooltip class="bg-grey-8" anchor="top middle" self="bottom middle">
-                            Sensitive Data Redaction
+                            {{ t('logStream.sdr') }}
                           </q-tooltip>
                         </span>
                         <span v-else>

--- a/web/src/components/logstream/schema.vue
+++ b/web/src/components/logstream/schema.vue
@@ -420,6 +420,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           <q-icon color="primary" size="12px" :name="outlinedPerson"></q-icon>
                           <q-icon color="primary" size="12px" :name="outlinedSchema"></q-icon>
                         </span>
+                        <span class="tw-pl-7" v-else-if="col.name === 'patterns'">
+                          {{ col.label }}
+                          <q-tooltip class="bg-grey-8" anchor="top middle" self="bottom middle">
+                            Sensitive Data Redaction
+                          </q-tooltip>
+                        </span>
                         <span v-else>
                           {{ col.label }}
                         </span>

--- a/web/src/components/settings/NoRegexPatterns.spec.ts
+++ b/web/src/components/settings/NoRegexPatterns.spec.ts
@@ -142,7 +142,7 @@ describe("NoRegexPatterns", () => {
       const importButtonText = wrapper.find(".import-button-text");
       
       expect(importButtonText.exists()).toBe(true);
-      expect(importButtonText.text()).toBe("Import Regex Pattern");
+      expect(importButtonText.text()).toBe("Import Pattern");
     });
   });
 
@@ -268,7 +268,7 @@ describe("NoRegexPatterns", () => {
       expect(titleText.text()).toBeTruthy();
       expect(subtitleText.text()).toBeTruthy();
       expect(createNewText.text()).toBe("Create New");
-      expect(importButtonText.text()).toBe("Import Regex Pattern");
+      expect(importButtonText.text()).toBe("Import Pattern");
     });
 
     it("should have proper button structure for import action", () => {

--- a/web/src/components/settings/NoRegexPatterns.vue
+++ b/web/src/components/settings/NoRegexPatterns.vue
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <span class="subtitle-text">Import patterns from your Library or <span class="create-new-text" @click="createNewRegexPattern">Create New</span></span>
         <div class="import-button-container">
             <q-btn no-caps class="q-mt-sm" @click="importRegexPattern">
-              <span class="import-button-text">Import Pattern</span>
+              <span class="import-button-text">{{ t("regex_patterns.import_title") }}</span>
             </q-btn>
         </div>    
     </div>

--- a/web/src/components/settings/NoRegexPatterns.vue
+++ b/web/src/components/settings/NoRegexPatterns.vue
@@ -25,10 +25,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         style="width: 125px; margin: 20vh auto 1rem"
       />
       <span class="title-text">{{ t("regex_patterns.no_data") }}</span>
-        <span class="subtitle-text">Import Regex patterns from your Library or <span class="create-new-text" @click="createNewRegexPattern">Create New</span></span>
+        <span class="subtitle-text">Import patterns from your Library or <span class="create-new-text" @click="createNewRegexPattern">Create New</span></span>
         <div class="import-button-container">
             <q-btn no-caps class="q-mt-sm" @click="importRegexPattern">
-              <span class="import-button-text">Import Regex Pattern</span>
+              <span class="import-button-text">Import Pattern</span>
             </q-btn>
         </div>    
     </div>

--- a/web/src/components/settings/RegexPatternList.vue
+++ b/web/src/components/settings/RegexPatternList.vue
@@ -6,7 +6,7 @@
       :class="store.state.theme == 'dark' ? 'o2-table-header-dark tw-border-gray-500' : 'o2-table-header-light tw-border-gray-200'"
     >
       <div class="q-table__title tw-font-[600]" data-test="regex-pattern-list-title">
-            {{ t("regex_patterns.header") }}
+            {{ t("regex_patterns.title") }}
           </div>
           <q-input
                 v-model="filterQuery"
@@ -128,7 +128,7 @@
         <template #bottom="scope">
           <div class="tw-flex tw-items-center tw-justify-end tw-w-full tw-h-[48px]">
             <div class="o2-table-footer-title tw-flex tw-items-center tw-w-[200px] tw-mr-md">
-                  {{ resultTotal }} {{ t('regex_patterns.header') }}
+                  {{ resultTotal }} {{ t('regex_patterns.bottom_header') }}
                 </div>
           <QTablePagination
             :scope="scope"

--- a/web/src/components/settings/index.vue
+++ b/web/src/components/settings/index.vue
@@ -174,7 +174,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <img :src="regexIcon" alt="regex" style="width: 24px; height: 24px;" />
             <span class="tw-text-sm tw-font-medium tw-ml-2"
             :class="store.state.theme === 'dark' && router.currentRoute.value.name !== 'regexPatterns'   ? 'tw-text-white' : 'tw-text-black'"
-            >{{ t('regex_patterns.header') }}</span>
+            >{{ t('regex_patterns.title') }}</span>
           </div>
         </q-route-tab>
         </q-tabs>

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -500,7 +500,7 @@
     "indexSize": "Index Size",
     "extendedStartDate": "Start Date",
     "extendedEndDate": "End Date",
-    "regexPatterns": "Regex Patterns",
+    "regexPatterns": "SDR",
     "envQuickModeMsg": "Environment quick mode field"
   },
   "pipeline": {
@@ -1323,9 +1323,10 @@
     "searchRegion": "Search Region"
   },
   "regex_patterns": {
+    "title":"Sensitive Data Redaction",
     "header": "Regex Patterns",
-    "create_pattern": "Create Pattern",
-    "search": "Search Regex Pattern",
+    "create_pattern": "Add Pattern",
+    "search": "Search Pattern",
     "no_data": "No Patterns in the Library",
     "name": "Name",
     "pattern": "Pattern",
@@ -1334,14 +1335,15 @@
     "actions": "Actions",
     "edit": "Edit",
     "delete": "Delete",
-    "create_regex_pattern": "Create New Regex Pattern",
+    "create_regex_pattern": "Create Pattern",
     "create_close":"Create and Close",
     "cancel":"Cancel",
-    "edit_regex_pattern": "Edit Regex Pattern",
+    "edit_regex_pattern": "Edit Pattern",
     "update_close": "Update and Close",
     "description": "Description",
     "create_regex_pattern_field": "Redact / Drop using Regex",
     "import": "Import",
-    "import_title": "Import Regex Pattern"
+    "import_title": "Import Pattern",
+    "bottom_header": "Pattern(s)"
   }
 }

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -501,7 +501,8 @@
     "extendedStartDate": "Start Date",
     "extendedEndDate": "End Date",
     "regexPatterns": "SDR",
-    "envQuickModeMsg": "Environment quick mode field"
+    "envQuickModeMsg": "Environment quick mode field",
+    "sdr":"Sensitive Data Redaction"
   },
   "pipeline": {
     "header": "Pipelines",


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Rename UI to Sensitive Data Redaction

- Update i18n keys and labels

- Adjust tooltips and table headers

- Simplify import/create wording


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Components (schema.vue, settings/*.vue)"] -- "rename labels/tooltips" --> SDR["Sensitive Data Redaction terminology"]
  I18N["en.json i18n strings"] -- "update keys/values" --> SDR
  SDR -- "reflected in lists, tabs, empty state" --> UX["Consistent SDR UI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.vue</strong><dd><code>Add SDR tooltip to patterns column</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/logstream/schema.vue

<ul><li>Add tooltip for <code>patterns</code> column<br> <li> Tooltip text: "Sensitive Data Redaction"</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8681/files#diff-9196be2ccae4054a00b0b1aa9d1e87b366c10920d6eaf9ef8c6e6293d50bcf46">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RegexPatternList.vue</strong><dd><code>Use SDR titles and footer labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/settings/RegexPatternList.vue

<ul><li>Switch header i18n key to <code>regex_patterns.title</code><br> <li> Update footer count label to <code>bottom_header</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8681/files#diff-524927acd9f5bb07b71bfac489e747470108574e21a6dde63ea7c1f219cea853">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.vue</strong><dd><code>Update settings tab to SDR title</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/settings/index.vue

- Use `regex_patterns.title` for tab label


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8681/files#diff-699c63979f851c48ad440a078e93282fd797a18fc065e5331b2e41122ddb8b69">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NoRegexPatterns.vue</strong><dd><code>Update empty state copy for patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/settings/NoRegexPatterns.vue

<ul><li>Simplify subtitle wording<br> <li> Rename import button text to "Import Pattern"</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8681/files#diff-279b923f20042948c87e907d2453e9d5a4c8c73672b23df951d7d7d823ff3a88">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>i18n updates for SDR terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/locales/languages/en.json

<ul><li>Add <code>regex_patterns.title</code>: "Sensitive Data Redaction"<br> <li> Shorten <code>sidebar.regexPatterns</code> to "SDR"<br> <li> Rename button/search labels (Add/Search/Edit/Import Pattern)<br> <li> Add <code>bottom_header</code>: "Pattern(s)"</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8681/files#diff-892aa3d75ab6e129ef9116aa21bec1b9a15ba69ce5366d2a19128078c690d824">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

