### PR TITLE
feat: add context support to chat requests and improve type safety

### DIFF
--- a/src/handler/http/models/ai.rs
+++ b/src/handler/http/models/ai.rs
@@ -13,8 +13,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use o2_enterprise::enterprise::ai::meta::AiMessage;
+use o2_enterprise::enterprise::ai::meta::{AiMessage, Role};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use utoipa::ToSchema;
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -25,11 +26,13 @@ pub struct PromptRequest {
     pub model: String,
     #[serde(default)]
     pub provider: String,
+    #[serde(default)]
+    pub context: Map<String, Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct PromptResponse {
-    pub role: String,
+    pub role: Role,
     pub content: String,
 }
 

--- a/src/handler/http/models/dashboards.rs
+++ b/src/handler/http/models/dashboards.rs
@@ -23,7 +23,8 @@ use serde_json::{Map, Value};
 use utoipa::ToSchema;
 
 /// HTTP request body for the `CreateDashboard`/`UpdateDashboard` endpoints.
-#[derive(Debug, ToSchema)]
+#[derive(Debug, ToSchema, Serialize)]
+#[serde(untagged)]
 pub enum DashboardRequestBody {
     V1(v1::Dashboard),
     V2(v2::Dashboard),

--- a/src/handler/http/request/ai/chat.rs
+++ b/src/handler/http/request/ai/chat.rs
@@ -68,8 +68,12 @@ pub async fn chat(Json(body): Json<PromptRequest>) -> impl Responder {
     let config = get_o2_config();
 
     if config.ai.enabled {
-        let response =
-            ai::service::chat(ai::meta::AiServerRequest::new(body.messages, body.model)).await;
+        let response = ai::service::chat(ai::meta::AiServerRequest::new(
+            body.messages,
+            body.model,
+            body.context,
+        ))
+        .await;
         match response {
             Ok(response) => HttpResponse::Ok().json(PromptResponse::from(response)),
             Err(e) => {
@@ -156,8 +160,7 @@ pub async fn chat_stream(
     let auth_str = crate::common::utils::auth::extract_auth_str(&in_req);
 
     let stream = match ai::service::chat_stream(
-        ai::meta::AiServerRequest::new(req_body.messages, req_body.model),
-        org_id.clone(),
+        ai::meta::AiServerRequest::new(req_body.messages, req_body.model, req_body.context),
         auth_str,
     )
     .await


### PR DESCRIPTION
### **User description**
- Add context parameter to PromptRequest for passing additional data
- Update AiServerRequest initialization to include context across chat endpoints
- Change PromptResponse role field from String to Role enum for type safety
- Add Serialize trait to DashboardRequestBody for serialization support


___

### **PR Type**
Enhancement


___

### **Description**
- Add `context` to `PromptRequest`

- Use `Role` enum in responses

- Pass context into AI server requests

- Serialize `DashboardRequestBody` with untagged enum


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PromptRequest["PromptRequest: +context Map<String, Value>"] -- "propagated" --> AiServerRequest["AiServerRequest::new(..., context)"]
  AiMessage["AiMessage"] -- "converted to" --> PromptResponse["PromptResponse: role -> Role enum"]
  DashboardReq["DashboardRequestBody"] -- "derive Serialize, untagged" --> HttpAPI["HTTP serialization compatibility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai.rs</strong><dd><code>Add context field and Role enum usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/models/ai.rs

<ul><li>Import <code>Role</code> and serde_json types.<br> <li> Add <code>context: Map<String, Value></code> to <code>PromptRequest</code>.<br> <li> Change <code>PromptResponse.role</code> from <code>String</code> to <code>Role</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8682/files#diff-2b7b829601e6ddfcea852172c859f66625e0d1e28971841e1f06faa234a52822">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboards.rs</strong><dd><code>Serialize untagged dashboard request enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/models/dashboards.rs

<ul><li>Derive <code>Serialize</code> for <code>DashboardRequestBody</code>.<br> <li> Mark enum as <code>#[serde(untagged)]</code> for flexible payloads.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8682/files#diff-250eeebeec9d4ac0ac271466ed83cd33fea3f121080491b340dc95d9af287259">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.rs</strong><dd><code>Propagate context to AI server requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/ai/chat.rs

<ul><li>Pass <code>context</code> into <code>AiServerRequest::new</code> in chat.<br> <li> Pass <code>context</code> into chat_stream request construction.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8682/files#diff-12a78cbb31b313cb3a0ca50f25c177470cf49b02708f179fe138ed3d66a2926b">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

