### PR TITLE
fix: query result error only for dashboards

### DIFF
--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -441,9 +441,6 @@ pub async fn search(
     //     should_cache_results = should_cache_results && res.function_error.is_empty();
     // }
 
-    // if function error is not empty and it only contains query limit error then we need to cache
-    // the results in merge results check if evert type is ui and then pass the query limit
-
     // Update: Don't cache any partial results
     let should_cache_results = res.new_start_time.is_none()
         && res.new_end_time.is_none()

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -160,11 +160,12 @@ pub async fn search(
     let cache_took = start.elapsed().as_millis() as usize;
     let mut results = Vec::new();
     let mut work_group_set = Vec::new();
-    let capped_query_limit = if in_req.search_type.as_ref() == Some(&SearchEventType::UI) {
-        cfg.limit.query_default_limit
-    } else {
-        c_resp.limit
-    };
+    let capped_query_limit =
+        if in_req.search_type.as_ref() == Some(&SearchEventType::UI) && c_resp.limit == -1 {
+            cfg.limit.query_default_limit
+        } else {
+            c_resp.limit
+        };
     let mut res = if !should_exec_query {
         merge_response(
             trace_id,

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -53,7 +53,6 @@ use crate::{
         search::{
             self as SearchService,
             cache::cacher::check_cache,
-            datafusion::optimizer::utils::QUERY_RESULT_BUFFER_SIZE,
             init_vrl_runtime,
             inspector::{SearchInspectorFieldsBuilder, search_inspector_fields},
         },
@@ -162,7 +161,7 @@ pub async fn search(
     let mut results = Vec::new();
     let mut work_group_set = Vec::new();
     let capped_query_limit = if in_req.search_type.as_ref() == Some(&SearchEventType::UI) {
-        cfg.limit.query_default_limit + QUERY_RESULT_BUFFER_SIZE as i64
+        cfg.limit.query_default_limit
     } else {
         c_resp.limit
     };

--- a/src/service/search/datafusion/optimizer/utils.rs
+++ b/src/service/search/datafusion/optimizer/utils.rs
@@ -32,7 +32,7 @@ use datafusion::{
 
 use crate::service::search::datafusion::table_provider::empty_table::NewEmptyTable;
 
-pub const QUERY_RESULT_BUFFER_SIZE: usize = 5;
+pub const QUERY_RESULT_BUFFER_SIZE: usize = 1;
 
 // check if the plan is a complex query that we can't add sort _timestamp
 pub fn is_complex_query(plan: &LogicalPlan) -> bool {

--- a/src/service/search/datafusion/optimizer/utils.rs
+++ b/src/service/search/datafusion/optimizer/utils.rs
@@ -32,7 +32,7 @@ use datafusion::{
 
 use crate::service::search::datafusion::table_provider::empty_table::NewEmptyTable;
 
-pub const QUERY_RESULT_BUFFER_SIZE: usize = 1;
+pub const QUERY_RESULT_BUFFER_SIZE: usize = 5;
 
 // check if the plan is a complex query that we can't add sort _timestamp
 pub fn is_complex_query(plan: &LogicalPlan) -> bool {

--- a/src/service/search/search_stream.rs
+++ b/src/service/search/search_stream.rs
@@ -170,12 +170,11 @@ pub async fn process_search_stream_request(
 
     if req.query.from == 0 && !req.query.track_total_hits && req.query.streaming_id.is_none() {
         // check cache for the first page
-        req.query.size =
-            if req.search_type.as_ref() == Some(&SearchEventType::UI) && req.query.size == -1 {
-                cfg.limit.query_default_limit
-            } else {
-                req.query.size
-            };
+        req.query.size = if req.query.size == -1 {
+            cfg.limit.query_default_limit
+        } else {
+            req.query.size
+        };
         let force_clear_cache = if !use_cache { Some(true) } else { None };
         let (c_resp, _should_exec_query) = match cache::prepare_cache_response(
             &trace_id,
@@ -279,7 +278,11 @@ pub async fn process_search_stream_request(
                 max_query_range
             }; // hours
 
-            let size = req.query.size;
+            let size = if req.query.size == -1 {
+                cfg.limit.query_default_limit
+            } else {
+                req.query.size
+            };
             // Step 1(a): handle cache responses & query the deltas
             if let Err(e) = handle_cache_responses_and_deltas(
                 &mut req,
@@ -363,12 +366,11 @@ pub async fn process_search_stream_request(
                 "[HTTP2_STREAM trace_id {trace_id}] No cache found, processing search request",
             );
 
-            let size =
-                if req.search_type.as_ref() == Some(&SearchEventType::UI) && req.query.size == -1 {
-                    cfg.limit.query_default_limit
-                } else {
-                    req.query.size
-                };
+            let size = if req.query.size == -1 {
+                cfg.limit.query_default_limit
+            } else {
+                req.query.size
+            };
             if let Err(e) = do_partitioned_search(
                 &mut req,
                 &trace_id,
@@ -501,8 +503,7 @@ pub async fn process_search_stream_request(
         }
     } else {
         // Step 4: Search without cache for req with from > 0
-        let size = if req.search_type.as_ref() == Some(&SearchEventType::UI) && req.query.size == -1
-        {
+        let size = if req.query.size == -1 {
             cfg.limit.query_default_limit
         } else {
             req.query.size

--- a/src/service/search/utils.rs
+++ b/src/service/search/utils.rs
@@ -26,10 +26,7 @@ use tokio::sync::Mutex;
 use {crate::service::grpc::make_grpc_search_client, config::meta::cluster::NodeInfo};
 
 use super::{DATAFUSION_RUNTIME, datafusion::distributed_plan::remote_scan::RemoteScanExec};
-use crate::{
-    common::meta::search::CAPPED_RESULTS_MSG,
-    service::search::{datafusion::optimizer::utils::QUERY_RESULT_BUFFER_SIZE, sql::Sql},
-};
+use crate::{common::meta::search::CAPPED_RESULTS_MSG, service::search::sql::Sql};
 
 type Cleanup = Pin<Box<dyn Future<Output = ()> + Send>>;
 
@@ -241,19 +238,20 @@ pub fn check_query_default_limit_exceeded(
     partial_err: &mut String,
     sql: &Sql,
     search_event_type: Option<String>,
-) {
+) -> bool {
+    let query_default_limit = config::get_config().limit.query_default_limit as usize;
+    let is_exceeded = num_rows > query_default_limit;
     if search_event_type.is_none()
         || search_event_type
             .as_ref()
             .and_then(|s| SearchEventType::try_from(s.as_ref()).ok())
             != Some(SearchEventType::Dashboards)
     {
-        return;
+        return is_exceeded;
     }
 
-    let query_default_limit = config::get_config().limit.query_default_limit as usize;
     if sql.limit > config::QUERY_WITH_NO_LIMIT && sql.limit <= 0 {
-        let capped_limit = query_default_limit + QUERY_RESULT_BUFFER_SIZE;
+        let capped_limit = query_default_limit;
         let capped_err = format!("{CAPPED_RESULTS_MSG} limit: {capped_limit}");
         if num_rows > query_default_limit {
             if !partial_err.is_empty() {
@@ -262,6 +260,9 @@ pub fn check_query_default_limit_exceeded(
             } else {
                 *partial_err = capped_err;
             }
+            return is_exceeded;
         }
     }
+
+    is_exceeded
 }

--- a/src/service/search/utils.rs
+++ b/src/service/search/utils.rs
@@ -251,8 +251,7 @@ pub fn check_query_default_limit_exceeded(
     }
 
     if sql.limit > config::QUERY_WITH_NO_LIMIT && sql.limit <= 0 {
-        let capped_limit = query_default_limit;
-        let capped_err = format!("{CAPPED_RESULTS_MSG} limit: {capped_limit}");
+        let capped_err = format!("{CAPPED_RESULTS_MSG} limit: {query_default_limit}");
         if num_rows > query_default_limit {
             if !partial_err.is_empty() {
                 partial_err.push('\n');

--- a/src/service/websocket_events/values.rs
+++ b/src/service/websocket_events/values.rs
@@ -262,17 +262,23 @@ pub async fn handle_values_request(
                 let safe_start_time = start_time.unwrap_or(0);
                 let safe_end_time = end_time.unwrap_or(0);
 
-                write_results_to_cache(c_resp, safe_start_time, safe_end_time, accumulated_results)
-                    .instrument(ws_values_span.clone())
-                    .await
-                    .map_err(|e| {
-                        log::error!(
-                            "[WS_VALUES] trace_id: {}, Error writing results to cache: {:?}",
-                            trace_id,
-                            e
-                        );
+                write_results_to_cache(
+                    c_resp,
+                    safe_start_time,
+                    safe_end_time,
+                    accumulated_results,
+                    search_req.search_type,
+                )
+                .instrument(ws_values_span.clone())
+                .await
+                .map_err(|e| {
+                    log::error!(
+                        "[WS_VALUES] trace_id: {}, Error writing results to cache: {:?}",
+                        trace_id,
                         e
-                    })?;
+                    );
+                    e
+                })?;
             }
         } else {
             // Step 4: Search without cache for req with from > 0

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -83,6 +83,7 @@ import config from "@/aws-exports";
 import useSearchWebSocket from "./useSearchWebSocket";
 import useActions from "./useActions";
 import useStreamingSearch from "./useStreamingSearch";
+import { hasHistogramFunction } from "@/utils/query/sqlUtils";
 
 const defaultObject = {
   organizationIdentifier: "",
@@ -2683,9 +2684,11 @@ const useLogs = () => {
 
       const isAggregation = searchObj.meta.sqlMode && parsedSQL != undefined && (hasAggregation(parsedSQL?.columns) || parsedSQL.groupby != null);
 
-      // if(searchObj.data.queryResults.histogram_interval) {
-      //   queryReq.query.histogram_interval = searchObj.data.queryResults.histogram_interval;
-      // }
+      const isHistograQuery = await hasHistogramFunction(parsedSQL);
+
+      if(searchObj.data.queryResults.histogram_interval && isHistograQuery) {
+        queryReq.query.histogram_interval = searchObj.data.queryResults.histogram_interval;
+      }
 
       // check if histogram interval is undefined, then set current response as histogram response
       // for visualization, will require to set histogram interval to fill missing values

--- a/web/src/utils/query/sqlUtils.ts
+++ b/web/src/utils/query/sqlUtils.ts
@@ -720,6 +720,7 @@ export const buildSqlQuery = (
   // Return the constructed query
   return query;
 };
+
 export const changeHistogramInterval = async (
   query: any,
   histogramInterval: any,
@@ -795,6 +796,116 @@ export const convertQueryIntoSingleLine = async (query: any) => {
 };
 
 
+export const hasHistogramFunction = async (query: any) => {
+  try {
+    if (!query || query === "") {
+      return false;
+    }
+
+    if(typeof query === "string") await importSqlParser();
+    const ast: any = typeof query === "string" ? parser.astify(query) : query;
+
+    const MAX_RECURSION_DEPTH = 50;
+    const visitedNodes = new WeakSet();
+
+    const checkHistogramInNode = (node: any, depth: number = 0): boolean => {
+      if (!node || depth > MAX_RECURSION_DEPTH) {
+        if (depth > MAX_RECURSION_DEPTH) {
+          console.warn("Maximum recursion depth reached while checking for histogram function");
+        }
+        return false;
+      }
+
+      if (typeof node === 'object' && node !== null) {
+        if (visitedNodes.has(node)) {
+          return false;
+        }
+        visitedNodes.add(node);
+      }
+
+      // Check if current node is a histogram function
+      if (node.type === "function" && node?.name?.name?.[0]?.value === "histogram") {
+        return true;
+      }
+
+      // Check columns for histogram functions
+      if (node.columns && Array.isArray(node.columns)) {
+        for (const column of node.columns) {
+          if (column.expr && column.expr.type === "function" &&
+              column.expr?.name?.name?.[0]?.value === "histogram") {
+            return true;
+          }
+          // Check nested subqueries in columns
+          if (column.expr && column.expr.ast && checkHistogramInNode(column.expr.ast, depth + 1)) {
+            return true;
+          }
+        }
+      }
+
+      // Check FROM clause for subqueries
+      if (node.from && Array.isArray(node.from)) {
+        for (const fromClause of node.from) {
+          if (fromClause.expr && fromClause.expr.ast &&
+              checkHistogramInNode(fromClause.expr.ast, depth + 1)) {
+            return true;
+          }
+        }
+      }
+
+      // Check WHERE clause for subqueries
+      if (node.where) {
+        if (checkHistogramInWhere(node.where, depth + 1)) {
+          return true;
+        }
+      }
+
+      // Check WITH statements
+      if (node.with && Array.isArray(node.with)) {
+        for (const withClause of node.with) {
+          if (withClause.stmt && checkHistogramInNode(withClause.stmt, depth + 1)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    };
+
+    const checkHistogramInWhere = (whereNode: any, depth: number = 0): boolean => {
+      if (!whereNode || depth > MAX_RECURSION_DEPTH) {
+        return false;
+      }
+
+      // Check if WHERE node itself is a histogram function
+      if (whereNode.type === "function" && whereNode?.name?.name?.[0]?.value === "histogram") {
+        return true;
+      }
+
+      // Check binary expressions (AND, OR, etc.)
+      if (whereNode.type === "binary_expr") {
+        if (whereNode.left && checkHistogramInWhere(whereNode.left, depth + 1)) {
+          return true;
+        }
+        if (whereNode.right && checkHistogramInWhere(whereNode.right, depth + 1)) {
+          return true;
+        }
+        // Check for subquery in right side
+        if (whereNode.right && whereNode.right.ast &&
+            checkHistogramInNode(whereNode.right.ast, depth + 1)) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
+    return checkHistogramInNode(ast);
+  } catch (error) {
+    console.error("Error checking for histogram function:", error);
+    return false;
+  }
+};
+
 export const getStreamNameFromQuery = async (query: any) => {
   let streamName = null;
   try {
@@ -808,7 +919,7 @@ export const getStreamNameFromQuery = async (query: any) => {
               // Recursively extract table names from the WITH statement with depth protection
               const MAX_RECURSION_DEPTH = 50; // Prevent stack overflow
               const visitedNodes = new WeakSet(); // Prevent circular references - more efficient for objects
-              
+
               const extractTablesFromNode = (node: any, depth: number = 0) => {
                 if (!node || depth > MAX_RECURSION_DEPTH) {
                   if (depth > MAX_RECURSION_DEPTH) {
@@ -816,7 +927,7 @@ export const getStreamNameFromQuery = async (query: any) => {
                   }
                   return;
                 }
-                
+
                 // Use WeakSet for efficient circular reference detection
                 if (typeof node === 'object' && node !== null) {
                   if (visitedNodes.has(node)) {
@@ -824,7 +935,7 @@ export const getStreamNameFromQuery = async (query: any) => {
                   }
                   visitedNodes.add(node);
                 }
-                
+
                 // Check if current node has a from clause
                 if (node.from && Array.isArray(node.from)) {
                   node.from.forEach((stream: any) => {
@@ -837,12 +948,12 @@ export const getStreamNameFromQuery = async (query: any) => {
                     }
                   });
                 }
-                
+
                 // Check for nested subqueries in WHERE clause
                 if (node.where && node.where.right && node.where.right.ast) {
                   extractTablesFromNode(node.where.right.ast, depth + 1);
                 }
-                
+
                 // Check for nested subqueries in SELECT expressions
                 if (node.columns && Array.isArray(node.columns)) {
                   node.columns.forEach((col: any) => {
@@ -852,7 +963,7 @@ export const getStreamNameFromQuery = async (query: any) => {
                   });
                 }
               };
-              
+
               // Start extraction from the WITH statement
               extractTablesFromNode(obj?.stmt);
             });


### PR DESCRIPTION
TODO: 
- [x] fix: http flow to honor query result limit while merging results
- [x] fix: http2 streaming flow to honor query result limit while merging results
    - http2 streaming will apply query result limitation on the entire duration of the request (unlike http which applies it per partition)
- [x] fix: `run_datafusion` to truncate the results from the record batches right after execution
- [x] fix: check if the results are only having a query limit error if so then it should be eligible for cache
- [x] http auto histogram ui needs to send histogram interval for when sql itself is a histogram 