### PR TITLE
feat: pipeline errors on ui

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -52,7 +52,7 @@ pub type RwAHashSet<K> = tokio::sync::RwLock<HashSet<K>>;
 pub type RwBTreeMap<K, V> = tokio::sync::RwLock<BTreeMap<K, V>>;
 
 // for DDL commands and migrations
-pub const DB_SCHEMA_VERSION: u64 = 9;
+pub const DB_SCHEMA_VERSION: u64 = 10;
 pub const DB_SCHEMA_KEY: &str = "/db_schema_version/";
 
 // global version variables

--- a/src/infra/src/table/entity/mod.rs
+++ b/src/infra/src/table/entity/mod.rs
@@ -13,6 +13,7 @@ pub mod enrichment_tables;
 pub mod folders;
 pub mod org_users;
 pub mod organizations;
+pub mod pipeline_last_errors;
 pub mod rate_limit_rules;
 pub mod re_pattern_stream_map;
 pub mod re_patterns;

--- a/src/infra/src/table/entity/pipeline_last_errors.rs
+++ b/src/infra/src/table/entity/pipeline_last_errors.rs
@@ -1,0 +1,22 @@
+//! `SeaORM` Entity for pipeline_last_errors table
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
+#[sea_orm(table_name = "pipeline_last_errors")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub pipeline_id: String,
+    pub org_id: String,
+    pub pipeline_name: String,
+    pub last_error_timestamp: i64,
+    pub error_summary: Option<String>,
+    pub node_errors: Option<Json>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/infra/src/table/entity/prelude.rs
+++ b/src/infra/src/table/entity/prelude.rs
@@ -7,6 +7,7 @@ pub use super::{
     distinct_value_fields::Entity as DistinctValueFields,
     enrichment_tables::Entity as EnrichmentTables, folders::Entity as Folders,
     org_users::Entity as OrgUsers, organizations::Entity as Organizations,
+    pipeline_last_errors::Entity as PipelineLastErrors,
     re_pattern_stream_map::Entity as RePatternStreamMap, re_patterns::Entity as RePatterns,
     report_dashboards::Entity as ReportDashboards, reports::Entity as Reports,
     search_job_partitions::Entity as SearchJobPartitions,

--- a/src/infra/src/table/migration/m20250930_000001_create_pipeline_last_errors_table.rs
+++ b/src/infra/src/table/migration/m20250930_000001_create_pipeline_last_errors_table.rs
@@ -1,0 +1,169 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(create_pipeline_last_errors_table_statement())
+            .await?;
+
+        // Create index for efficient org_id queries
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_pipeline_last_errors_org_timestamp")
+                    .table(PipelineLastErrors::Table)
+                    .col(PipelineLastErrors::OrgId)
+                    .col(PipelineLastErrors::LastErrorTimestamp)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(PipelineLastErrors::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+/// Statement to create the pipeline_last_errors table.
+fn create_pipeline_last_errors_table_statement() -> TableCreateStatement {
+    Table::create()
+        .table(PipelineLastErrors::Table)
+        .if_not_exists()
+        .col(
+            ColumnDef::new(PipelineLastErrors::PipelineId)
+                .string_len(255)
+                .not_null()
+                .primary_key(),
+        )
+        .col(
+            ColumnDef::new(PipelineLastErrors::OrgId)
+                .string_len(255)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(PipelineLastErrors::PipelineName)
+                .string_len(255)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(PipelineLastErrors::LastErrorTimestamp)
+                .big_integer()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(PipelineLastErrors::ErrorSummary)
+                .text()
+                .null(),
+        )
+        .col(ColumnDef::new(PipelineLastErrors::NodeErrors).json().null())
+        .col(
+            ColumnDef::new(PipelineLastErrors::CreatedAt)
+                .big_integer()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(PipelineLastErrors::UpdatedAt)
+                .big_integer()
+                .not_null(),
+        )
+        .to_owned()
+}
+
+/// Identifiers used in queries on the pipeline_last_errors table.
+#[derive(DeriveIden)]
+enum PipelineLastErrors {
+    Table,
+    PipelineId,
+    OrgId,
+    PipelineName,
+    LastErrorTimestamp,
+    ErrorSummary,
+    NodeErrors,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[cfg(test)]
+mod tests {
+    use collapse::*;
+
+    use super::*;
+
+    #[test]
+    fn postgres() {
+        collapsed_eq!(
+            &create_pipeline_last_errors_table_statement().to_string(PostgresQueryBuilder),
+            r#"
+                CREATE TABLE IF NOT EXISTS "pipeline_last_errors" (
+                "pipeline_id" varchar(255) NOT NULL PRIMARY KEY,
+                "org_id" varchar(255) NOT NULL,
+                "pipeline_name" varchar(255) NOT NULL,
+                "last_error_timestamp" bigint NOT NULL,
+                "error_summary" text,
+                "node_errors" json,
+                "created_at" bigint NOT NULL,
+                "updated_at" bigint NOT NULL
+            )"#
+        );
+    }
+
+    #[test]
+    fn mysql() {
+        collapsed_eq!(
+            &create_pipeline_last_errors_table_statement().to_string(MysqlQueryBuilder),
+            r#"
+                CREATE TABLE IF NOT EXISTS `pipeline_last_errors` (
+                `pipeline_id` varchar(255) NOT NULL PRIMARY KEY,
+                `org_id` varchar(255) NOT NULL,
+                `pipeline_name` varchar(255) NOT NULL,
+                `last_error_timestamp` bigint NOT NULL,
+                `error_summary` text,
+                `node_errors` json,
+                `created_at` bigint NOT NULL,
+                `updated_at` bigint NOT NULL
+            )"#
+        );
+    }
+
+    #[test]
+    fn sqlite() {
+        collapsed_eq!(
+            &create_pipeline_last_errors_table_statement().to_string(SqliteQueryBuilder),
+            r#"
+                CREATE TABLE IF NOT EXISTS "pipeline_last_errors" (
+                "pipeline_id" varchar(255) NOT NULL PRIMARY KEY,
+                "org_id" varchar(255) NOT NULL,
+                "pipeline_name" varchar(255) NOT NULL,
+                "last_error_timestamp" bigint NOT NULL,
+                "error_summary" text,
+                "node_errors" json,
+                "created_at" bigint NOT NULL,
+                "updated_at" bigint NOT NULL
+            )"#
+        );
+    }
+}

--- a/src/infra/src/table/migration/m20250930_000001_create_pipeline_last_errors_table.rs
+++ b/src/infra/src/table/migration/m20250930_000001_create_pipeline_last_errors_table.rs
@@ -156,7 +156,7 @@ mod tests {
                 "pipeline_name" varchar(255) NOT NULL,
                 "last_error_timestamp" bigint NOT NULL,
                 "error_summary" text,
-                "node_errors" json,
+                "node_errors" json_text,
                 "created_at" bigint NOT NULL,
                 "updated_at" bigint NOT NULL
             )"#

--- a/src/infra/src/table/migration/m20250930_000001_create_pipeline_last_errors_table.rs
+++ b/src/infra/src/table/migration/m20250930_000001_create_pipeline_last_errors_table.rs
@@ -74,12 +74,8 @@ fn create_pipeline_last_errors_table_statement() -> TableCreateStatement {
                 .big_integer()
                 .not_null(),
         )
-        .col(
-            ColumnDef::new(PipelineLastErrors::ErrorSummary)
-                .text()
-                .null(),
-        )
-        .col(ColumnDef::new(PipelineLastErrors::NodeErrors).json().null())
+        .col(ColumnDef::new(PipelineLastErrors::ErrorSummary).text())
+        .col(ColumnDef::new(PipelineLastErrors::NodeErrors).json())
         .col(
             ColumnDef::new(PipelineLastErrors::CreatedAt)
                 .big_integer()

--- a/src/infra/src/table/migration/mod.rs
+++ b/src/infra/src/table/migration/mod.rs
@@ -65,6 +65,7 @@ mod m20250731_000001_create_compactor_manual_jobs;
 mod m20250801_000001_create_system_prompts_table;
 mod m20250822_093713_add_updated_at_for_file_list_table;
 mod m20250923_000001_update_enrichment_table_data_size;
+mod m20250930_000001_create_pipeline_last_errors_table;
 
 pub struct Migrator;
 
@@ -122,6 +123,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250801_000001_create_system_prompts_table::Migration),
             Box::new(m20250822_093713_add_updated_at_for_file_list_table::Migration),
             Box::new(m20250923_000001_update_enrichment_table_data_size::Migration),
+            Box::new(m20250930_000001_create_pipeline_last_errors_table::Migration),
         ]
     }
 }

--- a/src/service/db/mod.rs
+++ b/src/service/db/mod.rs
@@ -39,6 +39,7 @@ pub mod ofga;
 pub mod org_users;
 pub mod organization;
 pub mod pipeline;
+pub mod pipeline_errors;
 #[cfg(feature = "enterprise")]
 pub mod re_pattern;
 pub mod saved_view;

--- a/src/service/db/pipeline_errors.rs
+++ b/src/service/db/pipeline_errors.rs
@@ -91,10 +91,10 @@ pub async fn batch_upsert(
     let txn = client.begin().await?;
 
     // Collect all pipeline_ids to check which exist
-    let pipeline_ids: Vec<String> = errors.iter().map(|(id, ..)| id.clone()).collect();
+    let pipeline_ids: Vec<&str> = errors.iter().map(|(id, ..)| id.as_str()).collect();
 
     let existing_records = PipelineLastErrors::find()
-        .filter(pipeline_last_errors::Column::PipelineId.is_in(pipeline_ids.clone()))
+        .filter(pipeline_last_errors::Column::PipelineId.is_in(pipeline_ids))
         .all(&txn)
         .await?;
 

--- a/src/service/db/pipeline_errors.rs
+++ b/src/service/db/pipeline_errors.rs
@@ -1,0 +1,331 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use config::{meta::self_reporting::error::PipelineError, utils::time::now_micros};
+use infra::{
+    db::{ORM_CLIENT, connect_to_orm},
+    table::entity::{pipeline_last_errors, prelude::PipelineLastErrors},
+};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
+
+/// Upserts a pipeline error record.
+///
+/// If the pipeline_id already exists, updates the existing record.
+/// If it doesn't exist, creates a new record.
+pub async fn upsert(
+    pipeline_id: &str,
+    pipeline_name: &str,
+    org_id: &str,
+    timestamp: i64,
+    error_data: &PipelineError,
+) -> Result<(), infra::errors::Error> {
+    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
+    // Serialize node_errors to JSON
+    let node_errors_json = if !error_data.node_errors.is_empty() {
+        Some(serde_json::to_value(&error_data.node_errors)?)
+    } else {
+        None
+    };
+
+    // Check if record exists
+    let existing = PipelineLastErrors::find_by_id(pipeline_id)
+        .one(client)
+        .await?;
+
+    if let Some(existing_model) = existing {
+        // Update existing record
+        let mut active_model: pipeline_last_errors::ActiveModel = existing_model.into();
+        active_model.last_error_timestamp = Set(timestamp);
+        active_model.error_summary = Set(error_data.error.clone());
+        active_model.node_errors = Set(node_errors_json);
+        active_model.updated_at = Set(now_micros());
+
+        active_model.update(client).await?;
+    } else {
+        // Insert new record
+        let now = now_micros();
+        let active_model = pipeline_last_errors::ActiveModel {
+            pipeline_id: Set(pipeline_id.to_string()),
+            org_id: Set(org_id.to_string()),
+            pipeline_name: Set(pipeline_name.to_string()),
+            last_error_timestamp: Set(timestamp),
+            error_summary: Set(error_data.error.clone()),
+            node_errors: Set(node_errors_json),
+            created_at: Set(now),
+            updated_at: Set(now),
+        };
+
+        active_model.insert(client).await?;
+    }
+
+    Ok(())
+}
+
+/// Batch upserts multiple pipeline error records in a single transaction.
+///
+/// This is more efficient than individual upserts when processing multiple errors.
+/// Uses a transaction to ensure atomicity.
+pub async fn batch_upsert(
+    errors: Vec<(String, String, String, i64, PipelineError)>, /* (pipeline_id, pipeline_name, org_id, timestamp, error_data) */
+) -> Result<(), infra::errors::Error> {
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+    let txn = client.begin().await?;
+
+    // Collect all pipeline_ids to check which exist
+    let pipeline_ids: Vec<String> = errors.iter().map(|(id, ..)| id.clone()).collect();
+
+    let existing_records = PipelineLastErrors::find()
+        .filter(pipeline_last_errors::Column::PipelineId.is_in(pipeline_ids.clone()))
+        .all(&txn)
+        .await?;
+
+    let existing_ids: std::collections::HashSet<String> = existing_records
+        .into_iter()
+        .map(|r| r.pipeline_id)
+        .collect();
+
+    let now = now_micros();
+
+    for (pipeline_id, pipeline_name, org_id, timestamp, error_data) in errors {
+        // Serialize node_errors to JSON
+        let node_errors_json = if !error_data.node_errors.is_empty() {
+            Some(serde_json::to_value(&error_data.node_errors)?)
+        } else {
+            None
+        };
+
+        if existing_ids.contains(&pipeline_id) {
+            // Update existing record
+            let existing = PipelineLastErrors::find_by_id(&pipeline_id)
+                .one(&txn)
+                .await?
+                .unwrap();
+
+            let mut active_model: pipeline_last_errors::ActiveModel = existing.into();
+            active_model.last_error_timestamp = Set(timestamp);
+            active_model.error_summary = Set(error_data.error.clone());
+            active_model.node_errors = Set(node_errors_json);
+            active_model.updated_at = Set(now);
+
+            active_model.update(&txn).await?;
+        } else {
+            // Insert new record
+            let active_model = pipeline_last_errors::ActiveModel {
+                pipeline_id: Set(pipeline_id),
+                org_id: Set(org_id),
+                pipeline_name: Set(pipeline_name),
+                last_error_timestamp: Set(timestamp),
+                error_summary: Set(error_data.error.clone()),
+                node_errors: Set(node_errors_json),
+                created_at: Set(now),
+                updated_at: Set(now),
+            };
+
+            active_model.insert(&txn).await?;
+        }
+    }
+
+    txn.commit().await?;
+    Ok(())
+}
+
+/// Retrieves all pipeline errors for a given organization.
+///
+/// Results are ordered by last_error_timestamp descending (most recent first).
+pub async fn list_by_org(
+    org_id: &str,
+) -> Result<Vec<pipeline_last_errors::Model>, infra::errors::Error> {
+    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
+    let errors = PipelineLastErrors::find()
+        .filter(pipeline_last_errors::Column::OrgId.eq(org_id))
+        .order_by_desc(pipeline_last_errors::Column::LastErrorTimestamp)
+        .all(client)
+        .await?;
+
+    Ok(errors)
+}
+
+/// Retrieves a pipeline error by pipeline_id.
+pub async fn get_by_pipeline_id(
+    pipeline_id: &str,
+) -> Result<Option<pipeline_last_errors::Model>, infra::errors::Error> {
+    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
+    let error = PipelineLastErrors::find_by_id(pipeline_id)
+        .one(client)
+        .await?;
+
+    Ok(error)
+}
+
+/// Deletes a pipeline error record by pipeline_id.
+pub async fn delete(pipeline_id: &str) -> Result<(), infra::errors::Error> {
+    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
+    PipelineLastErrors::delete_many()
+        .filter(pipeline_last_errors::Column::PipelineId.eq(pipeline_id))
+        .exec(client)
+        .await?;
+
+    Ok(())
+}
+
+/// Deletes all pipeline error records for an organization.
+pub async fn delete_by_org(org_id: &str) -> Result<(), infra::errors::Error> {
+    let client = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
+    PipelineLastErrors::delete_many()
+        .filter(pipeline_last_errors::Column::OrgId.eq(org_id))
+        .exec(client)
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use config::meta::self_reporting::error::{NodeErrors, PipelineError};
+
+    use super::*;
+
+    #[tokio::test]
+    #[ignore] // Requires database connection
+    async fn test_upsert_and_get() {
+        let pipeline_id = "test_pipeline_123";
+        let org_id = "test_org";
+        let pipeline_name = "Test Pipeline";
+        let timestamp = now_micros();
+
+        let mut node_errors = HashMap::new();
+        node_errors.insert(
+            "node_1".to_string(),
+            NodeErrors::new("node_1".to_string(), "function".to_string(), None),
+        );
+
+        let error_data = PipelineError {
+            pipeline_id: pipeline_id.to_string(),
+            pipeline_name: pipeline_name.to_string(),
+            error: Some("Test error message".to_string()),
+            node_errors,
+        };
+
+        // Insert
+        let result = upsert(pipeline_id, pipeline_name, org_id, timestamp, &error_data).await;
+        assert!(result.is_ok());
+
+        // Get
+        let retrieved = get_by_pipeline_id(pipeline_id).await.unwrap();
+        assert!(retrieved.is_some());
+        let model = retrieved.unwrap();
+        assert_eq!(model.pipeline_id, pipeline_id);
+        assert_eq!(model.org_id, org_id);
+
+        // Update
+        let updated_timestamp = timestamp + 1000;
+        let result = upsert(
+            pipeline_id,
+            pipeline_name,
+            org_id,
+            updated_timestamp,
+            &error_data,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        // Verify update
+        let retrieved = get_by_pipeline_id(pipeline_id).await.unwrap();
+        assert!(retrieved.is_some());
+        let model = retrieved.unwrap();
+        assert_eq!(model.last_error_timestamp, updated_timestamp);
+
+        // Cleanup
+        delete(pipeline_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires database connection
+    async fn test_list_by_org() {
+        let org_id = "test_org_list";
+        let timestamp = now_micros();
+
+        let error_data = PipelineError {
+            pipeline_id: "pl1".to_string(),
+            pipeline_name: "Pipeline 1".to_string(),
+            error: Some("Error 1".to_string()),
+            node_errors: HashMap::new(),
+        };
+
+        // Insert multiple records
+        upsert("pl1", "Pipeline 1", org_id, timestamp, &error_data)
+            .await
+            .unwrap();
+        upsert("pl2", "Pipeline 2", org_id, timestamp + 1000, &error_data)
+            .await
+            .unwrap();
+
+        // List
+        let errors = list_by_org(org_id).await.unwrap();
+        assert!(errors.len() >= 2);
+
+        // Verify ordering (most recent first)
+        if errors.len() >= 2 {
+            assert!(errors[0].last_error_timestamp >= errors[1].last_error_timestamp);
+        }
+
+        // Cleanup
+        delete_by_org(org_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires database connection
+    async fn test_delete() {
+        let pipeline_id = "test_pipeline_delete";
+        let org_id = "test_org";
+        let timestamp = now_micros();
+
+        let error_data = PipelineError {
+            pipeline_id: pipeline_id.to_string(),
+            pipeline_name: "Test Pipeline".to_string(),
+            error: Some("Test error".to_string()),
+            node_errors: HashMap::new(),
+        };
+
+        // Insert
+        upsert(pipeline_id, "Test Pipeline", org_id, timestamp, &error_data)
+            .await
+            .unwrap();
+
+        // Verify exists
+        let retrieved = get_by_pipeline_id(pipeline_id).await.unwrap();
+        assert!(retrieved.is_some());
+
+        // Delete
+        delete(pipeline_id).await.unwrap();
+
+        // Verify deleted
+        let retrieved = get_by_pipeline_id(pipeline_id).await.unwrap();
+        assert!(retrieved.is_none());
+    }
+}

--- a/src/service/ingestion/mod.rs
+++ b/src/service/ingestion/mod.rs
@@ -136,11 +136,13 @@ pub fn apply_vrl_fn(
                         TRANSFORM_FAILED,
                     ])
                     .inc();
-                let err_msg = format!(
-                    "{org_id}/{stream_name:?} vrl failed at processing result {err:?} on record {row:?}. Returning original row.",
+                // Log full error with record for debugging
+                log::warn!(
+                    "{org_id}/{stream_name:?} vrl failed at processing result {err:?} on record {row:?}. Returning original row."
                 );
-                log::warn!("{err_msg}");
-                (row, Some(err_msg))
+                // Return only error message without sensitive record data
+                let clean_err = format!("{org_id}/{stream_name:?} vrl failed: {err:?}");
+                (row, Some(clean_err))
             }
         },
         Err(err) => {
@@ -152,11 +154,13 @@ pub fn apply_vrl_fn(
                     TRANSFORM_FAILED,
                 ])
                 .inc();
-            let err_msg = format!(
-                "{org_id}/{stream_name:?} vrl runtime failed at getting result {err:?} on record {row:?}. Returning original row.",
+            // Log full error with record for debugging
+            log::warn!(
+                "{org_id}/{stream_name:?} vrl runtime failed at getting result {err:?} on record {row:?}. Returning original row."
             );
-            log::warn!("{err_msg}");
-            (row, Some(err_msg))
+            // Return only error message without sensitive record data
+            let clean_err = format!("{org_id}/{stream_name:?} vrl runtime error: {err:?}");
+            (row, Some(clean_err))
         }
     }
 }

--- a/src/service/self_reporting/mod.rs
+++ b/src/service/self_reporting/mod.rs
@@ -238,6 +238,8 @@ pub async fn publish_error(error_data: ErrorData) {
     if !cfg.common.usage_enabled {
         return;
     }
+
+    // Queue error for batch processing (includes DB upsert and _meta stream ingestion)
     match queues::ERROR_QUEUE
         .enqueue(ReportingData::Error(Box::new(error_data)))
         .await

--- a/src/service/self_reporting/queues.rs
+++ b/src/service/self_reporting/queues.rs
@@ -149,15 +149,19 @@ async fn ingest_buffered_data(thread_id: usize, buffered: Vec<ReportingData>) {
         buffered.len()
     );
 
-    let (usages, triggers, errors) = buffered.into_iter().fold(
-        (Vec::new(), Vec::new(), Vec::new()),
-        |(mut usages, mut triggers, mut errors), item| {
+    let (usages, triggers, errors, raw_errors) = buffered.into_iter().fold(
+        (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
+        |(mut usages, mut triggers, mut errors, mut raw_errors), item| {
             match item {
                 ReportingData::Usage(usage) => usages.push(*usage),
                 ReportingData::Trigger(trigger) => triggers.push(json::to_value(*trigger).unwrap()),
-                ReportingData::Error(error) => errors.push(json::to_value(*error).unwrap()),
+                ReportingData::Error(error) => {
+                    // Keep raw error data for DB batching
+                    raw_errors.push(*error.clone());
+                    errors.push(json::to_value(*error).unwrap());
+                }
             }
-            (usages, triggers, errors)
+            (usages, triggers, errors, raw_errors)
         },
     );
 
@@ -209,6 +213,42 @@ async fn ingest_buffered_data(thread_id: usize, buffered: Vec<ReportingData>) {
         let error_stream = StreamParams::new(META_ORG_ID, ERROR_STREAM, StreamType::Logs);
         if let Err(e) = super::ingestion::ingest_reporting_data(errors, error_stream).await {
             log::error!("[SELF-REPORTING] Error in ingesting ErrorData: {e}");
+        }
+    }
+
+    // Batch upsert pipeline errors to DB
+    if !raw_errors.is_empty() {
+        let pipeline_errors: Vec<_> = raw_errors
+            .into_iter()
+            .filter_map(|error_data| {
+                // Only process pipeline errors
+                if let config::meta::self_reporting::error::ErrorSource::Pipeline(pipeline_error) =
+                    error_data.error_source
+                {
+                    Some((
+                        pipeline_error.pipeline_id.clone(),
+                        pipeline_error.pipeline_name.clone(),
+                        error_data.stream_params.org_id.to_string(),
+                        error_data._timestamp,
+                        pipeline_error,
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if !pipeline_errors.is_empty() {
+            log::debug!(
+                "[SELF-REPORTING] thread_{thread_id} batch upserting {} pipeline errors to DB",
+                pipeline_errors.len()
+            );
+            if let Err(e) = crate::service::db::pipeline_errors::batch_upsert(pipeline_errors).await
+            {
+                log::error!(
+                    "[SELF-REPORTING] thread_{thread_id} failed to batch upsert pipeline errors to DB: {e}"
+                );
+            }
         }
     }
 }

--- a/src/service/self_reporting/queues.rs
+++ b/src/service/self_reporting/queues.rs
@@ -156,9 +156,10 @@ async fn ingest_buffered_data(thread_id: usize, buffered: Vec<ReportingData>) {
                 ReportingData::Usage(usage) => usages.push(*usage),
                 ReportingData::Trigger(trigger) => triggers.push(json::to_value(*trigger).unwrap()),
                 ReportingData::Error(error) => {
+                    let error_data = *error;
                     // Keep raw error data for DB batching
-                    raw_errors.push(*error.clone());
-                    errors.push(json::to_value(*error).unwrap());
+                    errors.push(json::to_value(&error_data).unwrap());
+                    raw_errors.push(error_data);
                 }
             }
             (usages, triggers, errors, raw_errors)

--- a/web/src/components/pipeline/PipelineView.vue
+++ b/web/src/components/pipeline/PipelineView.vue
@@ -47,7 +47,7 @@
   <script>
   import { getImageURL } from "@/utils/zincutils";
 import DropzoneBackground from "@/plugins/pipelines/DropzoneBackground.vue";
-  import { defineComponent, computed } from 'vue';
+  import { defineComponent, computed, watch } from 'vue';
   import { VueFlow } from "@vue-flow/core";
   import { ref, onMounted } from "vue";
 import CustomNode from '@/plugins/pipelines/CustomNode.vue';
@@ -87,11 +87,10 @@ const queryImage = getImageURL("images/pipeline/input_query.png");
   
 
       onMounted(async () => {
-
       if (vueFlowRef.value) {
         vueFlowRef.value.fitView({ padding: 0.1});
       }
-        
+
         pipelineObj.nodeTypes = [
   {
     label: "Source",
@@ -157,7 +156,6 @@ const queryImage = getImageURL("images/pipeline/input_query.png");
     isSectionHeader: false,
   },
 ];
-        pipelineObj.currentSelectedPipeline = props.pipeline;
 
         setTimeout(() => {
           if(vueFlowRef.value)
@@ -165,7 +163,14 @@ const queryImage = getImageURL("images/pipeline/input_query.png");
         }, 100);
 
       })
-  
+
+      // Watch for pipeline prop changes to update error information
+      watch(() => props.pipeline, (newPipeline) => {
+        if (newPipeline) {
+          pipelineObj.currentSelectedPipeline = newPipeline;
+        }
+      }, { immediate: true });
+
       // Return the computed properties
       return {
         lockedNodes,

--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -208,7 +208,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   round
                   flat
                   color="negative"
-                  :title="t('pipeline.lastError')"
                   @click.stop
                 >
                   <q-tooltip>

--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -196,24 +196,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <PipelineView :pipeline="props.row" />
                   </q-tooltip>
                 </q-btn>
-                <!-- Error Indicator -->
-                <q-btn
-                  v-if="props.row.last_error"
-                  :data-test="`pipeline-list-${props.row.name}-error-indicator`"
-                  icon="error"
-                  class="q-ml-xs pipeline-error-btn"
-                  padding="sm"
-                  unelevated
-                  size="sm"
-                  round
-                  flat
-                  color="negative"
-                  @click.stop
-                >
-                  <q-tooltip>
-                    Last error: {{ new Date(props.row.last_error.last_error_timestamp / 1000).toLocaleString() }}
-                  </q-tooltip>
-                </q-btn>
+                <!-- Error Indicator - Always render to maintain alignment -->
+                <div class="q-ml-xs pipeline-error-slot">
+                  <q-btn
+                    v-if="props.row.last_error"
+                    :data-test="`pipeline-list-${props.row.name}-error-indicator`"
+                    icon="error"
+                    class="pipeline-error-indicator"
+                    padding="sm"
+                    unelevated
+                    size="sm"
+                    round
+                    flat
+                    @click.stop
+                  >
+                    <q-tooltip>
+                      Last error: {{ new Date(props.row.last_error.last_error_timestamp / 1000).toLocaleString() }}
+                    </q-tooltip>
+                  </q-btn>
+                </div>
               </template>
             </q-td>
           </q-tr>
@@ -1082,11 +1083,18 @@ const bulkTogglePipelines = async (action: "pause" | "resume") => {
   align-items: center;
 }
 
-.pipeline-error-btn {
-  opacity: 0.9;
+.pipeline-error-slot {
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  vertical-align: middle;
+}
+
+.pipeline-error-indicator {
+  color: #ef4444 !important;
 
   &:hover {
-    opacity: 1;
+    background-color: rgba(239, 68, 68, 0.1) !important;
   }
 }
 </style>

--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -196,6 +196,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <PipelineView :pipeline="props.row" />
                   </q-tooltip>
                 </q-btn>
+                <!-- Error Indicator -->
+                <q-btn
+                  v-if="props.row.last_error"
+                  :data-test="`pipeline-list-${props.row.name}-error-indicator`"
+                  icon="error"
+                  class="q-ml-xs pipeline-error-btn"
+                  padding="sm"
+                  unelevated
+                  size="sm"
+                  round
+                  flat
+                  color="negative"
+                  :title="t('pipeline.lastError')"
+                  @click.stop
+                >
+                  <q-tooltip>
+                    Last error: {{ new Date(props.row.last_error.last_error_timestamp / 1000).toLocaleString() }}
+                  </q-tooltip>
+                </q-btn>
               </template>
             </q-td>
           </q-tr>
@@ -1062,5 +1081,13 @@ const bulkTogglePipelines = async (action: "pause" | "resume") => {
   width: 100%;
   justify-content: space-between;
   align-items: center;
+}
+
+.pipeline-error-btn {
+  opacity: 0.9;
+
+  &:hover {
+    opacity: 1;
+  }
 }
 </style>


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Surface last pipeline error in API

- Persist pipeline errors in new table

- Batch upsert pipeline errors from reporting

- Safer error messages in VRL failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Reporting["Self-reporting errors"] -- "batch_upsert" --> DB["Table: pipeline_last_errors"]
  API["GET /pipelines"] -- "join with errors" --> UIData["PipelineList.last_error"]
  UIData -- "render" --> ListUI["PipelinesList error icon"]
  UIData -- "per-node errors" --> NodeUI["CustomNode error badge"]
  Ingestion["VRL apply_vrl_fn"] -- "clean error message" --> Reporting
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>config.rs</strong><dd><code>Bump DB schema version to 10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Wire migration for last errors table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-7ee42a714d3d56c663da0412d15514613222055aebb5b50dafbc051a656a36f6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>pipelines.rs</strong><dd><code>Add last_error to pipeline model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-61bb28d7091130297c917a0530d96202fcb4b073b514410531f9fe71acfc814f">+22/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pipeline.rs</strong><dd><code>Join pipelines with last error data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-c69f4f94eee97ce226caddc497b2adf89e26869f2d72b0d0206dc31ab2714daf">+26/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Register pipeline_last_errors entity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-c539d7557d1425986d5c09849d8dbca42d1b309c2bc33d49db641d6a783098f6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pipeline_last_errors.rs</strong><dd><code>Define ORM entity for last errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-e4ff5af0cb9c6e6343ecaad06fbb03515ace8868be6ee6d192ff0f01ee4d3e17">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prelude.rs</strong><dd><code>Export PipelineLastErrors entity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-a818656b9fb01945155f28450270dd2ae20b67c8248c851ffa0f25e859d263ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>m20250930_000001_create_pipeline_last_errors_table.rs</strong><dd><code>Create pipeline_last_errors table and index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-173fe20fccfdcfa68563a13f9d69c2e6cb0901ac257d43386962bbac90f296de">+169/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Expose pipeline_errors DB module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-b7e3bf7f0ac23dd084c0c817a310a4d5e7a64ff532746d182986ef940fa03fd0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pipeline_errors.rs</strong><dd><code>CRUD and batch upsert for pipeline errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-627b6bb9ca334984b8f08f1405a67e5110c238788f165e30abda39b03f7ab68f">+331/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>queues.rs</strong><dd><code>Batch upsert pipeline errors during ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-ed15a56d4d3becc2dfb3d05af2dac7f92962ec3091199728fa953e6aed7ed767">+45/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PipelinesList.vue</strong><dd><code>Show pipeline-level last error indicator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-85e3ef322f3eea0fc6d74d89431ba338a1153cb82ee06bef0f7c5f439c04267d">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CustomNode.vue</strong><dd><code>Show node-level error badge and navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-b9d83cd503b6d3470b238accaaea0b4decf567add8ad4727c63c9e583725f408">+98/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Return sanitized VRL error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-7c7b5bca85f0ced652965cae66540c96f56dfcca4f4c16b77bf7b45aac203d1b">+12/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Clarify queuing of error data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8695/files#diff-c6255010f7a87d6acdb3ad04954fc9f2c27350ae319c53a1857b120aa06408a3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

