### PR TITLE
fix: pipeline_last_errors existing index issue

### DIFF
--- a/src/infra/src/table/migration/m20250930_000001_create_pipeline_last_errors_table.rs
+++ b/src/infra/src/table/migration/m20250930_000001_create_pipeline_last_errors_table.rs
@@ -33,6 +33,7 @@ impl MigrationTrait for Migration {
                     .table(PipelineLastErrors::Table)
                     .col(PipelineLastErrors::OrgId)
                     .col(PipelineLastErrors::LastErrorTimestamp)
+                    .if_not_exists()
                     .to_owned(),
             )
             .await?;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add safeguard to index creation

- Prevent failures on existing index


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Migration["Migration: create index on pipeline_last_errors"]
  IndexCreate["Index::create with OrgId, LastErrorTimestamp"]
  IfNotExists["Add .if_not_exists()"]
  SafeMigrate["Idempotent migration without duplicate index error"]

  Migration -- "build index" --> IndexCreate
  IndexCreate -- "ensure exists check" --> IfNotExists
  IfNotExists -- "prevents duplicate creation" --> SafeMigrate
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>m20250930_000001_create_pipeline_last_errors_table.rs</strong><dd><code>Guard index creation with if_not_exists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/table/migration/m20250930_000001_create_pipeline_last_errors_table.rs

<ul><li>Add <code>.if_not_exists()</code> to index creation<br> <li> Make migration idempotent on existing index</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8705/files#diff-173fe20fccfdcfa68563a13f9d69c2e6cb0901ac257d43386962bbac90f296de">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

