### PR TITLE
fix: alerts with threshold from dashboards

### DIFF
--- a/web/src/components/alerts/AddAlert.vue
+++ b/web/src/components/alerts/AddAlert.vue
@@ -1096,16 +1096,23 @@ export default defineComponent({
               await updateStreamFields(query.fields.stream);
             }
 
-            if (panelData.queryType === "sql" && query.query) {
+            // Set query type based on panel (SQL or PromQL)
+            if (panelData.queryType === "sql") {
               formData.value.query_condition.type = "sql";
-              formData.value.query_condition.sql = query.query;
-              isAggregationEnabled.value = false;
-            } else if (panelData.queryType === "promql" && query.query) {
+              // If the panel has a generated query, populate it
+              if (query.query) {
+                formData.value.query_condition.sql = query.query;
+              }
+            } else if (panelData.queryType === "promql") {
               formData.value.query_condition.type = "promql";
-              formData.value.query_condition.promql = query.query;
+              if (query.query) {
+                formData.value.query_condition.promql = query.query;
+              }
             }
 
-            if (query.customQuery === false && query.fields) {
+            // Handle query builder fields for SQL panels
+            if (panelData.queryType === "sql" && query.customQuery === false && query.fields) {
+              // Enable aggregation for query builder generated SQL
               isAggregationEnabled.value = true;
 
               if (query.fields.x && query.fields.x.length > 0) {
@@ -1183,6 +1190,32 @@ export default defineComponent({
               }
 
               formData.value.trigger_condition.period = periodInMinutes;
+            }
+
+            // Handle threshold and condition from context menu
+            if (panelData.threshold !== undefined && panelData.condition) {
+              formData.value.trigger_condition.threshold = panelData.threshold;
+
+              // Set the operator based on condition
+              if (panelData.condition === 'above') {
+                formData.value.trigger_condition.operator = '>=';
+              } else if (panelData.condition === 'below') {
+                formData.value.trigger_condition.operator = '<=';
+              }
+
+              // If aggregation is enabled, also set the having clause
+              if (isAggregationEnabled.value && formData.value.query_condition.aggregation) {
+                if (!formData.value.query_condition.aggregation.having) {
+                  formData.value.query_condition.aggregation.having = {
+                    column: "",
+                    operator: ">=",
+                    value: 1,
+                  };
+                }
+                formData.value.query_condition.aggregation.having.value = panelData.threshold;
+                formData.value.query_condition.aggregation.having.operator =
+                  panelData.condition === 'above' ? '>=' : '<=';
+              }
             }
           }
         } catch (error) {
@@ -1329,10 +1362,21 @@ export default defineComponent({
     // TODO OK: Refactor this code
     this.formData.ingest = ref(false);
     this.formData = { ...defaultValue, ...cloneDeep(this.modelValue) };
+
+    // Check if this is from a dashboard panel - if so, don't set default query type
+    const route = this.router.currentRoute.value;
+    const isFromPanel = route.query.fromPanel === "true" && route.query.panelData;
+
     if(!this.isUpdated){
       this.formData.is_real_time = this.alertType === 'realTime'? true : false;
     }
       this.formData.is_real_time = this.formData.is_real_time.toString();
+
+    // If from panel, we'll set the query type in loadPanelDataIfPresent
+    // So remove the default 'custom' type to avoid it showing Quick Mode initially
+    if (isFromPanel) {
+      this.formData.query_condition.type = ""; // Will be set by loadPanelDataIfPresent
+    }
 
     // Set default frequency to min_auto_refresh_interval
     if (this.store.state?.zoConfig?.min_auto_refresh_interval)

--- a/web/src/components/dashboards/AlertContextMenu.vue
+++ b/web/src/components/dashboards/AlertContextMenu.vue
@@ -1,0 +1,200 @@
+<!-- Copyright 2023 OpenObserve Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+  <teleport to="body">
+    <div
+      v-if="visible"
+      ref="menuRef"
+      class="alert-context-menu"
+      :style="menuStyle"
+      @click.stop
+      data-test="alert-context-menu"
+    >
+      <div
+        class="menu-item"
+        @click="handleMenuItemClick('above')"
+        @mouseenter="hoveredItem = 'above'"
+        @mouseleave="hoveredItem = null"
+        :class="{ 'hovered': hoveredItem === 'above' }"
+        data-test="alert-context-menu-above"
+      >
+        <q-icon name="arrow_upward" size="xs" class="q-mr-sm" />
+        <span>Create Alert with threshold above {{ formattedValue }}</span>
+      </div>
+      <div
+        class="menu-item"
+        @click="handleMenuItemClick('below')"
+        @mouseenter="hoveredItem = 'below'"
+        @mouseleave="hoveredItem = null"
+        :class="{ 'hovered': hoveredItem === 'below' }"
+        data-test="alert-context-menu-below"
+      >
+        <q-icon name="arrow_downward" size="xs" class="q-mr-sm" />
+        <span>Create Alert with threshold below {{ formattedValue }}</span>
+      </div>
+    </div>
+  </teleport>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
+
+export default defineComponent({
+  name: 'AlertContextMenu',
+  props: {
+    visible: {
+      type: Boolean,
+      default: false,
+    },
+    x: {
+      type: Number,
+      required: true,
+    },
+    y: {
+      type: Number,
+      required: true,
+    },
+    value: {
+      type: [Number, String],
+      required: true,
+    },
+  },
+  emits: ['select', 'close'],
+  setup(props, { emit }) {
+    const menuRef = ref<HTMLElement | null>(null);
+    const hoveredItem = ref<string | null>(null);
+
+    const formattedValue = computed(() => {
+      if (typeof props.value === 'number') {
+        return props.value.toLocaleString(undefined, {
+          maximumFractionDigits: 2,
+        });
+      }
+      return props.value;
+    });
+
+    const menuStyle = computed(() => ({
+      left: `${props.x}px`,
+      top: `${props.y}px`,
+    }));
+
+    const handleMenuItemClick = (condition: 'above' | 'below') => {
+      emit('select', {
+        condition,
+        threshold: props.value,
+      });
+    };
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.value && !menuRef.value.contains(event.target as Node)) {
+        emit('close');
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        emit('close');
+      }
+    };
+
+    watch(
+      () => props.visible,
+      (newVisible) => {
+        if (newVisible) {
+          setTimeout(() => {
+            document.addEventListener('click', handleClickOutside);
+            document.addEventListener('keydown', handleEscape);
+          }, 0);
+        } else {
+          document.removeEventListener('click', handleClickOutside);
+          document.removeEventListener('keydown', handleEscape);
+        }
+      },
+    );
+
+    onBeforeUnmount(() => {
+      document.removeEventListener('click', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    });
+
+    return {
+      menuRef,
+      hoveredItem,
+      formattedValue,
+      menuStyle,
+      handleMenuItemClick,
+    };
+  },
+});
+</script>
+
+<style scoped lang="scss">
+.alert-context-menu {
+  position: fixed;
+  z-index: 9999;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  min-width: 280px;
+  padding: 4px 0;
+
+  .menu-item {
+    display: flex;
+    align-items: center;
+    padding: 8px 16px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    font-size: 14px;
+    color: #333;
+
+    &.hovered,
+    &:hover {
+      background-color: #f5f5f5;
+    }
+
+    &:active {
+      background-color: #e0e0e0;
+    }
+
+    span {
+      user-select: none;
+    }
+  }
+}
+
+body.body--dark {
+  .alert-context-menu {
+    background: #2c2c2c;
+    border-color: #404040;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+
+    .menu-item {
+      color: #e0e0e0;
+
+      &.hovered,
+      &:hover {
+        background-color: #383838;
+      }
+
+      &:active {
+        background-color: #404040;
+      }
+    }
+  }
+}
+</style>


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add alert context menu on charts

- Pass threshold/condition to Add Alert

- Correct query-type handling from panels

- Sync HAVING with threshold when aggregated


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Chart["ChartRenderer (ECharts)"] -- "emit contextmenu {x,y,value}" --> Panel["PanelSchemaRenderer"]
  Panel -- "show AlertContextMenu" --> Menu["AlertContextMenu (above/below)"]
  Menu -- "select {condition, threshold}" --> Panel
  Panel -- "router.push addAlert?panelData=..." --> AddAlert["AddAlert.vue"]
  AddAlert -- "init form from panelData" --> Form["Query/Trigger setup"]
  AddAlert -- "set threshold/operator/HAVING" --> Form
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddAlert.vue</strong><dd><code>Robust panel-driven alert initialization and thresholds</code>&nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/AddAlert.vue

<ul><li>Set query type based on panel data<br> <li> Populate SQL/PromQL only if present<br> <li> Enable aggregation only for SQL builder queries<br> <li> Apply threshold/operator and HAVING from panel<br> <li> Avoid default 'custom' type when from panel</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8711/files#diff-7b426bb23e9ed0250c3877d6d97b099c42b2d20e22ddf4459915381b2233a0a8">+50/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AlertContextMenu.vue</strong><dd><code>Add alert creation context menu component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/AlertContextMenu.vue

<ul><li>New context menu component for alerts<br> <li> Provides above/below threshold actions<br> <li> Handles outside click and Escape close<br> <li> Dark/light themed styling</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8711/files#diff-1fef708fc24bed7cc2b198f86b39554690fd6ba3ba778651c3fffb42969770c5">+200/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PanelSchemaRenderer.vue</strong><dd><code>Integrate context menu and route to Add Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/PanelSchemaRenderer.vue

<ul><li>Wire chart contextmenu to open alert menu<br> <li> Lazy-load and render AlertContextMenu<br> <li> Build panelData payload with threshold/condition<br> <li> Navigate to Add Alert with encoded data</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8711/files#diff-e5376e7e77bf3aaf6590c2522d8c2dbffcc95a8006ae0d6dc0040a37825367d6">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChartRenderer.vue</strong><dd><code>Add contextmenu support for data point alerts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/panels/ChartRenderer.vue

<ul><li>Emit contextmenu with point coords and value<br> <li> Prevent default menu, support bar/line charts<br> <li> Unbind/bind contextmenu listener on lifecycle<br> <li> Extract value from diverse data formats</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8711/files#diff-353fab39cd76197438814db862c4a506636ea7e15633ee92d9269adbd97fe67c">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

