### PR TITLE
fix: histogram total count was getting set as 0 in case of streaming aggs

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -6343,7 +6343,7 @@ const useLogs = () => {
         searchAggData.hasAggregation = true;
         searchObj.meta.resultGrid.showPagination = false;
 
-        if (response.content?.streaming_aggs) {
+        if (response.content?.streaming_aggs && response.content?.results?.total) {
           searchAggData.total = response.content?.results?.total;
         } else {
           searchAggData.total =


### PR DESCRIPTION
The histogram total count was getting set to 0 in case of streaming aggs when the first partition returns results and next all partitions return empty hits. In this case it should consider the count of the first partition.