### PR TITLE
feat: cache hist query with non ts col order by

### DIFF
--- a/src/common/meta/search.rs
+++ b/src/common/meta/search.rs
@@ -50,10 +50,11 @@ pub struct CacheQueryRequest {
     pub ts_column: String,
     pub discard_interval: i64,
     pub is_descending: bool,
-    /// Flag indicating this is a histogram query with non-timestamp ORDER BY.
+    /// Flag indicating this is a histogram query with non-timestamp column ORDER BY.
     /// When true, cache file timestamps must be calculated by scanning all hits,
     /// not just first/last, since results may not be time-ordered.
-    pub is_non_ts_histogram: bool,
+    /// Example: SELECT histogram(_timestamp), count(*) ... ORDER BY count DESC
+    pub is_histogram_non_ts_order: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, Default)]

--- a/src/common/meta/search.rs
+++ b/src/common/meta/search.rs
@@ -50,6 +50,10 @@ pub struct CacheQueryRequest {
     pub ts_column: String,
     pub discard_interval: i64,
     pub is_descending: bool,
+    /// Flag indicating this is a histogram query with non-timestamp ORDER BY.
+    /// When true, cache file timestamps must be calculated by scanning all hits,
+    /// not just first/last, since results may not be time-ordered.
+    pub is_non_ts_histogram: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, Default)]

--- a/src/handler/grpc/request/query_cache.rs
+++ b/src/handler/grpc/request/query_cache.rs
@@ -45,7 +45,7 @@ impl QueryCache for QueryCacheServerImpl {
                 ts_column: req.timestamp_col,
                 discard_interval: req.discard_interval,
                 is_descending: req.is_descending,
-                is_non_ts_histogram: false, // gRPC handler: flag determined at query planning
+                is_histogram_non_ts_order: false, // gRPC handler: flag determined at query planning
             },
         )
         .await
@@ -97,7 +97,7 @@ impl QueryCache for QueryCacheServerImpl {
                 ts_column: req.timestamp_col,
                 discard_interval: req.discard_interval,
                 is_descending: req.is_descending,
-                is_non_ts_histogram: false, // gRPC handler: flag determined at query planning
+                is_histogram_non_ts_order: false, // gRPC handler: flag determined at query planning
             },
         )
         .await;

--- a/src/handler/grpc/request/query_cache.rs
+++ b/src/handler/grpc/request/query_cache.rs
@@ -45,6 +45,7 @@ impl QueryCache for QueryCacheServerImpl {
                 ts_column: req.timestamp_col,
                 discard_interval: req.discard_interval,
                 is_descending: req.is_descending,
+                is_non_ts_histogram: false, // gRPC handler: flag determined at query planning
             },
         )
         .await
@@ -96,6 +97,7 @@ impl QueryCache for QueryCacheServerImpl {
                 ts_column: req.timestamp_col,
                 discard_interval: req.discard_interval,
                 is_descending: req.is_descending,
+                is_non_ts_histogram: false, // gRPC handler: flag determined at query planning
             },
         )
         .await;

--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -218,7 +218,7 @@ pub async fn check_cache(
     // Determine if this is a histogram query with non-timestamp ORDER BY.
     // These queries need special handling because results may not be time-ordered,
     // requiring us to scan all hits to find the actual time range.
-    let is_non_ts_histogram = is_histogram_query
+    let is_histogram_non_ts_order = is_histogram_query
         && !order_by.is_empty()
         && !order_by
             .iter()
@@ -241,7 +241,7 @@ pub async fn check_cache(
                     ts_column: result_ts_col.clone(),
                     discard_interval,
                     is_descending,
-                    is_non_ts_histogram,
+                    is_histogram_non_ts_order,
                 },
                 is_streaming,
             )
@@ -326,7 +326,7 @@ pub async fn check_cache(
                 ts_column: result_ts_col.clone(),
                 discard_interval,
                 is_descending,
-                is_non_ts_histogram,
+                is_histogram_non_ts_order,
             },
         )
         .await

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -464,7 +464,7 @@ pub async fn search(
     {
         // Determine if this is a non-timestamp histogram query
         // Note: write_res.order_by_metadata contains the same ORDER BY info
-        let is_non_ts_histogram = c_resp.histogram_interval > 0
+        let is_histogram_non_ts_order = c_resp.histogram_interval > 0
             && !write_res.order_by_metadata.is_empty()
             && write_res
                 .order_by_metadata
@@ -482,7 +482,7 @@ pub async fn search(
             is_aggregate,
             c_resp.is_descending,
             c_resp.clear_cache,
-            is_non_ts_histogram,
+            is_histogram_non_ts_order,
         )
         .await;
     }
@@ -836,7 +836,7 @@ pub async fn _write_results(
     file_path: String,
     is_aggregate: bool,
     is_descending: bool,
-    is_non_ts_histogram: bool,
+    is_histogram_non_ts_order: bool,
 ) {
     // disable write_results_v1
     // return;
@@ -867,7 +867,7 @@ pub async fn _write_results(
     // Calculate actual time range of cached data.
     // For non-timestamp histogram queries, results may not be time-ordered,
     // so we must scan all hits to find the true min/max timestamps.
-    let (smallest_ts, largest_ts) = if is_non_ts_histogram {
+    let (smallest_ts, largest_ts) = if is_histogram_non_ts_order {
         // Scan all hits for non-timestamp ordered histogram queries
         let mut min_ts = i64::MAX;
         let mut max_ts = i64::MIN;
@@ -996,7 +996,7 @@ pub async fn write_results_v2(
     is_aggregate: bool,
     is_descending: bool,
     clear_cache: bool,
-    is_non_ts_histogram: bool,
+    is_histogram_non_ts_order: bool,
 ) {
     let mut local_resp = res.clone();
 
@@ -1098,7 +1098,7 @@ pub async fn write_results_v2(
 
     // For histogram queries with non-timestamp ORDER BY, we need to scan all hits
     // to find actual min/max timestamps, since results may not be time-ordered
-    let (smallest_ts, largest_ts) = if is_non_ts_histogram {
+    let (smallest_ts, largest_ts) = if is_histogram_non_ts_order {
         // For non-timestamp ordered histogram queries, scan all hits to find actual min/max
         let mut min_ts = i64::MAX;
         let mut max_ts = i64::MIN;

--- a/src/service/search/cache/multi.rs
+++ b/src/service/search/cache/multi.rs
@@ -200,7 +200,9 @@ async fn recursive_process_multiple_metas(
             if !cached_response.hits.is_empty() {
                 // For non-timestamp histogram queries, results are not sorted by time
                 // We need to scan all hits to find actual min/max timestamps
-                let (response_start_time, response_end_time) = if cache_req.is_non_ts_histogram {
+                let (response_start_time, response_end_time) = if cache_req
+                    .is_histogram_non_ts_order
+                {
                     let mut min_ts = i64::MAX;
                     let mut max_ts = i64::MIN;
                     for hit in &cached_response.hits {
@@ -306,7 +308,7 @@ fn get_allowed_up_to(
 ) -> i64 {
     // For non-timestamp histogram queries, results are not sorted by time
     // Scan all hits to find the actual maximum timestamp
-    if cache_req.is_non_ts_histogram {
+    if cache_req.is_histogram_non_ts_order {
         let max_ts = cached_response
             .hits
             .iter()

--- a/src/service/search/cache/result_utils.rs
+++ b/src/service/search/cache/result_utils.rs
@@ -40,3 +40,62 @@ pub fn round_down_to_nearest_minute(microseconds: i64) -> i64 {
     // Convert the adjusted time back to microseconds
     adjusted_seconds * microseconds_per_second
 }
+
+/// Checks if a field name matches the timestamp column, accounting for quoted names.
+///
+/// # Examples
+/// - `is_timestamp_field("_timestamp", "_timestamp")` returns `true`
+/// - `is_timestamp_field("\"_timestamp\"", "_timestamp")` returns `true`
+/// - `is_timestamp_field("count", "_timestamp")` returns `false`
+#[inline]
+pub fn is_timestamp_field(field: &str, ts_column: &str) -> bool {
+    field == ts_column || field.trim_matches('"') == ts_column
+}
+
+/// Checks if ORDER BY clause contains any non-timestamp columns.
+///
+/// Returns `true` if at least one ORDER BY field is not the timestamp column.
+///
+/// # Arguments
+/// * `order_by` - List of (field_name, order_direction) tuples
+/// * `ts_column` - The timestamp column name
+pub fn has_non_timestamp_ordering(
+    order_by: &[(String, config::meta::sql::OrderBy)],
+    ts_column: &str,
+) -> bool {
+    order_by
+        .iter()
+        .any(|(field, _)| !is_timestamp_field(field, ts_column))
+}
+
+/// Extracts the min and max timestamps from a set of hits.
+///
+/// For time-ordered results, this uses an optimization by only checking the first and last hits.
+/// For non-ordered results (e.g., histogram with `ORDER BY count DESC`), it scans all hits.
+///
+/// # Arguments
+/// * `hits` - The result hits to scan
+/// * `ts_column` - The timestamp column name
+/// * `is_time_ordered` - If `true`, uses first/last optimization; if `false`, scans all hits
+///
+/// # Returns
+/// A tuple of `(min_timestamp, max_timestamp)`
+pub fn extract_timestamp_range(
+    hits: &[config::utils::json::Value],
+    ts_column: &str,
+    is_time_ordered: bool,
+) -> (i64, i64) {
+    if is_time_ordered {
+        // Fast path: results are sorted by time, just check first and last
+        let first_ts = get_ts_value(ts_column, hits.first().unwrap());
+        let last_ts = get_ts_value(ts_column, hits.last().unwrap());
+        (first_ts.min(last_ts), first_ts.max(last_ts))
+    } else {
+        // Slow path: results are not time-ordered, must scan all hits
+        hits.iter()
+            .map(|hit| get_ts_value(ts_column, hit))
+            .fold((i64::MAX, i64::MIN), |(min_ts, max_ts), ts| {
+                (min_ts.min(ts), max_ts.max(ts))
+            })
+    }
+}

--- a/src/service/search/cluster/cache_multi.rs
+++ b/src/service/search/cluster/cache_multi.rs
@@ -215,7 +215,7 @@ pub async fn get_cached_results(
             ts_column: ts_column.to_string(),
             discard_interval: cache_req.discard_interval,
             is_descending: cache_req.is_descending,
-            is_non_ts_histogram: cache_req.is_non_ts_histogram, // Forward from original request
+            is_histogram_non_ts_order: cache_req.is_histogram_non_ts_order, // Forward from original request
         },
     )
     .await;

--- a/src/service/search/cluster/cache_multi.rs
+++ b/src/service/search/cluster/cache_multi.rs
@@ -215,6 +215,7 @@ pub async fn get_cached_results(
             ts_column: ts_column.to_string(),
             discard_interval: cache_req.discard_interval,
             is_descending: cache_req.is_descending,
+            is_non_ts_histogram: cache_req.is_non_ts_histogram, // Forward from original request
         },
     )
     .await;

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -214,6 +214,7 @@ pub async fn get_cached_results(
             ts_column,
             discard_interval: cache_req.discard_interval,
             is_descending: cache_req.is_descending,
+            is_non_ts_histogram: cache_req.is_non_ts_histogram, // Forward from original request
         },
     )
     .await

--- a/src/service/search/cluster/cacher.rs
+++ b/src/service/search/cluster/cacher.rs
@@ -214,7 +214,7 @@ pub async fn get_cached_results(
             ts_column,
             discard_interval: cache_req.discard_interval,
             is_descending: cache_req.is_descending,
-            is_non_ts_histogram: cache_req.is_non_ts_histogram, // Forward from original request
+            is_histogram_non_ts_order: cache_req.is_histogram_non_ts_order, // Forward from original request
         },
     )
     .await

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -1219,7 +1219,7 @@ pub async fn write_results_to_cache(
 
     if cfg.common.result_cache_enabled && should_cache_results {
         // Determine if this is a non-timestamp histogram query for websocket streaming
-        let is_non_ts_histogram = c_resp.histogram_interval > 0
+        let is_histogram_non_ts_order = c_resp.histogram_interval > 0
             && !merged_response.order_by_metadata.is_empty()
             && merged_response
                 .order_by_metadata
@@ -1237,7 +1237,7 @@ pub async fn write_results_to_cache(
             c_resp.is_aggregate,
             c_resp.is_descending,
             c_resp.clear_cache,
-            is_non_ts_histogram,
+            is_histogram_non_ts_order,
         )
         .await;
     }

--- a/src/service/websocket_events/search.rs
+++ b/src/service/websocket_events/search.rs
@@ -1218,6 +1218,15 @@ pub async fn write_results_to_cache(
         && !merged_response.hits.is_empty();
 
     if cfg.common.result_cache_enabled && should_cache_results {
+        // Determine if this is a non-timestamp histogram query for websocket streaming
+        let is_non_ts_histogram = c_resp.histogram_interval > 0
+            && !merged_response.order_by_metadata.is_empty()
+            && merged_response
+                .order_by_metadata
+                .first()
+                .map(|(field, _)| field != &c_resp.ts_column)
+                .unwrap_or(false);
+
         cache::write_results_v2(
             &c_resp.trace_id,
             &c_resp.ts_column,
@@ -1228,6 +1237,7 @@ pub async fn write_results_to_cache(
             c_resp.is_aggregate,
             c_resp.is_descending,
             c_resp.clear_cache,
+            is_non_ts_histogram,
         )
         .await;
     }


### PR DESCRIPTION
# Cache Non-Timestamp Order By Histogram Implementation 

- [x] Add `is_histogram_non_ts_order` flag to `CacheQueryRequest` struct
- [x] Calculate `is_histogram_non_ts_order` in `check_cache()` based on histogram + non-timestamp ORDER BY
- [x] Pass `is_histogram_non_ts_order` through all cache write paths (main, websocket, cluster)
- [x] Scan all hits for min/max timestamps when writing cache files for histogram non-ts ORDER BY queries
- [x] Fix `get_allowed_up_to()` to scan all hits for max timestamp (discard_ts calculation)
- [x] Fix `response_start_time`/`response_end_time` calculation in cache retrieval to scan all hits
- [x] Update retain filter boundary conditions (strict to inclusive where needed)
- [x] Preserve ORDER BY metadata in cached responses for correct result sorting
- [x] Refactor naming from `is_non_ts_histogram` to `is_histogram_non_ts_order` for clarity



# Test Queries for Histogram with Non-Timestamp Column ORDER BY Cache

## New Feature Test Queries (Histogram Non-TS Order)

### 1. Basic Histogram with COUNT ORDER BY DESC
```sql
SELECT histogram(_timestamp) AS x_axis_1, count(_timestamp) AS y_axis_1 
FROM "oly" 
GROUP BY x_axis_1 
ORDER BY y_axis_1 DESC
```
**Expected:** Results cached, ordered by count descending, correct count returned

### 2. Basic Histogram with COUNT ORDER BY ASC
```sql
SELECT histogram(_timestamp) AS x_axis_1, count(_timestamp) AS y_axis_1 
FROM "oly" 
GROUP BY x_axis_1 
ORDER BY y_axis_1 ASC
```
**Expected:** Results cached, ordered by count ascending

### 3. Histogram with SUM ORDER BY
```sql
SELECT histogram(_timestamp) AS time_bucket, SUM(bytes) AS total_bytes 
FROM "logs" 
GROUP BY time_bucket 
ORDER BY total_bytes DESC
```
**Expected:** Results cached, ordered by sum of bytes

### 4. Histogram with AVG ORDER BY
```sql
SELECT histogram(_timestamp) AS time_bucket, AVG(response_time) AS avg_response 
FROM "metrics" 
GROUP BY time_bucket 
ORDER BY avg_response DESC
```
**Expected:** Results cached, ordered by average

### 5. Histogram with Multiple Aggregations, Non-TS ORDER BY
```sql
SELECT histogram(_timestamp) AS time_bucket, 
       count(*) AS event_count,
       SUM(bytes) AS total_bytes
FROM "logs" 
GROUP BY time_bucket 
ORDER BY total_bytes DESC
```
**Expected:** Results cached, ordered by total_bytes

### 6. Histogram with MAX ORDER BY
```sql
SELECT histogram(_timestamp) AS time_bucket, MAX(value) AS max_val 
FROM "metrics" 
GROUP BY time_bucket 
ORDER BY max_val DESC
```
**Expected:** Results cached, ordered by max value

### 7. Multiple Histogram Columns with Non-TS ORDER BY
```sql
SELECT histogram(_timestamp) AS time_bucket,
       status_code,
       count(*) AS request_count
FROM "access_logs"
GROUP BY time_bucket, status_code
ORDER BY request_count DESC
```
**Expected:** Results cached with correct grouping and ordering

---

## Regression Test Queries (Existing Functionality)

### 8. Standard Histogram with Timestamp ORDER BY (Default ASC)
```sql
SELECT histogram(_timestamp) AS x_axis_1, count(_timestamp) AS y_axis_1 
FROM "oly" 
GROUP BY x_axis_1 
ORDER BY x_axis_1 ASC
```
**Expected:** Results cached, time-ordered ascending, should use fast first/last logic

### 9. Standard Histogram with Timestamp ORDER BY DESC
```sql
SELECT histogram(_timestamp) AS x_axis_1, count(_timestamp) AS y_axis_1 
FROM "oly" 
GROUP BY x_axis_1 
ORDER BY x_axis_1 DESC
```
**Expected:** Results cached, time-ordered descending, should use fast first/last logic

### 10. Histogram with NO ORDER BY (Default Time Order)
```sql
SELECT histogram(_timestamp) AS x_axis_1, count(_timestamp) AS y_axis_1 
FROM "oly" 
GROUP BY x_axis_1
```
**Expected:** Results cached, default time ordering, should use fast first/last logic

### 11. Histogram with Explicit _timestamp ORDER BY
```sql
SELECT histogram(_timestamp) AS time_bucket, count(*) AS cnt 
FROM "logs" 
GROUP BY time_bucket 
ORDER BY _timestamp DESC
```
**Expected:** Results cached, time-ordered, should use fast first/last logic

### 12. Non-Histogram Aggregate Query
```sql
SELECT count(*) AS total_count, SUM(bytes) AS total_bytes 
FROM "logs" 
WHERE _timestamp BETWEEN '2025-10-01' AND '2025-10-06'
```
**Expected:** Results cached normally (not affected by changes)

### 13. Raw Log Query (No Aggregation)
```sql
SELECT * FROM "logs" 
WHERE _timestamp BETWEEN '2025-10-01' AND '2025-10-06'
ORDER BY _timestamp DESC
LIMIT 1000
```
**Expected:** Results cached normally, time-ordered

### 14. Non-Histogram with Non-Timestamp ORDER BY
```sql
SELECT method, count(*) AS cnt 
FROM "access_logs" 
GROUP BY method 
ORDER BY cnt DESC
```
**Expected:** Should NOT use histogram non-ts order logic (no histogram)

---

## Edge Case Test Queries

### 15. Histogram with Mixed ORDER BY (Timestamp First, Then Count)
```sql
SELECT histogram(_timestamp) AS time_bucket, count(*) AS cnt 
FROM "logs" 
GROUP BY time_bucket 
ORDER BY time_bucket ASC, cnt DESC
```
**Expected:** Should be treated as time-ordered (first ORDER BY is timestamp)

### 16. Histogram with Empty Result Set
```sql
SELECT histogram(_timestamp) AS time_bucket, count(*) AS cnt 
FROM "logs" 
WHERE log_level = 'NONEXISTENT'
GROUP BY time_bucket 
ORDER BY cnt DESC
```
**Expected:** Cache should handle empty results gracefully

### 17. Very Large Time Range Histogram
```sql
SELECT histogram(_timestamp) AS time_bucket, count(*) AS cnt 
FROM "logs" 
WHERE _timestamp BETWEEN '2025-01-01' AND '2025-12-31'
GROUP BY time_bucket 
ORDER BY cnt DESC
```
**Expected:** Results cached with correct time range metadata

### 18. Histogram with Recent Data (Within Cache Delay)
```sql
SELECT histogram(_timestamp) AS time_bucket, count(*) AS cnt 
FROM "logs" 
WHERE _timestamp >= now() - INTERVAL '10 minutes'
GROUP BY time_bucket 
ORDER BY cnt DESC
```
**Expected:** Recent buckets (last 5 mins) should not be cached, older ones should be

### 19. Histogram with Multiple Non-Timestamp ORDER BY Columns
```sql
SELECT histogram(_timestamp) AS time_bucket, 
       status_code,
       count(*) AS cnt,
       SUM(bytes) AS total_bytes
FROM "access_logs"
GROUP BY time_bucket, status_code
ORDER BY cnt DESC, total_bytes DESC
```
**Expected:** Results cached, ordered by count then bytes

---

## Performance Test Queries

### 20. Large Dataset Histogram (Test Scan Performance)
```sql
SELECT histogram(_timestamp) AS time_bucket, count(*) AS cnt 
FROM "large_logs_table" 
WHERE _timestamp BETWEEN '2025-01-01' AND '2025-10-31'
GROUP BY time_bucket 
ORDER BY cnt DESC
```
**Expected:** Verify scanning all hits doesn't cause significant overhead

### 21. High Cardinality Histogram (Many Buckets)
```sql
SELECT histogram(_timestamp, '1m') AS time_bucket, count(*) AS cnt 
FROM "metrics" 
WHERE _timestamp BETWEEN '2025-10-01' AND '2025-10-06'
GROUP BY time_bucket 
ORDER BY cnt DESC
```
**Expected:** Handle many histogram buckets efficiently (1-minute granularity)

---

## Cache Behavior Verification Tests

### 22. First Query (Cold Cache)
```sql
SELECT histogram(_timestamp) AS x_axis_1, count(*) AS y_axis_1 
FROM "oly" 
GROUP BY x_axis_1 
ORDER BY y_axis_1 DESC
```
**Verify:** 
- `result_cache_ratio: 0` (no cache hit)
- Cache file created with correct timestamps
- `scan_records` > 0 (fresh query executed)

### 23. Second Query (Warm Cache)
```sql
-- Run same query as #22 again
SELECT histogram(_timestamp) AS x_axis_1, count(*) AS y_axis_1 
FROM "oly" 
GROUP BY x_axis_1 
ORDER BY y_axis_1 DESC
```
**Verify:**
- `result_cache_ratio: 100` (or close to 100)
- Cache hit successful
- `scan_records` minimal (only delta if any)
- Result count matches first query
- Result ordering matches first query

### 24. Query with Overlapping Time Range
```sql
SELECT histogram(_timestamp) AS x_axis_1, count(*) AS y_axis_1 
FROM "oly" 
WHERE _timestamp BETWEEN '2025-10-01' AND '2025-10-05'  -- Subset of cached range
GROUP BY x_axis_1 
ORDER BY y_axis_1 DESC
```
**Verify:**
- Cache hit for overlapping period
- Correct subset of results returned
- No duplicate buckets

### 25. Query with Extended Time Range
```sql
SELECT histogram(_timestamp) AS x_axis_1, count(*) AS y_axis_1 
FROM "oly" 
WHERE _timestamp BETWEEN '2025-10-01' AND '2025-10-10'  -- Extended beyond cache
GROUP BY x_axis_1 
ORDER BY y_axis_1 DESC
```
**Verify:**
- Partial cache hit
- Delta query for new time range
- Results properly merged without duplicates

---

