### PR TITLE
fix: promql editor issues in add alert page

### DIFF
--- a/web/src/components/alerts/ScheduledAlert.vue
+++ b/web/src/components/alerts/ScheduledAlert.vue
@@ -1320,11 +1320,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         :debounceTime="300"
                         v-model:query="promqlQuery"
                         @update:query="updateQueryValue"
-                      :class="[
-                        promqlQuery === '' ? 'empty-query' : '',
-                        store.state.theme === 'dark' ? 'dark-mode-editor dark-mode' : 'light-mode-editor light-mode',
-                        'tw-h-[calc(100%-62px)]'
-                      ]"
+                        :class="[
+                          promqlQuery === '' ? 'empty-query' : '',
+                          store.state.theme === 'dark' ? 'dark-mode-editor dark-mode' : 'light-mode-editor light-mode',
+                        ]"
+                        :style="{
+                            height:' calc(100% - 70px)'
+                          }"
                       @blur="onBlurQueryEditor"
                       style="min-height: 10rem;"
                     />
@@ -1513,12 +1515,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
           </div>
 
-          <div class="tw-w-full"
-          :class="expandSqlOutput ? 
-          expandCombinedOutput ?  'tw-flex-1 tw-h-[calc(50%-24px)]' : 'tw-flex-1tw-h-[calc(100%-24px)]' 
-          : expandCombinedOutput ? 'tw-flex-1 tw-h-[24px]' : 'tw-flex-1 tw-h-[calc(100%-24px)]'"
+          <div v-if="tab !== 'promql'"  class="tw-w-full"
+              :class="expandSqlOutput ? 
+              expandCombinedOutput ?  'tw-flex-1 tw-h-[calc(50%-24px)]' : 'tw-flex-1tw-h-[calc(100%-24px)]' 
+              : expandCombinedOutput ? 'tw-flex-1 tw-h-[24px]' : 'tw-flex-1 tw-h-[calc(100%-24px)]'"
           >
-            <div v-if="tab !== 'promql'" class="tw-flex tw-flex-col tw-items-start tw-justify-between tw-h-fit">
+            <div class="tw-flex tw-flex-col tw-items-start tw-justify-between tw-h-fit">
             <FullViewContainer
               name="Combined Output"
               label="Combined Output"
@@ -1869,6 +1871,8 @@ const updateTab = () => {
   updateAggregationToggle();
   emits("update:query_type", tab.value);
   emits("input:update", "query_type", tab.value);
+  outputEvents.value = "";
+  outputFnEvents.value = "";
 };
 
 const getDefaultPromqlCondition = () => {
@@ -2384,20 +2388,18 @@ const onColumnSelect = () => {
       const periodInMicroseconds = triggerData.value.period * 60 * 1000000;
       const endTime = new Date().getTime() * 1000; // ← Use 1000 to get microseconds
       const startTime = endTime - periodInMicroseconds;
-
-        queryReq.query.start_time = startTime;
-        queryReq.query.end_time = endTime;
-          outputEvents.value = "";
+        outputEvents.value = "";
+        queryReq.query = promqlQuery.value;
         try {
           const res = await searchService.metrics_query_range({
               org_identifier: store.state.selectedOrganization.identifier,
-              query: queryReq,
+              query: queryReq.query,
               start_time: startTime,
               end_time: endTime,
               step: '0'
             })
-          if(res.data.hits.length > 0){
-              outputEvents.value = JSON.stringify(res.data.hits,null,2);
+          if(res?.data?.data?.result.length > 0){
+              outputEvents.value = JSON.stringify(res?.data?.data?.result,null,2);
           }
         } catch (err: any) {
           runPromqlError.value = err.response.data.error ?? "Something went wrong";

--- a/web/src/components/alerts/ScheduledAlert.vue
+++ b/web/src/components/alerts/ScheduledAlert.vue
@@ -1215,7 +1215,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           }" :src="getBtnO2Logo" />
                           <span  
                           class=" tw-font-[400] tw-pl-[4px] tw-text-[12px] tw-pr-[6px] tw-py-[4px] tw-text-[#7980cc]" 
-                          >Generate SQL</span>
+                          > {{  tab == 'sql' ? 'Generate SQL' : 'Generate PromQL' }} </span>
                       </q-btn>
                       </div>
                       <div class="tw-h-full tw-flex tw-justify-center tw-items-center o2-select-input o2-input tw-w-full col"


### PR DESCRIPTION
### **User description**
This PR fixes the issues in
**No query is sent from the PromQL Editor resulting in error**
**PromQL Editor goes on infinite scrolling. shows console error ResizeObserver loop completed with undelivered notifications**


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix PromQL editor height and classes

- Correct query payload for PromQL range

- Reset outputs on tab change

- Dynamic AI button text by tab


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Tab switch & buttons"] -- "reset outputs" --> Outputs["Output panes"]
  UI -- "dynamic label" --> AIBtn["AI Generate button"]
  PromEditor["PromQL editor"] -- "stable height/style" --> Layout["Editor layout"]
  RunQuery["Run query (PromQL)"] -- "proper payload & parsing" --> Outputs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ScheduledAlert.vue</strong><dd><code>Stabilize PromQL UI and fix range query handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/ScheduledAlert.vue

<ul><li>AI button label depends on <code>tab</code> (SQL/PromQL).<br> <li> PromQL editor: remove hard class height; set style height.<br> <li> Hide SQL output area when on PromQL tab.<br> <li> Reset <code>outputEvents</code>/<code>outputFnEvents</code> on tab change.<br> <li> Use <code>promqlQuery</code> with <code>metrics_query_range</code>; adjust response parsing.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8748/files#diff-5e143a17ab0fa5d7817f6d9301667fb5597236f27184248c7a71728e85b8d999">+20/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

