### PR TITLE
fix: `timed_annotations.end_time` column update type

### DIFF
--- a/src/infra/src/table/timed_annotations.rs
+++ b/src/infra/src/table/timed_annotations.rs
@@ -378,7 +378,7 @@ pub async fn update(
     } else {
         update_query = update_query.col_expr(
             timed_annotations::Column::EndTime,
-            Expr::value(sea_orm::Value::Json(None)),
+            Expr::value(Option::<i64>::None),
         );
     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix null handling for `end_time` update

- Replace JSON None with integer None

- Ensure correct column value type


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UpdateFn["update() in timed_annotations.rs"] -- "when end_time is None" --> EndTimeExpr["Expr::value(Option::<i64>::None)"]
  UpdateFn -- "when end_time is Some" --> EndTimeValue["Expr::value(end_time)"]
  EndTimeExpr -- "correct null type" --> ColumnUpdate["timed_annotations::Column::EndTime"]
  EndTimeValue -- "set integer value" --> ColumnUpdate
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>timed_annotations.rs</strong><dd><code>Correct end_time None expression type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/table/timed_annotations.rs

<ul><li>Replace JSON None with Option<i64>::None.<br> <li> Update end_time null assignment expression.<br> <li> Align column type with integer value.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8751/files#diff-4bc910d02f5ddc598e394d06172debe456c7db655cc16fef53eab55005880378">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

