### PR TITLE
fix: alert querier should pick interactive querier when given role group is interactive

### DIFF
--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -76,8 +76,7 @@ use crate::{
 /// If given role group is None, it means the local node is the same role as the given role group.
 /// If given role group is RoleGroup::None, it still means local node is same as the given role.
 fn is_local_same_role(role_group: Option<RoleGroup>) -> bool {
-    if role_group.is_some() {
-        let role_group = role_group.unwrap();
+    if let Some(role_group) = role_group {
         role_group == RoleGroup::None || LOCAL_NODE.role_group == role_group
     } else {
         true
@@ -178,7 +177,7 @@ pub async fn search(
         // If LOCAL_NODE is alert querier and role group is background, we can use it
         // If LOCAL_NODE is not alert querier and role group is interactive, we can use it
         // If LOCAL_NODE is not alert querier and role group is background, we can NOT use it
-        if LOCAL_NODE.is_querier() && is_local_same_role(role_group.clone()) {
+        if LOCAL_NODE.is_querier() && is_local_same_role(role_group) {
             log::debug!(
                 "[trace_id {trace_id}] local node is a querier, nodes: {:?}",
                 nodes

--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -157,12 +157,19 @@ pub async fn search(
         })
         .unwrap_or(Some(RoleGroup::Interactive));
     let mut nodes = get_online_querier_nodes(trace_id, role_group).await?;
+    log::debug!("get online querier nodes {:?}", nodes);
 
     // local mode, only use local node as querier node
     if req.local_mode.unwrap_or_default() {
         if LOCAL_NODE.is_querier() {
+            log::debug!("local node is a querier, nodes: {:?}", nodes);
             nodes.retain(|n| n.name.eq(&LOCAL_NODE.name));
+            log::debug!(
+                "local node is a querier, nodes after filtering: {:?}",
+                nodes
+            );
         } else {
+            log::debug!("local node is not a querier, nodes: {:?}", nodes);
             nodes = nodes
                 .into_iter()
                 .filter(|n| n.is_querier())


### PR DESCRIPTION
Currently, if the given role_group is interactive and the LOCAL_NODE is an alert querier it still tries to run the below code 
```
nodes.retain(|n| n.name.eq(&LOCAL_NODE.name));
```
Which results in empty `nodes` vector and hence "no querier node online" because the `nodes` vec contains only the interactive queriers, not background queriers.