### PR TITLE
fix: add support for extracting series names from gauge charts

### DIFF
--- a/web/src/components/dashboards/addPanel/ColorBySeries.vue
+++ b/web/src/components/dashboards/addPanel/ColorBySeries.vue
@@ -115,10 +115,22 @@ export default defineComponent({
       ) {
         const pieDonutSeriesNames = chartOptions.series[0].data
           .filter((item: any) => item && item.name) // Filter out invalid items
-          .map((item: any) => ({  
+          .map((item: any) => ({
             name: item.name,
           }));
         return { series: pieDonutSeriesNames };
+      }
+      // For gauge charts, extract series names from each series' data[0].name
+      if (panelType === "gauge" && chartOptions?.series) {
+        const gaugeSeriesNames = chartOptions.series
+          .filter(
+            (series: any) =>
+              series && series.data && series.data[0] && series.data[0].name,
+          ) // Filter out invalid series
+          .map((series: any) => ({
+            name: series.data[0].name,
+          }));
+        return { series: gaugeSeriesNames };
       }
 
       // For other chart types, use the existing logic


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add gauge series name extraction

- Keep pie/donut name extraction logic

- Fallback to existing options unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  panel["Detect panel type"] --> pie["Pie/Donut: data[].name -> series"]
  panel --> gauge["Gauge: series[].data[0].name -> series"]
  panel --> other["Other: return existing options"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ColorBySeries.vue</strong><dd><code>Support gauge chart series name extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/ColorBySeries.vue

<ul><li>Add gauge chart handling for series names.<br> <li> Filter invalid gauge series safely.<br> <li> Preserve existing pie/donut extraction logic.<br> <li> Default to original options for other types.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8774/files#diff-2783259507b45f0b3664d9be68ca236690bbbf151472da3fa8b552d230af5b3f">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

