### PR TITLE
chore: add tests, fmt, clippy

### DIFF
--- a/src/handler/http/auth/jwt.rs
+++ b/src/handler/http/auth/jwt.rs
@@ -925,7 +925,7 @@ mod tests {
 
         for dn in test_cases {
             let result = parse_dn(dn);
-            assert!(result.is_some(), "Failed to parse DN: {}", dn);
+            assert!(result.is_some(), "Failed to parse DN: {dn}");
         }
     }
 
@@ -937,7 +937,7 @@ mod tests {
         let formatted_role = format_role_name_only(role);
         let full_role_name = format_role_name(org, role);
 
-        assert_eq!(full_role_name, format!("{}/{}", org, formatted_role));
+        assert_eq!(full_role_name, format!("{org}/{formatted_role}"));
         assert!(!full_role_name.contains("-"));
         assert!(!full_role_name.contains("@"));
     }

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -1255,24 +1255,4 @@ mod tests {
         let decoded = config::utils::base64::decode_url(invalid);
         assert!(decoded.is_err());
     }
-
-    #[test]
-    fn test_time_range_validation() {
-        let start_time = Utc::now().timestamp_micros();
-        let end_time = start_time + 3_600_000_000; // 1 hour later
-
-        assert!(end_time > start_time);
-        assert_eq!(end_time - start_time, 3_600_000_000);
-    }
-
-    #[test]
-    fn test_stream_names_parsing() {
-        let stream_names = "stream1,stream2,stream3";
-        let parsed: Vec<&str> = stream_names.split(',').collect();
-
-        assert_eq!(parsed.len(), 3);
-        assert_eq!(parsed[0], "stream1");
-        assert_eq!(parsed[1], "stream2");
-        assert_eq!(parsed[2], "stream3");
-    }
 }

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -1917,4 +1917,342 @@ mod tests {
         let sql = build_expr(&condition, "", &DataType::Utf8).unwrap();
         assert_eq!(sql, "str_match(\"auth_username\", 'enrique')");
     }
+
+    #[test]
+    fn test_to_float_from_number() {
+        let val = json!(42.5);
+        assert_eq!(to_float(&val), 42.5);
+
+        let val = json!(100);
+        assert_eq!(to_float(&val), 100.0);
+
+        let val = json!(0);
+        assert_eq!(to_float(&val), 0.0);
+
+        let val = json!(-50.25);
+        assert_eq!(to_float(&val), -50.25);
+    }
+
+    #[test]
+    fn test_to_float_from_string() {
+        let val = json!("42.5");
+        assert_eq!(to_float(&val), 42.5);
+
+        let val = json!("100");
+        assert_eq!(to_float(&val), 100.0);
+
+        let val = json!("0");
+        assert_eq!(to_float(&val), 0.0);
+
+        let val = json!("-50.25");
+        assert_eq!(to_float(&val), -50.25);
+    }
+
+    #[test]
+    fn test_to_float_invalid_string() {
+        let val = json!("not a number");
+        assert_eq!(to_float(&val), 0.0);
+
+        let val = json!("");
+        assert_eq!(to_float(&val), 0.0);
+    }
+
+    #[test]
+    fn test_to_float_null() {
+        let val = json!(null);
+        assert_eq!(to_float(&val), 0.0);
+    }
+
+    #[test]
+    fn test_var_value_str_len() {
+        let val = VarValue::Str("hello");
+        assert_eq!(val.len(), 5);
+
+        let val = VarValue::Str("");
+        assert_eq!(val.len(), 0);
+
+        let val = VarValue::Str("你好世界");
+        assert_eq!(val.len(), 4);
+    }
+
+    #[test]
+    fn test_var_value_vector_len() {
+        let strings = vec!["one".to_string(), "two".to_string(), "three".to_string()];
+        let val = VarValue::Vector(&strings);
+        assert_eq!(val.len(), 3);
+
+        let empty: Vec<String> = vec![];
+        let val = VarValue::Vector(&empty);
+        assert_eq!(val.len(), 0);
+    }
+
+    #[test]
+    fn test_var_value_str_to_string_with_length() {
+        let val = VarValue::Str("hello world");
+        assert_eq!(val.to_string_with_length(5, false), "hello");
+        assert_eq!(val.to_string_with_length(100, false), "hello world");
+        assert_eq!(val.to_string_with_length(0, false), "hello world");
+    }
+
+    #[test]
+    fn test_var_value_vector_to_string_with_length() {
+        let strings = vec![
+            "line1".to_string(),
+            "line2".to_string(),
+            "line3".to_string(),
+        ];
+        let val = VarValue::Vector(&strings);
+
+        // Test with separator for non-email
+        assert_eq!(val.to_string_with_length(2, false), "line1\\nline2");
+        assert_eq!(val.to_string_with_length(3, false), "line1\\nline2\\nline3");
+        assert_eq!(
+            val.to_string_with_length(100, false),
+            "line1\\nline2\\nline3"
+        );
+
+        // Test with no separator for email
+        assert_eq!(val.to_string_with_length(2, true), "line1line2");
+        assert_eq!(val.to_string_with_length(3, true), "line1line2line3");
+    }
+
+    #[test]
+    fn test_var_value_with_special_characters() {
+        let val = VarValue::Str("hello\nworld\t!");
+        let result = val.to_string_with_length(100, false);
+        assert_eq!(result, "hello\\nworld\\t!");
+    }
+
+    #[test]
+    fn test_process_variable_replace_simple() {
+        let mut tpl = "Hello {name}, welcome!".to_string();
+        process_variable_replace(&mut tpl, "name", &VarValue::Str("Alice"), false);
+        assert_eq!(tpl, "Hello Alice, welcome!");
+    }
+
+    #[test]
+    fn test_process_variable_replace_with_length() {
+        let mut tpl = "Message: {msg:10}".to_string();
+        process_variable_replace(
+            &mut tpl,
+            "msg",
+            &VarValue::Str("This is a very long message"),
+            false,
+        );
+        assert_eq!(tpl, "Message: This is a ");
+    }
+
+    #[test]
+    fn test_process_variable_replace_vector() {
+        let strings = vec!["row1".to_string(), "row2".to_string()];
+        let mut tpl = "Rows: {rows}".to_string();
+        process_variable_replace(&mut tpl, "rows", &VarValue::Vector(&strings), false);
+        assert_eq!(tpl, "Rows: row1\\nrow2");
+    }
+
+    #[test]
+    fn test_process_variable_replace_no_match() {
+        let mut tpl = "Hello {name}".to_string();
+        let original = tpl.clone();
+        process_variable_replace(&mut tpl, "age", &VarValue::Str("30"), false);
+        assert_eq!(tpl, original); // Should remain unchanged
+    }
+
+    #[test]
+    fn test_process_variable_replace_multiple_occurrences() {
+        let mut tpl = "{name} says hello to {name}".to_string();
+        process_variable_replace(&mut tpl, "name", &VarValue::Str("Bob"), false);
+        assert_eq!(tpl, "Bob says hello to Bob");
+    }
+
+    #[test]
+    fn test_get_row_column_map_empty() {
+        let rows: Vec<Map<String, Value>> = vec![];
+        let result = get_row_column_map(&rows);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_get_row_column_map_single_row() {
+        let mut row = Map::new();
+        row.insert("name".to_string(), json!("Alice"));
+        row.insert("age".to_string(), json!(30));
+        let rows = vec![row];
+
+        let result = get_row_column_map(&rows);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key("name"));
+        assert!(result.contains_key("age"));
+        assert!(result.get("name").unwrap().contains("Alice"));
+        assert!(result.get("age").unwrap().contains("30"));
+    }
+
+    #[test]
+    fn test_get_row_column_map_multiple_rows() {
+        let mut row1 = Map::new();
+        row1.insert("name".to_string(), json!("Alice"));
+        row1.insert("score".to_string(), json!(95.5));
+
+        let mut row2 = Map::new();
+        row2.insert("name".to_string(), json!("Bob"));
+        row2.insert("score".to_string(), json!(87.3));
+
+        let rows = vec![row1, row2];
+
+        let result = get_row_column_map(&rows);
+        assert_eq!(result.len(), 2);
+
+        let names = result.get("name").unwrap();
+        assert_eq!(names.len(), 2);
+        assert!(names.contains("Alice"));
+        assert!(names.contains("Bob"));
+
+        let scores = result.get("score").unwrap();
+        assert_eq!(scores.len(), 2);
+        assert!(scores.contains("95.50"));
+        assert!(scores.contains("87.30"));
+    }
+
+    #[test]
+    fn test_get_row_column_map_duplicate_values() {
+        let mut row1 = Map::new();
+        row1.insert("status".to_string(), json!("active"));
+
+        let mut row2 = Map::new();
+        row2.insert("status".to_string(), json!("active"));
+
+        let rows = vec![row1, row2];
+
+        let result = get_row_column_map(&rows);
+        let statuses = result.get("status").unwrap();
+        // HashSet should deduplicate
+        assert_eq!(statuses.len(), 1);
+        assert!(statuses.contains("active"));
+    }
+
+    #[test]
+    fn test_get_alert_start_end_time_with_given_time() {
+        let vars = HashMap::new();
+        let period = 5;
+        let rows_end_time = 1000000;
+        let start_time = Some(500000);
+        let use_given_time = true;
+
+        let (start, end) =
+            get_alert_start_end_time(&vars, period, rows_end_time, start_time, use_given_time);
+        assert_eq!(start, 500000);
+        assert_eq!(end, 1000000);
+    }
+
+    #[test]
+    fn test_get_alert_start_end_time_calculate_from_period() {
+        let vars = HashMap::new();
+        let period = 5; // 5 minutes
+        let rows_end_time = 1000000;
+        let start_time = None;
+        let use_given_time = true;
+
+        let (start, end) =
+            get_alert_start_end_time(&vars, period, rows_end_time, start_time, use_given_time);
+        assert_eq!(end, 1000000);
+        assert!(start < end);
+        // Should be approximately 5 minutes (300 seconds = 300,000,000 microseconds) before end
+        assert!(end - start >= 299_000_000 && end - start <= 301_000_000);
+    }
+
+    #[test]
+    fn test_get_alert_start_end_time_from_timestamp() {
+        let mut vars = HashMap::new();
+        let mut timestamps = HashSet::new();
+        timestamps.insert("800000".to_string());
+        timestamps.insert("900000".to_string());
+        vars.insert(TIMESTAMP_COL_NAME.to_string(), timestamps);
+
+        let period = 5;
+        let rows_end_time = 1000000;
+        let start_time = None;
+        let use_given_time = false;
+
+        let (start, end) =
+            get_alert_start_end_time(&vars, period, rows_end_time, start_time, use_given_time);
+        assert_eq!(start, 800000);
+        // end should be 900000 + 1 minute (60,000,000 microseconds)
+        assert_eq!(end, 60900000);
+    }
+
+    #[test]
+    fn test_get_alert_start_end_time_from_sql_time() {
+        let mut vars = HashMap::new();
+        let mut min_times = HashSet::new();
+        min_times.insert("700000".to_string());
+        vars.insert("zo_sql_min_time".to_string(), min_times);
+
+        let mut max_times = HashSet::new();
+        max_times.insert("950000".to_string());
+        vars.insert("zo_sql_max_time".to_string(), max_times);
+
+        let period = 5;
+        let rows_end_time = 1000000;
+        let start_time = None;
+        let use_given_time = false;
+
+        let (start, end) =
+            get_alert_start_end_time(&vars, period, rows_end_time, start_time, use_given_time);
+        assert_eq!(start, 700000);
+        // end should be 950000 + 1 minute (60,000,000 microseconds)
+        assert_eq!(end, 60950000);
+    }
+
+    #[test]
+    fn test_get_alert_start_end_time_no_data() {
+        let vars = HashMap::new();
+        let period = 10; // 10 minutes
+        let rows_end_time = 2000000;
+        let start_time = None;
+        let use_given_time = false;
+
+        let (start, end) =
+            get_alert_start_end_time(&vars, period, rows_end_time, start_time, use_given_time);
+        // Should use rows_end_time as end
+        assert_eq!(end, 2000000);
+        // Should calculate start from period
+        assert!(end - start >= 599_000_000 && end - start <= 601_000_000); // ~10 minutes
+    }
+
+    #[test]
+    fn test_get_alert_start_end_time_time_range_too_small() {
+        let mut vars = HashMap::new();
+        let mut timestamps = HashSet::new();
+        // Very close timestamps (less than 1 minute apart)
+        timestamps.insert("1000000".to_string());
+        timestamps.insert("1001000".to_string());
+        vars.insert(TIMESTAMP_COL_NAME.to_string(), timestamps);
+
+        let period = 5;
+        let rows_end_time = 1002000;
+        let start_time = Some(1000000);
+        let use_given_time = false;
+
+        let (start, end) =
+            get_alert_start_end_time(&vars, period, rows_end_time, start_time, use_given_time);
+        // The end time will be max timestamp + 1 minute = 1001000 + 60,000,000
+        assert_eq!(end, 61001000);
+        // When time range is too small and start_time is provided, it should use provided
+        // start_time
+        assert_eq!(start, 1000000);
+    }
+
+    #[test]
+    fn test_get_alert_start_end_time_with_explicit_start_time() {
+        let vars = HashMap::new();
+        let period = 15;
+        let rows_end_time = 3000000;
+        let start_time = Some(1500000);
+        let use_given_time = false;
+
+        let (start, _end) =
+            get_alert_start_end_time(&vars, period, rows_end_time, start_time, use_given_time);
+        // When range is too small, should use provided start_time
+        assert!(start <= 1500000 || start == 3000000 - 15 * 60 * 1_000_000);
+    }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2744,18 +2744,16 @@ mod tests {
             )
             .await;
 
-            if let Ok(trigger) = trigger {
-                if let Ok(scheduled_trigger_data) =
+            if let Ok(trigger) = trigger
+                && let Ok(scheduled_trigger_data) =
                     serde_json::from_str::<ScheduledTriggerData>(&trigger.data)
-                {
-                    if scheduled_trigger_data.period_end_time.is_some() {
-                        assert!(scheduled_trigger_data.period_end_time.unwrap() > 0);
-                        assert!(trigger.status == TriggerStatus::Waiting);
-                        assert!(trigger.next_run_at > now && trigger.retries == 0);
-                        trigger_updated = true;
-                        break;
-                    }
-                }
+                && scheduled_trigger_data.period_end_time.is_some()
+            {
+                assert!(scheduled_trigger_data.period_end_time.unwrap() > 0);
+                assert!(trigger.status == TriggerStatus::Waiting);
+                assert!(trigger.next_run_at > now && trigger.retries == 0);
+                trigger_updated = true;
+                break;
             }
 
             attempts += 1;
@@ -2764,8 +2762,7 @@ mod tests {
 
         assert!(
             trigger_updated,
-            "Trigger was not updated after {} attempts",
-            max_attempts
+            "Trigger was not updated after {max_attempts} attempts"
         );
     }
 


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Add extensive unit tests across modules

- Refactor tests for concision and coverage

- Minor assertions and format string fixes

- Improve test isolation with serialized setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  http_utils["HTTP utils tests"] -- refactor/add cases --> http_utils_ctx["Search context & params"]
  enc["Encoder module"] -- add comprehensive tests --> enc_paths["Gzip/Deflate/Brotli/Zstd paths"]
  db_mysql["MySQL helpers"] -- add tests --> key_parse_build["Key parse/build + index structs"]
  db_nats["NATS helpers"] -- add tests --> key_codec["Key encode/decode and Locker"]
  alerts_mig["Alerts migration"] -- add tests --> conversions["Type conversions + KSUID"]
  alerts_srv["Alerts service"] -- add tests --> vars_time["Var handling & time range"]
  compaction["Compaction"] -- add tests --> inverted_idx["Inverted index recordbatch"]
  otlp_logs["OTLP logs"] -- add tests --> request_types["All request types & attrs"]
  users_srv["Users service tests"] -- enhance --> setup_lock["Serialized test setup"]
  integration["Integration test"] -- cleanup --> asserts_fmt["If-let chain, fmt strings"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>http.rs</strong><dd><code>Simplify context extraction and expand tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-3b50a69c1ec2f63f8eebb5f9880e17826463a586768aed3e3e15242833609d6b">+69/-78</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>jwt.rs</strong><dd><code>Fix test format strings for clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-232cab74f4cbf135af424744272e17732fbda8ac005d33c0acb4597e65479d02">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>multi_streams.rs</strong><dd><code>Remove trivial tests, keep invalid base64 case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-c3233cdf1e68cb2455f91457719b9c2f477e735ee16546fdfe111e76768bd054">+0/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>encoder.rs</strong><dd><code>Add comprehensive encoder and header tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-1825b00f221539b371b9fe8aa89f9cbc1cfb94f3b731f053e64c51fb5c5934cd">+625/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mysql.rs</strong><dd><code>Add tests for key utils and index structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-412dc407af348f4b54b7d98de6a928876b0333ea501792498a0568850f83d7b7">+287/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>nats.rs</strong><dd><code>Add tests for key codec, Locker, prefixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-2d6809ea34ea04477afb9a6f8287c93cef488b45ef8f0ebeec2241571b93994c">+230/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>m20241217_155000_populate_alerts_table.rs</strong><dd><code>Add KSUID and conversion tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-83bd1f63b88ef21e8cf60f5e25fff67ba7ddb90c86bcc27039293217ae379184">+357/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>alert.rs</strong><dd><code>Add tests for var formatting and time range</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-574be3504bf4d855c65fd3d7a10797a970237ff552edac4962b474b3983e094e">+338/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>merge.rs</strong><dd><code>Add tests for inverted index batch generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-0ab016dbd5129c9c285c9c459bf78928147bce97dc92a03aa754da3da71168d7">+352/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>otlp.rs</strong><dd><code>Add OTLP logs handling tests for variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-183498d98b17ddf344cbab4da6b2d9fe89ac81112db51655c142a89023b46ef3">+643/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>users.rs</strong><dd><code>Serialize test setup to avoid races</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-98da2588a28d62bb2e301d989836125f89f89b76272cd7f75e08ec4deeea5f38">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>integration_test.rs</strong><dd><code>Streamline polling with if-let chain and fmt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8775/files#diff-7ff815b68943f08bef79f083c09e55ca8c18db8e25033034b12fa31f1d43dab4">+10/-13</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

