### PR TITLE
fix: update in kubernetes datasource configuration

### DIFF
--- a/web/src/components/ingestion/recommended/KubernetesConfig.vue
+++ b/web/src/components/ingestion/recommended/KubernetesConfig.vue
@@ -4,7 +4,7 @@
     <div class="text-subtitle1 q-pl-xs q-mt-md">Install cert-manager</div>
     <ContentCopy
       class="q-mt-sm"
-      content="kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.1/cert-manager.yaml"
+      content="kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.0/cert-manager.yaml"
     />
 
     <div class="text-subtitle1 q-pl-xs q-mt-md">
@@ -25,7 +25,7 @@
     </div>
     <ContentCopy
       class="q-mt-sm"
-      content="kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml"
+      content="kubectl apply -f https://raw.githubusercontent.com/openobserve/openobserve-helm-chart/refs/heads/main/opentelemetry-operator.yaml"
     />
 
     <div class="text-subtitle1 q-pl-xs q-mt-md">Create namespace</div>


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Update cert-manager install URL to v1.19.0

- Point OTel operator install to curated manifest


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["KubernetesConfig.vue"] -- "bump cert-manager URL" --> B["v1.16.1 -> v1.19.0"]
  A -- "change OTel operator source" --> C["GitHub latest -> OpenObserve curated YAML"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KubernetesConfig.vue</strong><dd><code>Refresh Kubernetes command URLs for dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/ingestion/recommended/KubernetesConfig.vue

<ul><li>Bump cert-manager install URL to v1.19.0.<br> <li> Update OpenTelemetry operator apply URL to OpenObserve curated <br>manifest.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8785/files#diff-7afbbe1e38d62a976fcbe23f28c3e33a6d3e90188d5edcb743e936f920ec7dd5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

