### PR TITLE
fix: (openapi) deprecate duplicate operationId

### DIFF
--- a/src/handler/http/request/folders.rs
+++ b/src/handler/http/request/folders.rs
@@ -304,7 +304,7 @@ pub mod deprecated {
     #[utoipa::path(
         context_path = "/api",
         tag = "Folders",
-        operation_id = "CreateFolder",
+        operation_id = "CreateFolderDeprecated",
         summary = "Create a new folder (deprecated)",
         description = "Creates a new dashboard folder - this endpoint is deprecated",
         security(
@@ -351,7 +351,7 @@ pub mod deprecated {
     #[utoipa::path(
         context_path = "/api",
         tag = "Folders",
-        operation_id = "UpdateFolder",
+        operation_id = "UpdateFolderDeprecated",
         summary = "Update an existing folder (deprecated)",
         description = "Updates folder details like name and description - this endpoint is deprecated",
         security(
@@ -396,7 +396,7 @@ pub mod deprecated {
     #[utoipa::path(
         context_path = "/api",
         tag = "Folders",
-        operation_id = "ListFolders",
+        operation_id = "ListFoldersDeprecated",
         summary = "List all folders (deprecated)",
         description = "Retrieves all dashboard folders for the organization - this endpoint is deprecated",
         security(
@@ -441,7 +441,7 @@ pub mod deprecated {
     #[utoipa::path(
         context_path = "/api",
         tag = "Folders",
-        operation_id = "GetFolder",
+        operation_id = "GetFolderDeprecated",
         summary = "Get folder by ID (deprecated)",
         description = "Retrieves a specific folder by its identifier - this endpoint is deprecated",
         security(
@@ -477,7 +477,7 @@ pub mod deprecated {
     #[utoipa::path(
         context_path = "/api",
         tag = "Folders",
-        operation_id = "GetFolderByName",
+        operation_id = "GetFolderByNameDeprecated",
         summary = "Get folder by name (deprecated)",
         description = "Retrieves a folder using its name instead of ID - this endpoint is deprecated",
         security(
@@ -513,7 +513,7 @@ pub mod deprecated {
     #[utoipa::path(
         context_path = "/api",
         tag = "Folders",
-        operation_id = "DeleteFolder",
+        operation_id = "DeleteFolderDeprecated",
         summary = "Delete a folder (deprecated)",
         description = "Removes a folder and all its contents - this endpoint is deprecated",
         security(


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Append Deprecated to deprecated operation IDs

- Prevent duplicate OpenAPI operationId collisions

- Clarify deprecation in folder endpoints


___

### Diagram Walkthrough


```mermaid
flowchart LR
  OpenAPI["OpenAPI operationId generation"] -- "duplicate IDs on deprecated + current" --> Collision["operationId collisions"]
  Change["Suffix 'Deprecated' to deprecated IDs"] -- "unique operationIds" --> NoCollision["No collisions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>folders.rs</strong><dd><code>Suffix deprecated folder operationIds to ensure uniqueness</code></dd></summary>
<hr>

src/handler/http/request/folders.rs

<ul><li>Renamed deprecated operation_ids to include 'Deprecated'<br> <li> Affected: Create, Update, List, Get, GetByName, Delete<br> <li> Maintains deprecation annotations and docs</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8794/files#diff-c8f71e56f73e87fe83bfb27b4374c097de66ee583b8e9aad87b7a078ce601134">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

