### PR TITLE
feat: add MCP protocol endpoints

### DIFF
--- a/src/handler/http/request/mcp/mod.rs
+++ b/src/handler/http/request/mcp/mod.rs
@@ -1,0 +1,208 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use actix_web::{HttpResponse, get, post, web};
+#[cfg(feature = "enterprise")]
+use {
+    actix_web::HttpRequest,
+    futures_util::StreamExt,
+    o2_enterprise::enterprise::mcp::{MCPRequest, handle_mcp_request, handle_mcp_request_stream},
+};
+
+/// Handler for MCP POST requests (single request/response)
+#[cfg(feature = "enterprise")]
+#[utoipa::path(
+    context_path = "/api",
+    tag = "MCP",
+    operation_id = "MCPRequest",
+    security(
+        ("Authorization" = [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+    ),
+    request_body(content = MCPRequest, description = "MCP request payload", content_type = "application/json"),
+    responses(
+        (status = 200, description = "Success", content_type = "application/json"),
+        (status = 500, description = "Internal Server Error"),
+    ),
+)]
+#[post("/{org_id}/mcp")]
+pub async fn handle_mcp_post(
+    _org_id: web::Path<String>,
+    web::Json(mcp_request): web::Json<MCPRequest>,
+    req: HttpRequest,
+) -> actix_web::Result<HttpResponse> {
+    // Extract auth token from Authorization header
+    let auth_token = req
+        .headers()
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    // Check Accept header to determine response format
+    let accept_header = req
+        .headers()
+        .get("Accept")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/json");
+
+    // Determine if client wants SSE streaming
+    let wants_sse = accept_header.contains("text/event-stream");
+
+    if wants_sse {
+        // Return streaming SSE response (MCP Streamable HTTP spec)
+        let stream = handle_mcp_request_stream(mcp_request, auth_token)
+            .await
+            .map_err(|e| actix_web::error::ErrorInternalServerError(format!("MCP error: {e}")))?;
+
+        let actix_stream = stream.map(|result| {
+            result.map_err(|e| {
+                actix_web::error::ErrorInternalServerError(format!("Stream error: {e}"))
+            })
+        });
+
+        Ok(HttpResponse::Ok()
+            .content_type("text/event-stream")
+            .insert_header(("Cache-Control", "no-cache"))
+            .insert_header(("X-Accel-Buffering", "no"))
+            .streaming(actix_stream))
+    } else {
+        // Return single JSON response (fallback for simpler clients)
+        let response = handle_mcp_request(mcp_request, auth_token)
+            .await
+            .map_err(|e| actix_web::error::ErrorInternalServerError(format!("MCP error: {e}")))?;
+
+        Ok(HttpResponse::Ok()
+            .content_type("application/json")
+            .json(response))
+    }
+}
+
+/// Handler for MCP GET requests (streaming)
+#[cfg(feature = "enterprise")]
+#[utoipa::path(
+    context_path = "/api",
+    tag = "MCP",
+    operation_id = "MCPRequestStream",
+    security(
+        ("Authorization" = [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Organization ID"),
+    ),
+    request_body(content = MCPRequest, description = "MCP request payload", content_type = "application/json"),
+    responses(
+        (status = 200, description = "Success (Streaming)", content_type = "application/json"),
+        (status = 500, description = "Internal Server Error"),
+    ),
+)]
+#[get("/{org_id}/mcp")]
+pub async fn handle_mcp_get(
+    _org_id: web::Path<String>,
+    body: web::Bytes,
+    req: HttpRequest,
+) -> actix_web::Result<HttpResponse> {
+    // Extract auth token from Authorization header
+    let auth_token = req
+        .headers()
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    // MCP Streamable HTTP: GET with empty body is optional
+    // for server-initiated notifications. This is deprecated
+    // and therefore not supported by O2
+    if body.is_empty() {
+        return Ok(HttpResponse::MethodNotAllowed()
+            .insert_header(("Allow", "POST"))
+            .json(serde_json::json!({
+                "error": "GET requests must include a JSON-RPC request body. Use POST for standard requests."
+            })));
+    }
+
+    // Parse JSON from body manually (GET with body is non-standard but MCP spec allows it)
+    let mcp_request: MCPRequest = serde_json::from_slice(&body)
+        .map_err(|e| actix_web::error::ErrorBadRequest(format!("Invalid JSON: {e}")))?;
+
+    // Handle the request with streaming (returns SSE format)
+    let stream = handle_mcp_request_stream(mcp_request, auth_token)
+        .await
+        .map_err(|e| actix_web::error::ErrorInternalServerError(format!("MCP error: {e}")))?;
+
+    // Convert the stream error type to actix_web::Error
+    let actix_stream = stream.map(|result| {
+        result.map_err(|e| actix_web::error::ErrorInternalServerError(format!("Stream error: {e}")))
+    });
+
+    Ok(HttpResponse::Ok()
+        .content_type("text/event-stream")
+        .insert_header(("Cache-Control", "no-cache"))
+        .insert_header(("X-Accel-Buffering", "no"))
+        .streaming(actix_stream))
+}
+
+// Dummy handlers for non-enterprise builds
+#[cfg(not(feature = "enterprise"))]
+#[utoipa::path(
+    context_path = "/api",
+    tag = "MCP",
+    operation_id = "MCPRequest",
+    security(
+        ("Authorization" = [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Organization ID"),
+    ),
+    request_body(content = Object, description = "MCP request payload", content_type = "application/json"),
+    responses(
+        (status = 404, description = "Not Found - MCP server is only available in enterprise edition", content_type = "application/json"),
+    ),
+)]
+#[post("/{org_id}/mcp")]
+pub async fn handle_mcp_post(
+    _org_id: web::Path<String>,
+    _body: web::Bytes,
+) -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::NotFound().json(serde_json::json!({
+        "error": "MCP server is only available in enterprise edition"
+    })))
+}
+
+#[cfg(not(feature = "enterprise"))]
+#[utoipa::path(
+    context_path = "/api",
+    tag = "MCP",
+    operation_id = "MCPRequestStream",
+    security(
+        ("Authorization" = [])
+    ),
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+    ),
+    request_body(content = Object, description = "MCP request payload", content_type = "application/json"),
+    responses(
+        (status = 404, description = "Not Found - MCP server is only available in enterprise edition", content_type = "application/json"),
+    ),
+)]
+#[get("/{org_id}/mcp")]
+pub async fn handle_mcp_get(
+    _org_id: web::Path<String>,
+    _body: web::Bytes,
+) -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::NotFound().json(serde_json::json!({
+        "error": "MCP server is only available in enterprise edition"
+    })))
+}

--- a/src/handler/http/request/mod.rs
+++ b/src/handler/http/request/mod.rs
@@ -31,6 +31,7 @@ pub mod functions;
 pub mod keys;
 pub mod kv;
 pub mod logs;
+pub mod mcp;
 pub mod metrics;
 pub mod organization;
 pub mod pipeline;

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -604,7 +604,9 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(re_pattern::delete)
         .service(re_pattern::test)
         .service(domain_management::get_domain_management_config)
-        .service(domain_management::set_domain_management_config);
+        .service(domain_management::set_domain_management_config)
+        .service(mcp::handle_mcp_post)
+        .service(mcp::handle_mcp_get);
 
     #[cfg(feature = "cloud")]
     let service = service
@@ -622,6 +624,11 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(cloud::marketing::handle_new_attribution_event)
         .service(organization::org::all_organizations)
         .service(organization::org::extend_trial_period);
+
+    #[cfg(not(feature = "enterprise"))]
+    let service = service
+        .service(mcp::handle_mcp_post)
+        .service(mcp::handle_mcp_get);
 
     svc.service(service);
 }

--- a/src/service/enrichment/storage.rs
+++ b/src/service/enrichment/storage.rs
@@ -640,7 +640,7 @@ mod tests {
         // Test store function
         let test_data = Values::Json(Arc::new(test_data));
         let result = local::store(org_id, table_name, test_data, updated_at).await;
-        println!("Store result: {:?}", result);
+        println!("Store result: {result:?}");
         assert!(result.is_ok(), "Store should succeed");
 
         // Verify file was created

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1450,10 +1450,7 @@ mod tests {
         let status = resp.status();
         let text = resp.into_body().try_into_bytes().unwrap_or_default();
         let text = String::from_utf8_lossy(&text).to_string();
-        println!(
-            "e2e_post_alert_template: status: {:?}, text: {:?}",
-            status, text
-        );
+        println!("e2e_post_alert_template: status: {status:?}, text: {text:?}");
         assert!(status.is_success());
     }
 
@@ -3896,7 +3893,7 @@ mod tests {
         // Test store function
         let test_data = Values::Json(Arc::new(test_data));
         let result = local::store(org_id, table_name, test_data, updated_at).await;
-        println!("Store result: {:?}", result);
+        println!("Store result: {result:?}");
         assert!(result.is_ok(), "Store should succeed");
 
         // Verify file was created


### PR DESCRIPTION
### **User description**
Integrate Model Context Protocol server endpoints at `/api/{org_id}/mcp` for both enterprise and non-enterprise builds.

Changes:
- Add POST and GET handlers for MCP requests with streaming support
- Extract and pass through Authorization header for API authentication
- Add non-enterprise stub endpoints that return "not available" error
- Update router to register MCP endpoints conditionally

Endpoints:
- POST `/api/{org_id}/mcp`: Single MCP request/response
- GET `/api/{org_id}/mcp`: Streaming MCP requests


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add MCP POST and GET handlers

- Conditional enterprise/non-enterprise routing

- Streamed MCP responses for GET

- Minor test logging formatting updates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New MCP handlers"] -- "POST /{org_id}/mcp" --> B["Single request/response"]
  A -- "GET /{org_id}/mcp" --> C["Streaming responses"]
  D["Router updates"] -- "register handlers" --> A
  E["Non-enterprise build"] -- "stub 404 JSON" --> F["MCP not available"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Introduce MCP request handlers with streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/mcp/mod.rs

<ul><li>Add enterprise MCP POST handler with auth<br> <li> Add enterprise MCP GET streaming handler<br> <li> Provide non-enterprise stub handlers returning 404 JSON<br> <li> Parse JSON-RPC and map errors to HTTP</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8798/files#diff-d68cc59ba80cf92618f1d22ccfcb04111863cc0ee0a8bdf02991d039d161bf4e">+96/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Register MCP routes conditionally</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/router/mod.rs

<ul><li>Register MCP handlers in default routes<br> <li> Conditionally include non-enterprise MCP stubs</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8798/files#diff-02556e3f515441b5d2b6bbea7829df488beac03c4cc41309a6638ae3c0e0aec6">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Expose MCP request module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/mod.rs

- Export new `mcp` request module


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8798/files#diff-a1cfd40da1ab6cd4db0181fd8664965034298047b3b7c3320c5385897a7c4aed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.rs</strong><dd><code>Modernize test logging formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/enrichment/storage.rs

- Update test println! to new formatting


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8798/files#diff-335bb1eea9193dc398da6838c6a6a11dd6f09e984a1ed4a2e611618a427754f0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integration_test.rs</strong><dd><code>Clean up integration test logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration_test.rs

- Use inline debug formatting in println!
- Minor test output cleanup


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8798/files#diff-7ff815b68943f08bef79f083c09e55ca8c18db8e25033034b12fa31f1d43dab4">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

