### PR TITLE
fix: improve slow log detail

### DIFF
--- a/src/handler/http/request/logs/loki.rs
+++ b/src/handler/http/request/logs/loki.rs
@@ -15,7 +15,7 @@
 
 use std::io::{Error, Read};
 
-use actix_web::{HttpRequest, HttpResponse, post, web};
+use actix_web::{HttpRequest, HttpResponse, http::header, post, web};
 use flate2::read::GzDecoder;
 use prost::Message;
 use proto::loki_rpc;
@@ -63,6 +63,13 @@ pub async fn loki_push(
     req: HttpRequest,
     body: web::Bytes,
 ) -> Result<HttpResponse, Error> {
+    // log start processing time
+    let process_time = if config::get_config().limit.http_slow_log_threshold > 0 {
+        config::utils::time::now_micros()
+    } else {
+        0
+    };
+
     let thread_id = **thread_id;
     let org_id = org_id.into_inner();
 
@@ -111,13 +118,22 @@ pub async fn loki_push(
         }
     };
 
-    match logs::loki::handle_request(thread_id, &org_id, request, user_email).await {
-        Ok(_) => Ok(HttpResponse::NoContent().finish()),
+    let mut resp = match logs::loki::handle_request(thread_id, &org_id, request, user_email).await {
+        Ok(_) => HttpResponse::NoContent().finish(),
         Err(e) => {
             log::error!("[Loki] Processing error for org '{org_id}': {e:?}");
-            Ok(e.into())
+            e.into()
         }
+    };
+
+    if process_time > 0 {
+        resp.headers_mut().insert(
+            header::HeaderName::from_static("o2_process_time"),
+            header::HeaderValue::from_str(&process_time.to_string()).unwrap(),
+        );
     }
+
+    Ok(resp)
 }
 
 fn parse_json_request(


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add processing time header to responses

- Capture start time based on slow-log threshold

- Standardize response construction across handlers

- Import header utilities for header insertion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Start["Request received"] -- "check slow-log threshold" --> MaybeTime["Capture start micros or 0"]
  MaybeTime -- "process request" --> BuildResp["Build HttpResponse"]
  BuildResp -- "if timing enabled" --> AddHeader["Insert o2_process_time header"]
  AddHeader -- "return" --> End["HTTP response"]
  BuildResp -- "no timing" --> End
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loki.rs</strong><dd><code>Add processing time header to Loki push</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/logs/loki.rs

<ul><li>Capture processing start time if threshold > 0<br> <li> Build response then add <code>o2_process_time</code> header<br> <li> Import <code>http::header</code> for header manipulation<br> <li> Return unified <code>HttpResponse</code> with optional header</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8811/files#diff-34691872632b619be8aadf255104f0e004fcf701dba98f88e231de5966eed099">+20/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ingest.rs</strong><dd><code>Add timing header to metrics ingest endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/metrics/ingest.rs

<ul><li>Measure start time for JSON and OTLP endpoints<br> <li> Convert direct returns to mutable response for header<br> <li> Append <code>o2_process_time</code> header when enabled<br> <li> Import header utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8811/files#diff-b9dc46d43cf8b966936962efff036b7fc0c2d6c55dddedfdaa82b45ef86362d5">+40/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add processing time header to traces handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/traces/mod.rs

<ul><li>Record start time based on slow-log threshold<br> <li> Normalize response building for proto/json branches<br> <li> Attach <code>o2_process_time</code> header conditionally<br> <li> Import header utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8811/files#diff-64694c886c809b6efe449e6eba9fbb33d31ce5a3c49cea1a30006fc1d9522665">+24/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

