### PR TITLE
feat: support inverted index for metadata stream

### DIFF
--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -132,10 +132,10 @@ pub enum StreamType {
 }
 
 impl StreamType {
-    pub fn is_basic_type(&self) -> bool {
+    pub fn support_index(&self) -> bool {
         matches!(
             *self,
-            StreamType::Logs | StreamType::Metrics | StreamType::Traces
+            StreamType::Logs | StreamType::Metrics | StreamType::Traces | StreamType::Metadata
         )
     }
 

--- a/src/config/src/utils/inverted_index.rs
+++ b/src/config/src/utils/inverted_index.rs
@@ -35,6 +35,7 @@ pub fn convert_parquet_file_name_to_tantivy_file(from: &str) -> Option<String> {
         "logs" => StreamType::Logs,
         "metrics" => StreamType::Metrics,
         "traces" => StreamType::Traces,
+        "metadata" => StreamType::Metadata,
         _ => return None,
     };
     parts[stream_type_pos] = Cow::Borrowed("index");
@@ -84,7 +85,10 @@ mod tests {
             ),
             (
                 "files/default/metadata/quickstart1/2024/02/16/16/7164299619311026293.parquet",
-                None,
+                Some(
+                    "files/default/index/quickstart1_metadata/2024/02/16/16/7164299619311026293.ttv"
+                        .to_string(),
+                ),
             ),
             (
                 "files/default/index/quickstart1/2024/02/16/16/7164299619311026293.parquet",

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -807,8 +807,8 @@ async fn merge_files(
     let account = storage::get_account(&new_file_key).unwrap_or_default();
     storage::put(&account, &new_file_key, buf.clone()).await?;
 
-    // skip index generation if not enabled or not basic type
-    if !cfg.common.inverted_index_enabled || !stream_type.is_basic_type() {
+    // skip index generation if not enabled or not supported by stream type
+    if !cfg.common.inverted_index_enabled || !stream_type.support_index() {
         return Ok((account, new_file_key, new_file_meta, retain_file_list));
     }
 

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -942,7 +942,7 @@ pub async fn merge_files(
             let account = storage::get_account(&new_file_key).unwrap_or_default();
             storage::put(&account, &new_file_key, buf.clone()).await?;
 
-            if cfg.common.inverted_index_enabled && stream_type.is_basic_type() && need_index {
+            if cfg.common.inverted_index_enabled && stream_type.support_index() && need_index {
                 // generate inverted index
                 generate_inverted_index(
                     &new_file_key,
@@ -982,7 +982,7 @@ pub async fn merge_files(
                 let account = storage::get_account(&new_file_key).unwrap_or_default();
                 storage::put(&account, &new_file_key, buf.clone()).await?;
 
-                if cfg.common.inverted_index_enabled && stream_type.is_basic_type() && need_index {
+                if cfg.common.inverted_index_enabled && stream_type.support_index() && need_index {
                     // generate inverted index
                     generate_inverted_index(
                         &new_file_key,
@@ -1113,7 +1113,7 @@ pub fn generate_inverted_idx_recordbatch(
     index_fields: &[String],
 ) -> Result<Option<RecordBatch>, anyhow::Error> {
     let cfg = get_config();
-    if !cfg.common.inverted_index_enabled || batches.is_empty() || !stream_type.is_basic_type() {
+    if !cfg.common.inverted_index_enabled || batches.is_empty() || !stream_type.support_index() {
         return Ok(None);
     }
 

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -875,7 +875,7 @@ pub async fn tantivy_search(
         "{}",
         search_inspector_fields(
             format!(
-                "[trace_id {}] search->tantivy: total hits for index_condition: {:?} found {} , is_add_filter_back: {}, file_num: {}, took: {} ms",
+                "[trace_id {}] search->tantivy: total hits for index_condition: {:?} found {}, is_add_filter_back: {}, file_num: {}, took: {} ms",
                 query.trace_id,
                 index_condition,
                 tantivy_result,


### PR DESCRIPTION
### **User description**
add this hotfix to v0.15.1


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enable inverted index for `Metadata`

- Update path conversion to support `metadata`

- Replace `is_basic_type` with `support_index`

- Adjust log formatting in Tantivy search


___

### Diagram Walkthrough


```mermaid
flowchart LR
  StreamType["StreamType: add support_index incl. Metadata"]
  InvertedPath["Inverted index path: add metadata mapping"]
  MergeJobs["Merge jobs: use support_index gate"]
  RecordBatch["RecordBatch index gen: use support_index"]
  Logging["Search logging: fix formatting"]

  StreamType -- "drives eligibility" --> MergeJobs
  StreamType -- "drives eligibility" --> RecordBatch
  InvertedPath -- "convert parquet->tantivy for metadata" --> MergeJobs
  MergeJobs -- "generate indexes when enabled" --> RecordBatch
  Logging -- "cleaner output" --> MergeJobs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stream.rs</strong><dd><code>StreamType adds support_index including Metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/stream.rs

<ul><li>Rename <code>is_basic_type</code> to <code>support_index</code>.<br> <li> Include <code>StreamType::Metadata</code> in supported set.<br> <li> Update matching to reflect new support.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8815/files#diff-2438d04c3fe97bc5452e5b74a303163b8723d93455cda32c95f0525435ad46bd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parquet.rs</strong><dd><code>Gate index generation via support_index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/job/files/parquet.rs

<ul><li>Use <code>support_index()</code> instead of <code>is_basic_type()</code>.<br> <li> Clarify comment on index generation condition.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8815/files#diff-27f710981cfe1b938aeeb53abaed05961596c32e2edf3b8a2a59d3e72b2f542b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>merge.rs</strong><dd><code>Use support_index across compaction and generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/compact/merge.rs

<ul><li>Replace <code>is_basic_type()</code> with <code>support_index()</code> in checks.<br> <li> Apply to multiple merge paths and recordbatch generator.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8815/files#diff-0ab016dbd5129c9c285c9c459bf78928147bce97dc92a03aa754da3da71168d7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inverted_index.rs</strong><dd><code>Add metadata handling to index path converter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/utils/inverted_index.rs

<ul><li>Map <code>"metadata"</code> to <code>StreamType::Metadata</code> in converter.<br> <li> Update tests to expect metadata index path.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8815/files#diff-ed40d918401ec740b884cb9cacf1268a9203f42e7e663290ac9dde4fa8b271fb">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.rs</strong><dd><code>Tweak Tantivy search log formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/grpc/storage.rs

<ul><li>Fix log message formatting: add missing comma separation.<br> <li> Improve readability of Tantivy search log line.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8815/files#diff-ab2d867e1e2e3dd8307505c2e130039628a84f8131a9b38cd2e7b4e1c141e094">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

