### PR TITLE
test: UTF8 queries pytests

### DIFF
--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -28,19 +28,8 @@ env:
 
 jobs:
   api_integration_tests:
-    name: api_tests / utf8_view=${{ matrix.utf8_view_enabled }}
+    name: api_integration_tests
     runs-on: ubicloud-standard-8
-    strategy:
-      matrix:
-        include:
-          - utf8_view_enabled: "true"
-            test_name: "UTF8_VIEW_ENABLED"
-          - utf8_view_enabled: "false" 
-            test_name: "UTF8_VIEW_DISABLED"
-    env:
-      # Utf8View regression test environment variables
-      ZO_FEATURE_JOIN_MATCH_ONE_ENABLED: true
-      ZO_UTF8_VIEW_ENABLED: ${{ matrix.utf8_view_enabled }}
     steps:
       - name: Remove unused tools
         run: |
@@ -129,5 +118,42 @@ jobs:
 
       - name: Run tests
         if: steps.check_changes.outputs.has_changes == 'true'
-        run: rye run pytest --force-sugar
+        run: |
+          echo "=== Running regression tests with ZO_UTF8_VIEW_ENABLED=false ==="
+          ZO_FEATURE_JOIN_MATCH_ONE_ENABLED=true ZO_UTF8_VIEW_ENABLED=false target/debug/openobserve > o2_utf8_false.log 2>&1 &
+          SERVER_PID_FALSE=$!
+          echo "OpenObserve PID for UTF8_VIEW=false: $SERVER_PID_FALSE"
+          sleep 15
+          
+          # Run regression tests with UTF8_VIEW=false
+          rye run pytest tests/test_subquery_join_match.py --force-sugar -v
+          
+          # Kill the server
+          kill $SERVER_PID_FALSE || true
+          sleep 5
+          
+          echo "=== Running regression tests with ZO_UTF8_VIEW_ENABLED=true ==="
+          ZO_FEATURE_JOIN_MATCH_ONE_ENABLED=true ZO_UTF8_VIEW_ENABLED=true target/debug/openobserve > o2_utf8_true.log 2>&1 &
+          SERVER_PID_TRUE=$!
+          echo "OpenObserve PID for UTF8_VIEW=true: $SERVER_PID_TRUE"
+          sleep 15
+          
+          # Run regression tests with UTF8_VIEW=true
+          rye run pytest tests/test_subquery_join_match.py --force-sugar -v
+          
+          # Kill the server
+          kill $SERVER_PID_TRUE || true
+          sleep 5
+          
+          echo "=== Running all other API tests with default settings ==="
+          target/debug/openobserve > o2_default.log 2>&1 &
+          SERVER_PID_DEFAULT=$!
+          echo "OpenObserve PID for other tests: $SERVER_PID_DEFAULT"
+          sleep 15
+          
+          # Run all other tests (excluding regression tests)
+          rye run pytest --ignore=tests/test_subquery_join_match.py --force-sugar
+          
+          # Kill the server
+          kill $SERVER_PID_DEFAULT || true
         working-directory: tests/api-testing/

--- a/tests/api-testing/tests/test_subquery_join_match.py
+++ b/tests/api-testing/tests/test_subquery_join_match.py
@@ -153,7 +153,7 @@ def test_subquery_with_substr_function(execute_search_query, query_timeframe, va
     Query: SELECT _timestamp, kubernetes_container_name FROM stream_pytest_data 
            WHERE kubernetes_container_name IN (
                SELECT kubernetes_container_name FROM stream_pytest_data 
-               WHERE substr(kubernetes_container_name, 0, 2) = 'p'
+               WHERE substr(kubernetes_container_name, 0, 2) = 'ap'
            )
     
     Expected: SUCCESS on fixed environments, Utf8View error on buggy environments
@@ -166,26 +166,26 @@ def test_subquery_with_substr_function(execute_search_query, query_timeframe, va
         WHERE kubernetes_container_name IN (
             SELECT kubernetes_container_name 
             FROM "stream_pytest_data" 
-            WHERE substr(kubernetes_container_name, 0, 2) = 'p'
+            WHERE substr(kubernetes_container_name, 0, 2) = 'ap'
         )
     """
     
     response = execute_search_query(sql_query, start_time, end_time)
     
-    def validate_prometheus_containers(hits, test_name):
-        """Validate that all containers start with 'p' (prometheus)."""
+    def validate_apiserver_containers(hits, test_name):
+        """Validate that all containers start with 'ap' (api-server)."""
         for i, hit in enumerate(hits):
             container_name = hit["kubernetes_container_name"]
-            assert container_name.startswith('p'), (
-                f"Hit {i}: container '{container_name}' should start with 'p'"
+            assert container_name.startswith('ap'), (
+                f"Hit {i}: container '{container_name}' should start with 'ap'"
             )
-        logging.info(f"{test_name}: Validated {len(hits)} prometheus containers")
+        logging.info(f"{test_name}: Validated {len(hits)} api-server containers")
     
     validate_query_response(
         response,
         ["_timestamp", "kubernetes_container_name"],
         "Subquery with substr",
-        validate_prometheus_containers
+        validate_apiserver_containers
     )
 
 
@@ -242,7 +242,7 @@ def test_subquery_with_concat_function(execute_search_query, query_timeframe):
         WHERE CONCAT(kubernetes_container_name, '|', kubernetes_namespace_name) IN (
             SELECT CONCAT(kubernetes_container_name, '|', kubernetes_namespace_name)
             FROM "stream_pytest_data"
-            WHERE substr(kubernetes_container_name, 0, 2) = 'p'
+            WHERE substr(kubernetes_container_name, 0, 2) = 'ap'
         )
         LIMIT 10
     """
@@ -261,8 +261,8 @@ def test_subquery_with_concat_function(execute_search_query, query_timeframe):
         
         for i, hit in enumerate(hits):
             container_name = hit["kubernetes_container_name"]
-            assert container_name.startswith('p'), (
-                f"Hit {i}: container '{container_name}' should start with 'p'"
+            assert container_name.startswith('ap'), (
+                f"Hit {i}: container '{container_name}' should start with 'ap'"
             )
 
 
@@ -342,7 +342,7 @@ def test_substr_without_subquery(execute_search_query, query_timeframe):
         SELECT _timestamp, kubernetes_container_name,
                substr(kubernetes_container_name, 0, 2) AS container_prefix
         FROM "stream_pytest_data"
-        WHERE substr(kubernetes_container_name, 0, 2) = 'p'
+        WHERE substr(kubernetes_container_name, 0, 2) = 'ap'
         LIMIT 10
     """
     
@@ -358,11 +358,11 @@ def test_substr_without_subquery(execute_search_query, query_timeframe):
     for i, hit in enumerate(hits):
         container_name = hit["kubernetes_container_name"]
         container_prefix = hit["container_prefix"]
-        assert container_name.startswith('p'), (
-            f"Hit {i}: container '{container_name}' should start with 'p'"
+        assert container_name.startswith('ap'), (
+            f"Hit {i}: container '{container_name}' should start with 'ap'"
         )
-        assert container_prefix == 'p', (
-            f"Hit {i}: container_prefix should be 'p', got '{container_prefix}'"
+        assert container_prefix == 'ap', (
+            f"Hit {i}: container_prefix should be 'ap', got '{container_prefix}'"
         )
 
 
@@ -393,13 +393,13 @@ def test_data_availability(execute_search_query, query_timeframe):
     
     if len(hits) > 0:
         container_names = [hit["kubernetes_container_name"] for hit in hits]
-        containers_with_p = [name for name in container_names if name.startswith('p')]
+        containers_with_ap = [name for name in container_names if name.startswith('ap')]
         
         logging.info(f"Available containers: {container_names}")
-        logging.info(f"Containers starting with 'p': {containers_with_p}")
+        logging.info(f"Containers starting with 'ap': {containers_with_ap}")
         
-        if len(containers_with_p) == 0:
-            pytest.skip("No containers starting with 'p' found - other tests may return empty results")
+        if len(containers_with_ap) == 0:
+            pytest.skip("No containers starting with 'ap' found - other tests may return empty results")
 
 
 """


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Add regression tests for substr subqueries

- Validate env flags causing Utf8View panic

- Add alternative query pattern coverage

- Verify data content and string functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Env flags set via monkeypatch"] -- "enable JOIN_MATCH_ONE, UTF8_VIEW" --> B["Execute queries against stream_pytest_data"]
  B -- "substr + IN subquery" --> C["Assert 200, validate hits"]
  B -- "alternative IN/JOIN/CONCAT/length" --> D["Cross-validate no Utf8View error"]
  B -- "data verification" --> E["Inspect container names/prefixes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_subquery_join_match.py</strong><dd><code>Add regression and coverage tests for substr subqueries</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/api-testing/tests/test_subquery_join_match.py

<ul><li>Add end-to-end regression tests reproducing Utf8View panic<br> <li> Set env vars via monkeypatch for failing conditions<br> <li> Cover substr IN, JOIN, CONCAT, and length() variants<br> <li> Add data verification and structural assertions on hits</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8818/files#diff-facac795b55980509f22b59fec9090910a8eb2c8d442936114c4b11f11008152">+564/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

