### PR TITLE
fix: dashboard flaky testcases

### DIFF
--- a/tests/ui-testing/playwright-tests/dashboards/dashboard.spec.js
+++ b/tests/ui-testing/playwright-tests/dashboards/dashboard.spec.js
@@ -854,10 +854,12 @@ test.describe("dashboard UI testcases", () => {
     );
 
     // await page.waitForTimeout(2000);
+    await page.waitForLoadState("networkidle");
 
     // Validate chart is properly rendered
     const chartContainer = page.locator('[data-test="chart-renderer"]');
     const boundingBox = await chartContainer.boundingBox();
+    await page.waitForLoadState("networkidle");
     const canvasCount = await page
       .locator('[data-test="chart-renderer"] canvas')
       .count();

--- a/tests/ui-testing/playwright-tests/dashboards/utils/dashCreation.js
+++ b/tests/ui-testing/playwright-tests/dashboards/utils/dashCreation.js
@@ -42,20 +42,20 @@ export async function deleteDashboard(page, dashboardName) {
 
   // Wait for page to be fully loaded
 // ✅ Wait for either the Dashboard API or Folder API (whichever comes first)
-await Promise.race([
-  page.waitForResponse(
-    (response) => {
-      const url = response.url();
-      return (
-        ( /\/api\/.*\/dashboards/.test(url) ||
-          /\/api\/.*\/folders/.test(url) ) &&
-        response.status() === 200
-      );
-    },
-    { timeout: 20000 }
-  ),
-  page.waitForSelector('[data-test="dashboard-table"]', { timeout: 20000 }),
-]);
+  await Promise.race([
+    page.waitForResponse(
+      (response) => {
+        const url = response.url();
+        return (
+          ( /\/api\/.*\/dashboards/.test(url) ||
+            /\/api\/.*\/folders/.test(url) ) &&
+          response.status() === 200
+        );
+      },
+      { timeout: 20000 }
+    ),
+    page.waitForSelector('[data-test="dashboard-table"]', { timeout: 20000 }),
+  ]);
 
   // const dashboardRow = page.locator(`//tr[.//td[text()="${dashboardName}"]]`);
   // await expect(dashboardRow).toBeVisible(); // Ensure the row is visible


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Stabilize dashboard deletion flow waits

- Add networkidle waits around chart checks

- Use API/selector race for readiness

- Simplify success toast assertion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  charts["Dashboard chart test"]
  networkIdle1["Wait networkidle before checks"]
  networkIdle2["Wait networkidle after boundingBox"]
  deletion["Delete dashboard util"]
  raceWait["Race: API response or table selector"]
  assertToast["Simplified success toast assertion"]

  charts -- "add waits" --> networkIdle1
  networkIdle1 -- "proceed" --> networkIdle2
  deletion -- "replace fixed waits" --> raceWait
  raceWait -- "proceed" --> assertToast
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.spec.js</strong><dd><code>Add networkidle waits around chart rendering checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/playwright-tests/dashboards/dashboard.spec.js

<ul><li>Add networkidle wait before chart validation.<br> <li> Add networkidle wait after fetching bounding box.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8820/files#diff-d0fa0042783dc109334b05266edce228bad97adcb568dd1e447920596238e9b4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashCreation.js</strong><dd><code>Robust deletion flow with adaptive waiting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/playwright-tests/dashboards/utils/dashCreation.js

<ul><li>Replace fixed waits with API/selector race.<br> <li> Adjust dashboard row locator formatting.<br> <li> Simplify success toast visibility assertion.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8820/files#diff-137f9f1fa23669cea684a9a98b42a9d04caaa18d75466b5605c717408e932122">+18/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

