### PR TITLE
fix: removed unused HAVING clause from traces RED queries

### DIFF
--- a/web/src/plugins/traces/metrics/metrics.json
+++ b/web/src/plugins/traces/metrics/metrics.json
@@ -78,7 +78,7 @@
           "queryType": "sql",
           "queries": [
             {
-              "query": "WITH base_traces AS ( SELECT min(_timestamp) AS _time, max(duration) AS max_duration, count(distinct(trace_id)) as rate, SUM(CASE WHEN span_status='ERROR' then 1 else 0 end) as error FROM [STREAM_NAME] [WHERE_CLAUSE] GROUP BY trace_id ) SELECT histogram(_time) AS time_bucket, max(max_duration) AS max_trace_duration, sum(rate) AS max_rate, max(error) AS error_rate FROM base_traces GROUP BY time_bucket [HAVING] ORDER BY time_bucket ASC",
+              "query": "WITH base_traces AS ( SELECT min(_timestamp) AS _time, max(duration) AS max_duration, count(distinct(trace_id)) as rate, SUM(CASE WHEN span_status='ERROR' then 1 else 0 end) as error FROM [STREAM_NAME] [WHERE_CLAUSE] GROUP BY trace_id ) SELECT histogram(_time) AS time_bucket, max(max_duration) AS max_trace_duration, sum(rate) AS max_rate, max(error) AS error_rate FROM base_traces GROUP BY time_bucket ORDER BY time_bucket ASC",
               "vrlFunctionQuery": "",
               "customQuery": true,
               "fields": {
@@ -202,7 +202,7 @@
           "queryType": "sql",
           "queries": [
             {
-              "query": "WITH base_traces AS ( SELECT min(_timestamp) AS _time, max(duration) AS max_duration, count(distinct(trace_id)) as rate, SUM(CASE WHEN span_status='ERROR' then 1 else 0 end) as error FROM [STREAM_NAME] [WHERE_CLAUSE] GROUP BY trace_id ) SELECT histogram(_time) AS time_bucket, max(max_duration) AS max_trace_duration, sum(rate) AS max_rate, max(error) AS error_rate FROM base_traces GROUP BY time_bucket [HAVING] ORDER BY time_bucket ASC",
+              "query": "WITH base_traces AS ( SELECT min(_timestamp) AS _time, max(duration) AS max_duration, count(distinct(trace_id)) as rate, SUM(CASE WHEN span_status='ERROR' then 1 else 0 end) as error FROM [STREAM_NAME] [WHERE_CLAUSE] GROUP BY trace_id ) SELECT histogram(_time) AS time_bucket, max(max_duration) AS max_trace_duration, sum(rate) AS max_rate, max(error) AS error_rate FROM base_traces GROUP BY time_bucket ORDER BY time_bucket ASC",
               "vrlFunctionQuery": "",
               "customQuery": true,
               "fields": {
@@ -327,7 +327,7 @@
           "queryType": "sql",
           "queries": [
             {
-              "query": "WITH base_traces AS ( SELECT min(_timestamp) AS _time, max(duration) AS max_duration, count(distinct(trace_id)) as rate, SUM(CASE WHEN span_status='ERROR' then 1 else 0 end) as error FROM [STREAM_NAME] [WHERE_CLAUSE] GROUP BY trace_id ) SELECT histogram(_time) AS time_bucket, max(max_duration) AS max_trace_duration, sum(rate) AS max_rate, max(error) AS error_rate FROM base_traces GROUP BY time_bucket [HAVING] ORDER BY time_bucket ASC",
+              "query": "WITH base_traces AS ( SELECT min(_timestamp) AS _time, max(duration) AS max_duration, count(distinct(trace_id)) as rate, SUM(CASE WHEN span_status='ERROR' then 1 else 0 end) as error FROM [STREAM_NAME] [WHERE_CLAUSE] GROUP BY trace_id ) SELECT histogram(_time) AS time_bucket, max(max_duration) AS max_trace_duration, sum(rate) AS max_rate, max(error) AS error_rate FROM base_traces GROUP BY time_bucket ORDER BY time_bucket ASC",
               "vrlFunctionQuery": "",
               "customQuery": true,
               "fields": {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove unsupported HAVING from RED queries

- Standardize time-bucket aggregation ordering

- Update three trace metrics SQL entries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  metricsJSON["metrics.json (traces RED queries)"]
  sqlBefore["SQL with [HAVING] placeholder"]
  sqlAfter["SQL without HAVING; GROUP BY + ORDER BY"]

  metricsJSON -- "replace query strings" --> sqlAfter
  sqlBefore -- "remove [HAVING]" --> sqlAfter
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metrics.json</strong><dd><code>Remove HAVING placeholder from RED metric queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/traces/metrics/metrics.json

<ul><li>Remove <code>[HAVING]</code> from three SQL query templates.<br> <li> Keep <code>GROUP BY time_bucket</code> and <code>ORDER BY ASC</code>.<br> <li> Affect RED metrics: duration, rate, error aggregations.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8821/files#diff-8bf43bcbba5150a185625f458adcb6756145e7bfcbbf632d87a9d487a937524e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

