### PR TITLE
fix: reset isPartialData state on error handling

### DIFF
--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -867,6 +867,7 @@ export const usePanelDataLoader = (
         state.loadingCompleted = 0;
         state.loadingProgressPercentage = 0;
         state.isOperationCancelled = false;
+        state.isPartialData = false;
         processApiError(response?.content, "sql");
       }
 
@@ -891,6 +892,7 @@ export const usePanelDataLoader = (
       state.loadingTotal = 0;
       state.loadingCompleted = 0;
       state.loadingProgressPercentage = 0;
+      state.isPartialData = false;
       state.errorDetail = {
         message: error?.message || "Unknown error in search response",
         code: error?.code ?? "",
@@ -993,6 +995,7 @@ export const usePanelDataLoader = (
     state.loadingCompleted = 0;
     state.loadingProgressPercentage = 0;
     state.isOperationCancelled = false;
+    state.isPartialData = false;
 
     processApiError(response?.content, "sql");
   };
@@ -1093,6 +1096,7 @@ export const usePanelDataLoader = (
       };
       state.loading = false;
       state.isOperationCancelled = false;
+      state.isPartialData = false;
     }
   };
 
@@ -1201,6 +1205,7 @@ export const usePanelDataLoader = (
       };
       state.loading = false;
       state.isOperationCancelled = false;
+      state.isPartialData = false;
     }
   };
 
@@ -2079,6 +2084,8 @@ export const usePanelDataLoader = (
    * @param {any} type - The type of error being processed.
    */
   const processApiError = async (error: any, type: any) => {
+    state.isPartialData = false;
+
     switch (type) {
       case "promql": {
         const errorDetailValue = error?.response?.data?.error || error?.message;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Reset `isPartialData` on error paths

- Prevent stale partial-data icon after failures

- Align error handlers to clear partial state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Start["Data loading flow"] -- "Error occurs" --> Err["Error handlers"]
  Err -- "Reset flags" --> Flags["loading/isCancelled/progress reset"]
  Err -- "Also reset" --> Partial["state.isPartialData = false"]
  Partial -- "Avoid stale UI" --> UI["No partial-data icon on error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usePanelDataLoader.ts</strong><dd><code>Reset partial-data flag across all error paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/dashboard/usePanelDataLoader.ts

<ul><li>Set <code>state.isPartialData = false</code> in multiple error branches<br> <li> Clear partial-data on API error responses and exceptions<br> <li> Ensure <code>processApiError</code> always resets partial-data state<br> <li> Keep other loading/reset flags unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8836/files#diff-5a42e9493a7bcd722b88e61fd38883c4f61001bc9cafa399f65f8eafda3aace9">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

