### PR TITLE
feat: add support for MCP clients

### DIFF
--- a/src/common/meta/user.rs
+++ b/src/common/meta/user.rs
@@ -456,6 +456,13 @@ pub struct AuthTokensExt {
     pub expires_in: i64,
 }
 
+impl AuthTokensExt {
+    /// Checks if the token is still valid or not
+    pub fn has_expired(&self) -> bool {
+        chrono::Utc::now().timestamp() - self.request_time > self.expires_in
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -986,16 +986,16 @@ impl From<&str> for StreamSettings {
             defined_schema_fields = fields;
         }
 
-        let flatten_level = settings.get("flatten_level").map(|v| v.as_i64().unwrap());
+        let flatten_level = settings.get("flatten_level").and_then(Value::as_i64);
 
         let store_original_data = settings
             .get("store_original_data")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+            .and_then(Value::as_bool)
+            .unwrap_or_default();
 
         let approx_partition = settings
             .get("approx_partition")
-            .and_then(|v| v.as_bool())
+            .and_then(Value::as_bool)
             .unwrap_or(
                 get_config()
                     .common
@@ -1013,7 +1013,7 @@ impl From<&str> for StreamSettings {
 
         let index_updated_at = settings
             .get("index_updated_at")
-            .and_then(|v| v.as_i64())
+            .and_then(Value::as_i64)
             .unwrap_or_default();
 
         let mut extended_retention_days = vec![];
@@ -1024,26 +1024,26 @@ impl From<&str> for StreamSettings {
             for item in values {
                 let start = item
                     .get("start")
-                    .and_then(|v| v.as_i64())
+                    .and_then(Value::as_i64)
                     .unwrap_or_default();
-                let end = item.get("end").and_then(|v| v.as_i64()).unwrap_or_default();
+                let end = item.get("end").and_then(Value::as_i64).unwrap_or_default();
                 extended_retention_days.push(TimeRange::new(start, end));
             }
         }
 
         let index_original_data = settings
             .get("index_original_data")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+            .and_then(Value::as_bool)
+            .unwrap_or_default();
 
         let index_all_values = settings
             .get("index_all_values")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+            .and_then(Value::as_bool)
+            .unwrap_or_default();
         let enable_distinct_fields = settings
             .get("enable_distinct_fields")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
+            .and_then(Value::as_bool)
+            .unwrap_or_default();
         Self {
             partition_time_level,
             partition_keys,

--- a/src/config/src/utils/base64.rs
+++ b/src/config/src/utils/base64.rs
@@ -17,7 +17,7 @@ use std::io::{Error, ErrorKind};
 
 use base64::Engine;
 
-pub fn decode(s: &str) -> Result<String, Error> {
+pub fn decode(s: impl AsRef<[u8]>) -> Result<String, Error> {
     match String::from_utf8(decode_raw(s)?) {
         Ok(v) => Ok(v),
         Err(e) => Err(Error::new(
@@ -27,9 +27,9 @@ pub fn decode(s: &str) -> Result<String, Error> {
     }
 }
 
-pub fn decode_raw(s: &str) -> Result<Vec<u8>, Error> {
+pub fn decode_raw(s: impl AsRef<[u8]>) -> Result<Vec<u8>, Error> {
     base64::engine::general_purpose::STANDARD
-        .decode(s.as_bytes())
+        .decode(s.as_ref())
         .map_err(|e| Error::new(ErrorKind::InvalidData, format!("base64 decode error: {e}")))
 }
 

--- a/src/handler/http/request/mcp/mod.rs
+++ b/src/handler/http/request/mcp/mod.rs
@@ -18,8 +18,18 @@ use actix_web::{HttpResponse, get, post, web};
 use {
     actix_web::HttpRequest,
     futures_util::StreamExt,
-    o2_enterprise::enterprise::mcp::{MCPRequest, handle_mcp_request, handle_mcp_request_stream},
+    o2_enterprise::enterprise::mcp::{
+        MCPRequest, OAuthServerMetadata, handle_mcp_request, handle_mcp_request_stream,
+    },
 };
+
+#[cfg(not(feature = "enterprise"))]
+/// Returns a 404 response for non-enterprise builds
+fn mcp_only_in_enterprise() -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::NotFound().json(serde_json::json!({
+        "error": "MCP server is only available in enterprise edition"
+    })))
+}
 
 /// Handler for MCP POST requests (single request/response)
 #[cfg(feature = "enterprise")]
@@ -112,6 +122,9 @@ pub async fn handle_mcp_post(
 #[get("/{org_id}/mcp")]
 pub async fn handle_mcp_get(
     _org_id: web::Path<String>,
+    // This is `Bytes` because body in HTTP GET is not defined,
+    // and actix-web tends to drop JSON body.
+    // This is a workaround to prevent that.
     body: web::Bytes,
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse> {
@@ -176,9 +189,7 @@ pub async fn handle_mcp_post(
     _org_id: web::Path<String>,
     _body: web::Bytes,
 ) -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::NotFound().json(serde_json::json!({
-        "error": "MCP server is only available in enterprise edition"
-    })))
+    mcp_only_in_enterprise()
 }
 
 #[cfg(not(feature = "enterprise"))]
@@ -202,7 +213,58 @@ pub async fn handle_mcp_get(
     _org_id: web::Path<String>,
     _body: web::Bytes,
 ) -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::NotFound().json(serde_json::json!({
-        "error": "MCP server is only available in enterprise edition"
-    })))
+    mcp_only_in_enterprise()
+}
+
+/// Handler for OAuth 2.0 Authorization Server Metadata (Enterprise)
+/// RFC 8414: https://datatracker.ietf.org/doc/html/rfc8414
+/// This endpoint provides discovery information for OAuth clients
+#[cfg(feature = "enterprise")]
+#[utoipa::path(
+    context_path = "/api",
+    tag = "MCP",
+    operation_id = "OAuthServerMetadata",
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+    ),
+    responses(
+        (status = 200, description = "Success", content_type = "application/json"),
+    ),
+)]
+#[get("/{org_id}/.well-known/oauth-authorization-server")]
+pub async fn oauth_authorization_server_metadata(
+    _org_id: web::Path<String>,
+) -> actix_web::Result<HttpResponse> {
+    use once_cell::sync::Lazy;
+
+    static METADATA: Lazy<OAuthServerMetadata> = Lazy::new(|| {
+        let dex_config = o2_dex::config::get_config();
+        let base_url = dex_config.dex_url.as_str();
+        OAuthServerMetadata::build(base_url)
+    });
+    Ok(HttpResponse::Ok()
+        .content_type("application/json")
+        .json(&*METADATA))
+}
+
+/// Handler for OAuth 2.0 Authorization Server Metadata (Non-Enterprise)
+/// RFC 8414: https://datatracker.ietf.org/doc/html/rfc8414
+/// This endpoint provides discovery information for OAuth clients
+#[cfg(not(feature = "enterprise"))]
+#[utoipa::path(
+    context_path = "/api",
+    tag = "MCP",
+    operation_id = "OAuthServerMetadata",
+    params(
+        ("org_id" = String, Path, description = "Organization name"),
+    ),
+    responses(
+        (status = 404, description = "Not Found - MCP server is only available in enterprise edition", content_type = "application/json"),
+    ),
+)]
+#[get("/{org_id}/.well-known/oauth-authorization-server")]
+pub async fn oauth_authorization_server_metadata(
+    _org_id: web::Path<String>,
+) -> actix_web::Result<HttpResponse> {
+    mcp_only_in_enterprise()
 }

--- a/src/handler/http/request/re_pattern/mod.rs
+++ b/src/handler/http/request/re_pattern/mod.rs
@@ -436,7 +436,7 @@ pub async fn test(web::Json(req): web::Json<PatternTestRequest>) -> Result<HttpR
         let pattern = req.pattern;
         let inputs = req.test_records;
         // Default to Redact if policy not specified for backward compatibility
-        let policy = req.policy.as_ref().map(|p| p.as_str()).unwrap_or("Redact");
+        let policy = req.policy.as_deref().unwrap_or("Redact");
         let policy = PatternPolicy::from(policy);
 
         let mut ret = Vec::with_capacity(inputs.len());

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -1238,7 +1238,7 @@ async fn values_v1(
                 .unwrap_or("".to_string());
             let num = row
                 .get("zo_sql_num")
-                .map(|v| v.as_i64().unwrap_or(0))
+                .and_then(json::Value::as_i64)
                 .unwrap_or(0);
             top_hits.push((key, num));
         }

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -562,7 +562,10 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(service_accounts::save)
         .service(service_accounts::delete)
         .service(service_accounts::update)
-        .service(service_accounts::get_api_token);
+        .service(service_accounts::get_api_token)
+        .service(mcp::handle_mcp_post)
+        .service(mcp::handle_mcp_get)
+        .service(mcp::oauth_authorization_server_metadata);
 
     #[cfg(feature = "enterprise")]
     let service = service
@@ -605,9 +608,7 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(re_pattern::delete)
         .service(re_pattern::test)
         .service(domain_management::get_domain_management_config)
-        .service(domain_management::set_domain_management_config)
-        .service(mcp::handle_mcp_post)
-        .service(mcp::handle_mcp_get);
+        .service(domain_management::set_domain_management_config);
 
     #[cfg(feature = "cloud")]
     let service = service
@@ -625,11 +626,6 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(cloud::marketing::handle_new_attribution_event)
         .service(organization::org::all_organizations)
         .service(organization::org::extend_trial_period);
-
-    #[cfg(not(feature = "enterprise"))]
-    let service = service
-        .service(mcp::handle_mcp_post)
-        .service(mcp::handle_mcp_get);
 
     svc.service(service);
 }

--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -790,7 +790,7 @@ fn key_encode(key: &str) -> String {
 
 #[inline]
 fn key_decode(key: &str) -> String {
-    base64::decode(&key.replace('-', "+").replace('_', "/")).unwrap()
+    base64::decode(key.replace('-', "+").replace('_', "/")).unwrap()
 }
 
 #[cfg(test)]

--- a/src/job/query_optimization_recommendation.rs
+++ b/src/job/query_optimization_recommendation.rs
@@ -13,8 +13,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg(feature = "enterprise")]
-
 use std::{pin::Pin, sync::Arc};
 
 use config::{META_ORG_ID, get_config, meta::stream::StreamType};
@@ -79,7 +77,7 @@ impl QueryRecommendationEngine for OptimizerContext {
         recommendations: Vec<OptimiserRecommendation>,
     ) -> Pin<Box<dyn Future<Output = Result<IngestionResponse, anyhow::Error>> + Send>> {
         Box::pin(async move {
-            let ingester = Ingester::default();
+            let ingester = Ingester;
             let request = IngestionRequest {
                 org_id: META_ORG_ID.to_string(),
                 stream_type: StreamType::Logs.to_string(),
@@ -95,8 +93,7 @@ impl QueryRecommendationEngine for OptimizerContext {
             Ok(ingester
                 .ingest(tonic::Request::new(request))
                 .await?
-                .into_inner()
-                .into())
+                .into_inner())
         })
     }
 }

--- a/src/service/promql/value.rs
+++ b/src/service/promql/value.rs
@@ -313,7 +313,7 @@ impl<'de> Deserialize<'de> for Exemplar {
 
 impl From<&json::Map<String, json::Value>> for Exemplar {
     fn from(data: &json::Map<String, json::Value>) -> Self {
-        let timestamp = data.get("_timestamp").map(|v| v.as_i64().unwrap_or(0));
+        let timestamp = data.get("_timestamp").and_then(json::Value::as_i64);
         let value = data.get("value").map(|v| v.as_f64().unwrap_or(0.0));
         let mut labels = vec![];
         for (k, v) in data.iter() {

--- a/src/service/search/streaming/utils.rs
+++ b/src/service/search/streaming/utils.rs
@@ -69,7 +69,7 @@ pub fn get_top_k_values(
             .unwrap_or_default();
         let num = hit
             .get("zo_sql_num")
-            .and_then(|v| v.as_i64())
+            .and_then(Value::as_i64)
             .unwrap_or_default();
         search_result_hits.push((key, num));
     }

--- a/src/service/search/utils.rs
+++ b/src/service/search/utils.rs
@@ -228,38 +228,38 @@ mod tests {
     #[test]
     fn test_is_cachable_function_error() {
         let error = vec![];
-        assert_eq!(is_permissable_function_error(&error), true);
+        assert!(is_permissable_function_error(&error));
 
         let error = vec!["".to_string()];
-        assert_eq!(is_permissable_function_error(&error), true);
+        assert!(is_permissable_function_error(&error));
 
         let error = vec![
             CAPPED_RESULTS_MSG.to_string(),
             PARTIAL_ERROR_RESPONSE_MESSAGE.to_string(),
         ];
-        assert_eq!(is_permissable_function_error(&error), true); // only this is cachable
+        assert!(is_permissable_function_error(&error)); // only this is cachable
 
         let error = vec![
             CAPPED_RESULTS_MSG.to_string(),
             PARTIAL_ERROR_RESPONSE_MESSAGE.to_string(),
             "parquet not found".to_string(),
         ];
-        assert_eq!(is_permissable_function_error(&error), false);
+        assert!(!is_permissable_function_error(&error));
 
         let error = vec![
             "parquet not found".to_string(),
             PARTIAL_ERROR_RESPONSE_MESSAGE.to_string(),
         ];
-        assert_eq!(is_permissable_function_error(&error), false);
+        assert!(!is_permissable_function_error(&error));
 
         let error = vec!["parquet not found".to_string()];
-        assert_eq!(is_permissable_function_error(&error), false);
+        assert!(!is_permissable_function_error(&error));
 
         let error = vec![
             "parquet not found".to_string(),
             CAPPED_RESULTS_MSG.to_string(),
         ];
-        assert_eq!(is_permissable_function_error(&error), false);
+        assert!(!is_permissable_function_error(&error));
     }
 
     #[test]


### PR DESCRIPTION
This PR adds support for MCP clients to connect with OpenObserve in the enterprise version. The change is aimed at clients such as Claude Code which require [Dynamic Client Registration](https://openid.net/specs/openid-connect-registration-1_0.html).

In addition to this, a few things have been standardized, such as the `WWW-authenticate` header response in the event of missing auth token.

Since OpenObserve uses Dex as the auth server, this change will only take effect after [dexidp/dex#4383](https://github.com/dexidp/dex/pull/4383) is merged, wherein the support for Dynamic Client Registration has been added.