### PR TITLE
feat: support choose kv watcher or queue for sync events

### DIFF
--- a/src/common/utils/auth_tests.rs
+++ b/src/common/utils/auth_tests.rs
@@ -3363,6 +3363,7 @@ mod tests {
                 event_max_age: u64::default(),
                 queue_max_size: i64::default(),
                 v211_support: bool::default(),
+                kv_watch_modules: String::default(),
             },
             s3: config::S3 {
                 provider: String::default(),

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -268,7 +268,30 @@ pub static COMPACT_OLD_DATA_STREAM_SET: Lazy<HashSet<String>> = Lazy::new(|| {
         .compact
         .old_data_streams
         .split(',')
-        .map(|s| s.trim().to_string())
+        .filter_map(|s| {
+            let s = s.trim();
+            if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            }
+        })
+        .collect()
+});
+
+pub static NATS_KV_WATCH_MODULES: Lazy<HashSet<String>> = Lazy::new(|| {
+    get_config()
+        .nats
+        .kv_watch_modules
+        .split(',')
+        .filter_map(|s| {
+            let s = s.trim();
+            if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            }
+        })
         .collect()
 });
 
@@ -1765,6 +1788,12 @@ pub struct Nats {
         default = false
     )]
     pub v211_support: bool,
+    #[env_config(
+        name = "ZO_NATS_KV_WATCH_MODULES",
+        help = "Set the modules which need to use kv watcher",
+        default = ""
+    )]
+    pub kv_watch_modules: String,
 }
 
 #[derive(Debug, Default, EnvConfig)]

--- a/src/infra/src/coordinator/events.rs
+++ b/src/infra/src/coordinator/events.rs
@@ -94,7 +94,7 @@ pub async fn init() -> Result<()> {
                     for (prefix, tx) in r.iter() {
                         if event.key.starts_with(prefix) {
                             log::debug!(
-                                "[COORDINATOR::EVENTS] sending event to watcher: [{:?}]{:?}",
+                                "[COORDINATOR::EVENTS] sending event to watcher: {:?}:{}",
                                 event.action,
                                 event.key
                             );


### PR DESCRIPTION
There is a new ENV `ZO_NATS_KV_WATCH_MODULES` and default value is empty.

If you want to set something to use `nats kv watcher` instead of `nats queue`, you can configure it like this:

for `nodes` events:
```
ZO_NATS_KV_WATCH_MODULES="/nodes/"
```
add `user_sessions` events:
```
ZO_NATS_KV_WATCH_MODULES="/nodes/,/user_sessions/"
```

When you start node, you will see some logs like this:
```
2025-10-21T06:24+00:00 DEBUG infra::db::nats: [NATS:kv_watch] bucket: o2_nodes, prefix: /nodes/
```