### PR TITLE
perf: improve get_min_ts to reduce db calls

### DIFF
--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -505,8 +505,6 @@ async fn get_stream_schema_status() -> (usize, usize, usize) {
     drop(r);
     let r = STREAM_SCHEMAS_LATEST.read().await;
     for (key, schema) in r.iter() {
-        stream_num += 1;
-        stream_schema_num += 1;
         mem_size += std::mem::size_of::<String>() + key.len();
         mem_size += schema.size();
     }

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -110,12 +110,6 @@ pub trait FileList: Sync + Send + 'static {
         limit: i64,
     ) -> Result<Vec<FileListDeleted>>;
     async fn list_deleted(&self) -> Result<Vec<FileListDeleted>>;
-    async fn get_min_ts(
-        &self,
-        org_id: &str,
-        stream_type: StreamType,
-        stream_name: &str,
-    ) -> Result<i64>;
     async fn get_min_date(
         &self,
         org_id: &str,
@@ -353,11 +347,6 @@ pub async fn query_deleted(
 #[inline]
 pub async fn list_deleted() -> Result<Vec<FileListDeleted>> {
     CLIENT.list_deleted().await
-}
-
-#[inline]
-pub async fn get_min_ts(org_id: &str, stream_type: StreamType, stream_name: &str) -> Result<i64> {
-    CLIENT.get_min_ts(org_id, stream_type, stream_name).await
 }
 
 #[inline]

--- a/src/infra/src/file_list/mysql.rs
+++ b/src/infra/src/file_list/mysql.rs
@@ -872,28 +872,6 @@ SELECT date
             .collect())
     }
 
-    async fn get_min_ts(
-        &self,
-        org_id: &str,
-        stream_type: StreamType,
-        stream_name: &str,
-    ) -> Result<i64> {
-        let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
-        let min_ts = config::utils::time::BASE_TIME.timestamp_micros();
-        let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list"])
-            .inc();
-        let ret: Option<i64> = sqlx::query_scalar(
-            r#"SELECT MIN(min_ts) AS num FROM file_list WHERE stream = ? AND min_ts > ?;"#,
-        )
-        .bind(stream_key)
-        .bind(min_ts)
-        .fetch_one(&pool)
-        .await?;
-        Ok(ret.unwrap_or_default())
-    }
-
     async fn get_min_date(
         &self,
         org_id: &str,

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -815,28 +815,6 @@ SELECT date
             .collect())
     }
 
-    async fn get_min_ts(
-        &self,
-        org_id: &str,
-        stream_type: StreamType,
-        stream_name: &str,
-    ) -> Result<i64> {
-        let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
-        let min_ts = config::utils::time::BASE_TIME.timestamp_micros();
-        let pool = CLIENT_RO.clone();
-        DB_QUERY_NUMS
-            .with_label_values(&["select", "file_list"])
-            .inc();
-        let ret: Option<i64> = sqlx::query_scalar(
-            r#"SELECT MIN(min_ts)::BIGINT AS num FROM file_list WHERE stream = $1 AND min_ts > $2;"#,
-        )
-        .bind(stream_key)
-        .bind(min_ts)
-        .fetch_one(&pool)
-        .await?;
-        Ok(ret.unwrap_or_default())
-    }
-
     async fn get_min_date(
         &self,
         org_id: &str,

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -661,25 +661,6 @@ SELECT date
             .collect())
     }
 
-    async fn get_min_ts(
-        &self,
-        org_id: &str,
-        stream_type: StreamType,
-        stream_name: &str,
-    ) -> Result<i64> {
-        let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
-        let min_ts = config::utils::time::BASE_TIME.timestamp_micros();
-        let pool = CLIENT_RO.clone();
-        let ret: Option<i64> = sqlx::query_scalar(
-            r#"SELECT MIN(min_ts) AS num FROM file_list WHERE stream = $1 AND min_ts > $2;"#,
-        )
-        .bind(stream_key)
-        .bind(min_ts)
-        .fetch_one(&pool)
-        .await?;
-        Ok(ret.unwrap_or_default())
-    }
-
     async fn get_min_date(
         &self,
         org_id: &str,

--- a/src/service/compact/retention.rs
+++ b/src/service/compact/retention.rs
@@ -430,12 +430,8 @@ pub async fn delete_by_date(
 
     // update stream stats retention time
     let mut stats = cache::stats::get_stream_stats(org_id, stream_name, stream_type);
-    let mut min_ts = infra_file_list::get_min_ts(org_id, stream_type, stream_name)
-        .await
-        .unwrap_or_default();
-    if min_ts == 0 {
-        min_ts = stats.doc_time_min;
-    };
+    // we use date_end as the new min doc time
+    let min_ts = date_end.timestamp_micros();
     infra_file_list::reset_stream_stats_min_ts(
         org_id,
         format!("{org_id}/{stream_type}/{stream_name}").as_str(),


### PR DESCRIPTION
### **User description**
This pull request removes the now-unused `get_min_ts` method and its related code from the file list infrastructure, simplifying both the trait and its implementations for MySQL, Postgres, and SQLite. Additionally, the logic for updating the minimum document timestamp in stream stats during retention is updated to use the retention end date directly.

**Retention logic update:**

* Updated `delete_by_date` in `retention.rs` to set the minimum document timestamp (`min_ts`) for stream stats directly from `date_end.timestamp_micros()` instead of querying for the minimum timestamp. This streamlines retention logic and ensures consistency.

**Minor code cleanup:**

* Removed unused counters for stream and schema numbers in `get_stream_schema_status` to prevent misleading statistics.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Remove unused file-list `get_min_ts`

- Simplify FileList trait and impls

- Reduce DB reads during retention

- Fix schema status counters inflation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Trait["FileList trait"] -- remove --> MinTsMethod["get_min_ts()"]
  ImplMy["MySQL impl"] -- drop method --> MinTsMethod
  ImplPg["Postgres impl"] -- drop method --> MinTsMethod
  ImplSql["SQLite impl"] -- drop method --> MinTsMethod
  Retention["Retention delete_by_date"] -- use --> DateEnd["date_end.timestamp_micros() as min_ts"]
  Status["HTTP status schema"] -- remove --> ExtraCounters["extra counters increments"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Fix overcount in latest stream schema status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/status/mod.rs

<ul><li>Stop incrementing <code>stream_num</code> and <code>stream_schema_num</code> for latest schemas.<br> <li> Prevents double counting in memory/stat reporting.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8861/files#diff-ca09c9c9b020049bdbc3382c466bfcca80daac92e98760d9a9a76172abf34049">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Drop get_min_ts from file-list interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/file_list/mod.rs

<ul><li>Remove <code>get_min_ts</code> from <code>FileList</code> trait.<br> <li> Remove public <code>get_min_ts</code> wrapper function.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8861/files#diff-3df833bc826eb12e0819620d1fe316ef1ac352d293c11e57cc3df0da3c031e93">+0/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mysql.rs</strong><dd><code>Remove MySQL get_min_ts implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/file_list/mysql.rs

- Delete `get_min_ts` implementation and related query/metrics.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8861/files#diff-06d02c738c6a4dc22ff022c16befef8d46aece6cfaa88bb4a5d3d5f92c2e50a1">+0/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>postgres.rs</strong><dd><code>Remove Postgres get_min_ts implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/file_list/postgres.rs

- Delete `get_min_ts` implementation and related query/metrics.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8861/files#diff-bb24a30c9c3744eb31fb49e4271a9651d1f9a94a87455ac0074364b879af9651">+0/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sqlite.rs</strong><dd><code>Remove SQLite get_min_ts implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/file_list/sqlite.rs

- Delete `get_min_ts` implementation and related query.


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8861/files#diff-85ff00530831fdaa4e13c05cb649f2e20479cce04a4b65ef78d131cdb89b6c71">+0/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>retention.rs</strong><dd><code>Use date_end for retention min_ts update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/compact/retention.rs

<ul><li>Set stream stats <code>min_ts</code> directly from <code>date_end</code>.<br> <li> Remove DB call to file-list <code>get_min_ts</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8861/files#diff-6abd048f5ef4e7163cffbb51cb4bee10c07fb88b871469d5b3724f7cd04743dc">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

