### PR TITLE
fix: cache missing of schema

### DIFF
--- a/src/infra/src/coordinator/events.rs
+++ b/src/infra/src/coordinator/events.rs
@@ -94,9 +94,10 @@ pub async fn init() -> Result<()> {
                     for (prefix, tx) in r.iter() {
                         if event.key.starts_with(prefix) {
                             log::debug!(
-                                "[COORDINATOR::EVENTS] sending event to watcher: {:?}:{}",
+                                "[COORDINATOR::EVENTS] sending event to watcher: {:?}:{}, start_dt: {:?}",
                                 event.action,
-                                event.key
+                                event.key,
+                                event.start_dt
                             );
                             if let Err(e) = tx.send(event.clone().into()).await {
                                 log::error!(
@@ -176,6 +177,7 @@ async fn subscribe(tx: mpsc::Sender<CoordinatorEvent>) -> Result<()> {
                                 continue;
                             }
                         };
+                        log::debug!("[COORDINATOR::EVENTS] received coordinator event: {event:?}");
                         match tx.send(event).await {
                             Ok(_) => {
                                 if let Err(e) = message.ack().await {
@@ -237,7 +239,7 @@ pub async fn put_event(key: &str, start_dt: Option<i64>, value: Option<Bytes>) -
 }
 
 pub async fn delete_event(key: &str, start_dt: Option<i64>) -> Result<()> {
-    log::debug!("[COORDINATOR::EVENTS] publishing delete event for key: {key}");
+    log::debug!("[COORDINATOR::EVENTS] publishing delete event for key: {key}, start_dt: {start_dt:?}");
     if let Err(e) = publish(CoordinatorEvent::Meta(MetaEvent {
         action: MetaAction::Delete,
         key: key.to_string(),

--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -390,7 +390,12 @@ impl super::Db for NatsDb {
                 .await
                 .map_err(|e| Error::Message(format!("[NATS:delete] bucket.purge error: {e}")))?;
             if need_watch && !use_kv_watcher(key) {
-                coordinator::events::delete_event(key, start_dt).await?;
+                let key = if start_dt.is_some() {
+                    format!("{}/{}", key, start_dt.unwrap())
+                } else {
+                    key.to_string()
+                };
+                coordinator::events::delete_event(&key, start_dt).await?;
             }
             return Ok(());
         }

--- a/src/service/db/schema.rs
+++ b/src/service/db/schema.rs
@@ -292,7 +292,7 @@ pub async fn watch() -> Result<(), anyhow::Error> {
         match ev {
             db::Event::Put(ev) => {
                 let key_columns = ev.key.split('/').collect::<Vec<&str>>();
-                let (ev_key, ev_start_dt) = if key_columns.len() > 5 {
+                let (ev_key, mut ev_start_dt) = if key_columns.len() > 5 {
                     (
                         key_columns[..5].join("/"),
                         key_columns[5].parse::<i64>().unwrap_or(0),
@@ -300,6 +300,9 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                 } else {
                     (ev.key.to_string(), ev.start_dt.unwrap_or_default())
                 };
+                if ev_start_dt == 0 && ev.start_dt.is_some() {
+                    ev_start_dt = ev.start_dt.unwrap();
+                }
 
                 let item_key = ev_key.strip_prefix(key).unwrap();
                 let r = STREAM_SCHEMAS.read().await;
@@ -405,15 +408,15 @@ pub async fn watch() -> Result<(), anyhow::Error> {
                 let stream_name = columns[2];
                 let start_dt = match columns.get(3) {
                     Some(start_dt) => start_dt.parse::<i64>().unwrap_or_default(),
-                    None => 0,
+                    None => ev.start_dt.unwrap_or_default(),
                 };
+                log::warn!(
+                    "[Schema:watch] Deleting schema cache for {org_id}/{stream_type}/{stream_name} with start_dt {start_dt}",
+                );
                 if start_dt > 0 {
                     // delete only one version
                     continue;
                 }
-                log::warn!(
-                    "[Schema:watch] Deleting schema cache for {org_id}/{stream_type}/{stream_name} with start_dt {start_dt}",
-                );
                 let mut w = STREAM_SCHEMAS.write().await;
                 w.remove(item_key);
                 w.shrink_to_fit();


### PR DESCRIPTION
The bug is we only get start_dt from key, we also need to check `ev.start_dt` when there is no `start_dt` from key.