### PR TITLE
feat: add event storage configuration and update queue creation logic

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1799,6 +1799,12 @@ pub struct Nats {
     )]
     pub queue_max_size: i64,
     #[env_config(
+        name = "ZO_NATS_EVENT_STORAGE",
+        help = "Set the storage type for the event stream, default is: memory, other value is: file",
+        default = "memory"
+    )]
+    pub event_storage: String,
+    #[env_config(
         name = "ZO_NATS_V211_SUPPORT",
         help = "Support NATS v2.11.x",
         default = false


### PR DESCRIPTION
### **User description**
Support storage type for nat queue.

## New env:
```
ZO_NATS_EVENT_STORAGE="memory"
```
Default is `memory`, support `memory` or `file`.

## Why we need this?
### Summary 

Benchmark by tools: https://github.com/openobserve/nats-benchmark
Storage with file:
```
🚀 Throughput:
  Operations/sec:        10965.17
  Throughput:            10.71 MB/s
  Data Transferred:      642.50 MB
```
Storage with memory:
```
🚀 Throughput:
  Operations/sec:        16957.44
  Throughput:            16.56 MB/s
  Data Transferred:      993.61 MB
```

### Storage with file
```
================================================================================
NATS Benchmark Results - JetStream PUBLISH
================================================================================
📊 Overall Statistics:
  Duration:              60.00s
  Total Operations:      657918
  Successful:            657918
  Failed:                0
  Success Rate:          100.00%
🚀 Throughput:
  Operations/sec:        10965.17
  Throughput:            10.71 MB/s
  Data Transferred:      642.50 MB
⏱️ Latency (microseconds):
  Min:                   240
  Max:                   12519
  Mean:                  911.03
  StdDev:                394.07
  p50:                   836
  p90:                   1284
  p95:                   1654
  p99:                   2123
  p99.9:                 5111
```

### Storage with memory:
```
================================================================================
NATS Benchmark Results - JetStream PUBLISH
================================================================================
📊 Overall Statistics:
  Duration:              60.00s
  Total Operations:      1017459
  Successful:            1017459
  Failed:                0
  Success Rate:          100.00%
🚀 Throughput:
  Operations/sec:        16957.44
  Throughput:            16.56 MB/s
  Data Transferred:      993.61 MB
⏱️ Latency (microseconds):
  Min:                   193
  Max:                   12767
  Mean:                  588.76
  StdDev:                403.22
  p50:                   424
  p90:                   1089
  p95:                   1214
  p99:                   1653
  p99.9:                 4907
```

___

### **PR Type**
Enhancement


___

### **Description**
- Add `ZO_NATS_EVENT_STORAGE` config option

- Introduce queue storage type enum

- Replace create APIs with config builder

- Configure coordinator stream via builder


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CFG["Config: add `event_storage`"] -- "read env" --> EVENTS["Coordinator events"]
  EVENTS -- "build QueueConfig (age, retention, storage)" --> QUEUE_API["Queue trait: create_with_config"]
  QUEUE_API -- "convert to NATS config" --> NATS_IMPL["NATS queue impl"]
  NATS_IMPL -- "create/get JetStream stream" --> NATS_JS["NATS JetStream"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add event storage config to NATS settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<ul><li>Add <code>ZO_NATS_EVENT_STORAGE</code> env config.<br> <li> Default storage set to <code>memory</code>.<br> <li> Provide help text for storage option.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8875/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>events.rs</strong><dd><code>Coordinator stream uses configurable storage and builder</code>&nbsp; </dd></summary>
<hr>

src/infra/src/coordinator/events.rs

<ul><li>Use new storage config to select storage type.<br> <li> Build <code>QueueConfig</code> with max age and retention.<br> <li> Switch to <code>create_with_config</code> API.<br> <li> Minor variable renames for clarity.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8875/files#diff-4cb256860c8e23ac60194362df1eaf9e8db3afece72d751da6295db9b5b72220">+18/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Introduce queue configuration builder and storage type</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/queue/mod.rs

<ul><li>Add <code>StorageType</code>, <code>QueueConfig</code>, and builder.<br> <li> Simplify Queue trait to <code>create_with_config</code>.<br> <li> Remove multiple create variants.<br> <li> Provide defaults and builder methods.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8875/files#diff-bff7752b2aae0e9cef3ece1b9ddf17b9aa2f52f81fa777e6249039580aefbd69">+55/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats.rs</strong><dd><code>NATS impl supports unified config and storage mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/queue/nats.rs

<ul><li>Map <code>StorageType</code> to JetStream storage.<br> <li> Implement <code>create_with_config</code> using builder values.<br> <li> Set retention, storage, age, replicas, and max bytes.<br> <li> Remove older create methods in impl.</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/8875/files#diff-b05729b03dff9a5e29eaf536d0f90e94a0c27a27d1a3a41b52f25dc6dc380138">+21/-29</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

