### PR TITLE
feat: add `$__range` variable for dashboard queries

### DIFF
--- a/web/src/composables/dashboard/usePanelDataLoader.spec.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.spec.ts
@@ -1688,6 +1688,120 @@ describe("usePanelDataLoader", () => {
         expect(loader.data.value).toBeDefined();
       });
 
+      it("should replace $__range variable in queries", async () => {
+        const panelSchema = createMockPanelSchema({
+          queries: [
+            {
+              query: "SELECT * FROM logs WHERE time >= now() - INTERVAL '$__range'",
+              fields: { stream_type: "logs" },
+            },
+          ],
+        });
+        const selectedTimeObj = createMockSelectedTimeObj();
+        const variablesData = createMockVariablesData();
+
+        const loader = usePanelDataLoader(
+          panelSchema,
+          selectedTimeObj,
+          variablesData,
+          ref({ offsetWidth: 1000 }),
+          ref(true),
+          ref("dashboards"),
+          ref("test-dashboard"),
+          ref("test-folder"),
+          ref(null),
+          ref(null), // runId
+          ref(null), // tabId
+          ref(null), // tabName
+          ref(null), // searchResponse
+          ref(false), // is_ui_histogram
+        );
+
+        await loader.loadData();
+
+        expect(loader.data.value).toBeDefined();
+        // Metadata should be defined even if queries array might be empty
+        expect(loader.metadata.value).toBeDefined();
+      });
+
+      it("should replace ${__range} with braces in queries", async () => {
+        const panelSchema = createMockPanelSchema({
+          queries: [
+            {
+              query: "SELECT * FROM logs WHERE time >= now() - INTERVAL '${__range}'",
+              fields: { stream_type: "logs" },
+            },
+          ],
+        });
+        const selectedTimeObj = createMockSelectedTimeObj();
+        const variablesData = createMockVariablesData();
+
+        const loader = usePanelDataLoader(
+          panelSchema,
+          selectedTimeObj,
+          variablesData,
+          ref({ offsetWidth: 1000 }),
+          ref(true),
+          ref("dashboards"),
+          ref("test-dashboard"),
+          ref("test-folder"),
+          ref(null),
+          ref(null), // runId
+          ref(null), // tabId
+          ref(null), // tabName
+          ref(null), // searchResponse
+          ref(false), // is_ui_histogram
+        );
+
+        await loader.loadData();
+
+        expect(loader.data.value).toBeDefined();
+      });
+
+      it("should correctly calculate $__range for different time spans", async () => {
+        // Test with 7 days time range
+        const panelSchema = createMockPanelSchema({
+          queries: [
+            {
+              query: "SELECT * FROM logs WHERE time >= now() - INTERVAL '$__range'",
+              fields: { stream_type: "logs" },
+            },
+          ],
+        });
+
+        const now = Date.now();
+        const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
+
+        const selectedTimeObj = ref({
+          start_time: new Date(sevenDaysAgo),
+          end_time: new Date(now),
+        });
+        const variablesData = createMockVariablesData();
+
+        const loader = usePanelDataLoader(
+          panelSchema,
+          selectedTimeObj,
+          variablesData,
+          ref({ offsetWidth: 1000 }),
+          ref(true),
+          ref("dashboards"),
+          ref("test-dashboard"),
+          ref("test-folder"),
+          ref(null),
+          ref(null), // runId
+          ref(null), // tabId
+          ref(null), // tabName
+          ref(null), // searchResponse
+          ref(false), // is_ui_histogram
+        );
+
+        await loader.loadData();
+
+        expect(loader.data.value).toBeDefined();
+        // The query should have been executed with __range replaced
+        expect(loader.metadata.value.queries).toBeDefined();
+      });
+
       it("should replace dependent variables in queries", async () => {
         const panelSchema = createMockPanelSchema({
           queries: [

--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -1906,6 +1906,14 @@ export const usePanelDataLoader = (
         formattedInterval.unit,
       ) * 1000;
 
+    // calculate range in seconds (total time range of the dashboard)
+    // Note: startISOTimestamp and endISOTimestamp are in microseconds (from API)
+    const __range_micros = endISOTimestamp - startISOTimestamp;
+    const __range_seconds = __range_micros / 1000000;  // Convert microseconds to seconds
+
+    // format range, ensuring it's never empty (minimum 1s for PromQL compatibility)
+    const formattedRange = formatRateInterval(__range_seconds) || "1s";
+
     const fixedVariables = [
       {
         name: "__interval_ms",
@@ -1918,6 +1926,18 @@ export const usePanelDataLoader = (
       {
         name: "__rate_interval",
         value: `${formatRateInterval(__rate_interval)}`,
+      },
+      {
+        name: "__range",
+        value: formattedRange,
+      },
+      {
+        name: "__range_s",
+        value: `${Math.floor(__range_seconds)}`,
+      },
+      {
+        name: "__range_ms",
+        value: `${Math.floor(__range_seconds * 1000)}`,
       },
     ];
 


### PR DESCRIPTION
Add support for $__range variable that represents the dashboard's total time window selection. This complements existing variables like `$__interval` and `$__rate_interval`.

Variables added:
- `$__range`: formatted time range (e.g., "1h", "24h", "7d")
- `$__range_s`: time range in seconds
- `$__range_ms`: time range in milliseconds

The variable dynamically updates when users change the dashboard time range and works with both PromQL and SQL queries.

Fixes #8914