### PR TITLE
feat: skip `aud` validation for MCP-invoked requests

### DIFF
--- a/src/common/utils/http.rs
+++ b/src/common/utils/http.rs
@@ -37,7 +37,7 @@ pub(crate) fn get_stream_type_from_request(query: &HashMap<String, String>) -> O
 pub(crate) fn get_enable_align_histogram_from_request(query: &HashMap<String, String>) -> bool {
     query
         .get("enable_align_histogram")
-        .map(|s| s.parse().unwrap_or_default())
+        .and_then(|s| s.parse::<bool>().ok())
         .unwrap_or_default()
 }
 
@@ -65,19 +65,11 @@ pub(crate) fn get_fallback_order_by_col_from_request(
 pub(crate) fn get_search_type_from_request(
     query: &HashMap<String, String>,
 ) -> Result<Option<SearchEventType>, Error> {
-    let event_type = match query.get("search_type") {
-        Some(s) => match SearchEventType::try_from(s.as_str()) {
-            Ok(search_type) => Some(search_type),
-            _ => {
-                return Err(Error::other(
-                    "'event_type' query param with value 'ui', 'dashboards', 'reports', 'alerts' , 'rum' or 'values' allowed",
-                ));
-            }
-        },
-        None => None,
-    };
-
-    Ok(event_type)
+    query
+        .get("search_type")
+        .map(|s| SearchEventType::try_from(s.as_str()))
+        .transpose()
+        .map_err(Error::other)
 }
 
 #[inline(always)]

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2148,7 +2148,7 @@ pub struct EnrichmentTable {
 pub struct ServiceGraph {
     #[env_config(
         name = "ZO_SGRAPH_ENABLED",
-        default = false,
+        default = true,
         help = "Enable service graph feature"
     )]
     pub enabled: bool,

--- a/src/handler/http/auth/token.rs
+++ b/src/handler/http/auth/token.rs
@@ -50,10 +50,17 @@ pub async fn token_validator(
     };
     let path_columns = path.split('/').collect::<Vec<&str>>();
 
-    // Check if this is an MCP endpoint request
-    let is_mcp_request = path_columns.get(1).map(|s| *s == "mcp").unwrap_or(false);
+    // Check if this is an MCP endpoint request or has the MCP header
+    let is_mcp_endpoint = path_columns.get(1).map(|s| *s == "mcp").unwrap_or(false);
+    let has_mcp_header = req
+        .headers()
+        .get("x-o2-mcp")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v == "true")
+        .unwrap_or_default();
+    let is_mcp_request = is_mcp_endpoint || has_mcp_header;
 
-    // For MCP endpoints with dynamic clients, skip audience validation
+    // For MCP requests with dynamic clients, skip audience validation
     let login_flow = !is_mcp_request;
 
     match jwt::verify_decode_token(

--- a/src/handler/http/models/ai.rs
+++ b/src/handler/http/models/ai.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use o2_enterprise::enterprise::ai::meta::{AiMessage, Role};
+use o2_enterprise::enterprise::ai::agent::meta::{AiMessage, Role};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use utoipa::ToSchema;

--- a/src/handler/http/request/actions/action.rs
+++ b/src/handler/http/request/actions/action.rs
@@ -175,7 +175,7 @@ pub async fn serve_action_zip(path: web::Path<(String, Ksuid)>) -> Result<HttpRe
         ("org_id" = String, Path, description = "Organization name"),
         ("action_id" = String, Path, description = "Action ID"),
     ),
-    request_body(content = Template, description = "Template data", content_type = "application/json"),
+    request_body(content = inline(Template), description = "Template data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error", content_type = "application/json", body = ()),

--- a/src/handler/http/request/actions/operations.rs
+++ b/src/handler/http/request/actions/operations.rs
@@ -47,7 +47,7 @@ use {
         ("org_id" = String, Path, description = "Organization name"),
         ("action_id" = String, Path, description = "Action ID"),
     ),
-    request_body(content = Template, description = "Template data", content_type = "application/json"),
+    request_body(content = inline(Template), description = "Template data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),

--- a/src/handler/http/request/ai/prompt.rs
+++ b/src/handler/http/request/ai/prompt.rs
@@ -17,7 +17,9 @@ use std::io::Error;
 
 use actix_web::{HttpResponse, Result, delete, get, http::StatusCode, put, web};
 use config::meta::ai::PromptType;
-use o2_enterprise::enterprise::ai::prompt::{meta::UpdatePromptRequest, service as prompt_service};
+use o2_enterprise::enterprise::ai::agent::prompt::{
+    meta::UpdatePromptRequest, service as prompt_service,
+};
 
 use crate::{
     common::meta::http::HttpResponse as MetaHttpResponse, handler::http::models::ai::PromptResponse,
@@ -37,7 +39,7 @@ use crate::{
         ("org_id" = String, Path, description = "Organization name")
     ),
     responses(
-        (status = StatusCode::OK, description = "Chat response", body = PromptResponse),
+        (status = StatusCode::OK, description = "Chat response", body = inline(PromptResponse)),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Internal Server Error", body = Object),
         (status = StatusCode::BAD_REQUEST, description = "Bad Request", body = Object),
     ),
@@ -76,7 +78,7 @@ pub async fn list_prompts(org_id: web::Path<String>) -> Result<HttpResponse, Err
         ("id" = String, Path, description = "Prompt ID")
     ),
     responses(
-        (status = StatusCode::OK, description = "Prompt retrieved", body = PromptResponse),
+        (status = StatusCode::OK, description = "Prompt retrieved", body = inline(PromptResponse)),
         (status = StatusCode::NOT_FOUND, description = "Prompt not found", body = Object),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Internal Server Error", body = Object),
         (status = StatusCode::BAD_REQUEST, description = "Bad Request", body = Object),
@@ -116,14 +118,14 @@ pub async fn get_prompt(path: web::Path<(String, PromptType)>) -> Result<HttpRes
         ("org_id" = String, Path, description = "Organization name")
     ),
     request_body(
-        content = UpdatePromptRequest,
+        content = inline(UpdatePromptRequest),
         description = "Prompt details", 
         example = json!({
             "content": "Write a SQL query to get the top 10 users by response time in the default stream"
         }),
     ),
     responses(
-        (status = StatusCode::OK, description = "Prompt updated", body = PromptResponse), 
+        (status = StatusCode::OK, description = "Prompt updated", body = inline(PromptResponse)), 
         (status = StatusCode::NOT_FOUND, description = "Prompt not found", body = Object),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Internal Server Error", body = Object),
         (status = StatusCode::BAD_REQUEST, description = "Bad Request", body = Object),
@@ -193,7 +195,7 @@ pub async fn update_prompt(
         ("org_id" = String, Path, description = "Organization name")
     ),
     responses(
-        (status = StatusCode::OK, description = "Prompt rolled back to default", body = PromptResponse),
+        (status = StatusCode::OK, description = "Prompt rolled back to default", body = inline(PromptResponse)),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Internal Server Error", body = Object),
         (status = StatusCode::BAD_REQUEST, description = "Bad Request", body = Object),
     ),

--- a/src/handler/http/request/alerts/deprecated.rs
+++ b/src/handler/http/request/alerts/deprecated.rs
@@ -57,7 +57,7 @@ use crate::{
         ("org_id" = String, Path, description = "Organization name"),
         ("stream_name" = String, Path, description = "Stream name"),
       ),
-    request_body(content = Alert, description = "Alert data", content_type = "application/json"),    
+    request_body(content = inline(Alert), description = "Alert data", content_type = "application/json"),    
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),
@@ -114,7 +114,7 @@ pub async fn save_alert(
         ("stream_name" = String, Path, description = "Stream name"),
         ("alert_name" = String, Path, description = "Alert name"),
       ),
-    request_body(content = Alert, description = "Alert data", content_type = "application/json"),    
+    request_body(content = inline(Alert), description = "Alert data", content_type = "application/json"),    
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),
@@ -336,7 +336,7 @@ async fn list_alerts(
         ("alert_name" = String, Path, description = "Alert name"),
       ),
     responses(
-        (status = 200, description = "Success",  content_type = "application/json", body = Alert),
+        (status = 200, description = "Success",  content_type = "application/json", body = inline(Alert)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     ),
     extensions(

--- a/src/handler/http/request/alerts/destinations.rs
+++ b/src/handler/http/request/alerts/destinations.rs
@@ -53,7 +53,7 @@ impl From<DestinationError> for HttpResponse {
     params(
         ("org_id" = String, Path, description = "Organization name"),
       ),
-    request_body(content = Destination, description = "Destination data", content_type = "application/json"),  
+    request_body(content = inline(Destination), description = "Destination data", content_type = "application/json"),  
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),
@@ -99,7 +99,7 @@ pub async fn save_destination(
         ("org_id" = String, Path, description = "Organization name"),
         ("destination_name" = String, Path, description = "Destination name"),
       ),
-    request_body(content = Destination, description = "Destination data", content_type = "application/json"),  
+    request_body(content = inline(Destination), description = "Destination data", content_type = "application/json"),  
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),
@@ -141,7 +141,7 @@ pub async fn update_destination(
         ("destination_name" = String, Path, description = "Destination name"),
       ),
     responses(
-        (status = 200, description = "Success",  content_type = "application/json", body = Destination),
+        (status = 200, description = "Success",  content_type = "application/json", body = inline(Destination)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()), 
     ),
     extensions(
@@ -175,7 +175,7 @@ async fn get_destination(path: web::Path<(String, String)>) -> Result<HttpRespon
         ("module" = Option<String>, Query, description = "Destination module filter, none, alert, or pipeline"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<Destination>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<Destination>)),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),
     ),
     extensions(

--- a/src/handler/http/request/alerts/history.rs
+++ b/src/handler/http/request/alerts/history.rs
@@ -101,7 +101,7 @@ pub struct AlertHistoryResponse {
         ("size" = Option<i64>, Query, description = "Number of results to return (default: 100, max: 1000)"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = AlertHistoryResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(AlertHistoryResponse)),
         (status = 400, description = "Bad Request", content_type = "application/json"),
         (status = 403, description = "Forbidden", content_type = "application/json"),
         (status = 500, description = "Internal Server Error", content_type = "application/json"),

--- a/src/handler/http/request/alerts/mod.rs
+++ b/src/handler/http/request/alerts/mod.rs
@@ -103,7 +103,7 @@ impl From<AlertError> for HttpResponse {
         ("org_id" = String, Path, description = "Organization name"),
         ("folder" = Option<String>, Query, description = "Folder ID (Required if alert folder is not the default folder)"),
       ),
-    request_body(content = CreateAlertRequestBody, description = "Alert data", content_type = "application/json"),
+    request_body(content = inline(CreateAlertRequestBody), description = "Alert data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),
@@ -158,7 +158,7 @@ pub async fn create_alert(
         ("folder" = Option<String>, Query, description = "Folder ID (Required if RBAC enabled)"),
       ),
     responses(
-        (status = 200, description = "Success",  content_type = "application/json", body = GetAlertResponseBody),
+        (status = 200, description = "Success",  content_type = "application/json", body = inline(GetAlertResponseBody)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -199,7 +199,7 @@ async fn get_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
         ("folder" = Option<String>, Query, description = "Folder ID (Required if RBAC enabled)"),
       ),
     responses(
-        (status = 200, description = "Success",  content_type = "application/json", body = GetAlertResponseBody),
+        (status = 200, description = "Success",  content_type = "application/json", body = inline(GetAlertResponseBody)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -239,7 +239,7 @@ pub async fn export_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
         ("alert_id" = String, Path, description = "Alert ID"),
         ("folder" = Option<String>, Query, description = "Folder ID (Required if RBAC enabled)"),
       ),
-    request_body(content = UpdateAlertRequestBody, description = "Alert data", content_type = "application/json"),
+    request_body(content = inline(UpdateAlertRequestBody), description = "Alert data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),
@@ -317,7 +317,7 @@ async fn delete_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
         ListAlertsQuery,
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = ListAlertsResponseBody),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(ListAlertsResponseBody)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Alerts", "operation": "list"}))
@@ -426,7 +426,7 @@ async fn enable_alert(path: web::Path<(String, Ksuid)>, req: HttpRequest) -> Htt
         ("org_id" = String, Path, description = "Organization name"),
         EnableAlertQuery,
     ),
-    request_body(content = AlertBulkEnableRequest, description = "Alert id list", content_type = "application/json"),
+    request_body(content = inline(AlertBulkEnableRequest), description = "Alert id list", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
@@ -535,7 +535,7 @@ async fn trigger_alert(path: web::Path<(String, Ksuid)>) -> HttpResponse {
         ("org_id" = String, Path, description = "Organization name"),
         ("folder" = Option<String>, Query, description = "From Folder ID (Required if RBAC enabled)"),
     ),
-    request_body(content = MoveAlertsRequestBody, description = "Identifies alerts and the destination folder", content_type = "application/json"),
+    request_body(content = inline(MoveAlertsRequestBody), description = "Identifies alerts and the destination folder", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),

--- a/src/handler/http/request/alerts/templates.rs
+++ b/src/handler/http/request/alerts/templates.rs
@@ -56,7 +56,7 @@ impl From<TemplateError> for HttpResponse {
     params(
         ("org_id" = String, Path, description = "Organization name"),
       ),
-    request_body(content = Template, description = "Template data", content_type = "application/json"),    
+    request_body(content = inline(Template), description = "Template data", content_type = "application/json"),    
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),
@@ -99,7 +99,7 @@ pub async fn save_template(
         ("org_id" = String, Path, description = "Organization name"),
         ("template_name" = String, Path, description = "Template name"),
       ),
-    request_body(content = Template, description = "Template data", content_type = "application/json"),    
+    request_body(content = inline(Template), description = "Template data", content_type = "application/json"),    
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),
@@ -139,7 +139,7 @@ pub async fn update_template(
         ("template_name" = String, Path, description = "Template name"),
       ),
     responses(
-        (status = 200, description = "Success",  content_type = "application/json", body = Template),
+        (status = 200, description = "Success",  content_type = "application/json", body = inline(Template)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -172,7 +172,7 @@ async fn get_template(path: web::Path<(String, String)>) -> Result<HttpResponse,
         ("org_id" = String, Path, description = "Organization name"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<Template>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<Template>)),
         (status = 400, description = "Error",   content_type = "application/json", body = ()),
     ),
     extensions(

--- a/src/handler/http/request/authz/fga.rs
+++ b/src/handler/http/request/authz/fga.rs
@@ -40,7 +40,7 @@ use crate::common::meta::{
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = UserRoleRequest, description = "UserRoleRequest", content_type = "application/json"),
+    request_body(content = inline(UserRoleRequest), description = "UserRoleRequest", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
@@ -94,7 +94,7 @@ pub async fn create_role(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = UserRoleRequest, description = "UserRoleRequest", content_type = "application/json"),
+    request_body(content = inline(UserRoleRequest), description = "UserRoleRequest", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
@@ -188,7 +188,7 @@ pub async fn delete_role(_path: web::Path<(String, String)>) -> Result<HttpRespo
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -255,7 +255,7 @@ pub async fn get_roles(
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -282,7 +282,7 @@ pub async fn get_roles(_org_id: web::Path<String>) -> Result<HttpResponse, Error
         ("org_id" = String, Path, description = "Organization name"),
         ("role_id" = String, Path, description = "Role Id"),
     ),
-    request_body(content = RoleRequest, description = "RoleRequest", content_type = "application/json"),
+    request_body(content = inline(RoleRequest), description = "RoleRequest", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
@@ -358,7 +358,7 @@ pub async fn update_role(
         ("resource" = String, Path, description = "resource"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<Object>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<Object>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -389,7 +389,7 @@ pub async fn get_role_permissions(
         ("resource" = String, Path, description = "resource"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<Object>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<Object>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -416,7 +416,7 @@ pub async fn get_role_permissions(
         ("role_id" = String, Path, description = "Role Id"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -444,7 +444,7 @@ pub async fn get_users_with_role(path: web::Path<(String, String)>) -> Result<Ht
         ("role_id" = String, Path, description = "Role Id"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -471,7 +471,7 @@ pub async fn get_users_with_role(
         ("user_email" = String, Path, description = "User email address"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -498,7 +498,7 @@ pub async fn get_roles_for_user(path: web::Path<(String, String)>) -> Result<Htt
         ("user_email" = String, Path, description = "User email address"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -523,7 +523,7 @@ pub async fn get_roles_for_user(_path: web::Path<(String, String)>) -> Result<Ht
         ("user_email" = String, Path, description = "User email address"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -551,7 +551,7 @@ pub async fn get_groups_for_user(path: web::Path<(String, String)>) -> Result<Ht
         ("user_email" = String, Path, description = "User email address"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -576,7 +576,7 @@ pub async fn get_groups_for_user(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = UserGroup, description = "UserGroup", content_type = "application/json"),
+    request_body(content = inline(UserGroup), description = "UserGroup", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
@@ -618,7 +618,7 @@ pub async fn create_group(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = UserGroup, description = "UserGroup", content_type = "application/json"),
+    request_body(content = inline(UserGroup), description = "UserGroup", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
@@ -647,7 +647,7 @@ pub async fn create_group(
         ("org_id" = String, Path, description = "Organization name"),
         ("group_name" = String, Path, description = "Group name"),
     ),
-    request_body(content = UserGroupRequest, description = "UserGroupRequest", content_type = "application/json"),
+    request_body(content = inline(UserGroupRequest), description = "UserGroupRequest", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
@@ -690,7 +690,7 @@ pub async fn update_group(
         ("org_id" = String, Path, description = "Organization name"),
         ("group_name" = String, Path, description = "Group name"),
     ),
-    request_body(content = UserGroupRequest, description = "UserGroupRequest", content_type = "application/json"),
+    request_body(content = inline(UserGroupRequest), description = "UserGroupRequest", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
@@ -719,7 +719,7 @@ pub async fn update_group(
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -786,7 +786,7 @@ pub async fn get_groups(
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -810,7 +810,7 @@ pub async fn get_groups(_path: web::Path<String>) -> Result<HttpResponse, Error>
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = UserGroup),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(UserGroup)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -838,7 +838,7 @@ pub async fn get_group_details(path: web::Path<(String, String)>) -> Result<Http
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = UserGroup),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(UserGroup)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -862,7 +862,7 @@ pub async fn get_group_details(_path: web::Path<(String, String)>) -> Result<Htt
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<Object>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<Object>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]
@@ -896,7 +896,7 @@ pub async fn get_resources(_org_id: web::Path<String>) -> Result<HttpResponse, E
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<Object>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<Object>)),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     )
 )]

--- a/src/handler/http/request/cloud/marketing.rs
+++ b/src/handler/http/request/cloud/marketing.rs
@@ -40,7 +40,7 @@ use crate::{
         ("org_id" = String, Path, description = "Organization name"),
     ),
     request_body(
-        content = NewUserAttribution,
+        content = inline(NewUserAttribution),
         description = "New user attribution info",
         example = json!({
             "from": "Over the web",

--- a/src/handler/http/request/cloud/org_usage.rs
+++ b/src/handler/http/request/cloud/org_usage.rs
@@ -35,7 +35,7 @@ use crate::{handler::http::models::billings::GetOrgUsageResponseBody, service::o
         ("usage_date" = String, Path, description = "Organization usage query range"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = GetOrgUsageResponseBody),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(GetOrgUsageResponseBody)),
         (status = 404, description = "Organization usage not found", content_type = "application/json", body = ()),
         (status = 500, description = "Failure", content_type = "application/json", body = ()),
     ),

--- a/src/handler/http/request/clusters/mod.rs
+++ b/src/handler/http/request/clusters/mod.rs
@@ -36,7 +36,7 @@ use {
         ("Authorization"= [])
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = HashMap<String, Vec<String>>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(HashMap<String, Vec<String>>)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Clusters", "operation": "get"}))

--- a/src/handler/http/request/dashboards/mod.rs
+++ b/src/handler/http/request/dashboards/mod.rs
@@ -89,7 +89,7 @@ impl From<DashboardError> for HttpResponse {
         ("org_id" = String, Path, description = "Organization name"),
     ),
     request_body(
-        content = DashboardRequestBody,
+        content = inline(DashboardRequestBody),
         description = "Dashboard details",
         example = json!({
             "title": "Network Traffic Overview",
@@ -97,7 +97,7 @@ impl From<DashboardError> for HttpResponse {
         }),
     ),
     responses(
-        (status = StatusCode::CREATED, description = "Dashboard created", body = DashboardResponseBody),
+        (status = StatusCode::CREATED, description = "Dashboard created", body = inline(DashboardResponseBody)),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Internal Server Error", body = ()),
     ),
     extensions(
@@ -140,9 +140,9 @@ pub async fn create_dashboard(
         ("org_id" = String, Path, description = "Organization name"),
         ("dashboard_id" = String, Path, description = "Dashboard ID"),
     ),
-    request_body(content = DashboardRequestBody, description = "Dashboard details"),
+    request_body(content = inline(DashboardRequestBody), description = "Dashboard details"),
     responses(
-        (status = StatusCode::OK, description = "Dashboard updated", body = DashboardResponseBody),
+        (status = StatusCode::OK, description = "Dashboard updated", body = inline(DashboardResponseBody)),
         (status = StatusCode::NOT_FOUND, description = "Dashboard not found", body = ()),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Failed to update the dashboard", body = ()),
     ),
@@ -191,7 +191,7 @@ async fn update_dashboard(
         ListDashboardsQuery
     ),
     responses(
-        (status = StatusCode::OK, body = ListDashboardsResponseBody),
+        (status = StatusCode::OK, body = inline(ListDashboardsResponseBody)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Dashboards", "operation": "list"}))
@@ -230,7 +230,7 @@ async fn list_dashboards(
         ("dashboard_id" = String, Path, description = "Dashboard ID"),
     ),
     responses(
-        (status = StatusCode::OK, body = DashboardResponseBody),
+        (status = StatusCode::OK, body = inline(DashboardResponseBody)),
         (status = StatusCode::NOT_FOUND, description = "Dashboard not found", body = ()),
     ),
     extensions(
@@ -263,7 +263,7 @@ async fn get_dashboard(path: web::Path<(String, String)>) -> impl Responder {
         ("dashboard_id" = String, Path, description = "Dashboard ID"),
     ),
     responses(
-        (status = StatusCode::OK, body = DashboardResponseBody),
+        (status = StatusCode::OK, body = inline(DashboardResponseBody)),
         (status = StatusCode::NOT_FOUND, description = "Dashboard not found", body = ()),
     ),
     extensions(
@@ -331,7 +331,7 @@ async fn delete_dashboard(path: web::Path<(String, String)>) -> impl Responder {
         ("dashboard_id" = String, Path, description = "Dashboard ID"),
     ),
      request_body(
-        content = MoveDashboardRequestBody,
+        content = inline(MoveDashboardRequestBody),
         description = "MoveDashboard details",
         example = json!({
             "from": "Source folder id",
@@ -384,7 +384,7 @@ async fn move_dashboard(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = MoveDashboardsRequestBody, description = "Identifies dashboards and the destination folder", content_type = "application/json"),    
+    request_body(content = inline(MoveDashboardsRequestBody), description = "Identifies dashboards and the destination folder", content_type = "application/json"),    
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),

--- a/src/handler/http/request/dashboards/reports.rs
+++ b/src/handler/http/request/dashboards/reports.rs
@@ -76,7 +76,7 @@ impl From<ReportError> for HttpResponse {
         ("org_id" = String, Path, description = "Organization name"),
     ),
     request_body(
-        content = Report,
+        content = inline(Report),
         description = "Report details",
         example = json!({
             "title": "Network Traffic Overview",
@@ -128,7 +128,7 @@ pub async fn create_report(
         ("name" = String, Path, description = "Report name"),
     ),
     request_body(
-        content = Report,
+        content = inline(Report),
         description = "Report details",
     ),
     responses(
@@ -173,7 +173,7 @@ async fn update_report(
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = StatusCode::OK, body = Vec<Report>),
+        (status = StatusCode::OK, body = inline(Vec<Report>)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Reports", "operation": "list"}))
@@ -276,7 +276,7 @@ async fn list_reports(
         ("name" = String, Path, description = "Report name"),
     ),
     responses(
-        (status = StatusCode::OK, body = Report),
+        (status = StatusCode::OK, body = inline(Report)),
         (status = StatusCode::NOT_FOUND, description = "Report not found", body = ()),
     ),
     extensions(

--- a/src/handler/http/request/dashboards/timed_annotations.rs
+++ b/src/handler/http/request/dashboards/timed_annotations.rs
@@ -38,7 +38,7 @@ use crate::{
         ("Authorization" = [])
     ),
     request_body(
-        content = TimedAnnotationReq,
+        content = inline(TimedAnnotationReq),
         description = "Timed annotation request payload",
         content_type = "application/json",
     ),
@@ -157,7 +157,7 @@ pub async fn get_annotations(
         ("Authorization" = [])
     ),
     request_body(
-        content = TimedAnnotationDelete,
+        content = inline(TimedAnnotationDelete),
         description = "Timed annotation delete request payload",
         content_type = "application/json",
     ),
@@ -210,7 +210,7 @@ pub async fn delete_annotations(
         ("Authorization" = [])
     ),
     request_body(
-        content = TimedAnnotation,
+        content = inline(TimedAnnotation),
         description = "Timed annotation update request payload",
         content_type = "application/json",
     ),
@@ -267,7 +267,7 @@ pub async fn update_annotations(
         ("Authorization" = [])
     ),
     request_body(
-        content = Vec<String>,
+        content = inline(Vec<String>),
         description = "IDs of dashboard panels from which to remove the timed annotation",
         content_type = "application/json",
     ),

--- a/src/handler/http/request/domain_management/mod.rs
+++ b/src/handler/http/request/domain_management/mod.rs
@@ -90,7 +90,7 @@ pub async fn get_domain_management_config(path: web::Path<String>) -> Result<Htt
     params(
         ("org_id" = String, Path, description = "Organization name (must be meta org)"),
     ),
-    request_body(content = DomainManagementRequest, description = "Domain management configuration", content_type = "application/json"),
+    request_body(content = inline(DomainManagementRequest), description = "Domain management configuration", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Bad Request", content_type = "application/json", body = ()),

--- a/src/handler/http/request/folders.rs
+++ b/src/handler/http/request/folders.rs
@@ -73,7 +73,7 @@ impl From<FolderError> for HttpResponse {
         ("folder_type" = FolderType, Path, description = "Type of data the folder can contain"),
     ),
     request_body(
-        content = CreateFolderRequestBody,
+        content = inline(CreateFolderRequestBody),
         description = "Folder details",
         example = json!({
             "name": "Infrastructure",
@@ -81,7 +81,7 @@ impl From<FolderError> for HttpResponse {
         }),
     ),
     responses(
-        (status = StatusCode::OK, description = "Folder created", body = CreateFolderResponseBody),
+        (status = StatusCode::OK, description = "Folder created", body = inline(CreateFolderResponseBody)),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Internal Server Error", body = ()),
     ),
     extensions(
@@ -120,7 +120,7 @@ pub async fn create_folder(
         ("folder_id" = String, Path, description = "Folder name"),
     ),
     request_body(
-        content = Folder,
+        content = inline(Folder),
         description = "Folder details",
         example = json!({
             "title": "Infra",
@@ -163,7 +163,7 @@ pub async fn update_folder(
         ("folder_type" = FolderType, Path, description = "Type of data the folder can contain"),
     ),
     responses(
-        (status = StatusCode::OK, body = ListFoldersResponseBody),
+        (status = StatusCode::OK, body = inline(ListFoldersResponseBody)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Folders", "operation": "list"}))
@@ -208,7 +208,7 @@ pub async fn list_folders(
         ("folder_id" = String, Path, description = "Folder ID"),
     ),
     responses(
-        (status = StatusCode::OK, body = GetFolderResponseBody),
+        (status = StatusCode::OK, body = inline(GetFolderResponseBody)),
         (status = StatusCode::NOT_FOUND, description = "Folder not found", body = ()),
     ),
     extensions(
@@ -243,7 +243,7 @@ pub async fn get_folder(path: web::Path<(String, FolderType, String)>) -> impl R
         ("folder_name" = String, Path, description = "Folder Name"),
     ),
     responses(
-        (status = StatusCode::OK, body = GetFolderResponseBody),
+        (status = StatusCode::OK, body = inline(GetFolderResponseBody)),
         (status = StatusCode::NOT_FOUND, description = "Folder not found", body = ()),
     ),
     extensions(
@@ -314,7 +314,7 @@ pub mod deprecated {
             ("org_id" = String, Path, description = "Organization name"),
         ),
         request_body(
-            content = CreateFolderRequestBody,
+            content = inline(CreateFolderRequestBody),
             description = "Folder details",
             example = json!({
                 "name": "Infrastructure",
@@ -322,7 +322,7 @@ pub mod deprecated {
             }),
         ),
         responses(
-            (status = StatusCode::OK, description = "Folder created", body = CreateFolderResponseBody),
+            (status = StatusCode::OK, description = "Folder created", body = inline(CreateFolderResponseBody)),
             (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Internal Server Error", body = ()),
         ),
         extensions(
@@ -362,7 +362,7 @@ pub mod deprecated {
             ("folder_id" = String, Path, description = "Folder name"),
         ),
         request_body(
-            content = Folder,
+            content = inline(Folder),
             description = "Folder details",
             example = json!({
                 "title": "Infra",
@@ -406,7 +406,7 @@ pub mod deprecated {
             ("org_id" = String, Path, description = "Organization name"),
         ),
         responses(
-            (status = StatusCode::OK, body = ListFoldersResponseBody),
+            (status = StatusCode::OK, body = inline(ListFoldersResponseBody)),
         ),
         extensions(
             ("x-o2-ratelimit" = json!({"module": "Folders", "operation": "list"}))
@@ -452,7 +452,7 @@ pub mod deprecated {
             ("folder_id" = String, Path, description = "Folder ID"),
         ),
         responses(
-            (status = StatusCode::OK, body = GetFolderResponseBody),
+            (status = StatusCode::OK, body = inline(GetFolderResponseBody)),
             (status = StatusCode::NOT_FOUND, description = "Folder not found", body = ()),
         ),
         extensions(
@@ -488,7 +488,7 @@ pub mod deprecated {
             ("folder_name" = String, Path, description = "Folder Name"),
         ),
         responses(
-            (status = StatusCode::OK, body = GetFolderResponseBody),
+            (status = StatusCode::OK, body = inline(GetFolderResponseBody)),
             (status = StatusCode::NOT_FOUND, description = "Folder not found", body = ()),
         ),
         extensions(

--- a/src/handler/http/request/functions/mod.rs
+++ b/src/handler/http/request/functions/mod.rs
@@ -37,7 +37,7 @@ use crate::{common::utils::auth::UserEmail, handler::http::extractors::Headers};
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = Transform, description = "Function data", content_type = "application/json"),
+    request_body(content = inline(Transform), description = "Function data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
@@ -76,7 +76,7 @@ pub async fn save_function(
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = FunctionList),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(FunctionList)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Functions", "operation": "list"}))
@@ -165,7 +165,7 @@ async fn delete_function(path: web::Path<(String, String)>) -> Result<HttpRespon
         ("org_id" = String, Path, description = "Organization name"),
         ("name" = String, Path, description = "Function name"),
     ),
-    request_body(content = Transform, description = "Function data", content_type = "application/json"),
+    request_body(content = inline(Transform), description = "Function data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
@@ -206,7 +206,7 @@ pub async fn update_function(
         ("name" = String, Path, description = "Function name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = FunctionList),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(FunctionList)),
         (status = 404, description = "Function not found", content_type = "application/json", body = ()),
         (status = 500, description = "Internal server error", content_type = "application/json", body = ()),
     ),
@@ -238,7 +238,7 @@ pub async fn list_pipeline_dependencies(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = TestVRLRequest, description = "Test run function", content_type = "application/json"),
+    request_body(content = inline(TestVRLRequest), description = "Test run function", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),

--- a/src/handler/http/request/keys/mod.rs
+++ b/src/handler/http/request/keys/mod.rs
@@ -46,7 +46,7 @@ use crate::common::meta::http::HttpResponse as MetaHttpResponse;
                    and validated before being made available for use. Key names cannot contain ':' characters. Only \
                    available in enterprise deployments for enhanced data security and compliance requirements.",
     request_body(
-        content = KeyAddRequest,
+        content = inline(KeyAddRequest),
         description = "Key data to add",
         content_type = "application/json",
     ),
@@ -323,7 +323,7 @@ pub async fn delete(path: web::Path<(String, String)>) -> Result<HttpResponse, E
         ("key_name" = String, Path, description = "name of the key to update", example = "test_key")
     ),
     request_body(
-        content = KeyAddRequest,
+        content = inline(KeyAddRequest),
         description = "updated key data",
         content_type = "application/json",
     ),

--- a/src/handler/http/request/kv/mod.rs
+++ b/src/handler/http/request/kv/mod.rs
@@ -160,7 +160,7 @@ pub async fn delete(path: web::Path<(String, String)>) -> Result<HttpResponse, E
         ("prefix" = Option<String>, Query, description = "Key prefix"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Vec<String>),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Vec<String>)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Key Values", "operation": "list"}))

--- a/src/handler/http/request/logs/ingest.rs
+++ b/src/handler/http/request/logs/ingest.rs
@@ -329,9 +329,9 @@ pub async fn json(
         ("org_id" = String, Path, description = "Organization name"),
         ("stream_name" = String, Path, description = "Stream name"),
     ),
-    request_body(content = KinesisFHRequest, description = "Ingest data (json array)", content_type = "application/json"),
+    request_body(content = inline(KinesisFHRequest), description = "Ingest data (json array)", content_type = "application/json"),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = KinesisFHIngestionResponse, example = json!({ "requestId": "ed4acda5-034f-9f42-bba1-f29aea6d7d8f","timestamp": 1578090903599_i64})),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(KinesisFHIngestionResponse), example = json!({ "requestId": "ed4acda5-034f-9f42-bba1-f29aea6d7d8f","timestamp": 1578090903599_i64})),
         (status = 500, description = "Failure", content_type = "application/json", body = (), example = json!({ "requestId": "ed4acda5-034f-9f42-bba1-f29aea6d7d8f", "timestamp": 1578090903599_i64, "errorMessage": "error processing request"})),
     )
 )]
@@ -584,8 +584,8 @@ pub async fn otlp_logs_write(
     ),
     request_body(content = String, description = "Ingest data (hec)"),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = HecResponse, example = json!({"text":"Success","code": 200})),
-        (status = 200, description = "Failure", content_type = "application/json", body = HecResponse, example = json!({"text":"Invalid data format","code": 400})),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(HecResponse), example = json!({"text":"Success","code": 200})),
+        (status = 200, description = "Failure", content_type = "application/json", body = inline(HecResponse), example = json!({"text":"Invalid data format","code": 400})),
     )
 )]
 #[post("/{org_id}/_hec")]

--- a/src/handler/http/request/logs/loki.rs
+++ b/src/handler/http/request/logs/loki.rs
@@ -37,7 +37,7 @@ use crate::{
                    Loki deployments to OpenObserve while maintaining API compatibility.",
     security(("Authorization"= [])),
     params(("org_id" = String, Path, description = "Organization name")),
-    request_body(content = LokiPushRequest, description = "Loki-compatible log push data in JSON format. Stream names are extracted from 'stream_name' label in the stream labels. Also supports Protobuf format (application/x-protobuf) with optional compression (gzip for JSON, snappy for Protobuf)", content_type = "application/json", example = json!({
+    request_body(content = inline(LokiPushRequest), description = "Loki-compatible log push data in JSON format. Stream names are extracted from 'stream_name' label in the stream labels. Also supports Protobuf format (application/x-protobuf) with optional compression (gzip for JSON, snappy for Protobuf)", content_type = "application/json", example = json!({
         "streams": [{
             "stream": {
                 "stream_name": "application_logs",

--- a/src/handler/http/request/organization/org.rs
+++ b/src/handler/http/request/organization/org.rs
@@ -63,7 +63,7 @@ use crate::{
         ("Authorization"= [])
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = OrganizationResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(OrganizationResponse)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Organizations", "operation": "list"}))
@@ -170,7 +170,7 @@ pub async fn organizations(
         ("Authorization"= [])
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = AllOrganizationResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(AllOrganizationResponse)),
     )
 )]
 #[get("/{org_id}/organizations")]
@@ -293,7 +293,7 @@ async fn org_summary(org_id: web::Path<String>) -> Result<HttpResponse, Error> {
         ("org_id" = String, Path, description = "Organization name"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = PasscodeResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(PasscodeResponse)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -335,7 +335,7 @@ async fn get_user_passcode(
         ("org_id" = String, Path, description = "Organization name"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = PasscodeResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(PasscodeResponse)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -377,7 +377,7 @@ async fn update_user_passcode(
         ("org_id" = String, Path, description = "Organization name"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = RumIngestionResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(RumIngestionResponse)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -419,7 +419,7 @@ async fn get_user_rumtoken(
         ("org_id" = String, Path, description = "Organization name"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = RumIngestionResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(RumIngestionResponse)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -461,7 +461,7 @@ async fn update_user_rumtoken(
         ("org_id" = String, Path, description = "Organization name"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = RumIngestionResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(RumIngestionResponse)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     ),
     extensions(
@@ -499,9 +499,9 @@ async fn create_user_rumtoken(
     security(
         ("Authorization"= [])
     ),
-    request_body(content = Organization, description = "Organization data", content_type = "application/json"),
+    request_body(content = inline(Organization), description = "Organization data", content_type = "application/json"),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = RumIngestionResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(RumIngestionResponse)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Organizations", "operation": "create"}))
@@ -532,7 +532,7 @@ async fn create_org(
     security(
         ("Authorization"= [])
     ),
-    request_body(content = ExtendTrialPeriodRequest, description = "Extend free trial request", content_type = "application/json"),
+    request_body(content = inline(ExtendTrialPeriodRequest), description = "Extend free trial request", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "text", body = String),
     )
@@ -597,9 +597,9 @@ async fn extend_trial_period(
     params(
         ("org_id" = String, Path, description = "Organization id"),
     ),
-    request_body(content = OrgRenameBody, description = "Organization new name", content_type = "application/json"),
+    request_body(content = inline(OrgRenameBody), description = "Organization new name", content_type = "application/json"),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Organization),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Organization)),
     )
 )]
 #[put("/{org_id}/rename")]
@@ -640,7 +640,7 @@ async fn rename_org(
         ("org_id" = String, Path, description = "Organization id"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = OrganizationInviteUserRecord),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(OrganizationInviteUserRecord)),
     )
 )]
 #[get("/{org_id}/invites")]
@@ -678,7 +678,7 @@ pub async fn get_org_invites(path: web::Path<String>) -> Result<HttpResponse, Er
         ("org_id" = String, Path, description = "Organization id"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Organization),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Organization)),
     )
 )]
 #[post("/{org_id}/invites")]
@@ -712,7 +712,7 @@ pub async fn generate_org_invite(
         ("id" = String, Path, description = "invitation token"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Organization),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Organization)),
     )
 )]
 #[delete("/{org_id}/invites/{token}")]
@@ -742,7 +742,7 @@ pub async fn delete_org_invite(path: web::Path<(String, String)>) -> Result<Http
         ("invite_token" = String, Path, description = "The token sent to the user"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Organization),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(Organization)),
     )
 )]
 #[put("/{org_id}/member_subscription/{invite_token}")]
@@ -787,7 +787,7 @@ async fn accept_org_invite(
         ("regions" = String, Query, description = "Optional comma-separated list of regions to filter by (e.g., 'us-east-1,us-west-2')")
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = NodeListResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(NodeListResponse)),
         (status = 403, description = "Forbidden - Not the _meta organization", content_type = "application/json", body = ()),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     )
@@ -876,7 +876,7 @@ pub async fn node_list_impl(
         ("regions" = String, Query, description = "Optional comma-separated list of regions to filter by (e.g., 'us-east-1,us-west-2')")
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = ClusterInfoResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(ClusterInfoResponse)),
         (status = 403, description = "Forbidden - Not the _meta organization", content_type = "application/json", body = ()),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     )

--- a/src/handler/http/request/organization/settings.rs
+++ b/src/handler/http/request/organization/settings.rs
@@ -50,7 +50,7 @@ use crate::{
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = OrganizationSettingPayload, description = "Organization settings", content_type = "application/json"),
+    request_body(content = inline(OrganizationSettingPayload), description = "Organization settings", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),

--- a/src/handler/http/request/patterns/mod.rs
+++ b/src/handler/http/request/patterns/mod.rs
@@ -266,8 +266,6 @@ pub async fn extract_patterns(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     fn test_pattern_extraction_uses_search_request() {
         // This endpoint now accepts config::meta::search::Request

--- a/src/handler/http/request/pipeline.rs
+++ b/src/handler/http/request/pipeline.rs
@@ -58,7 +58,7 @@ impl From<PipelineError> for HttpResponse {
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = Pipeline, description = "Pipeline data", content_type = "application/json"),
+    request_body(content = inline(Pipeline), description = "Pipeline data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
@@ -108,7 +108,7 @@ pub async fn save_pipeline(
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = PipelineList),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(PipelineList)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Pipeline", "operation": "list"}))
@@ -201,7 +201,7 @@ async fn list_pipelines(
         ("org_id" = String, Path, description = "Organization name"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = PipelineList),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(PipelineList)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Pipeline", "operation": "list"}))
@@ -265,7 +265,7 @@ async fn delete_pipeline(path: web::Path<(String, String)>) -> Result<HttpRespon
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = Pipeline, description = "Pipeline data", content_type = "application/json"),
+    request_body(content = inline(Pipeline), description = "Pipeline data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
@@ -353,7 +353,7 @@ pub async fn enable_pipeline(
         ("org_id" = String, Path, description = "Organization name"),
         ("value" = bool, Query, description = "Enable or disable pipeline"),
     ),
-    request_body(content = PipelineBulkEnableRequest, description = "Pipeline id list", content_type = "application/json"),
+    request_body(content = inline(PipelineBulkEnableRequest), description = "Pipeline id list", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),

--- a/src/handler/http/request/re_pattern/mod.rs
+++ b/src/handler/http/request/re_pattern/mod.rs
@@ -122,7 +122,7 @@ struct BuiltInPatternsQuery {
     summary = "Create a new regex pattern",
     description = "Stores a new regular expression pattern for log processing and data extraction",
     request_body(
-        content = PatternCreateRequest,
+        content = inline(PatternCreateRequest),
         description = "re_pattern to add",
         content_type = "application/json",
     ),
@@ -203,7 +203,7 @@ pub async fn save(
         (
             status = 200,
             description = "Pattern info",
-            body = PatternGetResponse,
+            body = inline(PatternGetResponse),
             content_type = "application/json",
         ),
         (status = 404, description = "Pattern not found", content_type = "text/plain")
@@ -246,7 +246,7 @@ pub async fn get(path: web::Path<(String, String)>) -> Result<HttpResponse, Erro
         (
             status = 200,
             description = "list all patterns in the org",
-            body = PatternListResponse,
+            body = inline(PatternListResponse),
             content_type = "application/json",
         ),
     ),
@@ -355,7 +355,7 @@ pub async fn delete(path: web::Path<(String, String)>) -> Result<HttpResponse, E
         ("id" = String, Path, description = "id of the pattern to update", example = "12345")
     ),
     request_body(
-        content = PatternCreateRequest,
+        content = inline(PatternCreateRequest),
         description = "updated pattern data",
         content_type = "application/json",
     ),
@@ -426,7 +426,7 @@ pub async fn update(
     summary = "Test regex pattern against sample data",
     description = "Tests a regex pattern against sample input strings to validate pattern matching",
     request_body(
-        content = PatternTestRequest,
+        content = inline(PatternTestRequest),
         description = "re_pattern to test and strings to test against",
         content_type = "application/json",
     ),
@@ -434,7 +434,7 @@ pub async fn update(
         (
             status = 200,
             description = "array of strings",
-            body = PatternTestResponse,
+            body = inline(PatternTestResponse),
             content_type = "application/json",
         ),
         (status = 400, description = "Invalid request", content_type = "application/json")

--- a/src/handler/http/request/rum/ingest.rs
+++ b/src/handler/http/request/rum/ingest.rs
@@ -204,7 +204,7 @@ pub async fn log(
         ("org_id" = String, Path, description = "Organization name"),
     ),
     request_body(
-        content = SegmentEvent, content_type = "multipart/form-data",
+        content = inline(SegmentEvent), content_type = "multipart/form-data",
         description = "Multipart form data containing compressed session replay segment and event metadata"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", 

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -175,7 +175,7 @@ async fn can_use_distinct_stream(
         ("is_ui_histogram" = bool, Query, description = "Whether to return histogram data for UI"),
         ("is_multi_stream_search" = bool, Query, description = "Indicate is search is for multi stream"),
     ),
-    request_body(content = Request, description = "Search query", content_type = "application/json", example = json!({
+    request_body(content = inline(Request), description = "Search query", content_type = "application/json", example = json!({
         "query": {
             "sql": "select * from k8s ",
             "start_time": 1675182660872049i64,
@@ -1322,7 +1322,7 @@ async fn values_v1(
         ("enable_align_histogram" = bool, Query, description = "Enable align histogram"),
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = config::meta::search::SearchPartitionRequest, description = "Search query", content_type = "application/json", example = json!({
+    request_body(content = inline(config::meta::search::SearchPartitionRequest), description = "Search query", content_type = "application/json", example = json!({
         "sql": "select * from k8s ",
         "start_time": 1675182660872049i64,
         "end_time": 1675185660872049i64
@@ -1456,7 +1456,7 @@ pub async fn search_partition(
         ("org_id" = String, Path, description = "Organization ID"),
     ),
     request_body(
-        content = config::meta::search::SearchHistoryRequest,
+        content = inline(config::meta::search::SearchHistoryRequest),
         description = "Search history request parameters",
         content_type = "application/json",
         example = json!({
@@ -1652,7 +1652,7 @@ pub async fn search_history(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = config::meta::search::Request, description = "Search query", content_type = "application/json", example = json!({
+    request_body(content = inline(config::meta::search::Request), description = "Search query", content_type = "application/json", example = json!({
         "query": {
             "sql": "select k8s_namespace_name as ns, histogram(_timestamp) from k8s group by k8s_namespace_name, histogram(_timestamp)",
             "start_time": 1675182660872049i64,

--- a/src/handler/http/request/search/saved_view.rs
+++ b/src/handler/http/request/search/saved_view.rs
@@ -47,7 +47,7 @@ use crate::{
         ("view_id" = String, Path, description = "The view_id which was stored"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = View, example = json!({
+        (status = 200, description = "Success", content_type = "application/json", body = inline(View), example = json!({
             "org_id": "some-org-id",
             "view_id": "some-uuid-v4",
             "view_name": "view-name",
@@ -126,7 +126,7 @@ pub async fn get_views(path: web::Path<String>) -> Result<HttpResponse, Error> {
         ("view_id" = String, Path, description = "The view_id to delete"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = DeleteViewResponse, example = json!([{
+        (status = 200, description = "Success", content_type = "application/json", body = inline(DeleteViewResponse), example = json!([{
             "org_id": "some-org-id",
             "view_id": "view_id",
         }])),
@@ -166,9 +166,9 @@ pub async fn delete_view(path: web::Path<(String, String)>) -> Result<HttpRespon
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = CreateViewRequest, description = "Create view data", content_type = "application/json"),
+    request_body(content = inline(CreateViewRequest), description = "Create view data", content_type = "application/json"),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = CreateViewResponse, example = json!([{
+        (status = 200, description = "Success", content_type = "application/json", body = inline(CreateViewResponse), example = json!([{
             "org_id": "some-org-id",
             "view_id": "view_id",
         }])),
@@ -214,9 +214,9 @@ pub async fn create_view(
         ("org_id" = String, Path, description = "Organization name"),
         ("view_id" = String, Path, description = "View id to be updated"),
     ),
-    request_body(content = UpdateViewRequest, description = "Update view data", content_type = "application/json"),
+    request_body(content = inline(UpdateViewRequest), description = "Update view data", content_type = "application/json"),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = View, example = json!([{
+        (status = 200, description = "Success", content_type = "application/json", body = inline(View), example = json!([{
             "org_id": "some-org-id",
             "view_name": "view-name",
             "view_id": "view-id",

--- a/src/handler/http/request/search/search_job.rs
+++ b/src/handler/http/request/search/search_job.rs
@@ -71,7 +71,7 @@ use crate::{common::utils::auth::UserEmail, handler::http::extractors::Headers};
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = config::meta::search::Request, description = "Search query", content_type = "application/json", example = json!({
+    request_body(content = inline(config::meta::search::Request), description = "Search query", content_type = "application/json", example = json!({
         "query": {
             "sql": "select * from k8s ",
             "start_time": 1675182660872049i64,
@@ -233,7 +233,7 @@ pub async fn submit_job(
         ("org_id" = String, Path, description = "Organization name")
     ),
     responses(
-        (status = 200, description = "List of search jobs", body = Vec<Object>, example = json!([{
+        (status = 200, description = "List of search jobs", body = inline(Vec<Object>), example = json!([{
             "id": "abc123",
             "trace_id": "xyz789",
             "org_id": "default",

--- a/src/handler/http/request/service_accounts/mod.rs
+++ b/src/handler/http/request/service_accounts/mod.rs
@@ -118,7 +118,7 @@ pub async fn list(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = ServiceAccountRequest, description = "ServiceAccount data", content_type = "application/json"),
+    request_body(content = inline(ServiceAccountRequest), description = "ServiceAccount data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
     ),
@@ -168,7 +168,7 @@ pub async fn save(
         ("org_id" = String, Path, description = "Organization name"),
         ("email_id" = String, Path, description = "Service Account email id"),
     ),
-    request_body(content = UpdateServiceAccountRequest, description = "Service Account data", content_type = "application/json"),
+    request_body(content = inline(UpdateServiceAccountRequest), description = "Service Account data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
     ),
@@ -290,7 +290,7 @@ pub async fn delete(
         ("email_id" = String, Path, description = "Service Account email id"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = APIToken),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(APIToken)),
         (status = 404, description = "NotFound", content_type = "application/json", body = ()),
     ),
     extensions(

--- a/src/handler/http/request/short_url/mod.rs
+++ b/src/handler/http/request/short_url/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     summary = "Create short URL",
     description = "Generates a shortened URL from a longer original URL. This is useful for creating more manageable links for dashboards, reports, or search queries that can be easily shared via email, chat, or documentation. The short URL remains valid and can be used to redirect back to the original destination.",
     request_body(
-        content = ShortenUrlRequest,
+        content = inline(ShortenUrlRequest),
         description = "The original URL to shorten",
         content_type = "application/json",
         example = json!({
@@ -43,7 +43,7 @@ use crate::{
         (
             status = 200,
             description = "Shortened URL",
-            body = ShortenUrlResponse,
+            body = inline(ShortenUrlResponse),
             content_type = "application/json",
             example = json!({
                 "short_url": "http://localhost:5080/short/ddbffcea3ad44292"

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -172,7 +172,7 @@ struct Rum {
                    requests. Returns a simple status indicator that can be used by load balancers, monitoring systems, \
                    and orchestration platforms to determine service availability and readiness.",
     responses(
-        (status = 200, description="Status OK", content_type = "application/json", body = HealthzResponse, example = json!({"status": "ok"}))
+        (status = 200, description="Status OK", content_type = "application/json", body = inline(HealthzResponse), example = json!({"status": "ok"}))
     )
 )]
 #[get("/healthz")]
@@ -199,8 +199,8 @@ pub async fn healthz_head() -> Result<HttpResponse, Error> {
                    is both online and enabled for task scheduling. Used by cluster management systems to determine \
                    which nodes are available for workload distribution and background job processing.",
     responses(
-        (status = 200, description="Status OK", content_type = "application/json", body = HealthzResponse, example = json!({"status": "ok"})),
-        (status = 404, description="Status Not OK", content_type = "application/json", body = HealthzResponse, example = json!({"status": "not ok"})),
+        (status = 200, description="Status OK", content_type = "application/json", body = inline(HealthzResponse), example = json!({"status": "ok"})),
+        (status = 404, description="Status Not OK", content_type = "application/json", body = inline(HealthzResponse), example = json!({"status": "not ok"})),
     )
 )]
 #[get("/schedulez")]

--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -153,7 +153,7 @@ async fn schema(
         ("stream_name" = String, Path, description = "Stream name"),
         ("type" = String, Query, description = "Stream type"),
     ),
-    request_body(content = StreamCreate, description = "Stream create", content_type = "application/json"),
+    request_body(content = inline(StreamCreate), description = "Stream create", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
@@ -202,7 +202,7 @@ async fn create(
         ("stream_name" = String, Path, description = "Stream name"),
         ("type" = String, Query, description = "Stream type"),
     ),
-    request_body(content = UpdateStreamSettings, description = "Stream settings", content_type = "application/json"),
+    request_body(content = inline(UpdateStreamSettings), description = "Stream settings", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
@@ -252,7 +252,7 @@ async fn update_settings(
         ("stream_name" = String, Path, description = "Stream name"),
         ("type" = String, Query, description = "Stream type"),
     ),
-    request_body(content = StreamUpdateFields, description = "Update stream fields to a specific data type", content_type = "application/json"),
+    request_body(content = inline(StreamUpdateFields), description = "Update stream fields to a specific data type", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = Object),
@@ -305,7 +305,7 @@ async fn update_fields(
         ("stream_name" = String, Path, description = "Stream name"),
         ("type" = String, Query, description = "Stream type"),
     ),
-    request_body(content = StreamDeleteFields, description = "Stream delete fields", content_type = "application/json"),
+    request_body(content = inline(StreamDeleteFields), description = "Stream delete fields", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
@@ -413,7 +413,7 @@ async fn delete(
         ("sort" = String, Query, description = "Sort"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = ListStream),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(ListStream)),
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
     ),
     extensions(

--- a/src/handler/http/request/users/mod.rs
+++ b/src/handler/http/request/users/mod.rs
@@ -136,7 +136,7 @@ pub async fn list(
     params(
         ("org_id" = String, Path, description = "Organization name"),
     ),
-    request_body(content = PostUserRequest, description = "User data", content_type = "application/json"),
+    request_body(content = inline(PostUserRequest), description = "User data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
     ),
@@ -197,7 +197,7 @@ pub async fn save(
         ("org_id" = String, Path, description = "Organization name"),
         ("email_id" = String, Path, description = "User's email id"),
     ),
-    request_body(content = UpdateUser, description = "User data", content_type = "application/json"),
+    request_body(content = inline(UpdateUser), description = "User data", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
     ),
@@ -270,7 +270,7 @@ pub async fn update(
         ("org_id" = String, Path, description = "Organization name"),
         ("email_id" = String, Path, description = "User's email id"),
     ),
-    request_body(content = UserRoleRequest, description = "User role", content_type = "application/json"),
+    request_body(content = inline(UserRoleRequest), description = "User role", content_type = "application/json"),
     responses(
         (status = 200, description = "Success", content_type = "application/json", body = Object),
     ),
@@ -354,9 +354,9 @@ context_path = "/auth",
                    Supports both JSON request body authentication and Authorization header-based authentication. \
                    Successful authentication establishes a session that allows access to protected resources and APIs \
                    throughout the platform.",
-    request_body(content = SignInUser, description = "User login", content_type = "application/json"),
+    request_body(content = inline(SignInUser), description = "User login", content_type = "application/json"),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = SignInResponse),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(SignInResponse)),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Users", "operation": "update"}))
@@ -851,7 +851,7 @@ pub async fn list_invitations(
         ("token" = String, Path, description = "invitation token"),
       ),
     responses(
-        (status = 200, description = "Success", content_type = "application/json", body = UserList),
+        (status = 200, description = "Success", content_type = "application/json", body = inline(UserList)),
     )
 )]
 #[delete("/invites/{token}")]

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -263,7 +263,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
     #[cfg(feature = "enterprise")]
     if LOCAL_NODE.is_querier() && get_enterprise_config().ai.enabled {
         tokio::task::spawn(async move {
-            o2_enterprise::enterprise::ai::prompt::prompts::load_system_prompt()
+            o2_enterprise::enterprise::ai::agent::prompt::prompts::load_system_prompt()
                 .await
                 .expect("load system prompt failed");
         });

--- a/src/service/db/ai_prompts.rs
+++ b/src/service/db/ai_prompts.rs
@@ -40,26 +40,13 @@ pub async fn watch() -> Result<(), anyhow::Error> {
             db::Event::Put(_) => {
                 // Call the enterprise update_prompt_in_memory function to update the cache
                 if let Err(e) =
-                    o2_enterprise::enterprise::ai::prompt::service::update_prompt_in_memory().await
+                    o2_enterprise::enterprise::ai::agent::prompt::service::update_prompt_in_memory()
+                        .await
                 {
                     log::error!("Failed to update AI prompt in memory cache: {e}");
                 }
                 log::debug!("Updated AI prompt in memory cache");
             }
-            // db::Event::Delete(ev) => {
-            //     let prompt_id = ev.key.strip_prefix(AI_PROMPTS_WATCH_PREFIX).unwrap();
-            //     // For delete events, we need to remove from memory cache
-            //     // Assuming there's a delete_prompt_in_memory function or we need to reload
-            //     if let Err(e) =
-            //         o2_enterprise::enterprise::ai::prompt::service::delete_prompt_in_memory(
-            //             prompt_id,
-            //         )
-            //         .await
-            //     {
-            //         log::error!("Failed to delete AI prompt from memory cache: {e}");
-            //     }
-            //     log::debug!("Deleted AI prompt from memory cache: {prompt_id}");
-            // }
             db::Event::Empty | db::Event::Delete(_) => {}
         }
     }
@@ -69,7 +56,7 @@ pub async fn watch() -> Result<(), anyhow::Error> {
 #[cfg(feature = "enterprise")]
 pub async fn cache() -> Result<(), anyhow::Error> {
     // Use the existing enterprise prompt manager to load all prompts
-    o2_enterprise::enterprise::ai::prompt::prompts::load_system_prompt().await?;
+    o2_enterprise::enterprise::ai::agent::prompt::prompts::load_system_prompt().await?;
     log::info!("AI prompts loaded into enterprise prompt manager cache");
     Ok(())
 }


### PR DESCRIPTION
- Add `x-o2-mcp` header support for MCP request identification in token validator
- Wrap OpenAPI schema types with `inline()` for better documentation generation
- Update AI module imports to use new agent namespace
- fix compilation for `cloud` feature, also return early if user isn't in trial
- Enable service graph by default