### PR TITLE
fix: dashboard multisearch api call issues

### DIFF
--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -1098,7 +1098,7 @@ export const usePanelDataLoader = (
                   state.metadata.queries.push(
                     timeShiftQueries[i]?.metadata ?? {},
                   );
-                  state.resultMetaData.push({});
+                  state.resultMetaData.push([]);
                 }
 
                 // Use HTTP2/streaming for multi-query (time-shift) queries
@@ -1150,14 +1150,17 @@ export const usePanelDataLoader = (
 
                       // Store the current query index for the next hits event
                       currentQueryIndexInStream = queryIndex;
-                      // Update metadata for this specific query index
-                      if (state.resultMetaData[queryIndex] !== undefined) {
-                        state.resultMetaData[queryIndex] = {
-                          ...(state.resultMetaData[queryIndex] ?? {}),
-                          ...results,
-                          streaming_aggs: response?.content?.streaming_aggs ?? false,
-                        };
+
+                      // Initialize metadata array if not exists
+                      if (!state.resultMetaData[queryIndex]) {
+                        state.resultMetaData[queryIndex] = [];
                       }
+
+                      // Push metadata for each partition
+                      state.resultMetaData[queryIndex].push({
+                        ...(response?.content ?? {}),
+                        ...(response?.content?.results ?? {}),
+                      });
                     }
 
                     if (response.type === "search_response_hits") {
@@ -1188,7 +1191,7 @@ export const usePanelDataLoader = (
                       ) {
                         // Check if streaming_aggs is enabled
                         const streaming_aggs =
-                          state.resultMetaData[queryIndex]?.streaming_aggs ?? false;
+                          state.resultMetaData[queryIndex]?.[0]?.streaming_aggs ?? false;
 
                         // If streaming_aggs, replace the data (aggregation query)
                         if (streaming_aggs) {
@@ -1265,7 +1268,7 @@ export const usePanelDataLoader = (
                 return { result: null, metadata: null };
               } finally {
                 // set loading to false
-                state.loading = false;
+                // state.loading = false;
               }
             } else {
               const { query: query1, metadata: metadata1 } = replaceQueryValue(


### PR DESCRIPTION
- Fill missing value issue due to `histogram_interval` config mismatch.
- Panel loader issue for multi search api call. 