### PR TITLE
fix: set default queue storage to file

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1825,7 +1825,7 @@ pub struct Nats {
     pub queue_max_size: i64,
     #[env_config(
         name = "ZO_NATS_EVENT_STORAGE",
-        help = "Set the storage type for the event stream, default is: memory, other value is: file",
+        help = "Set the storage type for the event stream, default is: file, other value is: memory",
         default = "file"
     )]
     pub event_storage: String,


### PR DESCRIPTION
We have one env `ZO_NATS_EVENT_STORAGE` to control the event queue storage for nats. default value is `file`, you can set to `memory` to improve performance but you need to have enough memory. at least double this size:

```
ZO_NATS_QUEUE_MAX_SIZE=2048
```
Default is `2GB`, if you don't have enough memory for nats, you can reduce this value or increase nats memory.