### PR TITLE
fix: debug query slow

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -2656,8 +2656,6 @@ fn check_disk_cache_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         cfg.common.result_cache_enabled = false;
         cfg.common.metrics_cache_enabled = false;
         cfg.common.feature_query_streaming_aggs = false;
-        cfg.cache_latest_files.enabled = false;
-        cfg.cache_latest_files.delete_merge_files = false;
     }
 
     let disks = sysinfo::disk::get_disk_usage();

--- a/src/config/src/utils/util.rs
+++ b/src/config/src/utils/util.rs
@@ -20,6 +20,10 @@ where
     if v == Default::default() { def } else { v }
 }
 
+pub fn is_power_of_two(n: u64) -> bool {
+    n == 0 || (n & (n - 1)) == 0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -33,5 +37,18 @@ mod tests {
         assert_eq!(zero_or(2.1, 1.1), 2.1);
         assert_eq!(zero_or("", "v"), "v");
         assert_eq!(zero_or("vv", "v"), "vv");
+    }
+
+    #[test]
+    fn test_is_power_of_two() {
+        assert!(is_power_of_two(0));
+        assert!(is_power_of_two(1));
+        assert!(is_power_of_two(2));
+        assert!(!is_power_of_two(3));
+        assert!(is_power_of_two(4));
+        assert!(!is_power_of_two(5));
+        assert!(!is_power_of_two(6));
+        assert!(!is_power_of_two(7));
+        assert!(is_power_of_two(8));
     }
 }

--- a/src/service/search/cache/multi.rs
+++ b/src/service/search/cache/multi.rs
@@ -228,7 +228,7 @@ async fn recursive_process_multiple_metas(
                     )
                 };
                 log::info!(
-                    "[CACHE RESULT {trace_id}] Get results from disk success for query key: {} with start time {} - end time {} , len {}",
+                    "[CACHE RESULT {trace_id}] Get results from disk success for query key: {} with start time {} - end time {}, len {}",
                     query_key,
                     matching_cache_meta.start_time,
                     matching_cache_meta.end_time,

--- a/src/service/search/grpc/storage.rs
+++ b/src/service/search/grpc/storage.rs
@@ -877,7 +877,7 @@ pub async fn filter_file_list_by_tantivy_index(
         "{}",
         search_inspector_fields(
             format!(
-                "[trace_id {}] search->tantivy: total hits for index_condition: {:?} found {} , is_add_filter_back: {}, file_num: {}, took: {} ms",
+                "[trace_id {}] search->tantivy: total hits for index_condition: {:?} found {}, is_add_filter_back: {}, file_num: {}, took: {} ms",
                 query.trace_id,
                 index_condition,
                 tantivy_result,
@@ -891,7 +891,7 @@ pub async fn filter_file_list_by_tantivy_index(
                 .search_role("follower".to_string())
                 .duration(search_start.elapsed().as_millis() as usize)
                 .desc(format!(
-                    "found {} , is_add_filter_back: {}, file_num: {}",
+                    "found {}, is_add_filter_back: {}, file_num: {}",
                     tantivy_result,
                     is_add_filter_back,
                     file_list_map.len(),

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -754,7 +754,7 @@ pub async fn search_partition(
             let records = (stats.doc_num as i64 / data_retention) * query_duration;
             let original_size = (stats.storage_size as i64 / data_retention) * query_duration;
             log::info!(
-                "[trace_id {trace_id}] using approximation: stream: {}, records: {}, original_size: {} , data_retention in seconds: {}",
+                "[trace_id {trace_id}] using approximation: stream: {}, records: {}, original_size: {}, data_retention in seconds: {}",
                 stream_name,
                 records,
                 original_size,


### PR DESCRIPTION
- [x] Don't change cache_latest_files value when disk cache is disabled
- [x] Add more logs for debug query slow with ENV: `ZO_PRINT_KEY_EVENT=true`

It only prints Flight event with series number which is power of 2.