### PR TITLE
feat: adding alert worker group

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -976,6 +976,16 @@ impl TryFrom<&str> for SearchEventType {
     }
 }
 
+impl SearchEventType {
+    /// Background tasks include: Alerts, Reports, and DerivedStream.
+    pub fn is_background(&self) -> bool {
+        matches!(
+            self,
+            Self::Alerts | Self::Reports | Self::DerivedStream | Self::SearchJob
+        )
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct ValuesEventContext {
@@ -1744,6 +1754,23 @@ mod tests {
         assert_eq!(SearchEventType::RUM.to_string(), "rum");
         assert_eq!(SearchEventType::DerivedStream.to_string(), "derived_stream");
         assert_eq!(SearchEventType::SearchJob.to_string(), "search_job");
+    }
+
+    #[test]
+    fn test_search_event_type_is_background() {
+        // Background tasks
+        assert!(SearchEventType::Alerts.is_background());
+        assert!(SearchEventType::Reports.is_background());
+        assert!(SearchEventType::DerivedStream.is_background());
+        assert!(SearchEventType::SearchJob.is_background());
+
+        // Non-background tasks
+        assert!(!SearchEventType::UI.is_background());
+        assert!(!SearchEventType::Dashboards.is_background());
+        assert!(!SearchEventType::Values.is_background());
+        assert!(!SearchEventType::Other.is_background());
+        assert!(!SearchEventType::RUM.is_background());
+        assert!(!SearchEventType::Download.is_background());
     }
 
     #[test]

--- a/src/service/search/cluster/flight.rs
+++ b/src/service/search/cluster/flight.rs
@@ -562,9 +562,20 @@ pub async fn check_work_group(
     let user_id = user_id.as_deref();
 
     // 1. get work group
-    let work_group: Option<o2_enterprise::enterprise::search::WorkGroup> = Some(
-        o2_enterprise::enterprise::search::work_group::predict(nodes, file_id_list_vec),
-    );
+    // Check if this is a background task (alerts, reports, derived streams)
+    let is_background_task = req
+        .search_event_type
+        .as_ref()
+        .and_then(|st| config::meta::search::SearchEventType::try_from(st.as_str()).ok())
+        .map(|st| st.is_background())
+        .unwrap_or(false);
+
+    let work_group: Option<o2_enterprise::enterprise::search::WorkGroup> =
+        Some(o2_enterprise::enterprise::search::work_group::predict(
+            nodes,
+            file_id_list_vec,
+            is_background_task,
+        ));
 
     SEARCH_SERVER
         .add_work_group(trace_id, work_group.clone())
@@ -591,7 +602,7 @@ pub async fn check_work_group(
     super::work_group_checking(trace_id, start, req, &work_group, &locker, None).await?;
 
     // 4. check user concurrency
-    if user_id.is_some() {
+    if user_id.is_some() && !is_background_task {
         super::work_group_checking(trace_id, start, req, &work_group, &locker, user_id).await?;
     }
 

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -259,12 +259,12 @@ pub async fn search(
             match stat.work_group.as_ref() {
                 Some(WorkGroup::Short) => _work_group = Some("short".to_string()),
                 Some(WorkGroup::Long) => _work_group = Some("long".to_string()),
+                Some(WorkGroup::Background) => _work_group = Some("background".to_string()),
                 None => _work_group = None,
             }
         };
     }
 
-    // do this because of clippy warning
     match res {
         Ok(mut res) => {
             if in_req.query.streaming_output && meta.order_by.is_empty() {
@@ -280,7 +280,6 @@ pub async fn search(
                             | search::SearchEventType::Dashboards
                             | search::SearchEventType::Values
                             | search::SearchEventType::Other
-                            // Alerts search now uses grpc cache::search which does report usage
                             | search::SearchEventType::Alerts
                             | search::SearchEventType::DerivedStream
                     ) {


### PR DESCRIPTION
resolves https://github.com/openobserve/openobserve/issues/8991

### Summary

- Introduces `is_background()` method in `SearchEventType`.  
- Identifies **Alerts**, **Reports**, and **DerivedStreams** as background tasks.  
- Routes these tasks to a dedicated **`BACKGROUND`** work group.  
