### PR TITLE
fix: Saved View preserves loadingHistogram State, leading to track total hits call on applying.

### DIFF
--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -3419,7 +3419,6 @@ export default defineComponent({
         savedSearchObj.loadingCounter = false;
         savedSearchObj.loadingStream = false;
         savedSearchObj.loadingSavedView = false;
-        savedSearchObj.stream.loading = false;
         
         savedSearchObj.data.timezone = store.state.timezone;
 


### PR DESCRIPTION
#9079 
1. A view was saved while the histogram was being loaded, which incorrectly hardcoded the loadingHistogram flag as true in the saved view data.
2. When this saved view was later loaded, the true value of loadingHistogram was retrieved.
3. This pre-existing true state bypassed the histogram loading logic and resulted in an incorrect call to the get page count.