### PR TITLE
fix: Saved View preserves loadingHistogram State, leading to track total hits call on applying

### DIFF
--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -3134,10 +3134,11 @@ export default defineComponent({
             });
             setTimeout(async () => {
               try {
+                searchObj.loadingHistogram = false;
                 searchObj.loading = true;
                 searchObj.meta.refreshHistogram = true;
                 // TODO OK: Remove all the instances of communicationMethod and below assignment aswell
-                searchObj.communicationMethod = "streaming";
+                searchObj.communicationMethod = "streaming";                
                 await extractFields();
                 await getQueryData();
                 store.dispatch("setSavedViewFlag", false);
@@ -3317,6 +3318,15 @@ export default defineComponent({
         delete savedSearchObj.data.savedViews;
         delete savedSearchObj.data.transforms;
 
+
+        // Turn off all loaders before saving view
+        savedSearchObj.loading = false;
+        savedSearchObj.loadingHistogram = false;
+        savedSearchObj.loadingCounter = false;
+        savedSearchObj.loadingStream = false;
+        savedSearchObj.loadingSavedView = false;
+        savedSearchObj.stream.loading = false;
+        
         savedSearchObj.data.timezone = store.state.timezone;
 
         if (savedSearchObj.data.parsedQuery) {


### PR DESCRIPTION
1. A view was saved while the histogram was being loaded, which incorrectly hardcoded the loadingHistogram flag as true in the saved view data.
2. When this saved view was later loaded, the true value of loadingHistogram was retrieved.
3. This pre-existing true state bypassed the histogram loading logic and resulted in an incorrect call to the get page count.