### PR TITLE
fix: when there is complete cache hit update is_histogram_eligible

### DIFF
--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -752,6 +752,10 @@ pub fn merge_response(
         cache_response.function_error.extend(fn_error);
         cache_response.is_partial = true;
     }
+    cache_response.is_histogram_eligible = search_response
+        .first()
+        .map(|res| res.is_histogram_eligible)
+        .unwrap_or_default();
     cache_response
 }
 


### PR DESCRIPTION
ref: https://github.com/openobserve/openobserve/pull/9028