### PR TITLE
chore: error handling for check_schema in metrics and traces

### DIFF
--- a/src/service/metrics/json.rs
+++ b/src/service/metrics/json.rs
@@ -416,7 +416,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
             }
 
             // check for schema evolution
-            let _ = check_for_schema(
+            let (_schema_evolution, _infer_schema) = check_for_schema(
                 org_id,
                 &stream_name,
                 StreamType::Metrics,
@@ -425,7 +425,7 @@ pub async fn ingest(org_id: &str, body: web::Bytes) -> Result<IngestionResponse>
                 timestamp,
                 false, // is_derived is false for metrics
             )
-            .await;
+            .await?;
 
             // write into buffer
             let schema = stream_schema_map

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -479,8 +479,8 @@ pub async fn remote_write(
                 }
             }
             drop(schema_fields);
-            if need_schema_check
-                && check_for_schema(
+            if need_schema_check {
+                let (schema_evolution, _infer_schema) = check_for_schema(
                     org_id,
                     &stream_name,
                     StreamType::Metrics,
@@ -489,10 +489,10 @@ pub async fn remote_write(
                     timestamp,
                     false, // is_derived is false for metrics
                 )
-                .await
-                .is_ok()
-            {
-                schema_evolved.insert(stream_name.clone(), true);
+                .await?;
+                if schema_evolution.is_schema_changed {
+                    schema_evolved.insert(stream_name.clone(), true);
+                }
             }
 
             let schema = metric_schema_map


### PR DESCRIPTION
## PR Summary

**Error Propagation:**
Fixed `check_for_schema` errors being silently ignored across traces, metrics (OTLP/Prom/JSON), and enrichment tables - now properly propagated using `?` operator or explicit error handling

**HTTP Status Code Fix:**
Changed schema validation errors (e.g., `ZO_COLS_PER_RECORD_LIMIT` exceeded) from returning HTTP 500 to HTTP 400 across all ingestion endpoints - correctly identifies these as client errors (Bad Request) instead of server errors