### PR TITLE
fix: make `WAL_DIR_DEFAULT_PREFIX` pub

### DIFF
--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -540,7 +540,7 @@ async fn get_stream_schema_status() -> (usize, usize, usize) {
 
 #[cfg(feature = "enterprise")]
 #[get("/redirect")]
-pub async fn redirect(req: HttpRequest) -> Result<HttpResponse, Error> {
+pub async fn redirect(req: actix_web::HttpRequest) -> Result<HttpResponse, Error> {
     use config::meta::user::UserRole;
 
     use crate::common::meta::user::AuthTokens;

--- a/src/ingester/src/lib.rs
+++ b/src/ingester/src/lib.rs
@@ -68,7 +68,7 @@ pub fn is_draining() -> bool {
     IS_INGESTER_DRAINING.load(Ordering::Acquire)
 }
 
-static WAL_DIR_DEFAULT_PREFIX: &str = "logs";
+pub static WAL_DIR_DEFAULT_PREFIX: &str = "logs";
 
 // writer signal
 pub enum WriterSignal {


### PR DESCRIPTION
https://github.com/openobserve/openobserve/pull/8876 had made this variable private, resulting in failed enterprise builds.

This commit reverts this specific change.