### PR TITLE
fix: temporarily disable alert history UI

### DIFF
--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -371,6 +371,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       </template>
                     </q-td>
                   </q-tr>
+                      <!-- //this is added temporarily so once alert history is implemented this wont be there
+                      //Version - 0.001 -->
                   <q-tr v-show="expandedRowDetails === props.row.alert_id" :props="props">
                     <q-td colspan="100%">
                       <div class="text-left tw-px-2 q-mb-sm expand-content">
@@ -947,7 +949,8 @@ export default defineComponent({
     const expandedAlertHistory: Ref<any[]> = ref([]);
     const isLoadingHistory = ref(false);
     const expandedRowDetails: Ref<any> = ref("");
-
+    //this is added temporarily so once alert history is implemented this wont be there
+    //Version - 0.001
     const triggerExpandRow = (props: any) => {
       if (expandedRowDetails.value === props.row.alert_id) {
         expandedRowDetails.value = null;
@@ -2539,6 +2542,8 @@ export default defineComponent({
       filterAlertsByQuery,
       bulkToggleAlerts,
       expandedRowDetails,
+      //this is added temporarily so once alert history is implemented this wont be there
+      //Version - 0.001
       triggerExpandRow,
     };
   },


### PR DESCRIPTION
This is required because cross-org triggers aren't yet available in cloud. This makes this feature unstable.

It'll remain enabled in `main` where everything is stable.