### PR TITLE
feat: support server url for azure

### DIFF
--- a/src/infra/src/storage/remote.rs
+++ b/src/infra/src/storage/remote.rs
@@ -327,6 +327,9 @@ fn init_azure_config(
     if !config.secret_key.is_empty() {
         builder = builder.with_access_key(&config.secret_key);
     }
+    if !config.server_url.is_empty() {
+        builder = builder.with_endpoint(config.server_url.clone());
+    }
     builder.build()
 }
 


### PR DESCRIPTION
If you get an wrong endpoint for azure like this:
```
https://12345.blob.core.windows.net
```
Then you can set it by:
```
ZO_S3_SERVER_URL="https://12345.blob.core.chinacloudapi.cn"
```