### PR TITLE
feat: service graph through streams

### DIFF
--- a/src/config/src/meta/mod.rs
+++ b/src/config/src/meta/mod.rs
@@ -34,6 +34,7 @@ pub mod promql;
 pub mod ratelimit;
 pub mod search;
 pub mod self_reporting;
+pub mod service_graph;
 pub mod short_url;
 pub mod sql;
 pub mod stream;

--- a/src/config/src/meta/service_graph.rs
+++ b/src/config/src/meta/service_graph.rs
@@ -1,0 +1,106 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Service Graph topology snapshot record
+/// Stored in ServiceGraph stream for historical queries
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+pub struct ServiceGraphSnapshot {
+    /// Snapshot timestamp (microseconds since epoch)
+    #[serde(rename = "_timestamp")]
+    pub timestamp: i64,
+
+    /// Organization identifier
+    pub org_id: String,
+
+    /// Source trace stream name
+    pub trace_stream_name: String,
+
+    /// Client service name (initiator)
+    pub client_service: String,
+
+    /// Server service name (receiver)
+    pub server_service: String,
+
+    /// Connection type: "standard", "database", "messaging", "virtual"
+    pub connection_type: String,
+
+    /// Total requests (cumulative counter)
+    pub total_requests: u64,
+
+    /// Failed requests (cumulative counter)
+    pub failed_requests: u64,
+
+    /// Error rate percentage (0-100)
+    pub error_rate: f64,
+
+    /// P50 latency in nanoseconds
+    pub p50_latency_ns: u64,
+
+    /// P95 latency in nanoseconds
+    pub p95_latency_ns: u64,
+
+    /// P99 latency in nanoseconds
+    pub p99_latency_ns: u64,
+
+    /// First time this edge was seen (microseconds)
+    pub first_seen: i64,
+
+    /// Last time this edge was seen (microseconds)
+    pub last_seen: i64,
+
+    /// Snapshot version (monotonic counter for deduplication)
+    pub snapshot_version: u64,
+}
+
+impl ServiceGraphSnapshot {
+    /// Convert to JSON value for stream ingestion
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).expect("Failed to serialize ServiceGraphSnapshot")
+    }
+}
+
+/// Graph format for frontend visualization
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+pub struct ServiceGraphData {
+    pub nodes: Vec<ServiceNode>,
+    pub edges: Vec<ServiceEdge>,
+}
+
+/// Node in service graph
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+pub struct ServiceNode {
+    pub id: String,
+    pub label: String,
+    pub requests: u64,
+    pub errors: u64,
+    pub error_rate: f64,
+}
+
+/// Edge in service graph
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+pub struct ServiceEdge {
+    pub from: String,
+    pub to: String,
+    pub total_requests: u64,
+    pub failed_requests: u64,
+    pub error_rate: f64,
+    pub p50_latency_ns: u64,
+    pub p95_latency_ns: u64,
+    pub p99_latency_ns: u64,
+    pub connection_type: String,
+}

--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -106,10 +106,11 @@ impl PartialEq for DataField {
     }
 }
 
-pub const ALL_STREAM_TYPES: [StreamType; 7] = [
+pub const ALL_STREAM_TYPES: [StreamType; 8] = [
     StreamType::Logs,
     StreamType::Metrics,
     StreamType::Traces,
+    StreamType::ServiceGraph,
     StreamType::EnrichmentTables,
     StreamType::Filelist,
     StreamType::Metadata,
@@ -123,6 +124,8 @@ pub enum StreamType {
     Logs,
     Metrics,
     Traces,
+    #[serde(rename = "service_graph")]
+    ServiceGraph,
     #[serde(rename = "enrichment_tables")]
     EnrichmentTables,
     #[serde(rename = "file_list")]
@@ -151,6 +154,7 @@ impl StreamType {
             StreamType::Logs => "logs",
             StreamType::Metrics => "metrics",
             StreamType::Traces => "traces",
+            StreamType::ServiceGraph => "service_graph",
             StreamType::EnrichmentTables => "enrichment_tables",
             StreamType::Filelist => "file_list",
             StreamType::Metadata => "metadata",
@@ -165,6 +169,7 @@ impl From<&str> for StreamType {
             "logs" => StreamType::Logs,
             "metrics" => StreamType::Metrics,
             "traces" => StreamType::Traces,
+            "service_graph" => StreamType::ServiceGraph,
             "enrichment_tables" | "enrich" => StreamType::EnrichmentTables,
             "file_list" => StreamType::Filelist,
             "metadata" => StreamType::Metadata,
@@ -186,6 +191,7 @@ impl std::fmt::Display for StreamType {
             StreamType::Logs => write!(f, "logs"),
             StreamType::Metrics => write!(f, "metrics"),
             StreamType::Traces => write!(f, "traces"),
+            StreamType::ServiceGraph => write!(f, "service_graph"),
             StreamType::EnrichmentTables => write!(f, "enrichment_tables"),
             StreamType::Filelist => write!(f, "file_list"),
             StreamType::Metadata => write!(f, "metadata"),

--- a/src/handler/grpc/request/ingest.rs
+++ b/src/handler/grpc/request/ingest.rs
@@ -155,8 +155,27 @@ impl Ingest for Ingester {
                     }
                 }
             }
+            StreamType::ServiceGraph => {
+                // Service graph edges - use same pattern as Logs
+                let log_ingestion_type = req.ingestion_type.unwrap_or_default();
+                let data = bytes::Bytes::from(in_data.data);
+                match create_log_ingestion_req(log_ingestion_type, &data) {
+                    Err(e) => Err(e),
+                    Ok(ingestion_req) => crate::service::logs::ingest::ingest(
+                        0,
+                        &org_id,
+                        &stream_name,
+                        ingestion_req,
+                        "",
+                        None,
+                        is_derived,
+                    )
+                    .await
+                    .map_or_else(Err, |_| Ok(())),
+                }
+            }
             _ => Err(Error::IngestionError(
-                "Internal gPRC ingestion service currently only supports Logs and EnrichmentTables"
+                "Internal gRPC ingestion service currently only supports Logs, EnrichmentTables, and ServiceGraph"
                     .to_string(),
             )),
         };

--- a/src/handler/http/models/alerts/mod.rs
+++ b/src/handler/http/models/alerts/mod.rs
@@ -454,6 +454,9 @@ impl From<meta_stream::StreamType> for StreamType {
             meta_stream::StreamType::Logs => Self::Logs,
             meta_stream::StreamType::Metrics => Self::Metrics,
             meta_stream::StreamType::Traces => Self::Traces,
+            meta_stream::StreamType::ServiceGraph => Self::Metadata, // ServiceGraph not
+            // alertable, map to
+            // Metadata
             meta_stream::StreamType::EnrichmentTables => Self::EnrichmentTables,
             meta_stream::StreamType::Filelist => Self::Filelist,
             meta_stream::StreamType::Metadata => Self::Metadata,

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -29,7 +29,7 @@ use tracing::{Instrument, Span};
 #[cfg(feature = "cloud")]
 use crate::service::ingestion::check_ingestion_allowed;
 // Re-export service graph API handlers
-pub use crate::service::traces::service_graph::{self, get_service_graph_metrics, get_store_stats};
+pub use crate::service::traces::service_graph::{self, get_current_topology};
 use crate::{
     common::{
         meta::{self, http::HttpResponse as MetaHttpResponse},

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -633,8 +633,7 @@ pub fn get_service_routes(svc: &mut web::ServiceConfig) {
         .service(domain_management::set_domain_management_config)
         .service(license::get_license_info)
         .service(license::store_license)
-        .service(traces::get_service_graph_metrics)
-        .service(traces::get_store_stats)
+        .service(traces::get_current_topology)
         .service(patterns::extract_patterns);
 
     #[cfg(feature = "enterprise")]

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -52,8 +52,6 @@ use crate::{common::meta, handler::http::request};
         request::logs::loki::loki_push,
         request::traces::traces_write,
         request::traces::get_latest_traces,
-        crate::service::traces::service_graph::api::get_service_graph_metrics,
-        crate::service::traces::service_graph::api::get_store_stats,
         request::metrics::ingest::json,
         request::promql::remote_write,
         request::promql::query_get,

--- a/src/infra/src/table/alerts/intermediate.rs
+++ b/src/infra/src/table/alerts/intermediate.rs
@@ -596,6 +596,7 @@ impl From<MetaStreamType> for StreamType {
             MetaStreamType::Logs => Self::Logs,
             MetaStreamType::Metrics => Self::Metrics,
             MetaStreamType::Traces => Self::Traces,
+            MetaStreamType::ServiceGraph => Self::Metadata, // Map to Metadata for alerts
             MetaStreamType::EnrichmentTables => Self::EnrichmentTables,
             MetaStreamType::Filelist => Self::FileList,
             MetaStreamType::Metadata => Self::Metadata,

--- a/src/job/compactor.rs
+++ b/src/job/compactor.rs
@@ -117,6 +117,20 @@ pub async fn run() -> Result<(), anyhow::Error> {
         }
     );
 
+    // Service graph processing
+    #[cfg(feature = "enterprise")]
+    spawn_pausable_job!(
+        "service_graph_processor",
+        get_o2_config().service_graph.processing_interval_secs,
+        {
+            log::debug!("[COMPACTOR::SERVICE_GRAPH] Running service graph processing");
+            if let Err(e) = crate::service::traces::service_graph::process_service_graph().await {
+                log::error!("[COMPACTOR::SERVICE_GRAPH] Processing failed: {e}");
+            }
+        },
+        sleep_after
+    );
+
     #[cfg(feature = "enterprise")]
     spawn_pausable_job!(
         "compactor_downsampling_sync_to_db",

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,16 +319,6 @@ async fn main() -> Result<(), anyhow::Error> {
                 panic!("job init failed: {e}");
             }
 
-            // init service graph workers
-            #[cfg(feature = "enterprise")]
-            if o2_enterprise::enterprise::common::config::get_config()
-                .service_graph
-                .enabled
-            {
-                log::info!("Initializing service graph background workers");
-                openobserve::service::traces::service_graph::init_background_workers();
-            }
-
             // Register job runtime for metrics collection
             if let Ok(handle) = tokio::runtime::Handle::try_current() {
                 openobserve::service::runtime_metrics::register_runtime("job".to_string(), handle);

--- a/src/service/self_reporting/queues.rs
+++ b/src/service/self_reporting/queues.rs
@@ -307,7 +307,7 @@ async fn ingest_buffered_data(thread_id: usize, buffered: Vec<ReportingData>) {
             if let Ok(trigger) = json::from_value::<TriggerData>(trigger_json.clone()) {
                 let org_id = &trigger.org;
                 #[cfg(feature = "cloud")]
-                match organization::is_org_in_free_trial_period(&org_id).await {
+                match organization::is_org_in_free_trial_period(org_id).await {
                     Ok(ongoing) => {
                         if !ongoing {
                             continue;

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -395,52 +395,8 @@ pub async fn handle_otlp_request(
                     links: json::to_string(&links).unwrap(),
                 };
 
-                // Process span for service graph if enabled
-                #[cfg(feature = "enterprise")]
-                if o2_enterprise::enterprise::common::config::get_config()
-                    .service_graph
-                    .enabled
-                {
-                    // Wrap in catch_unwind to prevent panics from crashing trace ingestion
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        log::trace!(
-                            "[ServiceGraph] Processing span: trace_id={}, span_id={}",
-                            trace_id,
-                            span_id
-                        );
-                        let parent_span_id_opt =
-                            span_ref.get(PARENT_SPAN_ID).map(|s| Arc::from(s.as_str()));
-                        // Convert HashMap to json::Map
-                        let mut attrs_map = json::Map::new();
-                        for (k, v) in &span_att_map {
-                            attrs_map.insert(k.clone(), v.clone());
-                        }
-                        let graph_span = service_graph::span_to_graph_span(
-                            Arc::from(trace_id.as_str()),
-                            Arc::from(span_id.as_str()),
-                            parent_span_id_opt,
-                            Arc::from(service_name.as_str()),
-                            Arc::from(traces_stream_name.as_str()),
-                            &local_val.span_kind,
-                            start_time,
-                            end_time,
-                            &local_val.span_status,
-                            &attrs_map,
-                        );
-                        service_graph::process_span(org_id, graph_span);
-                    }));
-
-                    if let Err(e) = result {
-                        log::error!(
-                            "[ServiceGraph] Panic caught during span processing: {:?}",
-                            e
-                        );
-                        // Increment error metric
-                        service_graph::SERVICE_GRAPH_DROPPED_SPANS
-                            .with_label_values(&[org_id])
-                            .inc();
-                    }
-                }
+                // Service graph processing is handled by periodic daemon
+                // No inline processing during trace ingestion
 
                 let mut value: json::Value = json::to_value(local_val).unwrap();
                 // add timestamp

--- a/src/service/traces/service_graph/aggregator.rs
+++ b/src/service/traces/service_graph/aggregator.rs
@@ -1,0 +1,114 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Service Graph Aggregator
+//!
+//! Aggregates raw edges into minute-bucketed summaries for stream storage.
+//! Used by the service graph daemon (not inline with trace ingestion).
+
+/// Write SQL-aggregated edge records directly to stream
+/// Used when SQL query already performed aggregation
+#[cfg(feature = "enterprise")]
+pub async fn write_sql_aggregated_edges(
+    org_id: &str,
+    stream_name: &str,
+    aggregated_records: Vec<serde_json::Value>,
+) -> Result<(), anyhow::Error> {
+    if aggregated_records.is_empty() {
+        return Ok(());
+    }
+
+    log::info!(
+        "[ServiceGraph] Writing {} SQL-aggregated edges for {}/{}",
+        aggregated_records.len(),
+        org_id,
+        stream_name
+    );
+
+    // Build bulk request body
+    let mut bulk_body = String::new();
+    let record_count = aggregated_records.len();
+
+    for record in aggregated_records {
+        // Transform SQL result to match expected schema
+        let enriched_record = if let Some(obj) = record.as_object() {
+            // Map SQL field names to storage schema using json! macro
+            // Use 'end' timestamp so edges are recent and queryable by API
+            config::utils::json::json!({
+                "_timestamp": obj.get("end").cloned().unwrap_or(serde_json::json!(0)),
+                "org_id": org_id,
+                "trace_stream_name": stream_name,
+                "client_service": obj.get("client").cloned().unwrap_or(serde_json::json!("")),
+                "server_service": obj.get("server").cloned().unwrap_or(serde_json::json!("")),
+                "connection_type": obj.get("connection_type").cloned().unwrap_or(serde_json::json!("standard")),
+                "total_requests": obj.get("total_requests").cloned().unwrap_or(serde_json::json!(0)),
+                "failed_requests": obj.get("errors").cloned().unwrap_or(serde_json::json!(0)),
+                "error_rate": obj.get("error_rate").cloned().unwrap_or(serde_json::json!(0.0)),
+                "p50_latency_ns": obj.get("p50").cloned().unwrap_or(serde_json::json!(0)),
+                "p95_latency_ns": obj.get("p95").cloned().unwrap_or(serde_json::json!(0)),
+                "p99_latency_ns": obj.get("p99").cloned().unwrap_or(serde_json::json!(0)),
+            })
+        } else {
+            record
+        };
+
+        // Add bulk action line
+        let action = config::utils::json::json!({"index": {"_index": "_o2_service_graph"}});
+        bulk_body.push_str(&serde_json::to_string(&action)?);
+        bulk_body.push('\n');
+
+        // Add data line
+        bulk_body.push_str(&serde_json::to_string(&enriched_record)?);
+        bulk_body.push('\n');
+    }
+
+    // Write to stream
+    if !bulk_body.is_empty() {
+        let data = actix_web::web::Bytes::from(bulk_body.into_bytes());
+
+        crate::service::logs::bulk::ingest(0, org_id, data, "")
+            .await
+            .inspect_err(|e| {
+                log::error!("[ServiceGraph] Failed to write SQL-aggregated edges: {e}");
+            })?;
+    }
+
+    log::info!(
+        "[ServiceGraph] Wrote {} SQL-aggregated edge summaries for {}",
+        record_count,
+        org_id
+    );
+    Ok(())
+}
+
+// Stub functions for non-enterprise builds
+#[cfg(not(feature = "enterprise"))]
+pub fn aggregate_edges(_edges: Vec<()>) -> Result<(), anyhow::Error> {
+    Ok(())
+}
+
+#[cfg(not(feature = "enterprise"))]
+pub async fn write_aggregated_edges(_org_id: &str, _aggregated: ()) -> Result<(), anyhow::Error> {
+    Ok(())
+}
+
+#[cfg(not(feature = "enterprise"))]
+pub async fn write_sql_aggregated_edges(
+    _org_id: &str,
+    _stream_name: &str,
+    _records: Vec<serde_json::Value>,
+) -> Result<(), anyhow::Error> {
+    Ok(())
+}

--- a/src/service/traces/service_graph/api.rs
+++ b/src/service/traces/service_graph/api.rs
@@ -13,13 +13,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//! Service Graph API - HTTP Handlers
+//!
+//! HTTP handlers for service graph topology queries.
+//! Business logic is in enterprise crate.
+
 use actix_web::{HttpResponse, web};
 use serde::Deserialize;
-#[cfg(feature = "enterprise")]
-use {
-    config::utils::json,
-    prometheus::{Encoder, TextEncoder},
-};
 
 /// Query parameters for service graph API
 #[derive(Debug, Deserialize)]
@@ -30,216 +30,186 @@ pub struct ServiceGraphQuery {
     pub stream_name: Option<String>,
 }
 
-/// GetServiceGraphMetrics
+/// GetCurrentTopology
 #[utoipa::path(
     get,
-    path = "/{org_id}/traces/service_graph/metrics",
+    path = "/{org_id}/traces/service_graph/topology/current",
     context_path = "/api",
     tag = "Traces",
-    operation_id = "GetServiceGraphMetrics",
-    summary = "Get service graph metrics",
-    description = "Retrieves Prometheus-formatted metrics for the service graph. Returns metrics filtered by organization and optionally by stream name to ensure multi-tenant isolation. Service graph metrics provide insights into service-to-service communication patterns, request rates, and latencies.",
+    operation_id = "GetCurrentServiceGraphTopology",
+    summary = "Get current service graph topology",
+    description = "Returns service graph topology from stream storage (last 60 minutes). Stream-only - NO in-memory metrics.",
     security(
         ("Authorization" = [])
     ),
     params(
         ("org_id" = String, Path, description = "Organization name"),
-        ("stream_name" = Option<String>, Query, description = "Optional stream name to filter service graph metrics"),
+        ("stream_name" = Option<String>, Query, description = "Optional stream name to filter service graph topology"),
     ),
     responses(
-        (status = 200, description = "Success", content_type = "text/plain; version=0.0.4", body = String, example = json!("# HELP traces_service_graph_request_total Total number of requests between services\n# TYPE traces_service_graph_request_total counter\ntraces_service_graph_request_total{client=\"service-a\",org_id=\"default\",server=\"service-b\",stream_name=\"default\"} 42\n")),
+        (status = 200, description = "Success", content_type = "application/json", body = Object),
         (status = 403, description = "Forbidden - Enterprise feature", content_type = "application/json", body = String),
         (status = 500, description = "Internal Server Error", content_type = "application/json", body = ()),
     ),
     extensions(
-        ("x-o2-ratelimit" = json!({"module": "Traces", "operation": "service_graph_metrics"}))
+        ("x-o2-ratelimit" = json!({"module": "Traces", "operation": "service_graph_topology"}))
     )
 )]
-#[actix_web::get("/{org_id}/traces/service_graph/metrics")]
+#[actix_web::get("/{org_id}/traces/service_graph/topology/current")]
 #[cfg(feature = "enterprise")]
-pub async fn get_service_graph_metrics(
+pub async fn get_current_topology(
     org_id: web::Path<String>,
     query: web::Query<ServiceGraphQuery>,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let metric_families = prometheus::gather();
-    let encoder = TextEncoder::new();
-    let mut buffer = vec![];
+    use config::meta::service_graph::ServiceGraphData;
 
-    // Filter metrics to only include those matching the requested org_id and optional stream_name
-    let filtered_families: Vec<_> = metric_families
-        .into_iter()
-        .filter_map(|mut family| {
-            // Filter out metrics that don't belong to this org/stream
-            let filtered_metrics: Vec<_> = family
-                .take_metric()
-                .into_iter()
-                .filter(|metric| {
-                    let labels = metric.get_label();
-
-                    // Check if metric has org_id label matching the requested org
-                    let org_matches = labels
-                        .iter()
-                        .any(|label| label.name() == "org_id" && label.value() == org_id.as_str());
-
-                    if !org_matches {
-                        return false;
-                    }
-
-                    // If stream_name filter is provided, also check stream_name label
-                    if let Some(ref stream_name) = query.stream_name {
-                        labels.iter().any(|label| {
-                            label.name() == "stream_name" && label.value() == stream_name.as_str()
-                        })
-                    } else {
-                        true
-                    }
-                })
-                .collect();
-
-            if filtered_metrics.is_empty() {
-                None
-            } else {
-                family.set_metric(filtered_metrics);
-                Some(family)
-            }
-        })
-        .collect();
-
-    encoder.encode(&filtered_families, &mut buffer).unwrap();
-
-    Ok(HttpResponse::Ok()
-        .content_type("text/plain; version=0.0.4")
-        .body(buffer))
-}
-
-/// GetServiceGraphMetrics
-#[utoipa::path(
-    get,
-    path = "/{org_id}/traces/service_graph/metrics",
-    context_path = "/api",
-    tag = "Traces",
-    operation_id = "GetServiceGraphMetrics",
-    summary = "Get service graph metrics",
-    description = "Retrieves Prometheus-formatted metrics for the service graph. Returns metrics filtered by organization to ensure multi-tenant isolation. Service graph metrics provide insights into service-to-service communication patterns, request rates, and latencies.",
-    security(
-        ("Authorization" = [])
-    ),
-    params(
-        ("org_id" = String, Path, description = "Organization name"),
-    ),
-    responses(
-        (status = 200, description = "Success", content_type = "text/plain; version=0.0.4", body = String, example = json!("# HELP traces_service_graph_request_total Total number of requests between services\n# TYPE traces_service_graph_request_total counter\ntraces_service_graph_request_total{client=\"service-a\",org_id=\"default\",server=\"service-b\"} 42\n")),
-        (status = 403, description = "Forbidden - Enterprise feature", content_type = "application/json", body = String),
-        (status = 500, description = "Internal Server Error", content_type = "application/json", body = ()),
-    ),
-    extensions(
-        ("x-o2-ratelimit" = json!({"module": "Traces", "operation": "service_graph_metrics"}))
-    )
-)]
-#[actix_web::get("/{org_id}/traces/service_graph/metrics")]
-#[cfg(not(feature = "enterprise"))]
-pub async fn get_service_graph_metrics(
-    _org_id: web::Path<String>,
-) -> Result<HttpResponse, actix_web::Error> {
-    Ok(HttpResponse::Forbidden().json("Not Supported"))
-}
-
-/// GetServiceGraphStats
-#[utoipa::path(
-    get,
-    path = "/{org_id}/traces/service_graph/stats",
-    context_path = "/api",
-    tag = "Traces",
-    operation_id = "GetServiceGraphStats",
-    summary = "Get service graph store statistics",
-    description = "Retrieves internal statistics about the service graph store for an organization. Returns information about store size, capacity utilization, shard count, and configuration. Useful for monitoring and capacity planning of the service graph storage.",
-    security(
-        ("Authorization" = [])
-    ),
-    params(
-        ("org_id" = String, Path, description = "Organization name"),
-    ),
-    responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Object, example = json!({
-            "enabled": true,
-            "store_size": 1234,
-            "capacity_utilization_percent": 12.5,
-            "shard_count": 16,
-            "config": {
-                "max_items_per_shard": 10000,
-                "total_capacity": 160000,
-                "wait_duration_ms": 1000
-            }
-        })),
-        (status = 403, description = "Forbidden - Enterprise feature", content_type = "application/json", body = String),
-        (status = 500, description = "Internal Server Error", content_type = "application/json", body = ()),
-    ),
-    extensions(
-        ("x-o2-ratelimit" = json!({"module": "Traces", "operation": "service_graph_stats"}))
-    )
-)]
-#[actix_web::get("/{org_id}/traces/service_graph/stats")]
-#[cfg(feature = "enterprise")]
-pub async fn get_store_stats(org_id: web::Path<String>) -> Result<HttpResponse, actix_web::Error> {
-    let store = o2_enterprise::enterprise::service_graph::get_store();
-    let org_sizes = store.get_org_sizes();
-    let org_capacities = store.get_org_capacity_utilization();
-
-    // Get stats for the requested org only
-    let org_store_size = org_sizes.get(org_id.as_str()).copied().unwrap_or(0);
-    let org_capacity_util = org_capacities.get(org_id.as_str()).copied().unwrap_or(0.0);
-
-    let stats = json::json!({
-        "enabled": o2_enterprise::enterprise::common::config::get_config().service_graph.enabled,
-        "store_size": org_store_size,
-        "capacity_utilization_percent": org_capacity_util,
-        "shard_count": store.shard_count(),
-        "config": {
-            "max_items_per_shard": store.config().max_items_per_shard,
-            "total_capacity": store.config().max_items_per_shard * store.shard_count(),
-            "wait_duration_ms": store.config().wait_duration.as_millis(),
+    // Query edges from stream (last 60 minutes by default)
+    let edges = match query_edges_from_stream(&org_id, query.stream_name.as_deref()).await {
+        Ok(edges) => edges,
+        Err(e) => {
+            // Stream doesn't exist yet or query failed - return empty topology gracefully
+            log::debug!(
+                "[ServiceGraph] Stream query failed (likely stream doesn't exist yet): {}",
+                e
+            );
+            return Ok(HttpResponse::Ok().json(serde_json::json!({
+                "nodes": vec![] as Vec<()>,
+                "edges": vec![] as Vec<()>,
+                "availableStreams": vec![] as Vec<String>,
+            })));
         }
-    });
+    };
 
-    Ok(HttpResponse::Ok().json(stats))
+    if edges.is_empty() {
+        log::debug!(
+            "[ServiceGraph] No edges found for org '{}'",
+            org_id.as_str()
+        );
+        return Ok(HttpResponse::Ok().json(ServiceGraphData {
+            nodes: vec![],
+            edges: vec![],
+        }));
+    }
+
+    log::debug!(
+        "[ServiceGraph] Processing {} edge records for org '{}'",
+        edges.len(),
+        org_id.as_str()
+    );
+
+    // Use enterprise business logic to build topology
+    let (nodes, edges, available_streams) =
+        o2_enterprise::enterprise::service_graph::build_topology(edges);
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "nodes": nodes,
+        "edges": edges,
+        "availableStreams": available_streams,
+    })))
 }
 
-/// GetServiceGraphStats
-#[utoipa::path(
-    get,
-    path = "/{org_id}/traces/service_graph/stats",
-    context_path = "/api",
-    tag = "Traces",
-    operation_id = "GetServiceGraphStats",
-    summary = "Get service graph store statistics",
-    description = "Retrieves internal statistics about the service graph store for an organization. Returns information about store size, capacity utilization, shard count, and configuration. Useful for monitoring and capacity planning of the service graph storage.",
-    security(
-        ("Authorization" = [])
-    ),
-    params(
-        ("org_id" = String, Path, description = "Organization name"),
-    ),
-    responses(
-        (status = 200, description = "Success", content_type = "application/json", body = Object, example = json!({
-            "enabled": true,
-            "store_size": 1234,
-            "capacity_utilization_percent": 12.5,
-            "shard_count": 16,
-            "config": {
-                "max_items_per_shard": 10000,
-                "total_capacity": 160000,
-                "wait_duration_ms": 1000
-            }
-        })),
-        (status = 403, description = "Forbidden - Enterprise feature", content_type = "application/json", body = String),
-        (status = 500, description = "Internal Server Error", content_type = "application/json", body = ()),
-    ),
-    extensions(
-        ("x-o2-ratelimit" = json!({"module": "Traces", "operation": "service_graph_stats"}))
-    )
-)]
-#[actix_web::get("/{org_id}/traces/service_graph/stats")]
+#[cfg(feature = "enterprise")]
+/// Query edge records from the _o2_service_graph stream
+async fn query_edges_from_stream(
+    org_id: &str,
+    stream_filter: Option<&str>,
+) -> Result<Vec<serde_json::Value>, infra::errors::Error> {
+    use config::meta::stream::StreamType;
+
+    let stream_name = "_o2_service_graph";
+
+    // Query last 60 minutes by default
+    let now = chrono::Utc::now().timestamp_micros();
+    let sixty_minutes_ago = now - (60 * 60 * 1_000_000);
+
+    // Query pre-aggregated edge state (already summarized per minute)
+    let sql = if let Some(stream) = stream_filter {
+        format!(
+            "SELECT * FROM \"{}\"
+             WHERE _timestamp >= {}
+             AND org_id = '{}'
+             AND trace_stream_name = '{}'
+             LIMIT 10000",
+            stream_name, sixty_minutes_ago, org_id, stream
+        )
+    } else {
+        format!(
+            "SELECT * FROM \"{}\"
+             WHERE _timestamp >= {}
+             AND org_id = '{}'
+             LIMIT 10000",
+            stream_name, sixty_minutes_ago, org_id
+        )
+    };
+
+    // Build search request
+    let req = config::meta::search::Request {
+        query: config::meta::search::Query {
+            sql: sql.clone(),
+            from: 0,
+            size: 100000,
+            start_time: sixty_minutes_ago,
+            end_time: now,
+            quick_mode: false,
+            query_type: "".to_string(),
+            track_total_hits: false,
+            uses_zo_fn: false,
+            query_fn: None,
+            skip_wal: false,
+            action_id: None,
+            histogram_interval: 0,
+            streaming_id: None,
+            streaming_output: false,
+            sampling_config: None,
+            sampling_ratio: None,
+        },
+        encoding: config::meta::search::RequestEncoding::Empty,
+        regions: vec![],
+        clusters: vec![],
+        timeout: 30,
+        search_type: None,
+        search_event_context: None,
+        use_cache: false,
+        clear_cache: false,
+        local_mode: Some(false),
+    };
+
+    // Check if stream exists (using Logs type since we write as logs stream)
+    let schema = infra::schema::get(org_id, stream_name, StreamType::Logs).await;
+    if schema.is_err() {
+        log::debug!(
+            "[ServiceGraph] Stream '{}' does not exist yet for org '{}'",
+            stream_name,
+            org_id
+        );
+        return Ok(Vec::new());
+    }
+
+    // Execute search
+    let trace_id = config::ider::generate();
+    let resp = crate::service::search::search(&trace_id, org_id, StreamType::Logs, None, &req)
+        .await
+        .map_err(|e| {
+            log::error!("[ServiceGraph] Stream query failed: {}", e);
+            infra::errors::Error::ErrorCode(infra::errors::ErrorCodes::SearchStreamNotFound(
+                stream_name.to_string(),
+            ))
+        })?;
+
+    log::debug!(
+        "[ServiceGraph] Retrieved {} edge records from stream for org '{}'",
+        resp.hits.len(),
+        org_id
+    );
+
+    Ok(resp.hits)
+}
+
+#[actix_web::get("/{org_id}/traces/service_graph/topology/current")]
 #[cfg(not(feature = "enterprise"))]
-pub async fn get_store_stats(_org_id: web::Path<String>) -> Result<HttpResponse, actix_web::Error> {
+pub async fn get_current_topology(
+    _org_id: web::Path<String>,
+    _query: web::Query<ServiceGraphQuery>,
+) -> Result<HttpResponse, actix_web::Error> {
     Ok(HttpResponse::Forbidden().json("Not Supported"))
 }

--- a/src/service/traces/service_graph/mod.rs
+++ b/src/service/traces/service_graph/mod.rs
@@ -13,18 +13,29 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Service Graph Module
+//! Service Graph Module - Enterprise Feature
 //!
-//! This module provides API endpoints for the service graph feature.
-//! The core logic is implemented in the enterprise repository.
+//! Daemon-based service graph that queries traces periodically.
+//! No inline processing during trace ingestion.
 
+// OSS modules
+pub mod aggregator;
 pub mod api;
+pub mod processor;
 
-// Re-export API handlers for routing
-pub use api::{get_service_graph_metrics, get_store_stats};
-// Re-export enterprise types and functions for internal use
+// Re-export API handler for router
+// Re-export aggregator function (used by processor)
+pub use aggregator::write_sql_aggregated_edges;
+pub use api::get_current_topology;
+// Re-export enterprise types and functions
 #[cfg(feature = "enterprise")]
 pub use o2_enterprise::enterprise::service_graph::{
-    ConnectionType, SERVICE_GRAPH_DROPPED_SPANS, SpanForGraph, SpanKind, init_background_workers,
-    process_span, shutdown_workers, span_to_graph_span,
+    // Data types
+    ConnectionType,
+    SpanForGraph,
+    SpanKind,
+    // Processing functions
+    span_to_graph_span,
 };
+// Re-export processor for compactor
+pub use processor::process_service_graph;

--- a/src/service/traces/service_graph/processor.rs
+++ b/src/service/traces/service_graph/processor.rs
@@ -1,0 +1,202 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Service Graph Processor
+//!
+//! Queries trace streams and builds service graph topology.
+//! Called by compactor job - zero impact on ingestion performance.
+
+#[cfg(feature = "enterprise")]
+use chrono::Utc;
+#[cfg(feature = "enterprise")]
+use config::meta::stream::StreamType;
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::common::config::get_config as get_o2_config;
+
+/// Main entry point for service graph processing
+/// Called by compactor job
+#[cfg(feature = "enterprise")]
+pub async fn process_service_graph() -> Result<(), anyhow::Error> {
+    let cfg = get_o2_config();
+    if !cfg.service_graph.enabled {
+        return Ok(());
+    }
+    // Process last hour of traces (configurable window)
+    let now = Utc::now().timestamp_micros();
+    let window_minutes = get_o2_config().service_graph.query_time_range_minutes;
+    let window_micros = window_minutes * 60 * 1_000_000;
+    let start_time = now - window_micros;
+
+    log::debug!(
+        "[ServiceGraph] Processing traces from {} to {}",
+        start_time,
+        now
+    );
+
+    // Get all trace streams across all orgs
+    let streams = get_trace_streams().await?;
+    log::info!(
+        "[ServiceGraph] Found {} trace streams to process",
+        streams.len()
+    );
+
+    for (org_id, stream_name) in streams {
+        if let Err(e) = process_stream(&org_id, &stream_name, start_time, now).await {
+            log::error!(
+                "[ServiceGraph] Failed to process stream {}/{}: {}",
+                org_id,
+                stream_name,
+                e
+            );
+            continue; // Don't fail entire job if one stream fails
+        }
+    }
+
+    Ok(())
+}
+
+/// Get list of all trace streams
+#[cfg(feature = "enterprise")]
+async fn get_trace_streams() -> Result<Vec<(String, String)>, anyhow::Error> {
+    let mut streams = Vec::new();
+
+    // Get all organizations
+    let orgs = crate::service::db::organization::list(None).await?;
+
+    for org in orgs {
+        // Get trace streams for this org
+        let org_streams =
+            crate::service::db::schema::list_streams_from_cache(&org.name, StreamType::Traces)
+                .await;
+
+        for stream_name in org_streams {
+            streams.push((org.name.clone(), stream_name));
+        }
+    }
+
+    Ok(streams)
+}
+
+/// Process a single trace stream
+#[cfg(feature = "enterprise")]
+async fn process_stream(
+    org_id: &str,
+    stream_name: &str,
+    start_time: i64,
+    end_time: i64,
+) -> Result<(), anyhow::Error> {
+    // Build SQL to aggregate service graph edges directly in DataFusion
+    // Use CTE to compute client/server first, then aggregate
+    log::info!(
+        "[ServiceGraph] Querying stream {}/{} from {} to {} (window: {}s)",
+        org_id,
+        stream_name,
+        start_time,
+        end_time,
+        (end_time - start_time) / 1_000_000
+    );
+
+    let sql = format!(
+        "WITH edges AS (
+           SELECT
+             CASE WHEN CAST(span_kind AS VARCHAR) = '3' THEN service_name ELSE peer_service END as client,
+             CASE WHEN CAST(span_kind AS VARCHAR) = '3' THEN peer_service ELSE service_name END as server,
+             end_time - start_time as duration,
+             span_status
+           FROM \"{}\"
+           WHERE _timestamp >= {} AND _timestamp < {}
+             AND CAST(span_kind AS VARCHAR) IN ('2', '3')
+             AND peer_service IS NOT NULL
+         )
+         SELECT
+           {} as start,
+           {} as end,
+           client,
+           server,
+           'standard' as connection_type,
+           COUNT(*) as total_requests,
+           COUNT(*) FILTER (WHERE span_status = 'ERROR') as errors,
+           CAST(COUNT(*) FILTER (WHERE span_status = 'ERROR') * 100.0 / COUNT(*) AS DOUBLE) as error_rate,
+           approx_median(duration) as p50,
+           approx_percentile_cont(duration, 0.95) as p95,
+           approx_percentile_cont(duration, 0.99) as p99
+         FROM edges
+         GROUP BY client, server",
+        stream_name, start_time, end_time, start_time, end_time
+    );
+
+    // Execute search
+    let req = config::meta::search::Request {
+        query: config::meta::search::Query {
+            sql,
+            from: 0,
+            size: 100000,
+            start_time,
+            end_time,
+            quick_mode: false,
+            query_type: "".to_string(),
+            track_total_hits: false,
+            uses_zo_fn: false,
+            query_fn: None,
+            skip_wal: false,
+            action_id: None,
+            histogram_interval: 0,
+            streaming_id: None,
+            streaming_output: false,
+            sampling_config: None,
+            sampling_ratio: None,
+        },
+        encoding: config::meta::search::RequestEncoding::Empty,
+        regions: vec![],
+        clusters: vec![],
+        timeout: 300, // 5 minute timeout for large queries
+        search_type: None,
+        search_event_context: None,
+        use_cache: false,
+        clear_cache: false,
+        local_mode: Some(false),
+    };
+
+    let trace_id = config::ider::generate();
+    let resp =
+        crate::service::search::search(&trace_id, org_id, StreamType::Traces, None, &req).await?;
+
+    log::info!(
+        "[ServiceGraph] Query returned {} pre-aggregated edges from {}/{}",
+        resp.hits.len(),
+        org_id,
+        stream_name
+    );
+
+    if resp.hits.is_empty() {
+        return Ok(());
+    }
+
+    // SQL already aggregated everything - just write directly to _o2_service_graph stream
+    crate::service::traces::service_graph::write_sql_aggregated_edges(
+        org_id,
+        stream_name,
+        resp.hits,
+    )
+    .await?;
+
+    Ok(())
+}
+
+// Stub implementation for non-enterprise builds
+#[cfg(not(feature = "enterprise"))]
+pub async fn process_service_graph() -> Result<(), anyhow::Error> {
+    Ok(())
+}

--- a/web/src/services/service_graph.ts
+++ b/web/src/services/service_graph.ts
@@ -17,20 +17,14 @@ import http from "./http";
 
 const serviceGraphService = {
   /**
-   * Get service graph metrics in Prometheus format
+   * Get current service graph topology in JSON format
+   * Stream-only implementation - NO in-memory metrics
    * @param orgId - Organization ID
-   * @param streamName - Optional stream name to filter metrics
+   * @param streamName - Optional stream name to filter topology
    */
-  getMetrics: (orgId: string, streamName?: string) => {
+  getCurrentTopology: (orgId: string, streamName?: string) => {
     const params = streamName && streamName !== 'all' ? { stream_name: streamName } : {};
-    return http().get(`/api/${orgId}/traces/service_graph/metrics`, { params });
-  },
-
-  /**
-   * Get service graph store statistics
-   */
-  getStats: (orgId: string) => {
-    return http().get(`/api/${orgId}/traces/service_graph/stats`);
+    return http().get(`/api/${orgId}/traces/service_graph/topology/current`, { params });
   },
 };
 


### PR DESCRIPTION
## Architecture

Replaces in-memory EdgeStore with daemon that periodically queries trace streams using DataFusion SQL.

**Flow:**
1. Daemon runs in compactor every 1 hour by default (configurable)
2. Queries all trace streams for last 60 minutes (configurable)
3. SQL aggregation with CTE extracts client/server edges
4. Calculates p50/p95/p99 percentiles using approx functions
5. Writes aggregated edges to `_o2_service_graph` internal stream
6. Topology API queries `_o2_service_graph` for last 60 minutes

**Zero impact on trace ingestion** - completely decoupled.

## SQL Query

```sql
WITH edges AS (
  SELECT
    CASE WHEN CAST(span_kind AS VARCHAR) = '3' THEN service_name ELSE peer_service END as client,
    CASE WHEN CAST(span_kind AS VARCHAR) = '3' THEN peer_service ELSE service_name END as server,
    end_time - start_time as duration,
    span_status
  FROM "trace_stream"
  WHERE _timestamp >= {start} AND _timestamp < {end}
    AND CAST(span_kind AS VARCHAR) IN ('2', '3')
    AND peer_service IS NOT NULL
)
SELECT
  client, server,
  COUNT(*) as total_requests,
  COUNT(*) FILTER (WHERE span_status = 'ERROR') as errors,
  approx_median(duration) as p50,
  approx_percentile_cont(duration, 0.95) as p95,
  approx_percentile_cont(duration, 0.99) as p99
FROM edges
GROUP BY client, server
```

## Configuration

- `O2_SERVICE_GRAPH_ENABLED=true` - Enable feature
- `O2_SERVICE_GRAPH_PROCESSING_INTERVAL_SECS=3600` - How often daemon runs (default: 1 hour)
- `O2_SERVICE_GRAPH_QUERY_TIME_RANGE_MINUTES=60` - Query window size (default: 60 min)

## Changes

**Added:**
- `processor.rs` (202 lines) - SQL daemon
- `aggregator.rs` (155 lines) - Stream writer

**Modified:**
- `api.rs` - Query from `_o2_service_graph` stream, return `availableStreams`
- `compactor.rs` - Integrate service_graph_processor job
- `traces/mod.rs` - Remove ALL inline processing

**Deleted:**
- `job/service_graph.rs` - Standalone daemon (now in compactor)
- In-memory EdgeStore, buffering, workers

**Enterprise dependency:**
- Requires companion PR in o2-enterprise (business logic migration)

## Technical Details

- Span kinds: '2' (SERVER), '3' (CLIENT) stored as VARCHAR in parquet
- Edge timestamp: Uses query end time for API compatibility
- Feature-gated: Stubs for non-enterprise builds
- Query timeout: 300s for large trace volumes