### PR TITLE
fix: alert history on alert should be called of 12hours

### DIFF
--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -957,7 +957,9 @@ export default defineComponent({
       selectedAlertDetails.value = props.row;
       showAlertDetailsDrawer.value = true;
       // Fetch history for this alert
-      fetchAlertHistory(props.row.alert_id);
+      if(config.isCloud == "false"){
+        fetchAlertHistory(props.row.alert_id);
+      }
     };
 
     // Handle ESC key and click outside to close drawer


### PR DESCRIPTION
fix: This PR fixes the issue of reducing alert history duration to 12hours from 30days in alertlist page