### PR TITLE
fix: result cache for histogram

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -1327,7 +1327,7 @@ const AGGREGATION_CACHE_INTERVALS: [(Option<Duration>, Interval); 6] = [
     (Duration::try_minutes(15), Interval::FiveMinutes),
 ];
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum Interval {
     Zero = 0,
     FiveMinutes = 5,

--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -358,6 +358,7 @@ pub async fn check_cache(
                     }),
                     req.query.start_time,
                     req.query.end_time,
+                    histogram_interval,
                     &mut deltas,
                 );
 
@@ -388,9 +389,13 @@ pub async fn check_cache(
                 }
             }
         };
-        multi_resp.deltas = c_resp.deltas.clone();
         multi_resp.has_cached_data = c_resp.has_cached_data;
-        multi_resp.cached_response.push(c_resp);
+        if !c_resp.deltas.is_empty() {
+            multi_resp.deltas = c_resp.deltas.clone();
+        };
+        if c_resp.has_cached_data {
+            multi_resp.cached_response.push(c_resp);
+        }
         multi_resp.took = start.elapsed().as_millis() as usize;
         multi_resp.cache_query_response = true;
         multi_resp.limit = sql.limit as i64;
@@ -482,11 +487,13 @@ pub async fn get_cached_results(
     let last_ts = get_ts_value(&cache_req.ts_column, cached_response.hits.last().unwrap());
     let data_start_time = std::cmp::min(first_ts, last_ts);
     let data_end_time = std::cmp::max(first_ts, last_ts);
+    // convert histogram interval to microseconds
+    let histogram_interval = cached_response.histogram_interval.unwrap_or_default() * 1_000_000;
     // check if need to filter the data
     if data_start_time < cache_req.q_start_time || data_end_time > cache_req.q_end_time {
         cached_response.hits.retain(|hit| {
             let hit_ts = get_ts_value(&cache_req.ts_column, hit);
-            hit_ts < hits_allowed_end_time && hit_ts >= hits_allowed_start_time
+            hit_ts + histogram_interval < hits_allowed_end_time && hit_ts >= hits_allowed_start_time
         });
         // if the data is empty after filtering, return None
         if cached_response.hits.is_empty() {
@@ -494,7 +501,8 @@ pub async fn get_cached_results(
         }
         // reset the start and end time
         let first_ts = get_ts_value(&cache_req.ts_column, cached_response.hits.first().unwrap());
-        let last_ts = get_ts_value(&cache_req.ts_column, cached_response.hits.last().unwrap());
+        let last_ts = get_ts_value(&cache_req.ts_column, cached_response.hits.last().unwrap())
+            + histogram_interval;
         matching_meta.start_time = std::cmp::min(first_ts, last_ts);
         matching_meta.end_time = std::cmp::max(first_ts, last_ts);
     }
@@ -523,6 +531,7 @@ pub fn calculate_deltas(
     result_meta: &ResultCacheMeta,
     query_start_time: i64,
     query_end_time: i64,
+    histogram_interval: i64,
     deltas: &mut Vec<QueryDelta>,
 ) {
     if query_start_time == result_meta.start_time && query_end_time == result_meta.end_time {
@@ -535,8 +544,13 @@ pub fn calculate_deltas(
         // for delta start time we need to add 1 microsecond to the end time
         // because we will include the start_time, if we don't add 1 microsecond
         // the start_time will be include in the next search, we will get duplicate data
+        let delta_start_time = if histogram_interval > 0 {
+            result_meta.end_time
+        } else {
+            result_meta.end_time + 1
+        };
         deltas.push(QueryDelta {
-            delta_start_time: result_meta.end_time + 1,
+            delta_start_time,
             delta_end_time: query_end_time,
         });
     }

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -813,12 +813,11 @@ pub async fn search_partition(
         return Ok(response);
     };
 
-    log::info!("[trace_id {trace_id}] search_partition: getting nodes");
     let nodes = infra_cluster::get_cached_online_querier_nodes(Some(RoleGroup::Interactive))
         .await
         .unwrap_or_default();
     if nodes.is_empty() {
-        log::error!("no querier node online");
+        log::error!("[trace_id {trace_id}] search_partition: no querier node online");
         return Err(Error::Message("no querier node online".to_string()));
     }
     let cpu_cores = nodes.iter().map(|n| n.cpu_num).sum::<u64>() as usize;
@@ -1045,8 +1044,13 @@ pub async fn search_partition(
                     query.end_time,
                 )
             } else {
-                match discover_cache_for_query(&cache_file_path, query.start_time, query.end_time)
-                    .await
+                match discover_cache_for_query(
+                    &cache_file_path,
+                    query.start_time,
+                    query.end_time,
+                    cache_interval,
+                )
+                .await
                 {
                     Ok(result) => result,
                     Err(e) => {

--- a/src/service/search/partition.rs
+++ b/src/service/search/partition.rs
@@ -158,9 +158,8 @@ impl PartitionGenerator {
         order_by: OrderBy,
         add_mini_partition: bool,
     ) -> Vec<[i64; 2]> {
-        let mini_partition_size = self.calculate_mini_partition_size(step);
-
         let mut partitions = if add_mini_partition {
+            let mini_partition_size = self.calculate_mini_partition_size(step);
             self.generate_histogram_aligned_partitions_with_mini(
                 start_time,
                 end_time,
@@ -190,13 +189,13 @@ impl PartitionGenerator {
         // Handle the alignment for the first and last partition
         let mut new_end = end_time;
         let last_partition_step = end_time % self.min_step;
-        if last_partition_step > 0 && duration > self.min_step * 3 {
+        if last_partition_step > 0 && duration > self.min_step {
             new_end = end_time - last_partition_step;
             partitions.push([new_end, end_time]);
         }
         let mut new_start = start_time;
         let last_partition_step = start_time % self.min_step;
-        if last_partition_step > 0 && duration > self.min_step * 3 {
+        if last_partition_step > 0 && duration > self.min_step {
             new_start = start_time + self.min_step - last_partition_step;
             partitions.push([start_time, new_start]);
         }

--- a/src/service/search/streaming/cache.rs
+++ b/src/service/search/streaming/cache.rs
@@ -45,8 +45,9 @@ pub async fn write_results_to_cache(
         return Ok(());
     }
 
+    let start = std::time::Instant::now();
     log::info!(
-        "[HTTP2_STREAM]: Writing results to file for trace_id: {}, file_path: {}, accumulated_results len: {}",
+        "[HTTP2_STREAM trace_id {}] Writing results to file: {}, accumulated_results len: {}",
         c_resp.trace_id,
         c_resp.file_path,
         accumulated_results.len()
@@ -104,9 +105,10 @@ pub async fn write_results_to_cache(
         )
         .await;
         log::info!(
-            "[HTTP2_STREAM]: Results written to file for trace_id: {}, file_path: {}",
+            "[HTTP2_STREAM trace_id {}] Results written to file: {}, async cache task created, took: {} ms",
             c_resp.trace_id,
             c_resp.file_path,
+            start.elapsed().as_millis()
         );
     }
 

--- a/src/service/search/streaming/execution.rs
+++ b/src/service/search/streaming/execution.rs
@@ -316,55 +316,6 @@ pub async fn do_partitioned_search(
         #[cfg(feature = "enterprise")]
         {
             let streaming_id = partition_resp.streaming_id.as_ref().unwrap();
-
-            // Delete mismatched-interval cache files BEFORE removing cache
-            // This ensures cache consistency - only files with the target interval are kept
-            // We do this before remove_cache() because we need GLOBAL_CACHE data
-            // Only runs when clear_cache is true (when overwrite_cache was requested)
-            //
-            // NOTE: There's a potential race condition if:
-            // - User1 refreshes cache with interval A (clear_cache=true)
-            // - User2 queries with interval B simultaneously
-            // - User2 might see partial results if deletion happens during cache discovery
-            if req.clear_cache {
-                // Get the cache file path and interval from GLOBAL_CACHE
-                if let Some(cache_file_path) = streaming_aggs_exec::GLOBAL_CACHE
-                    .id_cache
-                    .get_cache_file_path(streaming_id)
-                {
-                    let target_interval_mins =
-                        streaming_aggs_exec::GLOBAL_CACHE.get_cache_interval(streaming_id);
-
-                    if target_interval_mins > 0 {
-                        use o2_enterprise::enterprise::search::cache::streaming_agg::delete_mismatched_interval_cache_files;
-
-                        match delete_mismatched_interval_cache_files(
-                            streaming_id,
-                            &cache_file_path,
-                            modified_start_time,
-                            modified_end_time,
-                            target_interval_mins,
-                        )
-                        .await
-                        {
-                            Ok(deleted_count) => {
-                                if deleted_count > 0 {
-                                    log::info!(
-                                        "[trace_id: {trace_id}] [streaming_id: {streaming_id}] Successfully deleted {deleted_count} mismatched-interval cache files (target_interval: {target_interval_mins}min)"
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                log::warn!(
-                                    "[trace_id: {trace_id}] [streaming_id: {streaming_id}] Failed to delete mismatched-interval cache files: {e:?}"
-                                );
-                                // Don't fail the query if cleanup fails
-                            }
-                        }
-                    }
-                }
-            }
-
             streaming_aggs_exec::remove_cache(streaming_id)
         }
     }
@@ -499,9 +450,10 @@ pub async fn process_delta(
     }
 
     log::info!(
-        "[HTTP2_STREAM] Found {} partitions for trace_id: {}",
+        "[HTTP2_STREAM] Found {} partitions for trace_id: {}, partitions: {:?}",
         partitions.len(),
-        trace_id
+        trace_id,
+        &partitions
     );
 
     // for dashboards & histograms, expect for ui

--- a/src/service/search/streaming/mod.rs
+++ b/src/service/search/streaming/mod.rs
@@ -81,7 +81,7 @@ pub async fn process_search_stream_request(
     is_multi_stream_search: bool,
     extract_patterns: bool,
 ) {
-    log::debug!(
+    log::info!(
         "[HTTP2_STREAM trace_id {trace_id}] Received HTTP/2 stream request for org_id: {org_id}",
     );
 
@@ -294,10 +294,7 @@ pub async fn process_search_stream_request(
             // set max_query_range to `end_time - start_time` as hour if it is 0, to ensure
             // unlimited query range for cache only search
             let remaining_query_range = if max_query_range == 0 {
-                std::cmp::max(
-                    1,
-                    (req.query.end_time - req.query.start_time) / hour_micros(1),
-                )
+                (req.query.end_time - req.query.start_time) / hour_micros(1) + 1
             } else {
                 max_query_range
             }; // hours
@@ -460,6 +457,10 @@ pub async fn process_search_stream_request(
                 return;
             }
         }
+        log::info!(
+            "[HTTP2_STREAM trace_id {trace_id}] search is done, took: {} ms",
+            start.elapsed().as_millis()
+        );
         // Step 3: Write to results cache
         // cache only if from is 0 and is not an aggregate_query
         if req.query.from == 0


### PR DESCRIPTION
- [x] fix: result cache metadata for histogram
- [x] fix: partition generate for histogram
- [x] fix: cache filter for histogram
- [x] feat: no longer delete agg cache file, the solution is only use agg cache file which interval not greater than search interval