### PR TITLE
fix: temp disable datafusion topk optimizer[branch-30]

### DIFF
--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -417,6 +417,9 @@ pub fn create_session_config(
         config = config.set_bool("datafusion.execution.split_file_groups_by_statistics", true);
     }
 
+    // due to: https://github.com/apache/datafusion/issues/19219
+    config = config.set_bool("datafusion.optimizer.enable_topk_aggregation", false);
+
     // When set to true, skips verifying that the schema produced by planning the input of
     // `LogicalPlan::Aggregate` exactly matches the schema of the input plan.
     config = config.set_bool(


### PR DESCRIPTION
This is a datafusion bug will cause the query error: 
```
SELECT item, max(abc) as i2 from t group by item order by i2 LIMIT 1
```
abc's data type is string