### PR TITLE
test: add INTERSECT and EXCEPT query tests for PR #9544

### DIFF
--- a/tests/api-testing/tests/test_joinqueries.py
+++ b/tests/api-testing/tests/test_joinqueries.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+import time
 from datetime import datetime, timezone, timedelta
 
 # Load queries from the queries.json file
@@ -43,6 +44,9 @@ def test_e2e_join_queries(create_session, base_url, test_name, sql_query):
         f"{url}api/{org_id}/{stream_name_orders}/_json", json=orders_payload
     )
     assert resp_create_orders_logstream.status_code == 200, f"Failed to ingest orders data: {resp_create_orders_logstream.content}"
+
+    # Wait for data to be indexed
+    time.sleep(3)
 
     # Define time range for the query
     now = datetime.now(timezone.utc)

--- a/tests/test-data/joinqueries.json
+++ b/tests/test-data/joinqueries.json
@@ -39,6 +39,21 @@
     {
         "test_name": "Total Orders Query",
         "sql_query": "WITH total AS (SELECT COUNT(*) AS total_count FROM orders) SELECT u1.name, u1.status, o.amount, total.total_count AS total_orders FROM u1 JOIN orders o ON u1.user_id = o.user_id CROSS JOIN total"
+    },
+    {
+        "test_name": "INTERSECT query: Common user_ids in both streams",
+        "sql_query": "SELECT user_id FROM \"u1\" INTERSECT SELECT user_id FROM \"orders\""
+    },
+    {
+        "test_name": "EXCEPT query: Users without orders",
+        "sql_query": "SELECT user_id FROM \"u1\" EXCEPT SELECT user_id FROM \"orders\""
+    },
+    {
+        "test_name": "INTERSECT with WHERE clause: Active users with orders",
+        "sql_query": "SELECT user_id FROM \"u1\" WHERE status = 'active' INTERSECT SELECT user_id FROM \"orders\""
+    },
+    {
+        "test_name": "EXCEPT with multiple columns: Users details without orders",
+        "sql_query": "SELECT user_id, name FROM \"u1\" EXCEPT SELECT user_id, 'placeholder' FROM \"orders\""
     }
   ]
-  


### PR DESCRIPTION
Added 4 new test cases to verify the join optimization fix:
- INTERSECT query: Common user_ids in both streams
- EXCEPT query: Users without orders
- INTERSECT with WHERE clause: Active users with orders
- EXCEPT with multiple columns: Users details without orders

Also improved test_joinqueries.py by adding a 3-second sleep after data ingestion to allow proper indexing before querying.

