### PR TITLE
fix: allow merge files for the job which have no file

### DIFF
--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -24,7 +24,6 @@ use config::{
         cluster::{CompactionJobType, Role},
         stream::{ALL_STREAM_TYPES, PartitionTimeLevel, StreamType},
     },
-    utils::time::hour_micros,
 };
 use infra::{
     file_list as infra_file_list,
@@ -360,19 +359,6 @@ pub async fn run_merge(job_tx: mpsc::Sender<worker::MergeJob>) -> Result<(), any
     let mut need_release_ids = Vec::new();
     let mut need_done_ids = Vec::new();
     for job in jobs.iter() {
-        // check stream stats offset, if the merge offset greater than the stream stats offset, we
-        // need to wait for the stream stats to be updated first
-        if job.offsets + hour_micros(1) > stream_stats_offset {
-            // simple skip and don't release it, because release will cause it retry immediately, if
-            // we skip it, it need to wait for 10 minutes
-            log::warn!(
-                "[COMPACTOR] merge job stream {}, offset {}, skipped, it needs to wait stream_stats offset: {stream_stats_offset}",
-                job.stream,
-                job.offsets
-            );
-            continue;
-        }
-
         let columns = job.stream.split('/').collect::<Vec<&str>>();
         assert_eq!(columns.len(), 3);
         let org_id = columns[0].to_string();
@@ -486,6 +472,7 @@ pub async fn run_merge(job_tx: mpsc::Sender<worker::MergeJob>) -> Result<(), any
                 stream_name: stream_name.to_string(),
                 job_id: job.id,
                 offset: job.offsets,
+                stats_offset: stream_stats_offset,
             })
             .await
         {

--- a/src/service/compact/worker.rs
+++ b/src/service/compact/worker.rs
@@ -44,6 +44,7 @@ pub struct MergeJob {
     pub stream_name: String,
     pub job_id: i64,
     pub offset: i64,
+    pub stats_offset: i64,
 }
 
 /// JobScheduler is a worker that processes jobs
@@ -118,6 +119,7 @@ impl JobScheduler {
                                 &job.stream_name,
                                 job.job_id,
                                 job.offset,
+                                job.stats_offset,
                             )
                             .await
                             {


### PR DESCRIPTION
There is a bug in previous PR, it can't be done a merge job if there is no data.