### PR TITLE
fix(e2e): resolve histogram bar chart canvas click timeout

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -1587,7 +1587,8 @@ export class LogsPage {
                 // Wait for chart to stabilize - ECharts may re-render multiple times
                 await this.page.waitForTimeout(2000);
 
-                // Click with force:true to bypass actionability checks
+                // force:true required for ECharts canvas - canvas elements are interactive
+                // but fail Playwright's actionability checks (no pointer-events in traditional sense)
                 await canvasLocator.click({
                     position: { x: 182, y: 66 },
                     force: true,

--- a/tests/ui-testing/playwright-tests/Logs/logsqueries.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/logsqueries.spec.js
@@ -334,13 +334,15 @@ test.describe("Logs Queries testcases", () => {
 
     // Click refresh and wait for network to settle
     await pm.logsPage.clickRefreshButton();
-    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await page.waitForLoadState('networkidle', { timeout: 30000 })
+      .catch((e) => testLogger.debug('networkidle timeout (non-blocking)', { error: e.message }));
     await pm.logsPage.waitForTimeout(2000);
 
     // Toggle SQL mode and refresh
     await pm.logsPage.clickSQLModeToggle();
     await pm.logsPage.clickRefreshButton();
-    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await page.waitForLoadState('networkidle', { timeout: 30000 })
+      .catch((e) => testLogger.debug('networkidle timeout (non-blocking)', { error: e.message }));
     await pm.logsPage.waitForTimeout(2000);
 
     // Verify bar chart is visible in SQL mode then click
@@ -350,7 +352,8 @@ test.describe("Logs Queries testcases", () => {
     // Toggle SQL mode off and refresh
     await pm.logsPage.clickSQLModeToggle();
     await pm.logsPage.clickRefreshButton();
-    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await page.waitForLoadState('networkidle', { timeout: 30000 })
+      .catch((e) => testLogger.debug('networkidle timeout (non-blocking)', { error: e.message }));
     await pm.logsPage.waitForTimeout(2000);
 
     // Verify bar chart is visible in non-SQL mode then click


### PR DESCRIPTION
## Summary
- Fix TimeoutError in `logsqueries.spec.js` histogram bar chart test caused by ECharts canvas DOM re-rendering
- Add retry mechanism to `clickBarChartCanvas()` to handle canvas element detachment
- Add proper assertions using page object pattern

## Changes
- **logsPage.js**: Added retry mechanism (3 attempts) with network idle wait and stabilization delay
- **logsPage.js**: Added `expectBarChartCanvasVisible()` assertion method
- **logsqueries.spec.js**: Ensure histogram toggle is ON before test
- **logsqueries.spec.js**: Use `waitForLoadState('networkidle')` for reliability
- **logsqueries.spec.js**: Add visibility assertions before clicking canvas

## Test plan
- [x] Test passes locally
- [x] Test passes on repeat runs (verified with `--repeat-each=2`)
- [x] Sentinel code quality audit passed