### PR TITLE
fix: dashboard custom chart query splitter

### DIFF
--- a/web/src/views/Dashboards/addPanel/AddPanel.vue
+++ b/web/src/views/Dashboards/addPanel/AddPanel.vue
@@ -602,7 +602,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 style="height: calc(100vh - 99px); overflow-y: auto"
               >
                 <div class="col scroll" style="height: 100%; display: flex; flex-direction: column;">
-                  <div style="height: 500px; flex-shrink: 0;">
+                  <div style="height: 500px; flex-shrink: 0; overflow: hidden;">
                     <q-splitter
                       class="query-editor-splitter"
                       v-model="splitterModel"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add overflow hidden to query editor container


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddPanel.vue</strong><dd><code>Hide overflow in splitter container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/Dashboards/addPanel/AddPanel.vue

- Added `overflow: hidden` style to the fixed-height div


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9651/files#diff-c9632db1ad95af95aba10161bcbc7c5608318919f228637bdafae3f3a31267e8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

