### PR TITLE
fix: organizations ep permisions issue (#9667)

### DIFF
--- a/src/handler/http/auth/token.rs
+++ b/src/handler/http/auth/token.rs
@@ -101,7 +101,12 @@ pub async fn token_validator(
                             if all_users.is_empty() {
                                 None
                             } else {
-                                all_users.first().cloned()
+                                // For organizations/clusters endpoints, prioritize _meta org
+                                all_users
+                                    .iter()
+                                    .find(|u| u.org == config::META_ORG_ID)
+                                    .cloned()
+                                    .or_else(|| all_users.first().cloned())
                             }
                         }
                         Err(e) => {

--- a/src/handler/http/auth/validator.rs
+++ b/src/handler/http/auth/validator.rs
@@ -170,7 +170,13 @@ pub async fn validate_credentials(
                 if all_users.is_empty() {
                     None
                 } else {
-                    all_users.first().cloned()
+                    // For organizations endpoint, specifically look for user in _meta org
+                    // since permission check at line 966 expects the user to be in _meta
+                    all_users
+                        .iter()
+                        .find(|u| u.org == config::META_ORG_ID)
+                        .cloned()
+                        .or_else(|| all_users.first().cloned())
                 }
             }
             Err(e) => {
@@ -351,7 +357,13 @@ pub async fn validate_credentials_ext(
                 if all_users.is_empty() {
                     None
                 } else {
-                    all_users.first().cloned()
+                    // For organizations endpoint, specifically look for user in _meta org
+                    // since permission check at line 966 expects the user to be in _meta
+                    all_users
+                        .iter()
+                        .find(|u| u.org == config::META_ORG_ID)
+                        .cloned()
+                        .or_else(|| all_users.first().cloned())
                 }
             }
             Err(_) => None,


### PR DESCRIPTION

fixes: https://github.com/openobserve/openobserve/issues/9670


### **PR Type**
Bug fix


___

### **Description**
- Prioritize `META_ORG_ID` user in token validator

- Prioritize `META_ORG_ID` user in credentials validators

- Fallback to first available user when no META membership


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incoming request"] --> B["get_all_users()"]
  B --> C{"META_ORG_ID user exists?"}
  C -- "yes" --> D["Select META org user"]
  C -- "no" --> E["Select first user"]
  D --> F["Continue validation"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>token.rs</strong><dd><code>Prioritize META org user in token validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/auth/token.rs

<ul><li>Added logic to prioritize <code>META_ORG_ID</code> user<br> <li> Fallback to first user if META org missing<br> <li> Inserted explanatory comment for permission rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9669/files#diff-3339b4a964c121766ef87fcec0070f27a2b7085cf81281b53154e53d33cb28cf">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>validator.rs</strong><dd><code>Prioritize META org user in credentials validators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/auth/validator.rs

<ul><li>Applied META org prioritization logic<br> <li> Replaced <code>all_users.first()</code> with META find or fallback<br> <li> Updated both <code>validate_credentials</code> and <code>validate_credentials_ext</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9669/files#diff-f4d4b51574b378a8c372345ea48875834a4eadacfac33fa4d0ceca1e0ef96b35">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

