### PR TITLE
fix: add a lock fn to get metering lock in nats

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -85,9 +85,7 @@ async fn get_metering_lock() -> Result<Option<()>, infra::errors::Error> {
     if !LOCAL_NODE.is_alert_manager() {
         return Ok(None);
     }
-    use infra::dist_lock;
-
-    use crate::common::infra::cluster::get_node_by_uuid;
+    use infra::{cluster::get_node_by_uuid, dist_lock};
 
     let db = infra::db::get_db().await;
     let node = db


### PR DESCRIPTION
### **User description**
Adds changes required for metering changes


___

### **PR Type**
Enhancement


___

### **Description**
- Add `get_metering_lock` distributed locking function

- Restrict metering to alert manager nodes

- Integrate lock into `metering::init` call

- Use `infra::dist_lock` and DB key `/cloud/metering/node`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  init["init()"] --> init_call["metering::init(..., get_metering_lock)"]
  init_call --> get_lock["get_metering_lock()"]
  get_lock --> isAM["is_alert_manager()?"]
  isAM -- No --> endNone["return None"]
  isAM -- Yes --> readDB["read /cloud/metering/node"]
  readDB --> otherNode["node exists and alive?"]
  otherNode -- Yes --> endNone
  otherNode -- No --> lock["dist_lock.lock()"]
  lock --> writeDB["db.put(LOCAL_NODE.uuid)"]
  writeDB --> unlock["dist_lock.unlock()"]
  unlock --> endSome["return Some()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add distributed metering lock in job module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/job/mod.rs

<ul><li>Added async fn <code>get_metering_lock</code> under <code>#[cfg(feature = "cloud")]</code><br> <li> Check and enforce alert manager role before locking<br> <li> Use <code>infra::dist_lock</code> to acquire/release distributed lock<br> <li> Updated <code>init()</code> to pass <code>get_metering_lock</code> to <code>metering::init</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9679/files#diff-f2e4c29b8eef22189ec704a832633c4bd135a24444f054864c98064bd0963681">+58/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

