### PR TITLE
fix: applied function should be there for saved views

### DIFF
--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -2741,7 +2741,7 @@ export default defineComponent({
       searchObj.data.actionId = actionId.id;
     };
 
-    const populateFunctionImplementation = (fnValue, flag = false) => {
+    const populateFunctionImplementation = (fnValue, flag = false, openEditor = true) => {
       if (flag) {
         $q.notify({
           type: "positive",
@@ -2750,8 +2750,10 @@ export default defineComponent({
         });
       }
 
-      searchObj.meta.showTransformEditor = true;
-      searchObj.config.fnSplitterModel = 60;
+      if (openEditor) {
+        searchObj.meta.showTransformEditor = true;
+        searchObj.config.fnSplitterModel = 60;
+      }
       fnEditorRef?.value?.setValue(fnValue.function);
       searchObj.data.tempFunctionName = fnValue.name;
       searchObj.data.tempFunctionContent = fnValue.function;
@@ -2979,9 +2981,10 @@ export default defineComponent({
                 populateFunctionImplementation(
                   {
                     name: "",
-                    function: searchObj.data.tempFunctionContent,
+                    function: extractedObj.data.tempFunctionContent,
                   },
                   false,
+                  extractedObj.meta.showTransformEditor, // Use saved view's editor state
                 );
                 searchObj.data.tempFunctionContent =
                   extractedObj.data.tempFunctionContent;
@@ -2996,6 +2999,7 @@ export default defineComponent({
                     function: "",
                   },
                   false,
+                  extractedObj.meta.showTransformEditor, // No function content, so don't open editor
                 );
                 searchObj.data.tempFunctionContent = "";
                 searchObj.meta.functionEditorPlaceholderFlag = true;
@@ -3192,9 +3196,10 @@ export default defineComponent({
                 populateFunctionImplementation(
                   {
                     name: "",
-                    function: searchObj.data.tempFunctionContent,
+                    function: extractedObj.data.tempFunctionContent,
                   },
                   false,
+                  extractedObj.meta.showTransformEditor, // Use saved view's editor state
                 );
                 searchObj.data.tempFunctionContent =
                   extractedObj.data.tempFunctionContent;
@@ -3206,6 +3211,7 @@ export default defineComponent({
                     function: "",
                   },
                   false,
+                  false, // No function content, so don't open editor
                 );
                 searchObj.data.tempFunctionContent = "";
                 searchObj.meta.functionEditorPlaceholderFlag = true;
@@ -3225,7 +3231,8 @@ export default defineComponent({
               }
             }
 
-            if (searchObj.meta.toggleFunction == false) {
+            // Only reset function content if there's no function in the saved view
+            if (searchObj.meta.toggleFunction == false && !extractedObj.data.tempFunctionContent) {
               searchObj.config.fnSplitterModel = 100;
               resetFunctionContent();
             }


### PR DESCRIPTION
### **User description**
This PR fixes the issue in #9690


___

### **PR Type**
Bug fix


___

### **Description**
- Added `openEditor` flag to populateFunctionImplementation

- Conditionally show transform editor based on saved view

- Preserve saved view's editor open/closed state

- Prevent unintended function content reset


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SearchBar.vue</strong><dd><code>Support editor open state for saved views</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/SearchBar.vue

<ul><li>Added <code>openEditor</code> parameter to <code>populateFunctionImplementation</code><br> <li> Conditionally set <code>meta.showTransformEditor</code> and splitter<br> <li> Passed saved view's <code>meta.showTransformEditor</code> flag<br> <li> Refined reset logic for function content</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9713/files#diff-81893de4edf186b0556f610acb280c87baa2ffe67d3b48a60a866094c7635baf">+13/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

