### PR TITLE
fix: datetimepicker scroll issue fixed

### DIFF
--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -77,7 +77,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           >
             <div class="date-time-table relative column">
               <div
-                class="relative-row q-px-md q-py-sm"
+                class="relative-row q-pl-md q-py-sm"
                 v-for="(period, index) in relativePeriods"
                 :key="'date_' + index"
               >
@@ -212,8 +212,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       <q-input
                         v-model="selectedTime.startTime"
                         dense
-                        filled
+                        borderless
                         mask="fulltime"
+                        hide-bottom-space
                         :rules="['fulltime']"
                         @blur="
                           resetTime(
@@ -251,9 +252,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       <q-input
                         v-model="selectedTime.endTime"
                         dense
-                        filled
+                        borderless
                         mask="fulltime"
                         :rules="['fulltime']"
+                        hide-bottom-space
                         @blur="
                           resetTime(
                             selectedTime.startTime,
@@ -1333,8 +1335,10 @@ export default defineComponent({
   }
 }
 .startEndTime {
-  .q-field {
-    padding-bottom: 0.125rem;
+  margin: 0.5rem 0.4rem 0.3rem 0.4rem;
+  .q-field__control-container{
+    min-height: 32px;
+    height: 32px;
   }
   .label {
     font-size: 0.75rem;
@@ -1377,5 +1381,6 @@ export default defineComponent({
   .q-item:nth-child(2) {
     border-bottom: 1px solid #dcdcdc;
   }
+  margin: 0.5rem 0.4rem 0.5rem 0.4rem;
 }
 </style>


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Adjusted relative period row padding for scrolling

- Changed q-inputs to borderless and hid bottom space

- Refined startEndTime margins and field control height

- Added margins to timezone-select container


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateTime.vue</strong><dd><code>Style adjustments for DateTime component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/DateTime.vue

<ul><li>Updated <code>relative-row</code> class padding from <code>q-px-md</code> to <code>q-pl-md</code><br> <li> Switched <code>q-input</code> props: replaced <code>filled</code> with <code>borderless</code>, added <br><code>hide-bottom-space</code><br> <li> Removed <code>.q-field</code> padding, added margins and set <br><code>.q-field__control-container</code> height<br> <li> Added margin to <code>.timezone-select</code> styling</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9729/files#diff-c06c96ba750be6fc82f517a53ba809efff8aa619aba203b871d4d2aeb7f64f60">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

