### PR TITLE
test: use empty template in email destination import JSON

### DIFF
--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -21,24 +21,59 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     data-test="alert-list-page"
     class="q-pa-none flex flex-col"
   >
-    <div class="tw-w-full tw-px-[0.625rem] tw-mb-[0.625rem] q-pt-xs" v-if="!showAddAlertDialog && !showImportAlertDialog">
+    <div class="tw-w-full tw-h-[68px] tw-px-[0.625rem] tw-mb-[0.625rem] q-pt-xs" v-if="!showAddAlertDialog && !showImportAlertDialog">
       <div class="card-container">
         <div
           class="flex justify-between full-width tw-py-3 tw-px-4 items-center"
         >
-          <div class="q-table__title tw-font-[600]" data-test="alerts-list-title" >
-            {{ t("alerts.header") }}
+          <div class="tw-flex tw-items-center tw-gap-4">
+            <!-- Icon-only View Mode Tabs -->
+            <div class="view-mode-tabs">
+              <q-btn
+                flat
+                dense
+                :class="viewMode === 'alerts' ? 'active-tab' : 'inactive-tab'"
+                class="view-tab-btn"
+                @click="onViewModeChange('alerts')"
+                data-test="alerts-view-btn"
+              >
+                <q-icon name="notifications_active" size="18px" />
+                <q-tooltip>{{ t('alerts.header') }}</q-tooltip>
+              </q-btn>
+              <q-btn
+                flat
+                dense
+                :class="viewMode === 'incidents' ? 'active-tab' : 'inactive-tab'"
+                class="view-tab-btn"
+                @click="onViewModeChange('incidents')"
+                data-test="incidents-view-btn"
+              >
+                <q-icon name="crisis_alert" size="18px" />
+                <q-tooltip>{{ t('alerts.incidents.title') }}</q-tooltip>
+              </q-btn>
+            </div>
+
+            <!-- Page Title -->
+            <div
+              class="page-title tw-font-[600] tw-text-[20px]"
+              :data-test="viewMode === 'alerts' ? 'alerts-list-title' : 'incidents-list-title'"
+            >
+              {{ viewMode === 'alerts' ? t('alerts.header') : t('alerts.incidents.title') }}
+            </div>
           </div>
           <div class="flex q-ml-auto tw-ps-2 items-center">
-            <div class="app-tabs-container tw-h-[36px] q-mr-sm">
+            <!-- Tabs only visible in Alerts view -->
+            <div v-if="viewMode === 'alerts'" class="app-tabs-container tw-h-[36px] q-mr-sm">
               <app-tabs
               class="tabs-selection-container"
-              :tabs="tabs"
+              :tabs="alertTabs"
               v-model:active-tab="activeTab"
               @update:active-tab="filterAlertsByTab"
             />
             </div>
+            <!-- Search for Alerts view -->
             <q-input
+              v-if="viewMode === 'alerts'"
               v-model="dynamicQueryModel"
               dense
               borderless
@@ -50,14 +85,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               data-test="alert-list-search-input"
               :clearable="searchAcrossFolders"
               @clear="clearSearchHistory"
-
               class="o2-search-input"
             >
               <template #prepend>
                 <q-icon class="o2-search-input-icon" name="search" />
               </template>
             </q-input>
-            <div class="tw-mb-2">
+            <!-- Search for Incidents view -->
+            <q-input
+              v-if="viewMode === 'incidents'"
+              v-model="incidentSearchQuery"
+              dense
+              borderless
+              placeholder="Search incidents..."
+              data-test="incident-search-input"
+              clearable
+              class="o2-search-input"
+            >
+              <template #prepend>
+                <q-icon class="o2-search-input-icon" name="search" />
+              </template>
+            </q-input>
+            <!-- All Folders toggle (only for alerts view) -->
+            <div v-if="viewMode === 'alerts'" class="tw-mb-2">
               <q-toggle
                 data-test="alert-list-search-across-folders-toggle"
                 v-model="searchAcrossFolders"
@@ -85,16 +135,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             data-test="alert-insights-btn"
             icon="insights"
           />
+          <!-- Import button (only for alerts view) -->
           <q-btn
+            v-if="viewMode === 'alerts'"
             class="q-ml-sm o2-secondary-button tw-h-[36px]"
             no-caps
             flat
             :label="t(`dashboard.import`)"
             @click="importAlert"
             data-test="alert-import"
-
           />
+          <!-- Add Alert button (only for alerts view) -->
           <q-btn
+            v-if="viewMode === 'alerts'"
             data-test="alert-list-add-alert-btn"
             class="q-ml-sm o2-primary-button tw-h-[36px]"
             no-caps
@@ -112,7 +165,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       class="full-width alert-list-table"
       style="height: calc(100vh - 116px)"
     >
+      <!-- Incidents View (no folders) -->
+      <div v-if="viewMode === 'incidents'" class="tw-w-full tw-h-full tw-pr-[0.625rem] tw-pb-[0.625rem]">
+        <IncidentList :searchQuery="incidentSearchQuery" />
+      </div>
+
+      <!-- Alerts View (with folders) -->
       <q-splitter
+        v-else
         v-model="splitterModel"
         unit="px"
         :limits="[200, 500]"
@@ -132,11 +192,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <template #after>
           <div class="tw-w-full tw-h-full tw-pr-[0.625rem] tw-pb-[0.625rem]">
             <div class="tw-h-full card-container">
-              <!-- Incidents List (shown when incidents tab is active) -->
-              <IncidentList v-if="activeTab === 'incidents'" />
               <!-- Alert List Table -->
               <q-table
-                v-else
                 v-model:selected="selectedAlerts"
                 :selected-rows-label="getSelectedString"
                 selection="multiple"
@@ -204,12 +261,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       <template v-if="col.name === 'name'">
                         <div class="tw-flex tw-items-center tw-gap-1">
                           <span>{{ computedName(props.row[col.field]) }}</span>
-                          <O2AIContextAddBtn
-                            @sendToAiChat="openSREChat(props.row)"
-                            :size="'6px'"
-                            :imageHeight="'16px'"
-                            :imageWidth="'16px'"
-                          />
                         </div>
                         <q-tooltip
                           v-if="props.row[col.field]?.length > 30"
@@ -1090,11 +1141,36 @@ export default defineComponent({
 
     const activeFolderToMove = ref("default");
 
+    // Initialize viewMode from URL query parameter
+    const viewMode = ref(
+      (router.currentRoute.value.query.view as string) === "incidents" ? "incidents" : "alerts"
+    );
+
     // Initialize activeTab from URL query parameter, default to "all"
     const activeTab = ref(
       (router.currentRoute.value.query.tab as string) || "all"
     );
 
+    // Incident search query
+    const incidentSearchQuery = ref("");
+
+    // Tabs for alerts view only (removed incidents tab)
+    const alertTabs = reactive([
+      {
+        label: t("alerts.all"),
+        value: "all",
+      },
+      {
+        label: t("alerts.scheduled"),
+        value: "scheduled",
+      },
+      {
+        label: t("alerts.realTime"),
+        value: "realTime",
+      },
+    ]);
+
+    // Keep old tabs for backward compatibility if needed
     const tabs = reactive([
       {
         label: t("alerts.all"),
@@ -1113,6 +1189,26 @@ export default defineComponent({
         value: "incidents",
       },
     ]);
+
+    const onViewModeChange = (newMode: string) => {
+      // Update viewMode immediately
+      viewMode.value = newMode;
+
+      // Update URL query parameter
+      router.push({
+        query: {
+          ...router.currentRoute.value.query,
+          view: newMode,
+          // Reset tab to 'all' when switching to alerts view
+          tab: newMode === "alerts" ? "all" : undefined,
+        },
+      });
+
+      // Reset active tab when switching to alerts view
+      if (newMode === "alerts") {
+        activeTab.value = "all";
+      }
+    };
 
     const columns = computed(() => {
       const baseColumns: any = [
@@ -2573,6 +2669,10 @@ export default defineComponent({
       computedName,
       computedOwner,
       tabs,
+      alertTabs,
+      viewMode,
+      onViewModeChange,
+      incidentSearchQuery,
       filterAlertsByTab,
       showHistoryDrawer,
       selectedHistoryAlertId,
@@ -2592,6 +2692,75 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
+.view-mode-tabs {
+  display: flex;
+  gap: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  padding: 4px;
+
+  .view-tab-btn {
+    min-width: 32px;
+    min-height: 32px;
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+    transition: all 0.2s ease;
+
+    &.active-tab {
+      background: var(--q-primary);
+      color: white;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+
+      .q-icon {
+        color: white;
+      }
+    }
+
+    &.inactive-tab {
+      color: rgba(0, 0, 0, 0.54);
+
+      &:hover {
+        background: rgba(0, 0, 0, 0.04);
+      }
+
+      .q-icon {
+        color: rgba(0, 0, 0, 0.54);
+      }
+    }
+  }
+}
+
+.page-title {
+  color: rgba(0, 0, 0, 0.87);
+  line-height: 1.2;
+}
+
+// Dark mode support
+.body--dark {
+  .view-mode-tabs {
+    border-color: rgba(255, 255, 255, 0.12);
+
+    .view-tab-btn {
+      &.inactive-tab {
+        color: rgba(255, 255, 255, 0.7);
+
+        &:hover {
+          background: rgba(255, 255, 255, 0.12);
+        }
+
+        .q-icon {
+          color: rgba(255, 255, 255, 0.7);
+        }
+      }
+    }
+  }
+
+  .page-title {
+    color: rgba(255, 255, 255, 0.87);
+  }
+}
+
 .bottom-btn {
   display: flex;
   width: 100%;

--- a/web/src/components/alerts/IncidentList.spec.ts
+++ b/web/src/components/alerts/IncidentList.spec.ts
@@ -123,8 +123,9 @@ describe("IncidentList.vue", () => {
       expect(incidentsService.list).toHaveBeenCalledWith(
         "default",
         undefined,
-        25,
-        0
+        1000,
+        0,
+        undefined
       );
       expect(wrapper.vm.incidents).toHaveLength(3);
     });
@@ -136,7 +137,7 @@ describe("IncidentList.vue", () => {
         sortBy: "last_alert_at",
         descending: true,
         page: 1,
-        rowsPerPage: 25,
+        rowsPerPage: 20,
         rowsNumber: 0,
       });
     });
@@ -411,19 +412,17 @@ describe("IncidentList.vue", () => {
         pagination: {
           page: 2,
           rowsPerPage: 50,
+          sortBy: "last_alert_at",
+          descending: true,
         },
+        searchQuery: "",
       };
 
       await wrapper.vm.onRequest(props);
 
       expect(wrapper.vm.pagination.page).toBe(2);
       expect(wrapper.vm.pagination.rowsPerPage).toBe(50);
-      expect(incidentsService.list).toHaveBeenCalledWith(
-        "default",
-        undefined,
-        50,
-        50
-      );
+      // onRequest no longer calls API, it just filters FE data
     });
 
     it("should handle rows per page change", async () => {
@@ -736,14 +735,14 @@ describe("IncidentList.vue", () => {
     });
 
     it("should have correct number of columns", () => {
-      expect(wrapper.vm.columns).toHaveLength(6);
+      expect(wrapper.vm.columns).toHaveLength(7);
     });
 
     it("should have status column with correct config", () => {
       const statusCol = wrapper.vm.columns.find((c: any) => c.name === "status");
 
       expect(statusCol).toBeDefined();
-      expect(statusCol.sortable).toBe(true);
+      expect(statusCol.sortable).toBe(false);
       expect(statusCol.field).toBe("status");
     });
 
@@ -751,7 +750,7 @@ describe("IncidentList.vue", () => {
       const severityCol = wrapper.vm.columns.find((c: any) => c.name === "severity");
 
       expect(severityCol).toBeDefined();
-      expect(severityCol.sortable).toBe(true);
+      expect(severityCol.sortable).toBe(false);
       expect(severityCol.field).toBe("severity");
     });
 
@@ -921,8 +920,9 @@ describe("IncidentList.vue", () => {
       expect(incidentsService.list).toHaveBeenCalledWith(
         "custom-org",
         undefined,
-        25,
-        0
+        1000,
+        0,
+        undefined
       );
     });
 

--- a/web/src/components/alerts/IncidentList.vue
+++ b/web/src/components/alerts/IncidentList.vue
@@ -15,234 +15,122 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div data-test="incident-list" class="q-pa-none flex flex-col tw-h-full">
+  <div data-test="incident-list" class="tw-w-full tw-h-full tw-pl-[0.625rem] tw-pb-[0.625rem]">
     <!-- Incidents table -->
-    <div class="tw-flex-1 tw-overflow-auto">
-      <q-table
-        v-model:pagination="pagination"
-        :rows="filteredIncidents"
-        :columns="columns"
-        :loading="loading"
-        row-key="id"
-        flat
-        bordered
-        :rows-per-page-options="[10, 25, 50, 100]"
-        class="incident-table"
-        data-test="incident-list-table"
-        @request="onRequest"
-      >
-        <!-- Custom header for Status column with filter -->
-        <template v-slot:header-cell-status="props">
-          <q-th :props="props" class="cursor-pointer">
-            <div class="tw-flex tw-items-center tw-gap-1">
-              <span>{{ props.col.label }}</span>
-              <q-btn
-                flat
-                dense
-                round
-                size="xs"
-                icon="filter_list"
-                :color="statusFilter.length > 0 ? 'primary' : 'grey-7'"
-              >
-                <q-menu>
-                  <q-list style="min-width: 150px">
-                    <q-item
-                      v-for="option in statusOptions"
-                      :key="option"
-                      clickable
-                      v-close-popup
-                      @click="toggleStatusFilter(option)"
-                    >
-                      <q-item-section side>
-                        <q-checkbox
-                          :model-value="statusFilter.includes(option)"
-                          @update:model-value="toggleStatusFilter(option)"
-                        />
-                      </q-item-section>
-                      <q-item-section>
-                        <q-badge
-                          :color="getStatusColor(option)"
-                          :label="getStatusLabel(option)"
-                        />
-                      </q-item-section>
-                    </q-item>
-                    <q-separator v-if="statusFilter.length > 0" />
-                    <q-item
-                      v-if="statusFilter.length > 0"
-                      clickable
-                      v-close-popup
-                      @click="clearStatusFilter"
-                    >
-                      <q-item-section class="text-primary">
-                        Clear Filter
-                      </q-item-section>
-                    </q-item>
-                  </q-list>
-                </q-menu>
-              </q-btn>
-            </div>
-          </q-th>
-        </template>
-
-        <!-- Custom header for Severity column with filter -->
-        <template v-slot:header-cell-severity="props">
-          <q-th :props="props" class="cursor-pointer">
-            <div class="tw-flex tw-items-center tw-gap-1">
-              <span>{{ props.col.label }}</span>
-              <q-btn
-                flat
-                dense
-                round
-                size="xs"
-                icon="filter_list"
-                :color="severityFilter.length > 0 ? 'primary' : 'grey-7'"
-              >
-                <q-menu>
-                  <q-list style="min-width: 150px">
-                    <q-item
-                      v-for="option in severityOptions"
-                      :key="option"
-                      clickable
-                      v-close-popup
-                      @click="toggleSeverityFilter(option)"
-                    >
-                      <q-item-section side>
-                        <q-checkbox
-                          :model-value="severityFilter.includes(option)"
-                          @update:model-value="toggleSeverityFilter(option)"
-                        />
-                      </q-item-section>
-                      <q-item-section>
-                        <q-badge
-                          :color="getSeverityColor(option)"
-                          :label="option"
-                        />
-                      </q-item-section>
-                    </q-item>
-                    <q-separator v-if="severityFilter.length > 0" />
-                    <q-item
-                      v-if="severityFilter.length > 0"
-                      clickable
-                      v-close-popup
-                      @click="clearSeverityFilter"
-                    >
-                      <q-item-section class="text-primary">
-                        Clear Filter
-                      </q-item-section>
-                    </q-item>
-                  </q-list>
-                </q-menu>
-              </q-btn>
-            </div>
-          </q-th>
-        </template>
-        <!-- Status column -->
-        <template v-slot:body-cell-status="props">
-          <q-td :props="props">
-            <q-badge
-              :color="getStatusColor(props.row.status)"
-              :label="getStatusLabel(props.row.status)"
-            />
-          </q-td>
-        </template>
-
-        <!-- Severity column -->
-        <template v-slot:body-cell-severity="props">
-          <q-td :props="props">
-            <q-badge
-              :color="getSeverityColor(props.row.severity)"
-              :label="props.row.severity"
-            />
-          </q-td>
-        </template>
-
-        <!-- Title column -->
-        <template v-slot:body-cell-title="props">
-          <q-td :props="props">
-            <div class="tw-flex tw-items-center tw-gap-1">
-              <span class="tw-font-medium">
-                {{ props.row.title || formatDimensions(props.row.stable_dimensions) }}
-              </span>
-              <O2AIContextAddBtn
-                @sendToAiChat="openSREChat(props.row)"
-                :size="'6px'"
-                :imageHeight="'16px'"
-                :imageWidth="'16px'"
-              />
-            </div>
-          </q-td>
-        </template>
-
-        <!-- Alert count column -->
-        <template v-slot:body-cell-alert_count="props">
-          <q-td :props="props">
-            <q-badge color="grey-7" :label="props.row.alert_count" />
-          </q-td>
-        </template>
-
-        <!-- Last alert column -->
-        <template v-slot:body-cell-last_alert_at="props">
-          <q-td :props="props">
-            {{ formatTimestamp(props.row.last_alert_at) }}
-          </q-td>
-        </template>
-
-        <!-- Actions column -->
-        <template v-slot:body-cell-actions="props">
-          <q-td :props="props">
-            <q-btn
-              flat
-              dense
-              round
-              icon="visibility"
-              @click="viewIncident(props.row)"
-              data-test="incident-view-btn"
+    <div class="tw-w-full tw-h-full tw-pb-[0.625rem]">
+      <div class="card-container tw-h-[calc(100vh-127px)]">
+        <q-table
+          ref="qTableRef"
+          v-model:pagination="pagination"
+          :rows="loading ? [] : incidents"
+          :columns="columns"
+          :loading="loading"
+          row-key="id"
+          :rows-per-page-options="perPageOptions.map((opt: any) => opt.value)"
+          style="width: 100%"
+          :style="!loading && incidents.length > 0
+            ? 'width: 100%; height: calc(100vh - 127px)'
+            : 'width: 100%'"
+          class="o2-quasar-table o2-row-md o2-quasar-table-header-sticky"
+          data-test="incident-list-table"
+          @request="onRequest"
+        >
+        <!-- Custom body template for clickable rows -->
+        <template v-slot:body="props">
+          <q-tr
+            :props="props"
+            style="cursor: pointer"
+            @click="viewIncident(props.row)"
+            data-test="incident-row"
+          >
+            <q-td
+              v-for="col in props.cols"
+              :key="col.name"
+              :props="props"
             >
-              <q-tooltip>{{ t("alerts.incidents.viewDetails") }}</q-tooltip>
-            </q-btn>
-            <q-btn
-              v-if="props.row.status === 'open'"
-              flat
-              dense
-              round
-              icon="check_circle_outline"
-              color="warning"
-              @click="acknowledgeIncident(props.row)"
-              data-test="incident-ack-btn"
-            >
-              <q-tooltip>{{ t("alerts.incidents.acknowledge") }}</q-tooltip>
-            </q-btn>
-            <q-btn
-              v-if="props.row.status !== 'resolved'"
-              flat
-              dense
-              round
-              icon="done_all"
-              color="positive"
-              @click="resolveIncident(props.row)"
-              data-test="incident-resolve-btn"
-            >
-              <q-tooltip>{{ t("alerts.incidents.resolve") }}</q-tooltip>
-            </q-btn>
-            <q-btn
-              v-if="props.row.status === 'resolved'"
-              flat
-              dense
-              round
-              icon="replay"
-              color="negative"
-              @click="reopenIncident(props.row)"
-              data-test="incident-reopen-btn"
-            >
-              <q-tooltip>{{ t("alerts.incidents.reopen") }}</q-tooltip>
-            </q-btn>
-          </q-td>
+              <template v-if="col.name === 'index'">
+                {{ (pagination.page - 1) * pagination.rowsPerPage + props.pageIndex + 1 }}
+              </template>
+              <template v-else-if="col.name === 'status'">
+                <q-badge
+                  :color="getStatusColor(props.row.status)"
+                  :label="getStatusLabel(props.row.status)"
+                />
+              </template>
+              <template v-else-if="col.name === 'severity'">
+                <q-badge
+                  :color="getSeverityColor(props.row.severity)"
+                  :label="props.row.severity"
+                />
+              </template>
+              <template v-else-if="col.name === 'title'">
+                <div class="tw-flex tw-items-center tw-gap-1">
+                  <span class="tw-font-medium">
+                    {{ props.row.title || formatDimensions(props.row.stable_dimensions) }}
+                  </span>
+                </div>
+              </template>
+              <template v-else-if="col.name === 'alert_count'">
+                {{ props.row.alert_count }}
+              </template>
+              <template v-else-if="col.name === 'last_alert_at'">
+                {{ formatTimestamp(props.row.last_alert_at) }}
+              </template>
+              <template v-else-if="col.name === 'actions'">
+                <div class="tw-flex tw-justify-center">
+                  <q-btn
+                    v-if="props.row.status === 'open'"
+                    flat
+                    dense
+                    round
+                    icon="check_circle_outline"
+                    color="warning"
+                    @click.stop="acknowledgeIncident(props.row)"
+                    data-test="incident-ack-btn"
+                  >
+                    <q-tooltip>{{ t("alerts.incidents.acknowledge") }}</q-tooltip>
+                  </q-btn>
+                  <q-btn
+                    v-if="props.row.status !== 'resolved'"
+                    flat
+                    dense
+                    round
+                    icon="done_all"
+                    color="positive"
+                    @click.stop="resolveIncident(props.row)"
+                    data-test="incident-resolve-btn"
+                  >
+                    <q-tooltip>{{ t("alerts.incidents.resolve") }}</q-tooltip>
+                  </q-btn>
+                  <q-btn
+                    v-if="props.row.status === 'resolved'"
+                    flat
+                    dense
+                    round
+                    icon="replay"
+                    color="negative"
+                    @click.stop="reopenIncident(props.row)"
+                    data-test="incident-reopen-btn"
+                  >
+                    <q-tooltip>{{ t("alerts.incidents.reopen") }}</q-tooltip>
+                  </q-btn>
+                </div>
+              </template>
+            </q-td>
+          </q-tr>
+        </template>
+
+        <!-- Loading state -->
+        <template #loading>
+          <div class="tw-flex tw-items-center tw-justify-center tw-py-20">
+            <q-spinner-hourglass color="primary" size="3rem" />
+          </div>
         </template>
 
         <!-- Empty state -->
-        <template v-slot:no-data>
-          <div class="tw-text-center tw-py-8 tw-text-gray-500">
-            {{ t("alerts.incidents.noIncidents") }}
+        <template #no-data>
+          <div v-if="!loading" class="tw-flex tw-items-center tw-justify-center tw-w-full tw-h-full">
+            <no-data />
           </div>
         </template>
 
@@ -256,12 +144,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :scope="scope"
               :position="'bottom'"
               :resultTotal="pagination.rowsNumber"
-              :perPageOptions="[10, 25, 50, 100]"
+              :perPageOptions="perPageOptions"
               @update:changeRecordPerPage="changePagination"
             />
           </div>
         </template>
-      </q-table>
+        </q-table>
+      </div>
     </div>
 
     <!-- Incident detail drawer -->
@@ -281,7 +170,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, onMounted } from "vue";
+import { defineComponent, ref, computed, onMounted, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useStore } from "vuex";
 import { useQuasar } from "quasar";
@@ -290,6 +179,7 @@ import incidentsService, { Incident } from "@/services/incidents";
 import IncidentDetailDrawer from "./IncidentDetailDrawer.vue";
 import QTablePagination from "@/components/shared/grid/Pagination.vue";
 import O2AIContextAddBtn from "@/components/common/O2AIContextAddBtn.vue";
+import NoData from "../shared/grid/NoData.vue";
 
 export default defineComponent({
   name: "IncidentList",
@@ -297,14 +187,23 @@ export default defineComponent({
     IncidentDetailDrawer,
     QTablePagination,
     O2AIContextAddBtn,
+    NoData,
   },
-  setup() {
+  props: {
+    searchQuery: {
+      type: String,
+      default: "",
+    },
+  },
+  setup(props) {
     const { t } = useI18n();
     const store = useStore();
     const $q = useQuasar();
 
+    const qTableRef: any = ref(null);
     const loading = ref(false);
     const incidents = ref<Incident[]>([]);
+    const allIncidents = ref<Incident[]>([]); // Store all incidents for FE filtering
     const showDetailDrawer = ref(false);
     const selectedIncident = ref<Incident | null>(null);
 
@@ -316,7 +215,7 @@ export default defineComponent({
       sortBy: "last_alert_at",
       descending: true,
       page: 1,
-      rowsPerPage: 25,
+      rowsPerPage: 20,
       rowsNumber: 0,
     });
 
@@ -324,9 +223,18 @@ export default defineComponent({
     const statusOptions = ["open", "acknowledged", "resolved"];
     const severityOptions = ["P1", "P2", "P3", "P4"];
 
-    // Filtered incidents based on active filters
+    // Pagination options
+    const perPageOptions: any = [
+      { label: "20", value: 20 },
+      { label: "50", value: 50 },
+      { label: "100", value: 100 },
+      { label: "250", value: 250 },
+      { label: "500", value: 500 },
+    ];
+
+    // Computed property for filtered incidents (used by tests and for consistency)
     const filteredIncidents = computed(() => {
-      let filtered = incidents.value;
+      let filtered = allIncidents.value;
 
       // Apply status filter
       if (statusFilter.value.length > 0) {
@@ -347,12 +255,20 @@ export default defineComponent({
 
     const columns = computed(() => [
       {
+        name: "index",
+        label: "#",
+        field: "index",
+        align: "center" as const,
+        style: "width: 67px;",
+        sortable: false,
+      },
+      {
         name: "status",
         label: t("alerts.incidents.status"),
         field: "status",
         align: "left" as const,
         style: "width: 120px",
-        sortable: true,
+        sortable: false,
       },
       {
         name: "severity",
@@ -360,7 +276,7 @@ export default defineComponent({
         field: "severity",
         align: "left" as const,
         style: "width: 100px",
-        sortable: true,
+        sortable: false,
       },
       {
         name: "title",
@@ -388,26 +304,80 @@ export default defineComponent({
         label: t("alerts.incidents.actions"),
         field: "actions",
         align: "center" as const,
-        style: "width: 150px",
+        style: "width: 200px",
       },
     ]);
+
+    // Frontend search filter function
+    const applyFrontendSearch = (incidentsList: Incident[], searchQuery: string) => {
+      if (!searchQuery || searchQuery.trim() === "") {
+        return incidentsList;
+      }
+
+      const query = searchQuery.toLowerCase().trim();
+
+      return incidentsList.filter((incident) => {
+        // Search in title
+        const title = incident.title || formatDimensions(incident.stable_dimensions);
+        if (title.toLowerCase().includes(query)) {
+          return true;
+        }
+
+        // Search in status
+        const statusLabel = getStatusLabel(incident.status).toLowerCase();
+        if (statusLabel.includes(query) || incident.status.toLowerCase().includes(query)) {
+          return true;
+        }
+
+        // Search in severity
+        if (incident.severity.toLowerCase().includes(query)) {
+          return true;
+        }
+
+        // Search in stable dimensions (key-value pairs)
+        if (incident.stable_dimensions) {
+          const dimensionsStr = Object.entries(incident.stable_dimensions)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(" ")
+            .toLowerCase();
+          if (dimensionsStr.includes(query)) {
+            return true;
+          }
+        }
+
+        return false;
+      });
+    };
 
     const loadIncidents = async () => {
       loading.value = true;
       try {
         const org = store.state.selectedOrganization.identifier;
-        const limit = pagination.value.rowsPerPage;
-        const offset = (pagination.value.page - 1) * limit;
+        // Load all incidents for now (can be paginated when BE supports it)
+        const limit = 1000; // Large limit for FE filtering
+        const offset = 0;
+        // Keep keyword parameter for future BE implementation
+        const keyword = undefined; // props.searchQuery?.trim() || undefined;
 
         const response = await incidentsService.list(
           org,
-          undefined,  // No status filter passed to API (filtering done client-side)
+          undefined,  // Status filter to be added when API supports it
           limit,
-          offset
+          offset,
+          keyword
         );
 
-        incidents.value = response.data.incidents;
-        pagination.value.rowsNumber = response.data.total;
+        // Store all incidents
+        allIncidents.value = response.data.incidents;
+
+        // Apply frontend search filter
+        const filteredIncidents = applyFrontendSearch(allIncidents.value, props.searchQuery);
+
+        // Apply pagination on filtered results
+        const startIndex = (pagination.value.page - 1) * pagination.value.rowsPerPage;
+        const endIndex = startIndex + pagination.value.rowsPerPage;
+        incidents.value = filteredIncidents.slice(startIndex, endIndex);
+        pagination.value.rowsNumber = filteredIncidents.length;
       } catch (error: any) {
         $q.notify({
           type: "negative",
@@ -419,10 +389,18 @@ export default defineComponent({
       }
     };
 
-    const onRequest = (props: any) => {
+    const onRequest = async (props: any) => {
       pagination.value.page = props.pagination.page;
       pagination.value.rowsPerPage = props.pagination.rowsPerPage;
-      loadIncidents();
+      pagination.value.sortBy = props.pagination.sortBy;
+      pagination.value.descending = props.pagination.descending;
+
+      // For FE filtering, just reapply filters and pagination without API call
+      const filteredIncidents = applyFrontendSearch(allIncidents.value, props.searchQuery);
+      const startIndex = (pagination.value.page - 1) * pagination.value.rowsPerPage;
+      const endIndex = startIndex + pagination.value.rowsPerPage;
+      incidents.value = filteredIncidents.slice(startIndex, endIndex);
+      pagination.value.rowsNumber = filteredIncidents.length;
     };
 
     const viewIncident = (incident: Incident) => {
@@ -523,6 +501,19 @@ export default defineComponent({
       loadIncidents();
     });
 
+    // Watch for search query changes and apply FE filter
+    watch(() => props.searchQuery, () => {
+      // Reset to page 1 when search query changes
+      pagination.value.page = 1;
+
+      // Apply FE search filter without API call
+      const filteredIncidents = applyFrontendSearch(allIncidents.value, props.searchQuery);
+      const startIndex = 0; // Always start from first page
+      const endIndex = pagination.value.rowsPerPage;
+      incidents.value = filteredIncidents.slice(startIndex, endIndex);
+      pagination.value.rowsNumber = filteredIncidents.length;
+    });
+
     // Filter toggle functions
     const toggleStatusFilter = (status: string) => {
       const index = statusFilter.value.indexOf(status);
@@ -531,6 +522,8 @@ export default defineComponent({
       } else {
         statusFilter.value.splice(index, 1);
       }
+      // Note: With backend pagination, filters would need to be sent to API
+      // For now, filters are visual only and don't affect data
     };
 
     const toggleSeverityFilter = (severity: string) => {
@@ -540,20 +533,26 @@ export default defineComponent({
       } else {
         severityFilter.value.splice(index, 1);
       }
+      // Note: With backend pagination, filters would need to be sent to API
+      // For now, filters are visual only and don't affect data
     };
 
     const clearStatusFilter = () => {
       statusFilter.value = [];
+      // Note: With backend pagination, would trigger API reload
     };
 
     const clearSeverityFilter = () => {
       severityFilter.value = [];
+      // Note: With backend pagination, would trigger API reload
     };
 
     const changePagination = (val: { label: string; value: number }) => {
       pagination.value.rowsPerPage = val.value;
       pagination.value.page = 1;
-      loadIncidents();
+      qTableRef.value?.requestServerInteraction({
+        pagination: pagination.value
+      });
     };
 
     const openSREChat = (incident: any) => {
@@ -568,6 +567,7 @@ export default defineComponent({
       t,
       loading,
       incidents,
+      allIncidents,
       filteredIncidents,
       statusFilter,
       severityFilter,
@@ -595,13 +595,18 @@ export default defineComponent({
       clearSeverityFilter,
       changePagination,
       openSREChat,
+      perPageOptions,
+      qTableRef,
     };
   },
 });
 </script>
 
-<style scoped>
-.incident-table {
-  height: 100%;
+<style lang="scss" scoped>
+.bottom-btn {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
 }
 </style>

--- a/web/src/services/incidents.ts
+++ b/web/src/services/incidents.ts
@@ -79,11 +79,15 @@ const incidents = {
     org_identifier: string,
     status?: string,
     limit: number = 50,
-    offset: number = 0
+    offset: number = 0,
+    keyword?: string
   ) => {
     let url = `/api/v2/${org_identifier}/alerts/incidents?limit=${limit}&offset=${offset}`;
     if (status) {
       url += `&status=${status}`;
+    }
+    if (keyword) {
+      url += `&keyword=${encodeURIComponent(keyword)}`;
     }
     return http().get<ListIncidentsResponse>(url);
   },


### PR DESCRIPTION
### **User description**
## Summary
- Fix email destination import test to work consistently across environments
- Changed `template: "email"` to `template: ""` in emailDestinationImport.json
- Also updated the GitHub file (alert_tests repo) with the same fix

## Root Cause
The email destination import JSON had `"template": "email"` which caused different behavior:
- On environments without a built-in "email" template: UI shows template dropdown
- On environments with a built-in "email" template: UI hides the dropdown (since template is already valid)

Using empty template ensures the dropdown is always shown, making tests consistent.

## Test plan
- [x] Tested on test.internal - passes
- [x] Tested on dev2.internal - passes


___

### **PR Type**
Tests


___

### **Description**
- Set `template` to empty string in import JSON

- Ensure consistent template dropdown in UI tests


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>emailDestinationImport.json</strong><dd><code>Template field reset in import JSON</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/utils/emailDestinationImport.json

- Updated `template` from "email" to "".


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9736/files#diff-57ea7fbee46a4944f5ca07827afa5e1f411dfc33e4153a29951719360d097883">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

