### PR TITLE
fix: check if multi time range has already defined

### DIFF
--- a/web/src/components/alerts/AddAlert.vue
+++ b/web/src/components/alerts/AddAlert.vue
@@ -2252,15 +2252,21 @@ export default defineComponent({
     }
 
     this.formData.is_real_time = this.formData.is_real_time.toString();
-    this.formData.context_attributes = Object.keys(
-      this.formData.context_attributes,
-    ).map((attr) => {
-      return {
-        key: attr,
-        value: this.formData.context_attributes[attr],
-        id: getUUID(),
-      };
-    });
+    // Convert context_attributes from object to array format (only if it's an object)
+    if (this.formData.context_attributes && typeof this.formData.context_attributes === 'object' && !Array.isArray(this.formData.context_attributes)) {
+      this.formData.context_attributes = Object.keys(
+        this.formData.context_attributes,
+      ).map((attr) => {
+        return {
+          key: attr,
+          value: this.formData.context_attributes[attr],
+          id: getUUID(),
+        };
+      });
+    } else if (!this.formData.context_attributes) {
+      // If null or undefined, initialize as empty array
+      this.formData.context_attributes = [];
+    }
     // VERSION DETECTION AND CONVERSION
     // Supports three versions:
     // - V0: Flat array of conditions with implicit AND between all (no groups)

--- a/web/src/components/alerts/steps/QueryConfig.vue
+++ b/web/src/components/alerts/steps/QueryConfig.vue
@@ -275,7 +275,7 @@ export default defineComponent({
     });
 
     const updateTab = (tab: string) => {
-      const hasComparisonWindow = props.multiTimeRange.length > 0;
+      const hasComparisonWindow = props.multiTimeRange?.length > 0;
 
       // Check if switching to custom or promql while multi-windows are present
       if ((tab === 'custom' || tab === 'promql') && hasComparisonWindow) {


### PR DESCRIPTION
### **User description**
This PR checks while shifting to custom in conditions that multi time range is null or not


___

### **PR Type**
Bug fix


___

### **Description**
- Guard `context_attributes` conversion for objects only

- Initialize empty `context_attributes` if null/undefined

- Use optional chaining for `props.multiTimeRange` length check


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddAlert.vue</strong><dd><code>Guard and initialize context_attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/AddAlert.vue

<ul><li>Wrapped <code>context_attributes</code> conversion in object check<br> <li> Initialized to empty array when null/undefined<br> <li> Retained mapping logic for existing arrays</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9751/files#diff-7b426bb23e9ed0250c3877d6d97b099c42b2d20e22ddf4459915381b2233a0a8">+15/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>QueryConfig.vue</strong><dd><code>Use optional chaining for multiTimeRange</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/steps/QueryConfig.vue

<ul><li>Replaced direct length check with optional chaining<br> <li> Handled undefined <code>multiTimeRange</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9751/files#diff-7273c8de49b8ebf706d7bee5b275c75818c0493f41c73f00c55efe667cbd00d9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

