### PR TITLE
fix: dont overwrite the sql query when selecting the new stream

### DIFF
--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -2050,9 +2050,11 @@ const getStreamFields = () => {
         });
       })
       .finally(() => {
-        if (tab.value === "sql") {
+        // Only set default query if query is empty
+        // Don't overwrite user's custom query when they change streams
+        if (tab.value === "sql" && !query.value.trim()) {
           query.value = `SELECT * FROM "${selectedStreamName.value}"`;
-        } else if (tab.value === "promql") {
+        } else if (tab.value === "promql" && !query.value.trim()) {
           query.value = `${selectedStreamName.value}{}`;
         }
         expandState.value.query = true;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Preserve custom SQL queries on stream switch

- Only set default query if it's empty


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stream selected"] --> B{"Tab and empty query?"}
  B -- "SQL" --> C["Set default SQL query"]
  B -- "PromQL" --> D["Set default PromQL query"]
  B -- "No" --> E["Keep existing query"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ScheduledPipeline.vue</strong><dd><code>Avoid overwriting custom queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/pipeline/NodeForm/ScheduledPipeline.vue

<ul><li>Added emptiness check before setting default query<br> <li> Applied check for both SQL and PromQL tabs<br> <li> Prevented overwriting user-defined custom queries</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9767/files#diff-63d8f838bb880356e7804b4a57fd9223d4f2c189de7aadc7cf33cba723b29aaf">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

