### PR TITLE
fix: Invalid filters getting created on selection of rate and error in traces

### DIFF
--- a/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
+++ b/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
@@ -52,13 +52,10 @@ class="tw-mx-1 tw-text-red-500" />
       >
         <span class="chip-label"
           >{{ filter.panelTitle }}
-          <span v-if="filter.panelTitle === 'Rate'">
+          <span v-if="filter.panelTitle === 'Rate' || filter.panelTitle === 'Errors'">
             : {{ t('latencyInsights.timeRangeSelected') }}
           </span>
-          <span v-else-if="filter.panelTitle === 'Errors'">
-            >= {{ filter.start }}
-          </span>
-          <span v-else-if="filter.panelTitle === 'Duration'">
+          <span v-if="filter.panelTitle === 'Duration'">
             <span v-if="filter.start !== null && filter.end !== null">
               {{ formatTimeWithSuffix(filter.start) }} -
               {{ formatTimeWithSuffix(filter.end) }}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Merge Rate and Errors filter labels

- Remove numeric display for Errors filter

- Consolidate Duration filter conditional


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TracesMetricsDashboard.vue</strong><dd><code>Merge Rate and Error filter labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/traces/metrics/TracesMetricsDashboard.vue

<ul><li>Combined <code>Rate</code> and <code>Errors</code> cases into single label<br> <li> Removed <code>>= start</code> display for Errors filter<br> <li> Simplified <code>Duration</code> filter conditional logic</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9771/files#diff-7b6f29a2737d9501b18dbd8622eba4965e4bc2b92115627ae7d2e70cc3382087">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

