### PR TITLE
fix: upgrade monaco-editor to 0.55.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -46,7 +46,7 @@
         "marked": "^17.0.1",
         "moment": "^2.30.1",
         "moment-timezone": "^0.6.0",
-        "monaco-editor": "^0.52.2",
+        "monaco-editor": "^0.55.1",
         "node-polyfill-webpack-plugin": "^4.1.0",
         "quasar": "^2.17.7",
         "reodotdev": "^1.0.0",
@@ -11584,10 +11584,35 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/moo": {
       "version": "0.5.2",

--- a/web/package.json
+++ b/web/package.json
@@ -62,7 +62,7 @@
     "marked": "^17.0.1",
     "moment": "^2.30.1",
     "moment-timezone": "^0.6.0",
-    "monaco-editor": "^0.52.2",
+    "monaco-editor": "^0.55.1",
     "node-polyfill-webpack-plugin": "^4.1.0",
     "quasar": "^2.17.7",
     "reodotdev": "^1.0.0",


### PR DESCRIPTION
### **User description**
Upgraded monaco-editor from 0.52.2 to 0.55.1.
Type check and tests pass successfully.


___

### **PR Type**
Enhancement


___

### **Description**
- Bump monaco-editor to v0.55.1


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump monaco-editor dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/package.json

- Update monaco-editor dependency to ^0.55.1


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9772/files#diff-b861012a5dd72b8a9f3281b7cf09f5a779c98569d040b1bbc1db50f1b15e7cce">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

