### PR TITLE
fix: histogram cache issue

### DIFF
--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -501,10 +501,9 @@ pub async fn get_cached_results(
         }
         // reset the start and end time
         let first_ts = get_ts_value(&cache_req.ts_column, cached_response.hits.first().unwrap());
-        let last_ts = get_ts_value(&cache_req.ts_column, cached_response.hits.last().unwrap())
-            + histogram_interval;
+        let last_ts = get_ts_value(&cache_req.ts_column, cached_response.hits.last().unwrap());
         matching_meta.start_time = std::cmp::min(first_ts, last_ts);
-        matching_meta.end_time = std::cmp::max(first_ts, last_ts);
+        matching_meta.end_time = std::cmp::max(first_ts, last_ts) + histogram_interval;
     }
     cached_response.total = cached_response.hits.len();
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove interval addition from last timestamp

- Add interval to end_time calculation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fetch first_ts and last_ts"]
  B["Compute start_time=min(first_ts,last_ts)"]
  C["Compute end_time=max(first_ts,last_ts)+histogram_interval"]
  A --> B
  B --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cacher.rs</strong><dd><code>Adjust histogram interval on cache timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/cacher.rs

<ul><li>Removed <code>histogram_interval</code> from <code>last_ts</code> calculation<br> <li> Added <code>histogram_interval</code> to <code>matching_meta.end_time</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9777/files#diff-8c387b22b2c0a282600ee41ca702b3db60f5a284d507c0feb7418608ff062c6c">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

