### PR TITLE
fix: register promql language for monaco editor

### DIFF
--- a/web/src/components/CodeQueryEditor.vue
+++ b/web/src/components/CodeQueryEditor.vue
@@ -440,6 +440,9 @@ export default defineComponent({
 
     onMounted(async () => {
       provider.value?.dispose();
+      if(props.language === "promql") {
+        monaco.languages.register({ id: "promql" });
+      }
       if (props.language === "vrl") {
         monaco.languages.register({ id: "vrl" });
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Register `promql` language in CodeQueryEditor component


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CodeQueryEditor.vue</strong><dd><code>Add PromQL language registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/CodeQueryEditor.vue

<ul><li>Added <code>if(props.language === "promql")</code> check<br> <li> Invoked <code>monaco.languages.register({ id: "promql" })</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9779/files#diff-52a36bf2d64e590036ed1c1f89b07a4a6b971a84e4fae9b4272cbc69d63f9bef">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

