### PR TITLE
fix: service streams dimensions conflicts

### DIFF
--- a/src/infra/src/table/service_streams_dimensions.rs
+++ b/src/infra/src/table/service_streams_dimensions.rs
@@ -146,7 +146,7 @@ pub async fn add(record: DimensionValueRecord) -> Result<(), errors::Error> {
                 .on_conflict(
                     OnConflict::columns([Column::OrgId, Column::DimensionName, Column::ValueHash])
                         .do_nothing()
-                        .to_owned()
+                        .to_owned(),
                 )
                 .exec(client)
                 .await
@@ -159,7 +159,7 @@ pub async fn add(record: DimensionValueRecord) -> Result<(), errors::Error> {
                 .on_conflict(
                     OnConflict::columns([Column::OrgId, Column::DimensionName, Column::ValueHash])
                         .update_column(Column::Id)
-                        .to_owned()
+                        .to_owned(),
                 )
                 .exec(client)
                 .await


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added database-specific ON CONFLICT strategies

- Renamed local `record` to `active_record`

- Matched on backend to suppress duplicate key errors

- Fallback unique violation catch handles remaining errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Prepare ActiveModel with KSUID"] --> B["Get database backend"]
  B -- "Postgres/SQLite" --> C["ON CONFLICT DO NOTHING"]
  B -- "MySQL" --> D["ON DUPLICATE KEY UPDATE no-op"]
  C --> E["Execute insert"]
  D --> E
  E --> F["Fallback: catch unique violation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_streams_dimensions.rs</strong><dd><code>Insert conflict handling per database</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/table/service_streams_dimensions.rs

<ul><li>Added import <code>sea_query::OnConflict</code><br> <li> Renamed <code>record</code> variable to <code>active_record</code><br> <li> Introduced <code>get_database_backend</code> match branch<br>   - Postgres/SQLite: ON <br>CONFLICT DO NOTHING<br>   - MySQL: ON DUPLICATE KEY UPDATE id=id<br> <li> Retained fallback unique violation catch</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9789/files#diff-0eb93bd27bad311ec5527a89c61b4b29adc4fcb2c7a5a928d4658b3a9d4fbe75">+33/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

