### PR TITLE
fix(e2e): update firstConditionLabel selector in pipelinesPage

### DIFF
--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -124,7 +124,7 @@ export class PipelinesPage {
         this.scheduledAlertTabs = page.locator('[data-test="scheduled-alert-tabs"]');
         this.nestedGroups = page.locator('.el-border');
         this.operatorLabels = page.locator('span.tw\\:lowercase');
-        this.firstConditionLabel = page.locator('.tw\\:flex.tw\\:items-start.tw\\:gap-1').first().locator('span').first();
+        this.firstConditionLabel = page.locator('[data-test="add-condition-section"]').getByText('if', { exact: true }).first();
         this.noteContainer = page.locator('.note-container');
         this.noteHeading = page.locator('.note-heading');
         this.noteInfo = page.locator('.note-info');


### PR DESCRIPTION
### **User description**
## Summary
- Fix fragile CSS class-based selector for `firstConditionLabel` in pipeline conditions test
- Replace with robust `data-test` scoped text selector

## Problem
The selector `.tw:flex.tw:items-start.tw:gap-1` failed because Tailwind classes in the Vue template are space-separated, but the selector tried to match them as combined without spaces, resulting in "element(s) not found" error.

## Solution
Changed from:
```javascript
page.locator('.tw\\:flex.tw\\:items-start.tw\\:gap-1').first().locator('span').first()
```

To:
```javascript
page.locator('[data-test="add-condition-section"]').getByText('if', { exact: true }).first()
```

## Test Results
- ✅ Test passes locally (2.1 minutes execution time)


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Update e2e selector for first condition label

- Replace fragile Tailwind CSS locator

- Use robust `[data-test]` scoped text locator


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pipelinesPage.js</strong><dd><code>Replace Tailwind selector with data-test locator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/pages/pipelinesPages/pipelinesPage.js

<ul><li>Removed complex Tailwind CSS selector<br> <li> Added <code>[data-test="add-condition-section"]</code> locator<br> <li> Used <code>getByText('if', { exact: true })</code> on first element</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9797/files#diff-d5f2771fd1139c174c46d09a9ab2da0ea4588b853e2b87e4728322d072542f49">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

