### PR TITLE
fix(e2e): update getSeverityColors selector for robust DOM matching

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -3370,8 +3370,7 @@ export class LogsPage {
                         `"severity":${sev},`,
                         `"severity":${sev}}`,
                         `"severity": ${sev}`,
-                        `severity: ${sev}`,
-                        `"severity":"${sev}"`
+                        `severity: ${sev}`
                     ];
 
                     if (patterns.some(pattern => text.includes(pattern))) {


### PR DESCRIPTION
### **User description**
## Summary
- Fix severity color test failing due to CSS selector not matching DOM elements
- Update `getSeverityColors()` method in logsPage.js with multi-fallback selector strategy

## Problem
The original selector `div[class*="tw:absolute"][class*="tw:left-0"]` failed to match elements because Tailwind CSS class names with colons need different escaping in querySelector.

**Error:**
```
Expected: 8
Received: 0
```

## Solution
Implement robust multi-fallback approach:
1. First try inline style selector: `div[style*="background"]`
2. Fallback to escaped class selector: `div[class*="tw\\:absolute"]`
3. Final fallback: iterate through divs to find absolute positioned element with backgroundColor

## Test Results
All 8 severity levels now verified successfully:
- ✅ Severity 0-7 colors all match expected values
- ✅ Test passes in 28.7s


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add multi-fallback selector for severity color div

- Skip transparent or missing background elements

- Broaden severity text pattern matching


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logsPage.js</strong><dd><code>Robust colorDiv selector and severity parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/pages/logsPages/logsPage.js

<ul><li>Added inline style selector for background color div<br> <li> Fallback to escaped Tailwind class selector<br> <li> Computed style fallback for absolute-positioned div<br> <li> Skip transparent or missing divs before parsing<br> <li> Extended severity patterns for varied text formats</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9798/files#diff-8045b343491d8943869c1af74cdafab204dc49c02a70294417e73f47d35e0b59">+36/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

