### PR TITLE
fix: fix for first time data loading issue without clicking run query…

### DIFF
--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -262,8 +262,7 @@ const useLogs = () => {
       // in-progress and user select stream from dropdown in that case it loads data but it should wait for
       // additional details from the user like filter conditions and time range selection before load data
       // it should work in case of page refresh, navigate user from streams page or short url
-      let initialStreamSelected: boolean =
-        searchObj.data.stream.selectedStream.length > 0 ? true : false;
+      let initialStreamSelected: boolean = searchObj.data.stream.selectedStream.length > 0;
 
       await getStreamList();
       await getFunctions();


### PR DESCRIPTION
### **User description**
… button


___

### **PR Type**
Bug fix


___

### **Description**
- Introduce `initialStreamSelected` for initial loads

- Conditionally call `getQueryData()` on selections

- Set `loading` false if no stream selected


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["loadLogsData()"] --> B["Compute `initialStreamSelected`"]
  B -- "Stream selected" --> C["getQueryData()"]
  B -- "No stream selected" --> D["searchObj.loading = false"]
  C --> E["refreshData()"]
  D --> E["refreshData()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useLogs.ts</strong><dd><code>Conditional initial data load fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs.ts

<ul><li>Introduced <code>initialStreamSelected</code> boolean<br> <li> Wrapped <code>getQueryData()</code> call in conditional<br> <li> Set <code>searchObj.loading</code> false when unselected</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9805/files#diff-1040f61354f92711e0e77ed4e9bfa15586d45a94c7e2ab06cc37372068030e7b">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

