### PR TITLE
fix(e2e): improve stream selection in schema pagination test

### DIFF
--- a/tests/ui-testing/pages/generalPages/sanityPage.js
+++ b/tests/ui-testing/pages/generalPages/sanityPage.js
@@ -708,8 +708,9 @@ export class SanityPage {
 
         // Click the input to open/focus the dropdown
         await streamSelectInput.click();
-        // Wait for dropdown menu to appear instead of fixed delay
-        await this.page.waitForSelector('.q-menu', { state: 'visible', timeout: 10000 });
+        // Wait for any stream toggle to appear (indicates dropdown has opened and populated)
+        // Using data-test attribute with starts-with selector for robustness
+        await this.page.waitForSelector('[data-test^="log-search-index-list-stream-toggle-"]', { state: 'visible', timeout: 10000 });
 
         // Fill the input to filter streams - this is critical for finding the stream quickly
         await streamSelectInput.fill('e2e_automate');


### PR DESCRIPTION
### **User description**
## Summary
- Fixes failing sanity test "should display pagination for schema" by improving stream selection after page reload
- Uses search-and-filter approach to reliably find and select the e2e_automate stream
- Replaces broken pagination selector with proper data-test attribute selector
- Adds proper error handling when stream selection fails

## Test plan
- [x] Run sanity pagination test - passes
- [x] Run all sanity tests - 14 passed, 3 skipped


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Refactor stream selection using search-filter input

- Add multiple fallback click methods and throw error on failure

- Replace flaky pagination dropdown click with pagination button wait


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Page reload"] --> B["Stream select input visible"]
  B --> C["Click and fill filter input"]
  C --> D["Wait for stream toggle visible"]
  D --> E["Click toggle element"]
  D --> F["Fallback: click toggle element"]
  F --> G["Fallback: click by text"]
  G --> H["Error thrown on failure"]
  E --> I["Pagination first page button visible"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sanityPage.js</strong><dd><code>Enhance stream selection and pagination wait</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/pages/generalPages/sanityPage.js

<ul><li>Use search-filter input for stream dropdown selection<br> <li> Add multiple fallback mechanisms with descriptive logs<br> <li> Throw meaningful error when stream selection fails<br> <li> Replace pagination dropdown click with first-page button wait</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9809/files#diff-a0ac0217ef875311dc536edb97deda19927a64e73cede62123b97cbe7df113b8">+37/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

