### PR TITLE
fix: dashboard raw query save issue (#9815)

### DIFF
--- a/src/config/src/meta/dashboards/v8/mod.rs
+++ b/src/config/src/meta/dashboards/v8/mod.rs
@@ -221,6 +221,8 @@ pub struct AxisItem {
     pub treat_as_non_timestamp: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_field_as_json: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_query: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]


### PR DESCRIPTION
### **User description**
Bug fix

___
- Add `raw_query` field to `AxisItem` struct.

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>mod.rs</strong><dd><code>Add raw_query Option<String> to AxisItem</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/dashboards/v8/mod.rs

<ul><li>Introduce <code>raw_query: Option<String></code> field in <code>AxisItem</code>.<br> <li> Use <code>skip_serializing_if</code> to omit <code>raw_query</code> when <code>None</code>.</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/9815/files#diff-cbf3fe971525ba58892400391dfd7dac7e43d6049d6b4f5a9840ad104ebc5e08">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `raw_query` field to `AxisItem`

- Skip serializing `raw_query` if `None`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add raw_query to AxisItem</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/dashboards/v8/mod.rs

<ul><li>Introduced <code>raw_query: Option<String></code> field in <code>AxisItem</code><br> <li> Added <code>serde(skip_serializing_if = "Option::is_none")</code> for <code>raw_query</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9820/files#diff-cbf3fe971525ba58892400391dfd7dac7e43d6049d6b4f5a9840ad104ebc5e08">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

