### PR TITLE
fix(e2e): consolidate and stabilize alerts-incidents-tabs tests

### DIFF
--- a/tests/ui-testing/playwright-tests/Pipelines/scheduled-pipeline-stream-auto-update.spec.js
+++ b/tests/ui-testing/playwright-tests/Pipelines/scheduled-pipeline-stream-auto-update.spec.js
@@ -1,0 +1,206 @@
+import { test, expect } from "../baseFixtures.js";
+import logData from "../../fixtures/log.json";
+import logsdata from "../../../test-data/logs_data.json";
+import PageManager from "../../pages/page-manager.js";
+import { LoginPage } from "../../pages/generalPages/loginPage.js";
+const testLogger = require('../utils/test-logger.js');
+
+test.describe.configure({ mode: "serial" });
+
+test.use({
+  contextOptions: {
+    slowMo: 1000
+  }
+});
+
+test.describe("Scheduled Pipeline Stream Auto-Update", { tag: ['@all', '@scheduledPipeline'] }, () => {
+  let pageManager;
+  let loginPage;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testLogger.testStart(testInfo.title, testInfo.file);
+
+    // Login
+    loginPage = new LoginPage(page);
+    await loginPage.gotoLoginPage();
+    await loginPage.loginAsInternalUser();
+    await loginPage.login();
+
+    pageManager = new PageManager(page);
+
+    // Ingest test data to ensure streams exist
+    const streamNames = ["e2e_automate", "k8s_json"];
+    await pageManager.pipelinesPage.bulkIngestToStreams(streamNames, logsdata);
+
+    await page.goto(
+      `${logData.logsUrl}?org_identifier=${process.env["ORGNAME"]}`
+    );
+
+    testLogger.info('Test setup completed');
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    testLogger.testEnd(testInfo.title, testInfo.status);
+  });
+
+  // P0 - Smoke Tests
+
+  test("should auto-generate SELECT * query when stream changes", {
+    tag: ['@smoke', '@P0']
+  }, async ({ page }) => {
+    testLogger.info('Testing query is auto-generated when stream changes');
+
+    // Navigate to pipelines
+    await pageManager.pipelinesPage.openPipelineMenu();
+    await page.waitForTimeout(1000);
+
+    // Add new pipeline
+    await pageManager.pipelinesPage.addPipeline();
+
+    // Drag Query button to canvas - opens Query form dialog
+    await pageManager.pipelinesPage.dragStreamToTarget(pageManager.pipelinesPage.queryButton);
+    await page.waitForTimeout(500);
+
+    // Wait for scheduled pipeline form dialog to load
+    await pageManager.pipelinesPage.waitForScheduledPipelineDialog();
+    await page.waitForTimeout(1000);
+
+    // Expand "Build Query" section
+    await pageManager.pipelinesPage.expandBuildQuerySection();
+    await page.waitForTimeout(500);
+
+    // Select stream type (logs)
+    await pageManager.pipelinesPage.selectStreamType('logs');
+    await page.waitForTimeout(1000);
+
+    // Select first stream (e2e_automate)
+    await pageManager.pipelinesPage.selectStreamName('e2e_automate');
+    await page.waitForTimeout(1000);
+
+    // Verify default query generated
+    await pageManager.pipelinesPage.expectSqlEditorVisible();
+
+    // Get query text from Monaco editor
+    await pageManager.pipelinesPage.expectQueryToContain('e2e_automate');
+
+    // Change stream to k8s_json
+    testLogger.info('Changing stream to k8s_json');
+    await pageManager.pipelinesPage.selectStreamName('k8s_json');
+    await pageManager.pipelinesPage.waitForStreamChangeWatcher();
+
+    // Verify query is auto-generated with new stream name
+    await pageManager.pipelinesPage.expectQueryToContain('SELECT');
+    await pageManager.pipelinesPage.expectQueryToContain('FROM');
+    await pageManager.pipelinesPage.expectQueryToContain('k8s_json');
+    await pageManager.pipelinesPage.expectQueryNotToContain('e2e_automate');
+
+    testLogger.info('✅ Test passed: Query auto-generated correctly on stream change');
+  });
+
+  // Note: WHERE clause preservation tests removed
+  // New behavior auto-generates fresh SELECT * query on stream change
+  // This prevents field reference issues when switching between streams with different schemas
+
+  test("should handle initial stream selection (existing behavior)", {
+    tag: ['@regression', '@P1']
+  }, async ({ page }) => {
+    testLogger.info('Testing initial stream selection generates default query');
+
+    await pageManager.pipelinesPage.openPipelineMenu();
+    await page.waitForTimeout(1000);
+    await pageManager.pipelinesPage.addPipeline();
+
+    // Drag Query button to canvas - opens Query form dialog
+    await pageManager.pipelinesPage.dragStreamToTarget(pageManager.pipelinesPage.queryButton);
+    await page.waitForTimeout(500);
+
+    // Wait for scheduled pipeline form dialog to load
+    await pageManager.pipelinesPage.waitForScheduledPipelineDialog();
+    await page.waitForTimeout(1000);
+
+    // Verify query is empty initially (or not visible)
+    testLogger.info('Verifying empty state');
+
+    // Expand "Build Query" section
+    await pageManager.pipelinesPage.expandBuildQuerySection();
+    await page.waitForTimeout(500);
+
+    // Select stream type (logs)
+    await pageManager.pipelinesPage.selectStreamType('logs');
+    await page.waitForTimeout(1000);
+
+    // Select first stream
+    await pageManager.pipelinesPage.selectStreamName('e2e_automate');
+    await page.waitForTimeout(1000);
+
+    // Verify default query generated
+    await pageManager.pipelinesPage.expectSqlEditorVisible();
+    await pageManager.pipelinesPage.expectQueryToContain('SELECT');
+    await pageManager.pipelinesPage.expectQueryToContain('FROM');
+    await pageManager.pipelinesPage.expectQueryToContain('e2e_automate');
+
+    testLogger.info('✅ Test passed: Default query generated correctly');
+  });
+
+  test.skip("should not update PromQL tab when stream changes", {
+    tag: ['@functional', '@P1']
+  }, async ({ page }) => {
+    testLogger.info('Testing PromQL tab is unaffected by SQL watcher');
+
+    await pageManager.pipelinesPage.openPipelineMenu();
+    await page.waitForTimeout(1000);
+    await pageManager.pipelinesPage.addPipeline();
+
+    // Drag Query button to canvas - opens Query form dialog
+    await pageManager.pipelinesPage.dragStreamToTarget(pageManager.pipelinesPage.queryButton);
+    await page.waitForTimeout(500);
+
+    // Wait for scheduled pipeline form dialog to load
+    await pageManager.pipelinesPage.waitForScheduledPipelineDialog();
+    await page.waitForTimeout(1000);
+
+    // Expand "Build Query" section
+    await pageManager.pipelinesPage.expandBuildQuerySection();
+    await page.waitForTimeout(500);
+
+    // Select stream type (metrics) - PromQL only enabled for metrics
+    await pageManager.pipelinesPage.selectStreamType('metrics');
+    await page.waitForTimeout(1000);
+
+    // Select a metrics stream in SQL tab
+    testLogger.info('Selecting metrics stream');
+    await pageManager.pipelinesPage.streamNameLabel.click();
+    await page.waitForTimeout(500);
+    // Note: We'll use any available metrics stream
+    const streamOptions = page.getByRole("option").filter({ hasText: /^[a-z0-9_]+$/ }).first();
+    await streamOptions.click();
+    await page.waitForTimeout(2000);
+
+    // Get SQL query text
+    await pageManager.pipelinesPage.expectQueryToContain('FROM');
+
+    // Switch to PromQL tab (now enabled because we selected metrics)
+    testLogger.info('Switching to PromQL tab');
+    const promqlTab = pageManager.pipelinesPage.scheduledPipelineTabs.getByRole('button', { name: /PromQL/i });
+    await promqlTab.waitFor({ state: 'visible', timeout: 5000 });
+    await promqlTab.click();
+    await page.waitForTimeout(1000);
+
+    // Verify we're on PromQL tab
+    testLogger.info('Verifying PromQL tab active');
+
+    // Switch back to SQL tab
+    testLogger.info('Switching back to SQL tab');
+    const sqlTab = pageManager.pipelinesPage.scheduledPipelineTabs.getByRole('button', { name: /SQL/i });
+    await sqlTab.click();
+    await page.waitForTimeout(1000);
+
+    // Verify SQL query still exists (tab switching doesn't affect SQL query)
+    await pageManager.pipelinesPage.expectQueryToContain('FROM');
+
+    testLogger.info('✅ Test passed: PromQL tab independent of SQL watcher');
+  });
+
+  // Note: Manual edit protection test removed
+  // New behavior always auto-generates SELECT * query on stream change for data safety
+});

--- a/web/src/composables/useLatencyInsightsDashboard.ts
+++ b/web/src/composables/useLatencyInsightsDashboard.ts
@@ -367,6 +367,8 @@ export function useLatencyInsightsDashboard() {
           label_option: {
             rotate: 45,
           },
+          axis_label_rotate: 30,
+          axis_label_truncate_width: 80,
           color: isComparisonMode ? {
             mode: "palette-classic-by-series",
             fixedColor: ["#ffc107", "#1976d2"],

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -1824,8 +1824,11 @@ export const calculateRotatedLabelBottomSpace = (
     // Only add if totalNeeded exceeds a reasonable base (e.g., 40px)
     return Math.max(0, Math.ceil(totalNeededSpace - 40));
   } else {
-    // Without axis name, just add enough space for labels plus a margin
-    // verticalHeight already includes the diagonal extent
-    return Math.max(0, Math.ceil(verticalHeight - 15)); // Assuming ~15px is already available
+    // Without axis name, containLabel: true in grid config handles the space automatically
+    // for rotated labels. No additional bottom spacing is needed because:
+    // 1. containLabel: true makes ECharts automatically expand grid to fit labels
+    // 2. The grid.bottom value already provides base spacing
+    // 3. Adding extra space here causes unnecessary whitespace
+    return 10; // Let ECharts handle it with containLabel
   }
 };

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -1068,6 +1068,7 @@ export const convertSQLData = async (
     },
     tooltip: {
       trigger: "axis",
+      confine: true,
       textStyle: {
         color: store.state.theme === "dark" ? "#fff" : "#000",
         fontSize: 12,


### PR DESCRIPTION
### **User description**
## Summary
- Consolidated 13 test cases into 5 comprehensive tests for the Alerts/Incidents tabs feature
- Tests 1-3: UI validation, search functionality, edge cases (enterprise feature, running)
- Tests 4-5: Incident lifecycle actions and drawer validation (enterprise feature, skipped - requires incidents to exist)
- Added incident-related POM methods to alertsPage.js
- Fixed view tab locators to use correct AppTabs pattern (tab-alerts, tab-incidents)
- Added `waitForViewTabsReady()` method for stable test setup
- Added incident cleanup patterns to cleanup.spec.js
- Marked entire suite as @enterprise feature since Alerts/Incidents is enterprise-only

## Test Results
- 3 passed, 2 skipped (~32s)

## Test plan
- [x] Run alerts-incidents-tabs.spec.js - all 3 OSS tests pass
- [x] Verify 2 enterprise tests are correctly skipped
- [x] Cleanup patterns added for incident_e2e_* resources


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhance AlertsPage POM with incident locators

- Add helpers for view tabs and loading overlay

- Consolidate comprehensive alerts-incidents E2E tests

- Extend cleanup to include incident_e2e patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Navigate to Alerts Page"] --> B["waitForLoadingOverlayToDisappear"]
  B --> C["waitForAlertListPageReady"]
  C --> D["waitForViewTabsReady"]
  D --> E1["Test1: View UI Validation"]
  D --> E2["Test2: Search Functionality"]
  D --> E3["Test3: Edge Cases"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alertsPage.js</strong><dd><code>Enhance AlertsPage with incident methods and locators</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/pages/alertsPages/alertsPage.js

<ul><li>Added locators for incidents, drawer, and page structure<br> <li> Introduced waitForViewTabsReady and loading overlay helpers<br> <li> Added assertion helpers for alerts/incidents visibility<br> <li> Implemented incident lifecycle and drawer methods</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9837/files#diff-79ee01d6d7f145f19207b93b87143b545a1188cfc6a82bc8c45fecfbf68f8a1d">+329/-8</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>commonActions.js</strong><dd><code>Use `alert-list-page` in navigation check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/pages/commonActions.js

- Updated navigateToAlerts to check `alert-list-page`


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9837/files#diff-4d726dd2bdb34b2c90a31798ff49b6df5bc952bd049b7c38bebb18b6db0076e2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alerts-incidents-tabs.spec.js</strong><dd><code>New Alerts/Incidents tabs E2E tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/playwright-tests/Alerts/alerts-incidents-tabs.spec.js

<ul><li>Added new comprehensive E2E suite for Alerts/Incidents tabs<br> <li> Consolidates view UI, search, and edge case tests<br> <li> Skips enterprise incident action tests</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9837/files#diff-53a1a0dc2f68166f18211c151ef356b87a34b39fe6b3d2af5263a4036ae2dd99">+413/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>alertsIncidentsTabs.spec.js</strong><dd><code>Remove legacy alertsIncidentsTabs spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/playwright-tests/Alerts/alertsIncidentsTabs.spec.js

- Removed deprecated Alerts & Incidents tab spec file


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9837/files#diff-3776665660a181de2d08e4d3bccc481191e7ac88f4e4b0943c869ffa4eb12ffd">+0/-347</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cleanup.spec.js</strong><dd><code>Add `incident_e2e` cleanup patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/playwright-tests/cleanup.spec.js

- Extended cleanup patterns for `incident_e2e` resources


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9837/files#diff-c214275a512fa285a7e4f2ab61dfcb42d71a0436b0e4241f94d7b45693587983">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

