### PR TITLE
fix: show incident detail drawer details

### DIFF
--- a/web/src/components/alerts/IncidentList.vue
+++ b/web/src/components/alerts/IncidentList.vue
@@ -177,6 +177,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :maximized="true"
     >
       <IncidentDetailDrawer
+        :incident="selectedIncident"
         @close="closeDrawer"
         @status-updated="onStatusUpdated"
       />


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Pass selected incident to detail drawer


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IncidentList.vue</strong><dd><code>Add incident prop binding to drawer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentList.vue

- Added `:incident="selectedIncident"` prop binding


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9847/files#diff-953ad015996758a8c86e489499cd3b0a614501b99b0c9c5c242a299e34c24ff2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

