### PR TITLE
fix: toggle button issue on add alert page

### DIFF
--- a/web/src/components/alerts/steps/AlertSettings.vue
+++ b/web/src/components/alerts/steps/AlertSettings.vue
@@ -192,9 +192,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
           <q-toggle
             v-model="localIsAggregationEnabled"
-            size="md"
-            color="primary"
-            class="text-bold q-pl-0 o2-toggle-button-sm tw:h-[36px] tw:ml-1"
+            size="30px"
+            class="text-bold o2-toggle-button-xs"
             @update:model-value="toggleAggregation"
           />
         </div>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Changed `size` prop to "30px"

- Removed `color="primary"` prop

- Updated toggle CSS classes


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AlertSettings.vue</strong><dd><code>Adjust toggle UI sizing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/steps/AlertSettings.vue

<ul><li>Updated <code>size</code> prop from <code>"md"</code> to <code>"30px"</code><br> <li> Removed <code>color="primary"</code> prop<br> <li> Simplified CSS classes to <code>text-bold o2-toggle-button-xs</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9856/files#diff-1d5bfd6a1ea672884193649b1271d751d6f3b8ec84af759071c9bfd169a8ab28">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

