### PR TITLE
fix: update loading progress handling in PromQL response

### DIFF
--- a/web/src/composables/dashboard/usePanelDataLoader.ts
+++ b/web/src/composables/dashboard/usePanelDataLoader.ts
@@ -973,6 +973,11 @@ export const usePanelDataLoader = (
               }
 
               const handlePromQLResponse = (data: any, res: any) => {
+                if (res.type === "event_progress") {
+                  state.loadingProgressPercentage = res?.content?.percent ?? 0;
+                  state.isPartialData = true;
+                  saveCurrentStateToCache();
+                }
                 if (res?.type === "promql_response") {
                   // Backend sends: { content: { results: { result_type/resultType, result }, trace_id } }
                   // result is the actual PromQL data (vector/matrix with values)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Handle `event_progress` in PromQL loader

- Update loadingProgressPercentage from response

- Mark partial data and cache state on progress


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["res.type: event_progress"] -- "update progress" --> B["state.loadingProgressPercentage"]
  A -- "mark partial data" --> C["state.isPartialData"]
  A -- "save state to cache" --> D["saveCurrentStateToCache()"]
  E["res.type: promql_response"] -- "handle standard data" --> F["extract & accumulate results"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usePanelDataLoader.ts</strong><dd><code>Handle progress events in loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/dashboard/usePanelDataLoader.ts

<ul><li>Add handling for <code>event_progress</code> responses<br> <li> Set <code>loadingProgressPercentage</code> from <code>res.content.percent</code><br> <li> Mark partial data and save cache state on progress</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9859/files#diff-5a42e9493a7bcd722b88e61fd38883c4f61001bc9cafa399f65f8eafda3aace9">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

