### PR TITLE
fix: updated PromQL query update logic on metrics stream change

### DIFF
--- a/web/src/components/dashboards/addPanel/DashboardQueryBuilder.vue
+++ b/web/src/components/dashboards/addPanel/DashboardQueryBuilder.vue
@@ -724,7 +724,7 @@ import OperationsList from "@/components/promql/components/OperationsList.vue";
 import PromQLBuilderOptions from "@/components/promql/components/PromQLBuilderOptions.vue";
 import { promQueryModeller } from "@/components/promql/operations/queryModeller";
 import type { PromVisualQuery } from "@/components/promql/types";
-import usePromlqSuggestions from "@/composables/usePromqlSuggestions";
+import usePromqlSuggestions from "@/composables/usePromqlSuggestions";
 
 export default defineComponent({
   name: "DashboardQueryBuilder",
@@ -783,7 +783,7 @@ export default defineComponent({
       fetchPromQLLabels
     } = useDashboardPanelData(dashboardPanelDataPageKey);
 
-    const { parsePromQlQuery } = usePromlqSuggestions();
+    const { parsePromQlQuery } = usePromqlSuggestions();
 
     // Initialize treatAsNonTimestamp for existing fields (only for table charts)
     const initializeTreatAsNonTimestamp = () => {

--- a/web/src/components/dashboards/addPanel/FieldList.vue
+++ b/web/src/components/dashboards/addPanel/FieldList.vue
@@ -553,7 +553,7 @@ import { useLoading } from "@/composables/useLoading";
 import useStreams from "@/composables/useStreams";
 import { inject } from "vue";
 import useNotifications from "@/composables/useNotifications";
-import usePromlqSuggestions from "@/composables/usePromqlSuggestions";
+import usePromqlSuggestions from "@/composables/usePromqlSuggestions";
 
 export default defineComponent({
   name: "FieldList",
@@ -624,7 +624,7 @@ export default defineComponent({
     const onDragEnd = () => {
       cleanupDraggingFields();
     };
-    const { parsePromQlQuery } = usePromlqSuggestions();
+    const { parsePromQlQuery } = usePromqlSuggestions();
 
     const metricsIconMapping: any = {
       Summary: "description",

--- a/web/src/composables/usePromqlSuggestions.ts
+++ b/web/src/composables/usePromqlSuggestions.ts
@@ -2,7 +2,7 @@ import searchService from "@/services/search";
 import { nextTick, ref } from "vue";
 import { useStore } from "vuex";
 
-const usePromlqSuggestions = () => {
+const usePromqlSuggestions = () => {
   const autoCompleteData = ref({
     query: "",
     text: "",
@@ -292,4 +292,4 @@ const usePromlqSuggestions = () => {
   };
 };
 
-export default usePromlqSuggestions;
+export default usePromqlSuggestions;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Import parsePromQlQuery from usePromqlSuggestions

- Extract metricName from existing PromQL query

- Only reset query if metricName differs from streamName

- Remove unconditional PromQL query override


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stream changed"] --> B["parsePromQlQuery(currentQuery)"]
  B --> C{"metricName != streamName?"}
  C -- yes --> D["set query to streamName + {}"]
  C -- no --> E["keep existing query"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FieldList.vue</strong><dd><code>Refine PromQL query reset logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/FieldList.vue

<ul><li>Added import of <code>usePromqlSuggestions</code> and <code>parsePromQlQuery</code><br> <li> Parsed the current PromQL query to extract <code>metricName</code><br> <li> Changed logic to reset query only when names differ<br> <li> Removed old unconditional query assignment</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9862/files#diff-a071c06e3e26629cb4ae4751450acc39c61fa49b07a1cc4be3711697829668d4">+21/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

