### PR TITLE
fix: dashboard share url

### DIFF
--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -1044,8 +1044,8 @@ export default defineComponent({
      * Converts relative time periods to absolute times for sharing
      */
     const dashboardShareURL = computed(() => {
-      // Add reactive dependency on route to trigger re-evaluation when URL changes
-      const currentPath = route.fullPath;
+      // Establish reactive dependency on route.fullPath to recompute when URL changes
+      void route.fullPath;
       const urlObj = new URL(window.location.href);
       const urlSearchParams = urlObj?.searchParams;
 


### PR DESCRIPTION
### **User description**

___

### **PR Type**
Bug fix


___

### **Description**
- Add reactive dependency on route.fullPath

- Ensure share URL recomputes on route change

- Retain conversion of relative times to absolute


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ViewDashboard.vue</strong><dd><code>Enable reactive URL recomputation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/Dashboards/ViewDashboard.vue

<ul><li>Added <code>currentPath</code> reactive dependency on <code>route.fullPath</code><br> <li> Ensures <code>dashboardShareURL</code> recomputes when route changes</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9878/files#diff-052badb6758aff09ceaf1645869b9ba96125e6a0ea21abb01a8ee0a40d6467f3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

