### PR TITLE
fix: dashboard share-url tab redirection issue caused by the route path of url

### DIFF
--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -1044,6 +1044,8 @@ export default defineComponent({
      * Converts relative time periods to absolute times for sharing
      */
     const dashboardShareURL = computed(() => {
+      // Establish reactive dependency on route.fullPath to recompute when URL changes
+      void route.fullPath;
       const urlObj = new URL(window.location.href);
       const urlSearchParams = urlObj?.searchParams;
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add reactive dependency on `route.fullPath` in share URL


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ViewDashboard.vue</strong><dd><code>Add `route.fullPath` dependency to computed URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/Dashboards/ViewDashboard.vue

<ul><li>Inserted <code>void route.fullPath</code> to trigger reactivity<br> <li> Ensures <code>dashboardShareURL</code> recomputes on URL change</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9885/files#diff-052badb6758aff09ceaf1645869b9ba96125e6a0ea21abb01a8ee0a40d6467f3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

