### PR TITLE
fix: unsafe unwrap() in VectorSelector - Issue #1101

### DIFF
--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -452,13 +452,14 @@ impl Engine {
 
         let mut selector = selector.clone();
         if selector.name.is_none() {
-            let name = selector
-                .matchers
-                .find_matchers(NAME_LABEL)
-                .first()
-                .unwrap()
-                .value
-                .clone();
+            let name = match selector.matchers.find_matchers(NAME_LABEL).first() {
+                Some(mat) => mat.value.clone(),
+                None => {
+                    return Err(DataFusionError::Plan(
+                        "MatrixSelector: metric name is required".into(),
+                    ));
+                }
+            };
 
             selector.name = Some(name);
         }


### PR DESCRIPTION
### **User description**
## Summary
Fixes #1101 - Critical security vulnerability: unsafe `unwrap()` in `eval_matrix_selector()` causing Denial of Service

## Problem
A PromQL query without a metric name causes an `unwrap()` panic when accessing the NAME_LABEL matcher, crashing the query processing engine.

**Vulnerable code** (line 459):
```rust
let name = selector
    .matchers
    .find_matchers(NAME_LABEL)
    .first()
    .unwrap() // CRITICAL: Panics if no NAME_LABEL matcher found
    .value
    .clone();
```

## Solution
Replaced `unwrap()` with proper error handling using the same pattern already used in `eval_vector_selector()`:

```rust
let name = match selector.matchers.find_matchers(NAME_LABEL).first() {
    Some(mat) => mat.value.clone(),
    None => {
        return Err(DataFusionError::Plan(
            "MatrixSelector: metric name is required".into(),
        ));
    }
};
```

## Security Impact
- **Before**: DoS vulnerability - attacker can crash queries with malformed PromQL input
- **After**: Graceful error handling - returns descriptive error message instead of panicking
- **Severity**: Critical (CWE-252: Unchecked Return Value, CWE-248: Uncaught Exception)

## Changes
- **File**: `src/service/promql/engine.rs`
- **Lines**: 455-461
- **Type**: Security fix - minimal change, no new code, follows existing pattern
- **Pattern**: Same error handling as `eval_vector_selector()` (lines 353-360)

## Testing
- ✅ `cargo fmt --all` passed
- ✅ Pattern verified against existing implementation
- ✅ No dead code added
- ⏳ CI will run full test suite (clippy, tests, build)

## Verification Checklist
- [x] Follows existing error handling pattern
- [x] Error message is clear and specific
- [x] No `.unwrap()` remains in code path
- [x] Code formatted with `cargo fmt`
- [x] No dead code added (minimal fix)
- [x] Git commits verified and pushed

## References
- Issue: #1101
- Severity: Critical
- Detection: Kolega.dev Deep Code Scan
- CWE-252: Unchecked Return Value
- CWE-248: Uncaught Exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace unsafe `unwrap()` with match handling

- Return descriptive error when `NAME_LABEL` missing

- Prevent panic and service crash on malformed PromQL


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>engine.rs</strong><dd><code>Graceful error handling for missing metric name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/promql/engine.rs

<ul><li>Removed direct <code>unwrap()</code> on <code>NAME_LABEL</code> matcher<br> <li> Added <code>match</code> to handle <code>None</code> case with error return<br> <li> Returns <code>DataFusionError::Plan</code> if metric name absent</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9927/files#diff-a98ac5b55a4c9440c09c4e2dfa3b6f7f24f9e58fcb6bf8b10577a0b4f123ed41">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

