### PR TITLE
fix: issues 1102,1103,1104,1105,1106,1107

### DIFF
--- a/src/infra/src/db/mysql.rs
+++ b/src/infra/src/db/mysql.rs
@@ -134,10 +134,15 @@ impl super::Db for MysqlDb {
         let (module, key1, key2) = super::parse_key(key);
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
-        let query = format!(
-            "SELECT value FROM meta WHERE module = '{module}' AND key1 = '{key1}' AND key2 = '{key2}' ORDER BY start_dt DESC;"
-        );
-        let value: String = match sqlx::query_scalar(&query).fetch_one(&pool).await {
+        // Use parameterized query to prevent SQL injection
+        let query = "SELECT value FROM meta WHERE module = ? AND key1 = ? AND key2 = ? ORDER BY start_dt DESC;";
+        let value: String = match sqlx::query_scalar(query)
+            .bind(&module)
+            .bind(&key1)
+            .bind(&key2)
+            .fetch_one(&pool)
+            .await
+        {
             Ok(v) => v,
             Err(e) => {
                 if let sqlx::Error::RowNotFound = e {

--- a/src/infra/src/db/postgres.rs
+++ b/src/infra/src/db/postgres.rs
@@ -444,23 +444,59 @@ impl super::Db for PostgresDb {
 
     async fn list(&self, prefix: &str) -> Result<HashMap<String, Bytes>> {
         let (module, key1, key2) = super::parse_key(prefix);
-        let mut sql = "SELECT id, module, key1, key2, start_dt, value FROM meta".to_string();
+
+        // Build parameterized query to prevent SQL injection
+        // PostgreSQL uses $1, $2, etc. for parameters
+        let mut param_num = 1;
+        let mut conditions = Vec::new();
+
         if !module.is_empty() {
-            sql = format!("{sql} WHERE module = '{module}'");
+            conditions.push(format!("module = ${}", param_num));
+            param_num += 1;
         }
         if !key1.is_empty() {
-            sql = format!("{sql} AND key1 = '{key1}'");
+            conditions.push(format!("key1 = ${}", param_num));
+            param_num += 1;
         }
         if !key2.is_empty() {
-            sql = format!("{sql} AND (key2 = '{key2}' OR key2 LIKE '{key2}/%')");
+            conditions.push(format!(
+                "(key2 = ${} OR key2 LIKE ${})",
+                param_num,
+                param_num + 1
+            ));
         }
-        sql = format!("{sql} ORDER BY start_dt ASC");
+
+        let sql = if conditions.is_empty() {
+            "SELECT id, module, key1, key2, start_dt, value FROM meta ORDER BY start_dt ASC"
+                .to_string()
+        } else {
+            format!(
+                "SELECT id, module, key1, key2, start_dt, value FROM meta WHERE {} ORDER BY start_dt ASC",
+                conditions.join(" AND ")
+            )
+        };
 
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
-        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
-            .fetch_all(&pool)
-            .await?;
+        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql);
+        let ret = if !module.is_empty() {
+            ret.bind(&module)
+        } else {
+            ret
+        };
+        let ret = if !key1.is_empty() {
+            ret.bind(&key1)
+        } else {
+            ret
+        };
+        let like_pattern = format!("{}/%", key2);
+        let ret = if !key2.is_empty() {
+            ret.bind(&key2).bind(&like_pattern)
+        } else {
+            ret
+        };
+        let ret = ret.fetch_all(&pool).await?;
+
         Ok(ret
             .into_iter()
             .map(|r| {
@@ -474,22 +510,58 @@ impl super::Db for PostgresDb {
 
     async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
         let (module, key1, key2) = super::parse_key(prefix);
-        let mut sql = "SELECT id, module, key1, key2, start_dt, '' AS value FROM meta ".to_string();
+
+        // Build parameterized query to prevent SQL injection
+        let mut conditions = Vec::new();
+        let mut param_num = 1;
+
         if !module.is_empty() {
-            sql = format!("{sql} WHERE module = '{module}'");
+            conditions.push(format!("module = ${}", param_num));
+            param_num += 1;
         }
         if !key1.is_empty() {
-            sql = format!("{sql} AND key1 = '{key1}'");
+            conditions.push(format!("key1 = ${}", param_num));
+            param_num += 1;
         }
         if !key2.is_empty() {
-            sql = format!("{sql} AND (key2 = '{key2}' OR key2 LIKE '{key2}/%')");
+            conditions.push(format!(
+                "(key2 = ${} OR key2 LIKE ${})",
+                param_num,
+                param_num + 1
+            ));
         }
-        sql = format!("{sql} ORDER BY start_dt ASC");
+
+        let sql = if conditions.is_empty() {
+            "SELECT id, module, key1, key2, start_dt, '' AS value FROM meta ORDER BY start_dt ASC"
+                .to_string()
+        } else {
+            format!(
+                "SELECT id, module, key1, key2, start_dt, '' AS value FROM meta WHERE {} ORDER BY start_dt ASC",
+                conditions.join(" AND ")
+            )
+        };
+
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
-        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
-            .fetch_all(&pool)
-            .await?;
+        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql);
+        let ret = if !module.is_empty() {
+            ret.bind(&module)
+        } else {
+            ret
+        };
+        let ret = if !key1.is_empty() {
+            ret.bind(&key1)
+        } else {
+            ret
+        };
+        let like_pattern = format!("{}/%", key2);
+        let ret = if !key2.is_empty() {
+            ret.bind(&key2).bind(&like_pattern)
+        } else {
+            ret
+        };
+        let ret = ret.fetch_all(&pool).await?;
+
         Ok(ret
             .into_iter()
             .map(|r| format!("/{}/{}/{}", r.module, r.key1, r.key2))
@@ -518,24 +590,57 @@ impl super::Db for PostgresDb {
 
         let (min_dt, max_dt) = start_dt.unwrap();
         let (module, key1, key2) = super::parse_key(prefix);
-        let mut sql = "SELECT id, module, key1, key2, start_dt, value FROM meta".to_string();
+
+        // Build parameterized query to prevent SQL injection
+        let mut conditions = Vec::new();
+        let mut param_num = 1;
+
         if !module.is_empty() {
-            sql = format!("{sql} WHERE module = '{module}'");
+            conditions.push(format!("module = ${}", param_num));
+            param_num += 1;
         }
         if !key1.is_empty() {
-            sql = format!("{sql} AND key1 = '{key1}'");
+            conditions.push(format!("key1 = ${}", param_num));
+            param_num += 1;
         }
         if !key2.is_empty() {
-            sql = format!("{sql} AND (key2 = '{key2}' OR key2 LIKE '{key2}/%')");
+            conditions.push(format!(
+                "(key2 = ${} OR key2 LIKE ${})",
+                param_num,
+                param_num + 1
+            ));
+            param_num += 2;
         }
-        sql = format!("{sql} AND start_dt >= {min_dt} AND start_dt <= {max_dt}");
-        sql = format!("{sql} ORDER BY start_dt ASC");
+        conditions.push(format!("start_dt >= ${}", param_num));
+        conditions.push(format!("start_dt <= ${}", param_num + 1));
+
+        let sql = format!(
+            "SELECT id, module, key1, key2, start_dt, value FROM meta WHERE {} ORDER BY start_dt ASC",
+            conditions.join(" AND ")
+        );
 
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
-        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
-            .fetch_all(&pool)
-            .await?;
+        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql);
+        let ret = if !module.is_empty() {
+            ret.bind(&module)
+        } else {
+            ret
+        };
+        let ret = if !key1.is_empty() {
+            ret.bind(&key1)
+        } else {
+            ret
+        };
+        let like_pattern = format!("{}/%", key2);
+        let ret = if !key2.is_empty() {
+            ret.bind(&key2).bind(&like_pattern)
+        } else {
+            ret
+        };
+        let ret = ret.bind(min_dt).bind(max_dt);
+        let ret = ret.fetch_all(&pool).await?;
+
         Ok(ret
             .into_iter()
             .map(|r| (r.start_dt, Bytes::from(r.value)))
@@ -544,19 +649,56 @@ impl super::Db for PostgresDb {
 
     async fn count(&self, prefix: &str) -> Result<i64> {
         let (module, key1, key2) = super::parse_key(prefix);
-        let mut sql = "SELECT COUNT(*) AS num FROM meta".to_string();
+
+        // Build parameterized query to prevent SQL injection
+        let mut conditions = Vec::new();
+        let mut param_num = 1;
+
         if !module.is_empty() {
-            sql = format!("{sql} WHERE module = '{module}'");
+            conditions.push(format!("module = ${}", param_num));
+            param_num += 1;
         }
         if !key1.is_empty() {
-            sql = format!("{sql} AND key1 = '{key1}'");
+            conditions.push(format!("key1 = ${}", param_num));
+            param_num += 1;
         }
         if !key2.is_empty() {
-            sql = format!("{sql} AND (key2 = '{key2}' OR key2 LIKE '{key2}/%')");
+            conditions.push(format!(
+                "(key2 = ${} OR key2 LIKE ${})",
+                param_num,
+                param_num + 1
+            ));
         }
+
+        let sql = if conditions.is_empty() {
+            "SELECT COUNT(*) AS num FROM meta".to_string()
+        } else {
+            format!(
+                "SELECT COUNT(*) AS num FROM meta WHERE {}",
+                conditions.join(" AND ")
+            )
+        };
+
         let pool = CLIENT_RO.clone();
         DB_QUERY_NUMS.with_label_values(&["select", "meta"]).inc();
-        let count: i64 = sqlx::query_scalar(&sql).fetch_one(&pool).await?;
+        let query = sqlx::query_scalar(&sql);
+        let query = if !module.is_empty() {
+            query.bind(&module)
+        } else {
+            query
+        };
+        let query = if !key1.is_empty() {
+            query.bind(&key1)
+        } else {
+            query
+        };
+        let like_pattern = format!("{}/%", key2);
+        let query = if !key2.is_empty() {
+            query.bind(&key2).bind(&like_pattern)
+        } else {
+            query
+        };
+        let count: i64 = query.fetch_one(&pool).await?;
         Ok(count)
     }
 

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -549,22 +549,49 @@ impl super::Db for SqliteDb {
 
     async fn list(&self, prefix: &str) -> Result<HashMap<String, Bytes>> {
         let (module, key1, key2) = super::parse_key(prefix);
-        let mut sql = "SELECT id, module, key1, key2, start_dt, value FROM meta".to_string();
+
+        // Build parameterized query to prevent SQL injection
+        let mut conditions = Vec::new();
         if !module.is_empty() {
-            sql = format!("{sql} WHERE module = '{module}'");
+            conditions.push("module = ?");
         }
         if !key1.is_empty() {
-            sql = format!("{sql} AND key1 = '{key1}'");
+            conditions.push("key1 = ?");
         }
         if !key2.is_empty() {
-            sql = format!("{sql} AND (key2 = '{key2}' OR key2 LIKE '{key2}/%')");
+            conditions.push("(key2 = ? OR key2 LIKE ?)");
         }
-        sql = format!("{sql} ORDER BY start_dt ASC");
+
+        let sql = if conditions.is_empty() {
+            "SELECT id, module, key1, key2, start_dt, value FROM meta ORDER BY start_dt ASC"
+                .to_string()
+        } else {
+            format!(
+                "SELECT id, module, key1, key2, start_dt, value FROM meta WHERE {} ORDER BY start_dt ASC",
+                conditions.join(" AND ")
+            )
+        };
 
         let pool = CLIENT_RO.clone();
-        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
-            .fetch_all(&pool)
-            .await?;
+        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql);
+        let ret = if !module.is_empty() {
+            ret.bind(&module)
+        } else {
+            ret
+        };
+        let ret = if !key1.is_empty() {
+            ret.bind(&key1)
+        } else {
+            ret
+        };
+        let like_pattern = format!("{}/%", key2);
+        let ret = if !key2.is_empty() {
+            ret.bind(&key2).bind(&like_pattern)
+        } else {
+            ret
+        };
+        let ret = ret.fetch_all(&pool).await?;
+
         Ok(ret
             .into_iter()
             .map(|r| {
@@ -578,22 +605,49 @@ impl super::Db for SqliteDb {
 
     async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
         let (module, key1, key2) = super::parse_key(prefix);
-        let mut sql = "SELECT id, module, key1, key2, start_dt, '' AS value FROM meta".to_string();
+
+        // Build parameterized query to prevent SQL injection
+        let mut conditions = Vec::new();
         if !module.is_empty() {
-            sql = format!("{sql} WHERE module = '{module}'");
+            conditions.push("module = ?");
         }
         if !key1.is_empty() {
-            sql = format!("{sql} AND key1 = '{key1}'");
+            conditions.push("key1 = ?");
         }
         if !key2.is_empty() {
-            sql = format!("{sql} AND (key2 = '{key2}' OR key2 LIKE '{key2}/%')");
+            conditions.push("(key2 = ? OR key2 LIKE ?)");
         }
 
-        sql = format!("{sql} ORDER BY start_dt ASC");
+        let sql = if conditions.is_empty() {
+            "SELECT id, module, key1, key2, start_dt, '' AS value FROM meta ORDER BY start_dt ASC"
+                .to_string()
+        } else {
+            format!(
+                "SELECT id, module, key1, key2, start_dt, '' AS value FROM meta WHERE {} ORDER BY start_dt ASC",
+                conditions.join(" AND ")
+            )
+        };
+
         let pool = CLIENT_RO.clone();
-        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
-            .fetch_all(&pool)
-            .await?;
+        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql);
+        let ret = if !module.is_empty() {
+            ret.bind(&module)
+        } else {
+            ret
+        };
+        let ret = if !key1.is_empty() {
+            ret.bind(&key1)
+        } else {
+            ret
+        };
+        let like_pattern = format!("{}/%", key2);
+        let ret = if !key2.is_empty() {
+            ret.bind(&key2).bind(&like_pattern)
+        } else {
+            ret
+        };
+        let ret = ret.fetch_all(&pool).await?;
+
         Ok(ret
             .into_iter()
             .map(|r| format!("/{}/{}/{}", r.module, r.key1, r.key2))
@@ -622,23 +676,47 @@ impl super::Db for SqliteDb {
 
         let (min_dt, max_dt) = start_dt.unwrap();
         let (module, key1, key2) = super::parse_key(prefix);
-        let mut sql = "SELECT id, module, key1, key2, start_dt, value FROM meta".to_string();
+
+        // Build parameterized query to prevent SQL injection
+        let mut conditions = Vec::new();
         if !module.is_empty() {
-            sql = format!("{sql} WHERE module = '{module}'");
+            conditions.push("module = ?");
         }
         if !key1.is_empty() {
-            sql = format!("{sql} AND key1 = '{key1}'");
+            conditions.push("key1 = ?");
         }
         if !key2.is_empty() {
-            sql = format!("{sql} AND (key2 = '{key2}' OR key2 LIKE '{key2}/%')");
+            conditions.push("(key2 = ? OR key2 LIKE ?)");
         }
-        sql = format!("{sql} AND start_dt >= {min_dt} AND start_dt <= {max_dt}");
-        sql = format!("{sql} ORDER BY start_dt ASC");
+        conditions.push("start_dt >= ?");
+        conditions.push("start_dt <= ?");
+
+        let sql = format!(
+            "SELECT id, module, key1, key2, start_dt, value FROM meta WHERE {} ORDER BY start_dt ASC",
+            conditions.join(" AND ")
+        );
 
         let pool = CLIENT_RO.clone();
-        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql)
-            .fetch_all(&pool)
-            .await?;
+        let ret = sqlx::query_as::<_, super::MetaRecord>(&sql);
+        let ret = if !module.is_empty() {
+            ret.bind(&module)
+        } else {
+            ret
+        };
+        let ret = if !key1.is_empty() {
+            ret.bind(&key1)
+        } else {
+            ret
+        };
+        let like_pattern = format!("{}/%", key2);
+        let ret = if !key2.is_empty() {
+            ret.bind(&key2).bind(&like_pattern)
+        } else {
+            ret
+        };
+        let ret = ret.bind(min_dt).bind(max_dt);
+        let ret = ret.fetch_all(&pool).await?;
+
         Ok(ret
             .into_iter()
             .map(|r| (r.start_dt, Bytes::from(r.value)))
@@ -647,19 +725,47 @@ impl super::Db for SqliteDb {
 
     async fn count(&self, prefix: &str) -> Result<i64> {
         let (module, key1, key2) = super::parse_key(prefix);
-        let mut sql = "SELECT COUNT(*) AS num FROM meta".to_string();
+
+        // Build parameterized query to prevent SQL injection
+        let mut conditions = Vec::new();
         if !module.is_empty() {
-            sql = format!("{sql} WHERE module = '{module}'");
+            conditions.push("module = ?");
         }
         if !key1.is_empty() {
-            sql = format!("{sql} AND key1 = '{key1}'");
+            conditions.push("key1 = ?");
         }
         if !key2.is_empty() {
-            sql = format!("{sql} AND (key2 = '{key2}' OR key2 LIKE '{key2}/%')");
+            conditions.push("(key2 = ? OR key2 LIKE ?)");
         }
 
+        let sql = if conditions.is_empty() {
+            "SELECT COUNT(*) AS num FROM meta".to_string()
+        } else {
+            format!(
+                "SELECT COUNT(*) AS num FROM meta WHERE {}",
+                conditions.join(" AND ")
+            )
+        };
+
         let pool = CLIENT_RO.clone();
-        let count: i64 = sqlx::query_scalar(&sql).fetch_one(&pool).await?;
+        let query = sqlx::query_scalar(&sql);
+        let query = if !module.is_empty() {
+            query.bind(&module)
+        } else {
+            query
+        };
+        let query = if !key1.is_empty() {
+            query.bind(&key1)
+        } else {
+            query
+        };
+        let like_pattern = format!("{}/%", key2);
+        let query = if !key2.is_empty() {
+            query.bind(&key2).bind(&like_pattern)
+        } else {
+            query
+        };
+        let count: i64 = query.fetch_one(&pool).await?;
         Ok(count)
     }
 

--- a/src/infra/src/db/sqlite.rs
+++ b/src/infra/src/db/sqlite.rs
@@ -224,10 +224,15 @@ impl super::Db for SqliteDb {
     async fn get(&self, key: &str) -> Result<Bytes> {
         let (module, key1, key2) = super::parse_key(key);
         let pool = CLIENT_RO.clone();
-        let query = format!(
-            "SELECT value FROM meta WHERE module = '{module}' AND key1 = '{key1}' AND key2 = '{key2}' ORDER BY start_dt DESC;"
-        );
-        let value: String = match sqlx::query_scalar(&query).fetch_one(&pool).await {
+        // Use parameterized query to prevent SQL injection
+        let query = "SELECT value FROM meta WHERE module = ? AND key1 = ? AND key2 = ? ORDER BY start_dt DESC;";
+        let value: String = match sqlx::query_scalar(query)
+            .bind(&module)
+            .bind(&key1)
+            .bind(&key2)
+            .fetch_one(&pool)
+            .await
+        {
             Ok(v) => v,
             Err(e) => {
                 if let sqlx::Error::RowNotFound = e {


### PR DESCRIPTION
### **User description**
## 🤖 Batch Auto-Implementation (Backend/Frontend)

**Mode:** Single PR for multiple issues
**Branch:** `feat/batch-issues-1102-1103-1104-1105-1106-1107`

### Issues Implemented

- **#1102**: [Security] SQL Injection via Unescaped String Concatenation in Dynamic SQL Query Building
- **#1103**: [Security] Insecure Encryption Fallback - Master Key Defaults to None on Error
- **#1104**: [Security] Critical SQL Injection in Database Layer
- **#1105**: [Security] SQL Injection via String Interpolation in MySQL get() Method
- **#1106**: [Security] Unrestricted Dashboard Variable Injection
- **#1107**: [Security] Sensitive Data Exposure in Audit Logs


### Changes

- ✅ All issues implemented sequentially
- ✅ Quality gates passed for each issue
- ✅ Commits reference individual issues

### Related PRs

Check other repo for related changes

### Closes

Closes o2-enterprise#1102
Closes o2-enterprise#1103
Closes o2-enterprise#1104
Closes o2-enterprise#1105
Closes o2-enterprise#1106
Closes o2-enterprise#1107


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Parameterize SQL queries to prevent injection

- Redact sensitive fields in HTTP audit middleware

- Panic on invalid master encryption key initialization

- URL-encode and escape inputs in reports and alerts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Router Audit"] -- "sanitize bodies" --> B["Audit logs"]
  C["DB Modules"] -- "parameterized queries" --> D["Safe meta storage"]
  E["Cipher Table"] -- "panic on invalid key" --> F["Encryption enforced"]
  G["Report & Alerts"] -- "URL encode & escape" --> H["Injection protection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Add request sanitization in audit middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9933/files#diff-02556e3f515441b5d2b6bbea7829df488beac03c4cc41309a6638ae3c0e0aec6">+96/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>report.rs</strong><dd><code>URL-encode variables to prevent injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9933/files#diff-a8d5d0e0fc56e67b38a20a46b91cc2e6bf76ade360a37ad29fce51cc4661a9a6">+28/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>mysql.rs</strong><dd><code>Parameterize MySQL queries for security</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9933/files#diff-412dc407af348f4b54b7d98de6a928876b0333ea501792498a0568850f83d7b7">+147/-35</a></td>

</tr>

<tr>
  <td><strong>postgres.rs</strong><dd><code>Parameterize Postgres queries for security</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9933/files#diff-1554e69f6d6c29812af88f0dcf093240b24ff85f9e292322c71cb19b0dda808d">+181/-34</a></td>

</tr>

<tr>
  <td><strong>sqlite.rs</strong><dd><code>Parameterize SQLite queries for security</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9933/files#diff-85f17b22460902614e5c28df8966ea3e7073325bd8dd43fa396ed9268b6b4b06">+145/-34</a></td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Escape and validate columns in alert SQL builder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9933/files#diff-ba9b65130898444f7815fd6068bdb0dc590612f74cc893f79d91b0afc44cc851">+37/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>cipher.rs</strong><dd><code>Enforce encryption, panic on invalid master key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9933/files#diff-cf61023c41aebaf12aeac3c275c1323fac13cac6fb5ae4f3f3c548f8bebd1e3d">+12/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

