### PR TITLE
fix: default value for metrics query retention

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1392,7 +1392,7 @@ pub struct Limit {
     pub traces_file_retention: String,
     #[env_config(name = "ZO_METRICS_FILE_RETENTION", default = "hourly")]
     pub metrics_file_retention: String,
-    #[env_config(name = "ZO_METRICS_QUERY_RETENTION", default = "hourly")]
+    #[env_config(name = "ZO_METRICS_QUERY_RETENTION", default = "daily")]
     pub metrics_query_retention: String,
     #[env_config(name = "ZO_METRICS_LEADER_PUSH_INTERVAL", default = 15)]
     pub metrics_leader_push_interval: u64,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Update default metrics query retention to daily


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Update metrics query retention default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<ul><li>Changed default from "hourly" to "daily" for <br><code>ZO_METRICS_QUERY_RETENTION</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9934/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

