### PR TITLE
fix: traces insights variables changes based on new variables structure

### DIFF
--- a/web/src/plugins/traces/metrics/TracesAnalysisDashboard.vue
+++ b/web/src/plugins/traces/metrics/TracesAnalysisDashboard.vue
@@ -321,9 +321,12 @@ const showRefreshButton = computed(() => {
 
   // Use variables manager to check for uncommitted changes (same as ViewDashboard)
   const manager = variablesManager.value;
-  if (manager && 'hasUncommittedChanges' in manager) {
-    // Access the value (Vue auto-unwraps computed refs in composable returns)
-    const hasChanges = manager.hasUncommittedChanges;
+  // Use optional chaining for safer property access
+  if (manager?.hasUncommittedChanges !== undefined) {
+    // Access the value if it's a ref, otherwise use directly
+    const hasChanges = typeof manager.hasUncommittedChanges === 'object' && 'value' in manager.hasUncommittedChanges
+      ? manager.hasUncommittedChanges.value
+      : manager.hasUncommittedChanges;
     return hasChanges;
   }
 
@@ -515,6 +518,12 @@ const loadAnalysis = async () => {
 // Handler for when variables manager is ready from RenderDashboardCharts
 const onVariablesManagerReady = (manager: any) => {
   variablesManager.value = manager;
+
+  // Load analysis immediately when manager is ready to populate dashboard
+  // This ensures the dashboard shows data on initial load instead of remaining blank
+  if (activeAnalysisType.value === 'latency' && !dashboardData.value) {
+    loadAnalysis();
+  }
 };
 
 // Helper to get current percentile from variables manager


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove legacy variables data events

- Integrate VariablesManager for refresh logic

- Use getCurrentPercentile helper function

- Simplify percentile change handling


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TracesAnalysisDashboard.vue</strong><dd><code>Integrate VariablesManager for percentile control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/traces/metrics/TracesAnalysisDashboard.vue

<ul><li>Removed <code>@variablesData</code> and <code>@refreshedVariablesDataUpdated</code> events<br> <li> Added <code>@variablesManagerReady</code> event and handler<br> <li> Replaced manual percentile refs with <code>variablesManager</code><br> <li> Implemented <code>getCurrentPercentile</code> and refresh function</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9938/files#diff-d27dd619532ec278c376c09a05d5106fdb38863c3aa1c56e109fc2145a8a5a3a">+40/-26</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

