### PR TITLE
fix: gate correlation features behind enterprise license

### DIFF
--- a/web/src/plugins/logs/DetailTable.vue
+++ b/web/src/plugins/logs/DetailTable.vue
@@ -53,19 +53,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             name="table"
             :label="t('common.table')"
           />
-          <!-- Correlation Tabs (only visible when service streams enabled) -->
+          <!-- Correlation Tabs (only visible when service streams enabled and enterprise license) -->
           <q-tab
-            v-if="serviceStreamsEnabled"
+            v-if="serviceStreamsEnabled && config.isEnterprise === 'true'"
             name="correlated-logs"
             :label="t('correlation.correlatedLogs')"
           />
           <q-tab
-            v-if="serviceStreamsEnabled"
+            v-if="serviceStreamsEnabled && config.isEnterprise === 'true'"
             name="correlated-metrics"
             :label="t('correlation.correlatedMetrics')"
           />
           <q-tab
-            v-if="serviceStreamsEnabled"
+            v-if="serviceStreamsEnabled && config.isEnterprise === 'true'"
             name="correlated-traces"
             :label="t('correlation.correlatedTraces')"
           />
@@ -466,6 +466,7 @@ import { extractStatusFromLog } from "@/utils/logs/statusParser";
 import { logsUtils } from "@/composables/useLogs/logsUtils";
 import { searchState } from "@/composables/useLogs/searchState";
 import TelemetryCorrelationDashboard from "@/plugins/correlation/TelemetryCorrelationDashboard.vue";
+import config from "@/aws-exports";
 
 const defaultValue: any = () => {
   return {
@@ -766,6 +767,7 @@ export default defineComponent({
       tableRows,
       tablePagination,
       serviceStreamsEnabled,
+      config,
     };
   },
   async created() {

--- a/web/src/plugins/logs/JsonPreview.vue
+++ b/web/src/plugins/logs/JsonPreview.vue
@@ -533,6 +533,13 @@ export default {
     // The actual metric availability check happens when the button is clicked (in SearchResult.vue)
     onMounted(async () => {
       try {
+        // Gate correlation feature behind enterprise check to avoid 403 errors
+        if (config.isEnterprise !== "true") {
+          console.log("[JsonPreview] Correlation feature requires enterprise license");
+          showViewRelatedBtn.value = false;
+          return;
+        }
+
         const available = await isCorrelationAvailable();
         console.log("[JsonPreview] Correlation feature available:", available, "Mode:", props.mode);
 

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -152,16 +152,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       style="text-transform: capitalize"
       data-test="trace-details-sidebar-tabs-attributes"
     />
-    <!-- Correlation Tabs (only visible when service streams enabled) -->
+    <!-- Correlation Tabs (only visible when service streams enabled and enterprise license) -->
     <q-tab
-      v-if="serviceStreamsEnabled"
+      v-if="serviceStreamsEnabled && config.isEnterprise === 'true'"
       name="correlated-logs"
       :label="t('correlation.correlatedLogs')"
       style="text-transform: capitalize"
       data-test="trace-details-sidebar-tabs-correlated-logs"
     />
     <q-tab
-      v-if="serviceStreamsEnabled"
+      v-if="serviceStreamsEnabled && config.isEnterprise === 'true'"
       name="correlated-metrics"
       :label="t('correlation.correlatedMetrics')"
       style="text-transform: capitalize"
@@ -552,6 +552,7 @@ import LogsHighLighting from "@/components/logs/LogsHighLighting.vue";
 import TelemetryCorrelationDashboard from "@/plugins/correlation/TelemetryCorrelationDashboard.vue";
 import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import type { TelemetryContext } from "@/utils/telemetryCorrelation";
+import config from "@/aws-exports";
 
 export default defineComponent({
   name: "TraceDetailsSidebar",
@@ -1094,6 +1095,13 @@ export default defineComponent({
         return;
       }
 
+      // Gate correlation feature behind enterprise check to avoid 403 errors
+      if (config.isEnterprise !== "true") {
+        console.log("[TraceDetailsSidebar] Correlation feature requires enterprise license");
+        correlationError.value = "Correlation feature requires enterprise license";
+        return;
+      }
+
       if (!props.span || !props.streamName) {
         console.warn("[TraceDetailsSidebar] Cannot load correlation: missing span or stream name");
         correlationError.value = "Missing span or stream name";
@@ -1247,6 +1255,7 @@ export default defineComponent({
       correlationLoading,
       correlationError,
       correlationProps,
+      config,
     };
   },
 });


### PR DESCRIPTION
### **User description**
## Summary
Fixes #9960 

Gates correlation/service discovery features behind enterprise license check to prevent 403 errors when non-enterprise users expand log or trace details.

## Changes
- Added enterprise check before calling semantic-groups API
- Hide correlation tabs in log details drawer for non-enterprise users
- Hide correlation tabs in trace details sidebar for non-enterprise users  
- Hide "View Related" button for non-enterprise users

## Behavior
- **Enterprise users**: All correlation features work as before
- **Non-enterprise users**: Log/trace details open normally without correlation features or 403 errors

## Testing
- Verified log details drawer opens correctly
- Verified no 403 API errors when expanding logs
- Verified correlation tabs/buttons hidden for non-enterprise


___

### **PR Type**
Bug fix


___

### **Description**
- Gate correlation tabs and buttons behind enterprise license

- Skip correlation API calls for non-enterprise users

- Import `config` and check `config.isEnterprise` in components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["config.isEnterprise == 'true'?"]
  cfg -->|Yes| show["Show correlation tabs/buttons"]
  cfg -->|No| hide["Hide tabs and skip API calls"]
  show --> call["Proceed with correlation APIs"]
  hide --> skip["Return early and log error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DetailTable.vue</strong><dd><code>Gate correlation tabs behind license</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/DetailTable.vue

<ul><li>Imported <code>config</code> from <code>@/aws-exports</code><br> <li> Added <code>config.isEnterprise</code> check in <code>v-if</code> for correlation tabs<br> <li> Exposed <code>config</code> in component <code>setup</code> return</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9962/files#diff-80552b5d25fa6cef9fbbe430b1865d761c4b132284c2d2175afceea8cbabc8c7">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JsonPreview.vue</strong><dd><code>Gate correlation button behind license</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/JsonPreview.vue

<ul><li>Imported <code>config</code> from <code>@/aws-exports</code><br> <li> Added enterprise check before showing correlation button<br> <li> Early return and hide button if non-enterprise</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9962/files#diff-3985073134d35ff074742944b114d0905524038b42e6d2ac887fef2c8436fb16">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TraceDetailsSidebar.vue</strong><dd><code>Gate trace correlation behind license</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/traces/TraceDetailsSidebar.vue

<ul><li>Imported <code>config</code> from <code>@/aws-exports</code><br> <li> Added <code>config.isEnterprise</code> check in <code>v-if</code> for correlation tabs<br> <li> Added license gate in <code>loadCorrelation</code> to skip API calls<br> <li> Logged error message if non-enterprise user</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9962/files#diff-0017bc08d8da96af6433770d0b274f825798d24401b33ce091b16a50fbaf4b57">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

