### PR TITLE
fix: v0.50.0 issues (#1125)

### DIFF
--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -1139,7 +1139,9 @@ export default defineComponent({
 
     // Initialize viewMode from URL query parameter
     const viewMode = ref(
-      (router.currentRoute.value.query.view as string) === "incidents" ? "incidents" : "alerts"
+      (router.currentRoute.value.query.view as string) === "incidents" && config.isEnterprise === "true"
+        ? "incidents"
+        : "alerts"
     );
 
     // Initialize activeTab from URL query parameter, default to "all"
@@ -1151,16 +1153,24 @@ export default defineComponent({
     const incidentSearchQuery = ref("");
 
     // View mode tabs (Alerts / Incidents)
-    const viewTabs = computed(() => [
-      {
-        label: t('alerts.header'),
-        value: 'alerts',
-      },
-      {
-        label: t('alerts.incidents.title'),
-        value: 'incidents',
+    const viewTabs = computed(() => {
+      const tabs = [
+        {
+          label: t('alerts.header'),
+          value: 'alerts',
+        }
+      ];
+
+      // Only add incidents tab for enterprise builds
+      if (config.isEnterprise === "true") {
+        tabs.push({
+          label: t('alerts.incidents.title'),
+          value: 'incidents',
+        });
       }
-    ]);
+
+      return tabs;
+    });
 
     // Tabs for alerts view only (removed incidents tab)
     const alertTabs = reactive([

--- a/web/src/locales/languages/de.json
+++ b/web/src/locales/languages/de.json
@@ -2311,7 +2311,7 @@
     "dimensionsButton": "Felder ({count})",
     "dimensionsTooltip": "Zu analysierende Dimensionen hinzufügen oder entfernen",
     "selectDimensions": "Wählen Sie Felder",
-    "analyzeButtonLabel": "Analysieren",
+    "analyzeButtonLabel": "Einblicke",
     "refreshTooltip": "Analyse mit aktualisiertem Perzentil aktualisieren",
     "customSQLFieldsDisabled": "Die Feldauswahl ist für benutzerdefinierte SQL-Abfragen nicht verfügbar. Dimensionen werden aus Ihren Abfrageergebnissen extrahiert.",
     "timeRangeSelected": "Ausgewählter Zeitbereich"

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -874,7 +874,7 @@
     "dimensionsButton": "Fields ({count})",
     "dimensionsTooltip": "Add or remove dimensions to analyze",
     "selectDimensions": "Select Fields",
-    "analyzeButtonLabel": "Analyze",
+    "analyzeButtonLabel": "Insights",
     "refreshTooltip": "Refresh analysis with updated percentile",
     "customSQLFieldsDisabled": "Field selection is not available for custom SQL queries. Dimensions are extracted from your query results.",
     "timeRangeSelected": "Time Range Selected"

--- a/web/src/locales/languages/es.json
+++ b/web/src/locales/languages/es.json
@@ -2311,7 +2311,7 @@
     "dimensionsButton": "Campos ({count})",
     "dimensionsTooltip": "Agregar o eliminar dimensiones para analizar",
     "selectDimensions": "Seleccione campos",
-    "analyzeButtonLabel": "Analiza",
+    "analyzeButtonLabel": "Perspectivas",
     "refreshTooltip": "Actualice el análisis con un percentil actualizado",
     "customSQLFieldsDisabled": "La selección de campos no está disponible para las consultas SQL personalizadas. Las dimensiones se extraen de los resultados de la consulta.",
     "timeRangeSelected": "Intervalo de tiempo seleccionado"

--- a/web/src/locales/languages/fr.json
+++ b/web/src/locales/languages/fr.json
@@ -2311,7 +2311,7 @@
     "dimensionsButton": "Champs ({count})",
     "dimensionsTooltip": "Ajouter ou supprimer des dimensions à analyser",
     "selectDimensions": "Sélectionnez les champs",
-    "analyzeButtonLabel": "Analyser",
+    "analyzeButtonLabel": "Aperçus",
     "refreshTooltip": "Actualiser l'analyse avec un percentile mis à jour",
     "customSQLFieldsDisabled": "La sélection de champs n'est pas disponible pour les requêtes SQL personnalisées. Les dimensions sont extraites des résultats de votre requête.",
     "timeRangeSelected": "Plage de temps sélectionnée"

--- a/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
+++ b/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
@@ -79,9 +79,8 @@ class="tw:mx-1 tw:text-red-500" />
         />
       </div>
 
-      <!-- Unified Analyze Dimensions Button (only shown when brush selection exists) -->
+      <!-- Unified Insights Button (always visible) -->
       <q-btn
-        v-if="hasAnyBrushSelection"
         outline
         dense
         no-caps
@@ -617,8 +616,10 @@ const openUnifiedAnalysisDashboard = () => {
   let rateStart = null, rateEnd = null, rateTimeStart = null, rateTimeEnd = null;
   let errorStart = null, errorEnd = null, errorTimeStart = null, errorTimeEnd = null;
   let latestFilterType = null;
+  let hasAnySelection = false;
 
   rangeFilters.value.forEach((filter) => {
+    hasAnySelection = true;
 
     if (filter.panelTitle === "Duration") {
       durationStart = filter.start;
@@ -641,27 +642,54 @@ const openUnifiedAnalysisDashboard = () => {
     }
   });
 
-  // Set all filters
-  analysisDurationFilter.value = {
-    start: durationStart || 0,
-    end: durationEnd || Number.MAX_SAFE_INTEGER,
-    timeStart: durationTimeStart || undefined,
-    timeEnd: durationTimeEnd || undefined,
-  };
+  // If no brush selection exists, use baseline time range for all filters
+  if (!hasAnySelection) {
+    const baselineTimeStart = props.timeRange.startTime;
+    const baselineTimeEnd = props.timeRange.endTime;
 
-  analysisRateFilter.value = {
-    start: rateStart || 0,
-    end: rateEnd || Number.MAX_SAFE_INTEGER,
-    timeStart: rateTimeStart || undefined,
-    timeEnd: rateTimeEnd || undefined,
-  };
+    analysisDurationFilter.value = {
+      start: 0,
+      end: Number.MAX_SAFE_INTEGER,
+      timeStart: baselineTimeStart,
+      timeEnd: baselineTimeEnd,
+    };
 
-  analysisErrorFilter.value = {
-    start: errorStart || 0,
-    end: errorEnd || Number.MAX_SAFE_INTEGER,
-    timeStart: errorTimeStart || undefined,
-    timeEnd: errorTimeEnd || undefined,
-  };
+    analysisRateFilter.value = {
+      start: 0,
+      end: Number.MAX_SAFE_INTEGER,
+      timeStart: baselineTimeStart,
+      timeEnd: baselineTimeEnd,
+    };
+
+    analysisErrorFilter.value = {
+      start: 0,
+      end: Number.MAX_SAFE_INTEGER,
+      timeStart: baselineTimeStart,
+      timeEnd: baselineTimeEnd,
+    };
+  } else {
+    // Set all filters based on brush selections
+    analysisDurationFilter.value = {
+      start: durationStart || 0,
+      end: durationEnd || Number.MAX_SAFE_INTEGER,
+      timeStart: durationTimeStart || undefined,
+      timeEnd: durationTimeEnd || undefined,
+    };
+
+    analysisRateFilter.value = {
+      start: rateStart || 0,
+      end: rateEnd || Number.MAX_SAFE_INTEGER,
+      timeStart: rateTimeStart || undefined,
+      timeEnd: rateTimeEnd || undefined,
+    };
+
+    analysisErrorFilter.value = {
+      start: errorStart || 0,
+      end: errorEnd || Number.MAX_SAFE_INTEGER,
+      timeStart: errorTimeStart || undefined,
+      timeEnd: errorTimeEnd || undefined,
+    };
+  }
 
   // Set default tab based on most recent selection, or volume if no selection
   defaultAnalysisTab.value = latestFilterType || "volume";


### PR DESCRIPTION
### **User description**
- Hide Incidents feature in non-enterprise builds by adding enterprise check
- Rename 'Analyze' button to 'Insights' on traces page
- Make Insights button always visible (not conditional on selections)
- Fix analysis behavior to use baseline time range when no brush selection


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Hide incidents tab for non-enterprise builds

- Rename “Analyze” button to “Insights”

- Always display the Insights button

- Default analysis filters to baseline when unselected


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["config.isEnterprise?"] -- "true" --> B["Show Incidents Tab"]
  A -- "false" --> C["Hide Incidents Tab"]
  D["User clicks Insights Button"] --> E["openUnifiedAnalysisDashboard()"]
  E -- "no selection" --> F["Use baseline time range"]
  E -- "with selection" --> G["Use brush selection ranges"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AlertList.vue</strong><dd><code>Add enterprise check for incidents tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/AlertList.vue

<ul><li>Added enterprise flag check for <code>viewMode</code><br> <li> Conditionally include incidents tab based on Enterprise</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9963/files#diff-be3e41b823e163b226ffc270d95cc4981e59c600851e4e0d10ee5e4ee994ac8e">+20/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TracesMetricsDashboard.vue</strong><dd><code>Unify Insights button and analysis filter defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/traces/metrics/TracesMetricsDashboard.vue

<ul><li>Renamed Analyze button to Insights, always visible<br> <li> Introduced <code>hasAnySelection</code> flag for brush detection<br> <li> Default filters to baseline range if no selection<br> <li> Preserve brush-based filters when present</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9963/files#diff-7b6f29a2737d9501b18dbd8622eba4965e4bc2b92115627ae7d2e70cc3382087">+49/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>de.json</strong><dd><code>German locale Analyze-to-Insights update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/locales/languages/de.json

- Updated `analyzeButtonLabel` translation to "Einblicke"


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9963/files#diff-78f24ecb2dbcfc38fdf3ec22b2559a5b40d236ea689d1c55f5d3e87168310264">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>English locale Analyze-to-Insights update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/locales/languages/en.json

- Updated `analyzeButtonLabel` to "Insights"


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9963/files#diff-892aa3d75ab6e129ef9116aa21bec1b9a15ba69ce5366d2a19128078c690d824">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>es.json</strong><dd><code>Spanish locale Analyze-to-Insights update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/locales/languages/es.json

- Updated `analyzeButtonLabel` translation to "Perspectivas"


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9963/files#diff-ac2a2167b8b973e3f776f9fe3b43bef4576470d8ad33f3d7cfaff6edff0e5778">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fr.json</strong><dd><code>French locale Analyze-to-Insights update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/locales/languages/fr.json

- Updated `analyzeButtonLabel` translation to "Aperçus"


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9963/files#diff-db80e762b88ddf183820c050cdc6b215e6b02b365b5e73f5152af46b0d26f1a2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

