### PR TITLE
fix: enable alert history for cloud

### DIFF
--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -761,7 +761,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 data-test="to-be-clone-alert-name"
                 v-model="toBeCloneAlertName"
                 label="Alert Name"
-                class="showLabelOnTop q-mb-sm"
+                class="showLabelOnTop"
                 stack-label
                 hide-bottom-space
                 borderless
@@ -775,7 +775,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 @update:model-value="updateStreams()"
                 borderless
                 dense
-                class="showLabelOnTop no-case tw:mt-[1px] q-mb-sm"
+                class="showLabelOnTop no-case tw:mt-[1px]"
               />
               <q-select
                 data-test="to-be-clone-stream-name"
@@ -808,14 +808,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   class="o2-secondary-button tw:h-[36px]"
                   :label="t('alerts.cancel')"
                   text-color="light-text"
-                  padding="sm md"
                   no-caps
                 />
                 <q-btn
                   data-test="clone-alert-submit-btn"
                   :label="t('alerts.save')"
                   class="o2-primary-button tw:h-[36px] q-ml-md"
-                  padding="sm xl"
                   type="submit"
                   :disable="isSubmitting"
                   no-caps


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove cloud check for alert history fetch

- Always call fetchAlertHistory on alert selection


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AlertList.vue</strong><dd><code>Unconditional alert history fetch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/AlertList.vue

<ul><li>Deleted <code>if(config.isCloud == "false")</code> wrapper<br> <li> Now unconditionally invokes <code>fetchAlertHistory</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9972/files#diff-be3e41b823e163b226ffc270d95cc4981e59c600851e4e0d10ee5e4ee994ac8e">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

