### PR TITLE
fix: sync of backfill jobs

### DIFF
--- a/src/service/db/backfill.rs
+++ b/src/service/db/backfill.rs
@@ -1,0 +1,136 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use infra::errors::Result;
+pub use infra::table::backfill_jobs::BackfillJob;
+#[cfg(feature = "enterprise")]
+use o2_enterprise::enterprise::super_cluster::queue::BACKFILL_JOBS_KEY;
+
+/// Get a backfill job by org and job ID
+pub async fn get(org: &str, job_id: &str) -> Result<BackfillJob> {
+    infra::table::backfill_jobs::get(org, job_id).await
+}
+
+/// List all backfill jobs for an organization
+pub async fn list_by_org(org: &str) -> Result<Vec<BackfillJob>> {
+    infra::table::backfill_jobs::list_by_org(org).await
+}
+
+/// List all backfill jobs for a specific pipeline
+pub async fn list_by_pipeline(org: &str, pipeline_id: &str) -> Result<Vec<BackfillJob>> {
+    infra::table::backfill_jobs::list_by_pipeline(org, pipeline_id).await
+}
+
+/// Add a new backfill job
+pub async fn add(job: BackfillJob) -> Result<()> {
+    infra::table::backfill_jobs::add(job.clone()).await?;
+
+    // Super cluster support
+    #[cfg(feature = "enterprise")]
+    if o2_enterprise::enterprise::common::config::get_config()
+        .super_cluster
+        .enabled
+    {
+        let key = format!("{BACKFILL_JOBS_KEY}/{}/{}", job.org, job.id);
+        match config::utils::json::to_vec(&job) {
+            Err(e) => {
+                log::error!(
+                    "[BACKFILL] error serializing backfill job {}/{} for super_cluster event: {e}",
+                    job.org,
+                    job.id
+                );
+            }
+            Ok(value_vec) => {
+                if let Err(e) = o2_enterprise::enterprise::super_cluster::queue::backfill_add(
+                    &key,
+                    value_vec.into(),
+                )
+                .await
+                {
+                    log::error!(
+                        "[BACKFILL] error sending backfill job {}/{} to super_cluster: {e}",
+                        job.org,
+                        job.id
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Delete a backfill job
+pub async fn delete(org: &str, job_id: &str) -> Result<()> {
+    infra::table::backfill_jobs::delete(org, job_id).await?;
+
+    // Super cluster support
+    #[cfg(feature = "enterprise")]
+    if o2_enterprise::enterprise::common::config::get_config()
+        .super_cluster
+        .enabled
+    {
+        let key = format!("{BACKFILL_JOBS_KEY}/{}/{}", org, job_id);
+        if let Err(e) = o2_enterprise::enterprise::super_cluster::queue::backfill_delete(&key).await
+        {
+            log::error!(
+                "[BACKFILL] error sending backfill job {}/{} delete event to super_cluster: {e}",
+                org,
+                job_id
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Update an existing backfill job
+pub async fn update(job: &BackfillJob) -> Result<()> {
+    infra::table::backfill_jobs::update(job).await?;
+
+    // Super cluster support
+    #[cfg(feature = "enterprise")]
+    if o2_enterprise::enterprise::common::config::get_config()
+        .super_cluster
+        .enabled
+    {
+        let key = format!("{BACKFILL_JOBS_KEY}/{}/{}", job.org, job.id);
+        match config::utils::json::to_vec(job) {
+            Err(e) => {
+                log::error!(
+                    "[BACKFILL] error serializing backfill job {}/{} for super_cluster update event: {e}",
+                    job.org,
+                    job.id
+                );
+            }
+            Ok(value_vec) => {
+                if let Err(e) = o2_enterprise::enterprise::super_cluster::queue::backfill_update(
+                    &key,
+                    value_vec.into(),
+                )
+                .await
+                {
+                    log::error!(
+                        "[BACKFILL] error sending backfill job {}/{} update to super_cluster: {e}",
+                        job.org,
+                        job.id
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/service/db/mod.rs
+++ b/src/service/db/mod.rs
@@ -23,6 +23,7 @@ use {
 
 pub mod ai_prompts;
 pub mod alerts;
+pub mod backfill;
 pub mod compact;
 pub mod dashboards;
 pub mod distinct_values;

--- a/src/super_cluster_queue/pipelines.rs
+++ b/src/super_cluster_queue/pipelines.rs
@@ -16,7 +16,7 @@
 use config::{meta::pipeline::Pipeline, utils::json};
 use infra::{
     errors::{Error, Result},
-    table::enrichment_table_urls,
+    table::{backfill_jobs, enrichment_table_urls},
 };
 use o2_enterprise::enterprise::super_cluster::queue::{Message, MessageType};
 
@@ -59,6 +59,40 @@ pub(crate) async fn process(msg: Message) -> Result<()> {
                 return Err(Error::Message("Invalid key".to_string()));
             }
             enrichment_table_urls::delete(key_columns[2], key_columns[3]).await?;
+        }
+        MessageType::BackfillAdd => {
+            // format is /{BACKFILL_JOBS_KEY}/org/job_id
+            let bytes = msg
+                .value
+                .ok_or(Error::Message("Message missing value".to_string()))?;
+            let backfill_job: backfill_jobs::BackfillJob = json::from_slice(&bytes).inspect_err(|e| {
+                log::error!(
+                    "[SUPER_CLUSTER:BACKFILL] Failed to deserialize message value to backfill job: {e}"
+                );
+            })?;
+            backfill_jobs::add(backfill_job).await?;
+        }
+        MessageType::BackfillUpdate => {
+            // format is /{BACKFILL_JOBS_KEY}/org/job_id
+            let bytes = msg
+                .value
+                .ok_or(Error::Message("Message missing value".to_string()))?;
+            let backfill_job: backfill_jobs::BackfillJob = json::from_slice(&bytes).inspect_err(|e| {
+                log::error!(
+                    "[SUPER_CLUSTER:BACKFILL] Failed to deserialize message value to backfill job: {e}"
+                );
+            })?;
+            backfill_jobs::update(&backfill_job).await?;
+        }
+        MessageType::BackfillDelete => {
+            let key_columns: Vec<&str> = msg.key.split('/').collect();
+            // format is /{BACKFILL_JOBS_KEY}/org/job_id
+            if key_columns.len() != 4 || key_columns[2].is_empty() || key_columns[3].is_empty() {
+                return Err(Error::Message("Invalid key for BackfillDelete".to_string()));
+            }
+            let org = key_columns[2];
+            let job_id = key_columns[3];
+            backfill_jobs::delete(org, job_id).await?;
         }
         _ => {
             log::error!(


### PR DESCRIPTION
### **User description**
This pr fixes the sync issue of backfill jobs


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce `db::backfill` module wrapping backfill_jobs table

- Refactor alerts service to call `db::backfill` instead of `infra::table`

- Add enterprise super_cluster events for backfill job operations

- Extend super_cluster_queue to handle backfill job messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Alerts Service"] -->|uses| B["db::backfill module"]
  B -->|calls| C["infra::table::backfill_jobs"]
  B -->|emits events| D["SuperCluster Queue"]
  D -->|processes backfill| C["infra::table::backfill_jobs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backfill.rs</strong><dd><code>Refactor alerts service to use db::backfill</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/alerts/backfill.rs

<ul><li>Swapped <code>infra::table::backfill_jobs</code> references to <code>db::backfill</code><br> <li> Updated function signatures to accept <code>db::backfill::BackfillJob</code><br> <li> Replaced add/get/list/update/delete calls with <code>db::backfill</code> calls</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9975/files#diff-d6a8d32e1c42ba689cf4c2cb32b17205594cf2b7517cbbdafe5d7c9cfa9d7ed5">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backfill.rs</strong><dd><code>Implement db::backfill wrapper with queue support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/db/backfill.rs

<ul><li>New module wrapping <code>infra::table::backfill_jobs</code> functions<br> <li> Implements get, list_by_org, list_by_pipeline, add, delete, update<br> <li> Adds enterprise super_cluster queue events on add/delete/update</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9975/files#diff-870e0af2880330de5796f09f3831417a6b131ff0fbcedbb884704e77ffaa7e8b">+136/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pipelines.rs</strong><dd><code>Support backfill job messages in super_cluster_queue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/super_cluster_queue/pipelines.rs

<ul><li>Added handling of <code>MessageType::BackfillAdd</code>, <code>BackfillUpdate</code>, <br><code>BackfillDelete</code><br> <li> Deserialize message value to <code>backfill_jobs::BackfillJob</code><br> <li> Call <code>backfill_jobs</code> add/update/delete accordingly</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9975/files#diff-7c8aa678045dd00de89d4c2345cf4a0511ce9bfac5d6f64e7404178c81e541ad">+35/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Expose backfill module in db mod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/db/mod.rs

- Exposed `backfill` submodule in `db` module


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9975/files#diff-b7e3bf7f0ac23dd084c0c817a310a4d5e7a64ff532746d182986ef940fa03fd0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

