### PR TITLE
fix: about us page use appropriate label

### DIFF
--- a/web/src/components/about/FeatureComparisonTable.vue
+++ b/web/src/components/about/FeatureComparisonTable.vue
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div class="icon-wrapper" :class="store.state.theme === 'dark' ? 'icon-wrapper-dark' : 'icon-wrapper-light'">
           <q-icon name="compare_arrows" size="24px" />
         </div>
-        <h3 class="feature-title">{{ t("about.feature_comparision_lbl") }}</h3>
+        <h3 class="feature-title">{{ t("about.feature_comparison_lbl") }}</h3>
       </div>
       <div class="feature-subtitle-wrapper">
         <p


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix translation key typo in About page header


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FeatureComparisonTable.vue</strong><dd><code>Fix translation key typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/about/FeatureComparisonTable.vue

<ul><li>Corrected translation key from <code>about.feature_comparision_lbl</code> to <br><code>about.feature_comparison_lbl</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9976/files#diff-450bc4b412ffde37d04f96046199090e3d41face1ee85b32e446c9b470ce299e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

