### PR TITLE
fix: use english keys for period mapping

### DIFF
--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -764,12 +764,12 @@ export default defineComponent({
 
     const getPeriodLabel = computed(() => {
       const periodMapping = {
-        s: t("common.seconds"),
-        m: t("common.minutes"),
-        h: t("common.hours"),
-        d: t("common.days"),
-        w: t("common.weeks"),
-        M: t("common.months"),
+        s: "Seconds",
+        m: "Minutes",
+        h: "Hours",
+        d: "Days",
+        w: "Weeks",
+        M: "Months",
       };
       return periodMapping[relativePeriod.value];
     });


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Use static English labels for time periods

- Replace translation function calls with hard-coded strings


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateTime.vue</strong><dd><code>Static English period labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/DateTime.vue

<ul><li>Updated <code>periodMapping</code> values to English strings<br> <li> Removed <code>t("common.*")</code> translation calls</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9982/files#diff-c06c96ba750be6fc82f517a53ba809efff8aa619aba203b871d4d2aeb7f64f60">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

