### PR TITLE
fix: license rbac for token_validator (#9985)

### DIFF
--- a/src/handler/http/auth/token.rs
+++ b/src/handler/http/auth/token.rs
@@ -127,7 +127,31 @@ pub async fn token_validator(
                         }
                         None => {
                             if path_columns.len() == 1 && path_columns[0] == "license" {
-                                users::get_user(Some("_meta"), user_id).await
+                                // for get license, as long as user is part of o2, it is fine
+                                if req.method().as_str() == "GET" {
+                                    if let Ok(v) = db::user::get_user_record(user_id).await {
+                                        Some(config::meta::user::User {
+                                            email: v.email,
+                                            first_name: v.first_name,
+                                            last_name: v.last_name,
+                                            password: v.password,
+                                            salt: v.salt,
+                                            token: "".into(),
+                                            rum_token: None,
+                                            role: config::meta::user::UserRole::User,
+                                            org: "".into(),
+                                            is_external: v.user_type
+                                                == config::meta::user::UserType::External,
+                                            password_ext: v.password_ext,
+                                        })
+                                    } else {
+                                        None
+                                    }
+                                } else {
+                                    // for anything else, which will mostly be PUT/POST calls,
+                                    // the user must be in _meta org
+                                    users::get_user(Some("_meta"), user_id).await
+                                }
                             } else {
                                 users::get_user(None, user_id).await
                             }

--- a/src/handler/http/auth/validator.rs
+++ b/src/handler/http/auth/validator.rs
@@ -76,7 +76,7 @@ pub async fn validator(
     match if auth_info.auth.starts_with("{\"auth_ext\":") {
         let auth_token: AuthTokensExt =
             config::utils::json::from_str(&auth_info.auth).unwrap_or_default();
-        validate_credentials_ext(user_id, password, path, auth_token).await
+        validate_credentials_ext(user_id, password, path, auth_token, &auth_info.method).await
     } else {
         validate_credentials(user_id, password.trim(), path, auth_info.bypass_check).await
     } {
@@ -365,6 +365,7 @@ pub async fn validate_credentials_ext(
     in_password: &str,
     path: &str,
     auth_token: AuthTokensExt,
+    method: &str,
 ) -> Result<TokenValidationResponse, Error> {
     let cfg = get_config();
     let password_ext_salt = cfg.auth.ext_auth_salt.as_str();
@@ -408,7 +409,35 @@ pub async fn validate_credentials_ext(
                     users::get_user(Some(org_id), user_id).await
                 }
             }
-            None => users::get_user(None, user_id).await,
+            None => {
+                if path_columns.len() == 1 && path_columns[0] == "license" {
+                    // for license requests, we only need to check if part of o2
+                    // rest rbac is done in the handlers themselves
+                    if method == "GET" {
+                        if let Ok(v) = db::user::get_user_record(user_id).await {
+                            Some(config::meta::user::User {
+                                email: v.email,
+                                first_name: v.first_name,
+                                last_name: v.last_name,
+                                password: v.password,
+                                salt: v.salt,
+                                token: "".into(),
+                                rum_token: None,
+                                role: config::meta::user::UserRole::User,
+                                org: "".into(),
+                                is_external: v.user_type == config::meta::user::UserType::External,
+                                password_ext: v.password_ext,
+                            })
+                        } else {
+                            None
+                        }
+                    } else {
+                        users::get_user(Some("_meta"), user_id).await
+                    }
+                } else {
+                    users::get_user(None, user_id).await
+                }
+            }
         }
     };
 
@@ -509,6 +538,7 @@ pub async fn validate_credentials_ext(
     _in_password: &str,
     _path: &str,
     _auth_token: AuthTokensExt,
+    _method: &str,
 ) -> Result<TokenValidationResponse, Error> {
     Err(ErrorForbidden("Not allowed"))
 }


### PR DESCRIPTION
### **User description**
Adds correct handling of user check specifically for the license path. Cherry picked from v0.50.0 branch


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add GET-specific `/license` RBAC in validators

- Allow any O2 user for GET license

- Require `_meta` org membership for others

- Extend credentials_ext to accept HTTP method


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incoming request to `/license`"]
  B["Method is GET?"]
  C["Fetch record via db::user::get_user_record and map to config user"]
  D["Lookup user via `users::get_user(_meta)`"]
  A -- "token_validator & validator" --> B
  B -- "yes" --> C
  B -- "no" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>token.rs</strong><dd><code>Support GET-specific license RBAC in token_validator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/auth/token.rs

<ul><li>Add GET-specific license RBAC check<br> <li> Fetch and map DB user record on GET license<br> <li> Fallback to <code>_meta</code> org for non-GET license</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9994/files#diff-3339b4a964c121766ef87fcec0070f27a2b7085cf81281b53154e53d33cb28cf">+25/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>validator.rs</strong><dd><code>Extend validator for license RBAC and method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/auth/validator.rs

<ul><li>Pass HTTP method to <code>validate_credentials_ext</code><br> <li> Add license RBAC logic in validate_credentials_ext<br> <li> Maintain default lookup for other paths</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/9994/files#diff-f4d4b51574b378a8c372345ea48875834a4eadacfac33fa4d0ceca1e0ef96b35">+32/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

