### PR TITLE
fix: dashboard should not be created using PUT dashboard update api

### DIFF
--- a/src/handler/http/request/dashboards/mod.rs
+++ b/src/handler/http/request/dashboards/mod.rs
@@ -93,6 +93,7 @@ impl From<DashboardError> for HttpResponse {
     ),
     params(
         ("org_id" = String, Path, description = "Organization name"),
+        ("folder" = Option<String>, Query, description = "Folder ID where the dashboard will be created. Used for RBAC checks in enterprise version. Defaults to 'default' if not specified"),
     ),
     request_body(
         content = inline(DashboardRequestBody),
@@ -104,6 +105,7 @@ impl From<DashboardError> for HttpResponse {
     ),
     responses(
         (status = StatusCode::CREATED, description = "Dashboard created", body = inline(DashboardResponseBody)),
+        (status = StatusCode::NOT_FOUND, description = "Folder not found", body = ()),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Internal Server Error", body = ()),
     ),
     extensions(
@@ -146,11 +148,14 @@ pub async fn create_dashboard(
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("dashboard_id" = String, Path, description = "Dashboard ID"),
+        ("folder" = String, Query, description = "Folder ID where the dashboard is located"),
+        ("hash" = Option<String>, Query, description = "Hash value for conflict detection. Required when updating an existing dashboard to prevent concurrent edit conflicts"),
     ),
     request_body(content = inline(DashboardRequestBody), description = "Dashboard details"),
     responses(
         (status = StatusCode::OK, description = "Dashboard updated", body = inline(DashboardResponseBody)),
         (status = StatusCode::NOT_FOUND, description = "Dashboard not found", body = ()),
+        (status = StatusCode::CONFLICT, description = "Conflict: Failed to save due to concurrent changes", body = ()),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Failed to update the dashboard", body = ()),
     ),
     extensions(
@@ -237,10 +242,12 @@ async fn list_dashboards(
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("dashboard_id" = String, Path, description = "Dashboard ID"),
+        ("folder" = Option<String>, Query, description = "Folder ID where the dashboard is located. Used for RBAC permission checks in enterprise version"),
     ),
     responses(
         (status = StatusCode::OK, body = inline(DashboardResponseBody)),
         (status = StatusCode::NOT_FOUND, description = "Dashboard not found", body = ()),
+        (status = StatusCode::FORBIDDEN, description = "Unauthorized Access", body = ()),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Dashboards", "operation": "get"})),
@@ -271,10 +278,12 @@ async fn get_dashboard(path: web::Path<(String, String)>) -> impl Responder {
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("dashboard_id" = String, Path, description = "Dashboard ID"),
+        ("folder" = Option<String>, Query, description = "Folder ID where the dashboard is located. Used for RBAC permission checks in enterprise version"),
     ),
     responses(
         (status = StatusCode::OK, body = inline(DashboardResponseBody)),
         (status = StatusCode::NOT_FOUND, description = "Dashboard not found", body = ()),
+        (status = StatusCode::FORBIDDEN, description = "Unauthorized Access", body = ()),
     ),
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Dashboards", "operation": "get"})),
@@ -305,10 +314,12 @@ pub async fn export_dashboard(path: web::Path<(String, String)>) -> impl Respond
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("dashboard_id" = String, Path, description = "Dashboard ID"),
+        ("folder" = Option<String>, Query, description = "Folder ID where the dashboard is located. Used for RBAC permission checks in enterprise version"),
     ),
     responses(
         (status = StatusCode::OK, description = "Success", body = Object),
         (status = StatusCode::NOT_FOUND, description = "NotFound", body = ()),
+        (status = StatusCode::FORBIDDEN, description = "Unauthorized Access", body = ()),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Error", body = ()),
     ),
     extensions(
@@ -340,6 +351,7 @@ async fn delete_dashboard(path: web::Path<(String, String)>) -> impl Responder {
     ),
     params(
         ("org_id" = String, Path, description = "Organization name"),
+        ("folder" = Option<String>, Query, description = "Folder ID where the dashboards are located. Required for RBAC permission checks in enterprise version"),
     ),
     request_body(
         content = BulkDeleteRequest,
@@ -348,6 +360,7 @@ async fn delete_dashboard(path: web::Path<(String, String)>) -> impl Responder {
     ),
     responses(
         (status = StatusCode::OK, description = "Success", body = BulkDeleteResponse),
+        (status = StatusCode::FORBIDDEN, description = "Unauthorized Access", body = ()),
         (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Error", body = ()),
     ),
     extensions(

--- a/src/service/dashboards/mod.rs
+++ b/src/service/dashboards/mod.rs
@@ -381,6 +381,15 @@ pub async fn update_dashboard(
     dashboard: Dashboard,
     hash: Option<&str>,
 ) -> Result<Dashboard, DashboardError> {
+    // Check if dashboard exists and belongs to the specified folder.
+    // Note: We don't need to explicitly check if the folder exists because
+    // the folder-dashboard relationship is enforced by a foreign key constraint.
+    // If the dashboard exists in the folder, the folder must exist.
+    let existing = table::dashboards::get_from_folder(org_id, folder_id, dashboard_id).await?;
+    if existing.is_none() {
+        return Err(DashboardError::DashboardNotFound);
+    }
+
     let dashboard = put(org_id, dashboard_id, folder_id, None, dashboard, hash).await?;
 
     #[cfg(feature = "enterprise")]


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `folder` query parameter for all dashboard endpoints

- Introduce `hash` param for update conflict detection

- Enhance error responses with 404, 403, 409 statuses

- Prevent PUT-based update from creating dashboards


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add folder and error handling to HTTP handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/dashboards/mod.rs

<ul><li>Added <code>folder</code> query param to create, update, list, export, delete<br> <li> Introduced <code>hash</code> param on update endpoint<br> <li> Defined new error responses: 404, 403, 409 statuses</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10000/files#diff-1b3c257e1d174c826718499faa4a1d4e93465dd56cb2b7b273b690ff7e3223fd">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Validate dashboard existence before update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/dashboards/mod.rs

<ul><li>Check dashboard exists in folder before update<br> <li> Return <code>DashboardNotFound</code> to avoid creation via PUT</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10000/files#diff-6ae9e22ced40c50675dde5348b8d696f6559655bbbded915d7e6e88bf64b71a6">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

