### PR TITLE
fix: result cache retention

### DIFF
--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -1062,6 +1062,15 @@ pub async fn stream_delete_inner(
         return Err(e);
     }
 
+    // delete result cache for this stream
+    let cache_path = format!("{org_id}/{stream_type}/{stream_name}");
+    log::warn!("Deleting result cache for path: {cache_path}");
+    if let Err(e) = crate::service::search::cache::cacher::delete_cache(&cache_path, 0, None, None).await {
+        log::error!(
+            "Failed to delete result cache for stream: {org_id}/{stream_type}/{stream_name}, error: {e}"
+        );
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
### **User description**


___

### **PR Type**
Bug fix


___

### **Description**
- Delete result cache when deleting streams

- Log cache deletion initiation and errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["stream_delete_inner"] --> B["db::compact::files::del_offset"]
  B --> C["search::cache::cacher::delete_cache"]
  C --> D["Ok(())"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stream.rs</strong><dd><code>Add cache deletion to stream delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/stream.rs

<ul><li>Added cache deletion logic in <code>stream_delete_inner</code><br> <li> Constructed <code>cache_path</code> for the stream<br> <li> Logged warning before cache deletion<br> <li> Handled and logged cache deletion errors</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10002/files#diff-41452a7fb29b4634437174fd6aecf6a9050dbfdef41b9077a21d59af3d79e9ed">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

