### PR TITLE
fix: delete the org id if present before calling create api

### DIFF
--- a/web/src/components/iam/organizations/AddUpdateOrganization.vue
+++ b/web/src/components/iam/organizations/AddUpdateOrganization.vue
@@ -239,10 +239,10 @@ export default defineComponent({
         }
 
         const organizationId = this.organizationData.id;
-        delete this.organizationData.id;
         //here we will check if organizationId is there or not because we only get org id when we are updating the organization
         //if organizationId is not there we will create a new organization else we will update the existing organization
-        if (organizationId == "") {
+        if (!organizationId) {
+          delete this.organizationData.id;
           callOrganization = organizationService.create(this.organizationData);
         }
         else {


### PR DESCRIPTION
### **User description**
This PR fixes the #10012


___

### **PR Type**
Bug fix


___

### **Description**
- Only remove `organizationData.id` when creating

- Change empty-string check to truthy-check


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddUpdateOrganization.vue</strong><dd><code>Conditional deletion of organization ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/iam/organizations/AddUpdateOrganization.vue

<ul><li>Moved deletion of <code>organizationData.id</code> into creation branch<br> <li> Replaced <code>organizationId == ""</code> with <code>!organizationId</code> condition<br> <li> Removed unconditional <code>delete this.organizationData.id</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10014/files#diff-bca5bebfa6d5f435715dc5fa948876de02fef95a84e3e663e5c7922d601b4b9d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

