### PR TITLE
fix: delete the org id if present before calling create api

### DIFF
--- a/web/src/components/iam/organizations/AddUpdateOrganization.vue
+++ b/web/src/components/iam/organizations/AddUpdateOrganization.vue
@@ -239,10 +239,10 @@ export default defineComponent({
         }
 
         const organizationId = this.organizationData.id;
-        delete this.organizationData.id;
         //here we will check if organizationId is there or not because we only get org id when we are updating the organization
         //if organizationId is not there we will create a new organization else we will update the existing organization
-        if (organizationId == "") {
+        if (!organizationId) {
+          delete this.organizationData.id;
           callOrganization = organizationService.create(this.organizationData);
         }
         else {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Move `delete this.organizationData.id` into creation branch

- Change condition from `organizationId == ""` to `!organizationId`

- Preserve `id` for update (rename) calls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Form Submit"] --> B["Validate Form"]
  B --> C{"organizationId?"}
  C -- "falsy" --> D["delete id & call create API"]
  C -- "truthy" --> E["call rename_organization API"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddUpdateOrganization.vue</strong><dd><code>refine ID deletion and branch condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/iam/organizations/AddUpdateOrganization.vue

<ul><li>Moved <code>delete this.organizationData.id</code> inside the create branch<br> <li> Updated condition to <code>!organizationId</code> from empty-string check<br> <li> Ensured update branch retains <code>organizationData.id</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10015/files#diff-bca5bebfa6d5f435715dc5fa948876de02fef95a84e3e663e5c7922d601b4b9d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

