### PR TITLE
fix: dashboard query editor when switching to sql query color issue

### DIFF
--- a/web/src/components/dashboards/addPanel/DashboardQueryEditor.vue
+++ b/web/src/components/dashboards/addPanel/DashboardQueryEditor.vue
@@ -198,6 +198,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   ].customQuery
                 "
                 :language="dashboardPanelData.data.queryType"
+                :key="dashboardPanelData.data.queryType"
               ></QueryEditor>
             </template>
             <template #after>


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Add tests for histogram interval extraction bug
  - covers string, object, missing, empty, null, multiple fields

- Force `QueryEditor` re-render on queryType change


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ViewPanel.spec.ts</strong><dd><code>Add histogram interval extraction tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/viewPanel/ViewPanel.spec.ts

<ul><li>Added <code>Histogram Interval Extraction</code> test suite<br> <li> Tested interval extraction: string, object, missing, empty, null<br> <li> Verified selection of first valid interval from multiple fields</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10017/files#diff-177dbf7e92561bc76e13819fd7a1d681f77b845071a7c0901857a26660b3ba54">+273/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DashboardQueryEditor.vue</strong><dd><code>Force QueryEditor re-render on language change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/DashboardQueryEditor.vue

<ul><li>Added <code>:key="dashboardPanelData.data.queryType"</code> to <code>QueryEditor</code><br> <li> Ensures re-render on query type change fixing color issue</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10017/files#diff-68bf1b319223d103f1b99e0b681764e4eb76942399397779c81c2cd18f6485ff">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

