### PR TITLE
fix: dashboard table chart time for sql

### DIFF
--- a/web/src/components/dashboards/addPanel/PromQLChartConfig.vue
+++ b/web/src/components/dashboards/addPanel/PromQLChartConfig.vue
@@ -389,9 +389,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <q-toggle
           v-model="stickyFirstColumn"
           data-test="dashboard-config-sticky-first-column"
+          class="tw:h-[36px] -tw:ml-2 o2-toggle-button-lg"
+          size="lg"
         >
           <template v-slot:default>
-            <div class="row items-center all-pointer-events tw:mb-[-5px]">
+            <div class="row items-center all-pointer-events tw:mb-[-5px] tw:ml-2">
               {{ t("dashboard.stickyFirstColumn") }}
               <q-icon class="q-ml-xs" size="20px" name="info" />
               <q-tooltip class="bg-grey-8" max-width="300px">

--- a/web/src/components/dashboards/panels/TableRenderer.vue
+++ b/web/src/components/dashboards/panels/TableRenderer.vue
@@ -92,8 +92,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </template>
 
     <!-- Expose a bottom slot so callers (e.g., PromQL table) can provide footer content -->
-    <template v-slot:bottom>
-      <slot name="bottom" />
+    <template v-slot:bottom="scope" v-if="$slots.bottom">
+      <slot name="bottom" v-bind="scope" />
     </template>
   </q-table>
 </template>


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add timestamp parser for microseconds and ISO strings

- Refactor convertTableData to use unified parsing

- Cache timezone to optimize store lookups

- Improve toggle styling and bottom slot binding


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>convertTableData.ts</strong><dd><code>Unified timestamp parsing in convertTableData.ts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/dashboard/convertTableData.ts

<ul><li>Added <code>parseTimestampValue</code> helper for timestamp parsing<br> <li> Replaced inline date logic with unified parser<br> <li> Cached timezone lookup for performance<br> <li> Updated histogram field formatting to use helper</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10019/files#diff-a672094c46e697ee7b7a3949a901cc1f7f88ec06cddaf67370474b508d5b0960">+65/-71</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PromQLChartConfig.vue</strong><dd><code>Style tweak for sticky column toggle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/addPanel/PromQLChartConfig.vue

<ul><li>Added custom height and margin classes to <code>q-toggle</code><br> <li> Adjusted layout for <code>stickyFirstColumn</code> label</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10019/files#diff-305fcbfc89618c91ca0ee6c8c52cfa596169ca2dced6778eea6cd3c89f071573">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TableRenderer.vue</strong><dd><code>Conditionally bind bottom slot scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/panels/TableRenderer.vue

<ul><li>Added <code>v-if</code> check for bottom slot rendering<br> <li> Bound slot scope to bottom slot</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10019/files#diff-794706ea9da3a70012a0327c0464f9fd16802f78ece26055fe951716c2d73d59">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

