### PR TITLE
fix: allow service account token auth before native login restrictions

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -645,6 +645,8 @@ pub struct Auth {
     pub ext_auth_salt: String,
     #[env_config(name = "O2_ACTION_SERVER_TOKEN")]
     pub action_server_token: String,
+    #[env_config(name = "ZO_SERVICE_ACCOUNT_ENABLED", default = true)]
+    pub service_account_enabled: bool,
     /// Session cleanup interval in seconds (default: 3600 = 1 hour)
     /// How often to run the background job that deletes expired sessions
     #[env_config(name = "ZO_SESSION_CLEANUP_INTERVAL", default = 3600)]

--- a/src/handler/http/request/service_accounts/mod.rs
+++ b/src/handler/http/request/service_accounts/mod.rs
@@ -68,6 +68,11 @@ use crate::{
     )
 )]
 pub async fn list(Path(org_id): Path<String>, Headers(user_email): Headers<UserEmail>) -> Response {
+    let config = config::get_config();
+    if !config.auth.service_account_enabled {
+        return MetaHttpResponse::forbidden("Service Accounts Not Enabled");
+    }
+
     let user_id = &user_email.user_id;
     let mut _user_list_from_rbac = None;
     // Get List of allowed objects
@@ -137,6 +142,11 @@ pub async fn save(
     Headers(user_email): Headers<UserEmail>,
     Json(service_account): Json<ServiceAccountRequest>,
 ) -> Response {
+    let config = config::get_config();
+    if !config.auth.service_account_enabled {
+        return MetaHttpResponse::forbidden("Service Accounts Not Enabled");
+    }
+
     let initiator_id = user_email.user_id;
     let user = UserRequest {
         email: service_account.email.trim().to_string(),
@@ -191,6 +201,11 @@ pub async fn update(
     Headers(user_email): Headers<UserEmail>,
     Json(service_account): Json<UpdateServiceAccountRequest>,
 ) -> Response {
+    let config = config::get_config();
+    if !config.auth.service_account_enabled {
+        return MetaHttpResponse::forbidden("Service Accounts Not Enabled");
+    }
+
     let email_id = email_id.trim().to_lowercase();
 
     let rotate_token = match query.get("rotateToken") {
@@ -279,6 +294,11 @@ pub async fn delete(
     Path((org_id, email_id)): Path<(String, String)>,
     Headers(user_email): Headers<UserEmail>,
 ) -> Response {
+    let config = config::get_config();
+    if !config.auth.service_account_enabled {
+        return MetaHttpResponse::forbidden("Service Accounts Not Enabled");
+    }
+
     let initiator_id = user_email.user_id;
     match users::remove_user_from_org(&org_id, &email_id, &initiator_id).await {
         Ok(resp) => resp,
@@ -315,6 +335,11 @@ pub async fn delete_bulk(
     Headers(user_email): Headers<UserEmail>,
     Json(req): Json<BulkDeleteRequest>,
 ) -> Response {
+    let config = config::get_config();
+    if !config.auth.service_account_enabled {
+        return MetaHttpResponse::forbidden("Service Accounts Not Enabled");
+    }
+
     let initiator_id = user_email.user_id;
 
     #[cfg(feature = "enterprise")]
@@ -400,6 +425,11 @@ pub async fn get_api_token(
     Path((org, user_id)): Path<(String, String)>,
     Headers(_user_email): Headers<UserEmail>,
 ) -> Response {
+    let config = config::get_config();
+    if !config.auth.service_account_enabled {
+        return MetaHttpResponse::forbidden("Service Accounts Not Enabled");
+    }
+
     // Always return single token for the requested org
     let org_id = Some(org.as_str());
     match crate::service::organization::get_passcode(org_id, &user_id).await {

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -114,6 +114,7 @@ struct ConfigResponse<'a> {
     restricted_routes_on_empty_data: bool,
     sso_enabled: bool,
     native_login_enabled: bool,
+    service_account_enabled: bool,
     rbac_enabled: bool,
     super_cluster_enabled: bool,
     query_on_stream_selection: bool,
@@ -278,6 +279,8 @@ pub async fn zo_config() -> impl IntoResponse {
     #[cfg(not(feature = "enterprise"))]
     let native_login_enabled = true;
 
+    let service_account_enabled = cfg.auth.service_account_enabled;
+
     #[cfg(feature = "enterprise")]
     let rbac_enabled = openfga_cfg.enabled;
     #[cfg(not(feature = "enterprise"))]
@@ -396,6 +399,7 @@ pub async fn zo_config() -> impl IntoResponse {
         restricted_routes_on_empty_data: cfg.common.restricted_routes_on_empty_data,
         sso_enabled,
         native_login_enabled,
+        service_account_enabled,
         rbac_enabled,
         super_cluster_enabled,
         query_on_stream_selection: cfg.common.query_on_stream_selection,

--- a/web/src/composables/shared/useEnterpriseRoutes.ts
+++ b/web/src/composables/shared/useEnterpriseRoutes.ts
@@ -69,6 +69,17 @@ const useEnterpriseRoutes = () => {
           },
           component: ServiceAccountsList,
           beforeEnter(to: any, from: any, next: any) {
+            // Check if service accounts are enabled
+            // Note: Using window.store here because useStore() doesn't work in route guards
+            const store = (window as any).store;
+            const serviceAccountEnabled = store?.state?.zoConfig?.service_account_enabled ?? true;
+
+            if (!serviceAccountEnabled) {
+              // Redirect to users page if service accounts are disabled
+              next({ name: "users", query: to.query });
+              return;
+            }
+
             routeGuard(to, from, next);
           },
         },

--- a/web/src/views/IdentityAccessManagement.vue
+++ b/web/src/views/IdentityAccessManagement.vue
@@ -45,7 +45,7 @@
 
 <script setup lang="ts">
 import RouteTabs from "@/components/RouteTabs.vue";
-import { ref, watch } from "vue";
+import { ref, watch, computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useStore } from "vuex";
 import config from "@/aws-exports";
@@ -74,7 +74,7 @@ const collapseSidebar = () => {
   splitterModel.value = showSidebar.value ? lastSplitterPosition.value : 0;
 };
 
-const tabs = ref([
+const allTabs = [
   {
     dataTest: "iam-users-tab",
     name: "users",
@@ -159,7 +159,20 @@ const tabs = ref([
     label: t("iam.invitations"),
     class: "tab_content",
   },
-]);
+];
+
+// Filter tabs based on service_account_enabled config
+const tabs = computed(() => {
+  const serviceAccountEnabled = store.state.zoConfig.service_account_enabled ?? true;
+
+  return allTabs.filter((tab) => {
+    // Hide service accounts tab if disabled
+    if (tab.name === "serviceAccounts" && !serviceAccountEnabled) {
+      return false;
+    }
+    return true;
+  });
+});
 
 watch(
   () => router.currentRoute.value.name,


### PR DESCRIPTION
### **User description**
Resolves https://github.com/openobserve/o2-enterprise/issues/991

This PR ensures that service accounts and all users can use API tokens regardless of native login settings, allowing automated systems to continue functioning even when native login is disabled.


___

### **PR Type**
Bug fix


___

### **Description**
- Introduce `service_account_enabled` feature flag  

- Gate service account API endpoints on flag  

- Adjust token validation flow order  

- Expose flag in config API and UI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["Auth Config: service_account_enabled"]
  validator["Auth Validator: token flow"]
  api["Config API: zo_config response"]
  ui["UI Route Guard"]
  cfg -- "checked by" --> validator
  cfg -- "exposed in" --> api
  cfg -- "controls" --> ui
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useEnterpriseRoutes.ts</strong><dd><code>Route guard feature flag addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/shared/useEnterpriseRoutes.ts

<ul><li>Added feature flag check in serviceAccounts route guard  <br> <li> Redirect to users page if service accounts disabled</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10038/files#diff-962367ed3d329e73232da2c262cf10c60b14820dd43e95e94302cdcb2f080cbe">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IdentityAccessManagement.vue</strong><dd><code>Conditionally hide service accounts UI tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/IdentityAccessManagement.vue

<ul><li>Imported <code>computed</code> to derive tabs  <br> <li> Filtered out serviceAccounts tab based on flag</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10038/files#diff-60b63024c98ee8927e12f9ebec93e99ba7ff419038cfe1cc57d49de1f6f342d6">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add service_account_enabled config flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/config.rs

<ul><li>Defined <code>service_account_enabled</code> env config (default true)  <br> <li> Integrated flag into <code>Auth</code> struct</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10038/files#diff-9aeee4a74c0520daa40f9b81c7016f5b6b3254375b968dd7598e745630980d62">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Expose service_account_enabled in config API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/status/mod.rs

<ul><li>Included <code>service_account_enabled</code> in <code>ConfigResponse</code>  <br> <li> Exposed flag in <code>zo_config</code> API response</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10038/files#diff-ca09c9c9b020049bdbc3382c466bfcca80daac92e98760d9a9a76172abf34049">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validator.rs</strong><dd><code>Refactor auth validator and apply feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/auth/validator.rs

<ul><li>Extracted <code>build_token_validation_response</code> helper  <br> <li> Reordered token auth before native login check  <br> <li> Applied <code>service_account_enabled</code> gating in auth flow</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10038/files#diff-f4d4b51574b378a8c372345ea48875834a4eadacfac33fa4d0ceca1e0ef96b35">+51/-37</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Gate service accounts endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/service_accounts/mod.rs

<ul><li>Added pre-check of <code>service_account_enabled</code> in every endpoint  <br> <li> Return <code>Forbidden</code> response if service accounts disabled</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10038/files#diff-095d70f65b6e69bf7de0180fcbcddcd7c89c4cf00095d7b06f039a07e73916bb">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

