### PR TITLE
fix: revert expected status code back to 400 in dashboard import test

### DIFF
--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-import.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-import.spec.js
@@ -227,7 +227,7 @@ test.describe("dashboard Import testcases", () => {
       page.getByText("warning1 File(s) Failed to Import")
     ).toBeVisible();
     await expect(
-      page.getByText(" JSON 1 : Request failed with status code 422")
+      page.getByText(" JSON 1 : Request failed with status code 400")
     ).toBeVisible();
   });
 


### PR DESCRIPTION
### **User description**
## Summary
- Reverts the expected HTTP status code back to 400 in the dashboard import test

## Test plan
- Run the dashboard import E2E test to verify it passes with the expected 400 status code


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Revert expected status code in dashboard import test to 400


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-import.spec.js</strong><dd><code>Expect import failure status code 400</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/playwright-tests/Dashboards/dashboard-import.spec.js

- Updated assertion from status code 422 to 400


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10062/files#diff-19a69660b4842f0e2872aaefcb2a539ed25761b42daa804cfb8426d5a7cda567">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

