### PR TITLE
fix: metrics support stream name

### DIFF
--- a/src/handler/grpc/request/ingest.rs
+++ b/src/handler/grpc/request/ingest.rs
@@ -77,6 +77,11 @@ impl Ingest for Ingester {
                 }
             }
             StreamType::Metrics => {
+                let stream_name =  if stream_name.is_empty(){
+                    None
+                } else {
+                    Some(stream_name.as_str())
+                };
                 let log_ingestion_type: IngestionType = req
                     .ingestion_type
                     .unwrap_or_default()
@@ -88,7 +93,7 @@ impl Ingest for Ingester {
                     )))
                 } else {
                     let data = bytes::Bytes::from(in_data.data);
-                    crate::service::metrics::json::ingest(&org_id, data, internal_user)
+                    crate::service::metrics::json::ingest(&org_id, stream_name, data, internal_user)
                         .await
                         .map(|_| ()) // we don't care about success response
                         .map_err(|e| Error::IngestionError(format!("error in ingesting metrics {e}")))

--- a/src/handler/http/request/metrics/ingest.rs
+++ b/src/handler/http/request/metrics/ingest.rs
@@ -80,7 +80,7 @@ pub async fn json(
         return MetaHttpResponse::too_many_requests(e);
     }
 
-    let mut resp = match metrics::json::ingest(&org_id, body, user).await {
+    let mut resp = match metrics::json::ingest(&org_id, None, body, user).await {
         Ok(v) => {
             if v.code == StatusCode::OK.as_u16() {
                 MetaHttpResponse::json(v)

--- a/src/job/promql_self_consume.rs
+++ b/src/job/promql_self_consume.rs
@@ -118,6 +118,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
             let bytes = bytes::Bytes::from(metrics);
             match service::metrics::json::ingest(
                 org,
+                None,
                 bytes,
                 IngestUser::SystemJob(SystemJobType::SelfMetricsPromql),
             )


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Support optional stream_name in ingest calls

- Validate metrics types against whitelist

- Default missing metrics type to gauge

- Generalize schema creation for all types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Handler["HTTP/gRPC/Job Handler"]
  Handler -- "pass stream_name" --> Ingest["metrics::json::ingest"]
  Ingest -- "validate metrics type" --> Validation["VALID_METRICS_TYPES"]
  Ingest -- "default to gauge" --> Default["Default gauge for missing type"]
  Ingest -- "merge schema metadata" --> Schema["Schema retrieval & merge"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ingest.rs</strong><dd><code>Pass optional stream_name in gRPC ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/grpc/request/ingest.rs

<ul><li>Compute optional <code>stream_name</code> from input<br> <li> Pass <code>stream_name</code> to JSON ingest call</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10065/files#diff-27ffe683f384ff836c6aac746240d755bdf17f3c6e0a65d8ec1a1ff82aaf7d5c">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ingest.rs</strong><dd><code>Include stream_name param in HTTP ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/metrics/ingest.rs

<ul><li>Update JSON ingest call to include <code>None</code> stream_name<br> <li> Adjust signature to match new <code>ingest</code> API</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10065/files#diff-b9dc46d43cf8b966936962efff036b7fc0c2d6c55dddedfdaa82b45ef86362d5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>promql_self_consume.rs</strong><dd><code>Update self-consume ingest stream_name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/job/promql_self_consume.rs

<ul><li>Pass <code>None</code> for <code>stream_name</code> in self-consume ingest<br> <li> Reflect updated ingest function signature</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10065/files#diff-31ab6fde695e02bc1d0a2f5a928f7956cb1f2a7b7d443955e2046365c7fa6d93">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>json.rs</strong><dd><code>Enhance JSON metrics ingest validation & schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/metrics/json.rs

<ul><li>Add <code>stream_name</code> parameter to <code>ingest</code> function<br> <li> Introduce metrics type whitelist and validation<br> <li> Default missing type to <code>gauge</code><br> <li> Generalize schema check and metadata creation</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10065/files#diff-506987e61095a54e47f7f208dad89f9f1bce595fa6bf1ba8a7d746f2b2ff6c4a">+51/-42</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

