### PR TITLE
fix: ensure variables structure exists for dashboards without variables

### DIFF
--- a/web/src/utils/commons.ts
+++ b/web/src/utils/commons.ts
@@ -591,6 +591,25 @@ export const updateDashboard = async (
   }
 };
 
+// Helper function to ensure variables structure exists with proper defaults
+const ensureVariablesStructure = (dashboard: any): void => {
+  if (!dashboard.variables) {
+    dashboard.variables = {
+      showDynamicFilters: false,
+      list: []
+    };
+  } else {
+    // Ensure showDynamicFilters has a default value
+    if (dashboard.variables.showDynamicFilters === undefined) {
+      dashboard.variables.showDynamicFilters = false;
+    }
+    // Ensure list is an array
+    if (!Array.isArray(dashboard.variables.list)) {
+      dashboard.variables.list = [];
+    }
+  }
+};
+
 export const getDashboard = async (
   store: any,
   dashboardId: any,
@@ -620,14 +639,7 @@ export const getDashboard = async (
   }
 
   // Ensure variables structure always exists (fix for dashboards with no variables)
-  if (!dashboardJson.variables) {
-    dashboardJson.variables = {
-      showDynamicFilters: false,
-      list: []
-    };
-  } else if (!dashboardJson.variables.list) {
-    dashboardJson.variables.list = [];
-  }
+  ensureVariablesStructure(dashboardJson);
 
   // Fix duplicate panel IDs and check if any were found
   const hasDuplicates = fixDuplicatePanelIds(dashboardJson);
@@ -658,14 +670,7 @@ export const getDashboard = async (
     );
 
     // Ensure variables structure exists after re-fetching too
-    if (!dashboardJson.variables) {
-      dashboardJson.variables = {
-        showDynamicFilters: false,
-        list: []
-      };
-    } else if (!dashboardJson.variables.list) {
-      dashboardJson.variables.list = [];
-    }
+    ensureVariablesStructure(dashboardJson);
   }
 
   return dashboardJson;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Ensure `dashboardJson.variables` always initialized
  - Default `showDynamicFilters: false` and empty `list`

- Handle missing `variables.list` by setting empty array

- Apply initialization both before and after re-fetch


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commons.ts</strong><dd><code>Initialize missing dashboard variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/commons.ts

<ul><li>Add guard to initialize <code>dashboardJson.variables</code> if missing<br> <li> Set default <code>showDynamicFilters</code> and empty <code>list</code><br> <li> Ensure <code>variables.list</code> exists when undefined<br> <li> Apply the same initialization after re-fetching dashboard</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10066/files#diff-17cb74f8142984fc46bbfecdeaacccc118fd5d4ab7f040a55695caaa309d104f">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

