### PR TITLE
perf: optimize date formatting performance using DateTimeFormat in PromQL and SQL data conversion

### DIFF
--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -961,6 +961,7 @@ export default defineComponent({
         validatePanelData?.value?.length === 0
       ) {
         try {
+          logTimeStart("convertPanelData");
           panelData.value = await convertPanelData(
             panelSchema.value,
             filteredData.value,
@@ -973,6 +974,11 @@ export default defineComponent({
             annotations,
             loading.value,
           );
+          logTimeEnd("convertPanelData");
+
+          // logMessage(
+          //   "Converted Panel Data: " + JSON.stringify(panelData.value),
+          // );
 
           limitNumberOfSeriesWarningMessage.value =
             panelData.value?.extras?.limitNumberOfSeriesWarningMessage ?? "";

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -38,14 +38,13 @@ export const formatDateWithFormatter = (
   formatter: Intl.DateTimeFormat,
 ): string => {
   const parts = formatter.formatToParts(date);
-  const year = parts.find((p) => p.type === "year")?.value;
-  const month = parts.find((p) => p.type === "month")?.value;
-  const day = parts.find((p) => p.type === "day")?.value;
-  const hour = parts.find((p) => p.type === "hour")?.value;
-  const minute = parts.find((p) => p.type === "minute")?.value;
-  const second = parts.find((p) => p.type === "second")?.value;
+  const partMap: Record<string, string> = {};
 
-  return `${year}-${month}-${day}T${hour}:${minute}:${second}`;
+  for (const part of parts) {
+    partMap[part.type] = part.value;
+  }
+
+  return `${partMap.year}-${partMap.month}-${partMap.day}T${partMap.hour}:${partMap.minute}:${partMap.second}`;
 };
 
 const units: any = {

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -4,6 +4,50 @@ import functionValidation from "@/components/dashboards/addPanel/dynamicFunction
 import { getColorPalette } from "./colorPalette";
 import { fromZonedTime } from "date-fns-tz";
 
+/**
+ * Creates a reusable date formatter using Intl.DateTimeFormat
+ * This is significantly faster than using date-fns format() or toZonedTime() in loops
+ * @param {string} timezone - The timezone string (e.g., "UTC", "America/New_York", defaults to "UTC")
+ * @returns {Intl.DateTimeFormat} Formatter configured for the specified timezone
+ */
+export const createDateFormatter = (
+  timezone: string = "UTC",
+): Intl.DateTimeFormat => {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+};
+
+/**
+ * Formats a date to ISO-like string in format: yyyy-MM-dd'T'HH:mm:ss
+ * Uses pre-compiled Intl.DateTimeFormat for optimal performance in loops
+ * Works with any timezone - 10-20x faster than date-fns or date-fns-tz
+ * @param {Date} date - The date to format
+ * @param {Intl.DateTimeFormat} formatter - Pre-created formatter from createDateFormatter()
+ * @returns {string} Formatted date string (e.g., "2024-01-15T08:30:45")
+ */
+export const formatDateWithFormatter = (
+  date: Date,
+  formatter: Intl.DateTimeFormat,
+): string => {
+  const parts = formatter.formatToParts(date);
+  const year = parts.find((p) => p.type === "year")?.value;
+  const month = parts.find((p) => p.type === "month")?.value;
+  const day = parts.find((p) => p.type === "day")?.value;
+  const hour = parts.find((p) => p.type === "hour")?.value;
+  const minute = parts.find((p) => p.type === "minute")?.value;
+  const second = parts.find((p) => p.type === "second")?.value;
+
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}`;
+};
+
 const units: any = {
   bytes: [
     { unit: "B", divisor: 1 },

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -22,6 +22,8 @@ import {
   getUnitValue,
   calculateDynamicNameGap,
   calculateRotatedLabelBottomSpace,
+  createDateFormatter,
+  formatDateWithFormatter,
 } from "./convertDataIntoUnitValue";
 import { calculateGridPositions } from "./calculateGridForSubPlot";
 import {
@@ -47,48 +49,6 @@ const importMoment = async () => {
   }
 
   return moment;
-};
-
-/**
- * Creates a reusable date formatter using Intl.DateTimeFormat
- * This is significantly faster than using date-fns format() or toZonedTime() in loops
- * @param {string} timezone - The timezone string (e.g., "UTC", "America/New_York", defaults to "UTC")
- * @returns {Intl.DateTimeFormat} Formatter configured for the specified timezone
- */
-const createDateFormatter = (timezone: string = "UTC"): Intl.DateTimeFormat => {
-  return new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
-};
-
-/**
- * Formats a date to ISO-like string in format: yyyy-MM-dd'T'HH:mm:ss
- * Uses pre-compiled Intl.DateTimeFormat for optimal performance in loops
- * Works with any timezone - 10-20x faster than date-fns or date-fns-tz
- * @param {Date} date - The date to format
- * @param {Intl.DateTimeFormat} formatter - Pre-created formatter from createDateFormatter()
- * @returns {string} Formatted date string (e.g., "2024-01-15T08:30:45")
- */
-const formatDateWithFormatter = (
-  date: Date,
-  formatter: Intl.DateTimeFormat,
-): string => {
-  const parts = formatter.formatToParts(date);
-  const year = parts.find((p) => p.type === "year")?.value;
-  const month = parts.find((p) => p.type === "month")?.value;
-  const day = parts.find((p) => p.type === "day")?.value;
-  const hour = parts.find((p) => p.type === "hour")?.value;
-  const minute = parts.find((p) => p.type === "minute")?.value;
-  const second = parts.find((p) => p.type === "second")?.value;
-
-  return `${year}-${month}-${day}T${hour}:${minute}:${second}`;
 };
 
 const getMarkLineData = (panelSchema: any) => {

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -36,6 +36,8 @@ import {
   isTimeStamp,
   calculateDynamicNameGap,
   calculateRotatedLabelBottomSpace,
+  createDateFormatter,
+  formatDateWithFormatter,
 } from "./convertDataIntoUnitValue";
 import {
   calculateGridPositions,
@@ -62,48 +64,6 @@ import {
   shouldApplyChartAlignment,
   generateChartAlignmentProperties,
 } from "./legendConfiguration";
-
-/**
- * Creates a reusable date formatter using Intl.DateTimeFormat
- * This is significantly faster than using date-fns format() or toZonedTime() in loops
- * @param {string} timezone - The timezone string (e.g., "UTC", "America/New_York", defaults to "UTC")
- * @returns {Intl.DateTimeFormat} Formatter configured for the specified timezone
- */
-const createDateFormatter = (timezone: string = "UTC"): Intl.DateTimeFormat => {
-  return new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
-};
-
-/**
- * Formats a date to ISO-like string in format: yyyy-MM-dd'T'HH:mm:ss
- * Uses pre-compiled Intl.DateTimeFormat for optimal performance in loops
- * Works with any timezone - 10-20x faster than date-fns or date-fns-tz
- * @param {Date} date - The date to format
- * @param {Intl.DateTimeFormat} formatter - Pre-created formatter from createDateFormatter()
- * @returns {string} Formatted date string (e.g., "2024-01-15T08:30:45")
- */
-const formatDateWithFormatter = (
-  date: Date,
-  formatter: Intl.DateTimeFormat,
-): string => {
-  const parts = formatter.formatToParts(date);
-  const year = parts.find((p) => p.type === "year")?.value;
-  const month = parts.find((p) => p.type === "month")?.value;
-  const day = parts.find((p) => p.type === "day")?.value;
-  const hour = parts.find((p) => p.type === "hour")?.value;
-  const minute = parts.find((p) => p.type === "minute")?.value;
-  const second = parts.find((p) => p.type === "second")?.value;
-
-  return `${year}-${month}-${day}T${hour}:${minute}:${second}`;
-};
 
 /**
  * Calculates chart container properties for pie/donut charts based on legend position and chart alignment

--- a/web/src/utils/dashboard/debuggingLogs.ts
+++ b/web/src/utils/dashboard/debuggingLogs.ts
@@ -1,0 +1,47 @@
+/**
+ * Performance timing function with flag control
+ * Starts a timer with console.time()
+ *
+ * @param {string} label - The label for the timer
+ *
+ * @example
+ * logTimeStart("my-operation");
+ */
+export const logTimeStart = (label: string) => {
+  if (true) {
+    // Toggle true/false to enable/disable timing logs
+    console.time(label);
+  }
+};
+
+/**
+ * Performance timing function with flag control
+ * Ends a timer with console.timeEnd()
+ *
+ * @param {string} label - The label for the timer (must match logTimeStart label)
+ *
+ * @example
+ * logTimeEnd("my-operation");
+ */
+export const logTimeEnd = (label: string) => {
+  if (true) {
+    // Toggle true/false to enable/disable timing logs
+    console.timeEnd(label);
+  }
+};
+
+/**
+ * Performance message logging function with flag control
+ * Logs a message to console.log()
+ *
+ * @param {string} message - The message to log
+ *
+ * @example
+ * logMessage("Data processing started");
+ */
+export const logMessage = (message: string) => {
+  if (true) {
+    // Toggle true/false to enable/disable logs
+    console.log(message);
+  }
+};

--- a/web/src/utils/dashboard/promql/convertPromQLTableChart.ts
+++ b/web/src/utils/dashboard/promql/convertPromQLTableChart.ts
@@ -23,6 +23,7 @@ import {
   createDateFormatter,
   formatDateWithFormatter,
 } from "../convertDataIntoUnitValue";
+import { logTimeStart, logTimeEnd } from "../debuggingLogs";
 
 /**
  * Converter for table charts
@@ -425,7 +426,7 @@ export class TableConverter implements PromQLChartConverter {
       const dateFormatter = createDateFormatter(timezone);
 
       const singleModeLabel = `table-single-mode-conversion-${panelSchema.id}`;
-      console.time(singleModeLabel);
+      logTimeStart(singleModeLabel);
       processedData.forEach((queryData, qIndex) => {
         queryData.series.forEach((seriesData, sIndex) => {
           // Create a row for each data point
@@ -442,7 +443,7 @@ export class TableConverter implements PromQLChartConverter {
           });
         });
       });
-      console.timeEnd(singleModeLabel);
+      logTimeEnd(singleModeLabel);
 
       // Apply row limit if specified
       if (config.row_limit) {
@@ -458,7 +459,7 @@ export class TableConverter implements PromQLChartConverter {
       const dateFormatter = createDateFormatter(timezone);
 
       const expandedModeLabel = `table-expanded-timeseries-conversion-${panelSchema.id}`;
-      console.time(expandedModeLabel);
+      logTimeStart(expandedModeLabel);
       processedData.forEach((queryData, qIndex) => {
         queryData.series.forEach((seriesData, sIndex) => {
           // Create a row for each data point with all metadata
@@ -477,7 +478,7 @@ export class TableConverter implements PromQLChartConverter {
           });
         });
       });
-      console.timeEnd(expandedModeLabel);
+      logTimeEnd(expandedModeLabel);
 
       // Apply row limit if specified
       if (config.row_limit) {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduce reusable Intl.DateTimeFormat formatter

- Replace date-fns-tz loops with formatDateWithFormatter

- Add console.time benchmarking for conversions

- Optimize SQL and PromQL data processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["createDateFormatter"] --> B["formatDateWithFormatter"]
  B --> C["convertPromQLData"]
  B --> D["convertSQLData"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>convertPromQLData.ts</strong><dd><code>PromQL data timezone formatting enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/dashboard/convertPromQLData.ts

<ul><li>Removed <code>toZonedTime</code> import in PromQL conversion<br> <li> Added <code>createDateFormatter</code> and <code>formatDateWithFormatter</code><br> <li> Replaced loop formatting with precompiled formatter<br> <li> Added <code>console.time</code> logs for benchmarking</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10078/files#diff-68d70ba6c622911d48cdb567940dc404a4a6468b86c6d24fb54e5f1d8aa5ca2a">+69/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>convertSQLData.ts</strong><dd><code>SQL data timezone formatting optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/dashboard/convertSQLData.ts

<ul><li>Introduced reusable formatter functions<br> <li> Replaced date-fns loops with formatDateWithFormatter<br> <li> Wrapped conversion loops with <code>console.time</code><br> <li> Improved missing value fill loop performance</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10078/files#diff-88c0e865040a20b2c8bb7d77e7f6bd187a5b07c1645c120223bc9d59603752c3">+127/-41</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

