### PR TITLE
fix: dashboard variables on initial load set url

### DIFF
--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -577,35 +577,33 @@ export default defineComponent({
     };
 
     // Handler for when variables manager is ready from RenderDashboardCharts
-    const onVariablesManagerReady = (manager: any) => {
+    const onVariablesManagerReady = async (manager: any) => {
       variablesManager.value = manager;
 
       // Immediately update URL with initial committed values
       // This handles variables that don't require loading (constant, textbox, custom_value)
-      nextTick(() => {
+      await nextTick();
+      if (selectedDate.value && variablesManager.value) {
+        updateUrlWithCurrentState();
+      }
+    };
+
+    // Watch for changes to committed variables data
+    // This will trigger URL updates when variables finish loading (auto-commit for query_values)
+    watch(
+      () => {
+        if (!variablesManager.value) return null;
+        // Watch the committed variables data deeply
+        return JSON.stringify(variablesManager.value.committedVariablesData);
+      },
+      async () => {
+        // When committed variables change, update the URL
+        await nextTick();
         if (selectedDate.value && variablesManager.value) {
           updateUrlWithCurrentState();
         }
-      });
-
-      // Watch for changes to committed variables data
-      // This will trigger URL updates when variables finish loading (auto-commit for query_values)
-      watch(
-        () => {
-          if (!variablesManager.value) return null;
-          // Watch the committed variables data deeply
-          return JSON.stringify(variablesManager.value.committedVariablesData);
-        },
-        () => {
-          // When committed variables change, update the URL
-          nextTick(() => {
-            if (selectedDate.value && variablesManager.value) {
-              updateUrlWithCurrentState();
-            }
-          });
-        },
-      );
-    };
+      },
+    );
 
     const isVariablesChanged = computed(() => {
       // If using variables manager, access hasUncommittedChanges directly from the manager


### PR DESCRIPTION
- #10102 

### **PR Type**
Bug fix


___

### **Description**
- Consolidate URL updates into helper function

- Sync URL on initial variable load

- Watch committed variable changes for URL updates

- Use helper for refresh/date/tab watcher


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VariablesManager Ready"] -- "initial load" --> C["updateUrlWithCurrentState()"]
  B["Committed variables changed"] -- "on change" --> C
  D["Refresh/Date/Tab changed"] -- "on watch" --> C
  C -- "router.replace query" --> E["Update URL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ViewDashboard.vue</strong><dd><code>Consolidated URL update logic into helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/Dashboards/ViewDashboard.vue

<ul><li>Added <code>updateUrlWithCurrentState</code> helper for URL updates<br> <li> Triggered initial URL sync in <code>onVariablesManagerReady</code><br> <li> Watched deep <code>committedVariablesData</code> for URL updates<br> <li> Refactored refresh interval watcher to use helper</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10095/files#diff-052badb6758aff09ceaf1645869b9ba96125e6a0ea21abb01a8ee0a40d6467f3">+69/-39</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

