### PR TITLE
fix: visualization stream selection issue v50

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -2065,7 +2065,7 @@ export default defineComponent({
     const copyDashboardDataToVisualize = async () => {
       // Extract and assign stream info BEFORE copying
       const currentQueryIndex = dashboardPanelData.layout.currentQueryIndex;
-      const currentQuery = dashboardPanelData.data.queries[currentQueryIndex];
+      const currentQuery = dashboardPanelData.data.queries?.[currentQueryIndex];
 
       if (currentQuery) {
         // Try to extract stream from the query if it exists


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Guarantee stream name before copying data

- Introduce helper `copyDashboardDataToVisualize`

- Replace JSON deep clones with helper calls

- Ensure `stream_type` fallback to "logs"


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Preserve and propagate stream info for visualization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/Index.vue

<ul><li>Imported <code>getStreamFromQuery</code> utility function<br> <li> Added <code>copyDashboardDataToVisualize</code> helper<br> <li> Replaced JSON deep clones with helper invocations<br> <li> Ensured <code>stream</code> and <code>stream_type</code> are preserved</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10099/files#diff-0323c3da69b369843c5d72bf4df5b00ca6b5147192a213baf331659ecf92af62">+36/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

