### PR TITLE
chore: remove non-existent serviceMaps.spec.js from workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -242,7 +242,6 @@ jobs:
                 "traceErrorFilter.spec.js",
                 "traceDetails.spec.js",
                 "traceAdvancedFiltering.spec.js",
-                "serviceMaps.spec.js",
               ]
 
           - testfolder: "RegressionSet"


### PR DESCRIPTION
### **User description**
## Summary
- Removed `serviceMaps.spec.js` from the Traces test folder config in playwright.yml as this file does not exist

## Milestone
v0.60.0


___

### **PR Type**
Tests


___

### **Description**
- Remove non-existent `serviceMaps.spec.js` from Playwright workflow


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playwright.yml</strong><dd><code>Remove serviceMaps.spec.js entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/playwright.yml

<ul><li>Deleted <code>serviceMaps.spec.js</code> from <code>run_files</code> list under Traces tests</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10113/files#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

