### PR TITLE
fix: Logs state getting mutated due to Query Execution Plan dialog

### DIFF
--- a/web/src/components/QueryPlanDialog.vue
+++ b/web/src/components/QueryPlanDialog.vue
@@ -28,16 +28,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <q-separator />
 
       <q-card-section class="query-plan-content full-height q-pa-none">
-        <q-splitter
-          v-model="splitterPosition"
-          class="full-height"
-        >
+        <q-splitter v-model="splitterPosition" class="full-height">
           <!-- Left Pane: SQL Query -->
           <template #before>
             <div class="sql-query-pane full-height">
               <div
                 class="pane-header q-pa-sm tw:px-[1rem] row items-center"
-                :class="store.state.theme === 'dark' ? 'pane-header-dark' : 'pane-header-light'"
+                :class="
+                  store.state.theme === 'dark'
+                    ? 'pane-header-dark'
+                    : 'pane-header-light'
+                "
               >
                 <q-icon name="code" size="20px" class="q-mr-sm" />
                 <div class="text-subtitle1 text-weight-medium">SQL Query</div>
@@ -45,7 +46,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <q-separator />
               <div
                 class="sql-query-content q-pa-md"
-                :class="store.state.theme === 'dark' ? 'sql-query-content-dark' : 'sql-query-content-light'"
+                :class="
+                  store.state.theme === 'dark'
+                    ? 'sql-query-content-dark'
+                    : 'sql-query-content-light'
+                "
               >
                 <div class="sql-query-wrapper">
                   <pre class="sql-query-text">{{ sqlQuery }}</pre>
@@ -58,11 +63,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <template #after>
             <div class="explain-results-pane full-height">
               <div
-                class="pane-header q-pa-sm tw:px-[1rem]  row items-center"
-                :class="store.state.theme === 'dark' ? 'pane-header-dark' : 'pane-header-light'"
+                class="pane-header q-pa-sm tw:px-[1rem] row items-center"
+                :class="
+                  store.state.theme === 'dark'
+                    ? 'pane-header-dark'
+                    : 'pane-header-light'
+                "
               >
                 <div class="text-subtitle1 text-weight-medium">
-                  {{ showAnalyzeResults ? t("search.analyzeResults") : t("search.explainResults") }}
+                  {{
+                    showAnalyzeResults
+                      ? t("search.analyzeResults")
+                      : t("search.explainResults")
+                  }}
                 </div>
                 <q-space />
                 <q-btn
@@ -83,7 +96,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <div class="text-center">
                   <q-spinner-dots color="primary" size="50px" />
                   <div class="q-mt-md">
-                    {{ isAnalyzing ? t("search.runningAnalyze") : t("search.loadingPlan") }}
+                    {{
+                      isAnalyzing
+                        ? t("search.runningAnalyze")
+                        : t("search.loadingPlan")
+                    }}
                   </div>
                 </div>
               </div>
@@ -98,7 +115,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </div>
 
               <!-- EXPLAIN ANALYZE view -->
-              <div v-else-if="showAnalyzeResults" class="plan-container q-pa-md">
+              <div
+                v-else-if="showAnalyzeResults"
+                class="plan-container q-pa-md"
+              >
                 <!-- Metrics Summary Card -->
                 <MetricsSummaryCard
                   v-if="summaryMetrics"
@@ -218,7 +238,7 @@ export default defineComponent({
     const { t } = useI18n();
     const store = useStore();
     const $q = useQuasar();
-    const { buildSearch } = useSearchStream();
+    const { getSearchQueryPayload } = useSearchStream();
 
     const loading = ref(false);
     const error = ref("");
@@ -290,8 +310,12 @@ export default defineComponent({
         // We need to nest Phase 1+ plans as children of Phase 0 RemoteExec
 
         // Separate phases
-        const phase0Hits = responseData.hits.filter((hit: any) => hit.phase === 0);
-        const phase1Hits = responseData.hits.filter((hit: any) => hit.phase === 1);
+        const phase0Hits = responseData.hits.filter(
+          (hit: any) => hit.phase === 0,
+        );
+        const phase1Hits = responseData.hits.filter(
+          (hit: any) => hit.phase === 1,
+        );
 
         if (phase0Hits.length > 0 && phase1Hits.length > 0) {
           // Parse phase 0
@@ -359,11 +383,19 @@ export default defineComponent({
         });
 
         // Fallback: if no plan_type, try to parse from combined text
-        if (!logicalPlan.value && !physicalPlan.value && responseData.hits.length > 0) {
-          const combined = responseData.hits.map((h: any) => h.plan || JSON.stringify(h)).join("\n");
+        if (
+          !logicalPlan.value &&
+          !physicalPlan.value &&
+          responseData.hits.length > 0
+        ) {
+          const combined = responseData.hits
+            .map((h: any) => h.plan || JSON.stringify(h))
+            .join("\n");
 
           // Try to split by plan_type markers
-          const logicalMatch = combined.match(/logical_plan[:\s]+(.+?)(?=physical_plan|$)/is);
+          const logicalMatch = combined.match(
+            /logical_plan[:\s]+(.+?)(?=physical_plan|$)/is,
+          );
           const physicalMatch = combined.match(/physical_plan[:\s]+(.+?)$/is);
 
           if (logicalMatch) {
@@ -380,27 +412,30 @@ export default defineComponent({
       // Parse Server-Sent Events format response
       // Format: event: <event_type>\ndata: <json>\n\n
       try {
-        const lines = sseText.split('\n');
-        let currentEvent = '';
+        const lines = sseText.split("\n");
+        let currentEvent = "";
         let result: any = null;
 
         for (const line of lines) {
           const trimmed = line.trim();
 
-          if (trimmed.startsWith('event:')) {
+          if (trimmed.startsWith("event:")) {
             currentEvent = trimmed.substring(6).trim();
-          } else if (trimmed.startsWith('data:')) {
+          } else if (trimmed.startsWith("data:")) {
             const dataContent = trimmed.substring(5).trim();
 
             // Skip progress events and done marker
-            if (dataContent === '[[DONE]]' || currentEvent === 'progress') {
+            if (dataContent === "[[DONE]]" || currentEvent === "progress") {
               continue;
             }
 
             try {
               const parsed = JSON.parse(dataContent);
               // Look for actual search results with hits
-              if (parsed && (parsed.hits !== undefined || parsed.total !== undefined)) {
+              if (
+                parsed &&
+                (parsed.hits !== undefined || parsed.total !== undefined)
+              ) {
                 result = parsed;
               }
             } catch (e) {
@@ -425,21 +460,9 @@ export default defineComponent({
       showAnalyzeResults.value = false;
 
       try {
-        // Save the current histogram state before calling buildSearch()
-        // This is necessary because buildSearch() modifies the global searchObj.data.histogram
-        // when histogram is turned off, which would clear the title on the logs page
-        const savedHistogram = searchObj.meta.showHistogram === false
-          ? JSON.parse(JSON.stringify(searchObj.data.histogram))
-          : null;
-
-        // Build the complete query using buildSearch()
-        const queryReq = buildSearch();
-
-        // Restore the histogram state after buildSearch() only if histogram is still off
-        // This prevents QueryPlanDialog from clearing the histogram title on the logs page
-        if (savedHistogram !== null && searchObj.meta.showHistogram === false) {
-          searchObj.data.histogram = savedHistogram;
-        }
+        // Build the complete query using getSearchQueryPayload()
+        // This method doesn't mutate searchObj, so no need to save/restore state
+        const queryReq = getSearchQueryPayload();
 
         if (!queryReq || !queryReq.query || !queryReq.query.sql) {
           error.value = t("search.errorFetchingPlan");
@@ -482,7 +505,10 @@ export default defineComponent({
         }
       } catch (err: any) {
         console.error("Error fetching explain plan:", err);
-        error.value = err.response?.data?.message || err.message || t("search.errorFetchingPlan");
+        error.value =
+          err.response?.data?.message ||
+          err.message ||
+          t("search.errorFetchingPlan");
       } finally {
         loading.value = false;
       }
@@ -494,21 +520,9 @@ export default defineComponent({
       isAnalyzing.value = true;
 
       try {
-        // Save the current histogram state before calling buildSearch()
-        // This is necessary because buildSearch() modifies the global searchObj.data.histogram
-        // when histogram is turned off, which would clear the title on the logs page
-        const savedHistogram = searchObj.meta.showHistogram === false
-          ? JSON.parse(JSON.stringify(searchObj.data.histogram))
-          : null;
-
-        // Build the complete query using buildSearch()
-        const queryReq = buildSearch();
-
-        // Restore the histogram state after buildSearch() only if histogram is still off
-        // This prevents QueryPlanDialog from clearing the histogram title on the logs page
-        if (savedHistogram !== null && searchObj.meta.showHistogram === false) {
-          searchObj.data.histogram = savedHistogram;
-        }
+        // Build the complete query using getSearchQueryPayload()
+        // This method doesn't mutate searchObj, so no need to save/restore state
+        const queryReq = getSearchQueryPayload();
 
         if (!queryReq || !queryReq.query || !queryReq.query.sql) {
           error.value = t("search.errorRunningAnalyze");
@@ -554,7 +568,10 @@ export default defineComponent({
         }
       } catch (err: any) {
         console.error("Error running analyze:", err);
-        error.value = err.response?.data?.message || err.message || t("search.errorRunningAnalyze");
+        error.value =
+          err.response?.data?.message ||
+          err.message ||
+          t("search.errorRunningAnalyze");
       } finally {
         loading.value = false;
         isAnalyzing.value = false;
@@ -580,7 +597,7 @@ export default defineComponent({
           // Reset to logical tab when opening
           activeTab.value = "logical";
         }
-      }
+      },
     );
 
     // Reset activeTab when switching between EXPLAIN and ANALYZE
@@ -591,7 +608,7 @@ export default defineComponent({
           // Switching back to EXPLAIN - reset to logical tab
           activeTab.value = "logical";
         }
-      }
+      },
     );
 
     // Add ESC key listener when dialog opens
@@ -603,7 +620,7 @@ export default defineComponent({
         } else {
           document.removeEventListener("keydown", handleEscKey);
         }
-      }
+      },
     );
 
     return {

--- a/web/src/composables/useLogs/useSearchQuery.ts
+++ b/web/src/composables/useLogs/useSearchQuery.ts
@@ -43,7 +43,8 @@ export const useSearchQuery = () => {
     checkTimestampAlias,
   } = logsUtils();
 
-  const { searchObj, notificationMsg, initialQueryPayload, searchAggData } = searchState();
+  const { searchObj, notificationMsg, initialQueryPayload, searchAggData } =
+    searchState();
 
   const getQueryReq = (isPagination: boolean): SearchRequestPayload | null => {
     searchObj.data.highlightQuery = "";
@@ -67,8 +68,10 @@ export const useSearchQuery = () => {
       return null;
     }
 
-    if (Number.isNaN(searchObj.data.datetime.endTime))   searchObj.data.datetime.endTime = "Invalid Date"
-    if (Number.isNaN(searchObj.data.datetime.startTime)) searchObj.data.datetime.startTime = "Invalid Date"
+    if (Number.isNaN(searchObj.data.datetime.endTime))
+      searchObj.data.datetime.endTime = "Invalid Date";
+    if (Number.isNaN(searchObj.data.datetime.startTime))
+      searchObj.data.datetime.startTime = "Invalid Date";
 
     const queryReq: SearchRequestPayload = buildSearch();
 
@@ -148,13 +151,12 @@ export const useSearchQuery = () => {
       (searchObj.data.resultGrid.currentPage - 1) *
       searchObj.meta.resultGrid.rowsPerPage;
 
-
     // Use configurable scan size when patterns mode is enabled to get data for pattern extraction
     queryReq.query.size =
       searchObj.meta.logsVisualizeToggle === "patterns"
-      ? patternsState.value.scanSize
-      : searchObj.meta.resultGrid.rowsPerPage;
-  
+        ? patternsState.value.scanSize
+        : searchObj.meta.resultGrid.rowsPerPage;
+
     const parsedSQL: any = fnParsedSQL();
 
     searchObj.meta.resultGrid.showPagination = true;
@@ -196,12 +198,36 @@ export const useSearchQuery = () => {
     return queryReq;
   };
 
-  const buildSearch = (): SearchRequestPayload => {
+  /**
+   * Build search query payload with optional read-only mode
+   *
+   * Constructs the complete query payload for search operations. Can operate in two modes:
+   * 1. Normal mode (readOnly=false): Builds query AND mutates searchObj state (clears errors, updates timestamps, etc.)
+   * 2. Read-only mode (readOnly=true): Builds query WITHOUT mutating searchObj state
+   *
+   * Read-only mode is used for operations that need the query structure but shouldn't
+   * affect the current search state (e.g., EXPLAIN/ANALYZE queries in QueryPlanDialog).
+   *
+   * Mutations that are skipped in read-only mode:
+   * - searchObj.data.filterErrMsg, missingStreamMessage, missingStreamMultiStreamFilter
+   * - searchObj.data.stream.interestingFieldList (creates filtered copy instead)
+   * - searchObj.data.datetime timestamps
+   * - searchObj.meta.resultGrid.chartKeyFormat and chartInterval
+   * - searchObj.data.queryResults.hits (not cleared when LIMIT is present)
+   *
+   * @param readOnly - If true, prevents all mutations to searchObj (default: false)
+   * @returns SearchRequestPayload - The constructed query payload, or null on error
+   */
+  const buildSearch = (readOnly: boolean = false): SearchRequestPayload => {
     try {
       let query = searchObj.data.query.trim();
-      searchObj.data.filterErrMsg = "";
-      searchObj.data.missingStreamMessage = "";
-      searchObj.data.stream.missingStreamMultiStreamFilter = [];
+
+      // Only clear error messages in normal mode
+      if (!readOnly) {
+        searchObj.data.filterErrMsg = "";
+        searchObj.data.missingStreamMessage = "";
+        searchObj.data.stream.missingStreamMultiStreamFilter = [];
+      }
       const req: any = {
         query: {
           sql: searchObj.meta.sqlMode
@@ -230,25 +256,34 @@ export const useSearchQuery = () => {
           (item: any) => item.name,
         );
 
-      for (
-        let i = searchObj.data.stream.interestingFieldList.length - 1;
-        i >= 0;
-        i--
-      ) {
-        const fieldName = searchObj.data.stream.interestingFieldList[i];
-        if (!streamFieldNames.includes(fieldName)) {
-          searchObj.data.stream.interestingFieldList.splice(i, 1);
+      // In read-only mode, create a filtered copy; in normal mode, mutate in place
+      let interestingFields: string[];
+      if (readOnly) {
+        // Read-only: Create a filtered copy without mutating
+        interestingFields = searchObj.data.stream.interestingFieldList.filter(
+          (fieldName: string) => streamFieldNames.includes(fieldName),
+        );
+      } else {
+        // Normal mode: Mutate the array in place
+        for (
+          let i = searchObj.data.stream.interestingFieldList.length - 1;
+          i >= 0;
+          i--
+        ) {
+          const fieldName = searchObj.data.stream.interestingFieldList[i];
+          if (!streamFieldNames.includes(fieldName)) {
+            searchObj.data.stream.interestingFieldList.splice(i, 1);
+          }
         }
+        interestingFields = searchObj.data.stream.interestingFieldList;
       }
 
-      if (
-        searchObj.data.stream.interestingFieldList.length > 0 &&
-        searchObj.meta.quickMode
-      ) {
+      // Replace field list placeholder with appropriate values
+      if (interestingFields.length > 0 && searchObj.meta.quickMode) {
         if (searchObj.data.stream.selectedStream.length == 1) {
           req.query.sql = req.query.sql.replace(
             "[FIELD_LIST]",
-            searchObj.data.stream.interestingFieldList.join(","),
+            interestingFields.join(","),
           );
         }
       } else {
@@ -262,7 +297,8 @@ export const useSearchQuery = () => {
             )
           : cloneDeep(searchObj.data.datetime);
 
-      if (searchObj.data.datetime.type === "relative") {
+      // Only mutate datetime timestamps in normal mode
+      if (searchObj.data.datetime.type === "relative" && !readOnly) {
         searchObj.data.datetime.startTime = timestamps.startTime;
         searchObj.data.datetime.endTime = timestamps.endTime;
       }
@@ -275,27 +311,34 @@ export const useSearchQuery = () => {
           notificationMsg.value = "Start time cannot be greater than end time";
           return null;
         }
-        searchObj.meta.resultGrid.chartKeyFormat = "HH:mm:ss";
+
+        // Only set chartKeyFormat in normal mode
+        if (!readOnly) {
+          searchObj.meta.resultGrid.chartKeyFormat = "HH:mm:ss";
+        }
 
         req.query.start_time = timestamps.startTime;
         req.query.end_time = timestamps.endTime;
 
-        setChartInterval(req);
+        // Only set chart interval in normal mode
+        if (!readOnly) {
+          setChartInterval(req);
+        }
       } else {
-        if(timestamps.startTime == "Invalid Date") {
-          notificationMsg.value = "The selected start time is  invalid. Please choose a valid time."
-        }
-        else if(timestamps.endTime == "Invalid Date") {
-          notificationMsg.value = "The selected end time is  invalid. Please choose a valid time."
-        }
-        else {
-          notificationMsg.value = "Invalid date format."
+        if (timestamps.startTime == "Invalid Date") {
+          notificationMsg.value =
+            "The selected start time is  invalid. Please choose a valid time.";
+        } else if (timestamps.endTime == "Invalid Date") {
+          notificationMsg.value =
+            "The selected end time is  invalid. Please choose a valid time.";
+        } else {
+          notificationMsg.value = "Invalid date format.";
         }
         return null;
       }
 
       if (searchObj.meta.sqlMode == true) {
-        return handleSqlMode(query, req);
+        return handleSqlMode(query, req, readOnly);
       } else {
         return handleNonSqlMode(query, req);
       }
@@ -337,21 +380,26 @@ export const useSearchQuery = () => {
     }
   };
 
-  const handleSqlMode = (query: string, req: any): SearchRequestPayload => {
-    searchObj.data.query = query;
+  const handleSqlMode = (
+    query: string,
+    req: any,
+    readOnly: boolean = false,
+  ): SearchRequestPayload => {
+    // Only mutate query in normal mode
+    if (!readOnly) {
+      searchObj.data.query = query;
+    }
     const parsedSQL: any = fnParsedSQL();
 
     if (parsedSQL != undefined) {
-
-     if (!checkTimestampAlias(searchObj.data.query)) {
-            const errorMsg = `Alias '${store.state.zoConfig.timestamp_column || "_timestamp"}' is not allowed.`;
-            notificationMsg.value = errorMsg;
-            return null;
-          }
+      if (!checkTimestampAlias(searchObj.data.query)) {
+        const errorMsg = `Alias '${store.state.zoConfig.timestamp_column || "_timestamp"}' is not allowed.`;
+        notificationMsg.value = errorMsg;
+        return null;
+      }
 
       if (Array.isArray(parsedSQL) && parsedSQL.length == 0) {
-        notificationMsg.value =
-          "SQL query is missing or invalid.";
+        notificationMsg.value = "SQL query is missing or invalid.";
         return null;
       }
 
@@ -369,7 +417,12 @@ export const useSearchQuery = () => {
 
         query = fnUnparsedSQL(parsedSQL);
         query = query.replace(/`/g, '"');
-        searchObj.data.queryResults.hits = [];
+
+        // CRITICAL: Only clear queryResults.hits in normal mode
+        // This prevents resetting the logs page results when opening QueryPlanDialog
+        if (!readOnly) {
+          searchObj.data.queryResults.hits = [];
+        }
       }
     }
 
@@ -380,6 +433,14 @@ export const useSearchQuery = () => {
     req.query["sql_mode"] = "full";
 
     return finalizeRequest(req);
+  };
+
+  /**
+   * Convenience wrapper for read-only mode
+   * Use this when you need the query payload without mutating searchObj
+   */
+  const getSearchQueryPayload = (): SearchRequestPayload => {
+    return buildSearch(true);
   };
 
   const handleNonSqlMode = (query: string, req: any): SearchRequestPayload => {
@@ -615,6 +676,7 @@ export const useSearchQuery = () => {
   return {
     getQueryReq,
     buildSearch,
+    getSearchQueryPayload,
     validateFilterForMultiStream,
     extractFilterColumns,
   };

--- a/web/src/composables/useLogs/useSearchStream.ts
+++ b/web/src/composables/useLogs/useSearchStream.ts
@@ -193,6 +193,7 @@ export const useSearchStream = () => {
     // Query building
     getQueryReq: queryBuilder.getQueryReq,
     buildSearch: queryBuilder.buildSearch,
+    getSearchQueryPayload: queryBuilder.getSearchQueryPayload,
 
     // Connection management
     buildWebSocketPayload: connectionManager.buildWebSocketPayload,


### PR DESCRIPTION
#10103 

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add read-only flag to buildSearch to prevent state mutations

- Introduce getSearchQueryPayload for non-mutating query payload

- Update QueryPlanDialog to use non-mutating payload function

- Remove histogram save/restore hacks in QueryPlanDialog

- Apply minor formatting and template cleanups


___

### Diagram Walkthrough


```mermaid
flowchart LR
  QueryBar["Log Search Component"]
  buildSearchNorm["buildSearch(normal)"]
  buildSearchRO["buildSearch(readOnly)"]
  getSearchQP["getSearchQueryPayload()"]
  QueryPlanDialog["QueryPlanDialog"]
  QueryBar --> buildSearchNorm
  getSearchQP --> buildSearchRO
  QueryPlanDialog --> getSearchQP
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useSearchQuery.ts</strong><dd><code>Add buildSearch read-only mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs/useSearchQuery.ts

<ul><li>Add <code>readOnly</code> parameter to <code>buildSearch</code><br> <li> Skip <code>searchObj</code> mutations when <code>readOnly=true</code><br> <li> Introduce <code>getSearchQueryPayload</code> wrapper<br> <li> Adapt <code>handleSqlMode</code> to accept <code>readOnly</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10120/files#diff-82f20961268fa282f9bc1e48085d1d7db53d2548e48dda743b0af4e4a20fbd17">+109/-47</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useSearchStream.ts</strong><dd><code>Expose non-mutating query payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs/useSearchStream.ts

- Export `getSearchQueryPayload` in composable return


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10120/files#diff-0b7e910195d1ec4b1301973bd2f4193e1e23442103f69a9fbd189d3f78547014">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QueryPlanDialog.vue</strong><dd><code>Refactor QueryPlanDialog to use non-mutating queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/QueryPlanDialog.vue

<ul><li>Replace <code>buildSearch</code> calls with <code>getSearchQueryPayload</code><br> <li> Remove histogram state save/restore workaround<br> <li> Adjust template <code>:class</code> and formatting<br> <li> Clean up SSE parsing and error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10120/files#diff-857bd0334ca601c4cd4e3ce2be7bff0dca583460a2fdf02d6d1c2f25a65f0ccd">+75/-58</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

