### PR TITLE
fix: dashboard view panel error of object object (#9990)

### DIFF
--- a/web/src/components/dashboards/viewPanel/ViewPanel.vue
+++ b/web/src/components/dashboards/viewPanel/ViewPanel.vue
@@ -534,10 +534,42 @@ export default defineComponent({
         for (let i = 0; i < histogramFields.value.length; i++) {
           if (
             histogramFields.value[i]?.args &&
-            histogramFields.value[i]?.args[0]?.value
+            histogramFields.value[i]?.args.length > 0
           ) {
-            histogramInterval.value = histogramFields.value[i]?.args[0]?.value;
-            break;
+            // Histogram function signature: histogram(field, interval)
+            // args[0] = timestamp field (object)
+            // args[1] = interval (string like '5m', '1h', etc.)
+
+            // Check if there's a second argument (the interval)
+            if (histogramFields.value[i].args.length > 1 && histogramFields.value[i].args[1]) {
+              const intervalArg = histogramFields.value[i].args[1];
+
+              // Extract interval value with explicit type checking
+              let intervalValue: string | null = null;
+
+              if (typeof intervalArg === 'string') {
+                // Direct string value
+                intervalValue = intervalArg;
+              } else if (typeof intervalArg === 'object' && intervalArg !== null) {
+                // Object with value property
+                if ('value' in intervalArg && typeof intervalArg.value === 'string') {
+                  intervalValue = intervalArg.value;
+                }
+              }
+
+              // Set the histogram interval only if we have a valid non-empty string
+              if (intervalValue && intervalValue.trim() !== '') {
+                histogramInterval.value = intervalValue;
+              } else {
+                // No valid interval - use Auto mode
+                histogramInterval.value = null;
+              }
+              break;
+            } else {
+              // No interval specified - this is "Auto" mode
+              histogramInterval.value = null;
+              break;
+            }
           }
         }
       }


### PR DESCRIPTION
### **User description**
- #9987


___

### **PR Type**
Bug fix


___

### **Description**
- Robust histogram interval extraction logic

- Support both string and object `args[1]` interval

- Fallback to auto mode when invalid or missing interval

- Prevent errors from undefined or malformed args


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["histogramFields loop"]
  B["Check args length >1"]
  C["Extract intervalArg"]
  D["Set valid interval"]
  E["Fallback to null"]
  A -- "fields exist" --> B
  B -- "args[1] available" --> C
  C -- "valid string/object" --> D
  C -- "invalid or missing" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ViewPanel.vue</strong><dd><code>Improve histogram interval extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/viewPanel/ViewPanel.vue

<ul><li>Replaced old <code>args[0]</code> logic with <code>args[1]</code> usage<br> <li> Added type checks for string and object interval args<br> <li> Set <code>histogramInterval</code> to <code>null</code> for Auto mode fallback<br> <li> Maintained loop break after interval extraction</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10125/files#diff-e7b26fbbfe7ae57f50377c0f002155df17109ea54708b0f134dd2005356b2930">+35/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

