### PR TITLE
fix: pipeline destination text cut off

### DIFF
--- a/web/src/components/pipeline/NodeForm/CreateDestinationForm.vue
+++ b/web/src/components/pipeline/NodeForm/CreateDestinationForm.vue
@@ -137,7 +137,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <!-- OpenObserve Organization and Stream fields -->
             <div
               v-if="formData.destination_type === 'openobserve'"
-              class="row q-col-gutter-sm q-mt-xs tw:ml-[0.1rem]"
+              class="row q-col-gutter-xs q-mt-xs q-ml-xs"
             >
               <div class="col-6">
                 <q-input


### PR DESCRIPTION
### **User description**
This PR fixes the issue in #10072


___

### **PR Type**
Bug fix


___

### **Description**
- Fix text cut-off in OpenObserve destination fields

- Change gutter from `q-col-gutter-sm` to `q-col-gutter-xs`

- Replace `tw:ml-[0.1rem]` with `q-ml-xs` margin


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateDestinationForm.vue</strong><dd><code>Update gutter and margin classes for spacing fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/pipeline/NodeForm/CreateDestinationForm.vue

<ul><li>Updated CSS gutter class for tighter column spacing<br> <li> Replaced Tailwind margin override with Quasar margin utility<br> <li> Ensured OpenObserve destination form spacing fixes cutoff</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10127/files#diff-4ceb6df12bae90de73e526fe68d79c1a7f6e9990b8672484e8fb91a1e326dd6e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

