### PR TITLE
fix: remove border radius that was added to app tabs

### DIFF
--- a/web/src/components/common/AppTabs.vue
+++ b/web/src/components/common/AppTabs.vue
@@ -88,7 +88,6 @@ const changeTab = (tab: Tab) => {
     border-bottom: 2px solid var(--o2-primary-btn-bg);
     background-color: color-mix(in srgb, var(--o2-primary-btn-bg) 20%, white 10%);
     color: var(--o2-card-text) !important;
-    // border-radius: 0.375rem 0.375rem 0 0;
   }
 }
 </style>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove border radius on active app tabs


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AppTabs.vue</strong><dd><code>Remove `.active` border-radius property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/common/AppTabs.vue

- Removed `border-radius` property from the `.active` class


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10128/files#diff-f69ae88c0f2018ea808724a0eaee5bd008fd1608c52f7ca20215fc6033f00573">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

