### PR TITLE
feat: allow x-openobserve-trace-id custom request header for rum-trace correlation

### DIFF
--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -81,6 +81,7 @@ pub fn cors_layer() -> CorsLayer {
             header::ACCEPT,
             header::CONTENT_TYPE,
             header::HeaderName::from_lowercase(b"traceparent").unwrap(),
+            header::HeaderName::from_lowercase(b"x-openobserve-trace-id").unwrap(),
         ])
         .allow_origin(AllowOrigin::mirror_request())
         .allow_credentials(true)


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests

Design at: application-monitoring/rum

___

### **Description**
- Add support for `x-openobserve-trace-id` header

- Validate header as 32-character hex non-zero ID

- Inject synthetic `traceparent` when valid

- Fallback to W3C `traceparent` or generate new ID

- Update CORS to allow the new header


___

### Diagram Walkthrough


```mermaid
flowchart LR
  H["Incoming Headers"]
  C["Valid x-openobserve-trace-id?"]
  T["Valid traceparent?"]
  G["Generate new trace ID"]
  E["Return trace ID"]
  H --> C
  C -- yes --> E
  C -- no --> T
  T -- yes --> E
  T -- no --> G
  G --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http.rs</strong><dd><code>Support x-openobserve-trace-id header & tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/common/utils/http.rs

<ul><li>Insert check for <code>x-openobserve-trace-id</code> header<br> <li> Validate it as 32 hex characters and not all zeros<br> <li> Create synthetic <code>traceparent</code> and set span parent<br> <li> Added tests for valid, invalid, zero, non-hex, priority, fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10130/files#diff-3b50a69c1ec2f63f8eebb5f9880e17826463a586768aed3e3e15242833609d6b">+125/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Allow custom trace ID header in CORS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/router/mod.rs

- Allow `x-openobserve-trace-id` in CORS `allow_headers`


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10130/files#diff-02556e3f515441b5d2b6bbea7829df488beac03c4cc41309a6638ae3c0e0aec6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

