### PR TITLE
fix: pipeline destination text cut off (#10127)

### DIFF
--- a/web/src/components/pipeline/NodeForm/CreateDestinationForm.vue
+++ b/web/src/components/pipeline/NodeForm/CreateDestinationForm.vue
@@ -137,7 +137,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <!-- OpenObserve Organization and Stream fields -->
             <div
               v-if="formData.destination_type === 'openobserve'"
-              class="row q-col-gutter-sm q-mt-xs tw:ml-[0.1rem]"
+              class="row q-col-gutter-xs q-mt-xs q-ml-xs"
             >
               <div class="col-6">
                 <q-input


### PR DESCRIPTION
### **User description**
This PR fixes the issue in #10072


___

### **PR Type**
Bug fix


___

### **Description**
- Fix text cut-off in OpenObserve destination fields

- Tighter column spacing with `q-col-gutter-xs`

- Replace Tailwind margin with `q-ml-xs`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateDestinationForm.vue</strong><dd><code>Update spacing classes in destination form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/pipeline/NodeForm/CreateDestinationForm.vue

<ul><li>Changed <code>q-col-gutter-sm</code> to <code>q-col-gutter-xs</code><br> <li> Replaced <code>tw:ml-[0.1rem]</code> with <code>q-ml-xs</code><br> <li> Ensured proper spacing for OpenObserve form fields</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10136/files#diff-4ceb6df12bae90de73e526fe68d79c1a7f6e9990b8672484e8fb91a1e326dd6e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

