### PR TITLE
fix: now micro timestamp should be used as end time if the meta stats of an enrichment table is not present

### DIFF
--- a/src/service/enrichment/mod.rs
+++ b/src/service/enrichment/mod.rs
@@ -16,7 +16,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
-use config::utils::time::parse_str_to_time;
+use config::utils::time::{now_micros, parse_str_to_time};
 use vector_enrichment::{Case, IndexHandle, Table};
 use vrl::value::{KeyString, ObjectMap, Value};
 
@@ -187,11 +187,17 @@ pub async fn get_enrichment_table_inner(
 
     let values = if (db_stats.end_time > local_last_updated) || local_last_updated == 0 {
         log::debug!("get_enrichment_table: fetching from remote: {org_id}/{table_name}");
+        // Use current timestamp if end_time is 0 (no meta stats exist)
+        let end_time = if db_stats.end_time == 0 {
+            now_micros()
+        } else {
+            db_stats.end_time + 1 // search query end time is not inclusive
+        };
         enrichment_table::get_enrichment_table_data(
             org_id,
             table_name,
             apply_primary_region_if_specified,
-            db_stats.end_time + 1, // search query end time is not inclusive
+            end_time,
         )
         .await?
     } else {


### PR DESCRIPTION
### **User description**
Currently to fetch the enrichment table data we use the meta stats stored in the meta table to get the end time of the enrichment table. And this end time we use for query. But if the meta stats itself is not present for the enrichment table, instead of using the current timestamp, it uses `0` and hence results in invalid timerange.


___

### **PR Type**
Bug fix


___

### **Description**
- Handle missing `db_stats.end_time` using `now_micros()`

- Adjust import to include `now_micros` utility

- Compute `end_time` fallback for remote fetch query


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["db_stats.end_time"] --> B{"end_time == 0?"}
  B -- "Yes" --> C["use now_micros()"]
  B -- "No" --> D["use end_time + 1"]
  C --> E["get_enrichment_table_data(..., end_time)"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add fallback now_micros for missing end_time</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/enrichment/mod.rs

<ul><li>Imported <code>now_micros</code> for current timestamp fallback<br> <li> Updated end_time logic for remote data fetch<br> <li> Used <code>now_micros()</code> when <code>db_stats.end_time</code> is zero</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10137/files#diff-0ea1823eb8a3a9845cde8bb2264ccdb749fad5be6d9acda8b17d76b2dbfdcc9f">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

