### PR TITLE
fix: sync issue for user token and rum token updates

### DIFF
--- a/src/super_cluster_queue/org_user.rs
+++ b/src/super_cluster_queue/org_user.rs
@@ -129,11 +129,11 @@ async fn update_token(msg: Message) -> Result<()> {
         None => "".to_string(),
     };
     let keys = msg.key.split('/').collect::<Vec<&str>>();
-    if keys.len() < 4 {
+    if keys.len() < 5 {
         return Err(Error::Message("Invalid key".to_string()));
     }
-    let org_id = keys[2];
-    let user_email = keys[3];
+    let org_id = keys[3];
+    let user_email = keys[4];
     if db_org_users::get(org_id, user_email).await.is_err() {
         // User not found, ignore
         log::warn!(
@@ -157,11 +157,11 @@ async fn update_rum_token(msg: Message) -> Result<()> {
         None => "".to_string(),
     };
     let keys = msg.key.split('/').collect::<Vec<&str>>();
-    if keys.len() < 4 {
+    if keys.len() < 5 {
         return Err(Error::Message("Invalid key".to_string()));
     }
-    let org_id = keys[2];
-    let user_email = keys[3];
+    let org_id = keys[3];
+    let user_email = keys[4];
     if db_org_users::get(org_id, user_email).await.is_err() {
         // User not found, ignore
         log::warn!(
@@ -181,12 +181,12 @@ async fn update_rum_token(msg: Message) -> Result<()> {
 
 async fn delete(msg: Message) -> Result<()> {
     let keys = msg.key.split('/').collect::<Vec<&str>>();
-    if keys.len() < 4 {
+    if keys.len() < 5 {
         return Err(Error::Message("Invalid key".to_string()));
     }
-    let org_id = keys[2];
-    let user_email = keys[3];
-    if keys[1].eq("many") {
+    let org_id = keys[3];
+    let user_email = keys[4];
+    if keys[2].eq("many") {
         if let Err(e) = org_users::remove_by_user(user_email).await {
             log::error!("[SUPER_CLUSTER:sync] Failed to delete org user: {user_email}, error: {e}");
             return Err(e);

--- a/src/super_cluster_queue/user.rs
+++ b/src/super_cluster_queue/user.rs
@@ -101,7 +101,7 @@ async fn update(msg: Message) -> Result<()> {
 
 async fn delete(msg: Message) -> Result<()> {
     let keys = msg.key.split('/').collect::<Vec<_>>();
-    if keys.len() != 2 {
+    if keys.len() != 3 {
         log::error!(
             "[SUPER_CLUSTER:sync] Invalid key: {}, expected 3 parts, got {}",
             msg.key,
@@ -109,7 +109,7 @@ async fn delete(msg: Message) -> Result<()> {
         );
         return Err(Error::Message("Invalid key".to_string()));
     }
-    let email = keys[1];
+    let email = keys[2];
     if let Err(e) = org_users::remove_by_user(email).await {
         log::error!("[SUPER_CLUSTER:sync] Failed to delete user: {email}, error: {e}");
         return Err(e);


### PR DESCRIPTION
### **User description**
Currently the user token/rum token update and user delete is not synced properly in super cluster env. This pr fixes this.


___

### **PR Type**
Bug fix


___

### **Description**
- Adjust key length and parsing in org_user token updates

- Correct key parsing in org_user delete handler

- Fix key length and email index in user delete


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>org_user.rs</strong><dd><code>Fix key parsing in org_user handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/super_cluster_queue/org_user.rs

<ul><li>Increased key length check from 4 to 5<br> <li> Shifted org_id to keys[3] and user_email to keys[4]<br> <li> Updated 'many' check index in delete function</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10152/files#diff-faeed09b713e8a50ab6b87975c493bf3eca0d1436a7cc3c54c5ad35d7e9cb03e">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>user.rs</strong><dd><code>Correct user delete key parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/super_cluster_queue/user.rs

<ul><li>Updated delete key length from 2 to 3<br> <li> Adjusted email extraction to keys[2]</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10152/files#diff-6e88bc7163c6de5e218404539c4ac8689cdf2287617f5ce91a255dd09e62cb05">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

