### PR TITLE
fix: set redirect policy of reqwest to none

### DIFF
--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -45,6 +45,7 @@ fn get_http_client() -> &'static reqwest::Client {
     HTTP_CLIENT.get_or_init(|| {
         let cfg = get_config();
         reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
             .timeout(std::time::Duration::from_secs(cfg.route.timeout))
             .pool_max_idle_per_host(cfg.route.max_connections)
             .build()


### PR DESCRIPTION
### **User description**
Fixes to NOT follow redirect when doing proxy on router.


___

### **PR Type**
Bug fix


___

### **Description**
- Set redirect policy to none on HTTP client


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Set no-redirect policy on HTTP client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/router/http/mod.rs

- Added `.redirect(reqwest::redirect::Policy::none())` before timeout


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10164/files#diff-d7987e62dcc7b1ec1bd4aeabef94f85d8c41b2ea33de5ab78660794fa4d51a9e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

