### PR TITLE
fix: create incident for user-triggered alerts as well

### DIFF
--- a/src/handler/http/request/cloud/billings.rs
+++ b/src/handler/http/request/cloud/billings.rs
@@ -19,7 +19,7 @@ use axum::{
     body::Body,
     extract::{Path, Query},
     http::{HeaderMap, StatusCode, header},
-    response::{IntoResponse, Response},
+    response::Response,
 };
 use config::{get_config, utils::json};
 use o2_enterprise::enterprise::cloud::billings::{self as o2_cloud_billings};

--- a/src/handler/http/request/organization/org.rs
+++ b/src/handler/http/request/organization/org.rs
@@ -526,8 +526,6 @@ pub async fn extend_trial_period(
     Path(org_id): Path<String>,
     Json(req): Json<ExtendTrialPeriodRequest>,
 ) -> Response {
-    use axum::body::Body;
-
     use crate::service::db::organization::ORG_KEY_PREFIX;
 
     let org = org_id;

--- a/src/service/alerts/alert.rs
+++ b/src/service/alerts/alert.rs
@@ -841,6 +841,54 @@ pub async fn trigger_by_id<C: ConnectionTrait>(
     };
     let now = Utc::now().timestamp_micros();
     let (success_message, err_message) = alert.send_notification(&[], now, None, now).await?;
+
+    #[cfg(feature = "enterprise")]
+    if o2_enterprise::enterprise::common::config::get_config()
+        .incidents
+        .enabled
+    {
+        // Create synthetic result row with alert metadata
+        let synthetic_row = config::utils::json::json!({
+            "stream_name": alert.stream_name,
+            "stream_type": alert.stream_type.to_string(),
+            "alert_name": alert.name,
+            "alert_id": alert_id.to_string(),
+            "trigger_type": "manual"
+        });
+        let synthetic_row = synthetic_row.as_object().unwrap();
+
+        match crate::service::alerts::incidents::correlate_alert_to_incident(
+            &alert,
+            synthetic_row,
+            now,
+            None,
+            None,
+        )
+        .await
+        {
+            Ok(Some((incident_id, service_name))) => {
+                log::info!(
+                    "Manual trigger for alert {}/{} correlated to incident {} (service: {})",
+                    org_id,
+                    &alert.name,
+                    incident_id,
+                    service_name
+                );
+            }
+            Ok(None) => {
+                log::debug!(
+                    "No incident correlation for manually triggered alert {}/{}",
+                    org_id,
+                    &alert.name
+                );
+            }
+            Err(e) => {
+                log::error!("Error correlating manual trigger to incident: {e}");
+                // Don't fail the trigger if incident correlation fails
+            }
+        }
+    }
+
     Ok((success_message, err_message))
 }
 
@@ -858,6 +906,54 @@ pub async fn trigger_by_name(
     };
     let now = Utc::now().timestamp_micros();
     let (success_message, err_message) = alert.send_notification(&[], now, None, now).await?;
+
+    // [ENTERPRISE] Create incident for manual trigger
+    #[cfg(feature = "enterprise")]
+    if o2_enterprise::enterprise::common::config::get_config()
+        .incidents
+        .enabled
+    {
+        // Create synthetic result row with alert metadata
+        let synthetic_row = config::utils::json::json!({
+            "stream_name": alert.stream_name,
+            "stream_type": alert.stream_type.to_string(),
+            "alert_name": alert.name,
+            "trigger_type": "manual"
+        });
+        let synthetic_row = synthetic_row.as_object().unwrap();
+
+        match crate::service::alerts::incidents::correlate_alert_to_incident(
+            &alert,
+            synthetic_row,
+            now,
+            None,
+            None,
+        )
+        .await
+        {
+            Ok(Some((incident_id, service_name))) => {
+                log::info!(
+                    "Manual trigger for alert {}/{} correlated to incident {} (service: {})",
+                    org_id,
+                    &alert.name,
+                    incident_id,
+                    service_name
+                );
+            }
+            Ok(None) => {
+                log::debug!(
+                    "No incident correlation for manually triggered alert {}/{}",
+                    org_id,
+                    &alert.name
+                );
+            }
+            Err(e) => {
+                log::error!("Error correlating manual trigger to incident: {e}");
+                // Don't fail the trigger if incident correlation fails
+            }
+        }
+    }
+
     Ok((success_message, err_message))
 }
 


### PR DESCRIPTION
### **User description**
Originally, incidents were created when an alert was triggered through alert manager evaluation, not when the same alert was triggered by a user on the UI. This is now taken care of.

Additionally, a bug in incident API's response on the UI resulted in a discrepancy in the count of alert triggers. This is fixed now.

+ clippy fixes.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Create incidents for user-triggered alerts

- Support synthetic alert metadata for correlation

- Update metadata only on dimension changes

- Clippy and import cleanups across handlers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UserManual["Manual alert trigger"]
  SendNotif["send_notification"]
  Correlate["correlate_alert_to_incident"]
  AddToInc["add_alert_to_incident"]
  UpdMeta["update_incident_metadata"]
  UserManual --> SendNotif
  SendNotif --> Correlate
  Correlate -- "incident found" --> AddToInc
  AddToInc -- "dimensions_changed?" --> UpdMeta
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat.rs</strong><dd><code>Refactor agent type and error formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/ai/chat.rs

<ul><li>Use <code>is_some_and</code> for incident_id check<br> <li> Simplify error formatting with <code>{e}</code><br> <li> Correct <code>format!</code> placeholder in <code>http.target</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10170/files#diff-12a78cbb31b313cb3a0ca50f25c177470cf49b02708f179fe138ed3d66a2926b">+10/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>billings.rs</strong><dd><code>Simplify imports in billings handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/cloud/billings.rs

- Remove `IntoResponse` import
- Simplify `response::Response` import


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10170/files#diff-725936e3d6e955175e6100e8ca6f4437f334a2b554d6f11fa349ee9cbac70425">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>org.rs</strong><dd><code>Remove unused import in org handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/organization/org.rs

- Remove unused `Body` import in `extend_trial_period`


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10170/files#diff-b47c0c1a8a78524196176430268eecdbfaf6f46d6b95873d3cbe70cfd67182b0">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alert.rs</strong><dd><code>Add manual trigger incident correlation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/alerts/alert.rs

<ul><li>Add enterprise logic to correlate manual triggers to incidents<br> <li> Log correlation outcomes without failing trigger</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10170/files#diff-574be3504bf4d855c65fd3d7a10797a970237ff552edac4962b474b3983e094e">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>incidents.rs</strong><dd><code>Refine incident metadata update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/alerts/incidents.rs

<ul><li>Remove redundant metadata updates before adding alerts<br> <li> Use <code>add_alert_to_incident</code> for count and timestamp<br> <li> Update metadata only when dimensions change</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10170/files#diff-2411d921fd8b8783c049deea11da06726ed986550d405477d486234892353ca9">+18/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

