### PR TITLE
test: add timestamp verification to backfill test

### DIFF
--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -124,7 +124,7 @@ jobs:
           sleep 5
 
           echo "=== Running all other API tests with default settings ==="
-          target/debug/openobserve > o2_default.log 2>&1 &
+          ZO_INGEST_ALLOWED_UPTO=48 target/debug/openobserve > o2_default.log 2>&1 &
           SERVER_PID_DEFAULT=$!
           echo "OpenObserve PID for other tests: $SERVER_PID_DEFAULT"
           sleep 15


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Add timestamp verification for backdated ingestion

- Calculate record ages in minutes from timestamps

- Assert oldest record age > 10 minutes


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_backfill.py</strong><dd><code>Add timestamp verification in backfill test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/api-testing/tests/test_backfill.py

<ul><li>Added printing and verification of backdated timestamps<br> <li> Converted <code>_timestamp</code> to UTC datetime and computed age<br> <li> Asserted oldest record age exceeds 10 minutes<br> <li> Printed timestamp range for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10179/files#diff-644fee0c3348626de59a5b38627f499f0c57afcffcc1a203533ff5fefa5df6dd">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

