### PR TITLE
fix: allow multiple free orgs

### DIFF
--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -44,6 +44,7 @@ fn get_http_client() -> &'static reqwest::Client {
     HTTP_CLIENT.get_or_init(|| {
         let cfg = get_config();
         reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
             .timeout(std::time::Duration::from_secs(cfg.route.timeout))
             .pool_max_idle_per_host(cfg.route.max_connections)
             .build()


### PR DESCRIPTION
### **User description**
Allows user to be part of multiple free orgs upto a limit.


___

### **PR Type**
Enhancement


___

### **Description**
- Disable HTTP client auto-redirects

- Enhance free org operations:
  - Fetch cloud config limit
  - Count existing free orgs
  - Compare with max_free_orgs_allowed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  HTTP["HTTP client builder"] --> RED["Set redirect policy none"]
  CFG["Fetch cloud config"] --> CNT["Count user's free orgs"]
  CNT --> CMP["free_org_count < max_free_orgs_allowed?"]
  CMP -- "yes" --> OK["Proceed operation"]
  CMP -- "no" --> ERR["Return limit exceeded error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Disable HTTP client redirects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/router/http/mod.rs

<ul><li>Added <code>.redirect(reqwest::redirect::Policy::none())</code><br> <li> Updated HTTP client builder configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10180/files#diff-d7987e62dcc7b1ec1bd4aeabef94f85d8c41b2ea33de5ab78660794fa4d51a9e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>organization.rs</strong><dd><code>Allow configurable multiple free organizations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/organization.rs

<ul><li>Imported cloud config for free-org limits<br> <li> Replaced hard-limit error with counter logic<br> <li> Count free orgs before create/invite/accept<br> <li> Compare count against <code>max_free_orgs_allowed</code><br> <li> Updated error messages with limit value</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10180/files#diff-6b3c3c2b027c1158c0d41302cc69dfcd20ab68a6a4fa365cda403f838940bbb4">+40/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

