### PR TITLE
chore: make OSS Docker image build manual-only

### DIFF
--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.run_id }}
+  group: ${{ github.workflow }}-${{ inputs.branch }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary
- Switch `build-pr-image.yml` from auto-triggering on every PR to `workflow_dispatch` only

## Why
OSS Docker image builds on every PR waste CI compute. The image isn't always needed — developers can trigger it manually when required.