### PR TITLE
fix: Pricing UI fix

### DIFF
--- a/web/src/enterprise/components/billings/enterprisePlan.vue
+++ b/web/src/enterprise/components/billings/enterprisePlan.vue
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <q-separator spaced />
 
-    <div class="q-px-md q-pt-sm" style="margin-bottom: 268px;">
+    <div class="q-px-md q-pt-sm" style="margin-bottom: 239px;">
       <div class="o2-page-subtitle1">{{ t("billing.features") }}</div>
       <div class="o2-page-subtitle2 q-mb-md q-mt-xs">{{ t("billing.included") }}</div>
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Adjust bottom margin of the features section


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enterprisePlan.vue</strong><dd><code>Adjust bottom margin styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/enterprise/components/billings/enterprisePlan.vue

- Reduced `margin-bottom` from 268px to 239px


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10195/files#diff-f7fa88084375d33ceff7ec4816843de2705f2ed393590b9d1d993a67ff8ac29b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

