### PR TITLE
fix: remove trigger from scheduled job for expired orgs

### DIFF
--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -346,6 +346,21 @@ async fn handle_alert_triggers(
                     &trigger.module_key
                 );
             }
+
+            if let Err(e) = db::scheduler::delete(
+                &trigger.org,
+                db::scheduler::TriggerModule::Alert,
+                &trigger.module_key,
+            )
+            .await
+            {
+                log::error!(
+                    "[SCHEDULER trace_id {scheduler_trace_id}] Failed to remove alert from scheduled_jobs due to trial expiry: {}/{} : {e}",
+                    &trigger.org,
+                    &trigger.module_key
+                );
+            }
+
             return Ok(());
         }
     }
@@ -1213,6 +1228,21 @@ async fn handle_report_triggers(
                     report_name
                 );
             }
+
+            if let Err(e) = db::scheduler::delete(
+                &trigger.org,
+                db::scheduler::TriggerModule::Report,
+                &trigger.module_key,
+            )
+            .await
+            {
+                log::error!(
+                    "[SCHEDULER trace_id {scheduler_trace_id}] Failed to remove report from scheduled_jobs due to trial expiry: {}/{} : {e}",
+                    &trigger.org,
+                    report_name
+                );
+            }
+
             return Ok(());
         }
     }
@@ -1518,6 +1548,21 @@ async fn handle_derived_stream_triggers(
                     pipeline.name
                 );
             }
+
+            if let Err(e) = db::scheduler::delete(
+                &trigger.org,
+                db::scheduler::TriggerModule::DerivedStream,
+                &trigger.module_key,
+            )
+            .await
+            {
+                log::error!(
+                    "[SCHEDULER trace_id {scheduler_trace_id}] Failed to remove pipeline from scheduled_jobs due to trial expiry: {}/{} : {e}",
+                    &trigger.org,
+                    pipeline.name
+                );
+            }
+
             return Ok(());
         }
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add deletion of scheduled jobs on trial expiry
  - Alerts handler
  - Reports handler
  - Derived streams handler

- Log errors if deletion fails


___

### Diagram Walkthrough


```mermaid
flowchart LR
  TE["Trial expiry detected"] --> PT["Pause trigger job"]
  PT --> DJ["Delete scheduled job entry"]
  DJ --> LE["Log deletion failure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handlers.rs</strong><dd><code>Add scheduled job deletion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/alerts/scheduler/handlers.rs

<ul><li>Insert <code>db::scheduler::delete</code> after pausing expired triggers<br> <li> Apply deletion logic in alerts, reports, pipelines<br> <li> Log errors on deletion failure with trace ID</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10212/files#diff-5eca8995a88fcecb6d6b8efd3c7c4496f4a96a4b060fb4ed85593574f7cf49eb">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

