### PR TITLE
fix: use error tooltip color for pipeline tooltip

### DIFF
--- a/web/src/plugins/pipelines/CustomNode.vue
+++ b/web/src/plugins/pipelines/CustomNode.vue
@@ -1007,9 +1007,11 @@ function getIcon(data, ioType) {
   border-top-color: #dc2626;
 }
 
-// Pipeline error tooltip styling
+// Pipeline error tooltip styling - increased specificity to override global theme styles
+.body--dark .pipeline-error-tooltip,
+.body--light .pipeline-error-tooltip,
 .pipeline-error-tooltip {
-  background: #ef4444 !important;
+  background-color: #ef4444 !important;
   color: white !important;
   font-size: 12px !important;
   white-space: pre-wrap !important;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Increase tooltip specificity to override themes

- Add .body--dark and .body--light selectors

- Switch to background-color for error tooltip


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CustomNode.vue</strong><dd><code>Override theme styles for error tooltip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/pipelines/CustomNode.vue

<ul><li>Added theme-specific selectors (.body--dark, .body--light)<br> <li> Increased specificity for .pipeline-error-tooltip<br> <li> Switched to background-color property for tooltip</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10215/files#diff-b9d83cd503b6d3470b238accaaea0b4decf567add8ad4727c63c9e583725f408">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

