### PR TITLE
fix: incident correlation with proper semantic dimensions and filters

### DIFF
--- a/web/src/components/alerts/IncidentDetailDrawer.vue
+++ b/web/src/components/alerts/IncidentDetailDrawer.vue
@@ -1432,9 +1432,16 @@ export default defineComponent({
       if (!incidentDetails.value) {
         return { startTime: 0, endTime: 0 };
       }
+
+      // Expand time range to ensure we capture relevant telemetry
+      // If first_alert_at == last_alert_at (single alert), expand ±15 minutes
+      const FIFTEEN_MINUTES_MICROS = 15 * 60 * 1000000;
+      const startTime = incidentDetails.value.first_alert_at - FIFTEEN_MINUTES_MICROS;
+      const endTime = incidentDetails.value.last_alert_at + FIFTEEN_MINUTES_MICROS;
+
       return {
-        startTime: incidentDetails.value.first_alert_at,
-        endTime: incidentDetails.value.last_alert_at,
+        startTime,
+        endTime,
       };
     });
 

--- a/web/src/services/incidents.ts
+++ b/web/src/services/incidents.ts
@@ -98,7 +98,7 @@ export interface IncidentCorrelatedStreams {
   logStreams: StreamInfo[];
   metricStreams: StreamInfo[];
   traceStreams: StreamInfo[];
-  correlationData: CorrelationResponse;
+  correlationData: CorrelationResponse | null;
 }
 
 // Service Graph visualization types
@@ -219,6 +219,19 @@ const incidents = {
 
     const response = await serviceStreamsApi.correlate(org_identifier, request);
     const correlationData = response.data;
+
+    // Handle null response when no service is found
+    if (!correlationData) {
+      return {
+        serviceName: "Unknown Service",
+        matchedDimensions: {},
+        additionalDimensions: dimensions,
+        logStreams: [],
+        metricStreams: [],
+        traceStreams: [],
+        correlationData: null,
+      };
+    }
 
     return {
       serviceName: correlationData.service_name,


### PR DESCRIPTION
### **User description**
- Load default semantic groups when org config unavailable
- Expand telemetry time range ±15min for single-alert incidents
- Handle null _correlate API response gracefully in frontend

Fixes correlation failures where incidents had incomplete stable_dimensions and overly restrictive time ranges prevented telemetry queries from returning data.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Load default semantic groups on missing config

- Expand telemetry time range by ±15 minutes

- Handle null correlate API response gracefully


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>incidents.ts</strong><dd><code>Handle null correlation API response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/services/incidents.ts

<ul><li>Allow <code>correlationData</code> nullable in <code>IncidentCorrelatedStreams</code><br> <li> Add null-response check, return default empty streams</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10225/files#diff-ff3182e820c3a01b1ba243b2bccc18f5d9e2dfffc0ec3431742bf74ec499f05c">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>incidents.rs</strong><dd><code>Default semantic groups fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/alerts/incidents.rs

<ul><li>Fallback to enterprise default semantic groups if config missing<br> <li> Use feature flag guards for default config on error</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10225/files#diff-2411d921fd8b8783c049deea11da06726ed986550d405477d486234892353ca9">+35/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IncidentDetailDrawer.vue</strong><dd><code>Expand telemetry time range</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentDetailDrawer.vue

- Expand telemetry time range ±15 minutes for single-alert incidents


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10225/files#diff-6973d58a5f49658b07d3533d4db5d32cc6430433b51732481e7497243dadb0b0">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

