### PR TITLE
fix: use correct config flag on UI for incidents

### DIFF
--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -158,19 +158,11 @@ struct ConfigResponse<'a> {
     log_page_default_field_list: String,
     query_values_default_num: i64,
     mysql_deprecated_warning: bool,
-    #[cfg(feature = "enterprise")]
     service_graph_enabled: bool,
-    #[cfg(not(feature = "enterprise"))]
-    service_graph_enabled: bool,
-    #[cfg(feature = "enterprise")]
-    service_streams_enabled: bool,
-    #[cfg(not(feature = "enterprise"))]
+    incidents_enabled: bool,
     service_streams_enabled: bool,
     /// Available FQN priority dimensions from O2_FQN_PRIORITY_DIMENSIONS env var
     /// Used by UI to populate the FQN priority dimension selector
-    #[cfg(feature = "enterprise")]
-    fqn_priority_dimensions: Vec<String>,
-    #[cfg(not(feature = "enterprise"))]
     fqn_priority_dimensions: Vec<String>,
 }
 
@@ -345,6 +337,11 @@ pub async fn zo_config() -> impl IntoResponse {
     let service_graph_enabled = false;
 
     #[cfg(feature = "enterprise")]
+    let incidents_enabled = o2cfg.incidents.enabled;
+    #[cfg(not(feature = "enterprise"))]
+    let incidents_enabled = false;
+
+    #[cfg(feature = "enterprise")]
     let service_streams_enabled = o2cfg.service_streams.enabled;
     #[cfg(not(feature = "enterprise"))]
     let service_streams_enabled = false;
@@ -455,6 +452,7 @@ pub async fn zo_config() -> impl IntoResponse {
         query_values_default_num: cfg.limit.query_values_default_num,
         mysql_deprecated_warning: cfg.common.meta_store.starts_with("mysql"),
         service_graph_enabled,
+        incidents_enabled,
         service_streams_enabled,
         #[cfg(feature = "enterprise")]
         fqn_priority_dimensions: o2_enterprise::enterprise::common::config::get_config()

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -361,7 +361,7 @@ export default defineComponent({
     const isIncidentsEnabled = computed(() => {
       return (
         (config.isEnterprise == "true" || config.isCloud == "true") &&
-        store.state.zoConfig.service_graph_enabled
+        store.state.zoConfig.incidents_enabled
       );
     });
 


### PR DESCRIPTION
### **User description**
Earlier, the UI code was using `service_graph_enabled` to show (or hide) the incidents screen, this was wrong.

Now `incidents_enabled` is used and sent by the backend as part of `/config` API call.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `incidents_enabled` to backend config response

- Populate `incidents_enabled` in `zo_config` handler

- Update UI `isIncidentsEnabled` to use `incidents_enabled`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Include `incidents_enabled` in backend config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/status/mod.rs

<ul><li>Insert <code>incidents_enabled: bool</code> in <code>ConfigResponse</code><br> <li> Remove feature-gates on <code>service_graph_enabled</code> and <br><code>fqn_priority_dimensions</code><br> <li> Add <code>incidents_enabled</code> retrieval in <code>zo_config</code> handler<br> <li> Include <code>incidents_enabled</code> in outgoing response</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10226/files#diff-ca09c9c9b020049bdbc3382c466bfcca80daac92e98760d9a9a76172abf34049">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MainLayout.vue</strong><dd><code>Use `incidents_enabled` in UI logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/layouts/MainLayout.vue

<ul><li>Replace <code>service_graph_enabled</code> with <code>incidents_enabled</code> in UI<br> <li> Update <code>isIncidentsEnabled</code> computed property</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10226/files#diff-91e4134141264c4624d4eb4cfa987b33ed31eb6f551e089c0b26f2610dd54362">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

