### PR TITLE
fix: set dex_refresh method to get instead of POST

### DIFF
--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -471,7 +471,7 @@ pub fn config_routes() -> Router {
         .route("/reload", get(status::config_reload))
         .route("/redirect", get(status::redirect))
         .route("/dex_login", get(status::dex_login))
-        .route("/dex_refresh", post(status::refresh_token_with_dex))
+        .route("/dex_refresh", get(status::refresh_token_with_dex))
         .route("/token", post(users::service_accounts::exchange_token))
         .layer(cors_layer())
 }


### PR DESCRIPTION
### **User description**
dex refresh on config should be GET not POST


___

### **PR Type**
Bug fix


___

### **Description**
- Switch `/dex_refresh` route to GET method


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Switch dex_refresh method to GET</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/router/mod.rs

- Changed `/dex_refresh` route from POST to GET


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10234/files#diff-02556e3f515441b5d2b6bbea7829df488beac03c4cc41309a6638ae3c0e0aec6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

