### PR TITLE
ci: update runner for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
   release:
     name: Release artifacts
     needs: [build]
-    runs-on: ubicloud-standard-4
+    runs-on: repo-openobserve-standard-4
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Switch release job runner to new VM label


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Update release job runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Changed <code>runs-on</code> from <code>ubicloud-standard-4</code> to <br><code>repo-openobserve-standard-4</code> in release job</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10235/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

