### PR TITLE
fix: correct session duration by passing all event types in session replay player

### DIFF
--- a/web/src/components/rum/VideoPlayer.vue
+++ b/web/src/components/rum/VideoPlayer.vue
@@ -75,12 +75,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           class="progressTime absolute cursor-pointer"
           :class="getEventMarkerClass(event)"
           :style="{
-            width: event.frustration_types && event.frustration_types.length > 0 ? '3px' : '2px',
+            width:
+              event.frustration_types && event.frustration_types.length > 0
+                ? '3px'
+                : '2px',
             left:
               (event.relativeTime / playerState.totalTime) * playerState.width +
               'px',
             bottom: '-0.3125rem',
-            height: event.frustration_types && event.frustration_types.length > 0 ? '1.125rem' : '0.9375rem',
+            height:
+              event.frustration_types && event.frustration_types.length > 0
+                ? '1.125rem'
+                : '0.9375rem',
           }"
           :title="getEventTooltip(event)"
         />
@@ -279,8 +285,6 @@ const setupSession = async () => {
   props.segments.forEach((segment: any) => {
     segment.records.forEach((record: any) => {
       let segCopy = cloneDeep(record);
-      const supportedTypes = [2, 3, 4, 8];
-      if (!supportedTypes.includes(segCopy.type)) return;
       if (segCopy.type === 8) {
         const seg = {
           ...segCopy,
@@ -416,6 +420,10 @@ const setupSession = async () => {
   // });
 
   if (!player.value) return;
+  updatePlayerState();
+};
+
+const updatePlayerState = () => {
   const playerMeta = player.value?.getMetaData();
   playerState.value.startTime = playerMeta.startTime;
   playerState.value.endTime = playerMeta.endTime;
@@ -427,29 +435,31 @@ const setupSession = async () => {
   const playbackBarWidth = playbackBarRef.value?.clientWidth || 0;
   // calculate width of progress bar
   playerState.value.width = playbackBarWidth;
-
   player.value.triggerResize();
 };
 
 const getEventMarkerClass = (event: any) => {
   if (event.frustration_types && event.frustration_types.length > 0) {
-    return 'bg-frustration-marker';
+    return "bg-frustration-marker";
   }
-  if (event.type === 'error') {
-    return 'bg-red-5';
+  if (event.type === "error") {
+    return "bg-red-5";
   }
-  return 'bg-secondary';
+  return "bg-secondary";
 };
 
 const getEventTooltip = (event: any) => {
-  const eventName = event.name.length > 100
-    ? event.name.slice(0, 100) + '...'
-    : event.name;
+  const eventName =
+    event.name.length > 100 ? event.name.slice(0, 100) + "..." : event.name;
 
   if (event.frustration_types && event.frustration_types.length > 0) {
-    const frustrationLabels = event.frustration_types.map((type: string) => {
-      return type.replace(/_/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase());
-    }).join(', ');
+    const frustrationLabels = event.frustration_types
+      .map((type: string) => {
+        return type
+          .replace(/_/g, " ")
+          .replace(/\b\w/g, (l: string) => l.toUpperCase());
+      })
+      .join(", ");
     return `⚠️ FRUSTRATION: ${frustrationLabels}\n${eventName}`;
   }
 
@@ -580,6 +590,7 @@ defineExpose({
   setSpeed,
   toggleSkipInactive,
   playerState,
+  updatePlayerState,
 });
 </script>
 

--- a/web/src/views/RUM/SessionViewer.vue
+++ b/web/src/views/RUM/SessionViewer.vue
@@ -489,6 +489,11 @@ const getSessionErrorLogs = () => {
       });
 
       segmentEvents.value.sort((a, b) => a.timestamp - b.timestamp);
+
+      videoPlayerRef.value?.updatePlayerState();
+
+      // Calculate time_spent based on actual event timestamps (lastEvent - firstEvent)
+      // This matches rrweb-player's calculation
     })
     .catch((error) => {
       console.error("Failed to fetch sesion error logs:", error);


### PR DESCRIPTION
#10241 
### **User description**


___

### **PR Type**
Bug fix


___

### **Description**
- Include all event types in session replay

- Extract and expose updatePlayerState method

- Refresh player metadata after setupSession

- Trigger metadata update after error logs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Segments fetched"] --> B["VideoPlayer.setupSession"]
  B --> C["updatePlayerState()"]
  C --> D["playerState.totalTime"]
  D --> E["SessionViewer.time_spent calc"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VideoPlayer.vue</strong><dd><code>Remove event filter and add updatePlayerState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/rum/VideoPlayer.vue

<ul><li>Remove supportedTypes filter to include all events<br> <li> Extract updatePlayerState from setupSession logic<br> <li> Call updatePlayerState after session setup<br> <li> Expose updatePlayerState via defineExpose</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10238/files#diff-5cb7c9f5d73672eaaabf9214cfeb949f533772e87780829664fac444e3c6fa35">+26/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SessionViewer.vue</strong><dd><code>Sync player state after error logs fetch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/RUM/SessionViewer.vue

<ul><li>Invoke updatePlayerState after fetching error logs<br> <li> Add comment on actual time_spent calculation<br> <li> Sort and map raw events before updating player state</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10238/files#diff-9f7a183be1e2cfcb3c3c852c059f66003dd4f3f586421b012e1b835724929ca1">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

