### PR TITLE
fix: if stream size is NaN, show 0 MB instead of showing NaN on UI

### DIFF
--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -481,6 +481,10 @@ export const formatLargeNumber = (number: number) => {
 export const formatSizeFromMB = (sizeInMB: string) => {
   let size = parseFloat(sizeInMB);
 
+  if (isNaN(size)) {
+    return "0 MB";
+  }
+
   const units = ["KB", "MB", "GB", "TB", "PB"];
   let index = 1; // Start from MB
 


### PR DESCRIPTION
### **User description**
## Summary
Fixed the Enrichment Tables page displaying "NaN MB" for Ingested Data and Compressed Size columns when values are undefined or null.

## Changes
- Added `isNaN` check in `formatSizeFromMB` function to return "0 MB" instead of "NaN MB"

## File Changed
- `web/src/utils/zincutils.ts`


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent "NaN MB" display by returning "0 MB"


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zincutils.ts</strong><dd><code>Add NaN guard in size formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/zincutils.ts

<ul><li>Added <code>isNaN</code> check after parsing size<br> <li> Early return <code>"0 MB"</code> when size is NaN</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10240/files#diff-d3d59688cccdcc6c84ebe88b698c6910030abecc3125f4c0ef81b0df023699ba">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

