### PR TITLE
feat: allow sending email alerts to users outside organization

### DIFF
--- a/src/service/alerts/destinations.rs
+++ b/src/service/alerts/destinations.rs
@@ -52,14 +52,14 @@ const BLOCKED_PUBLIC_EMAIL_DOMAINS: [&str; 24] = [
 ];
 
 fn is_blocked_public_email_domain(email: &str) -> bool {
-    email
-        .rsplit_once('@')
-        .map(|(_, domain)| domain.trim())
-        .is_some_and(|domain| {
-            BLOCKED_PUBLIC_EMAIL_DOMAINS
-                .iter()
-                .any(|blocked| domain == *blocked)
-        })
+    let Ok(mailbox) = email.parse::<lettre::message::Mailbox>() else {
+        return false;
+    };
+    let domain = mailbox.email.domain().trim().trim_end_matches('.');
+    let domain = domain.to_lowercase();
+    BLOCKED_PUBLIC_EMAIL_DOMAINS
+        .iter()
+        .any(|blocked| domain == *blocked)
 }
 
 pub async fn save(

--- a/src/service/db/alerts/destinations.rs
+++ b/src/service/db/alerts/destinations.rs
@@ -46,7 +46,7 @@ pub enum DestinationError {
     UserNotPermitted,
     #[error("Email destination must have SMTP configured")]
     SMTPUnavailable,
-    #[error("Email destination recipients cannot use public email domains")]
+    #[error("Non-member recipients cannot use public email domains")]
     BlockedPublicEmailDomain,
     #[error("Alert destination must have a template")]
     TemplateNotFound,


### PR DESCRIPTION
### Motivation
- Preserve existing org-member lookup for email recipients while allowing external (non-member) addresses where appropriate.  
- Block use of well-known public email provider domains for non-member recipients to reduce risk of sensitive alerts being sent to public mail services.  
- Centralize the blocked-domain list and checking logic so it can be extended and unit-tested later.

### Description
- Added a centralized list `BLOCKED_PUBLIC_EMAIL_DOMAINS` and helper `is_blocked_public_email_domain()` in `src/service/alerts/destinations.rs` to check recipient domains.  
- Updated `save()` email recipient validation to keep the org-member lookup (`user::get(Some(&destination.org_id), &email)`), normalize recipients to lowercase, allow non-member addresses unless their domain is on the blocked list, and reject with a clear error when blocked.  
- Introduced a new error variant `BlockedPublicEmailDomain` in `src/service/db/alerts/destinations.rs` so the blocked-case returns an explicit, consistent error.

### Note
- Changes were created using `codex`

Fixes #10228 