### PR TITLE
fix: Home page compress tile 0.50.0

### DIFF
--- a/web/src/test/unit/HomeView.spec.ts
+++ b/web/src/test/unit/HomeView.spec.ts
@@ -658,6 +658,7 @@ describe("HomeView.vue", () => {
 
       const compressedSize = 50;
 
+      // Set up the mock BEFORE creating the wrapper so it's used on mount
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: {
@@ -779,6 +780,7 @@ describe("HomeView.vue", () => {
         }
       };
 
+      // Set up the mock BEFORE creating the wrapper so it's used on mount
       orgService.get_organization_summary.mockResolvedValue(mockData);
 
       wrapper = createWrapper();
@@ -828,13 +830,16 @@ describe("HomeView.vue", () => {
     });
 
     it("should not call getSummary on mount when no organization", () => {
+      // Set empty organization and clear mocks to prevent watcher from being counted
       store.state.selectedOrganization = {};
+      vi.clearAllMocks(); // Clear the mock call history after changing the store
+
       orgService.get_organization_summary.mockResolvedValue({
         data: { streams: { num_streams: 0 } }
       });
-      
+
       wrapper = createWrapper();
-      
+
       expect(orgService.get_organization_summary).not.toHaveBeenCalled();
     });
   });

--- a/web/src/test/unit/HomeView.spec.ts
+++ b/web/src/test/unit/HomeView.spec.ts
@@ -107,8 +107,16 @@ describe("HomeView.vue", () => {
     orgService.get_organization_summary.mockResolvedValue({
       data: {
         streams: { num_streams: 0 },
-        alerts: { num_realtime: 0, num_scheduled: 0 },
-        pipelines: { num_realtime: 0, num_scheduled: 0 },
+        alerts: {
+          num_realtime: 0,
+          num_scheduled: 0,
+          trigger_status: { failed: 0, healthy: 0, warning: 0 }
+        },
+        pipelines: {
+          num_realtime: 0,
+          num_scheduled: 0,
+          trigger_status: { failed: 0, healthy: 0, warning: 0 }
+        },
         total_dashboards: 0,
         total_functions: 0
       }
@@ -214,8 +222,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 5, total_storage_size: 100, total_compressed_size: 50, total_records: 1000, total_index_size: 25 },
-          pipelines: { num_scheduled: 3, num_realtime: 2 },
-          alerts: { num_realtime: 4, num_scheduled: 6 },
+          pipelines: {
+            num_scheduled: 3,
+            num_realtime: 2,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          alerts: {
+            num_realtime: 4,
+            num_scheduled: 6,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 8,
           total_functions: 12
         }
@@ -233,8 +249,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 0 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -253,8 +277,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -338,8 +370,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -359,8 +399,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -392,8 +440,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -441,8 +497,16 @@ describe("HomeView.vue", () => {
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -467,8 +531,16 @@ describe("HomeView.vue", () => {
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -486,8 +558,16 @@ describe("HomeView.vue", () => {
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -505,8 +585,16 @@ describe("HomeView.vue", () => {
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -524,8 +612,16 @@ describe("HomeView.vue", () => {
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -595,8 +691,16 @@ describe("HomeView.vue", () => {
             total_records: 1000,
             total_index_size: 25
           },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -668,8 +772,16 @@ describe("HomeView.vue", () => {
             total_records: 1000,
             total_index_size: 25
           },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -738,8 +850,16 @@ describe("HomeView.vue", () => {
               total_records: 1000,
               total_index_size: 25
             },
-            alerts: { num_realtime: 1, num_scheduled: 1 },
-            pipelines: { num_realtime: 1, num_scheduled: 1 },
+            alerts: {
+              num_realtime: 1,
+              num_scheduled: 1,
+              trigger_status: { failed: 0, healthy: 0, warning: 0 }
+            },
+            pipelines: {
+              num_realtime: 1,
+              num_scheduled: 1,
+              trigger_status: { failed: 0, healthy: 0, warning: 0 }
+            },
             total_dashboards: 1,
             total_functions: 1
           }
@@ -773,8 +893,16 @@ describe("HomeView.vue", () => {
             total_records: 1000,
             total_index_size: 25
           },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -785,6 +913,7 @@ describe("HomeView.vue", () => {
 
       wrapper = createWrapper();
       await flushPromises();
+      await nextTick();
 
       // Data should still be loaded even if tile is not rendered
       expect(wrapper.vm.summary.compressed_size_raw).toBe(75);

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -145,7 +145,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
 
             
-            <div class="tile">
+            <div class="tile" v-if="config.isCloud == 'true'">
               <div class="tile-content rounded-borders text-center column justify-between "
               :class="store.state.theme === 'dark' ? 'dark-tile-content' : 'light-tile-content'"
                role="article"
@@ -859,6 +859,7 @@ export default defineComponent({
       t,
       store,
       summary,
+      config,
       no_data_ingest,
       getSummary,
       isCloud,

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -906,9 +906,9 @@ export default defineComponent({
   },
   watch: {
     selectedOrg(newVal: any, oldVal: any) {
-      if (newVal != oldVal || this.summary.value == undefined) {
+      if (newVal && (newVal != oldVal || this.summary.value == undefined)) {
         this.summary = {};
-        this.getSummary(this.store.state?.selectedOrganization?.identifier);
+        this.getSummary(newVal);
       }
     },
   },


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Add conditional rendering for compressed size tile

- Expose `config` in HomeView component return

- Write tests for cloud and non-cloud compressed tile display

- Cover data handling when tile is hidden


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HomeView.vue: export `config`"] --> B["HomeView.vue: add v-if for `config.isCloud=='true'` on tile"]
  B --> C["HomeView.spec.ts: mock `isCloud` values"]
  C --> D["Tests: verify tile rendering and data handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HomeView.vue</strong><dd><code>Add cloud‐only v-if on compressed tile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/HomeView.vue

<ul><li>Added <code>config</code> to the returned component state<br> <li> Wrapped compressed size tile in <code>v-if="config.isCloud=='true'"</code><br> <li> Ensured non-cloud mode hides the tile</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10261/files#diff-9af441af191d3254ef5f9db603dca75486de7638cda41a3c050e7b3c33d68280">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HomeView.spec.ts</strong><dd><code>Add tests for compressed size tile behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/test/unit/HomeView.spec.ts

<ul><li>Introduced "Compressed Size Tile" test suite<br> <li> Mocked <code>isCloud</code> in aws-exports for true/false cases<br> <li> Verified tile absence in non-cloud and presence in cloud<br> <li> Checked compressed size value and data loading when hidden</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10261/files#diff-73e32dfbcdec6f87abe68984231fb1227502397e28fd1d91cd9579024010fb82">+246/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

