### PR TITLE
fix: ensure histogram interval changes are applied correctly on initial setup (#10224)

### DIFF
--- a/web/src/views/Dashboards/RenderDashboardCharts.vue
+++ b/web/src/views/Dashboards/RenderDashboardCharts.vue
@@ -237,7 +237,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :dashboardId="dashboardData.dashboardId"
             :panelId="viewPanelId"
             :selectedDateForViewPanel="selectedDateForViewPanel"
-            :initialVariableValues="variablesData"
+            :initialVariableValues="getMergedVariablesForPanel(viewPanelId)"
             :searchType="searchType"
             @close-panel="() => (showViewPanel = false)"
             @update:initial-variable-values="updateInitialVariableValues"


### PR DESCRIPTION


Bug fix

___
- Skip suppressing histogram interval on initial load

- Introduce `isInitialHistogramSetup` flag for watch logic

- Invert `isVariablesChanged` default and usage logic

- Update chart refresh logic in `refreshData`

___

```mermaid
flowchart LR
  A["Component Mount"] --> B["isInitialHistogramSetup = true"]
  B --> C["Watch histogramInterval"]
  C -->|on change| D{"isInitialHistogramSetup?"}
  D -->|true| E["Skip marking variablesChanged"]
  D -->|false| F["Set isVariablesChanged = false"]
  E --> G["Initial setup complete"]
  G --> F
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>ViewPanel.vue</strong><dd><code>Control histogram interval change application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

web/src/components/dashboards/viewPanel/ViewPanel.vue

<ul><li>Set <code>isVariablesChanged</code> default to <code>true</code><br> <li> Add <code>isInitialHistogramSetup</code> flag for initial watch<br> <li> Conditionally update
<code>isVariablesChanged</code> in histogram watcher<br> <li> Update <code>isVariablesChanged</code> logic in <code>refreshData</code></ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10224/files#diff-e7b26fbbfe7ae57f50377c0f002155df17109ea54708b0f134dd2005356b2930">+18/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___