### PR TITLE
fix: tooltip behind component fixed

### DIFF
--- a/web/src/components/alerts/AlertWizardRightColumn.vue
+++ b/web/src/components/alerts/AlertWizardRightColumn.vue
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
       <div v-show="expandState.preview" class="section-content">
         <preview-alert
-          style="height: 100%; overflow: auto;"
+          style="height: 100%;"
           ref="previewAlertRef"
           :formData="formData"
           :query="previewQuery"
@@ -70,7 +70,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           class="expand-toggle-btn"
         />
       </div>
-      <div v-show="expandState.summary" class="section-content">
+      <div v-show="expandState.summary" class="summary-section-content">
         <alert-summary
           style="height: 100%; overflow: auto;"
           :formData="formData"
@@ -86,7 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, reactive, watch, type PropType } from "vue";
+import { defineComponent, ref, computed, reactive, watch, onMounted, onUnmounted, type PropType } from "vue";
 import { useStore } from "vuex";
 import PreviewAlert from "./PreviewAlert.vue";
 import AlertSummary from "./AlertSummary.vue";
@@ -214,6 +214,29 @@ export default defineComponent({
       }
     };
 
+    // Handle window resize to rerender chart
+    let resizeTimeout: ReturnType<typeof setTimeout>;
+    const handleResize = () => {
+      // Debounce resize events to avoid excessive rerenders
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(() => {
+        if (previewAlertRef.value && expandState.preview) {
+          (previewAlertRef.value as any).refreshData();
+        }
+      }, 300);
+    };
+
+    // Setup resize listener on mount
+    onMounted(() => {
+      window.addEventListener('resize', handleResize);
+    });
+
+    // Cleanup resize listener on unmount
+    onUnmounted(() => {
+      window.removeEventListener('resize', handleResize);
+      clearTimeout(resizeTimeout);
+    });
+
     // Expose the method to parent component
     expose({
       refreshData,
@@ -242,7 +265,7 @@ export default defineComponent({
   border-radius: 0.375rem;
   box-shadow: 0 0 5px 1px var(--o2-hover-shadow);
   border: 1px solid var(--o2-border-color, rgba(0, 0, 0, 0.08));
-  overflow: hidden;
+  // overflow: hidden;
 
   .section-header {
     flex-shrink: 0;
@@ -259,8 +282,12 @@ export default defineComponent({
       background: rgba(0, 0, 0, 0.06);
     }
   }
-
   .section-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+  .summary-section-content {
     flex: 1;
     overflow: hidden;
     display: flex;

--- a/web/src/components/alerts/PreviewAlert.vue
+++ b/web/src/components/alerts/PreviewAlert.vue
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :variablesData="{}"
         searchType="UI"
         :is_ui_histogram="isUsingBackendSql"
-        style="height: 180px; width: 100%; overflow-x: hidden;"
+        style="height: 100%; width: 100%;"
       />
     </div>
   </div>


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Remove overflow hidden to show tooltips

- Debounce resize events to refresh chart

- Add mount and unmount hooks for cleanup

- Adjust styles for full-height preview alert


___

### Diagram Walkthrough


```mermaid
flowchart LR
  M["Component mounted"] -->|add listener| R["Window resize"]
  R -->|debounced| H["handleResize"]
  H -->|if preview open| F["PreviewAlert.refreshData()"]
  U["Component unmounted"] -->|remove listener| R
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AlertWizardRightColumn.vue</strong><dd><code>Add debounced resize handling and CSS fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/AlertWizardRightColumn.vue

<ul><li>Remove inline overflow style for preview section<br> <li> Rename summary section CSS class<br> <li> Add <code>onMounted</code> and <code>onUnmounted</code> hooks for resize logic<br> <li> Implement debounced resize for chart refresh</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10269/files#diff-f599a1960d1ac37e352854ad368d23e080b3cec2b217df22f40d0e15a4db6986">+32/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PreviewAlert.vue</strong><dd><code>Adjust style for full-size preview chart</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/PreviewAlert.vue

<ul><li>Remove fixed height and overflow styles<br> <li> Set preview container to full height and width</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10269/files#diff-760f5f0a261910f17eb167f81802e8a52477b99a83d2d7fc1aeefc7185801795">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

