### PR TITLE
fix: Home page compress tile 0.60.0

### DIFF
--- a/web/src/test/unit/HomeView.spec.ts
+++ b/web/src/test/unit/HomeView.spec.ts
@@ -107,8 +107,16 @@ describe("HomeView.vue", () => {
     orgService.get_organization_summary.mockResolvedValue({
       data: {
         streams: { num_streams: 0 },
-        alerts: { num_realtime: 0, num_scheduled: 0 },
-        pipelines: { num_realtime: 0, num_scheduled: 0 },
+        alerts: {
+          num_realtime: 0,
+          num_scheduled: 0,
+          trigger_status: { failed: 0, healthy: 0, warning: 0 }
+        },
+        pipelines: {
+          num_realtime: 0,
+          num_scheduled: 0,
+          trigger_status: { failed: 0, healthy: 0, warning: 0 }
+        },
         total_dashboards: 0,
         total_functions: 0
       }
@@ -214,8 +222,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 5, total_storage_size: 100, total_compressed_size: 50, total_records: 1000, total_index_size: 25 },
-          pipelines: { num_scheduled: 3, num_realtime: 2 },
-          alerts: { num_realtime: 4, num_scheduled: 6 },
+          pipelines: {
+            num_scheduled: 3,
+            num_realtime: 2,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          alerts: {
+            num_realtime: 4,
+            num_scheduled: 6,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 8,
           total_functions: 12
         }
@@ -233,8 +249,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 0 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -253,8 +277,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -338,8 +370,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -359,8 +399,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -392,8 +440,16 @@ describe("HomeView.vue", () => {
       const mockResponse = {
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -441,8 +497,16 @@ describe("HomeView.vue", () => {
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -467,8 +531,16 @@ describe("HomeView.vue", () => {
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -486,8 +558,16 @@ describe("HomeView.vue", () => {
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -505,8 +585,16 @@ describe("HomeView.vue", () => {
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -524,8 +612,16 @@ describe("HomeView.vue", () => {
       orgService.get_organization_summary.mockResolvedValue({
         data: {
           streams: { num_streams: 1 },
-          alerts: { num_realtime: 0, num_scheduled: 0 },
-          pipelines: { num_realtime: 0, num_scheduled: 0 },
+          alerts: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 0,
+            num_scheduled: 0,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 0,
           total_functions: 0
         }
@@ -595,8 +691,16 @@ describe("HomeView.vue", () => {
             total_records: 1000,
             total_index_size: 25
           },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -668,8 +772,16 @@ describe("HomeView.vue", () => {
             total_records: 1000,
             total_index_size: 25
           },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -738,8 +850,16 @@ describe("HomeView.vue", () => {
               total_records: 1000,
               total_index_size: 25
             },
-            alerts: { num_realtime: 1, num_scheduled: 1 },
-            pipelines: { num_realtime: 1, num_scheduled: 1 },
+            alerts: {
+              num_realtime: 1,
+              num_scheduled: 1,
+              trigger_status: { failed: 0, healthy: 0, warning: 0 }
+            },
+            pipelines: {
+              num_realtime: 1,
+              num_scheduled: 1,
+              trigger_status: { failed: 0, healthy: 0, warning: 0 }
+            },
             total_dashboards: 1,
             total_functions: 1
           }
@@ -773,8 +893,16 @@ describe("HomeView.vue", () => {
             total_records: 1000,
             total_index_size: 25
           },
-          alerts: { num_realtime: 1, num_scheduled: 1 },
-          pipelines: { num_realtime: 1, num_scheduled: 1 },
+          alerts: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
+          pipelines: {
+            num_realtime: 1,
+            num_scheduled: 1,
+            trigger_status: { failed: 0, healthy: 0, warning: 0 }
+          },
           total_dashboards: 1,
           total_functions: 1
         }
@@ -785,6 +913,7 @@ describe("HomeView.vue", () => {
 
       wrapper = createWrapper();
       await flushPromises();
+      await nextTick();
 
       // Data should still be loaded even if tile is not rendered
       expect(wrapper.vm.summary.compressed_size_raw).toBe(75);

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -906,9 +906,9 @@ export default defineComponent({
   },
   watch: {
     selectedOrg(newVal: any, oldVal: any) {
-      if (newVal != oldVal || this.summary.value == undefined) {
+      if (newVal && (newVal != oldVal || this.summary.value == undefined)) {
         this.summary = {};
-        this.getSummary(this.store.state?.selectedOrganization?.identifier);
+        this.getSummary(newVal);
       }
     },
   },


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add conditional rendering for compressed size tile

- Introduce comprehensive unit tests for cloud tile

- Extend mock data with `trigger_status` in tests

- Guard watcher to avoid empty org calls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HomeView mounted"] --> B["Invoke getSummary"]
  B --> C{"config.isCloud == 'true'"}
  C -- yes --> D["Render compressed size tile"]
  C -- no --> E["Do not render compressed tile"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HomeView.spec.ts</strong><dd><code>Add compressed tile tests and trigger_status mocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/test/unit/HomeView.spec.ts

<ul><li>Added "Compressed Size Tile - Cloud Conditional Rendering" suite<br> <li> Mocked <code>aws-exports</code>.default.isCloud values<br> <li> Tested tile presence for true/false cases<br> <li> Extended existing mocks with <code>trigger_status</code> fields</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10274/files#diff-73e32dfbcdec6f87abe68984231fb1227502397e28fd1d91cd9579024010fb82">+406/-26</a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HomeView.vue</strong><dd><code>Conditional render compressed tile in HomeView</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/HomeView.vue

<ul><li>Wrapped compressed size tile with <code>v-if="config.isCloud == 'true'"</code><br> <li> Included <code>config</code> in component return object<br> <li> Strengthened <code>selectedOrg</code> watcher guard</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10274/files#diff-9af441af191d3254ef5f9db603dca75486de7638cda41a3c050e7b3c33d68280">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

