### PR TITLE
fix: adding reporting in HTTP models enum

### DIFF
--- a/src/handler/http/models/folders.rs
+++ b/src/handler/http/models/folders.rs
@@ -51,6 +51,7 @@ pub struct ListFoldersResponseBody {
 pub enum FolderType {
     Dashboards,
     Alerts,
+    Reports,
 }
 
 /// Common folder fields used in HTTP request and response bodies.
@@ -96,6 +97,7 @@ impl From<FolderType> for config::meta::folder::FolderType {
         match value {
             FolderType::Dashboards => Self::Dashboards,
             FolderType::Alerts => Self::Alerts,
+            FolderType::Reports => Self::Reports,
         }
     }
 }


### PR DESCRIPTION
### **User description**
OFGA and migration are already working


___

### **PR Type**
Enhancement


___

### **Description**
- Add `Reports` variant to `FolderType`

- Extend `From<FolderType>` conversion mapping


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>folders.rs</strong><dd><code>Introduce Reports folder variant and mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/models/folders.rs

<ul><li>Added <code>Reports</code> variant to <code>FolderType</code> enum<br> <li> Updated <code>From<FolderType></code> mapping for <code>Reports</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10277/files#diff-3d6faeebd404db5b13f071895c7d4729bbd62a85c5c7ea6d67c9c69a44babb11">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

