### PR TITLE
fix: route for gcp and aws

### DIFF
--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -544,8 +544,6 @@ pub fn service_routes() -> Router {
         .route("/{org_id}/_bulk", post(logs::ingest::bulk))
         .route("/{org_id}/{stream_name}/_multi", post(logs::ingest::multi))
         .route("/{org_id}/{stream_name}/_json", post(logs::ingest::json))
-        .route("/{org_id}/{stream_name}/_kinesis_firehose", post(logs::ingest::handle_kinesis_request))
-        .route("/{org_id}/{stream_name}/_sub", post(logs::ingest::handle_gcp_request))
         .route("/{org_id}/_hec", post(logs::ingest::hec))
         .route("/{org_id}/loki/api/v1/push", post(logs::loki::loki_push))
         .route("/{org_id}/v1/logs", post(logs::ingest::otlp_logs_write))
@@ -882,7 +880,7 @@ pub fn other_service_routes() -> Router {
     // AWS routes - with standard decompression (gzip/deflate/brotli) + snappy preprocessing
     let aws_routes = Router::new()
         .route(
-            "/{org_id}/_kinesis_firehose",
+            "/{org_id}/{stream_name}/_kinesis_firehose",
             post(logs::ingest::handle_kinesis_request),
         )
         .layer(middleware::from_fn(aws_auth_middleware))
@@ -893,7 +891,10 @@ pub fn other_service_routes() -> Router {
 
     // GCP routes - with standard decompression (gzip/deflate/brotli) + snappy preprocessing
     let gcp_routes = Router::new()
-        .route("/{org_id}/_sub", post(logs::ingest::handle_gcp_request))
+        .route(
+            "/{org_id}/{stream_name}/_sub",
+            post(logs::ingest::handle_gcp_request),
+        )
         .layer(middleware::from_fn(gcp_auth_middleware))
         .layer(RequestDecompressionLayer::new())
         .layer(middleware::from_fn(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove Kinesis/GCP routes from main service router

- Add `/{stream_name}` to AWS Kinesis endpoint

- Add `/{stream_name}` to GCP Pub/Sub endpoint


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Fix AWS/GCP ingestion route definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/router/mod.rs

<ul><li>Removed <code>.route("/{org_id}/{stream_name}/_kinesis_firehose", ...)</code> from <br>main routes<br> <li> Removed <code>.route("/{org_id}/{stream_name}/_sub", ...)</code> from main routes<br> <li> Changed AWS route path to <code>"/{org_id}/{stream_name}/_kinesis_firehose"</code><br> <li> Changed GCP route path to <code>"/{org_id}/{stream_name}/_sub"</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10296/files#diff-02556e3f515441b5d2b6bbea7829df488beac03c4cc41309a6638ae3c0e0aec6">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

