### PR TITLE
fix: Home page compress tile 0.50.0 v1

### DIFF
--- a/web/src/components/iam/users/MemberInvitation.vue
+++ b/web/src/components/iam/users/MemberInvitation.vue
@@ -68,9 +68,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           top: 1px;
         "
       />
-      <label class="inputHint q-pl-md" style="display: block">{{
-        t("user.inviteByEmailHint")
-      }}</label>
     </div>
   </q-page>
 </template>

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -145,7 +145,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
 
             
-            <div class="tile">
+            <div class="tile" v-if="config.isCloud == 'true'">
               <div class="tile-content rounded-borders text-center column justify-between "
               :class="store.state.theme === 'dark' ? 'dark-tile-content' : 'light-tile-content'"
                role="article"
@@ -859,6 +859,7 @@ export default defineComponent({
       t,
       store,
       summary,
+      config,
       no_data_ingest,
       getSummary,
       isCloud,
@@ -905,9 +906,9 @@ export default defineComponent({
   },
   watch: {
     selectedOrg(newVal: any, oldVal: any) {
-      if (newVal != oldVal || this.summary.value == undefined) {
+      if (newVal && (newVal != oldVal || this.summary.value == undefined)) {
         this.summary = {};
-        this.getSummary(this.store.state?.selectedOrganization?.identifier);
+        this.getSummary(newVal);
       }
     },
   },


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Show compress tile only for cloud users

- Update selectedOrg watcher logic

- Add `config` to returned component data

- Remove invite-by-email hint label


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["selectedOrg watcher"]
  B["Condition: newVal && (changed or summary undefined)"]
  C["getSummary(newVal)"]
  D["config.isCloud == 'true'?"]
  E["Compress tile display"]
  A --> B
  B --> C
  D -- "true" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MemberInvitation.vue</strong><dd><code>Remove invite-by-email hint label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/iam/users/MemberInvitation.vue

- Removed invite-by-email hint label


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10300/files#diff-20f4b05df2b88fa14ea0a22e8804b6472271ee0e240cf9039849c0b8cf302fee">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HomeView.vue</strong><dd><code>Improve cloud tile rendering and watcher logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/HomeView.vue

<ul><li>Added <code>config</code> to returned component data<br> <li> Conditionally render compress tile for cloud users<br> <li> Enhanced selectedOrg watcher condition<br> <li> Updated <code>getSummary</code> to use <code>newVal</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10300/files#diff-9af441af191d3254ef5f9db603dca75486de7638cda41a3c050e7b3c33d68280">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

