### PR TITLE
fix: sync billing and login frontend fixes from main

### DIFF
--- a/web/src/enterprise/components/billings/Billing.vue
+++ b/web/src/enterprise/components/billings/Billing.vue
@@ -90,6 +90,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 content-class="tab_content"
               />
               <q-route-tab
+                v-if="showInvoiceTab"
                 exact
                 name="invoice_history"
                 :to="

--- a/web/src/enterprise/components/billings/TrialPeriod.vue
+++ b/web/src/enterprise/components/billings/TrialPeriod.vue
@@ -87,12 +87,14 @@ export default defineComponent({
     // Check if org is on AWS billing - don't show trial message for AWS orgs
     onMounted(async () => {
       try {
-        const res = await BillingService.list_subscription(
-          store.state.selectedOrganization.identifier
-        );
-        if (res.data?.provider === "aws") {
-          // AWS billing - don't show trial period message
-          showTrialPeriodMsg.value = false;
+        if (config.isCloud === "true") {
+          const res = await BillingService.list_subscription(
+            store.state.selectedOrganization.identifier
+          );
+          if (res.data?.provider === "aws") {
+            // AWS billing - don't show trial period message
+            showTrialPeriodMsg.value = false;
+          }
         }
       } catch (e) {
         // If fetch fails, keep the default behavior

--- a/web/src/views/Login.spec.ts
+++ b/web/src/views/Login.spec.ts
@@ -455,21 +455,33 @@ describe("Login.vue", () => {
     });
 
     it("should redirect to sessionStorage URI when available", async () => {
-      mockSessionStorage.getItem.mockReturnValue("/dashboard");
+      // Mock azure_marketplace_token as null so it checks redirectURI
+      mockSessionStorage.getItem.mockImplementation((key: string) => {
+        if (key === "azure_marketplace_token") return null;
+        if (key === "redirectURI") return "/dashboard";
+        return null;
+      });
       const pushSpy = vi.spyOn(router, "push");
 
       wrapper.vm.redirectUser();
 
+      expect(mockSessionStorage.getItem).toHaveBeenCalledWith("azure_marketplace_token");
       expect(mockSessionStorage.getItem).toHaveBeenCalledWith("redirectURI");
       expect(mockSessionStorage.removeItem).toHaveBeenCalledWith("redirectURI");
       expect(pushSpy).toHaveBeenCalledWith({ path: "/dashboard" });
     });
 
     it("should redirect to external URL when redirectURI contains http", async () => {
-      mockSessionStorage.getItem.mockReturnValue("https://external.com");
+      // Mock azure_marketplace_token as null so it checks redirectURI
+      mockSessionStorage.getItem.mockImplementation((key: string) => {
+        if (key === "azure_marketplace_token") return null;
+        if (key === "redirectURI") return "https://external.com";
+        return null;
+      });
 
       wrapper.vm.redirectUser();
 
+      expect(mockSessionStorage.getItem).toHaveBeenCalledWith("azure_marketplace_token");
       expect(mockSessionStorage.getItem).toHaveBeenCalledWith("redirectURI");
       expect(mockSessionStorage.removeItem).toHaveBeenCalledWith("redirectURI");
       expect(window.location.href).toBe("https://external.com");
@@ -494,7 +506,12 @@ describe("Login.vue", () => {
     });
 
     it("should always remove redirectURI from sessionStorage", async () => {
-      mockSessionStorage.getItem.mockReturnValue("/some-path");
+      // Mock azure_marketplace_token as null so it checks redirectURI
+      mockSessionStorage.getItem.mockImplementation((key: string) => {
+        if (key === "azure_marketplace_token") return null;
+        if (key === "redirectURI") return "/some-path";
+        return null;
+      });
 
       wrapper.vm.redirectUser();
 


### PR DESCRIPTION
### **User description**
- Add v-if="showInvoiceTab" to conditionally render invoice tab (Stripe only)
- Add BillingService mock and async handling in Billing.spec.ts
- Fix Login.spec.ts to mock azure_marketplace_token before redirectURI
- Add isCloud check in TrialPeriod.vue before calling list_subscription


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Conditionally render invoice tab in Billing.vue

- Add cloud check in TrialPeriod.vue before fetch

- Enhance Billing.spec.ts with async mocks and awaits

- Improve Login.spec.ts redirect token tests


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Billing.spec.ts</strong><dd><code>Enhance Billing.spec with async billing mocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/enterprise/components/billings/Billing.spec.ts

<ul><li>Add factory mock for BillingService.list_subscription<br> <li> Use async beforeEach and mockResolvedValue<br> <li> Await wrapper.vm.$nextTick() after mount<br> <li> Update tests to async/await router pushes</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10303/files#diff-1a0b142f75498e27ca70fd5a70cfb4ca0fe76baf0b0f283e4659936599a5a439">+62/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Login.spec.ts</strong><dd><code>Improve Login.spec redirectUser tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/Login.spec.ts

<ul><li>Mock azure_marketplace_token before redirectURI<br> <li> Assert getItem calls with specific keys<br> <li> Ensure redirectURI removal in all cases<br> <li> Test external URL redirect logic</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10303/files#diff-92c3c0344a73a30eadb1c98f849f7297c460f50804cdbb2d34dd374fbcf83d74">+20/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Billing.vue</strong><dd><code>Conditional invoice tab rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/enterprise/components/billings/Billing.vue

<ul><li>Add v-if="showInvoiceTab" on invoice_history tab<br> <li> Conditionally render invoice tab for Stripe only</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10303/files#diff-08d804667873a5d984027ad69438432a14973e0318cf78ad981bc7b9a31c1bf4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TrialPeriod.vue</strong><dd><code>Add cloud guard in trial period component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/enterprise/components/billings/TrialPeriod.vue

<ul><li>Wrap BillingService.list_subscription in isCloud check<br> <li> Skip AWS billing trial message when provider is aws<br> <li> Retain default on fetch error with console.error</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10303/files#diff-cc999442352001a0c7a756db0974f99ec3a21d566e9082d1b113c85ca897dafa">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

