### PR TITLE
fix: compress size fix

### DIFF
--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -145,7 +145,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
 
             
-            <div class="tile" v-if="config.isCloud == 'true'">
+            <div class="tile" v-if="config.isCloud == 'false'">
               <div class="tile-content rounded-borders text-center column justify-between "
               :class="store.state.theme === 'dark' ? 'dark-tile-content' : 'light-tile-content'"
                role="article"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Invert `config.isCloud` condition for tile display

- Show compressed data size tile when not in cloud mode


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HomeView.vue</strong><dd><code>Invert `isCloud` condition for tile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/HomeView.vue

<ul><li>Changed <code>v-if</code> condition from <code>"true"</code> to <code>"false"</code><br> <li> Ensures tile appears in non-cloud configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10308/files#diff-9af441af191d3254ef5f9db603dca75486de7638cda41a3c050e7b3c33d68280">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

