### PR TITLE
fix: o2 assistant issues

### DIFF
--- a/src/config/src/meta/dashboards/v8/mod.rs
+++ b/src/config/src/meta/dashboards/v8/mod.rs
@@ -160,8 +160,8 @@ pub struct PanelFields {
     pub stream_type: StreamType,
     pub x: Vec<AxisItem>,
     pub y: Vec<AxisItem>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub z: Option<Vec<AxisItem>>,
+    #[serde(default)]
+    pub z: Vec<AxisItem>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub breakdown: Option<Vec<AxisItem>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/handler/http/request/dashboards/mod.rs
+++ b/src/handler/http/request/dashboards/mod.rs
@@ -114,7 +114,7 @@ impl From<DashboardError> for Response {
     extensions(
         ("x-o2-ratelimit" = json!({"module": "Dashboards", "operation": "create"})),
         ("x-o2-mcp" = json!({
-            "description": "Create a dashboard with panels on a 192-column grid. Each panel needs layout: {x, y, w, h, i}. x=column position (0-191), y=row position, w=width, h=height, i=panel ID. Rules: (1) panels in same row must have same height, (2) side-by-side widths sum to ~192. Common sizes: full-width w=192, half w=96, third w=64, quarter w=48. Stack rows by adding previous h to y value. IMPORTANT: you MUST set the correct queryType based on the stream type.",
+            "description": "Create a dashboard with visualization panels. LAYOUT: 192-column grid with {x, y, w, h, i} where x=column(0-191), y=row, w=width, h=height, i=panel_id. Common widths: full=192, half=96, third=64. PANEL QUERIES: Each panel query needs 'fields' with x/y/z arrays populated EVEN when customQuery=true. AXIS RULES: x=dimension/time field, y=metric field(s), z=only for heatmaps(color intensity)/stacked-charts(breakdown field)/geo-maps(value). For most charts (line/area/bar/pie), leave z=[]. Use SELECT aliases as column values. Example: 'SELECT histogram(_timestamp) as ts, COUNT(*) as cnt' needs x=[{label:'ts',alias:'ts',column:'ts',aggregationFunction:null}], y=[{label:'cnt',alias:'cnt',column:'cnt',aggregationFunction:null}], z=[].",
             "category": "dashboards"
         }))
     )

--- a/src/handler/http/request/pipeline.rs
+++ b/src/handler/http/request/pipeline.rs
@@ -86,7 +86,21 @@ NODE STRUCTURE (each node requires):
 NODE DATA TYPES:
 1. Stream node (input/output): { "node_type": "stream", "org_id": "default", "stream_name": "your_stream", "stream_type": "logs"|"metrics"|"traces" }
 2. Function node: { "node_type": "function", "name": "function_name", "after_flatten": true|false }
-3. Condition node: { "node_type": "condition", "conditions": { "column": "field", "operator": "=", "value": "val" } }
+3. Condition node: { "node_type": "condition", "conditions": <condition_object> }
+
+CONDITION OPERATORS: =, !=, >, >=, <, <=, contains, not_contains
+
+CONDITION FORMATS:
+- Single condition: { "column": "field", "operator": "=", "value": "val", "ignore_case": false }
+- AND conditions: { "and": [<condition>, <condition>, ...] }
+- OR conditions: { "or": [<condition>, <condition>, ...] }
+- NOT condition: { "not": <condition> }
+- Nested: { "and": [{ "column": "a", "operator": "=", "value": "1" }, { "or": [{ "column": "b", "operator": ">", "value": "5" }, { "column": "c", "operator": "contains", "value": "err" }] }] }
+
+CONDITION EXAMPLES:
+- severity = "error": { "column": "severity", "operator": "=", "value": "error" }
+- level > 5: { "column": "level", "operator": ">", "value": "5" }
+- severity = "error" AND level > 5: { "and": [{ "column": "severity", "operator": "=", "value": "error" }, { "column": "level", "operator": ">", "value": "5" }] }
 
 EDGE STRUCTURE:
 - id: Format "e{source_id}-{target_id}"


### PR DESCRIPTION
### **User description**
- dashboard z axis issue
- incremental save agent messages to chat
- pipeline tool improvement
- dashboard tool improvement


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix dashboard `z` axis serialization defaults

- Improve dashboard creation MCP tool instructions

- Document richer pipeline condition node syntax

- Throttle chat history saves during streaming


___

### Diagram Walkthrough


```mermaid
flowchart LR
  a1["Dashboard panel schema (z axis)"]
  a2["Dashboard MCP prompt guidance"]
  b1["Pipeline condition node docs"]
  c1["O2AIChat streaming updates"]
  c2["Throttled history persistence"]
  c1 -- "periodic/forced saves" --> c2
  a1 -- "align prompt with schema" --> a2
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Default `z` axis to empty array</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/dashboards/v8/mod.rs

<ul><li>Replace optional <code>z</code> with <code>Vec<AxisItem></code><br> <li> Use <code>#[serde(default)]</code> so <code>z</code> becomes <code>[]</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10315/files#diff-cbf3fe971525ba58892400391dfd7dac7e43d6049d6b4f5a9840ad104ebc5e08">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Expand MCP dashboard tool query guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/dashboards/mod.rs

<ul><li>Update tool description for layout parameters<br> <li> Require <code>fields</code> x/y/z arrays even with <code>customQuery</code><br> <li> Clarify when <code>z</code> should be populated vs <code>[]</code><br> <li> Add SQL alias-to-axis mapping example</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10315/files#diff-1b3c257e1d174c826718499faa4a1d4e93465dd56cb2b7b273b690ff7e3223fd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pipeline.rs</strong><dd><code>Document complex condition node object format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/pipeline.rs

<ul><li>Change condition <code>conditions</code> to generic object placeholder<br> <li> List supported operators including contains variants<br> <li> Add AND/OR/NOT and nested condition formats<br> <li> Provide concrete condition JSON examples</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10315/files#diff-c69f4f94eee97ce226caddc497b2adf89e26869f2d72b0d0206dc31ab2714daf">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>O2AIChat.vue</strong><dd><code>Throttle streaming saves to prevent data loss</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/O2AIChat.vue

<ul><li>Track last streaming save timestamp<br> <li> Save immediately on first assistant message creation<br> <li> Throttle subsequent saves to every 3 seconds<br> <li> Add <code>throttledStreamingSave()</code> helper wrapping <code>saveToHistory()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10315/files#diff-a6a125719a7b32b31b53fcfe05c12081d82c139a401699affdda0db8e73887e3">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

