### PR TITLE
fix: include functions validation in mcp

### DIFF
--- a/src/handler/http/request/functions/mod.rs
+++ b/src/handler/http/request/functions/mod.rs
@@ -348,11 +348,11 @@ pub async fn list_pipeline_dependencies(
     context_path = "/api",
     tag = "Functions",
     operation_id = "testFunction",
-    summary = "Test function execution",
-    description = "Tests a VRL transformation function against sample events to validate the function logic and preview \
-                   the expected output before deployment to production pipelines. Allows developers to verify data \
-                   transformations, debug VRL code issues, and ensure correct field mappings without affecting live \
-                   data processing workflows.",
+    summary = "Validate VRL function syntax",
+    description = "Validates VRL (Vector Remap Language) transformation function syntax by testing it against sample events. \
+                   Returns validation results with any syntax errors or successful transformation output. \
+                   Use this to verify VRL code is correct before creating or updating a function. \
+                   Accepts function code, sample events to test against, and optional trans_type (0 for VRL, 1 for JS).",
     security(
         ("Authorization"= [])
     ),
@@ -365,6 +365,7 @@ pub async fn list_pipeline_dependencies(
         (status = 400, description = "Failure", content_type = "application/json", body = ()),
     ),
     extensions(
+        ("x-o2-mcp" = json!({"category": "functions"})),
     )
 )]
 pub async fn test_function(


### PR DESCRIPTION
### **PR Type**
Documentation, Enhancement


___

### **Description**
- Update function test endpoint docs

- Clarify VRL/JS validation behavior

- Add MCP extension metadata


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["/api/{org_id}/functions/test endpoint"] -- "updates OpenAPI summary/description" --> B["Clearer VRL/JS validation docs"]
  A["/api/{org_id}/functions/test endpoint"] -- "adds extension" --> C["x-o2-mcp category metadata"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Refine testFunction docs and MCP metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/request/functions/mod.rs

<ul><li>Change OpenAPI summary to validation focus<br> <li> Rewrite description to emphasize syntax validation<br> <li> Document <code>trans_type</code> VRL/JS options<br> <li> Add <code>x-o2-mcp</code> OpenAPI extension metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10324/files#diff-a5e1b3644cef9feb689dfe66382e44e5434ecadbff3469127346a333d4733102">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

