### PR TITLE
fix: use created at as unique key

### DIFF
--- a/web/src/components/alerts/IncidentAlertTriggersTable.vue
+++ b/web/src/components/alerts/IncidentAlertTriggersTable.vue
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       ref="qTableRef"
       :rows="triggers"
       :columns="columns"
-      row-key="alert_id"
+      row-key="created_at"
       :pagination="pagination"
       style="height: calc(100vh - 220px)"
       flat


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix table row identity using `created_at`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  t1["IncidentAlertTriggersTable.vue"] 
  t2["QTable row-key uses `created_at`"] 
  t1 -- "sets row-key" --> t2
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IncidentAlertTriggersTable.vue</strong><dd><code>Use `created_at` as QTable row key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentAlertTriggersTable.vue

- Update QTable `row-key` from `alert_id` to `created_at`


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10338/files#diff-8c7abdab1feb590b04dc4fd067d0791902eb9cf41b627bcfce03e074cbc4b06a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

