### PR TITLE
fix: adding dashboard ID based search on UI

### DIFF
--- a/src/config/src/meta/dashboards/mod.rs
+++ b/src/config/src/meta/dashboards/mod.rs
@@ -139,6 +139,10 @@ pub struct ListDashboardsParams {
     /// dashboards.
     pub title_pat: Option<String>,
 
+    /// The optional case-insensitive dashboard ID substring with which to filter
+    /// dashboards.
+    pub dashboard_id_pat: Option<String>,
+
     /// The optional page size and page index of results to retrieve.
     pub page_size_and_idx: Option<(u64, u64)>,
 }
@@ -151,6 +155,7 @@ impl ListDashboardsParams {
             org_id: org_id.to_string(),
             folder_id: None,
             title_pat: None,
+            dashboard_id_pat: None,
             page_size_and_idx: None,
         }
     }
@@ -167,6 +172,15 @@ impl ListDashboardsParams {
     /// contains the case-insitive title pattern.
     pub fn where_title_contains(mut self, title_pat: &str) -> Self {
         self.title_pat = Some(title_pat.to_string());
+        self
+    }
+
+    /// Filter dashboards by the case-insensitive dashboard ID pattern.
+    ///
+    /// Listed dashboards will only include dashboards with a dashboard ID that
+    /// contains the case-insensitive dashboard ID pattern.
+    pub fn where_dashboard_id_contains(mut self, dashboard_id_pat: &str) -> Self {
+        self.dashboard_id_pat = Some(dashboard_id_pat.to_string());
         self
     }
 

--- a/src/handler/http/models/dashboards.rs
+++ b/src/handler/http/models/dashboards.rs
@@ -213,9 +213,15 @@ impl ListDashboardsQuery {
             }
         }
 
-        // If no filter parameters are provided, default to the default folder
-        // for backwards-compatibility
-        if self.folder.is_none() && self.title.is_none() && self.dashboard_id.is_none() {
+        // If no filter parameters are provided (or all are empty strings),
+        // default to the default folder for backwards-compatibility.
+        // When searching by title or dashboard_id, we want to search across all folders,
+        // so we don't apply the default folder in that case.
+        let has_folder = self.folder.as_ref().is_some_and(|f| !f.is_empty());
+        let has_title = self.title.as_ref().is_some_and(|t| !t.is_empty());
+        let has_dashboard_id = self.dashboard_id.as_ref().is_some_and(|id| !id.is_empty());
+
+        if !has_folder && !has_title && !has_dashboard_id {
             query = query.with_folder_id(config::meta::folder::DEFAULT_FOLDER);
         }
 

--- a/src/infra/src/table/dashboards.rs
+++ b/src/infra/src/table/dashboards.rs
@@ -579,6 +579,7 @@ mod tests {
             org_id: "orgId".to_owned(),
             folder_id: Some("folderId".to_owned()),
             title_pat: Some("tItLePat".to_owned()),
+            dashboard_id_pat: None,
             page_size_and_idx: Some((100, 2)),
         };
         list_models(&db, params).await?;
@@ -609,6 +610,7 @@ mod tests {
             org_id: "orgId".to_owned(),
             folder_id: Some("folderId".to_owned()),
             title_pat: Some("tItLePat".to_owned()),
+            dashboard_id_pat: None,
             page_size_and_idx: Some((100, 2)),
         };
         list_models(&db, params).await?;
@@ -639,6 +641,7 @@ mod tests {
             org_id: "orgId".to_owned(),
             folder_id: Some("folderId".to_owned()),
             title_pat: Some("tItLePat".to_owned()),
+            dashboard_id_pat: None,
             page_size_and_idx: Some((100, 2)),
         };
         list_models(&db, params).await?;

--- a/src/service/alerts/derived_streams.rs
+++ b/src/service/alerts/derived_streams.rs
@@ -137,7 +137,7 @@ pub async fn save(
         {
             return Err(anyhow::anyhow!(
                 "DerivedStream not saved due to failed test run caused by {}",
-                e.to_string()
+                e
             ));
         };
     }

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -107,9 +107,9 @@ pub async fn remote_write(
 
     let decoded = snap::raw::Decoder::new()
         .decompress_vec(&body)
-        .map_err(|e| anyhow::anyhow!("Invalid snappy compressed data: {}", e.to_string()))?;
+        .map_err(|e| anyhow::anyhow!("Invalid snappy compressed data: {}", e))?;
     let request = prometheus_rpc::WriteRequest::decode(bytes::Bytes::from(decoded))
-        .map_err(|e| anyhow::anyhow!("Invalid protobuf: {}", e.to_string()))?;
+        .map_err(|e| anyhow::anyhow!("Invalid protobuf: {}", e))?;
 
     // records buffer
     let mut json_data_by_stream: HashMap<String, Vec<_>> = HashMap::new();

--- a/src/service/tantivy/puffin/reader.rs
+++ b/src/service/tantivy/puffin/reader.rs
@@ -193,10 +193,10 @@ impl PuffinFooterBytesReader {
         if self.flags.contains(PuffinFooterFlags::COMPRESSED) {
             let decoder = zstd::Decoder::new(bytes)?;
             serde_json::from_reader(decoder)
-                .map_err(|e| anyhow!("Error decompress footer payload {}", e.to_string()))
+                .map_err(|e| anyhow!("Error decompress footer payload {}", e))
         } else {
             serde_json::from_slice(bytes)
-                .map_err(|e| anyhow!("Error serializing footer {}", e.to_string()))
+                .map_err(|e| anyhow!("Error serializing footer {}", e))
         }
     }
 

--- a/src/service/tantivy/puffin/reader.rs
+++ b/src/service/tantivy/puffin/reader.rs
@@ -195,8 +195,7 @@ impl PuffinFooterBytesReader {
             serde_json::from_reader(decoder)
                 .map_err(|e| anyhow!("Error decompress footer payload {}", e))
         } else {
-            serde_json::from_slice(bytes)
-                .map_err(|e| anyhow!("Error serializing footer {}", e))
+            serde_json::from_slice(bytes).map_err(|e| anyhow!("Error serializing footer {}", e))
         }
     }
 

--- a/web/src/services/dashboards.ts
+++ b/web/src/services/dashboards.ts
@@ -24,7 +24,8 @@ const dashboards = {
     name: string,
     organization: string,
     folderId: string,
-    title: string
+    title: string,
+    dashboardId: string = ""
   ) => {
     const params: any = {
       page_num,
@@ -39,6 +40,10 @@ const dashboards = {
     // Only add title if it is provided
     if (title) {
       params.title = title;
+    }
+    // Only add dashboardId if it is provided
+    if (dashboardId) {
+      params.dashboardId = dashboardId;
     }
     return http().get(`/api/${organization}/dashboards`, { params });
   },

--- a/web/src/views/Dashboards/Dashboards.vue
+++ b/web/src/views/Dashboards/Dashboards.vue
@@ -1164,7 +1164,10 @@ export default defineComponent({
           store.state.selectedOrganization.identifier,
           "",
           query,
+          query,
         );
+        // Check if this response is stale (user has typed something new since the request was made)
+        // Since we send the same query to both title and dashboardId, we only need to check one
         if (response.config.params.title != searchQuery.value) {
           return [];
         }
@@ -1391,7 +1394,10 @@ export default defineComponent({
         const filtered = [];
         terms = terms.toLowerCase();
         for (let i = 0; i < rows.length; i++) {
-          if (rows[i]["name"].toLowerCase().includes(terms)) {
+          if (
+            rows[i]["name"].toLowerCase().includes(terms) ||
+            (rows[i]["identifier"] && rows[i]["identifier"].toLowerCase().includes(terms))
+          ) {
             filtered.push(rows[i]);
           }
         }

--- a/web/src/views/Dashboards/Dashboards.vue
+++ b/web/src/views/Dashboards/Dashboards.vue
@@ -1167,8 +1167,12 @@ export default defineComponent({
           query,
         );
         // Check if this response is stale (user has typed something new since the request was made)
-        // Since we send the same query to both title and dashboardId, we only need to check one
-        if (response.config.params.title != searchQuery.value) {
+        // We send the same query to both title and dashboardId, so check both to be safe
+        const titleMatches = response.config.params.title === searchQuery.value;
+        const dashboardIdMatches = response.config.params.dashboardId === searchQuery.value;
+
+        // If neither matches the current search query, this is a stale response
+        if (!titleMatches && !dashboardIdMatches) {
           return [];
         }
 

--- a/web/src/views/Dashboards/Dashboards.vue
+++ b/web/src/views/Dashboards/Dashboards.vue
@@ -1398,10 +1398,10 @@ export default defineComponent({
         const filtered = [];
         terms = terms.toLowerCase();
         for (let i = 0; i < rows.length; i++) {
-          if (
-            rows[i]["name"].toLowerCase().includes(terms) ||
-            (rows[i]["identifier"] && rows[i]["identifier"].toLowerCase().includes(terms))
-          ) {
+          const name = String(rows[i]["name"] ?? "").toLowerCase();
+          const identifier = String(rows[i]["identifier"] ?? "").toLowerCase();
+
+          if (name.includes(terms) || identifier.includes(terms)) {
             filtered.push(rows[i]);
           }
         }


### PR DESCRIPTION
### **User description**
small issue we dont have dashboard ID based search in UI, sometime LLM gives me result as dashboard ID which is my preferred way to search but search dosent work, following is the PR for solving the same -


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add dashboard ID search parameter end-to-end

- Support title/ID OR filtering in DB

- Update UI filtering to match by ID

- Preserve default-folder listing behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ui["Dashboards.vue (search + local filter)"]
  websvc["web dashboards service (adds dashboardId param)"]
  httpmodel["HTTP query model (dashboard_id)"]
  metaparams["ListDashboardsParams (dashboard_id_pat)"]
  dbquery["SeaORM query (OR title/id)"]
  ui -- "passes query as title + dashboardId" --> websvc
  websvc -- "GET /dashboards?title&dashboardId" --> httpmodel
  httpmodel -- "build params" --> metaparams
  metaparams -- "filters" --> dbquery
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboards.ts</strong><dd><code>Add dashboardId to dashboards list query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/services/dashboards.ts

<ul><li>Add optional <code>dashboardId</code> argument to <code>list</code><br> <li> Include <code>params.dashboardId</code> when provided<br> <li> Keep existing title/folder parameter behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10350/files#diff-913b3f54367036b1b3960aa3eddd7e17b509b1d6011c5ab68ae0e935653179c5">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Extend list params with dashboard ID filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/dashboards/mod.rs

<ul><li>Add <code>dashboard_id_pat</code> to <code>ListDashboardsParams</code><br> <li> Initialize <code>dashboard_id_pat</code> to <code>None</code> in <code>new</code><br> <li> Add <code>where_dashboard_id_contains</code> builder method</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10350/files#diff-5bf716db7e1d91dfbd427a2e320ce407c4f0c92d55d68f8e636daed1b02abd56">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboards.rs</strong><dd><code>Parse dashboard_id and build query params</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/models/dashboards.rs

<ul><li>Add <code>dashboard_id</code> field to <code>ListDashboardsQuery</code><br> <li> Refactor <code>into()</code> to apply folder/title/id filters<br> <li> Default to <code>DEFAULT_FOLDER</code> when no filters<br> <li> Apply pagination when title or ID searching</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10350/files#diff-250eeebeec9d4ac0ac271466ed83cd33fea3f121080491b340dc95d9af287259">+32/-32</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboards.rs</strong><dd><code>Support OR filtering by title or dashboard ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/src/table/dashboards.rs

<ul><li>Import <code>Condition</code> to build compound filters<br> <li> Add optional <code>dashboard_id_pat</code> handling<br> <li> Use OR logic when both title and ID provided<br> <li> Filter by <code>dashboards::Column::DashboardId</code> when needed</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10350/files#diff-edd90c6ec720f676311aa31a635f954d559e63582f0b4c39cb9206bfb095737b">+42/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dashboards.vue</strong><dd><code>Send ID search and broaden local filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/Dashboards/Dashboards.vue

<ul><li>Pass <code>query</code> as both title and <code>dashboardId</code> params<br> <li> Keep stale-response guard for rapid typing<br> <li> Update local <code>filterData</code> to match <code>name</code> or <code>identifier</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10350/files#diff-8da3187db8ce3d795d0f196ede6b2290221ffa3e27b15dcc2b645e44dd196213">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

