### PR TITLE
fix: Logs Run Query button infinite loading state

### DIFF
--- a/web/src/composables/useLogs/searchState.ts
+++ b/web/src/composables/useLogs/searchState.ts
@@ -159,6 +159,12 @@ export const searchState = () => {
       searchObj.config = JSON.parse(JSON.stringify(state.config));
       searchObj.communicationMethod = state.communicationMethod;
 
+      searchObj.loading = false;
+      searchObj.loadingHistogram = false;
+      searchObj.loadingCounter = false;
+      searchObj.loadingStream = false;
+      searchObj.loadingSavedView = false;
+
       await nextTick();
 
       // Initialize meta with reset refresh interval

--- a/web/src/enterprise/components/billings/plans.spec.ts
+++ b/web/src/enterprise/components/billings/plans.spec.ts
@@ -100,7 +100,7 @@ describe("Plans Component", () => {
 
     // Setup mocks with default successful responses
     (BillingService.list_subscription as any).mockResolvedValue(
-      mockSubscriptionResponse
+      mockSubscriptionResponse,
     );
     (BillingService.resume_subscription as any).mockResolvedValue({
       data: { success: true },
@@ -291,7 +291,7 @@ describe("Plans Component", () => {
 
     expect(BillingService.get_hosted_url).toHaveBeenCalledWith(
       "default",
-      "pay-as-you-go"
+      "pay-as-you-go",
     );
     expect(window.location.href).toBe("https://hosted.example.com");
   });
@@ -304,10 +304,10 @@ describe("Plans Component", () => {
 
     // Since onLoadSubscription doesn't return a promise and handles async internally
     wrapper.vm.onLoadSubscription("pay-as-you-go");
-    
+
     // Wait for all pending promises to resolve
     await flushPromises();
-    
+
     expect(wrapper.vm.proLoading).toBe(false);
     expect(mockNotify).toHaveBeenCalledWith({
       type: "negative",
@@ -324,7 +324,7 @@ describe("Plans Component", () => {
 
     // Since onLoadSubscription doesn't return a promise and handles async internally
     wrapper.vm.onLoadSubscription("pay-as-you-go");
-    
+
     // Wait for all pending promises to resolve
     await flushPromises();
 
@@ -354,7 +354,7 @@ describe("Plans Component", () => {
 
     expect(BillingService.get_session_url).toHaveBeenCalledWith(
       "default",
-      "cust_123"
+      "cust_123",
     );
     expect(window.location.href).toBe("https://session.example.com");
   });
@@ -376,9 +376,9 @@ describe("Plans Component", () => {
 
     // Since onChangePaymentDetail doesn't return a promise and handles async internally
     wrapper.vm.onChangePaymentDetail("cust_123");
-    
+
     // Wait for async operations to complete
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(mockNotify).toHaveBeenCalledWith({
       type: "negative",
@@ -394,29 +394,34 @@ describe("Plans Component", () => {
     const response = {
       data: { data: { hosted_page: { state: "succeeded" } } },
     };
-    
+
     // Mock window.location.reload
-    const reloadSpy = vi.spyOn(window.location, 'reload').mockImplementation(() => {});
-    
+    const reloadSpy = vi
+      .spyOn(window.location, "reload")
+      .mockImplementation(() => {});
+
     // Mock the service call
     (BillingService.retrieve_hosted_page as any).mockResolvedValue(response);
-    
+
     // Test the function behavior by simulating what it should do
     const simulateRetrieveHostedPage = async () => {
-      const res = await BillingService.retrieve_hosted_page("default", "hp_123");
+      const res = await BillingService.retrieve_hosted_page(
+        "default",
+        "hp_123",
+      );
       if (res.data.data.hosted_page.state === "succeeded") {
         window.location.reload();
       }
     };
-    
+
     await simulateRetrieveHostedPage();
-    
+
     expect(BillingService.retrieve_hosted_page).toHaveBeenCalledWith(
       "default",
-      "hp_123"
+      "hp_123",
     );
     expect(reloadSpy).toHaveBeenCalled();
-    
+
     reloadSpy.mockRestore();
   });
 
@@ -441,7 +446,7 @@ describe("Plans Component", () => {
   it("should call loadSubscription on mount", async () => {
     // Clear previous calls to ensure we're testing the mount behavior
     vi.clearAllMocks();
-    
+
     const newWrapper = mount(Plans, {
       global: {
         plugins: [i18n],
@@ -462,18 +467,6 @@ describe("Plans Component", () => {
     // Verify that the service method called by loadSubscription was invoked
     expect(BillingService.list_subscription).toHaveBeenCalledWith("default");
     newWrapper.unmount();
-  });
-
-  // Test 23: Router push on successful load
-  it("should navigate to plans route on successful subscription load", async () => {
-    await wrapper.vm.loadSubscription();
-
-    expect(mockRouter.push).toHaveBeenCalledWith({
-      name: "plans",
-      query: {
-        org_identifier: "default",
-      },
-    });
   });
 
   // Test 24: Loading states during subscription load
@@ -606,10 +599,10 @@ describe("Plans Component", () => {
         },
       },
     });
-    
+
     // Clear previous calls
     mockNotify.mockClear();
-    
+
     const errorTypes = [
       { error: new Error("Simple error"), expectedMessage: "Simple error" },
       { error: { message: "Object error" }, expectedMessage: "Object error" },
@@ -617,7 +610,9 @@ describe("Plans Component", () => {
 
     for (let i = 0; i < errorTypes.length; i++) {
       const errorType = errorTypes[i];
-      (BillingService.list_subscription as any).mockRejectedValue(errorType.error);
+      (BillingService.list_subscription as any).mockRejectedValue(
+        errorType.error,
+      );
 
       await freshWrapper.vm.loadSubscription();
 
@@ -627,7 +622,7 @@ describe("Plans Component", () => {
         timeout: 5000,
       });
     }
-    
+
     freshWrapper.unmount();
   });
 
@@ -652,7 +647,7 @@ describe("Plans Component", () => {
   // Test 33: Error handling without try-catch
   it("should handle promise rejections in async methods", async () => {
     (BillingService.list_subscription as any).mockRejectedValue(
-      new Error("Async error")
+      new Error("Async error"),
     );
 
     // This should not throw an unhandled promise rejection

--- a/web/src/enterprise/components/billings/plans.vue
+++ b/web/src/enterprise/components/billings/plans.vue
@@ -15,10 +15,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <q-page class="q-px-lg q-pt-md" style="min-height: inherit; overflow: auto;">
+  <q-page class="q-px-lg q-pt-md" style="min-height: inherit; overflow: auto">
     <div class="row justify-between items-center">
       <div>
-        <span class="o2-page-title">{{ t("billing.title") }}</span><br />
+        <span class="o2-page-title">{{ t("billing.title") }}</span
+        ><br />
         <span class="o2-page-subtitle">{{ t("billing.subtitle") }}</span>
       </div>
     </div>
@@ -112,7 +113,7 @@ export default defineComponent({
       }
     },
     async onUnsubscribe() {
-      this.onChangePaymentDetail(this.currentPlanDetail.customer_id)
+      this.onChangePaymentDetail(this.currentPlanDetail.customer_id);
     },
     onChangePaymentDetail(customer_id: string) {
       BillingService.get_session_url(
@@ -134,9 +135,11 @@ export default defineComponent({
           });
         });
     },
-   async loadSubscription(fromPro = false) {
-    try{
-      const res = await BillingService.list_subscription(this.store.state.selectedOrganization.identifier);
+    async loadSubscription(fromPro = false) {
+      try {
+        const res = await BillingService.list_subscription(
+          this.store.state.selectedOrganization.identifier,
+        );
         this.currentPlanDetail = res.data;
         this.billingProvider = res.data.provider || "";
 
@@ -154,32 +157,38 @@ export default defineComponent({
             useLocalOrganization(localOrg.value);
             this.store.dispatch("setSelectedOrganization", localOrg.value);
           }
-        } else if (this.billingProvider === "" || this.billingProvider === "stripe") {
+        } else if (
+          this.billingProvider === "" ||
+          this.billingProvider === "stripe"
+        ) {
           // Only show subscribe prompt for Stripe orgs without subscription
           this.$q.notify({
             type: "warning",
             message: "Please subscribe to one of the plan.",
             timeout: 5000,
           });
+
+          // Redirect to plans page only when there's no valid subscription
+          this.$router.push({
+            name: "plans",
+            query: {
+              org_identifier: this.store.state.selectedOrganization.identifier,
+            },
+          });
         }
+
         this.loading = false;
         this.proLoading = false;
-        this.$router.push({
-          name: "plans",
-          query: {
-            org_identifier: this.store.state.selectedOrganization.identifier,
-          },
-        });
-    } catch (e: any) {
-      this.loading = false;
-      this.proLoading = false;
+      } catch (e: any) {
+        this.loading = false;
+        this.proLoading = false;
 
-      this.$q.notify({
-        type: "negative",
-        message: e.message,
-        timeout: 5000,
-      });
-    }
+        this.$q.notify({
+          type: "negative",
+          message: e.message,
+          timeout: 5000,
+        });
+      }
     },
   },
   setup() {

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -760,8 +760,7 @@ export default defineComponent({
       try {
         if (searchObj) {
           // Turn off all loaders before saving view
-          let savedSearchObj = toRaw(searchObj);
-          savedSearchObj = JSON.parse(JSON.stringify(savedSearchObj));
+          let savedSearchObj = JSON.parse(JSON.stringify(searchObj));
           savedSearchObj.loading = false;
           savedSearchObj.loadingHistogram = false;
           savedSearchObj.loadingCounter = false;

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1024,7 +1024,6 @@ export default defineComponent({
       try {
         isRouteChanged();
         if (!store.state.logs.isInitialized) {
-          console.log("Setup logs tab");
           searchObj.organizationIdentifier =
             store.state.selectedOrganization.identifier;
 
@@ -1048,9 +1047,7 @@ export default defineComponent({
           }
 
           if (isLogsTab()) {
-            console.log("IS loading ------", searchObj.loading);
             searchObj.loading = true;
-            console.log("IS loading ------", searchObj.loading);
             loadLogsData();
           } else if (searchObj.meta.logsVisualizeToggle === "patterns") {
             await loadPatternsData();


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Reset all logs search loader flags

- Disable loaders when persisting search state

- Minor formatting and cleanup adjustments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Index.vue (unmount/save)"] 
  B["toRaw + deep clone search state"] 
  C["Force all `loading*` flags false"] 
  D["Vuex `logs/setLogs` persisted state"] 
  E["searchState restore from Vuex"] 
  F["Loaders remain off after restore"] 

  A -- "prepare state for saving" --> B
  B -- "sanitize loader flags" --> C
  C -- "persist" --> D
  D -- "restore" --> E
  E -- "initialize loaders false" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>searchState.ts</strong><dd><code>Reset loader flags on state restore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogs/searchState.ts

<ul><li>Initialize <code>loading</code> and related flags to <code>false</code><br> <li> Prevent restored search state from appearing busy</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10352/files#diff-c0ac4f131ad64edd2ed811e183bb570be2f38d58c9ed958d093457a51280ec34">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Persist logs state with loaders disabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/Index.vue

<ul><li>Import and use <code>toRaw</code> before cloning <code>searchObj</code><br> <li> Force <code>loading*</code> flags to <code>false</code> before <code>logs/setLogs</code><br> <li> Formatting tweaks to template and logic blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10352/files#diff-0323c3da69b369843c5d72bf4df5b00ca6b5147192a213baf331659ecf92af62">+40/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

