### PR TITLE
fix: don't panic if function could not be deserialized when caching

### DIFF
--- a/src/service/self_reporting/mod.rs
+++ b/src/service/self_reporting/mod.rs
@@ -309,6 +309,7 @@ pub async fn publish_error(error_data: ErrorData) {
     let error_source = match &error_data.error_source {
         config::meta::self_reporting::error::ErrorSource::Alert => "Alert",
         config::meta::self_reporting::error::ErrorSource::Dashboard => "Dashboard",
+        config::meta::self_reporting::error::ErrorSource::Function(_) => "Function",
         config::meta::self_reporting::error::ErrorSource::Ingestion => "Ingestion",
         config::meta::self_reporting::error::ErrorSource::Pipeline(_) => "Pipeline",
         config::meta::self_reporting::error::ErrorSource::Search => "Search",


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Prevent panic on function cache deserialization

- Publish function errors to `_meta/errors`

- Add `Function` source with details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cache["Function cache loader"]
  deserialize["Deserialize `Transform`"]
  insert["Insert into `QUERY_FUNCTIONS`"]
  err["Deserialize failure"]
  report["Publish `_meta/errors` event"]
  cache -- "loads from DB" --> deserialize
  deserialize -- "success" --> insert
  deserialize -- "error" --> err
  err -- "emit `ErrorSource::Function`" --> report
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Add `Function` self-reporting error source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/src/meta/self_reporting/error.rs

<ul><li>Add <code>ErrorSource::Function(FunctionError)</code> variant<br> <li> Serialize <code>function_name</code> and truncated <code>error</code><br> <li> Introduce <code>FunctionError</code> struct and constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10364/files#diff-00a00a557343475be7131843f748fbae2d0c1a4041a5c4dddec56c940a03e613">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Recognize `Function` error source for logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/self_reporting/mod.rs

- Add `ErrorSource::Function(_)` mapping to `"Function"`


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10364/files#diff-c6255010f7a87d6acdb3ad04954fc9f2c27350ae319c53a1857b120aa06408a3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>functions.rs</strong><dd><code>Report function cache deserialization failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/db/functions.rs

<ul><li>Replace <code>unwrap()</code> with handled deserialization<br> <li> Log failure and continue caching loop<br> <li> Publish <code>ErrorData</code> with <code>ErrorSource::Function</code><br> <li> Parse <code>org_id</code> and function name from key</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10364/files#diff-b60526246821d795f444a4f285e8068a576777f4fc6c8a22ccde0b5005c82e08">+36/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

