### PR TITLE
fix: In trace-details added validation for _rumdata stream

### DIFF
--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -951,8 +951,8 @@ export default defineComponent({
 
       // Standalone mode - fetch from API
       if (props.mode === "standalone") {
-        await getTraceMeta();
         await loadLogStreams();
+        await getTraceMeta();
       }
     };
 
@@ -1112,6 +1112,16 @@ export default defineComponent({
       endTime: number,
     ) => {
       try {
+        // Check if _rumdata stream exists in logs
+        if (!logStreams.value.includes("_rumdata")) {
+          return [];
+        }
+
+        // Check if traceId is valid (indicating _oo_trace_id might be present)
+        if (!traceId) {
+          return [];
+        }
+
         const req = {
           query: {
             sql: `SELECT * FROM "_rumdata" WHERE _oo_trace_id = '${traceId}' ORDER BY ${store.state.zoConfig.timestamp_column} ASC`,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Reorder standalone initialization for log streams

- Guard RUM trace queries on stream

- Skip RUM fetch when traceId missing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TraceDetails standalone init"] --> B["loadLogStreams() first"]
  B["loadLogStreams() first"] -- "enables stream validation" --> C["fetchRumEventsForTrace() guards"]
  C["fetchRumEventsForTrace() guards"] -- "only if _rumdata + traceId" --> D["Query _rumdata by _oo_trace_id"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TraceDetails.vue</strong><dd><code>Add guards for RUM trace event fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/traces/TraceDetails.vue

<ul><li>Load log streams before calling <code>getTraceMeta()</code> in standalone mode<br> <li> Return early if <code>_rumdata</code> stream is absent<br> <li> Return early when <code>traceId</code> is empty before querying RUM events</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10366/files#diff-bc7fe6b6339ee2cde6494c0982d4b860847447e79f7431f07d598e0446df06f2">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

