### PR TITLE
fix: line chart issue with vrl for visualization

### DIFF
--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -1617,9 +1617,7 @@ export default defineComponent({
             ) {
               dashboardPanelData.data.queries[
                 dashboardPanelData.layout.currentQueryIndex
-              ].vrlFunctionQuery = b64EncodeUnicode(
-                searchObj.data.tempFunctionContent,
-              );
+              ].vrlFunctionQuery = searchObj.data.tempFunctionContent;
             } else {
               dashboardPanelData.data.queries[
                 dashboardPanelData.layout.currentQueryIndex
@@ -1725,6 +1723,24 @@ export default defineComponent({
               dashboardPanelData.data.type = "table";
               // Enable dynamic columns for VRL table charts
               dashboardPanelData.data.config.table_dynamic_columns = true;
+            }
+
+            // Clear VRL if chart type is not table (VRL only supported for table in visualization)
+            if (
+              dashboardPanelData.data.type !== "table" &&
+              dashboardPanelData.data.queries[
+                dashboardPanelData.layout.currentQueryIndex
+              ].vrlFunctionQuery
+            ) {
+              dashboardPanelData.data.queries[
+                dashboardPanelData.layout.currentQueryIndex
+              ].vrlFunctionQuery = "";
+            }
+
+            // Recalculate shouldUseHistogramQuery after chart type is finalized
+            // Table charts should not use histogram query
+            if (dashboardPanelData.data.type === "table") {
+              shouldUseHistogramQuery.value = false;
             }
 
             // set logs page data to searchResponseForVisualization
@@ -1876,15 +1892,15 @@ export default defineComponent({
           ].customQuery = true;
 
           // Update VRL function query if present
+          // VRL is only supported for table chart type in visualization
           if (
             searchObj.data.tempFunctionContent &&
-            searchObj.data.transformType === "function"
+            searchObj.data.transformType === "function" &&
+            dashboardPanelData.data.type === "table"
           ) {
             dashboardPanelData.data.queries[
               dashboardPanelData.layout.currentQueryIndex
-            ].vrlFunctionQuery = b64EncodeUnicode(
-              searchObj.data.tempFunctionContent,
-            );
+            ].vrlFunctionQuery = searchObj.data.tempFunctionContent;
           } else {
             dashboardPanelData.data.queries[
               dashboardPanelData.layout.currentQueryIndex
@@ -2313,15 +2329,19 @@ export default defineComponent({
 
         checkAbort();
 
-        /* Decide whether to use histogram query - don't use for table charts, when there are group_by fields, or when VRL functions are present */
-        const hasVrlFunction =
-          searchObj.data.tempFunctionContent &&
-          searchObj.data.transformType === "function";
+        /* Decide whether to use histogram query - don't use for table charts or when there are group_by fields */
+        /* Note: VRL functions are only supported for table charts, and VRL will force table chart type */
+        /* So if VRL is present and autoSelectChartType is true, we know chart will be table */
+        const willBeTableChart =
+          dashboardPanelData.data.type === "table" ||
+          (autoSelectChartType &&
+            searchObj.data.tempFunctionContent &&
+            searchObj.data.transformType === "function");
 
         shouldUseHistogramQuery.value =
-          dashboardPanelData.data.type !== "table" &&
-          !(extractedFields?.group_by && extractedFields.group_by.length) &&
-          !hasVrlFunction;
+          !willBeTableChart &&
+          !(extractedFields?.group_by && extractedFields.group_by.length);
+
 
         const finalQuery = logsPageQuery;
 


### PR DESCRIPTION
### **User description**
- #10281


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Stop base64-encoding VRL visualization queries

- Restrict VRL usage to table visualizations

- Clear VRL when switching chart types

- Refine histogram-query selection for charts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Logs visualization state"] 
  B["VRL function query (table-only)"] 
  C["Chart type finalization"] 
  D["Histogram query decision"] 
  A -- "provides VRL + settings" --> B
  B -- "forces/clears based on type" --> C
  C -- "updates shouldUseHistogramQuery" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Index.vue</strong><dd><code>Fix table-only VRL logic and histogram selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/Index.vue

<ul><li>Save VRL query as plain text<br> <li> Apply VRL only for <code>type === "table"</code><br> <li> Clear VRL when non-table selected<br> <li> Recompute histogram eligibility after type</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10374/files#diff-0323c3da69b369843c5d72bf4df5b00ca6b5147192a213baf331659ecf92af62">+34/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

