### PR TITLE
fix: introduce restore of filter , current page , no of records (#10368)

### DIFF
--- a/web/src/components/alerts/IncidentList.vue
+++ b/web/src/components/alerts/IncidentList.vue
@@ -198,7 +198,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, onMounted, watch } from "vue";
+import { defineComponent, ref, computed, onMounted, watch, nextTick } from "vue";
 import { useI18n } from "vue-i18n";
 import { useStore } from "vuex";
 import { useQuasar } from "quasar";
@@ -227,6 +227,7 @@ export default defineComponent({
     const incidents = ref<Incident[]>([]);
     const allIncidents = ref<Incident[]>([]); // Store all incidents for FE filtering
     const searchQuery = ref("");
+    const isRestoringState = ref(false); // Simple flag to prevent watch from firing during restoration
 
     // Filter state for status and severity columns
     const statusFilter = ref<string[]>([]);
@@ -423,9 +424,29 @@ export default defineComponent({
       const endIndex = startIndex + pagination.value.rowsPerPage;
       incidents.value = filteredIncidents.slice(startIndex, endIndex);
       pagination.value.rowsNumber = filteredIncidents.length;
+
+      // Save to store after pagination update (only search query, page, and rowsPerPage)
+      store.dispatch('incidents/setIncidents', {
+        searchQuery: searchQuery.value,
+        pagination: {
+          page: pagination.value.page,
+          rowsPerPage: pagination.value.rowsPerPage
+        },
+        organizationIdentifier: store.state.selectedOrganization.identifier
+      });
     };
 
     const viewIncident = (incident: Incident) => {
+      // Ensure state is saved before navigation (only search query, page, and rowsPerPage)
+      store.dispatch('incidents/setIncidents', {
+        searchQuery: searchQuery.value,
+        pagination: {
+          page: pagination.value.page,
+          rowsPerPage: pagination.value.rowsPerPage
+        },
+        organizationIdentifier: store.state.selectedOrganization.identifier
+      });
+
       // Navigate to incident detail page
       router.push({
         name: "incidentDetail",
@@ -524,21 +545,181 @@ export default defineComponent({
         .join(", ");
     };
 
+    /**
+     * Restores state from Vuex store or resets if organization changed
+     * @returns {boolean} True if state was restored, false if reset
+     */
+    const restoreStateFromStore = (): boolean => {
+      const savedState = store.state.incidents.incidents;
+      const isInitialized = store.state.incidents.isInitialized;
+      const currentOrg = store.state.selectedOrganization.identifier;
+
+      // Check if organization has changed - if so, reset the store
+      if (isInitialized && savedState && savedState.organizationIdentifier &&
+          savedState.organizationIdentifier !== currentOrg) {
+        // Organization changed - reset store to clear old org's state
+        store.dispatch('incidents/resetIncidents');
+
+        // Reset local state to defaults
+        searchQuery.value = "";
+        pagination.value = {
+          sortBy: "last_alert_at",
+          descending: true,
+          page: 1,
+          rowsPerPage: 20,
+          rowsNumber: 0,
+        };
+        return false;
+      }
+      // Restore state if available and same organization
+      else if (isInitialized && savedState &&
+               savedState.organizationIdentifier === currentOrg) {
+
+        // Prevent watch from interfering during restoration
+        isRestoringState.value = true;
+
+        // Restore pagination
+        if (savedState.pagination) {
+          pagination.value.page = savedState.pagination.page || 1;
+          pagination.value.rowsPerPage = savedState.pagination.rowsPerPage || 20;
+        }
+
+        // Restore search query
+        if (savedState.searchQuery !== undefined) {
+          searchQuery.value = savedState.searchQuery;
+        }
+
+        // Note: isRestoringState reset at end of onMounted after all async ops complete
+
+        return true;
+      }
+
+      return false;
+    };
+
+    /**
+     * Validates pagination after data load and auto-corrects if current page is out of bounds
+     * This handles edge cases like:
+     * - User had page=3 with 150 records, comes back to find only 10 records left
+     * - Search results have fewer items than expected
+     * - All data was deleted (totalRecords = 0)
+     * - Invalid rowsPerPage values (e.g., 0, negative, corrupt store data)
+     * - pageBeforeSearch out of bounds when clearing search
+     * @returns {boolean} True if pagination was corrected, false if valid
+     */
+    const validateAndCorrectPagination = (): boolean => {
+      const totalRecords = pagination.value.rowsNumber;
+      let currentPage = pagination.value.page;
+      let rowsPerPage = pagination.value.rowsPerPage;
+      let wasCorrected = false;
+
+      // Safety: Validate rowsPerPage (must be positive, default to 20)
+      if (!rowsPerPage || rowsPerPage <= 0) {
+        pagination.value.rowsPerPage = 20;
+        rowsPerPage = 20;
+        wasCorrected = true;
+      }
+
+      // Safety: Validate currentPage (must be positive, default to 1)
+      if (!currentPage || currentPage < 1) {
+        pagination.value.page = 1;
+        currentPage = 1;
+        wasCorrected = true;
+      }
+
+      // Calculate max valid page (at least 1)
+      const maxPage = Math.max(1, Math.ceil(totalRecords / rowsPerPage));
+
+      // Check if current page is out of bounds
+      if (currentPage > maxPage) {
+        pagination.value.page = maxPage;
+        wasCorrected = true;
+      }
+
+      // Re-apply pagination if any correction was made
+      if (wasCorrected) {
+        const filteredIncidents = applyFrontendSearch(allIncidents.value, searchQuery.value);
+        const startIndex = (pagination.value.page - 1) * pagination.value.rowsPerPage;
+        const endIndex = startIndex + pagination.value.rowsPerPage;
+        incidents.value = filteredIncidents.slice(startIndex, endIndex);
+      }
+
+      return wasCorrected;
+    };
+
     onMounted(async () => {
+      // Restore state from store (or reset if org changed)
+      const hasRestoredState = restoreStateFromStore();
+
+      // Load incidents with restored or default state
       await loadIncidents();
+
+      // Validate pagination after loading data (edge case: restored page is out of bounds)
+      const wasCorrected = validateAndCorrectPagination();
+
+      // Mark as initialized after first load
+      if (!store.state.incidents.isInitialized) {
+        store.dispatch('incidents/setIsInitialized', true);
+      }
+
+      // Save the state to store (either restored or corrected)
+      if (hasRestoredState || wasCorrected) {
+        store.dispatch('incidents/setIncidents', {
+          searchQuery: searchQuery.value,
+          pagination: {
+            page: pagination.value.page,
+            rowsPerPage: pagination.value.rowsPerPage
+          },
+          organizationIdentifier: store.state.selectedOrganization.identifier
+        });
+      }
+
+      // Wait for next tick to ensure watches fire with isRestoringState=true
+      await nextTick();
+
+      // Clear restoration flag after all operations complete
+      isRestoringState.value = false;
     });
 
     // Watch for search query changes and apply FE filter
-    watch(() => searchQuery.value, () => {
-      // Reset to page 1 when search query changes
-      pagination.value.page = 1;
+    watch(() => searchQuery.value, (newValue, oldValue) => {
+      // Skip page manipulation during state restoration
+      if (!isRestoringState.value) {
+        // If starting a search (going from empty to something)
+        if (!oldValue && newValue) {
+          store.dispatch('incidents/setPageBeforeSearch', pagination.value.page);
+          pagination.value.page = 1;
+        }
+        // If clearing the search (going from something to empty)
+        else if (oldValue && !newValue) {
+          const pageBeforeSearch = store.state.incidents.pageBeforeSearch;
+          pagination.value.page = pageBeforeSearch || 1;
+        }
+        // If changing search query (both old and new have values)
+        else if (oldValue && newValue) {
+          pagination.value.page = 1;
+        }
+      }
 
       // Apply FE search filter without API call
       const filteredIncidents = applyFrontendSearch(allIncidents.value, searchQuery.value);
-      const startIndex = 0; // Always start from first page
-      const endIndex = pagination.value.rowsPerPage;
+      const startIndex = (pagination.value.page - 1) * pagination.value.rowsPerPage;
+      const endIndex = startIndex + pagination.value.rowsPerPage;
       incidents.value = filteredIncidents.slice(startIndex, endIndex);
       pagination.value.rowsNumber = filteredIncidents.length;
+
+      // Validate pagination after applying search (handles edge case: pageBeforeSearch is out of bounds)
+      validateAndCorrectPagination();
+
+      // Save to store (only search query, page, and rowsPerPage - not sort settings)
+      store.dispatch('incidents/setIncidents', {
+        searchQuery: searchQuery.value,
+        pagination: {
+          page: pagination.value.page,
+          rowsPerPage: pagination.value.rowsPerPage
+        },
+        organizationIdentifier: store.state.selectedOrganization.identifier
+      });
     });
 
     // Filter toggle functions
@@ -580,6 +761,16 @@ export default defineComponent({
       qTableRef.value?.requestServerInteraction({
         pagination: pagination.value
       });
+
+      // Save to store (only search query, page, and rowsPerPage)
+      store.dispatch('incidents/setIncidents', {
+        searchQuery: searchQuery.value,
+        pagination: {
+          page: pagination.value.page,
+          rowsPerPage: pagination.value.rowsPerPage
+        },
+        organizationIdentifier: store.state.selectedOrganization.identifier
+      });
     };
 
 
@@ -614,6 +805,7 @@ export default defineComponent({
       changePagination,
       perPageOptions,
       qTableRef,
+      validateAndCorrectPagination, // Expose for testing
     };
   },
 });

--- a/web/src/stores/incidents.ts
+++ b/web/src/stores/incidents.ts
@@ -1,0 +1,64 @@
+// Copyright 2025 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+export default {
+  namespaced: true,
+  state: {
+    incidents: {},
+    pageBeforeSearch: 1, // Track page number before search starts (for smart restoration)
+    isInitialized: false
+  },
+  getters: {
+    getIncidents(state: any) {
+      return state.incidents;
+    },
+    getPageBeforeSearch(state: any) {
+      return state.pageBeforeSearch;
+    },
+    getIsInitialized(state: any) {
+      return state.isInitialized;
+    },
+  },
+  mutations: {
+    setIncidents(state: any, incidents: any) {
+      state.incidents = incidents;
+    },
+    setPageBeforeSearch(state: any, page: number) {
+      state.pageBeforeSearch = page;
+    },
+    setIsInitialized(state: any, isInitialized: boolean) {
+      state.isInitialized = isInitialized;
+    },
+    resetIncidents(state: any) {
+      state.incidents = {};
+      state.pageBeforeSearch = 1;
+      state.isInitialized = false;
+    },
+  },
+  actions: {
+    setIncidents(context: any, incidents: any) {
+      context.commit('setIncidents', incidents);
+    },
+    setPageBeforeSearch(context: any, page: number) {
+      context.commit('setPageBeforeSearch', page);
+    },
+    setIsInitialized(context: any, isInitialized: boolean) {
+      context.commit('setIsInitialized', isInitialized);
+    },
+    resetIncidents(context: any) {
+      context.commit('resetIncidents');
+    },
+  },
+};

--- a/web/src/stores/index.ts
+++ b/web/src/stores/index.ts
@@ -21,6 +21,7 @@ import {
 } from "../utils/zincutils";
 import streams from "./streams";
 import logs from "./logs";
+import incidents from "./incidents";
 
 const pos = window.location.pathname.indexOf("/web/");
 
@@ -440,6 +441,7 @@ export default createStore({
   },
   modules: {
     streams,
-    logs
+    logs,
+    incidents
   },
 });

--- a/web/src/test/unit/helpers/store.ts
+++ b/web/src/test/unit/helpers/store.ts
@@ -279,6 +279,55 @@ const store = createStore({
         },
       },
     },
+    incidents: {
+      namespaced: true,
+      state: {
+        incidents: {},
+        pageBeforeSearch: 1,
+        isInitialized: false
+      },
+      getters: {
+        getIncidents(state: any) {
+          return state.incidents;
+        },
+        getPageBeforeSearch(state: any) {
+          return state.pageBeforeSearch;
+        },
+        getIsInitialized(state: any) {
+          return state.isInitialized;
+        },
+      },
+      mutations: {
+        setIncidents(state: any, incidents: any) {
+          state.incidents = incidents;
+        },
+        setPageBeforeSearch(state: any, page: number) {
+          state.pageBeforeSearch = page;
+        },
+        setIsInitialized(state: any, isInitialized: boolean) {
+          state.isInitialized = isInitialized;
+        },
+        resetIncidents(state: any) {
+          state.incidents = {};
+          state.pageBeforeSearch = 1;
+          state.isInitialized = false;
+        },
+      },
+      actions: {
+        setIncidents(context: any, incidents: any) {
+          context.commit('setIncidents', incidents);
+        },
+        setPageBeforeSearch(context: any, page: number) {
+          context.commit('setPageBeforeSearch', page);
+        },
+        setIsInitialized(context: any, isInitialized: boolean) {
+          context.commit('setIsInitialized', isInitialized);
+        },
+        resetIncidents(context: any) {
+          context.commit('resetIncidents');
+        },
+      },
+    },
   },
   actions: {
     login(context, payload) {


### PR DESCRIPTION
### **User description**
## Add Vuex-Based State Persistence and Comprehensive Test Coverage for Incident List

### Overview
This PR implements robust state persistence for the Incident List page, enabling users to maintain their search context, pagination position, and filter preferences when navigating between pages. Additionally, it adds comprehensive unit test coverage (114 tests) to ensure reliability across all edge cases.

### Key Features

#### **State Persistence**
- Implemented Vuex store module for incidents with persistent state management
- Preserves search query, current page, and rows-per-page settings across navigation
- Organization-aware state that automatically resets when switching organizations
- Smart restoration using `isRestoringState` flag with Vue's `nextTick()` timing control

#### **Smart Page Management**
- Introduced `pageBeforeSearch` tracking to remember original page position before searching
- When users clear a restored search query, the page correctly returns to the original position (fixes critical UX bug)
- Automatic pagination validation with graceful correction for out-of-bounds pages

#### **Edge Case Handling**
The implementation handles seven critical edge cases:
1. **Restored page exceeding available pages** → auto-corrects to maxPage
2. **pageBeforeSearch out of bounds** → validates and corrects on search clear
3. **All data deleted (0 records)** → resets to page 1
4. **Invalid rowsPerPage (0, negative)** → resets to default (20)
5. **Invalid currentPage (0, negative)** → resets to page 1
6. **Search results fewer than expected** → auto-corrects page
7. **Clearing restored search** → preserves original page position

#### **Test Coverage**
Added 37 new test suites covering:
- State persistence and restoration (4 tests)
- Search query watch behavior (4 tests)
- Vuex store integration (4 tests)
- Frontend search filtering (6 tests)
- Pagination validation (5 tests)
- All edge cases with **100% pass rate** (114/114 tests)

### Technical Implementation
- Added `incidents` module to Vuex store with namespaced actions/mutations
- Exposed `validateAndCorrectPagination` function for comprehensive testing
- Used Vue's reactive system with proper timing control to prevent race conditions
- Implemented `isRestoringState` flag to bypass watch logic during state restoration
- Added test helper store module for proper unit test isolation

### Files Modified
- `web/src/components/alerts/IncidentList.vue` - Added state persistence logic
- `web/src/stores/incidents.ts` - Created incidents Vuex module
- `web/src/stores/index.ts` - Registered incidents module
- `web/src/components/alerts/IncidentList.spec.ts` - Added 114 comprehensive tests
- `web/src/test/unit/helpers/store.ts` - Added incidents module to test store

### User Impact
Users can now:
- Navigate to incident details and return without losing their place
- Search for incidents and have the search persist across navigation
- Clear searches and return to their original page position
- Experience graceful handling of edge cases (data deletion, invalid states)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Persist IncidentList search and pagination

- Restore/reset state per organization change

- Fix clear-restored-search page regression

- Add extensive Vuex and pagination tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["`IncidentList.vue` UI state"] 
  Watch["Search watcher page logic"]
  Vuex["Vuex `incidents` module"]
  Restore["Restore/reset on mount"]
  Validate["`validateAndCorrectPagination` corrections"]
  Tests["`IncidentList.spec.ts` coverage"]
  UI -- "dispatch save state" --> Vuex
  Restore -- "read org-scoped state" --> Vuex
  Restore -- "apply restored values" --> UI
  Watch -- "start/clear/change search" --> UI
  Watch -- "store pageBeforeSearch" --> Vuex
  UI -- "post-load validate" --> Validate
  Validate -- "correct page/rowsPerPage" --> UI
  Tests -- "assert behaviors" --> UI
  Tests -- "assert store integration" --> Vuex
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IncidentList.vue</strong><dd><code>Persist and restore IncidentList state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentList.vue

<ul><li>Add Vuex-backed restore/reset on mount<br> <li> Save <code>searchQuery</code> and pagination to store<br> <li> Track <code>pageBeforeSearch</code> for search clear<br> <li> Add pagination validation and correction helper</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10376/files#diff-953ad015996758a8c86e489499cd3b0a614501b99b0c9c5c242a299e34c24ff2">+198/-6</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>incidents.ts</strong><dd><code>Add Vuex module for incidents state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/stores/incidents.ts

<ul><li>Introduce <code>incidents</code> namespaced module<br> <li> Store <code>incidents</code>, <code>pageBeforeSearch</code>, <code>isInitialized</code><br> <li> Add getters, mutations, and actions<br> <li> Provide reset action for org changes</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10376/files#diff-99af0a5ee4e917dce84a85663e25ecb072ae0cfa87f60f8b49b94d9320ebf87d">+64/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Register incidents module in root store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/stores/index.ts

<ul><li>Import <code>./incidents</code> module<br> <li> Add <code>incidents</code> to Vuex <code>modules</code> list</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10376/files#diff-955a15c7ee060f1545e82be22911dd0c14307dee5a70071a394e9fd583bd2c55">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>store.ts</strong><dd><code>Extend unit-test store with incidents module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/test/unit/helpers/store.ts

<ul><li>Add mocked <code>incidents</code> module to test store<br> <li> Mirror production state/getters/mutations/actions<br> <li> Support new component dispatches in unit tests</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10376/files#diff-0f8dff694a1fcfaa42d432168e435b7a2aa122d075fedfd6e75e532aca3b2a73">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IncidentList.spec.ts</strong><dd><code>Add comprehensive tests for persistence and edges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentList.spec.ts

<ul><li>Reset incidents store state in test setup<br> <li> Add Vuex persistence/restoration and org reset tests<br> <li> Cover search watcher page behaviors and primary bug<br> <li> Add pagination validation and edge-case suites</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10376/files#diff-633b95716cea25470b98f260f00e6fbc641c1fbe8ed82713e346eef014ca4d50">+845/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

