### PR TITLE
fix: redirection to trace details from logs correlation

### DIFF
--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -2730,7 +2730,6 @@
     "noTracesFound": "No correlated traces found",
     "noTracesDescription": "No traces found for service {service} in the selected time range",
     "viewInTraces": "View in Traces",
-    "viewInTracesTooltip": "Open traces page with RED metrics dashboard and all correlated traces",
     "filters": "Filters",
     "semanticFieldGroupsTitle": "Field Mappings",
     "semanticFieldGroupsCaption": "Define field name mappings for correlation and deduplication (e.g., host, hostname, node → 'host' group)",

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
@@ -407,7 +407,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     class="tw:text-xs"
                   >
                     <q-tooltip>
-                      {{ t("correlation.viewInTracesTooltip") }}
+                      {{ t("correlation.viewInTraces") }}
                     </q-tooltip>
                   </q-btn>
                   <q-chip dense color="primary" text-color="white">
@@ -760,7 +760,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   class="tw:text-xs"
                 >
                   <q-tooltip>
-                    {{ t("correlation.viewInTracesTooltip") }}
+                    {{ t("correlation.viewInTraces") }}
                   </q-tooltip>
                 </q-btn>
               </div>

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -518,10 +518,7 @@ import { b64EncodeUnicode } from "@/utils/zincutils";
 import { useRouter } from "vue-router";
 import searchService from "@/services/search";
 import useNotifications from "@/composables/useNotifications";
-import {
-  parseUsageDetails,
-  parseCostDetails,
-} from "@/utils/llmUtils";
+import { parseUsageDetails, parseCostDetails } from "@/utils/llmUtils";
 
 export default defineComponent({
   name: "TraceDetails",
@@ -683,7 +680,7 @@ export default defineComponent({
     // Calculate sidebar width based on leftWidth
     // Sidebar should take ~84% of the remaining space after left panel
     const sidebarWidth = computed(() => {
-      if (!parentContainer.value) return '84%';
+      if (!parentContainer.value) return "84%";
       const containerWidth = parentContainer.value.clientWidth || 1200;
       const remainingWidth = containerWidth - leftWidth.value;
       const sidebarWidthPx = Math.max(remainingWidth * 0.84, 300); // Minimum 300px
@@ -1587,7 +1584,7 @@ export default defineComponent({
       // Parse usage details from split fields
       const usage = parseUsageDetails(span);
       const cost = parseCostDetails(span);
-      
+
       return {
         [store.state.zoConfig.timestamp_column]:
           span[store.state.zoConfig.timestamp_column],
@@ -1892,10 +1889,12 @@ export default defineComponent({
         org_identifier: effectiveOrgIdentifier.value,
       };
 
-      router.push({
-        name: "traces",
+      const route = router.resolve({
+        name: "traceDetails",
         query,
       });
+
+      window.open(route.href, "_blank");
     };
 
     const routeToTracesList = () => {


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix correlated trace opening trace details

- Open trace details in new tab

- Simplify "View in Traces" tooltip text


___

### Diagram Walkthrough


```mermaid
flowchart LR
  dash["`TelemetryCorrelationDashboard.vue` correlation UI"]
  openFn["Open traces action (`openTracesPage`)"]
  routerRes["`router.resolve({ name: \"traceDetails\" })`"]
  newTab["`window.open(href, \"_blank\")` trace details"]
  i18n["`en.json` i18n strings"]
  dash -- "Click View in Traces" --> openFn
  openFn -- "Resolve details route" --> routerRes
  routerRes -- "Open resolved URL" --> newTab
  dash -- "Tooltip text update" --> i18n
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TelemetryCorrelationDashboard.vue</strong><dd><code>Update "View in Traces" tooltip label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/correlation/TelemetryCorrelationDashboard.vue

<ul><li>Replace tooltip translation key with <code>correlation.viewInTraces</code><br> <li> Apply the tooltip change in both dashboard locations</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10379/files#diff-b77a766fa0094f641873071a8f13c73704933b941f387ed105e85a4e59efdb38">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TraceDetails.vue</strong><dd><code>Open trace details via resolved route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/traces/TraceDetails.vue

<ul><li>Resolve route to <code>traceDetails</code> instead of <code>traces</code><br> <li> Open trace details in a new tab via <code>window.open</code><br> <li> Minor formatting/consistency tweaks in imports and strings</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10379/files#diff-bc7fe6b6339ee2cde6494c0982d4b860847447e79f7431f07d598e0446df06f2">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Remove unused traces tooltip translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/locales/languages/en.json

<ul><li>Delete <code>correlation.viewInTracesTooltip</code> entry<br> <li> Keep <code>correlation.viewInTraces</code> as the tooltip text</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10379/files#diff-892aa3d75ab6e129ef9116aa21bec1b9a15ba69ce5366d2a19128078c690d824">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

