### PR TITLE
fix: sre-agent error propogation

### DIFF
--- a/web/src/components/O2AIChat.vue
+++ b/web/src/components/O2AIChat.vue
@@ -819,6 +819,7 @@ export default defineComponent({
                   // Handle error events - display error message to user
                   if (data && data.type === 'error') {
                     // Complete any active tool call first
+                    let lastMessage = chatMessages.value[chatMessages.value.length - 1];
                     if (activeToolCall.value) {
                       const completedToolBlock: ContentBlock = {
                         type: 'tool_call',
@@ -826,7 +827,6 @@ export default defineComponent({
                         message: activeToolCall.value.message,
                         context: activeToolCall.value.context
                       };
-                      let lastMessage = chatMessages.value[chatMessages.value.length - 1];
                       if (lastMessage && lastMessage.role === 'assistant') {
                         if (!lastMessage.contentBlocks) lastMessage.contentBlocks = [];
                         lastMessage.contentBlocks.push(completedToolBlock);
@@ -846,8 +846,8 @@ export default defineComponent({
                       errorMessage += `\n\n${data.suggestion}`;
                     }
 
-                    // Get or create assistant message for error
-                    let lastMessage = chatMessages.value[chatMessages.value.length - 1];
+                    // Get or create assistant message for error (reuse lastMessage)
+                    lastMessage = chatMessages.value[chatMessages.value.length - 1];
                     if (!lastMessage || lastMessage.role !== 'assistant') {
                       chatMessages.value.push({
                         role: 'assistant',
@@ -1037,6 +1037,7 @@ export default defineComponent({
                 // Handle error events - display error message to user
                 if (data && data.type === 'error') {
                   // Complete any active tool call first
+                  let lastMessage = chatMessages.value[chatMessages.value.length - 1];
                   if (activeToolCall.value) {
                     const completedToolBlock: ContentBlock = {
                       type: 'tool_call',
@@ -1044,7 +1045,6 @@ export default defineComponent({
                       message: activeToolCall.value.message,
                       context: activeToolCall.value.context
                     };
-                    let lastMessage = chatMessages.value[chatMessages.value.length - 1];
                     if (lastMessage && lastMessage.role === 'assistant') {
                       if (!lastMessage.contentBlocks) lastMessage.contentBlocks = [];
                       lastMessage.contentBlocks.push(completedToolBlock);
@@ -1064,8 +1064,8 @@ export default defineComponent({
                     errorMessage += `\n\n${data.suggestion}`;
                   }
 
-                  // Get or create assistant message for error
-                  let lastMessage = chatMessages.value[chatMessages.value.length - 1];
+                  // Get or create assistant message for error (reuse lastMessage)
+                  lastMessage = chatMessages.value[chatMessages.value.length - 1];
                   if (!lastMessage || lastMessage.role !== 'assistant') {
                     chatMessages.value.push({
                       role: 'assistant',


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Display streamed `error` events in chat

- Finalize active tool calls on errors

- Persist error messages to history

- Stop further stream processing on error


___

### Diagram Walkthrough


```mermaid
flowchart LR
  stream["Streamed event payloads"] 
  toolcall["Active tool call state"] 
  chat["Assistant chat message"] 
  history["Saved chat history"] 
  stream -- "type=error" --> toolcall
  toolcall -- "finalize tool_call block" --> chat
  stream -- "format error + suggestion" --> chat
  chat -- "saveToHistory()" --> history
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>O2AIChat.vue</strong><dd><code>Handle streamed errors and finalize tool calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/O2AIChat.vue

<ul><li>Add <code>data.type === 'error'</code> handling in stream loops<br> <li> Convert any <code>activeToolCall</code> into a completed <code>tool_call</code> block<br> <li> Append/create assistant message with formatted error and optional <br>suggestion<br> <li> Save error to history, scroll, then return</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10383/files#diff-a6a125719a7b32b31b53fcfe05c12081d82c139a401699affdda0db8e73887e3">+112/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

