### PR TITLE
fix: cache with query size (#10384)

### DIFF
--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -558,7 +558,11 @@ pub async fn prepare_cache_response(
     }
 
     // calculate hash for the query with version (after normalizing histogram interval)
-    let mut hash_body = vec![CACHE_VERSION.to_string(), origin_sql.to_string()];
+    let mut hash_body = vec![
+        CACHE_VERSION.to_string(),
+        origin_sql.to_string(),
+        req.query.size.to_string(),
+    ];
     if let Some(vrl_function) = &query_fn {
         hash_body.push(vrl_function.to_string());
     }

--- a/src/service/search/grpc/flight.rs
+++ b/src/service/search/grpc/flight.rs
@@ -196,7 +196,7 @@ pub async fn search(
     let query_params = Arc::new(QueryParams {
         trace_id: trace_id.to_string(),
         org_id: org_id.clone(),
-        stream,
+        stream: stream.clone(),
         stream_type,
         stream_name: stream_name.to_string(),
         time_range: (req.search_info.start_time, req.search_info.end_time),
@@ -411,7 +411,7 @@ pub async fn search(
         // get the enrichment table from db
         let enrichment_table = EnrichTable::new(
             &org_id,
-            &stream_name,
+            &stream,
             empty_exec.full_schema().clone(),
             query_params.time_range,
         );

--- a/src/service/search/sql/mod.rs
+++ b/src/service/search/sql/mod.rs
@@ -240,6 +240,9 @@ impl Sql {
         let mut histogram_interval_visitor =
             HistogramIntervalVisitor::new(Some((query.start_time, query.end_time)));
         let _ = statement.visit(&mut histogram_interval_visitor);
+        if let Some(error) = histogram_interval_visitor.error {
+            return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(error)));
+        }
         let mut histogram_interval = if query.histogram_interval > 0 {
             Some(validate_and_adjust_histogram_interval(
                 query.histogram_interval,

--- a/src/service/search/sql/visitor/histogram_interval.rs
+++ b/src/service/search/sql/visitor/histogram_interval.rs
@@ -23,6 +23,7 @@ pub struct HistogramIntervalVisitor {
     pub is_histogram: bool,
     pub interval: Option<i64>,
     time_range: Option<(i64, i64)>,
+    pub error: Option<String>,
 }
 
 impl HistogramIntervalVisitor {
@@ -31,6 +32,7 @@ impl HistogramIntervalVisitor {
             is_histogram: false,
             interval: None,
             time_range,
+            error: None,
         }
     }
 }
@@ -49,10 +51,15 @@ impl VisitorMut for HistogramIntervalVisitor {
                 let _ = args.next();
                 // second is interval
                 let interval = if let Some(interval) = args.next() {
-                    interval
+                    let v = interval
                         .to_string()
                         .trim_matches(|v| v == '\'' || v == '"')
-                        .to_string()
+                        .to_string();
+                    if v.parse::<i64>().is_ok() {
+                        self.error = Some(format!("Invalid histogram interval: {v}"));
+                        return ControlFlow::Break(());
+                    }
+                    v
                 } else {
                     generate_histogram_interval(self.time_range).to_string()
                 };

--- a/tests/api-testing/tests/test_enrichment_table_join.py
+++ b/tests/api-testing/tests/test_enrichment_table_join.py
@@ -550,6 +550,7 @@ low,72,L4"""
             FROM "{self.STREAM_NAME}" AS a
             LEFT JOIN enrich.{self.enrichment_table_name} AS b
             ON a.kubernetes_namespace_name = b.namespace_name
+            WHERE a.kubernetes_namespace_name IS NOT NULL
             LIMIT 5
         """
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Include `size` in cache key hash

- Skip timestamp filter for enrich schemas

- Surface invalid histogram interval as error

- Stabilize enrichment join test filtering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Search request (SQL + params)"]
  B["Cache hash_body includes `size`"]
  C["EnrichTable uses TableReference"]
  D["Conditional timestamp filter"]
  E["HistogramIntervalVisitor collects error"]
  F["SQL builder returns SearchSQLNotValid"]
  G["Updated enrichment join test query"]
  A -- "hash inputs" --> B
  A -- "enrich stream ref" --> C
  C -- "schema-based decision" --> D
  A -- "parse histogram()" --> E
  E -- "error propagated" --> F
  A -- "test coverage" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add query size to cache hash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/mod.rs

<ul><li>Add <code>req.query.size</code> into <code>hash_body</code><br> <li> Improve cache key uniqueness per page size</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10387/files#diff-f07bfacc0501b9c234e64b16c1dd8eb0ae8fcbe231f90c81fed72bcc94946f74">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>histogram_interval.rs</strong><dd><code>Track histogram interval parsing errors in visitor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/sql/visitor/histogram_interval.rs

<ul><li>Add <code>error: Option<String></code> to visitor state<br> <li> Set error and break when interval is invalid</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10387/files#diff-0442907b4d8a3b5c4bd9553fd5475c3044fe74a2853cda8e4017bf295d714b4b">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enrich_table.rs</strong><dd><code>Use TableReference and conditional timestamp filtering</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/datafusion/table_provider/enrich_table.rs

<ul><li>Replace <code>name: String</code> with <code>stream: TableReference</code><br> <li> Introduce <code>timestamp_filter: Option<(i64,i64)></code><br> <li> Disable timestamp filter for <code>enrich</code>/<code>enrichment_tables</code> schemas<br> <li> Adjust projection logic and <code>EnrichExec</code> construction</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10387/files#diff-285405c12b45909532cdb2459fc9aa3272dfeb6ef6a4e5706cefeeaac224f2b9">+28/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flight.rs</strong><dd><code>Pass stream reference into enrichment table provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/grpc/flight.rs

<ul><li>Clone <code>stream</code> into <code>QueryParams</code><br> <li> Construct <code>EnrichTable::new</code> with <code>&stream</code> reference</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10387/files#diff-8f9464a4df8af407ec61aef1ac4853c0474c99c8698fae38f9cfea344207fc2f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Return SQL error on invalid histogram interval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/sql/mod.rs

<ul><li>Check <code>histogram_interval_visitor.error</code> after visiting<br> <li> Convert visitor error into <code>SearchSQLNotValid</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10387/files#diff-dc0ab53d0ff551cf3cd12027c73d0da5e66680c0bf2d1830778639a33bac3464">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_enrichment_table_join.py</strong><dd><code>Tighten join test with non-null filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/api-testing/tests/test_enrichment_table_join.py

<ul><li>Add <code>WHERE a.kubernetes_namespace_name IS NOT NULL</code><br> <li> Reduce flakiness from NULL join keys</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10387/files#diff-59300e59ac91f497cbad0e9df7ee3c47ade382b0f37382da4f25861eac3e2628">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

