### PR TITLE
ci: disable sccache

### DIFF
--- a/deploy/build/Dockerfile.sccache.aarch64
+++ b/deploy/build/Dockerfile.sccache.aarch64
@@ -6,7 +6,7 @@ RUN rustup target add aarch64-unknown-linux-gnu
 RUN rustup component add rustfmt clippy llvm-tools
 RUN cargo install --locked sccache
 ENV SCCACHE_IDLE_TIMEOUT=1800
-ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
+# ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
 
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-aarch_64.zip \
     && unzip protoc-21.12-linux-aarch_64.zip -d protoc \

--- a/deploy/build/Dockerfile.sccache.amd64
+++ b/deploy/build/Dockerfile.sccache.amd64
@@ -6,7 +6,7 @@ RUN rustup target add x86_64-unknown-linux-gnu
 RUN rustup component add rustfmt clippy llvm-tools
 RUN cargo install --locked sccache
 ENV SCCACHE_IDLE_TIMEOUT=1800
-ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
+# ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
 
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip \
     && unzip protoc-21.12-linux-x86_64.zip -d protoc \


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Disable `sccache` as Rust compiler wrapper

- Keep `sccache` installed for optional use


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker build images"] 
  B["sccache installed"]
  C["RUSTC_WRAPPER disabled"]
  D["Rust builds run without wrapper"]
  A -- "includes" --> B
  A -- "comments out" --> C
  C -- "results in" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.sccache.aarch64</strong><dd><code>Disable sccache wrapper for aarch64 builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deploy/build/Dockerfile.sccache.aarch64

<ul><li>Comment out <code>ENV RUSTC_WRAPPER</code> setting<br> <li> Retain <code>sccache</code> install and timeout config</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10392/files#diff-29bd379faa768633438c185ed7dcd69c2614a5c70f9ee4a6a9bf68291573c6d9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.sccache.amd64</strong><dd><code>Disable sccache wrapper for amd64 builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deploy/build/Dockerfile.sccache.amd64

<ul><li>Comment out <code>ENV RUSTC_WRAPPER</code> setting<br> <li> Retain <code>sccache</code> install and timeout config</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10392/files#diff-69f0b75646e9deaa4458c7dd6eec2b239eef8bacffaad4ec3c5ef65fef2ee31d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

