### PR TITLE
fix: router follows redirects

### DIFF
--- a/src/service/tls/mod.rs
+++ b/src/service/tls/mod.rs
@@ -20,7 +20,6 @@ use std::{
 };
 
 use itertools::Itertools;
-use reqwest::redirect::Policy;
 use rustls_pemfile::{certs, private_key};
 use x509_parser::prelude::*;
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Disable outgoing HTTP redirect following

- Prevent router from auto-following redirects

- Add redirect policy to reqwest client


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Router reqwest client builder"]
  B["Redirect policy: none()"]
  C["No automatic redirect following"]
  A -- "configure" --> B
  B -- "enforces" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Disable redirects for reqwest client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/tls/mod.rs

<ul><li>Add <code>reqwest::redirect::Policy</code> import<br> <li> Configure client with <code>.redirect(Policy::none())</code><br> <li> Prevent automatic redirect following in routing</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10397/files#diff-5061e662a8899b7e00e5744bd72f808b28ac479a8921ac519f7409bffdc4438a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

