### PR TITLE
fix: query cache sync from main

### DIFF
--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 OpenObserve Inc.
+// Copyright 2026 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -558,7 +558,11 @@ pub async fn prepare_cache_response(
     }
 
     // calculate hash for the query with version (after normalizing histogram interval)
-    let mut hash_body = vec![CACHE_VERSION.to_string(), origin_sql.to_string()];
+    let mut hash_body = vec![
+        CACHE_VERSION.to_string(),
+        origin_sql.to_string(),
+        req.query.size.to_string(),
+    ];
     if let Some(vrl_function) = &query_fn {
         hash_body.push(vrl_function.to_string());
     }

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 OpenObserve Inc.
+// Copyright 2026 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -613,7 +613,7 @@ pub async fn search_partition(
     skip_max_query_range: bool,
     is_http_req: bool,
     enable_align_histogram: bool,
-    use_aggs_cache: bool,
+    use_cache: bool,
 ) -> Result<search::SearchPartitionResponse, Error> {
     let start = std::time::Instant::now();
     let cfg = get_config();
@@ -903,12 +903,13 @@ pub async fn search_partition(
     }
 
     log::info!(
-        "[trace_id {trace_id}] search_partition: original_size: {}, cpu_cores: {}, base_speed: {}, partition_secs: {}, part_num: {}",
+        "[trace_id {trace_id}] search_partition: \
+        original_size: {}, cpu_cores: {cpu_cores}, base_speed: {}, \
+        partition_secs: {}, part_num: {part_num}, \
+        is_streaming_aggregate: {is_streaming_aggregate}, use_cache: {use_cache}",
         resp.original_size,
-        cpu_cores,
         cfg.limit.query_group_base_speed,
         cfg.limit.query_partition_by_secs,
-        part_num
     );
 
     // Calculate step with all constraints
@@ -1030,7 +1031,7 @@ pub async fn search_partition(
             );
 
             // Discover existing cache files for this query
-            let cache_discovery_result = if !use_aggs_cache {
+            let cache_discovery_result = if !use_cache {
                 o2_enterprise::enterprise::search::cache::streaming_agg::CacheDiscoveryResult::empty(
                     query.start_time,
                     query.end_time,

--- a/src/service/search/sql/mod.rs
+++ b/src/service/search/sql/mod.rs
@@ -240,6 +240,9 @@ impl Sql {
         let mut histogram_interval_visitor =
             HistogramIntervalVisitor::new(Some((query.start_time, query.end_time)));
         let _ = statement.visit(&mut histogram_interval_visitor);
+        if let Some(error) = histogram_interval_visitor.error {
+            return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(error)));
+        }
         let mut histogram_interval = if query.histogram_interval > 0 {
             Some(validate_and_adjust_histogram_interval(
                 query.histogram_interval,

--- a/src/service/search/sql/visitor/histogram_interval.rs
+++ b/src/service/search/sql/visitor/histogram_interval.rs
@@ -23,6 +23,7 @@ pub struct HistogramIntervalVisitor {
     pub is_histogram: bool,
     pub interval: Option<i64>,
     time_range: Option<(i64, i64)>,
+    pub error: Option<String>,
 }
 
 impl HistogramIntervalVisitor {
@@ -31,6 +32,7 @@ impl HistogramIntervalVisitor {
             is_histogram: false,
             interval: None,
             time_range,
+            error: None,
         }
     }
 }
@@ -49,10 +51,15 @@ impl VisitorMut for HistogramIntervalVisitor {
                 let _ = args.next();
                 // second is interval
                 let interval = if let Some(interval) = args.next() {
-                    interval
+                    let v = interval
                         .to_string()
                         .trim_matches(|v| v == '\'' || v == '"')
-                        .to_string()
+                        .to_string();
+                    if v.parse::<i64>().is_ok() {
+                        self.error = Some(format!("Invalid histogram interval: {v}"));
+                        return ControlFlow::Break(());
+                    }
+                    v
                 } else {
                     generate_histogram_interval(self.time_range).to_string()
                 };

--- a/src/service/search/streaming/cache.rs
+++ b/src/service/search/streaming/cache.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 OpenObserve Inc.
+// Copyright 2026 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -342,9 +342,15 @@ async fn send_cached_responses(
     is_result_array_skip_vrl: bool,
     backup_query_fn: Option<String>,
 ) -> Result<(), infra::errors::Error> {
-    log::info!("[HTTP2_STREAM]: Processing cached response for trace_id: {trace_id}");
+    log::info!(
+        "[HTTP2_STREAM]: Processing cached response for trace_id: {trace_id}, cache_order_by: {cache_order_by:?}, fallback_order_by_col: {fallback_order_by_col:?}"
+    );
 
     let mut cached = cached.clone();
+    cached.cached_response.trace_id = trace_id.to_string();
+    if cached.cached_response.order_by.is_none() && fallback_order_by_col.is_none() {
+        cached.cached_response.order_by = Some(*cache_order_by);
+    }
 
     // add cache hits to `curr_res_size`
     *curr_res_size += cached.cached_response.hits.len() as i64;


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Include `size` in query cache key

- Rework multi-cache delta gap calculation

- Validate SQL histogram interval parsing errors

- Improve streaming cached response ordering metadata


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Search request inputs"] --> B["Cache key hashing"]
  B -- "add req.query.size" --> C["Cache lookup correctness"]
  A --> D["Cached ranges"]
  D -- "sort + compute gaps" --> E["Query deltas"]
  A --> F["SQL histogram interval visitor"]
  F -- "surface parsing error" --> G["Fail fast invalid SQL"]
  D --> H["Streaming cached response"]
  H -- "set trace_id/order_by fallback" --> I["Consistent streamed ordering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cacher.rs</strong><dd><code>Fix multi-cache delta calculation and ordering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/cacher.rs

<ul><li>Pass <code>is_aggregate</code> and <code>is_descending</code> into delta logic<br> <li> Sort cached results by <code>response_end_time</code> descending<br> <li> Recompute gaps using <code>calculate_deltas</code> helper<br> <li> Add test call arguments for new signature</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10402/files#diff-8c387b22b2c0a282600ee41ca702b3db60f5a284d507c0feb7418608ff062c6c">+39/-39</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add query size into cache hash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/cache/mod.rs

<ul><li>Extend <code>hash_body</code> to include <code>req.query.size</code><br> <li> Reduce cache collisions across different sizes</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10402/files#diff-f07bfacc0501b9c234e64b16c1dd8eb0ae8fcbe231f90c81fed72bcc94946f74">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>histogram_interval.rs</strong><dd><code>Add error field for histogram interval parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/sql/visitor/histogram_interval.rs

<ul><li>Track parsing failures via new <code>error: Option<String></code><br> <li> Break AST traversal early on invalid interval<br> <li> Store a formatted invalid-interval message</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10402/files#diff-0442907b4d8a3b5c4bd9553fd5475c3044fe74a2853cda8e4017bf295d714b4b">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Rename cache toggle and improve logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/mod.rs

<ul><li>Rename <code>use_aggs_cache</code> parameter to <code>use_cache</code><br> <li> Log <code>use_cache</code> and streaming aggregate flags<br> <li> Use <code>use_cache</code> gate for cache discovery</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10402/files#diff-c3b85ea662a885fbd39797968928b291cb59a58f53a03f7b7dfd7ba8b6a7985a">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cache.rs</strong><dd><code>Set trace_id and order_by for cached streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/streaming/cache.rs

<ul><li>Expand log context with order-by details<br> <li> Copy <code>trace_id</code> into <code>cached_response</code><br> <li> Set <code>order_by</code> fallback when missing</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10402/files#diff-55769b7cb67b550daf45363c6d7d569b39d4a6235f6a68c091beb40f16b6511e">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Propagate histogram interval visitor errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/service/search/sql/mod.rs

<ul><li>Return <code>SearchSQLNotValid</code> when visitor reports error<br> <li> Prevent continuing with invalid histogram interval SQL</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10402/files#diff-dc0ab53d0ff551cf3cd12027c73d0da5e66680c0bf2d1830778639a33bac3464">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

