### PR TITLE
fix: query cache sync from main

### DIFF
--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -17,7 +17,7 @@ use bytes::Bytes;
 use config::{
     TIMESTAMP_COL_NAME,
     meta::{search::Response, sql::OrderBy, stream::StreamType},
-    utils::{file::scan_files, json, time::now_micros},
+    utils::{file::scan_files, json},
 };
 use infra::cache::{
     file_data::disk::{self, QUERY_RESULT_CACHE},
@@ -25,7 +25,6 @@ use infra::cache::{
 };
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::search::cache::streaming_agg::STREAMING_AGGS_CACHE_DIR;
-use proto::cluster_rpc::SearchQuery;
 
 use crate::{
     common::meta::search::{
@@ -36,10 +35,7 @@ use crate::{
             MultiCachedQueryResponse,
             result_utils::{get_ts_value, has_non_timestamp_ordering, is_timestamp_field},
         },
-        sql::{
-            RE_HISTOGRAM, RE_SELECT_FROM, Sql,
-            visitor::histogram_interval::generate_histogram_interval,
-        },
+        sql::{RE_HISTOGRAM, Sql, visitor::histogram_interval::generate_histogram_interval},
     },
 };
 
@@ -88,31 +84,23 @@ pub async fn invalidate_cached_response_by_stream_min_ts(
 pub async fn check_cache(
     trace_id: &str,
     org_id: &str,
-    stream_type: StreamType,
     req: &mut config::meta::search::Request,
-    origin_sql: &mut String,
-    file_path: &mut String,
+    origin_sql: &mut str,
+    file_path: &str,
     is_aggregate: bool,
+    sql: &Sql,
+    result_ts_col: &str,
+    is_descending: bool,
     should_exec_query: &mut bool,
 ) -> MultiCachedQueryResponse {
     let start = std::time::Instant::now();
 
-    let query: SearchQuery = req.query.clone().into();
-    let sql = match Sql::new(&query, org_id, stream_type, req.search_type).await {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!("Error parsing sql: {e}");
-            return MultiCachedQueryResponse::default();
-        }
-    };
+    let order_by = &sql.order_by;
 
     // skip the queries with no timestamp column
-    let ts_result = get_ts_col_order_by(&sql, TIMESTAMP_COL_NAME, is_aggregate);
-    let order_by = sql.order_by;
-    let mut result_ts_col = ts_result.map(|(ts_col, _)| ts_col);
-    if result_ts_col.is_none() && (is_aggregate || !sql.group_by.is_empty()) {
+    if result_ts_col.is_empty() && (is_aggregate || !sql.group_by.is_empty()) {
         return MultiCachedQueryResponse {
-            order_by,
+            order_by: order_by.clone(),
             ..Default::default()
         };
     }
@@ -127,82 +115,39 @@ pub async fn check_cache(
         || (!order_by.is_empty()
             && order_by.first().as_ref().unwrap().0 != TIMESTAMP_COL_NAME
             && !is_histogram_query
-            && (result_ts_col.is_none()
-                || (result_ts_col.is_some()
-                    && result_ts_col.as_ref().unwrap() != &order_by.first().as_ref().unwrap().0)))
+            && !result_ts_col.is_empty()
+            && result_ts_col != order_by.first().as_ref().unwrap().0)
     {
         return MultiCachedQueryResponse {
-            order_by,
+            order_by: order_by.clone(),
             ..Default::default()
         };
     }
 
-    // Hack select for _timestamp
-    if !is_aggregate && sql.group_by.is_empty() && order_by.is_empty() && !origin_sql.contains('*')
-    {
-        let caps = RE_SELECT_FROM.captures(origin_sql.as_str()).unwrap();
-        let cap_str = caps.get(1).unwrap().as_str();
-        if !cap_str.contains(TIMESTAMP_COL_NAME) {
-            *origin_sql =
-                origin_sql.replacen(cap_str, &format!("{TIMESTAMP_COL_NAME},{cap_str}"), 1);
-        }
-        req.query.sql = origin_sql.clone();
-        result_ts_col = Some(TIMESTAMP_COL_NAME.to_string());
-    }
-    if !is_aggregate && origin_sql.contains('*') {
-        result_ts_col = Some(TIMESTAMP_COL_NAME.to_string());
-    }
+    // Note: Both result_ts_col refinement and SQL modification (adding _timestamp to SELECT)
+    // are now done in prepare_cache_response() before calling this function.
+    // just use the refined result_ts_col that was passed in.
 
-    // Check ts_col again, if it is still None, return default
-    let Some(result_ts_col) = result_ts_col else {
+    // Check ts_col again, if it is still empty, return default
+    if result_ts_col.is_empty() {
         return MultiCachedQueryResponse {
-            order_by,
+            order_by: order_by.clone(),
             ..Default::default()
         };
-    };
+    }
 
     let mut histogram_interval = -1;
     if is_aggregate && let Some(interval) = sql.histogram_interval {
-        *file_path = format!("{file_path}_{interval}_{result_ts_col}");
-
-        let mut req_time_range = (req.query.start_time, req.query.end_time);
-        if req_time_range.1 == 0 {
-            req_time_range.1 = now_micros();
-        }
-
-        let meta_time_range_is_empty = sql.time_range.is_none() || sql.time_range == Some((0, 0));
-        let q_time_range =
-            if meta_time_range_is_empty && (req_time_range.0 > 0 || req_time_range.1 > 0) {
-                Some(req_time_range)
-            } else {
-                sql.time_range
-            };
-        handle_histogram(origin_sql, q_time_range, req.query.histogram_interval);
-        req.query.sql = origin_sql.clone();
+        // Note: handle_histogram is now called in prepare_cache_response() before hash computation
+        // to ensure consistent hashing. We just need to update req.query.sql with the normalized
+        // SQL.
+        req.query.sql = origin_sql.to_owned();
         histogram_interval = interval * 1000 * 1000; // in microseconds
     }
 
-    let mut is_descending = true;
+    // Note: is_descending refinement for histogram queries is now done in prepare_cache_response()
+    // before calling this function, so we use the pre-refined value directly
 
-    if !order_by.is_empty() {
-        // For histogram queries, if ORDER BY is not on the histogram/timestamp column,
-        // we should still cache based on the histogram's inherent time ordering
-        // Check if any order_by field matches the result_ts_col
-        let mut found_ts_order = false;
-        for (field, order) in &order_by {
-            if is_timestamp_field(field, &result_ts_col) {
-                is_descending = order == &OrderBy::Desc;
-                found_ts_order = true;
-                break;
-            }
-        }
-
-        // For histogram queries ordered by non-timestamp columns (e.g., ORDER BY count),
-        // use ascending as default
-        if !found_ts_order && is_histogram_query {
-            is_descending = false;
-        }
-    }
     if is_aggregate && order_by.is_empty() && result_ts_col.is_empty() {
         return MultiCachedQueryResponse::default();
     }
@@ -212,7 +157,7 @@ pub async fn check_cache(
     // requiring us to scan all hits to find the actual time range.
     let is_histogram_non_ts_order = is_histogram_query
         && !order_by.is_empty()
-        && has_non_timestamp_ordering(&order_by, &result_ts_col);
+        && has_non_timestamp_ordering(order_by, result_ts_col);
 
     let mut multi_resp = MultiCachedQueryResponse {
         trace_id: trace_id.to_string(),
@@ -239,7 +184,7 @@ pub async fn check_cache(
                 q_start_time: req.query.start_time,
                 q_end_time: req.query.end_time,
                 is_aggregate,
-                ts_column: result_ts_col.clone(),
+                ts_column: result_ts_col.to_string(),
                 histogram_interval,
                 is_descending,
                 is_histogram_non_ts_order,
@@ -269,6 +214,8 @@ pub async fn check_cache(
             &cached_responses,
             req.query.start_time,
             req.query.end_time,
+            is_aggregate,
+            is_descending,
             histogram_interval,
         );
         multi_resp.total_cache_duration = cache_duration as usize;
@@ -301,11 +248,11 @@ pub async fn check_cache(
             }
         }
         multi_resp.cache_query_response = true;
-        multi_resp.limit = sql.limit as i64;
-        multi_resp.ts_column = result_ts_col;
+        multi_resp.limit = sql.limit;
+        multi_resp.ts_column = result_ts_col.to_string();
         multi_resp.took = start.elapsed().as_millis() as usize;
         multi_resp.file_path = file_path.to_string();
-        multi_resp.order_by = order_by;
+        multi_resp.order_by = order_by.clone();
         multi_resp.is_aggregate = is_aggregate;
         multi_resp
     } else {
@@ -316,7 +263,7 @@ pub async fn check_cache(
                 q_start_time: req.query.start_time,
                 q_end_time: req.query.end_time,
                 is_aggregate,
-                ts_column: result_ts_col.clone(),
+                ts_column: result_ts_col.to_string(),
                 histogram_interval,
                 is_descending,
                 is_histogram_non_ts_order,
@@ -398,10 +345,10 @@ pub async fn check_cache(
         }
         multi_resp.took = start.elapsed().as_millis() as usize;
         multi_resp.cache_query_response = true;
-        multi_resp.limit = sql.limit as i64;
-        multi_resp.ts_column = result_ts_col;
+        multi_resp.limit = sql.limit;
+        multi_resp.ts_column = result_ts_col.to_string();
         multi_resp.file_path = file_path.to_string();
-        multi_resp.order_by = order_by;
+        multi_resp.order_by = order_by.clone();
         multi_resp.is_aggregate = is_aggregate;
         multi_resp
     }
@@ -684,6 +631,77 @@ pub fn get_ts_col_order_by(
     }
 }
 
+/// Computes the cache file path based on query metadata and histogram information.
+/// This function ensures consistent file path generation across different code paths.
+///
+/// # Arguments
+/// * `base_path` - The base path format: "{org_id}/{stream_type}/{stream_name}/{hashed_query}"
+/// * `is_aggregate` - Whether the query is an aggregate query
+/// * `histogram_interval` - Optional histogram interval from the SQL query
+/// * `ts_column` - The timestamp column name
+///
+/// # Returns
+/// The complete file path with histogram information appended if applicable
+pub fn compute_cache_file_path(
+    base_path: &str,
+    is_aggregate: bool,
+    histogram_interval: Option<i64>,
+    ts_column: &str,
+) -> String {
+    let mut file_path = base_path.to_string();
+
+    // For histogram queries, append interval and ts_column to file_path
+    if is_aggregate && let Some(interval) = histogram_interval {
+        file_path = format!("{file_path}_{interval}_{ts_column}");
+    }
+
+    file_path
+}
+
+/// Refines is_descending for histogram queries with non-timestamp ORDER BY.
+///
+/// For histogram queries, if ORDER BY is not on the timestamp column,
+/// we use ascending as the default for cache operations.
+///
+/// # Arguments
+/// * `sql` - Parsed SQL query
+/// * `ts_column` - The timestamp column name
+/// * `initial_is_descending` - The initial is_descending value from ORDER BY
+///
+/// # Returns
+/// Refined is_descending value
+pub fn refine_is_descending_for_histogram(
+    sql: &Sql,
+    ts_column: &str,
+    initial_is_descending: bool,
+) -> bool {
+    let is_histogram_query = sql.histogram_interval.is_some();
+
+    if !is_histogram_query || sql.order_by.is_empty() {
+        return initial_is_descending;
+    }
+
+    // Check if ORDER BY includes the timestamp column
+    let mut found_ts_order = false;
+    let mut refined_is_descending = initial_is_descending;
+
+    for (field, order) in &sql.order_by {
+        if is_timestamp_field(field, ts_column) {
+            refined_is_descending = order == &OrderBy::Desc;
+            found_ts_order = true;
+            break;
+        }
+    }
+
+    // For histogram queries ordered by non-timestamp columns (e.g., ORDER BY count),
+    // use ascending as default
+    if !found_ts_order {
+        refined_is_descending = false;
+    }
+
+    refined_is_descending
+}
+
 enum DeletionCriteria {
     TimeRange(i64, i64),
     ThresholdTimestamp(i64),
@@ -887,53 +905,51 @@ fn calculate_deltas_multi(
     results: &[CachedQueryResponse],
     start_time: i64,
     end_time: i64,
+    is_aggregate: bool,
+    is_descending: bool,
     histogram_interval: i64,
 ) -> (Vec<QueryDelta>, Option<i64>, i64) {
     let mut deltas = Vec::new();
     let mut cache_duration = 0_i64;
 
-    let mut current_end_time = start_time;
+    let mut current_start_time = end_time;
+    let mut current_end_time = end_time;
 
+    // sort the results by response end time descending
+    let mut results = results.to_vec();
+    results.sort_by(|a, b| b.response_end_time.cmp(&a.response_end_time));
     for meta in results {
         cache_duration += meta.response_end_time - meta.response_start_time;
-        let delta_end_time = if histogram_interval > 0 && !meta.cached_response.hits.is_empty() {
-            // If histogram interval > 0, we need to adjust the end time to the nearest interval
-            let mut end_time = meta.response_start_time;
-            if end_time % histogram_interval != 0 {
-                end_time = end_time - (end_time % histogram_interval);
-                if end_time < start_time {
-                    end_time = start_time;
-                }
-            }
-            end_time
-        } else {
-            meta.response_start_time
-        };
-        if meta.response_start_time > current_end_time {
-            // There is a gap (delta) between current coverage and the next meta
-            deltas.push(QueryDelta {
-                delta_start_time: current_end_time,
-                delta_end_time,
-            });
-        }
-        // Update the current end time to the end of the current meta
-        current_end_time = meta.response_end_time;
+        current_start_time = meta.response_start_time;
+        calculate_deltas(
+            &ResultCacheMeta {
+                start_time: meta.response_start_time,
+                end_time: meta.response_end_time,
+                is_aggregate,
+                is_descending,
+            },
+            current_start_time,
+            current_end_time,
+            histogram_interval,
+            &mut deltas,
+        );
+        current_end_time = current_start_time;
     }
 
-    // Check if there is a gap at the end
-    if current_end_time < end_time
-        && results
-            .last()
-            .is_some_and(|last_meta| !last_meta.cached_response.hits.is_empty())
-    {
-        let mut expected_delta_start_time = current_end_time;
-        if expected_delta_start_time > end_time {
-            expected_delta_start_time = current_end_time;
-        }
-        deltas.push(QueryDelta {
-            delta_start_time: expected_delta_start_time,
-            delta_end_time: end_time,
-        });
+    // Check if there is a gap at the start
+    if current_start_time > start_time {
+        calculate_deltas(
+            &ResultCacheMeta {
+                start_time: current_start_time,
+                end_time: current_end_time,
+                is_aggregate,
+                is_descending,
+            },
+            start_time,
+            current_end_time,
+            histogram_interval,
+            &mut deltas,
+        );
     }
 
     deltas.sort(); // Sort the deltas to bring duplicates together
@@ -947,12 +963,16 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_schema::{Field, Schema};
-    use config::meta::{
-        search::{Query, Request, RequestEncoding, Response, ResponseTook, SearchEventType},
-        sql::OrderBy,
+    use config::{
+        meta::{
+            search::{Query, Request, RequestEncoding, Response, ResponseTook, SearchEventType},
+            sql::OrderBy,
+        },
+        utils::time::now_micros,
     };
     use datafusion::common::TableReference;
     use infra::schema::{STREAM_SCHEMAS_LATEST, SchemaCache};
+    use proto::cluster_rpc::SearchQuery;
 
     use super::*;
     use crate::{common::meta::search::CachedQueryResponse, service::search::Sql};
@@ -1016,6 +1036,8 @@ mod tests {
             &[cached_response],
             query_start_time,
             query_end_time,
+            true,
+            false,
             histogram_interval,
         );
         println!("Deltas: {deltas:?}");
@@ -1232,18 +1254,28 @@ mod tests {
             local_mode: None,
         };
         let mut origin_sql = req.query.sql.clone();
-        let mut file_path = "test_org/logs/test_stream".to_string();
+        let file_path = "test_org/logs/test_stream".to_string();
         let is_aggregate = false;
         let mut should_exec_query = true;
+
+        // Parse SQL to get metadata (new signature requires this)
+        let query: SearchQuery = req.query.clone().into();
+        let sql = Sql::new(&query, org_id, stream_type, req.search_type)
+            .await
+            .unwrap();
+        let (result_ts_col, is_descending) =
+            get_ts_col_order_by(&sql, TIMESTAMP_COL_NAME, is_aggregate).unwrap_or_default();
 
         let result = check_cache(
             trace_id,
             org_id,
-            stream_type,
             &mut req,
             &mut origin_sql,
-            &mut file_path,
+            &file_path,
             is_aggregate,
+            &sql,
+            &result_ts_col,
+            is_descending,
             &mut should_exec_query,
         )
         .await;

--- a/src/service/search/cache/mod.rs
+++ b/src/service/search/cache/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 OpenObserve Inc.
+// Copyright 2026 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -35,7 +35,7 @@ use config::{
         hash::Sum64,
         json,
         sql::{is_aggregate_query, is_eligible_for_histogram},
-        time::{format_duration, second_micros},
+        time::{format_duration, now_micros, second_micros},
     },
 };
 use infra::{
@@ -59,6 +59,7 @@ use crate::{
             cache::{cacher::check_cache, result_utils::extract_timestamp_range},
             init_vrl_runtime,
             inspector::{SearchInspectorFieldsBuilder, search_inspector_fields},
+            sql::RE_SELECT_FROM,
         },
         self_reporting::{http_report_metrics, report_request_usage_stats},
     },
@@ -69,7 +70,7 @@ pub mod multi;
 pub mod result_utils;
 
 // Define cache version
-const CACHE_VERSION: &str = "v2";
+const CACHE_VERSION: &str = "v3";
 
 #[tracing::instrument(name = "service:search:cacher:search", skip_all)]
 #[allow(clippy::too_many_arguments)]
@@ -525,8 +526,43 @@ pub async fn prepare_cache_response(
         .as_ref()
         .and_then(|v| svix_ksuid::Ksuid::from_str(v).ok());
 
-    // calculate hash for the query with version
-    let mut hash_body = vec![CACHE_VERSION.to_string(), origin_sql.to_string()];
+    // Parse SQL first to get metadata needed for normalization
+    let query: SearchQuery = req.query.clone().into();
+    let sql = match crate::service::search::Sql::new(&query, org_id, stream_type, req.search_type)
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!("Error parsing sql: {e}");
+            return Ok((MultiCachedQueryResponse::default(), true));
+        }
+    };
+
+    // Normalize histogram interval in SQL before computing hash
+    // This ensures the hash is consistent regardless of when handle_histogram is called
+    if is_aggregate && sql.histogram_interval.is_some() {
+        let mut req_time_range = (req.query.start_time, req.query.end_time);
+        // If end_time is 0, it means "now" (current time)
+        if req_time_range.1 == 0 {
+            req_time_range.1 = now_micros();
+        }
+
+        let meta_time_range_is_empty = sql.time_range.is_none() || sql.time_range == Some((0, 0));
+        let q_time_range =
+            if meta_time_range_is_empty && (req_time_range.0 > 0 || req_time_range.1 > 0) {
+                Some(req_time_range)
+            } else {
+                sql.time_range
+            };
+        cacher::handle_histogram(&mut origin_sql, q_time_range, req.query.histogram_interval);
+    }
+
+    // calculate hash for the query with version (after normalizing histogram interval)
+    let mut hash_body = vec![
+        CACHE_VERSION.to_string(),
+        origin_sql.to_string(),
+        req.query.size.to_string(),
+    ];
     if let Some(vrl_function) = &query_fn {
         hash_body.push(vrl_function.to_string());
     }
@@ -542,51 +578,69 @@ pub async fn prepare_cache_response(
     let mut h = config::utils::hash::gxhash::new();
     let hashed_query = h.sum64(&hash_body.join(","));
 
+    let (mut ts_column, mut is_descending) =
+        cacher::get_ts_col_order_by(&sql, TIMESTAMP_COL_NAME, is_aggregate).unwrap_or_default();
+
+    // Refine ts_column for non-aggregate queries with SELECT * or missing _timestamp
+    // Also modify the SQL to add _timestamp to SELECT clause if missing
+    if !is_aggregate && origin_sql.contains('*') {
+        ts_column = TIMESTAMP_COL_NAME.to_string();
+    } else if !is_aggregate
+        && sql.group_by.is_empty()
+        && sql.order_by.is_empty()
+        && !origin_sql.contains('*')
+        && let Some(caps) = RE_SELECT_FROM.captures(&origin_sql)
+        && let Some(cap) = caps.get(1)
+    {
+        let cap_str = cap.as_str();
+        if !cap_str.contains(TIMESTAMP_COL_NAME) {
+            // Add _timestamp to SELECT clause
+            origin_sql =
+                origin_sql.replacen(cap_str, &format!("{TIMESTAMP_COL_NAME},{cap_str}"), 1);
+            req.query.sql = origin_sql.clone();
+            ts_column = TIMESTAMP_COL_NAME.to_string();
+        }
+    }
+
+    // Refine is_descending for histogram queries with non-timestamp ORDER BY
+    is_descending = cacher::refine_is_descending_for_histogram(&sql, &ts_column, is_descending);
+
+    // Compute the complete file path once for both branches
+    let base_file_path = format!("{org_id}/{stream_type}/{stream_name}/{hashed_query}");
+    let file_path = cacher::compute_cache_file_path(
+        &base_file_path,
+        is_aggregate,
+        sql.histogram_interval,
+        &ts_column,
+    );
+
     let mut should_exec_query = true;
 
-    let mut file_path = format!("{org_id}/{stream_type}/{stream_name}/{hashed_query}");
     let resp = if use_cache {
         // if cache is used, we need to check the cache
         check_cache(
             trace_id,
             org_id,
-            stream_type,
             req,
             &mut origin_sql,
-            &mut file_path,
+            &file_path,
             is_aggregate,
+            &sql,
+            &ts_column,
+            is_descending,
             &mut should_exec_query,
         )
         .await
     } else {
-        // if cache is not used, we need to parse the sql to get the ts column and is descending
-        let query: SearchQuery = req.query.clone().into();
-        match crate::service::search::Sql::new(&query, org_id, stream_type, req.search_type).await {
-            Ok(v) => {
-                let (ts_column, is_descending) =
-                    cacher::get_ts_col_order_by(&v, TIMESTAMP_COL_NAME, is_aggregate)
-                        .unwrap_or_default();
-
-                // For histogram queries, append interval and ts_column to file_path
-                // This matches the logic in check_cache function
-                if is_aggregate && let Some(interval) = v.histogram_interval {
-                    file_path = format!("{file_path}_{interval}_{ts_column}");
-                }
-
-                MultiCachedQueryResponse {
-                    ts_column,
-                    is_aggregate,
-                    is_descending,
-                    order_by: v.order_by,
-                    limit: v.limit,
-                    file_path: file_path.clone(),
-                    ..Default::default()
-                }
-            }
-            Err(e) => {
-                log::error!("Error parsing sql: {e}");
-                MultiCachedQueryResponse::default()
-            }
+        // if cache is not used, return the parsed metadata
+        MultiCachedQueryResponse {
+            ts_column,
+            is_aggregate,
+            is_descending,
+            order_by: sql.order_by,
+            limit: sql.limit,
+            file_path,
+            ..Default::default()
         }
     };
     Ok((resp, should_exec_query))

--- a/src/service/search/cache/result_utils.rs
+++ b/src/service/search/cache/result_utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 OpenObserve Inc.
+// Copyright 2026 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -20,9 +20,9 @@ pub fn get_ts_value(ts_column: &str, record: &json::Value) -> i64 {
         None => 0_i64,
         Some(ts) => match ts {
             serde_json::Value::String(ts) => {
-                parse_str_to_timestamp_micros_as_option(ts.as_str()).unwrap()
+                parse_str_to_timestamp_micros_as_option(ts.as_str()).unwrap_or(0)
             }
-            serde_json::Value::Number(ts) => ts.as_i64().unwrap(),
+            serde_json::Value::Number(ts) => ts.as_i64().unwrap_or(0),
             _ => 0_i64,
         },
     }

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 OpenObserve Inc.
+// Copyright 2026 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -612,7 +612,7 @@ pub async fn search_partition(
     skip_max_query_range: bool,
     is_http_req: bool,
     enable_align_histogram: bool,
-    use_aggs_cache: bool,
+    use_cache: bool,
 ) -> Result<search::SearchPartitionResponse, Error> {
     let start = std::time::Instant::now();
     let cfg = get_config();
@@ -902,12 +902,13 @@ pub async fn search_partition(
     }
 
     log::info!(
-        "[trace_id {trace_id}] search_partition: original_size: {}, cpu_cores: {}, base_speed: {}, partition_secs: {}, part_num: {}",
+        "[trace_id {trace_id}] search_partition: \
+        original_size: {}, cpu_cores: {cpu_cores}, base_speed: {}, \
+        partition_secs: {}, part_num: {part_num}, \
+        is_streaming_aggregate: {is_streaming_aggregate}, use_cache: {use_cache}",
         resp.original_size,
-        cpu_cores,
         cfg.limit.query_group_base_speed,
         cfg.limit.query_partition_by_secs,
-        part_num
     );
 
     // Calculate step with all constraints
@@ -1029,7 +1030,7 @@ pub async fn search_partition(
             );
 
             // Discover existing cache files for this query
-            let cache_discovery_result = if !use_aggs_cache {
+            let cache_discovery_result = if !use_cache {
                 o2_enterprise::enterprise::search::cache::streaming_agg::CacheDiscoveryResult::empty(
                     query.start_time,
                     query.end_time,

--- a/src/service/search/sql/mod.rs
+++ b/src/service/search/sql/mod.rs
@@ -240,6 +240,9 @@ impl Sql {
         let mut histogram_interval_visitor =
             HistogramIntervalVisitor::new(Some((query.start_time, query.end_time)));
         let _ = statement.visit(&mut histogram_interval_visitor);
+        if let Some(error) = histogram_interval_visitor.error {
+            return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(error)));
+        }
         let mut histogram_interval = if query.histogram_interval > 0 {
             Some(validate_and_adjust_histogram_interval(
                 query.histogram_interval,

--- a/src/service/search/sql/visitor/histogram_interval.rs
+++ b/src/service/search/sql/visitor/histogram_interval.rs
@@ -23,6 +23,7 @@ pub struct HistogramIntervalVisitor {
     pub is_histogram: bool,
     pub interval: Option<i64>,
     time_range: Option<(i64, i64)>,
+    pub error: Option<String>,
 }
 
 impl HistogramIntervalVisitor {
@@ -31,6 +32,7 @@ impl HistogramIntervalVisitor {
             is_histogram: false,
             interval: None,
             time_range,
+            error: None,
         }
     }
 }
@@ -49,10 +51,15 @@ impl VisitorMut for HistogramIntervalVisitor {
                 let _ = args.next();
                 // second is interval
                 let interval = if let Some(interval) = args.next() {
-                    interval
+                    let v = interval
                         .to_string()
                         .trim_matches(|v| v == '\'' || v == '"')
-                        .to_string()
+                        .to_string();
+                    if v.parse::<i64>().is_ok() {
+                        self.error = Some(format!("Invalid histogram interval: {v}"));
+                        return ControlFlow::Break(());
+                    }
+                    v
                 } else {
                     generate_histogram_interval(self.time_range).to_string()
                 };

--- a/src/service/search/streaming/cache.rs
+++ b/src/service/search/streaming/cache.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 OpenObserve Inc.
+// Copyright 2026 OpenObserve Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -342,9 +342,15 @@ async fn send_cached_responses(
     is_result_array_skip_vrl: bool,
     backup_query_fn: Option<String>,
 ) -> Result<(), infra::errors::Error> {
-    log::info!("[HTTP2_STREAM]: Processing cached response for trace_id: {trace_id}");
+    log::info!(
+        "[HTTP2_STREAM]: Processing cached response for trace_id: {trace_id}, cache_order_by: {cache_order_by:?}, fallback_order_by_col: {fallback_order_by_col:?}"
+    );
 
     let mut cached = cached.clone();
+    cached.cached_response.trace_id = trace_id.to_string();
+    if cached.cached_response.order_by.is_none() && fallback_order_by_col.is_none() {
+        cached.cached_response.order_by = Some(*cache_order_by);
+    }
 
     // add cache hits to `curr_res_size`
     *curr_res_size += cached.cached_response.hits.len() as i64;


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Normalize histogram SQL before cache hashing

- Add deterministic cache path and ordering helpers

- Fix multi-cache delta calculation ordering

- Harden timestamp parsing and interval validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["prepare_cache_response()"] --> B["Normalize histogram SQL"]
  B --> C["Compute hash (v3 + size)"]
  C --> D["Compute cache file path"]
  D --> E["check_cache() uses precomputed metadata"]
  E --> F["Multi/single cache lookup + deltas"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>cacher.rs</strong><dd><code>Refactor cache checks and delta computation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10404/files#diff-8c387b22b2c0a282600ee41ca702b3db60f5a284d507c0feb7418608ff062c6c">+165/-133</a></td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Surface histogram interval visitor errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10404/files#diff-dc0ab53d0ff551cf3cd12027c73d0da5e66680c0bf2d1830778639a33bac3464">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cache.rs</strong><dd><code>Propagate trace_id and ensure order_by fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10404/files#diff-55769b7cb67b550daf45363c6d7d569b39d4a6235f6a68c091beb40f16b6511e">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Normalize SQL before hashing and bump version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10404/files#diff-f07bfacc0501b9c234e64b16c1dd8eb0ae8fcbe231f90c81fed72bcc94946f74">+90/-36</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>result_utils.rs</strong><dd><code>Make timestamp extraction resilient to bad values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10404/files#diff-fb601e2f37657029b6a4dcb82d16aeff5916e13660d284e7fb00db6002dc0f73">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>histogram_interval.rs</strong><dd><code>Track invalid histogram interval parsing as error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10404/files#diff-0442907b4d8a3b5c4bd9553fd5475c3044fe74a2853cda8e4017bf295d714b4b">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Rename cache flag and improve partition logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10404/files#diff-c3b85ea662a885fbd39797968928b291cb59a58f53a03f7b7dfd7ba8b6a7985a">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

