### PR TITLE
fix: enhance incidents UI and fix correlation field resolution (#10390)

### DIFF
--- a/web/src/components/alerts/IncidentDetailDrawer.vue
+++ b/web/src/components/alerts/IncidentDetailDrawer.vue
@@ -1216,7 +1216,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, computed, PropType, nextTick, onUnmounted } from "vue";
+import { defineComponent, ref, watch, computed, PropType, nextTick, onMounted, onBeforeUnmount, onUnmounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { useStore } from "vuex";
 import { useQuasar } from "quasar";
@@ -1597,71 +1597,86 @@ export default defineComponent({
         const streamType = firstAlert.stream_type || "logs";
         const streamName = firstAlert.stream_name || "default";
 
-        // Get stream schema
+        // Step 1: Get stream schema (like logs page does)
         const schemaResponse = await streamService.schema(org, streamName, streamType);
         const schema = schemaResponse.data;
 
-        // Get semantic groups
+        // Step 2: Extract schema fields (like logs page does)
+        // CRITICAL FIX: Use uds_schema (user-defined schema) if available!
+        // The logs page shows uds_schema fields in the left pane, NOT all schema fields
+        // uds_schema is the curated list of fields the user cares about
+        const schemaFieldsArray = (schema.uds_schema && schema.uds_schema.length > 0)
+          ? schema.uds_schema
+          : (schema.schema || schema.fields || []);
+        const schemaFields = new Set(schemaFieldsArray.map((f: any) => f.name));
+
+        console.log("[Fallback Correlation] Incident dimensions:", incident.stable_dimensions);
+        console.log("[Fallback Correlation] Using schema type:", schema.uds_schema && schema.uds_schema.length > 0 ? 'uds_schema (user-defined)' : 'schema (full)');
+        console.log("[Fallback Correlation] Total schema fields:", schemaFields.size);
+        console.log("[Fallback Correlation] Schema fields:", Array.from(schemaFields).filter(f => !f.startsWith('_')).slice(0, 30));
+
+        // Step 3: Get semantic groups to resolve dimension names to field patterns
         const semanticGroupsResponse = await serviceStreamsApi.getSemanticGroups(org);
         const semanticGroups = semanticGroupsResponse.data;
 
-        // Map incident dimensions to field names in schema
-        // Schema response has .schema array with {name, type} objects
-        const schemaFields = new Set(
-          (schema.schema || schema.fields || []).map((f: any) => f.name)
-        );
-
-        console.log("[Fallback Correlation] Incident dimensions:", incident.stable_dimensions);
-        console.log("[Fallback Correlation] Total schema fields:", schemaFields.size);
-        console.log("[Fallback Correlation] Sample schema fields:", Array.from(schemaFields).slice(0, 10));
-
         const filters: Record<string, string> = {};
 
+        // Step 4: For each dimension, find the matching schema field
         for (const [dimId, dimValue] of Object.entries(incident.stable_dimensions)) {
-          // Find semantic group
+          console.log(`[Fallback Correlation] Processing dimension: ${dimId} = ${dimValue}`);
+
+          let matchedField = null;
+
+          // Get semantic group
           const group = semanticGroups.find((g: any) => g.id === dimId);
 
-          console.log(`[Fallback Correlation] Processing ${dimId} = ${dimValue}`);
+          if (group && group.fields && group.fields.length > 0) {
+            console.log(`[Fallback Correlation] Semantic group fields for ${dimId}:`, group.fields);
+            console.log(`[Fallback Correlation] Checking which fields exist in schema...`);
 
-          if (!group) {
+            // Check each field from semantic group
+            for (const fieldName of group.fields) {
+              const existsInSchema = schemaFields.has(fieldName);
+              console.log(`  - ${fieldName}: ${existsInSchema ? '✅ EXISTS' : '❌ not in schema'}`);
+
+              if (existsInSchema && !matchedField) {
+                matchedField = fieldName;
+                // Don't break - keep logging all fields for debugging
+              }
+            }
+
+            if (matchedField) {
+              console.log(`[Fallback Correlation] ✅ Selected field from semantic group: ${matchedField}`);
+            }
+          } else {
             console.warn(`[Fallback Correlation] No semantic group found for: ${dimId}`);
-            continue;
           }
 
-          if (!group.fields || group.fields.length === 0) {
-            console.warn(`[Fallback Correlation] Semantic group ${dimId} has empty fields array`);
-            continue;
-          }
+          // Fallback: If semantic group didn't work, scan schema directly by pattern
+          if (!matchedField) {
+            console.warn(`[Fallback Correlation] Semantic group failed, scanning schema fields directly...`);
+            const dimParts = dimId.split('-');
+            console.log(`[Fallback Correlation] Looking for fields matching parts:`, dimParts);
 
-          console.log(`[Fallback Correlation] Trying field variants for ${dimId}:`, group.fields.slice(0, 5));
+            const schemaFieldsArray = Array.from(schemaFields).filter(f => !f.startsWith('_'));
+            for (const schemaField of schemaFieldsArray) {
+              const fieldLower = schemaField.toLowerCase();
+              const allPartsMatch = dimParts.every(part => fieldLower.includes(part.toLowerCase()));
 
-          // Collect ALL matching field names and pick the best one
-          const matchingFields = [];
-          for (const fieldName of group.fields) {
-            if (schemaFields.has(fieldName)) {
-              matchingFields.push(fieldName);
+              if (allPartsMatch) {
+                matchedField = schemaField;
+                console.log(`[Fallback Correlation] ✅ Found via pattern match: ${schemaField}`);
+                break;
+              }
             }
           }
 
-          if (matchingFields.length > 0) {
-            // Prefer shorter field names without prefixes
-            const bestField = matchingFields.sort((a, b) => {
-              // Penalize long prefixes
-              const aPenalty = a.startsWith('service_') ? 1000 :
-                               a.startsWith('resource_') ? 500 :
-                               a.startsWith('attributes_') ? 300 : 0;
-              const bPenalty = b.startsWith('service_') ? 1000 :
-                               b.startsWith('resource_') ? 500 :
-                               b.startsWith('attributes_') ? 300 : 0;
-
-              // Then by length (shorter = better)
-              return (a.length + aPenalty) - (b.length + bPenalty);
-            })[0];
-
-            filters[bestField] = dimValue;
-            console.log(`[Fallback Correlation] ✅ Mapped ${dimId} → ${bestField} = ${dimValue} (from ${matchingFields.length} options: ${matchingFields.slice(0, 3).join(', ')})`);
+          if (matchedField) {
+            filters[matchedField] = dimValue;
+            console.log(`[Fallback Correlation] ✅✅✅ FINAL: ${dimId} → ${matchedField} = ${dimValue}`);
           } else {
-            console.warn(`[Fallback Correlation] ❌ No matching field in schema for ${dimId}`);
+            console.error(`[Fallback Correlation] ❌❌❌ FAILED to find field for: ${dimId}`);
+            console.error(`[Fallback Correlation] Schema fields:`, Array.from(schemaFields).filter(f => !f.startsWith('_')).slice(0, 30));
           }
         }
 
@@ -2029,6 +2044,32 @@ export default defineComponent({
       });
     };
 
+    // Handle ESC key to close incident detail
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' || event.key === 'Esc') {
+        // Don't close if user is editing title
+        if (isEditingTitle.value) {
+          return;
+        }
+        // Don't close if there are any open dialogs/menus (they should handle ESC first)
+        const hasOpenDialog = document.querySelector('.q-dialog, .q-menu');
+        if (hasOpenDialog) {
+          return;
+        }
+        close();
+      }
+    };
+
+    // Add keyboard event listener on mount
+    onMounted(() => {
+      window.addEventListener('keydown', handleEscapeKey);
+    });
+
+    // Remove keyboard event listener on unmount
+    onBeforeUnmount(() => {
+      window.removeEventListener('keydown', handleEscapeKey);
+    });
+
     const updateStatus = async (newStatus: "open" | "acknowledged" | "resolved") => {
       if (!incidentDetails.value) return;
       updating.value = true;
@@ -2047,6 +2088,8 @@ export default defineComponent({
           type: "positive",
           message: t("alerts.incidents.statusUpdated"),
         });
+        // Mark data as stale so incident list will refresh when navigating back
+        store.dispatch('incidents/setShouldRefresh', true);
         emit("status-updated");
       } catch (error) {
         console.error("[UPDATE STATUS] Failed to update status:", error);
@@ -2109,6 +2152,8 @@ export default defineComponent({
           message: t("alerts.incidents.incidentTitleUpdatedSuccess"),
           timeout: 2000,
         });
+        // Mark data as stale so incident list will refresh
+        store.dispatch('incidents/setShouldRefresh', true);
       } catch (error: any) {
         console.error("Failed to update title:", error);
         $q.notify({
@@ -2267,6 +2312,8 @@ export default defineComponent({
           message: `Incident status updated to ${response.data.status}`,
           timeout: 2000,
         });
+        // Mark data as stale so incident list will refresh
+        store.dispatch('incidents/setShouldRefresh', true);
       } catch (error: any) {
         console.error("Failed to update status:", error);
         $q.notify({
@@ -2311,6 +2358,8 @@ export default defineComponent({
           message: `Incident severity updated to ${response.data.severity}`,
           timeout: 2000,
         });
+        // Mark data as stale so incident list will refresh
+        store.dispatch('incidents/setShouldRefresh', true);
       } catch (error: any) {
         console.error("Failed to update severity:", error);
         $q.notify({

--- a/web/src/components/alerts/IncidentList.spec.ts
+++ b/web/src/components/alerts/IncidentList.spec.ts
@@ -94,8 +94,10 @@ describe("IncidentList.vue", () => {
     // Reset incidents store state
     store.state.incidents = {
       incidents: {},
+      cachedData: [],
       pageBeforeSearch: 1,
-      isInitialized: false
+      isInitialized: false,
+      shouldRefresh: false
     };
 
     // Default mock implementation
@@ -590,23 +592,23 @@ describe("IncidentList.vue", () => {
     });
 
     it("should return correct color for open status", () => {
-      expect(wrapper.vm.getStatusColor("open")).toBe("negative");
+      expect(wrapper.vm.getStatusColorClass("open")).toBe("status-open");
     });
 
     it("should return correct color for acknowledged status", () => {
-      expect(wrapper.vm.getStatusColor("acknowledged")).toBe("warning");
+      expect(wrapper.vm.getStatusColorClass("acknowledged")).toBe("status-acknowledged");
     });
 
     it("should return correct color for resolved status", () => {
-      expect(wrapper.vm.getStatusColor("resolved")).toBe("positive");
+      expect(wrapper.vm.getStatusColorClass("resolved")).toBe("status-resolved");
     });
 
     it("should return grey for unknown status", () => {
-      expect(wrapper.vm.getStatusColor("unknown")).toBe("grey");
+      expect(wrapper.vm.getStatusColorClass("unknown")).toBe("status-default");
     });
 
     it("should handle empty status", () => {
-      expect(wrapper.vm.getStatusColor("")).toBe("grey");
+      expect(wrapper.vm.getStatusColorClass("")).toBe("status-default");
     });
   });
 
@@ -644,23 +646,23 @@ describe("IncidentList.vue", () => {
     });
 
     it("should return correct color for P1 severity", () => {
-      expect(wrapper.vm.getSeverityColor("P1")).toBe("red-10");
+      expect(wrapper.vm.getSeverityColorClass("P1")).toBe("severity-p1");
     });
 
     it("should return correct color for P2 severity", () => {
-      expect(wrapper.vm.getSeverityColor("P2")).toBe("orange-8");
+      expect(wrapper.vm.getSeverityColorClass("P2")).toBe("severity-p2");
     });
 
     it("should return correct color for P3 severity", () => {
-      expect(wrapper.vm.getSeverityColor("P3")).toBe("amber-8");
+      expect(wrapper.vm.getSeverityColorClass("P3")).toBe("severity-p3");
     });
 
     it("should return correct color for P4 severity", () => {
-      expect(wrapper.vm.getSeverityColor("P4")).toBe("grey-7");
+      expect(wrapper.vm.getSeverityColorClass("P4")).toBe("severity-p4");
     });
 
     it("should return grey for unknown severity", () => {
-      expect(wrapper.vm.getSeverityColor("unknown")).toBe("grey");
+      expect(wrapper.vm.getSeverityColorClass("unknown")).toBe("severity-default");
     });
   });
 
@@ -749,7 +751,7 @@ describe("IncidentList.vue", () => {
     });
 
     it("should have correct number of columns", () => {
-      expect(wrapper.vm.columns).toHaveLength(7);
+      expect(wrapper.vm.columns).toHaveLength(8);
     });
 
     it("should have status column with correct config", () => {
@@ -924,8 +926,10 @@ describe("IncidentList.vue", () => {
       // Reset incidents store state
       store.state.incidents = {
         incidents: {},
+        cachedData: [],
         pageBeforeSearch: 1,
-        isInitialized: false
+        isInitialized: false,
+        shouldRefresh: false
       };
     });
 
@@ -1037,8 +1041,10 @@ describe("IncidentList.vue", () => {
     beforeEach(async () => {
       store.state.incidents = {
         incidents: {},
+        cachedData: [],
         pageBeforeSearch: 1,
-        isInitialized: false
+        isInitialized: false,
+        shouldRefresh: false
       };
 
       (incidentsService.list as any).mockResolvedValue({
@@ -1142,8 +1148,10 @@ describe("IncidentList.vue", () => {
     beforeEach(async () => {
       store.state.incidents = {
         incidents: {},
+        cachedData: [],
         pageBeforeSearch: 1,
-        isInitialized: false
+        isInitialized: false,
+        shouldRefresh: false
       };
 
       (incidentsService.list as any).mockResolvedValue({
@@ -1206,8 +1214,10 @@ describe("IncidentList.vue", () => {
     beforeEach(() => {
       store.state.incidents = {
         incidents: {},
+        cachedData: [],
         pageBeforeSearch: 1,
-        isInitialized: false
+        isInitialized: false,
+        shouldRefresh: false
       };
     });
 
@@ -1271,8 +1281,10 @@ describe("IncidentList.vue", () => {
     beforeEach(() => {
       store.state.incidents = {
         incidents: {},
+        cachedData: [],
         pageBeforeSearch: 1,
-        isInitialized: false
+        isInitialized: false,
+        shouldRefresh: false
       };
 
       (incidentsService.list as any).mockResolvedValue({
@@ -1331,8 +1343,10 @@ describe("IncidentList.vue", () => {
     beforeEach(() => {
       store.state.incidents = {
         incidents: {},
+        cachedData: [],
         pageBeforeSearch: 1,
-        isInitialized: false
+        isInitialized: false,
+        shouldRefresh: false
       };
 
       (incidentsService.list as any).mockResolvedValue({
@@ -1426,8 +1440,10 @@ describe("IncidentList.vue", () => {
     beforeEach(() => {
       store.state.incidents = {
         incidents: {},
+        cachedData: [],
         pageBeforeSearch: 1,
-        isInitialized: false
+        isInitialized: false,
+        shouldRefresh: false
       };
     });
 
@@ -1534,8 +1550,10 @@ describe("IncidentList.vue", () => {
     beforeEach(() => {
       store.state.incidents = {
         incidents: {},
+        cachedData: [],
         pageBeforeSearch: 1,
-        isInitialized: false
+        isInitialized: false,
+        shouldRefresh: false
       };
     });
 
@@ -1621,8 +1639,10 @@ describe("IncidentList.vue", () => {
     beforeEach(() => {
       store.state.incidents = {
         incidents: {},
+        cachedData: [],
         pageBeforeSearch: 1,
-        isInitialized: false
+        isInitialized: false,
+        shouldRefresh: false
       };
     });
 

--- a/web/src/components/alerts/IncidentList.vue
+++ b/web/src/components/alerts/IncidentList.vue
@@ -24,7 +24,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             {{ t("alerts.incidents.title") }}
           </div>
 
-          <div class="tw:flex tw:items-center">
+          <div class="tw:flex tw:items-center tw:gap-2">
+            <q-btn
+              flat
+              round
+              :loading="loading"
+              @click="refreshIncidents"
+              data-test="incident-refresh-btn"
+              class="o2-secondary-button"
+            >
+             Refresh
+            </q-btn>
             <q-input
               v-model="searchQuery"
               dense
@@ -77,21 +87,58 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 {{ (pagination.page - 1) * pagination.rowsPerPage + props.pageIndex + 1 }}
               </template>
               <template v-else-if="col.name === 'status'">
-                <q-badge
-                  :color="getStatusColor(props.row.status)"
-                  :label="getStatusLabel(props.row.status)"
-                />
+                <span
+                  class="status-badge"
+                  :class="getStatusColorClass(props.row.status)"
+                >
+                  {{ getStatusLabel(props.row.status) }}
+                </span>
               </template>
               <template v-else-if="col.name === 'severity'">
-                <q-badge
-                  :color="getSeverityColor(props.row.severity)"
-                  :label="props.row.severity"
-                />
+                <span
+                  class="severity-badge"
+                  :class="getSeverityColorClass(props.row.severity)"
+                >
+                  {{ props.row.severity }}
+                </span>
               </template>
               <template v-else-if="col.name === 'title'">
                 <div class="tw:flex tw:items-center tw:gap-1">
                   <span class="tw:font-medium">
                     {{ props.row.title || formatDimensions(props.row.stable_dimensions) }}
+                  </span>
+                </div>
+              </template>
+              <template v-else-if="col.name === 'dimensions'">
+                <div class="tw:flex tw:flex-wrap tw:gap-1">
+                  <!-- Show first 2 dimensions -->
+                  <span
+                    v-for="[key, value] in getSortedDimensions(props.row.stable_dimensions).slice(0, 2)"
+                    :key="key"
+                    class="dimension-badge"
+                    :class="getDimensionColorClass(key)"
+                  >
+                    <span class="tw:font-medium">{{ key }}</span>=<span>{{ value }}</span>
+                    <q-tooltip :delay="300" class="tw:text-xs">
+                      {{ key }}={{ value }}
+                    </q-tooltip>
+                  </span>
+                  <!-- Show +X more badge if there are more than 2 dimensions -->
+                  <span
+                    v-if="getSortedDimensions(props.row.stable_dimensions).length > 2"
+                    class="dimension-badge badge-more"
+                  >
+                    +{{ getSortedDimensions(props.row.stable_dimensions).length - 2 }} more
+                    <q-tooltip :delay="300" class="tw:text-xs tw:max-w-md">
+                      <div class="tw:space-y-1">
+                        <div
+                          v-for="[key, value] in getSortedDimensions(props.row.stable_dimensions).slice(2)"
+                          :key="key"
+                        >
+                          <span class="tw:font-medium">{{ key }}</span>=<span>{{ value }}</span>
+                        </div>
+                      </div>
+                    </q-tooltip>
                   </span>
                 </div>
               </template>
@@ -102,14 +149,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 {{ formatTimestamp(props.row.last_alert_at) }}
               </template>
               <template v-else-if="col.name === 'actions'">
-                <div class="tw:flex tw:justify-end">
+                <div class="action-buttons">
                   <q-btn
                     v-if="props.row.status === 'open'"
                     flat
                     dense
-                    round
-                    icon="check_circle_outline"
-                    color="warning"
+                    size="sm"
+                    icon="visibility"
+                    class="action-btn acknowledge-btn"
                     @click.stop="acknowledgeIncident(props.row)"
                     data-test="incident-ack-btn"
                   >
@@ -119,9 +166,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     v-if="props.row.status !== 'resolved'"
                     flat
                     dense
-                    round
-                    icon="done_all"
-                    color="positive"
+                    size="sm"
+                    icon="task_alt"
+                    class="action-btn resolve-btn"
                     @click.stop="resolveIncident(props.row)"
                     data-test="incident-resolve-btn"
                   >
@@ -131,9 +178,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     v-if="props.row.status === 'resolved'"
                     flat
                     dense
-                    round
-                    icon="replay"
-                    color="negative"
+                    size="sm"
+                    icon="restart_alt"
+                    class="action-btn reopen-btn"
                     @click.stop="reopenIncident(props.row)"
                     data-test="incident-reopen-btn"
                   >
@@ -285,12 +332,10 @@ export default defineComponent({
         sortable: false,
       },
       {
-        name: "status",
-        label: t("alerts.incidents.status"),
-        field: "status",
+        name: "title",
+        label: t("alerts.incidents.title_field"),
+        field: "title",
         align: "left" as const,
-        style: "width: 120px",
-        sortable: false,
       },
       {
         name: "severity",
@@ -301,10 +346,20 @@ export default defineComponent({
         sortable: false,
       },
       {
-        name: "title",
-        label: t("alerts.incidents.title_field"),
-        field: "title",
+        name: "status",
+        label: t("alerts.incidents.status"),
+        field: "status",
         align: "left" as const,
+        style: "width: 120px",
+        sortable: false,
+      },
+
+      {
+        name: "dimensions",
+        label: "Dimensions",
+        field: "stable_dimensions",
+        align: "left" as const,
+        style: "width: 400px;",
       },
       {
         name: "alert_count",
@@ -393,6 +448,9 @@ export default defineComponent({
         // Store all incidents
         allIncidents.value = response.data.incidents;
 
+        // Cache data in store for when navigating back
+        store.dispatch('incidents/setCachedData', response.data.incidents);
+
         // Apply frontend search filter
         const filteredIncidents = applyFrontendSearch(allIncidents.value, searchQuery.value);
 
@@ -467,7 +525,10 @@ export default defineComponent({
           type: "positive",
           message: t("alerts.incidents.statusUpdated"),
         });
+        // Reload the incidents list to show updated status
         loadIncidents();
+        // Also mark data as stale in store for when navigating back from other pages
+        store.dispatch('incidents/setShouldRefresh', true);
       } catch (error: any) {
         $q.notify({
           type: "negative",
@@ -490,16 +551,16 @@ export default defineComponent({
     };
 
 
-    const getStatusColor = (status: string) => {
+    const getStatusColorClass = (status: string) => {
       switch (status) {
         case "open":
-          return "negative";
+          return "status-open";
         case "acknowledged":
-          return "warning";
+          return "status-acknowledged";
         case "resolved":
-          return "positive";
+          return "status-resolved";
         default:
-          return "grey";
+          return "status-default";
       }
     };
 
@@ -516,18 +577,18 @@ export default defineComponent({
       }
     };
 
-    const getSeverityColor = (severity: string) => {
+    const getSeverityColorClass = (severity: string) => {
       switch (severity) {
         case "P1":
-          return "red-10";
+          return "severity-p1";
         case "P2":
-          return "orange-8";
+          return "severity-p2";
         case "P3":
-          return "amber-8";
+          return "severity-p3";
         case "P4":
-          return "grey-7";
+          return "severity-p4";
         default:
-          return "grey";
+          return "severity-default";
       }
     };
 
@@ -545,12 +606,69 @@ export default defineComponent({
         .join(", ");
     };
 
+    const getSortedDimensions = (dimensions: Record<string, string>) => {
+      if (!dimensions || Object.keys(dimensions).length === 0) {
+        return [];
+      }
+
+      // Sort keys alphabetically for consistency
+      return Object.keys(dimensions)
+        .sort()
+        .map(key => [key, dimensions[key]] as [string, string]);
+    };
+
+    const getDimensionColorClass = (key: string) => {
+      // Color palette using CSS classes matching schema.scss style
+      const colorMap: Record<string, string> = {
+        'k8s-deployment': 'badge-blue',
+        'k8s-namespace': 'badge-orange',
+        'deployment': 'badge-blue',
+        'namespace': 'badge-orange',
+        'env': 'badge-green',
+        'environment': 'badge-green',
+        'host': 'badge-purple',
+        'hostname': 'badge-purple',
+        'service': 'badge-cyan',
+        'service_name': 'badge-cyan',
+        'region': 'badge-pink',
+        'zone': 'badge-pink',
+        'cluster': 'badge-indigo',
+        'pod': 'badge-teal',
+        'container': 'badge-red',
+        'app': 'badge-yellow',
+        'application': 'badge-yellow',
+      };
+
+      // Check for exact match first
+      if (colorMap[key]) {
+        return colorMap[key];
+      }
+
+      // Check for partial matches
+      const lowerKey = key.toLowerCase();
+      for (const [pattern, className] of Object.entries(colorMap)) {
+        if (lowerKey.includes(pattern)) {
+          return className;
+        }
+      }
+
+      // Hash-based fallback for consistency
+      const classes = ['badge-gray', 'badge-amber', 'badge-violet', 'badge-rose'];
+      let hash = 0;
+      for (let i = 0; i < key.length; i++) {
+        hash = ((hash << 5) - hash) + key.charCodeAt(i);
+        hash = hash & hash;
+      }
+      return classes[Math.abs(hash) % classes.length];
+    };
+
     /**
      * Restores state from Vuex store or resets if organization changed
      * @returns {boolean} True if state was restored, false if reset
      */
     const restoreStateFromStore = (): boolean => {
       const savedState = store.state.incidents.incidents;
+      const cachedData = store.state.incidents.cachedData;
       const isInitialized = store.state.incidents.isInitialized;
       const currentOrg = store.state.selectedOrganization.identifier;
 
@@ -562,6 +680,7 @@ export default defineComponent({
 
         // Reset local state to defaults
         searchQuery.value = "";
+        allIncidents.value = [];
         pagination.value = {
           sortBy: "last_alert_at",
           descending: true,
@@ -577,6 +696,11 @@ export default defineComponent({
 
         // Prevent watch from interfering during restoration
         isRestoringState.value = true;
+
+        // Restore cached data
+        if (cachedData && cachedData.length > 0) {
+          allIncidents.value = cachedData;
+        }
 
         // Restore pagination
         if (savedState.pagination) {
@@ -651,8 +775,27 @@ export default defineComponent({
       // Restore state from store (or reset if org changed)
       const hasRestoredState = restoreStateFromStore();
 
-      // Load incidents with restored or default state
-      await loadIncidents();
+      // Check if data should be refreshed (e.g., after incident updates)
+      const shouldRefresh = store.state.incidents?.shouldRefresh || false;
+
+      // Load incidents if:
+      // 1. We don't have cached data, OR
+      // 2. shouldRefresh flag is set (indicates changes were made)
+      if (allIncidents.value.length === 0 || shouldRefresh) {
+        // Load incidents with restored or default state
+        await loadIncidents();
+        // Clear the shouldRefresh flag after loading
+        if (shouldRefresh) {
+          store.dispatch('incidents/setShouldRefresh', false);
+        }
+      } else {
+        // We have cached data and no refresh needed, just reapply filters and pagination
+        const filteredIncidents = applyFrontendSearch(allIncidents.value, searchQuery.value);
+        const startIndex = (pagination.value.page - 1) * pagination.value.rowsPerPage;
+        const endIndex = startIndex + pagination.value.rowsPerPage;
+        incidents.value = filteredIncidents.slice(startIndex, endIndex);
+        pagination.value.rowsNumber = filteredIncidents.length;
+      }
 
       // Validate pagination after loading data (edge case: restored page is out of bounds)
       const wasCorrected = validateAndCorrectPagination();
@@ -773,6 +916,16 @@ export default defineComponent({
       });
     };
 
+    const refreshIncidents = async () => {
+      // Force reload from API
+      await loadIncidents();
+      $q.notify({
+        type: "positive",
+        message: "Incidents refreshed",
+        timeout: 1500,
+      });
+    };
+
 
     return {
       t,
@@ -788,16 +941,19 @@ export default defineComponent({
       columns,
       searchQuery,
       loadIncidents,
+      refreshIncidents,
       onRequest,
       viewIncident,
       acknowledgeIncident,
       resolveIncident,
       reopenIncident,
-      getStatusColor,
+      getStatusColorClass,
       getStatusLabel,
-      getSeverityColor,
+      getSeverityColorClass,
       formatTimestamp,
       formatDimensions,
+      getSortedDimensions,
+      getDimensionColorClass,
       toggleStatusFilter,
       toggleSeverityFilter,
       clearStatusFilter,
@@ -806,6 +962,7 @@ export default defineComponent({
       perPageOptions,
       qTableRef,
       validateAndCorrectPagination, // Expose for testing
+      store,
     };
   },
 });
@@ -821,5 +978,330 @@ export default defineComponent({
 
 .o2-search-input {
   width: 250px;
+}
+
+/* Status badge styling - matching schema.scss */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.status-open {
+  border: 1px solid #dc2626;
+}
+
+.status-acknowledged {
+  border: 1px solid #d97706;
+}
+
+.status-resolved {
+  border: 1px solid #065f46;
+}
+
+.status-default {
+  border: 1px solid #6b7280;
+}
+
+/* Severity badge styling - matching schema.scss */
+.severity-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.severity-p1 {
+  border: 1px solid #991b1b;
+}
+
+.severity-p2 {
+  border: 1px solid #c2410c;
+}
+
+.severity-p3 {
+  border: 1px solid #92400e;
+}
+
+.severity-p4 {
+  border: 1px solid #6b7280;
+}
+
+.severity-default {
+  border: 1px solid #6b7280;
+}
+
+/* Dark mode adjustments for status and severity badges - border only */
+body.body--dark {
+  .status-open {
+    border: 1px solid #fca5a5;
+  }
+
+  .status-acknowledged {
+    border: 1px solid #fbbf24;
+  }
+
+  .status-resolved {
+    border: 1px solid #6ee7b7;
+  }
+
+  .status-default {
+    border: 1px solid #d1d5db;
+  }
+
+  .severity-p1 {
+    border: 1px solid #fca5a5;
+  }
+
+  .severity-p2 {
+    border: 1px solid #fdba74;
+  }
+
+  .severity-p3 {
+    border: 1px solid #fcd34d;
+  }
+
+  .severity-p4 {
+    border: 1px solid #d1d5db;
+  }
+
+  .severity-default {
+    border: 1px solid #d1d5db;
+  }
+}
+
+/* Dimension badge base styling - matching schema.scss */
+.dimension-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  margin: 2px;
+  max-width: 180px;
+  overflow: hidden;
+
+  span {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+/* "+X more" badge styling - with background */
+.badge-more {
+  background: #e5e7eb;
+  color: #6b7280;
+  cursor: help;
+  font-weight: 500;
+}
+
+body.body--dark .badge-more {
+  background: #4b5563;
+  color: #d1d5db;
+}
+
+/* Color scheme matching schema.scss type badges - border only */
+.badge-blue {
+  border: 1px solid #1d4ed8;
+}
+
+.badge-green {
+  border: 1px solid #065f46;
+}
+
+.badge-yellow {
+  border: 1px solid #92400e;
+}
+
+.badge-pink {
+  border: 1px solid #9f1239;
+}
+
+.badge-purple {
+  border: 1px solid #7c3aed;
+}
+
+.badge-orange {
+  border: 1px solid #c2410c;
+}
+
+.badge-cyan {
+  border: 1px solid #0e7490;
+}
+
+.badge-indigo {
+  border: 1px solid #4f46e5;
+}
+
+.badge-teal {
+  border: 1px solid #0f766e;
+}
+
+.badge-red {
+  border: 1px solid #dc2626;
+}
+
+.badge-gray {
+  border: 1px solid #4b5563;
+}
+
+.badge-amber {
+  border: 1px solid #d97706;
+}
+
+.badge-violet {
+  border: 1px solid #7c3aed;
+}
+
+.badge-rose {
+  border: 1px solid #e11d48;
+}
+
+/* Dark mode adjustments - border only with lighter colors */
+body.body--dark {
+  .badge-blue {
+    border: 1px solid #93c5fd;
+  }
+
+  .badge-green {
+    border: 1px solid #6ee7b7;
+  }
+
+  .badge-yellow {
+    border: 1px solid #fcd34d;
+  }
+
+  .badge-pink {
+    border: 1px solid #f9a8d4;
+  }
+
+  .badge-purple {
+    border: 1px solid #c4b5fd;
+  }
+
+  .badge-orange {
+    border: 1px solid #fdba74;
+  }
+
+  .badge-cyan {
+    border: 1px solid #67e8f9;
+  }
+
+  .badge-indigo {
+    border: 1px solid #a5b4fc;
+  }
+
+  .badge-teal {
+    border: 1px solid #5eead4;
+  }
+
+  .badge-red {
+    border: 1px solid #fca5a5;
+  }
+
+  .badge-gray {
+    border: 1px solid #d1d5db;
+  }
+
+  .badge-amber {
+    border: 1px solid #fbbf24;
+  }
+
+  .badge-violet {
+    border: 1px solid #c4b5fd;
+  }
+
+  .badge-rose {
+    border: 1px solid #fda4af;
+  }
+}
+
+/* Action buttons styling */
+.action-buttons {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 4px;
+}
+
+.action-btn {
+  min-width: 28px;
+  height: 28px;
+  padding: 0 6px;
+  transition: all 0.2s ease;
+  border-radius: 6px;
+}
+
+.action-btn:hover {
+  transform: translateY(-1px);
+}
+
+/* Acknowledge button - eye/visibility icon */
+.acknowledge-btn {
+  color: #d97706;
+}
+
+.acknowledge-btn:hover {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+/* Resolve button - checkmark icon */
+.resolve-btn {
+  color: #059669;
+}
+
+.resolve-btn:hover {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+/* Reopen button - refresh icon */
+.reopen-btn {
+  color: #ea580c;
+}
+
+.reopen-btn:hover {
+  background: #fed7aa;
+  color: #c2410c;
+}
+
+/* Dark mode adjustments for action buttons */
+body.body--dark {
+  .acknowledge-btn {
+    color: #fbbf24;
+  }
+
+  .acknowledge-btn:hover {
+    background: #78350f;
+    color: #fde68a;
+  }
+
+  .resolve-btn {
+    color: #34d399;
+  }
+
+  .resolve-btn:hover {
+    background: #065f46;
+    color: #6ee7b7;
+  }
+
+  .reopen-btn {
+    color: #fb923c;
+  }
+
+  .reopen-btn:hover {
+    background: #7c2d12;
+    color: #fdba74;
+  }
 }
 </style>

--- a/web/src/components/rum/common/performance/MetricCard.vue
+++ b/web/src/components/rum/common/performance/MetricCard.vue
@@ -111,7 +111,7 @@ const formattedValue = computed(() => {
 
   // Format numbers with commas
   if (typeof props.value === "number") {
-    return props.value.toLocaleString();
+    return props.value.toLocaleString("en-US");
   }
 
   return String(props.value);

--- a/web/src/composables/useCorrelatedLogs.ts
+++ b/web/src/composables/useCorrelatedLogs.ts
@@ -15,10 +15,9 @@
 
 import { ref, computed, watch, onUnmounted } from "vue";
 import { useStore } from "vuex";
-import type { StreamInfo, SemanticFieldGroup } from "@/services/service_streams";
+import type { StreamInfo } from "@/services/service_streams";
 import { SELECT_ALL_VALUE } from "@/utils/dashboard/constants";
 import { generateTraceContext } from "@/utils/zincutils";
-import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import useHttpStreamingSearch from "@/composables/useStreamingSearch";
 
 export interface TimeRange {
@@ -66,7 +65,6 @@ export interface SearchResponse {
  */
 export function useCorrelatedLogs(props: CorrelatedLogsProps) {
   const store = useStore();
-  const { loadSemanticGroups } = useServiceCorrelation();
   const { fetchQueryDataWithHttpStream, cancelStreamQueryBasedOnRequestId } = useHttpStreamingSearch();
 
   // State
@@ -92,9 +90,6 @@ export function useCorrelatedLogs(props: CorrelatedLogsProps) {
   // Current trace ID for request cancellation
   let currentTraceId: string | null = null;
 
-  // Cache for semantic patterns (loaded once per component instance)
-  let semanticPatternsCache: Record<string, string[]> | null = null;
-
   // Computed
   const hasResults = computed(() => searchResults.value.length > 0);
   const isLoading = computed(() => loading.value);
@@ -116,128 +111,50 @@ export function useCorrelatedLogs(props: CorrelatedLogsProps) {
     return '';
   });
 
-  /**
-   * Get default semantic patterns as fallback
-   * These are common patterns that work for standard K8s/AWS/GCP setups
-   */
-  const getDefaultSemanticPatterns = (): Record<string, string[]> => {
-    return {
-      'k8s-namespace': ['k8s_namespace_name', 'k8s.namespace.name', 'namespace'],
-      'k8s-deployment': ['k8s_deployment_name', 'k8s.deployment.name', 'deployment'],
-      'k8s-pod': ['k8s_pod_name', 'k8s.pod.name', 'pod_name', 'pod'],
-      'k8s-container': ['k8s_container_name', 'k8s.container.name', 'container_name', 'container'],
-      'k8s-statefulset': ['k8s_statefulset_name', 'k8s.statefulset.name', 'statefulset'],
-      'k8s-daemonset': ['k8s_daemonset_name', 'k8s.daemonset.name', 'daemonset'],
-      'k8s-replicaset': ['k8s_replicaset_name', 'k8s.replicaset.name', 'replicaset'],
-      'k8s-job': ['k8s_job_name', 'k8s.job.name', 'job'],
-      'k8s-cronjob': ['k8s_cronjob_name', 'k8s.cronjob.name', 'cronjob'],
-      'k8s-node': ['k8s_node_name', 'k8s.node.name', 'node_name', 'node'],
-      'k8s-cluster': ['k8s_cluster_name', 'k8s.cluster.name', 'cluster'],
-      'host-name': ['host_name', 'host.name', 'hostname'],
-      'cloud-region': ['cloud_region', 'cloud.region', 'region'],
-      'cloud-availability-zone': ['cloud_availability_zone', 'cloud.availability_zone', 'availability_zone', 'zone'],
-      'container-name': ['container_name', 'container.name'],
-      'container-id': ['container_id', 'container.id'],
-      'service-name': ['service_name', 'service.name', 'service', 'svc'],
-    };
-  };
+  // REMOVED: getDefaultSemanticPatterns() function
+  // No longer needed - we use exact field names from StreamInfo.filters
 
-  /**
-   * Load semantic patterns from backend or use defaults
-   * Converts SemanticFieldGroup[] to pattern format: { id: string[] }
-   *
-   * @returns Promise resolving to semantic patterns
-   */
-  const loadSemanticPatterns = async (): Promise<Record<string, string[]>> => {
-    // Return cached patterns if available
-    if (semanticPatternsCache) {
-      console.log('[useCorrelatedLogs] Using cached semantic patterns');
-      return semanticPatternsCache;
-    }
+  // REMOVED: loadSemanticPatterns() function
+  // No longer needed - we use exact field names from StreamInfo.filters
 
-    try {
-      // Load semantic groups from backend (uses global cache in useServiceCorrelation)
-      console.log('[useCorrelatedLogs] Loading semantic groups from backend...');
-      const semanticGroups: SemanticFieldGroup[] = await loadSemanticGroups();
-
-      if (semanticGroups && semanticGroups.length > 0) {
-        // Convert SemanticFieldGroup[] to pattern format
-        const patterns: Record<string, string[]> = {};
-        for (const group of semanticGroups) {
-          patterns[group.id] = group.fields;
-        }
-
-        console.log(`[useCorrelatedLogs] Loaded ${Object.keys(patterns).length} semantic patterns from backend`);
-        semanticPatternsCache = patterns;
-        return patterns;
-      } else {
-        console.warn('[useCorrelatedLogs] No semantic groups returned from backend, using defaults');
-        const defaults = getDefaultSemanticPatterns();
-        semanticPatternsCache = defaults;
-        return defaults;
-      }
-    } catch (err) {
-      console.error('[useCorrelatedLogs] Failed to load semantic groups, using defaults:', err);
-      const defaults = getDefaultSemanticPatterns();
-      semanticPatternsCache = defaults;
-      return defaults;
-    }
-  };
-
-  /**
-   * Create reverse mapping from semantic dimension names to actual field names
-   * This is critical for building SQL queries with correct field names
-   *
-   * Example:
-   * - Semantic name: "k8s-statefulset"
-   * - Actual field names: "k8s_statefulset_name", "k8s.statefulset.name"
-   * - We check availableDimensions to find which actual field name exists
-   *
-   * @returns Map of semantic dimension name → actual field name
-   */
-  const getSemanticToFieldMapping = async (): Promise<Record<string, string>> => {
-    const mapping: Record<string, string> = {};
-
-    // If no availableDimensions provided, we can't do reverse mapping
-    if (!props.availableDimensions) {
-      console.warn('[useCorrelatedLogs] No availableDimensions provided for field name mapping');
-      return mapping;
-    }
-
-    // Load semantic patterns (from backend or defaults)
-    const semanticPatterns = await loadSemanticPatterns();
-
-    // For each semantic dimension, find the first matching field name in availableDimensions
-    for (const [semanticName, possibleFieldNames] of Object.entries(semanticPatterns)) {
-      for (const fieldName of possibleFieldNames) {
-        if (fieldName in props.availableDimensions) {
-          mapping[semanticName] = fieldName;
-          console.log(`[useCorrelatedLogs] Mapped semantic dimension "${semanticName}" → field "${fieldName}"`);
-          break;
-        }
-      }
-    }
-
-    return mapping;
-  };
+  // REMOVED: getSemanticToFieldMapping() function
+  // No longer needed - we use exact field names from StreamInfo.filters
+  // The /_correlate API (or fallback) provides the correct field names for each stream
 
   /**
    * Build SQL query with proper escaping for special characters and SQL injection prevention
    * Note: Time range is handled by the search API's start_time/end_time parameters, not in SQL WHERE clause
+   *
+   * IMPORTANT: Uses exact field names from StreamInfo.filters (provided by /_correlate API or fallback)
+   * These filters already have the correct field names that exist in the stream schema.
+   * NO semantic mapping needed - just use the field names as-is.
    */
   const buildSQLQuery = async (
     streamName: string,
-    filters: Record<string, string>,
+    _filters: Record<string, string>, // Unused: we use StreamInfo.filters instead
     _timeRange: TimeRange, // Unused: time range handled by API parameters
     limit: number = 100
   ): Promise<string> => {
     const conditions: string[] = [];
 
-    // Get mapping from semantic dimension names to actual field names (async now)
-    const semanticToFieldMap = await getSemanticToFieldMapping();
+    // Find the matching StreamInfo from logStreams to get exact field names
+    const streamInfo = props.logStreams.find(s => s.stream_name === streamName);
 
-    // Add dimension filters
-    for (const [field, value] of Object.entries(filters)) {
+    if (!streamInfo) {
+      console.warn(`[useCorrelatedLogs] No StreamInfo found for stream "${streamName}"`);
+      console.warn(`[useCorrelatedLogs] Available log streams:`, props.logStreams.map(s => s.stream_name));
+      // Return empty query that will return no results
+      return `SELECT * FROM "${streamName}" WHERE 1=0`;
+    }
+
+    // ALWAYS use the exact filters from StreamInfo - never use the provided filters parameter
+    // The StreamInfo.filters come from the /_correlate API (or fallback) and have the correct field names
+    const exactFilters = streamInfo.filters;
+
+    console.log('[useCorrelatedLogs] Using filters from StreamInfo:', exactFilters);
+
+    // Add dimension filters using exact field names from StreamInfo
+    for (const [field, value] of Object.entries(exactFilters)) {
       // Skip wildcard values (SELECT_ALL_VALUE = "_o2_all_")
       if (value === SELECT_ALL_VALUE) {
         continue;
@@ -253,19 +170,11 @@ export function useCorrelatedLogs(props: CorrelatedLogsProps) {
         continue;
       }
 
-      // Map semantic dimension name to actual field name if available
-      // This is the critical fix: convert "k8s-statefulset" → "k8s_statefulset_name"
-      const actualFieldName = semanticToFieldMap[field] || field;
-
-      // Log the mapping for debugging
-      if (semanticToFieldMap[field]) {
-        console.log(`[useCorrelatedLogs] Using field "${actualFieldName}" for semantic dimension "${field}"`);
-      }
-
+      // Use the field name directly from StreamInfo.filters (already correct for this stream)
       // Quote field names if they contain special characters (dots, hyphens, etc.)
-      const quotedField = /[^a-zA-Z0-9_]/.test(actualFieldName)
-        ? `"${actualFieldName.replace(/"/g, '""')}"`
-        : actualFieldName;
+      const quotedField = /[^a-zA-Z0-9_]/.test(field)
+        ? `"${field.replace(/"/g, '""')}"`
+        : field;
 
       // Escape single quotes in values
       const escapedValue = String(value).replace(/'/g, "''");

--- a/web/src/stores/incidents.ts
+++ b/web/src/stores/incidents.ts
@@ -17,12 +17,17 @@ export default {
   namespaced: true,
   state: {
     incidents: {},
+    cachedData: [], // Cache the actual incidents data
     pageBeforeSearch: 1, // Track page number before search starts (for smart restoration)
-    isInitialized: false
+    isInitialized: false,
+    shouldRefresh: false // Flag to indicate when data should be refreshed (e.g., after updates)
   },
   getters: {
     getIncidents(state: any) {
       return state.incidents;
+    },
+    getCachedData(state: any) {
+      return state.cachedData;
     },
     getPageBeforeSearch(state: any) {
       return state.pageBeforeSearch;
@@ -30,10 +35,16 @@ export default {
     getIsInitialized(state: any) {
       return state.isInitialized;
     },
+    getShouldRefresh(state: any) {
+      return state.shouldRefresh;
+    },
   },
   mutations: {
     setIncidents(state: any, incidents: any) {
       state.incidents = incidents;
+    },
+    setCachedData(state: any, data: any[]) {
+      state.cachedData = data;
     },
     setPageBeforeSearch(state: any, page: number) {
       state.pageBeforeSearch = page;
@@ -41,21 +52,32 @@ export default {
     setIsInitialized(state: any, isInitialized: boolean) {
       state.isInitialized = isInitialized;
     },
+    setShouldRefresh(state: any, shouldRefresh: boolean) {
+      state.shouldRefresh = shouldRefresh;
+    },
     resetIncidents(state: any) {
       state.incidents = {};
+      state.cachedData = [];
       state.pageBeforeSearch = 1;
       state.isInitialized = false;
+      state.shouldRefresh = false;
     },
   },
   actions: {
     setIncidents(context: any, incidents: any) {
       context.commit('setIncidents', incidents);
     },
+    setCachedData(context: any, data: any[]) {
+      context.commit('setCachedData', data);
+    },
     setPageBeforeSearch(context: any, page: number) {
       context.commit('setPageBeforeSearch', page);
     },
     setIsInitialized(context: any, isInitialized: boolean) {
       context.commit('setIsInitialized', isInitialized);
+    },
+    setShouldRefresh(context: any, shouldRefresh: boolean) {
+      context.commit('setShouldRefresh', shouldRefresh);
     },
     resetIncidents(context: any) {
       context.commit('resetIncidents');


### PR DESCRIPTION
### **User description**
Improves incidents UI with better visual presentation and fixes field resolution in incident correlation.

- Add dimensions column with color-coded chips for visual distinction
- Implement state caching to eliminate redundant API calls during navigation
- Enable ESC key navigation for quick return to list view
- Fix correlation fallback to use user-defined schema fields instead of all fields

The correlation fix ensures consistent field name resolution across logs, metrics, and traces by using `uds_schema` when available, matching the logs page behavior.

___

Enhancement, Bug fix

___

- Add dimensions chips and refresh button

- Cache incident list data in store

- Enable ESC to close detail drawer

- Fix correlation fallback using `uds_schema`

___

```mermaid
flowchart LR
  A["IncidentList UI"]
  B["Vuex incidents store cache"]
  C["IncidentDetailDrawer"]
  D["Correlation fallback field resolution"]
  E["Logs query builder (StreamInfo.filters)"]

  A -- "caches incidents" --> B
  B -- "restores on navigation" --> A
  A -- "open/close details" --> C
  C -- "uses uds_schema + semantic groups" --> D
  D -- "produces StreamInfo.filters" --> E
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>useCorrelatedLogs.ts</strong><dd><code>Use `StreamInfo.filters` for SQL building</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useCorrelatedLogs.ts

<ul><li>Remove semantic-groups mapping and caching<br> <li> Build WHERE clauses from <code>StreamInfo.filters</code><br> <li> Return <code>WHERE 1=0</code> on missing stream<br> <li> Quote special-character field names directly</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10390/files#diff-310992fb4914c6eaffbbce225e0c0683c2edad2bb0ab0f8e43530fc38152ed2a">+34/-125</a></td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>IncidentDetailDrawer.vue</strong><dd><code>Improve correlation fallback and ESC close</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentDetailDrawer.vue

<ul><li>Prefer <code>schema.uds_schema</code> over full schema<br> <li> Add detailed field-matching debug logging<br> <li> Add ESC key handler to close drawer<br> <li> Register/unregister key listener on lifecycle</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10390/files#diff-6973d58a5f49658b07d3533d4db5d32cc6430433b51732481e7497243dadb0b0">+80/-44</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>incidents.ts</strong><dd><code>Add cached incidents data to store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

web/src/stores/incidents.ts

<ul><li>Add <code>cachedData</code> to incidents state<br> <li> Add getter/mutation/action for cache<br> <li> Clear <code>cachedData</code> on <code>resetIncidents</code></ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10390/files#diff-99af0a5ee4e917dce84a85663e25ecb072ae0cfa87f60f8b49b94d9320ebf87d">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>IncidentList.vue</strong><dd><code>Add dimensions column and navigation caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

web/src/components/alerts/IncidentList.vue

<ul><li>Add refresh button with loading state<br> <li> Render dimensions as color-coded <code>q-chip</code>s<br> <li> Cache/restore incidents list from Vuex store<br> <li> Skip reload when cached data exists</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10390/files#diff-953ad015996758a8c86e489499cd3b0a614501b99b0c9c5c242a299e34c24ff2">+145/-3</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

---------


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add dimensions chips and refresh button

- Cache incident list data in Vuex

- Close incident drawer via ESC key

- Fix correlation field selection via `uds_schema`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["IncidentList.vue UI"] --> B["Vuex incidents store cache"]
  B["Vuex incidents store cache"] --> A2["Restore list without API"]
  C["IncidentDetailDrawer.vue"] --> D["Set shouldRefresh on updates"]
  D["Set shouldRefresh on updates"] --> A3["Reload list on return"]
  E["Fallback correlation"] --> F["Use `uds_schema` fields first"]
  G["useCorrelatedLogs"] --> H["Use StreamInfo.filters field names"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IncidentList.spec.ts</strong><dd><code>Update incident list tests for new UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentList.spec.ts

<ul><li>Extend mocked incidents store with <code>cachedData</code><br> <li> Add <code>shouldRefresh</code> to store state setup<br> <li> Update assertions to new CSS class helpers<br> <li> Adjust columns count for added dimensions</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10420/files#diff-633b95716cea25470b98f260f00e6fbc641c1fbe8ed82713e346eef014ca4d50">+41/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useCorrelatedLogs.ts</strong><dd><code>Use StreamInfo filters without semantic mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useCorrelatedLogs.ts

<ul><li>Remove semantic groups/types and mapping logic<br> <li> Build SQL using exact <code>StreamInfo.filters</code> field names<br> <li> Add guard when <code>StreamInfo</code> not found<br> <li> Quote fields directly from filter keys</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10420/files#diff-310992fb4914c6eaffbbce225e0c0683c2edad2bb0ab0f8e43530fc38152ed2a">+34/-125</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IncidentDetailDrawer.vue</strong><dd><code>Improve fallback correlation and add ESC close</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentDetailDrawer.vue

<ul><li>Prefer <code>schema.uds_schema</code> when resolving fields<br> <li> Add detailed semantic-group field matching logs<br> <li> Add ESC key handler with dialog/edit guards<br> <li> Set <code>incidents/shouldRefresh</code> after updates</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10420/files#diff-6973d58a5f49658b07d3533d4db5d32cc6430433b51732481e7497243dadb0b0">+93/-44</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MetricCard.vue</strong><dd><code>Make number formatting locale deterministic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/rum/common/performance/MetricCard.vue

- Format numeric values with `toLocaleString("en-US")`


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10420/files#diff-3666ababe7e5a472c88da967ba6e5e632dfd907abb8555a6bb4baeabc0215e32">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>incidents.ts</strong><dd><code>Add incident list caching and refresh flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/stores/incidents.ts

<ul><li>Add <code>cachedData</code> for storing loaded incidents<br> <li> Add <code>shouldRefresh</code> flag for stale list detection<br> <li> Add getters/mutations/actions for new state<br> <li> Reset cache and refresh flag on reset</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10420/files#diff-99af0a5ee4e917dce84a85663e25ecb072ae0cfa87f60f8b49b94d9320ebf87d">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IncidentList.vue</strong><dd><code>Enhance incident list UI and state restoration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentList.vue

<ul><li>Add Refresh button and cached restore logic<br> <li> Add Dimensions column with color-coded badges<br> <li> Replace QBadge colors with CSS class badges<br> <li> Rework action buttons styling and icons</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10420/files#diff-953ad015996758a8c86e489499cd3b0a614501b99b0c9c5c242a299e34c24ff2">+524/-42</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

