### PR TITLE
fix: route for member status

### DIFF
--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -808,7 +808,7 @@ pub fn service_routes() -> Router {
             )
             .route(
                 "/{org_id}/member_subscription/{invite_token}",
-                post(organization::org::accept_org_invite),
+                put(organization::org::accept_org_invite),
             )
             .route(
                 "/{org_id}/billings/hosted_subscription_url",


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Change invite acceptance method to PUT


___

### Diagram Walkthrough


```mermaid
flowchart LR
  r1["Router: org routes"] 
  r2["Invite acceptance endpoint"]
  r1 -- "use PUT instead of POST" --> r2
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Use PUT for invite acceptance route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handler/http/router/mod.rs

- Switch `accept_org_invite` route from POST to PUT


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10424/files#diff-02556e3f515441b5d2b6bbea7829df488beac03c4cc41309a6638ae3c0e0aec6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

