### PR TITLE
fix: dashboard variables for child, set default value (#10406)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -236,19 +236,20 @@ jobs:
                 "ui-regression.spec.js",
                 "pipeline-regression.spec.js",
               ]
-            # - testfolder: "Dashboards-Variables-Scoped"
-            #   browser: "chrome"
-            #   run_files:
-            #     [
-            #       "dashboard-variables-global.spec.js",
-            #       "dashboard-variables-tab-level.spec.js",
-            #       "dashboard-variables-panel-level.spec.js",
-            #       "dashboard-variables-dependency.spec.js",
-            #       "dashboard-variables-refresh.spec.js",
-            #       "dashboard-variables-url-sync.spec.js",
-            #       "dashboard-variables-creation-scopes.spec.js",
-            #       "dashboard-variables-null-handling.spec.js",
-            #     ]
+          - testfolder: "Dashboards-Variables"
+            browser: "chrome"
+            run_files:
+              [
+                # "dashboard-variables-setting.spec.js",
+                # "dashboard-variables-global.spec.js",
+                # "dashboard-variables-tab-level.spec.js",
+                # "dashboard-variables-panel-level.spec.js",
+                # "dashboard-variables-dependency.spec.js",
+                # "dashboard-variables-refresh.spec.js",
+                # "dashboard-variables-url-sync.spec.js",
+                # "dashboard-variables-creation-scopes.spec.js",
+                "dashboard-variables-default-values-chain.spec.js",
+              ]
     steps:
       - name: Clone the current repo
         uses: actions/checkout@v5

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
@@ -39,6 +39,8 @@ export default class DashboardVariablesScoped {
       dependsOn = null,
       dependsOnMultiple = [],
       defaultValue = null,
+      defaultValueType = null, // "all" | "custom" | "first" (default)
+      customValues = [], // Array of custom values for "custom" default type
       hideOnDashboard = false,
     } = options;
 
@@ -213,7 +215,46 @@ export default class DashboardVariablesScoped {
         .click();
     }
 
-    // Set default value if provided
+    // Handle default value type (all, custom, or first)
+    if (defaultValueType === "all") {
+      // Set default to "All"
+      // Note: Even for single-select, we use the multi-select toggle selector
+      await this.page
+        .locator('[data-test="dashboard-multi-select-default-value-toggle-all-values"]')
+        .click();
+    } else if (defaultValueType === "custom") {
+      // Set default to custom values
+      if (showMultipleValues) {
+        // Multi-select: use multi-select custom toggle
+        await this.page
+          .locator('[data-test="dashboard-multi-select-default-value-toggle-custom"]')
+          .click();
+
+        // Add custom values
+        if (customValues.length > 0) {
+          for (let i = 0; i < customValues.length; i++) {
+            // if (i > 0) {
+              // Click add button for additional values
+              await this.page.locator('[data-test="dashboard-add-custom-value-btn"]').click();
+            // }
+            await this.page.locator(`[data-test="dashboard-variable-custom-value-${i}"]`).fill(customValues[i]);
+          }
+        }
+      } else {
+        // Single-select: use single-select custom toggle
+        await this.page
+          .locator('[data-test="dashboard-multi-select-default-value-toggle-custom"]')
+          .click();
+
+        // Add single custom value
+        if (customValues.length > 0) {
+          await this.page.locator('[data-test="dashboard-variable-custom-value-0"]').fill(customValues[0]);
+        }
+      }
+    }
+    // If defaultValueType is "first" or null, do nothing (default behavior)
+
+    // Legacy: Set default value if provided (deprecated, use defaultValueType instead)
     if (defaultValue) {
       await this.setDefaultValue(defaultValue);
     }
@@ -223,7 +264,7 @@ export default class DashboardVariablesScoped {
       await this.page.locator('[data-test="dashboard-variable-hide_on_dashboard"]').click();
     }
 
-    // Custom value search
+    // Legacy: Custom value search (deprecated, use defaultValueType instead)
     if (customValueSearch) {
       await this.page
         .locator('[data-test="dashboard-multi-select-default-value-toggle-custom"]')

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-default-values-chain.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-default-values-chain.spec.js
@@ -1,0 +1,475 @@
+/**
+ * Dashboard Variables - Default Values in Dependency Chain Test Suite
+ * Tests that variables with "all" and "custom" defaults maintain their values
+ * when parent variables change, and that dependent children load properly.
+ */
+
+const { test, expect, navigateToBase } = require("../utils/enhanced-baseFixtures.js");
+import { ingestion } from "./utils/dashIngestion.js";
+import PageManager from "../../pages/page-manager.js";
+import DashboardVariablesScoped from "../../pages/dashboardPages/dashboard-variables-scoped.js";
+import { waitForDashboardPage, deleteDashboard } from "./utils/dashCreation.js";
+import { monitorVariableAPICalls } from "../utils/variable-helpers.js";
+const { safeWaitForHidden, safeWaitForNetworkIdle, safeWaitForDOMContentLoaded } = require("../utils/wait-helpers.js");
+// Import centralized selectors
+const {
+  SELECTORS,
+  getVariableSelector,
+} = require("../../pages/dashboardPages/dashboard-selectors.js");
+
+test.describe.configure({ mode: "parallel" });
+
+test.describe("Dashboard Variables - Default Values in Dependency Chain", { tag: ['@dashboards', '@dashboardVariables', '@defaultValues', '@P1'] }, () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToBase(page);
+    await ingestion(page);
+  });
+
+  test("1-should maintain 'all' default value when parent changes - single-select (A -> B[all, single])", async ({ page }) => {
+    const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
+    const dashboardName = `Dashboard_AllDefault_${Date.now()}`;
+    const varA = `var_a_${Date.now()}`;
+    const varB = `var_b_${Date.now()}`;
+
+    await pm.dashboardList.menuItem("dashboards-item");
+    await waitForDashboardPage(page);
+    await pm.dashboardCreate.waitForDashboardUIStable();
+    await pm.dashboardCreate.createDashboard(dashboardName);
+
+    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+
+    // Add variable A (independent)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varA,
+      "logs",
+      "e2e_automate",
+      "kubernetes_namespace_name",
+      { scope: "global" }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+
+    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 10000 });
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    // Add variable B (depends on A, with "all" default, single-select)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varB,
+      "logs",
+      "e2e_automate",
+      "kubernetes_container_name",
+      {
+        scope: "global",
+        dependsOn: varA,
+        dependsOnField: "kubernetes_namespace_name",
+        defaultValueType: "all"
+      }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+
+    // Verify B has "All" value
+    const varBSelector = page.locator(getVariableSelector(varB));
+    await varBSelector.waitFor({ state: "visible", timeout: 10000 });
+    const varBValue = await varBSelector.locator('span.ellipsis').textContent();
+    expect(varBValue).toContain("ALL");
+
+    // Change A and verify B still has "All"
+    const result = await scopedVars.changeVariableValueAndMonitorDependencies(varA, {
+      optionIndex: 1,
+      expectedAPICalls: 1,
+      timeout: 15000
+    });
+
+    expect(result.success).toBe(true);
+
+    // Verify B still has "All" value after A changes
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+    const varBValueAfter = await varBSelector.locator('span.ellipsis').textContent();
+    expect(varBValueAfter).toContain("ALL");
+
+    // Cleanup
+    await pm.dashboardCreate.backToDashboardList();
+    await deleteDashboard(page, dashboardName);
+  });
+
+  test("2-should maintain custom default value when parent changes - multi-select (A -> B[custom, multi])", async ({ page }) => {
+    const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
+    const dashboardName = `Dashboard_CustomDefault_${Date.now()}`;
+    const varA = `var_a_${Date.now()}`;
+    const varB = `var_b_${Date.now()}`;
+
+    await pm.dashboardList.menuItem("dashboards-item");
+    await waitForDashboardPage(page);
+    await pm.dashboardCreate.waitForDashboardUIStable();
+    await pm.dashboardCreate.createDashboard(dashboardName);
+
+    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+
+    // Add variable A (independent)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varA,
+      "logs",
+      "e2e_automate",
+      "kubernetes_namespace_name",
+      { scope: "global" }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+
+    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 10000 });
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    // Add variable B (depends on A, with custom default, multi-select)
+    const customValue1 = "custom_value_1";
+    const customValue2 = "custom_value_2";
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varB,
+      "logs",
+      "e2e_automate",
+      "kubernetes_container_name",
+      {
+        scope: "global",
+        dependsOn: varA,
+        dependsOnField: "kubernetes_namespace_name",
+        showMultipleValues: true,
+        defaultValueType: "custom",
+        customValues: [customValue1, customValue2]
+      }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+
+
+    // Verify B has custom values
+    const varBSelector = page.locator(getVariableSelector(varB));
+    await varBSelector.waitFor({ state: "visible", timeout: 10000 });
+    const varBValue = await varBSelector.locator('span.ellipsis').textContent();
+    expect(varBValue).toContain(customValue1);
+
+    // Change A and verify B still has custom values
+    const result = await scopedVars.changeVariableValueAndMonitorDependencies(varA, {
+      optionIndex: 1,
+      expectedAPICalls: 1,
+      timeout: 15000
+    });
+
+    expect(result.success).toBe(true);
+
+    // Verify B still has custom values after A changes
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+    const varBValueAfter = await varBSelector.locator('span.ellipsis').textContent();
+    expect(varBValueAfter).toContain(customValue1);
+
+    // Cleanup
+    await pm.dashboardCreate.backToDashboardList();
+    await deleteDashboard(page, dashboardName);
+  });
+
+  test("3-should load grandchild with first value when parent has 'all' default (A -> B[all, multi] -> C[first, single])", async ({ page }) => {
+    const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
+    const dashboardName = `Dashboard_GrandchildFirst_${Date.now()}`;
+    const varA = `var_a_${Date.now()}`;
+    const varB = `var_b_${Date.now()}`;
+    const varC = `var_c_${Date.now()}`;
+
+    await pm.dashboardList.menuItem("dashboards-item");
+    await waitForDashboardPage(page);
+    await pm.dashboardCreate.waitForDashboardUIStable();
+    await pm.dashboardCreate.createDashboard(dashboardName);
+
+    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+
+    // Add variable A (independent)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varA,
+      "logs",
+      "e2e_automate",
+      "kubernetes_namespace_name",
+      { scope: "global" }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    // Add variable B (depends on A, with "all" default, multi-select)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varB,
+      "logs",
+      "e2e_automate",
+      "kubernetes_container_name",
+      {
+        scope: "global",
+        dependsOn: varA,
+        dependsOnField: "kubernetes_namespace_name",
+        showMultipleValues: true,
+        defaultValueType: "all"
+      }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    // Add variable C (depends on B, first value default - no custom or all)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varC,
+      "logs",
+      "e2e_automate",
+      "_timestamp",
+      {
+        scope: "global",
+        dependsOn: varB,
+        dependsOnField: "kubernetes_container_name"
+      }
+    );
+
+    await pm.dashboardSetting.closeSettingWindow();
+
+    // Verify all variables are visible
+    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 10000 });
+    await page.locator(getVariableSelector(varB)).waitFor({ state: "visible", timeout: 10000 });
+    await page.locator(getVariableSelector(varC)).waitFor({ state: "visible", timeout: 10000 });
+
+    // Verify B has "All" value
+    const varBSelector = page.locator(getVariableSelector(varB));
+    const varBValue = await varBSelector.locator('span.ellipsis').textContent();
+    expect(varBValue).toContain("ALL");
+
+    // Verify C has a value (not null)
+    const varCSelector = page.locator(getVariableSelector(varC));
+    const varCValue = await varCSelector.locator('span.ellipsis').textContent();
+    expect(varCValue).toBeTruthy();
+    expect(varCValue.length).toBeGreaterThan(0);
+
+    // Change A and verify C still loads properly
+    const result = await scopedVars.changeVariableValueAndMonitorDependencies(varA, {
+      optionIndex: 1,
+      expectedAPICalls: 2, // B stays as "all", C reloads
+      timeout: 20000
+    });
+
+    expect(result.success).toBe(true);
+
+    // Verify B still has "All"
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+    const varBValueAfter = await varBSelector.locator('span.ellipsis').textContent();
+    expect(varBValueAfter).toContain("ALL");
+
+    // Verify C still has a value (not null)
+    const varCValueAfter = await varCSelector.locator('span.ellipsis').textContent();
+    expect(varCValueAfter).toBeTruthy();
+    expect(varCValueAfter.length).toBeGreaterThan(0);
+
+    // Cleanup
+    await pm.dashboardCreate.backToDashboardList();
+    await deleteDashboard(page, dashboardName);
+  });
+
+  test("4-should handle full chain: A -> B[all, multi] -> C[custom, multi] -> D[first, single]", async ({ page }) => {
+    test.setTimeout(120000); // 2 minutes for this complex test
+
+    const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
+    const dashboardName = `Dashboard_FullChain_${Date.now()}`;
+    const varA = `a_${Date.now()}`;
+    const varB = `b_${Date.now()}`;
+    const varC = `c_${Date.now()}`;
+    const varD = `d_${Date.now()}`;
+
+    await pm.dashboardList.menuItem("dashboards-item");
+    await waitForDashboardPage(page);
+    await pm.dashboardCreate.waitForDashboardUIStable();
+    await pm.dashboardCreate.createDashboard(dashboardName);
+
+    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+
+    // Add A (independent)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(varA, "logs", "e2e_automate", "kubernetes_namespace_name", { scope: "global" });
+    await pm.dashboardSetting.closeSettingWindow();
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    // Add B (depends on A, "all" default, multi-select)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varB,
+      "logs",
+      "e2e_automate",
+      "kubernetes_container_name",
+      {
+        scope: "global",
+        dependsOn: varA,
+        dependsOnField: "kubernetes_namespace_name",
+        showMultipleValues: true,
+        defaultValueType: "all"
+      }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    // Add C (depends on B, custom default, multi-select)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varC,
+      "logs",
+      "e2e_automate",
+      "kubernetes_pod_name",
+      {
+        scope: "global",
+        dependsOn: varB,
+        dependsOnField: "kubernetes_container_name",
+        showMultipleValues: true,
+        defaultValueType: "custom",
+        customValues: ["custom_pod_1", "custom_pod_2"]
+      }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    // Add D (depends on C, first value default)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varD,
+      "logs",
+      "e2e_automate",
+      "_timestamp",
+      {
+        scope: "global",
+        dependsOn: varC,
+        dependsOnField: "kubernetes_pod_name"
+      }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+
+    // Verify all variables are visible
+    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 10000 });
+    await page.locator(getVariableSelector(varB)).waitFor({ state: "visible", timeout: 10000 });
+    await page.locator(getVariableSelector(varC)).waitFor({ state: "visible", timeout: 10000 });
+    await page.locator(getVariableSelector(varD)).waitFor({ state: "visible", timeout: 10000 });
+
+    // Verify initial values
+    const varBValue = await page.locator(getVariableSelector(varB)).locator('span.ellipsis').textContent();
+    expect(varBValue).toContain("ALL");
+
+    const varCValue = await page.locator(getVariableSelector(varC)).locator('span.ellipsis').textContent();
+    expect(varCValue).toContain("custom_pod");
+
+    const varDValue = await page.locator(getVariableSelector(varD)).locator('span.ellipsis').textContent();
+    expect(varDValue).toBeTruthy();
+
+    // Change A and verify the entire chain
+    const result = await scopedVars.changeVariableValueAndMonitorDependencies(varA, {
+      optionIndex: 1,
+      expectedAPICalls: 2, // B keeps "all", C keeps custom, D reloads
+      timeout: 30000
+    });
+
+    expect(result.success).toBe(true);
+
+    // Verify all values are maintained/loaded properly
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    const varBValueAfter = await page.locator(getVariableSelector(varB)).locator('span.ellipsis').textContent();
+    expect(varBValueAfter).toContain("ALL");
+
+    const varCValueAfter = await page.locator(getVariableSelector(varC)).locator('span.ellipsis').textContent();
+    expect(varCValueAfter).toContain("custom_pod");
+
+    const varDValueAfter = await page.locator(getVariableSelector(varD)).locator('span.ellipsis').textContent();
+    expect(varDValueAfter).toBeTruthy();
+    expect(varDValueAfter.length).toBeGreaterThan(0);
+
+    // Cleanup
+    await pm.dashboardCreate.backToDashboardList();
+    await deleteDashboard(page, dashboardName);
+  });
+
+  test("5-should maintain custom default value with single-select (A -> B[custom, single])", async ({ page }) => {
+    const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
+    const dashboardName = `Dashboard_CustomDefaultSingle_${Date.now()}`;
+    const varA = `var_a_${Date.now()}`;
+    const varB = `var_b_${Date.now()}`;
+
+    await pm.dashboardList.menuItem("dashboards-item");
+    await waitForDashboardPage(page);
+    await pm.dashboardCreate.waitForDashboardUIStable();
+    await pm.dashboardCreate.createDashboard(dashboardName);
+
+    await page.locator(SELECTORS.ADD_PANEL_BTN).waitFor({ state: "visible" });
+
+    // Add variable A (independent)
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varA,
+      "logs",
+      "e2e_automate",
+      "kubernetes_namespace_name",
+      { scope: "global" }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+
+    await page.locator(getVariableSelector(varA)).waitFor({ state: "visible", timeout: 10000 });
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    // Add variable B (depends on A, with custom default, single-select)
+    const customValue = "custom_single_value";
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    await scopedVars.addScopedVariable(
+      varB,
+      "logs",
+      "e2e_automate",
+      "kubernetes_container_name",
+      {
+        scope: "global",
+        dependsOn: varA,
+        dependsOnField: "kubernetes_namespace_name",
+        defaultValueType: "custom",
+        customValues: [customValue]
+      }
+    );
+    await pm.dashboardSetting.closeSettingWindow();
+
+    // Verify B has custom value
+    const varBSelector = page.locator(getVariableSelector(varB));
+    await varBSelector.waitFor({ state: "visible", timeout: 10000 });
+    const varBValue = await varBSelector.locator('span.ellipsis').textContent();
+    expect(varBValue).toContain(customValue);
+
+    // Change A and verify B still has custom value
+    const result = await scopedVars.changeVariableValueAndMonitorDependencies(varA, {
+      optionIndex: 1,
+      expectedAPICalls: 1,
+      timeout: 15000
+    });
+
+    expect(result.success).toBe(true);
+
+    // Verify B still has custom value after A changes
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+    const varBValueAfter = await varBSelector.locator('span.ellipsis').textContent();
+    expect(varBValueAfter).toContain(customValue);
+
+    // Cleanup
+    await pm.dashboardCreate.backToDashboardList();
+    await deleteDashboard(page, dashboardName);
+  });
+
+});

--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -995,9 +995,15 @@ export default defineComponent({
         const oldValue = oldVariablesData[v.name];
         const currentValue = v.value;
 
+        // Check if variable has custom or "all" default selection configured
+        const hasCustomOrAllDefault =
+          v.selectAllValueForMultiSelect === "custom" ||
+          v.selectAllValueForMultiSelect === "all";
+
         // CRITICAL FIX: If manager has reset a variable's value to null/empty array,
         // we MUST clear oldVariablesData immediately, otherwise the old value will be
         // restored when API response arrives
+        // HOWEVER: If variable has custom/all default, set it to that value instead
         const managerHasResetValue =
           (currentValue === null || (Array.isArray(currentValue) && currentValue.length === 0)) &&
           oldValue !== undefined &&
@@ -1005,8 +1011,56 @@ export default defineComponent({
           (!Array.isArray(oldValue) || oldValue.length > 0);
 
         if (managerHasResetValue) {
-          // Manager reset this variable - clear oldVariablesData so it gets fresh value from API
-          oldVariablesData[v.name] = undefined;
+          // Manager reset this variable
+          if (hasCustomOrAllDefault) {
+            // Variable has custom/all default - set it to the configured value
+            if (v.selectAllValueForMultiSelect === "custom" && v.customMultiSelectValue?.length > 0) {
+              const customValue = v.multiSelect
+                ? v.customMultiSelectValue
+                : v.customMultiSelectValue[0];
+              oldVariablesData[v.name] = customValue;
+              v.value = customValue;
+              // Mark as partially loaded so child variables know this variable is ready
+              v.isVariablePartialLoaded = true;
+              v.isLoading = false;
+              v.isVariableLoadingPending = false;
+
+              // Notify manager that this variable is loaded so it can trigger children
+              if (useManager && manager) {
+                const variableKey = getVariableKey(
+                  v.name,
+                  v.scope || "global",
+                  v.tabId,
+                  v.panelId,
+                );
+                manager.onVariablePartiallyLoaded(variableKey);
+              }
+            } else if (v.selectAllValueForMultiSelect === "all") {
+              const allValue = v.multiSelect
+                ? [SELECT_ALL_VALUE]
+                : SELECT_ALL_VALUE;
+              oldVariablesData[v.name] = allValue;
+              v.value = allValue;
+              // Mark as partially loaded so child variables know this variable is ready
+              v.isVariablePartialLoaded = true;
+              v.isLoading = false;
+              v.isVariableLoadingPending = false;
+
+              // Notify manager that this variable is loaded so it can trigger children
+              if (useManager && manager) {
+                const variableKey = getVariableKey(
+                  v.name,
+                  v.scope || "global",
+                  v.tabId,
+                  v.panelId,
+                );
+                manager.onVariablePartiallyLoaded(variableKey);
+              }
+            }
+          } else {
+            // No custom/all default - clear oldVariablesData so it gets fresh value from API
+            oldVariablesData[v.name] = undefined;
+          }
           return; // Skip further processing for this variable
         }
 
@@ -1024,11 +1078,6 @@ export default defineComponent({
         // Check if this is a child variable
         const isChildVariable =
           variablesDependencyGraph[v.name]?.parentVariables?.length > 0;
-
-        // Check if variable has custom or "all" default selection configured
-        const hasCustomOrAllDefault =
-          v.selectAllValueForMultiSelect === "custom" ||
-          v.selectAllValueForMultiSelect === "all";
 
         // If currently reset AND variable is marked as pending (about to load)
         // OR if options are empty (was reset), then clear oldVariablesData
@@ -1756,6 +1805,46 @@ export default defineComponent({
           const hasCustomOrAllDefault =
             variableObject.selectAllValueForMultiSelect === "custom" ||
             variableObject.selectAllValueForMultiSelect === "all";
+
+          // IMPORTANT: Before loading, check if variable has custom or "all" default
+          // and if its value is empty/null, set it to the default value
+          // This applies to both initial load and subsequent loads (e.g., when parent changes)
+          if (hasCustomOrAllDefault && !searchText) {
+            const currentValueIsEmpty =
+              variableObject.value === null ||
+              variableObject.value === undefined ||
+              (Array.isArray(variableObject.value) &&
+                variableObject.value.length === 0);
+
+            if (currentValueIsEmpty) {
+              variableLog(
+                variableObject.name,
+                `Variable has no value but has custom/all default - setting default value before load`,
+              );
+
+              // Set the default value based on configuration
+              if (
+                variableObject.selectAllValueForMultiSelect === "custom" &&
+                variableObject.customMultiSelectValue?.length > 0
+              ) {
+                variableObject.value = variableObject.multiSelect
+                  ? variableObject.customMultiSelectValue
+                  : variableObject.customMultiSelectValue[0];
+              } else if (variableObject.selectAllValueForMultiSelect === "all") {
+                variableObject.value = variableObject.multiSelect
+                  ? [SELECT_ALL_VALUE]
+                  : SELECT_ALL_VALUE;
+              }
+
+              // Update oldVariablesData to track this value
+              oldVariablesData[variableObject.name] = variableObject.value;
+
+              variableLog(
+                variableObject.name,
+                `Set default value to: ${JSON.stringify(variableObject.value)}`,
+              );
+            }
+          }
 
           // for initial loading check if the value is already available,
           // do not load the values


### PR DESCRIPTION
### **User description**
Bug fix, Tests

___
- Preserve custom/all defaults on resets

- Mark variables loaded, notify manager

- Pre-set defaults before query loading

- Add Playwright dependency-chain coverage

___

```mermaid
flowchart LR
  parent["Parent variable changes"]
  manager["Variables manager resets children"]
  selector["VariablesValueSelector sync/default logic"]
  defaults["Apply `all`/`custom` default value"]
  notify["Notify manager partial loaded"]
  children["Dependent children load correctly"]
  tests["Playwright chain default tests"]
  parent -- "triggers" --> manager
  manager -- "clears child values" --> selector
  selector -- "sets when configured" --> defaults
  defaults -- "unblocks" --> notify
  notify -- "enables" --> children
  tests -- "verifies" --> children
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>VariablesValueSelector.vue</strong><dd><code>Keep custom/all defaults during dependency resets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

web/src/components/dashboards/VariablesValueSelector.vue

<ul><li>Detect <code>custom</code>/<code>all</code> default configuration<br> <li> Set defaults when manager resets value<br> <li> Mark variable partially loaded and ready<br> <li> Pre-apply defaults before query load</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10406/files#diff-5c6e3bcb87cb64f25bf8157a541604b7a4904c1282acf662cab5d76a5be6bd56">+96/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table> <tr>
  <td>
    <details>

<summary><strong>dashboard-variables-scoped.js</strong><dd><code>Support selecting all/custom default in UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js

<ul><li>Add <code>defaultValueType</code> and <code>customValues</code> options<br> <li> Toggle default mode to <code>all</code> or <code>custom</code><br> <li> Fill custom default values for single/multi<br> <li> Keep legacy <code>defaultValue</code> path</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10406/files#diff-86abb9f90fabd982dedfdd9a21a052a47b6984edc7bd29a51ee104c8c473aec4">+43/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>

<summary><strong>dashboard-variables-default-values-chain.spec.js</strong><dd><code>Add dependency-chain default values Playwright suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-default-values-chain.spec.js

<ul><li>Test <code>all</code> default survives parent change<br> <li> Test <code>custom</code> defaults for single/multi<br> <li> Validate grandchild load with parent defaults<br> <li> Cover full A→B→C→D dependency chain</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10406/files#diff-2221c8f751dfff03ae4d77245c5b3b881a33c2ffb09e7b7db3052f5f7381bb22">+475/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration
changes</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>playwright.yml</strong><dd><code>Run new dashboard variables chain spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/playwright.yml

<ul><li>Include
<code>dashboard-variables-default-values-chain.spec.js</code> in run list</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10406/files#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Preserve `all`/`custom` defaults on resets

- Pre-apply defaults before query loading

- Notify manager when variable partially loaded

- Add Playwright chain-default coverage and CI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  parent["Parent variable value changes"]
  manager["Variables manager resets child values"]
  selector["VariablesValueSelector syncs old/current values"]
  defaults["Apply `all`/`custom` configured default"]
  notify["Mark partial loaded + notify manager"]
  children["Dependent children load with correct inputs"]
  tests["Playwright dependency-chain default tests"]
  ci["GitHub Actions runs dashboard variables spec"]
  parent -- "triggers" --> manager
  manager -- "clears value" --> selector
  selector -- "detects reset" --> defaults
  defaults -- "unblocks" --> notify
  notify -- "enables" --> children
  tests -- "verifies" --> children
  ci -- "executes" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VariablesValueSelector.vue</strong><dd><code>Keep custom/all defaults during dependency resets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/VariablesValueSelector.vue

<ul><li>Detect <code>custom</code>/<code>all</code> default configuration<br> <li> Apply defaults when manager resets children<br> <li> Mark variable partially loaded, stop loading<br> <li> Pre-set defaults before query-values load</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10425/files#diff-5c6e3bcb87cb64f25bf8157a541604b7a4904c1282acf662cab5d76a5be6bd56">+96/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-variables-scoped.js</strong><dd><code>Support configuring all/custom default types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js

<ul><li>Add <code>defaultValueType</code> and <code>customValues</code> options<br> <li> Drive UI toggles for <code>all</code>/<code>custom</code> defaults<br> <li> Keep legacy <code>defaultValue</code>/<code>customValueSearch</code> paths</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10425/files#diff-86abb9f90fabd982dedfdd9a21a052a47b6984edc7bd29a51ee104c8c473aec4">+43/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-variables-default-values-chain.spec.js</strong><dd><code>Add Playwright tests for chained defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-default-values-chain.spec.js

<ul><li>Cover <code>all</code>/<code>custom</code> defaults across dependencies<br> <li> Validate single- and multi-select behaviors<br> <li> Assert grandchildren load when parents change<br> <li> Include full A→B→C→D chain scenario</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10425/files#diff-2221c8f751dfff03ae4d77245c5b3b881a33c2ffb09e7b7db3052f5f7381bb22">+475/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playwright.yml</strong><dd><code>Enable dashboard variable default-chain test in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/playwright.yml

<ul><li>Add <code>Dashboards-Variables</code> job entry<br> <li> Run <code>dashboard-variables-default-values-chain.spec.js</code></ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10425/files#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3">+14/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

