### PR TITLE
refactor: redesign the query inspector with the colorize query in query-inspector (#10249)

### DIFF
--- a/tests/ui-testing/pages/dashboardPages/visualise.js
+++ b/tests/ui-testing/pages/dashboardPages/visualise.js
@@ -502,7 +502,7 @@ export default class LogsVisualise {
 
   //wait for query inspector to be visible
   async waitForQueryInspector(page) {
-    const queryInspector = page.getByText("Query Inspectorclose");
-    await expect(queryInspector).toBeVisible({ timeout: 10000 });
+    const queryInspectorCloseBtn = page.locator('[data-test="query-inspector-close-btn"]');
+    await queryInspectorCloseBtn.waitFor({ state: "visible", timeout: 10000 });
   }
 }

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-filter.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-filter.spec.js
@@ -119,10 +119,9 @@ test.describe("dashboard filter testcases", () => {
       .click();
 
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'ziox\' AND kubernetes_container_image <> \'ziox\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'ziox\' AND kubernetes_container_image <> \'ziox\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -143,10 +142,9 @@ test.describe("dashboard filter testcases", () => {
       .click();
 
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'ziox\' OR kubernetes_container_image <> \'ziox\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'ziox\' OR kubernetes_container_image <> \'ziox\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -234,10 +232,9 @@ test.describe("dashboard filter testcases", () => {
     await page.waitForTimeout(2000);
 
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'ziox\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'ziox\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -340,10 +337,9 @@ test.describe("dashboard filter testcases", () => {
       .click();
 
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE (kubernetes_container_name = \'ziox\' AND (kubernetes_container_image <> \'ziox\')) GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1"'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -423,15 +419,15 @@ test.describe("dashboard filter testcases", () => {
       .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
       .click();
 
-    const cell = await page.getByRole("cell", {
-      name: /SELECT kubernetes_container_name as "x_axis_1", count\(kubernetes_container_image\) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_namespace_name IN \('ingress-nginx', 'kube-system'\) GROUP BY x_axis_1/,
-    });
+    // Verify the query is displayed in the Query Inspector
+    const queryEditor = page.locator('.inspector-query-editor').filter({
+      hasText:  `SELECT kubernetes_container_name as "x_axis_1", count(kubernetes_container_image) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_namespace_name IN ('ingress-nginx', 'kube-system') GROUP BY x_axis_1`
+    }).last();
 
-    // Ensure the cell is visible
-    await expect(cell.first()).toBeVisible();
+    await expect(queryEditor).toBeVisible();
 
-    // Verify the text matches
-    await expect(cell.first()).toHaveText(
+    // Verify the exact query text matches
+    await expect(queryEditor).toHaveText(
       'SELECT kubernetes_container_name as "x_axis_1", count(kubernetes_container_image) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_namespace_name IN (\'ingress-nginx\', \'kube-system\') GROUP BY x_axis_1'
     );
 
@@ -669,10 +665,9 @@ test.describe("dashboard filter testcases", () => {
       .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
       .click();
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1", kubernetes_container_name as "breakdown_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'$variablename\' GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1", kubernetes_container_name as "breakdown_1" FROM "e2e_automate" WHERE kubernetes_container_name = \'$variablename\' GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
     await page.locator('[data-test="query-inspector-close-btn"]').click();
 
@@ -898,10 +893,9 @@ test.describe("dashboard filter testcases", () => {
       .click();
 
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE (kubernetes_container_name = \'ziox\' AND (kubernetes_container_image <> \'ziox\')) GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE (kubernetes_container_name = \'ziox\' AND (kubernetes_container_image <> \'ziox\')) GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -997,10 +991,9 @@ test.describe("dashboard filter testcases", () => {
 
     // Verify that the SQL query contains the str_match() function for Contains operator
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE str_match(kubernetes_container_name, \'ziox\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE str_match(kubernetes_container_name, \'ziox\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -1098,10 +1091,9 @@ test.describe("dashboard filter testcases", () => {
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name NOT IN (${variablename}) GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name NOT IN (${variablename}) GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -1196,10 +1188,9 @@ test.describe("dashboard filter testcases", () => {
 
     // Verify that the SQL query contains the str_match() function for Contains operator
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE str_match(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(_timestamp) as "y_axis_1" FROM "e2e_automate" WHERE str_match(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -1294,10 +1285,9 @@ test.describe("dashboard filter testcases", () => {
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE re_match(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE re_match(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -1392,10 +1382,9 @@ test.describe("dashboard filter testcases", () => {
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE match_all(\'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE match_all(\'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -1490,10 +1479,9 @@ test.describe("dashboard filter testcases", () => {
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE str_match_ignore_case(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE str_match_ignore_case(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -1588,10 +1576,9 @@ test.describe("dashboard filter testcases", () => {
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE re_not_match(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE re_not_match(kubernetes_container_name, \'$variablename\') GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -1686,10 +1673,9 @@ test.describe("dashboard filter testcases", () => {
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name LIKE \'$variablename%\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name LIKE \'$variablename%\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -1784,10 +1770,9 @@ test.describe("dashboard filter testcases", () => {
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name LIKE \'%$variablename\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name LIKE \'%$variablename\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();
@@ -1882,10 +1867,9 @@ test.describe("dashboard filter testcases", () => {
 
     // Verify that the SQL query contains the NOT IN clause
     await expect(
-      page.getByRole("cell", {
-        name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name NOT LIKE \'%$variablename%\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-        exact: true,
-      })
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_container_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_container_name NOT LIKE \'%$variablename%\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC'
+      }).last()
     ).toBeVisible();
 
     await page.locator('[data-test="query-inspector-close-btn"]').click();

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-multi-y-axis.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-multi-y-axis.spec.js
@@ -70,10 +70,10 @@ test.describe("dashboard multi y axis testcases", () => {
       .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
       .click();
     await page.waitForTimeout(1000);
+    // Verify the query is displayed in the Query Inspector
     await expect(
-      page
-        .getByRole("cell", {
-          name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_namespace_name) as "y_axis_1", count(kubernetes_container_name) as "y_axis_2", kubernetes_labels_name as "breakdown_1" FROM "e2e_automate" GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC',
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_namespace_name) as "y_axis_1", count(kubernetes_container_name) as "y_axis_2", kubernetes_labels_name as "breakdown_1" FROM "e2e_automate" GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC',
         })
         .first()
     ).toBeVisible();
@@ -132,10 +132,10 @@ test.describe("dashboard multi y axis testcases", () => {
     await page
       .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
       .click();
+    // Verify the query is displayed in the Query Inspector
     await expect(
-      page
-        .getByRole("cell", {
-          name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_namespace_name) as "y_axis_1", count(kubernetes_container_name) as "y_axis_2", kubernetes_labels_name as "breakdown_1" FROM "e2e_automate" GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC',
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_namespace_name) as "y_axis_1", count(kubernetes_container_name) as "y_axis_2", kubernetes_labels_name as "breakdown_1" FROM "e2e_automate" GROUP BY x_axis_1, breakdown_1 ORDER BY x_axis_1 ASC',
         })
         .first()
     ).toBeVisible();

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-null-handling.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-null-handling.spec.js
@@ -134,11 +134,11 @@ test.describe("Dashboard Variables - Null Handling", () => {
     // .locator('[data-test="dashboard-panel-data-view-query-inspector-btn"]')
     // .click();
 
+  // Verify the query is displayed in the Query Inspector (Executed Query section)
   await expect(
-    page.getByRole("cell", {
-      name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_pod_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_pod_name = \'_o2_all_\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
-      exact: true,
-    })
+    page.locator('.inspector-query-editor').filter({
+      hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_pod_name) as "y_axis_1" FROM "e2e_automate" WHERE kubernetes_pod_name = \'_o2_all_\' GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
+    }).last()
   ).toBeVisible();
 
     // Close Query Inspector dialog

--- a/tests/ui-testing/playwright-tests/Dashboards/visualize.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/visualize.spec.js
@@ -468,10 +468,10 @@ test.describe("logs testcases", () => {
 
     await pm.logsVisualise.waitForQueryInspector(page);
 
+    // Verify the query is displayed in the Query Inspector
     await expect(
-      page
-        .getByRole("cell", {
-          name: 'SELECT kubernetes_annotations_kubectl_kubernetes_io_default_container as "x_axis_1", count(kubernetes_container_hash) as "y_axis_1", count(kubernetes_container_name) as "y_axis_2", count(kubernetes_host) as "y_axis_3", count(kubernetes_labels_app_kubernetes_io_instance) as "y_axis_4", count(kubernetes_labels_app_kubernetes_io_name) as "y_axis_5", count(kubernetes_labels_app_kubernetes_io_version) as "y_axis_6", count(kubernetes_labels_operator_prometheus_io_name) as "y_axis_7", count(kubernetes_labels_prometheus) as "y_axis_8", kubernetes_labels_statefulset_kubernetes_io_pod_name as "breakdown_1" FROM "e2e_automate" WHERE kubernetes_namespace_name IS NOT NULL GROUP BY x_axis_1, breakdown_1',
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT kubernetes_annotations_kubectl_kubernetes_io_default_container as "x_axis_1", count(kubernetes_container_hash) as "y_axis_1", count(kubernetes_container_name) as "y_axis_2", count(kubernetes_host) as "y_axis_3", count(kubernetes_labels_app_kubernetes_io_instance) as "y_axis_4", count(kubernetes_labels_app_kubernetes_io_name) as "y_axis_5", count(kubernetes_labels_app_kubernetes_io_version) as "y_axis_6", count(kubernetes_labels_operator_prometheus_io_name) as "y_axis_7", count(kubernetes_labels_prometheus) as "y_axis_8", kubernetes_labels_statefulset_kubernetes_io_pod_name as "breakdown_1" FROM "e2e_automate" WHERE kubernetes_namespace_name IS NOT NULL GROUP BY x_axis_1, breakdown_1',
         })
         .first()
     ).toBeVisible();
@@ -514,10 +514,10 @@ test.describe("logs testcases", () => {
 
     await pm.logsVisualise.waitForQueryInspector(page);
 
+    // Verify the query is displayed in the Query Inspector
     await expect(
-      page
-        .getByRole("cell", {
-          name: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_namespace_name) as "y_axis_1" FROM "e2e_automate" GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) as "x_axis_1", count(kubernetes_namespace_name) as "y_axis_1" FROM "e2e_automate" GROUP BY x_axis_1 ORDER BY x_axis_1 ASC',
         })
         .first()
     ).toBeVisible();
@@ -568,10 +568,10 @@ test.describe("logs testcases", () => {
 
     await pm.logsVisualise.waitForQueryInspector(page);
 
+    // Verify the query is displayed in the Query Inspector
     await expect(
-      page
-        .getByRole("cell", {
-          name: 'SELECT histogram(_timestamp) AS zo_sql_key, count(*) AS zo_sql_num FROM "e2e_automate" GROUP BY zo_sql_key ORDER BY zo_sql_key DESC',
+      page.locator('.inspector-query-editor').filter({
+        hasText: 'SELECT histogram(_timestamp) AS zo_sql_key, count(*) AS zo_sql_num FROM "e2e_automate" GROUP BY zo_sql_key ORDER BY zo_sql_key DESC',
         })
         .first()
     ).toBeVisible();

--- a/web/src/components/dashboards/QueryInspector.spec.ts
+++ b/web/src/components/dashboards/QueryInspector.spec.ts
@@ -14,22 +14,20 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { installQuasar } from "@/test/unit/helpers/install-quasar-plugin";
 import { nextTick } from "vue";
 
-// Mock Quasar components
-vi.mock("quasar", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    Quasar: actual.Quasar,
-  };
-});
+// Mock colorizeQuery utility
+vi.mock("@/utils/query/colorizeQuery", () => ({
+  colorizeQuery: vi.fn((query: string) => {
+    return Promise.resolve(`<span class="mock-colorized">${query}</span>`);
+  }),
+}));
 
 // Mock utility functions
 vi.mock("@/utils/zincutils", () => ({
-  timestampToTimezoneDate: vi.fn((timestamp, timezone, format) => {
+  timestampToTimezoneDate: vi.fn(() => {
     return `2024-01-01 12:00:00.000`;
   }),
 }));
@@ -37,6 +35,7 @@ vi.mock("@/utils/zincutils", () => ({
 import QueryInspector from "@/components/dashboards/QueryInspector.vue";
 import i18n from "@/locales";
 import store from "@/test/unit/helpers/store";
+import { colorizeQuery } from "@/utils/query/colorizeQuery";
 
 installQuasar();
 
@@ -48,10 +47,10 @@ describe("QueryInspector", () => {
       queries: [
         {
           originalQuery: "SELECT * FROM logs WHERE level = 'error'",
-          query: "SELECT * FROM logs WHERE level = 'error' AND timestamp >= 1640995200000 AND timestamp < 1641081600000",
+          query: "SELECT * FROM logs WHERE level = 'error' AND timestamp >= 1640995200000",
           startTime: 1640995200000,
           endTime: 1641081600000,
-          queryType: "sql",
+          queryType: "SQL",
           variables: [
             {
               name: "level",
@@ -73,10 +72,10 @@ describe("QueryInspector", () => {
         },
         {
           originalQuery: "SELECT count(*) FROM metrics",
-          query: "SELECT count(*) FROM metrics WHERE timestamp >= 1640995200000 AND timestamp < 1641081600000",
+          query: "SELECT count(*) FROM metrics WHERE timestamp >= 1640995200000",
           startTime: 1640995200000,
           endTime: 1641081600000,
-          queryType: "sql",
+          queryType: "SQL",
           variables: [],
         },
       ],
@@ -90,6 +89,14 @@ describe("QueryInspector", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     store.state.timezone = "UTC";
+    store.state.theme = "light";
+
+    // Mock clipboard API
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn(() => Promise.resolve()),
+      },
+    });
   });
 
   afterEach(() => {
@@ -113,57 +120,69 @@ describe("QueryInspector", () => {
           QCard: { template: '<div data-test="q-card"><slot /></div>' },
           QCardSection: { template: '<div data-test="q-card-section"><slot /></div>' },
           QBtn: {
-            template: '<button data-test="q-btn" v-bind="$attrs"><slot /></button>',
-            props: ['icon', 'flat', 'round', 'dense'],
+            template: '<button data-test="q-btn" @click="$emit(\'click\')" v-bind="$attrs"><slot /></button>',
+            props: ['icon', 'flat', 'round', 'dense', 'color', 'size', 'noCaps'],
           },
-          QSpace: { template: '<div data-test="q-space"></div>' },
-          QTable: {
-            template: '<div data-test="q-table" v-bind="$attrs"><slot /></div>',
-            props: ['rows', 'pagination', 'virtualScroll', 'rowsPerPageOptions', 'virtualScrollStickyStart', 'dense', 'hideBottom', 'hideHeader', 'rowKey', 'wrapCells'],
+          QInput: {
+            template: '<input data-test="q-input" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" v-bind="$attrs"><slot name="prepend" /></input>',
+            props: ['modelValue', 'placeholder', 'dense', 'color', 'dark'],
           },
+          QIcon: {
+            template: '<span data-test="q-icon" :class="name"><slot /></span>',
+            props: ['name', 'size'],
+          },
+        },
+        directives: {
+          'close-popup': () => {},
         },
       },
     });
   };
 
   describe("Component Initialization", () => {
-    it("should render component with default props", () => {
+    it("should render component with default props", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(wrapper.exists()).toBe(true);
       expect(wrapper.vm).toBeTruthy();
     });
 
-    it("should initialize with required props", () => {
+    it("should initialize with required props", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(wrapper.vm.$props.metaData).toEqual(defaultProps.metaData);
       expect(wrapper.vm.$props.data).toEqual(defaultProps.data);
     });
 
-    it("should initialize reactive data", () => {
+    it("should initialize reactive data correctly", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(wrapper.vm.queryData).toBeDefined();
-      expect(wrapper.vm.pagination).toBeDefined();
       expect(wrapper.vm.totalQueries).toBeDefined();
       expect(wrapper.vm.dataTitle).toBeDefined();
+      expect(wrapper.vm.searchQuery).toBeDefined();
+      expect(wrapper.vm.colorizedQueries).toBeDefined();
     });
 
-    it("should handle empty metaData gracefully", () => {
+    it("should handle empty metaData gracefully", async () => {
       wrapper = createWrapper({
         metaData: {},
       });
+      await flushPromises();
 
       expect(wrapper.exists()).toBe(true);
       expect(wrapper.vm.queryData).toEqual([]);
       expect(wrapper.vm.totalQueries).toBe(0);
     });
 
-    it("should handle null metaData gracefully", () => {
+    it("should handle null metaData gracefully", async () => {
       wrapper = createWrapper({
         metaData: null,
       });
+      await flushPromises();
 
       expect(wrapper.exists()).toBe(true);
       expect(wrapper.vm.queryData).toEqual([]);
@@ -172,52 +191,77 @@ describe("QueryInspector", () => {
   });
 
   describe("Template Rendering", () => {
-    it("should display query inspector title", () => {
+    it("should display query inspector title", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(wrapper.text()).toContain("Query Inspector");
     });
 
-    it("should display panel title", () => {
+    it("should display panel title", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(wrapper.text()).toContain("Panel : Error Analysis Dashboard");
     });
 
-    it("should display total queries count", () => {
+    it("should display total queries count", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      expect(wrapper.text()).toContain("Total Query(s) Executed: 2");
+      expect(wrapper.text()).toContain("Total Queries: 2");
     });
 
-    it("should render close button", () => {
+    it("should render close button", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       const closeBtn = wrapper.find('[data-test="query-inspector-close-btn"]');
       expect(closeBtn.exists()).toBe(true);
     });
 
-    it("should render query table", () => {
+    it("should render search input", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      // Check that the component renders and contains table-related structure
-      expect(wrapper.html()).toContain("my-sticky-virtscroll-table");
+      const searchInput = wrapper.find('[data-test="q-input"]');
+      expect(searchInput.exists()).toBe(true);
     });
 
-    it("should display query numbers", () => {
+    it("should display query numbers", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      expect(wrapper.text()).toContain("Query: 1");
-      expect(wrapper.text()).toContain("Query: 2");
+      expect(wrapper.text()).toContain("Query 1");
+      expect(wrapper.text()).toContain("Query 2");
     });
 
-    it("should handle empty data title", () => {
+    it("should display query types", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("SQL");
+    });
+
+    it("should render empty state when no queries", async () => {
+      wrapper = createWrapper({
+        metaData: {
+          queries: [],
+        },
+      });
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("No queries executed for this panel");
+    });
+
+    it("should handle empty data title", async () => {
       wrapper = createWrapper({
         data: {
           title: "",
           id: "dashboard-1",
         },
       });
+      await flushPromises();
 
       expect(wrapper.text()).toContain("Panel :");
     });
@@ -234,195 +278,402 @@ describe("QueryInspector", () => {
       expect(props.data.required).toBe(true);
       expect(props.data.type).toBe(Object);
     });
-
-    it("should validate metaData prop", () => {
-      const props = QueryInspector.props;
-      const validator = props.metaData.validator;
-
-      expect(validator({})).toBe(true);
-      expect(validator(undefined)).toBe(false);
-      expect(validator({ queries: [] })).toBe(true);
-      expect(validator("invalid")).toBe(false);
-      expect(validator(123)).toBe(false);
-    });
   });
 
   describe("Query Data Processing", () => {
-    it("should process query data from metaData", () => {
+    it("should process query data from metaData", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(wrapper.vm.queryData).toEqual(defaultProps.metaData.queries);
     });
 
-    it("should handle missing queries in metaData", () => {
-      wrapper = createWrapper({
-        metaData: {
-          otherData: "test",
-        },
-      });
-
-      expect(wrapper.vm.queryData).toEqual([]);
-    });
-
-    it("should compute total queries correctly", () => {
+    it("should compute total queries correctly", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(wrapper.vm.totalQueries).toBe(2);
     });
 
-    it("should compute total queries as 0 when no queries", () => {
+    it("should compute total queries as 0 when no queries", async () => {
       wrapper = createWrapper({
         metaData: {
           queries: [],
         },
       });
+      await flushPromises();
 
       expect(wrapper.vm.totalQueries).toBe(0);
     });
+
+    it("should display original query when present", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("Original Query");
+    });
+
+    it("should display executed query", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("Executed Query");
+    });
   });
 
-  describe("getRows Method", () => {
-    it("should generate correct rows for query with variables", () => {
+  describe("formatTimestamp Method", () => {
+    it("should format timestamps correctly", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      const query = defaultProps.metaData.queries[0];
-      const rows = wrapper.vm.getRows(query);
-
-      expect(rows).toHaveLength(8);
-      expect(rows[0]).toEqual(["Original Query", query.originalQuery]);
-      expect(rows[1]).toEqual(["Query", query.query]);
-      expect(rows[2]).toEqual(["Start Time", expect.stringContaining("1640995200000")]);
-      expect(rows[3]).toEqual(["End Time", expect.stringContaining("1641081600000")]);
-      expect(rows[4]).toEqual(["Query Type", "sql"]);
+      const formattedTime = wrapper.vm.formatTimestamp(1640995200000);
+      expect(formattedTime).toContain("1640995200000");
+      expect(formattedTime).toContain("2024-01-01 12:00:00.000");
+      expect(formattedTime).toContain("UTC");
     });
 
-    it("should handle variables correctly", () => {
+    it("should return dash for missing timestamp", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      const query = defaultProps.metaData.queries[0];
-      const rows = wrapper.vm.getRows(query);
-
-      expect(rows[5][1]).toContain("level: error");
-      expect(rows[6][1]).toContain("service: api");
-      expect(rows[7][1]).toContain("count >= 100");
+      const formattedTime = wrapper.vm.formatTimestamp(null);
+      expect(formattedTime).toBe("-");
     });
 
-    it("should handle query without variables", () => {
+    it("should return dash for undefined timestamp", async () => {
       wrapper = createWrapper();
+      await flushPromises();
+
+      const formattedTime = wrapper.vm.formatTimestamp(undefined);
+      expect(formattedTime).toBe("-");
+    });
+
+    it("should return dash for zero timestamp", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const formattedTime = wrapper.vm.formatTimestamp(0);
+      expect(formattedTime).toBe("-");
+    });
+
+    it("should use timezone from store", async () => {
+      store.state.timezone = "America/New_York";
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const formattedTime = wrapper.vm.formatTimestamp(1640995200000);
+      expect(formattedTime).toContain("America/New_York");
+    });
+  });
+
+  describe("getVariablesByType Method", () => {
+    it("should filter variables by type correctly", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const query = defaultProps.metaData.queries[0];
+      const standardVars = wrapper.vm.getVariablesByType(query, "variable");
+      const fixedVars = wrapper.vm.getVariablesByType(query, "fixed");
+      const dynamicVars = wrapper.vm.getVariablesByType(query, "dynamicVariable");
+
+      expect(standardVars).toHaveLength(1);
+      expect(standardVars[0].name).toBe("level");
+      expect(fixedVars).toHaveLength(1);
+      expect(fixedVars[0].name).toBe("service");
+      expect(dynamicVars).toHaveLength(1);
+      expect(dynamicVars[0].name).toBe("count");
+    });
+
+    it("should return empty array when no variables match type", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
 
       const query = defaultProps.metaData.queries[1];
-      const rows = wrapper.vm.getRows(query);
+      const vars = wrapper.vm.getVariablesByType(query, "variable");
 
-      expect(rows[5][1]).toBe("-");
-      expect(rows[6][1]).toBe("-");
-      expect(rows[7][1]).toBe("-");
+      expect(vars).toEqual([]);
     });
 
-    it("should format timestamps correctly", () => {
+    it("should handle query without variables", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      const query = defaultProps.metaData.queries[0];
-      const rows = wrapper.vm.getRows(query);
+      const query = { ...defaultProps.metaData.queries[0], variables: undefined };
+      const vars = wrapper.vm.getVariablesByType(query, "variable");
 
-      expect(rows[2][1]).toContain("2024-01-01 12:00:00.000");
-      expect(rows[3][1]).toContain("2024-01-01 12:00:00.000");
-      expect(rows[2][1]).toContain("UTC");
-      expect(rows[3][1]).toContain("UTC");
+      expect(vars).toEqual([]);
     });
 
-    it("should handle missing timestamps", () => {
+    it("should handle query with empty variables array", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      const query = {
-        ...defaultProps.metaData.queries[0],
-        startTime: undefined,
-        endTime: undefined,
-      };
-      const rows = wrapper.vm.getRows(query);
+      const query = { ...defaultProps.metaData.queries[0], variables: [] };
+      const vars = wrapper.vm.getVariablesByType(query, "variable");
 
-      expect(rows[2][1]).toContain("undefined");
-      expect(rows[3][1]).toContain("undefined");
+      expect(vars).toEqual([]);
+    });
+  });
+
+  describe("updateColorizedQueries Method", () => {
+    it("should colorize queries on mount", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      expect(colorizeQuery).toHaveBeenCalled();
+      expect(wrapper.vm.colorizedQueries).toBeDefined();
     });
 
-    it("should handle different variable types", () => {
+    it("should call colorizeQuery for each query with correct language", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const query1 = defaultProps.metaData.queries[0];
+      const query2 = defaultProps.metaData.queries[1];
+
+      expect(colorizeQuery).toHaveBeenCalledWith(query1.originalQuery, "sql");
+      expect(colorizeQuery).toHaveBeenCalledWith(query1.query, "sql");
+      expect(colorizeQuery).toHaveBeenCalledWith(query2.originalQuery, "sql");
+      expect(colorizeQuery).toHaveBeenCalledWith(query2.query, "sql");
+    });
+
+    it("should handle queries without originalQuery", async () => {
       wrapper = createWrapper({
         metaData: {
           queries: [
             {
-              ...defaultProps.metaData.queries[0],
-              variables: [
-                {
-                  name: "var1",
-                  value: "value1",
-                  type: "variable",
-                },
-                {
-                  name: "var2",
-                  value: "value2",
-                  type: "fixed",
-                },
-                {
-                  name: "var3",
-                  value: "value3",
-                  operator: "=",
-                  type: "dynamicVariable",
-                },
-                {
-                  name: "unknown",
-                  value: "test",
-                  type: "unknown",
-                },
-              ],
+              query: "SELECT * FROM logs",
+              startTime: 1640995200000,
+              endTime: 1641081600000,
+              queryType: "SQL",
+              variables: [],
+            },
+          ],
+        },
+      });
+      await flushPromises();
+
+      expect(colorizeQuery).toHaveBeenCalledWith("SELECT * FROM logs", "sql");
+    });
+
+    it("should store colorized queries with correct keys", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      expect(wrapper.vm.colorizedQueries["0-Original Query"]).toBeDefined();
+      expect(wrapper.vm.colorizedQueries["0-Query"]).toBeDefined();
+      expect(wrapper.vm.colorizedQueries["1-Original Query"]).toBeDefined();
+      expect(wrapper.vm.colorizedQueries["1-Query"]).toBeDefined();
+    });
+
+    it("should update colorized queries when metaData changes", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      vi.clearAllMocks();
+
+      await wrapper.setProps({
+        metaData: {
+          queries: [
+            {
+              query: "NEW QUERY",
+              queryType: "SQL",
+              startTime: 1640995200000,
+              endTime: 1641081600000,
+              variables: [],
             },
           ],
         },
       });
 
-      const rows = wrapper.vm.getRows(wrapper.vm.queryData[0]);
+      await flushPromises();
 
-      expect(rows[5][1]).toBe("var1: value1");
-      expect(rows[6][1]).toBe("var2: value2");
-      expect(rows[7][1]).toBe("var3 = value3");
+      expect(colorizeQuery).toHaveBeenCalledWith("NEW QUERY", "sql");
+    });
+  });
+
+  describe("highlightSearch Method", () => {
+    it("should return html unchanged when no search query", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const html = "<span>test query</span>";
+      wrapper.vm.searchQuery = "";
+      const result = wrapper.vm.highlightSearch(html);
+
+      expect(result).toBe(html);
     });
 
-    it("should handle multiple variables of same type", () => {
-      wrapper = createWrapper({
-        metaData: {
-          queries: [
-            {
-              ...defaultProps.metaData.queries[0],
-              variables: [
-                {
-                  name: "var1",
-                  value: "value1",
-                  type: "variable",
-                },
-                {
-                  name: "var2",
-                  value: "value2",
-                  type: "variable",
-                },
-              ],
-            },
-          ],
-        },
+    it("should highlight matching text", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const html = "<span>test query</span>";
+      wrapper.vm.searchQuery = "query";
+      const result = wrapper.vm.highlightSearch(html);
+
+      expect(result).toContain("<mark");
+      expect(result).toContain("query");
+    });
+
+    it("should escape special regex characters", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const html = "test (query) with special chars";
+      wrapper.vm.searchQuery = "(query)";
+      const result = wrapper.vm.highlightSearch(html);
+
+      expect(result).toContain("<mark");
+      expect(result).toContain("(query)");
+    });
+
+    it("should be case insensitive", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const html = "Test QUERY Query";
+      wrapper.vm.searchQuery = "query";
+      const result = wrapper.vm.highlightSearch(html);
+
+      expect(result).toContain("<mark");
+      // The regex matches case-insensitively but may match fewer times depending on HTML structure
+      expect((result.match(/<mark/g) || []).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should not highlight text inside HTML tags", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const html = '<span class="test">query</span>';
+      wrapper.vm.searchQuery = "class";
+      const result = wrapper.vm.highlightSearch(html);
+
+      // Should not highlight "class" inside the tag attribute
+      expect(result).toBe(html);
+    });
+
+    it("should return html unchanged for empty html", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      wrapper.vm.searchQuery = "test";
+      const result = wrapper.vm.highlightSearch("");
+
+      expect(result).toBe("");
+    });
+
+    it("should return html unchanged for null html", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      wrapper.vm.searchQuery = "test";
+      const result = wrapper.vm.highlightSearch(null);
+
+      expect(result).toBe(null);
+    });
+
+    it("should handle regex errors gracefully", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const html = "test query";
+      wrapper.vm.searchQuery = "test";
+
+      // Mock a regex that might throw
+      const spy = vi.spyOn(String.prototype, 'replace').mockImplementationOnce(() => {
+        throw new Error("Regex error");
       });
 
-      const rows = wrapper.vm.getRows(wrapper.vm.queryData[0]);
+      const result = wrapper.vm.highlightSearch(html);
 
-      expect(rows[5][1]).toBe("var1: value1, var2: value2");
+      expect(result).toBe(html);
+      spy.mockRestore();
+    });
+  });
+
+  describe("copyText Method", () => {
+    it("should copy text to clipboard", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const testText = "SELECT * FROM logs";
+      wrapper.vm.copyText(testText);
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(testText);
+    });
+
+    it("should not copy empty text", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      wrapper.vm.copyText("");
+
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
+
+    it("should not copy null text", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      wrapper.vm.copyText(null);
+
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
+
+    it("should not copy undefined text", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      wrapper.vm.copyText(undefined);
+
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
+
+    it("should handle copy button clicks", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const copyButtons = wrapper.findAll('[data-test="q-btn"]');
+      const copyButton = copyButtons.find((btn: any) => btn.text().includes("Copy"));
+
+      if (copyButton) {
+        await copyButton.trigger('click');
+        expect(navigator.clipboard.writeText).toHaveBeenCalled();
+      }
+    });
+
+    it("should copy executed query when copy button is clicked", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      // Find all copy buttons and click the one for executed query
+      const copyButtons = wrapper.findAll('[data-test="q-btn"]');
+
+      // There should be multiple copy buttons (one for originalQuery, one for query per query item)
+      // Find the button that would copy the executed query
+      for (const btn of copyButtons) {
+        if (btn.text().includes("Copy")) {
+          await btn.trigger('click');
+        }
+      }
+
+      // Verify clipboard writeText was called
+      expect(navigator.clipboard.writeText).toHaveBeenCalled();
     });
   });
 
   describe("Computed Properties", () => {
-    it("should compute dataTitle from props.data.title", () => {
+    it("should compute dataTitle from props.data.title", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(wrapper.vm.dataTitle).toBe("Error Analysis Dashboard");
     });
 
     it("should update dataTitle when props change", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(wrapper.vm.dataTitle).toBe("Error Analysis Dashboard");
 
@@ -436,244 +687,444 @@ describe("QueryInspector", () => {
       expect(wrapper.vm.dataTitle).toBe("New Dashboard Title");
     });
 
-    it("should compute totalQueries from queryData length", () => {
+    it("should compute totalQueries from queryData length", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(wrapper.vm.totalQueries).toBe(2);
     });
+  });
 
-    it("should update totalQueries when metaData changes", async () => {
+  describe("getQueryTypeDisplay Method", () => {
+    it("should return SQL for empty queryType", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      expect(wrapper.vm.totalQueries).toBe(2);
+      const result = wrapper.vm.getQueryTypeDisplay("");
+      expect(result).toBe("SQL");
+    });
 
-      // Since queryData is set in setup(), it doesn't automatically update with prop changes
-      // This test verifies the computed property works correctly for the initial data
-      expect(wrapper.vm.queryData.length).toBe(2);
+    it("should return SQL for null queryType", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay(null);
+      expect(result).toBe("SQL");
+    });
+
+    it("should return SQL for undefined queryType", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay(undefined);
+      expect(result).toBe("SQL");
+    });
+
+    it("should return SQL for sql queryType", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay("sql");
+      expect(result).toBe("SQL");
+    });
+
+    it("should return SQL for SQL queryType in uppercase", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay("SQL");
+      expect(result).toBe("SQL");
+    });
+
+    it("should return SQL for SQL queryType in mixed case", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay("SqL");
+      expect(result).toBe("SQL");
+    });
+
+    it("should return PromQL for promql queryType", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay("promql");
+      expect(result).toBe("PromQL");
+    });
+
+    it("should return PromQL for PromQL queryType in uppercase", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay("PROMQL");
+      expect(result).toBe("PromQL");
+    });
+
+    it("should return PromQL for metrics queryType", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay("metrics");
+      expect(result).toBe("PromQL");
+    });
+
+    it("should return PromQL for METRICS queryType in uppercase", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay("METRICS");
+      expect(result).toBe("PromQL");
+    });
+
+    it("should return uppercase for unknown queryType", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay("vrl");
+      expect(result).toBe("VRL");
+    });
+
+    it("should return uppercase for custom queryType", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay("custom");
+      expect(result).toBe("CUSTOM");
+    });
+
+    it("should handle queryType with special characters", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const result = wrapper.vm.getQueryTypeDisplay("my-query");
+      expect(result).toBe("MY-QUERY");
     });
   });
 
   describe("Store Integration", () => {
-    it("should use timezone from store", () => {
+    it("should use timezone from store", async () => {
       store.state.timezone = "America/New_York";
       wrapper = createWrapper();
+      await flushPromises();
 
-      const query = defaultProps.metaData.queries[0];
-      const rows = wrapper.vm.getRows(query);
-
-      expect(rows[2][1]).toContain("America/New_York");
-      expect(rows[3][1]).toContain("America/New_York");
+      const formattedTime = wrapper.vm.formatTimestamp(1640995200000);
+      expect(formattedTime).toContain("America/New_York");
     });
 
-    it("should handle different timezones", () => {
-      store.state.timezone = "Asia/Tokyo";
+    it("should use theme from store for input", async () => {
+      store.state.theme = "dark";
       wrapper = createWrapper();
+      await flushPromises();
 
-      const query = defaultProps.metaData.queries[0];
-      const rows = wrapper.vm.getRows(query);
-
-      expect(rows[2][1]).toContain("Asia/Tokyo");
-      expect(rows[3][1]).toContain("Asia/Tokyo");
+      expect(wrapper.vm.store.state.theme).toBe("dark");
     });
   });
 
-  describe("Edge Cases", () => {
-    it("should handle null query", () => {
+  describe("Watch Functionality", () => {
+    it("should watch metaData changes and update colorized queries", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      expect(() => {
-        wrapper.vm.getRows(null);
-      }).not.toThrow();
-    });
+      vi.clearAllMocks();
 
-    it("should handle query with missing properties", () => {
-      wrapper = createWrapper();
-
-      const incompleteQuery = {
-        originalQuery: "SELECT * FROM logs",
-        // Missing other properties
-      };
-
-      expect(() => {
-        wrapper.vm.getRows(incompleteQuery);
-      }).not.toThrow();
-    });
-
-    it("should handle empty variables array", () => {
-      wrapper = createWrapper({
+      await wrapper.setProps({
         metaData: {
           queries: [
             {
-              ...defaultProps.metaData.queries[0],
+              query: "UPDATED QUERY",
+              queryType: "SQL",
+              startTime: 1640995200000,
+              endTime: 1641081600000,
               variables: [],
             },
           ],
         },
       });
 
-      const rows = wrapper.vm.getRows(wrapper.vm.queryData[0]);
+      await flushPromises();
 
-      expect(rows[5][1]).toBe("-");
-      expect(rows[6][1]).toBe("-");
-      expect(rows[7][1]).toBe("-");
+      expect(colorizeQuery).toHaveBeenCalled();
     });
 
-    it("should handle variables without proper structure", () => {
+    it("should handle deep metaData changes", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      vi.clearAllMocks();
+
+      const newMetaData = {
+        queries: [
+          {
+            ...defaultProps.metaData.queries[0],
+            query: "MODIFIED QUERY",
+          },
+        ],
+      };
+
+      await wrapper.setProps({ metaData: newMetaData });
+      await flushPromises();
+
+      expect(colorizeQuery).toHaveBeenCalled();
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle queries with missing properties", async () => {
       wrapper = createWrapper({
         metaData: {
           queries: [
             {
-              ...defaultProps.metaData.queries[0],
+              query: "SELECT * FROM logs",
+              // Missing other properties
+            },
+          ],
+        },
+      });
+      await flushPromises();
+
+      expect(wrapper.exists()).toBe(true);
+    });
+
+    it("should handle very long query strings", async () => {
+      const longQuery = "SELECT * FROM logs WHERE " + "condition AND ".repeat(100) + "final_condition";
+
+      wrapper = createWrapper({
+        metaData: {
+          queries: [
+            {
+              originalQuery: longQuery,
+              query: longQuery,
+              queryType: "SQL",
+              startTime: 1640995200000,
+              endTime: 1641081600000,
+              variables: [],
+            },
+          ],
+        },
+      });
+      await flushPromises();
+
+      expect(wrapper.exists()).toBe(true);
+    });
+
+    it("should handle special characters in queries", async () => {
+      const specialQuery = "SELECT * FROM logs WHERE field LIKE '%test%' AND other = '$var'";
+
+      wrapper = createWrapper({
+        metaData: {
+          queries: [
+            {
+              query: specialQuery,
+              queryType: "SQL",
+              startTime: 1640995200000,
+              endTime: 1641081600000,
+              variables: [],
+            },
+          ],
+        },
+      });
+      await flushPromises();
+
+      expect(wrapper.exists()).toBe(true);
+    });
+
+    it("should handle multiple queries with different types", async () => {
+      wrapper = createWrapper({
+        metaData: {
+          queries: [
+            {
+              query: "SELECT * FROM logs",
+              queryType: "SQL",
+              startTime: 1640995200000,
+              endTime: 1641081600000,
+              variables: [],
+            },
+            {
+              query: "rate(http_requests[5m])",
+              queryType: "PromQL",
+              startTime: 1640995200000,
+              endTime: 1641081600000,
+              variables: [],
+            },
+          ],
+        },
+      });
+      await flushPromises();
+
+      expect(wrapper.exists()).toBe(true);
+      expect(colorizeQuery).toHaveBeenCalledWith(expect.any(String), "sql");
+      expect(colorizeQuery).toHaveBeenCalledWith(expect.any(String), "promql");
+    });
+
+    it("should handle variables without operator", async () => {
+      wrapper = createWrapper({
+        metaData: {
+          queries: [
+            {
+              query: "SELECT * FROM logs",
+              queryType: "SQL",
+              startTime: 1640995200000,
+              endTime: 1641081600000,
               variables: [
                 {
-                  // Missing name, value, type
-                },
-                {
-                  name: "incomplete",
-                  // Missing value, type
+                  name: "test",
+                  value: "value",
+                  type: "dynamicVariable",
+                  // Missing operator
                 },
               ],
             },
           ],
         },
       });
+      await flushPromises();
 
-      expect(() => {
-        wrapper.vm.getRows(wrapper.vm.queryData[0]);
-      }).not.toThrow();
-    });
-
-    it("should handle very long query strings", () => {
-      const longQuery = "SELECT * FROM logs WHERE " + "condition AND ".repeat(100) + "final_condition";
-      
-      wrapper = createWrapper({
-        metaData: {
-          queries: [
-            {
-              ...defaultProps.metaData.queries[0],
-              originalQuery: longQuery,
-              query: longQuery,
-            },
-          ],
-        },
-      });
-
-      const rows = wrapper.vm.getRows(wrapper.vm.queryData[0]);
-
-      expect(rows[0][1]).toBe(longQuery);
-      expect(rows[1][1]).toBe(longQuery);
+      expect(wrapper.exists()).toBe(true);
     });
   });
 
   describe("Component Lifecycle", () => {
-    it("should handle component mounting without errors", () => {
+    it("should handle component mounting without errors", async () => {
       expect(() => {
         wrapper = createWrapper();
       }).not.toThrow();
+      await flushPromises();
     });
 
-    it("should handle component unmounting without errors", () => {
+    it("should handle component unmounting without errors", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
       expect(() => {
         wrapper.unmount();
       }).not.toThrow();
     });
 
-    it("should maintain reactivity after mounting", () => {
+    it("should clean up watchers on unmount", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      expect(wrapper.vm.totalQueries).toBe(2);
-      expect(wrapper.vm.dataTitle).toBe("Error Analysis Dashboard");
+      const initialCallCount = (colorizeQuery as any).mock.calls.length;
+
+      wrapper.unmount();
+
+      // Try to trigger a prop change after unmount (should not call colorizeQuery)
+      await nextTick();
+
+      expect((colorizeQuery as any).mock.calls.length).toBe(initialCallCount);
     });
   });
 
-  describe("Table Configuration", () => {
-    it("should configure pagination correctly", () => {
+  describe("Search Functionality", () => {
+    it("should initialize search query as empty string", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      expect(wrapper.vm.pagination.rowsPerPage).toBe(0);
+      expect(wrapper.vm.searchQuery).toBe("");
     });
 
-    it("should render table for each query", () => {
+    it("should update search query on input", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      // Since the component uses v-for to render tables, check if the wrapper contains the expected structure
-      expect(wrapper.text()).toContain("Query: 1");
-      expect(wrapper.text()).toContain("Query: 2");
+      wrapper.vm.searchQuery = "test search";
+      await nextTick();
+
+      expect(wrapper.vm.searchQuery).toBe("test search");
     });
 
-    it("should pass correct props to table", () => {
+    it("should bind searchQuery to input v-model", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      const table = wrapper.find('[data-test="q-table"]');
-      if (table.exists()) {
-        expect(table.attributes("virtual-scroll")).toBeDefined();
-        expect(table.attributes("dense")).toBeDefined();
-      } else {
-        // If table stub isn't rendering, verify the component structure still exists
-        expect(wrapper.exists()).toBe(true);
-      }
-    });
-  });
+      const searchInput = wrapper.find('[data-test="q-input"]');
+      expect(searchInput.exists()).toBe(true);
 
-  describe("Query Inspector Layout", () => {
-    it("should render card container", () => {
-      wrapper = createWrapper();
+      // Simulate user typing into the search input
+      await searchInput.setValue("error");
+      await nextTick();
 
-      const card = wrapper.find('[data-test="q-card"]');
-      expect(card.exists()).toBe(true);
+      expect(wrapper.vm.searchQuery).toBe("error");
     });
 
-    it("should render card section", () => {
+    it("should filter displayed content based on search", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      const cardSection = wrapper.find('[data-test="q-card-section"]');
-      expect(cardSection.exists()).toBe(true);
-    });
+      wrapper.vm.searchQuery = "error";
+      await nextTick();
 
-    it("should render space component", () => {
-      wrapper = createWrapper();
-
-      const space = wrapper.find('[data-test="q-space"]');
-      expect(space.exists()).toBe(true);
-    });
-
-    it("should have proper CSS classes", () => {
-      wrapper = createWrapper();
-
-      expect(wrapper.html()).toContain("my-sticky-virtscroll-table");
+      const highlighted = wrapper.vm.highlightSearch("SELECT * FROM logs WHERE level = 'error'");
+      expect(highlighted).toContain("<mark");
     });
   });
 
-  describe("Data Display", () => {
-    it("should display all query information fields", () => {
+  describe("Variables Display", () => {
+    it("should display standard variables", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      const query = defaultProps.metaData.queries[0];
-      const rows = wrapper.vm.getRows(query);
-
-      expect(rows[0][0]).toBe("Original Query");
-      expect(rows[1][0]).toBe("Query");
-      expect(rows[2][0]).toBe("Start Time");
-      expect(rows[3][0]).toBe("End Time");
-      expect(rows[4][0]).toBe("Query Type");
-      expect(rows[5][0]).toBe("Variable(s)");
-      expect(rows[6][0]).toBe("Fixed Variable(s)");
-      expect(rows[7][0]).toBe("Dynamic Variable(s)");
+      expect(wrapper.text()).toContain("Variable(s)");
+      expect(wrapper.text()).toContain("level");
+      expect(wrapper.text()).toContain("error");
     });
 
-    it("should format start and end times consistently", () => {
+    it("should display fixed variables", async () => {
       wrapper = createWrapper();
+      await flushPromises();
 
-      const query = defaultProps.metaData.queries[0];
-      const rows = wrapper.vm.getRows(query);
+      expect(wrapper.text()).toContain("Fixed Variable(s)");
+      expect(wrapper.text()).toContain("service");
+      expect(wrapper.text()).toContain("api");
+    });
 
-      const startTimePattern = /\d+ \(2024-01-01 12:00:00\.000 UTC\)/;
-      const endTimePattern = /\d+ \(2024-01-01 12:00:00\.000 UTC\)/;
+    it("should display dynamic variables with operators", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
 
-      expect(rows[2][1]).toMatch(startTimePattern);
-      expect(rows[3][1]).toMatch(endTimePattern);
+      expect(wrapper.text()).toContain("Dynamic Variable(s)");
+      expect(wrapper.text()).toContain("count");
+      expect(wrapper.text()).toContain(">=");
+      expect(wrapper.text()).toContain("100");
+    });
+
+    it("should show dash for missing variables", async () => {
+      wrapper = createWrapper({
+        metaData: {
+          queries: [
+            {
+              query: "SELECT * FROM logs",
+              queryType: "SQL",
+              startTime: 1640995200000,
+              endTime: 1641081600000,
+              variables: [],
+            },
+          ],
+        },
+      });
+      await flushPromises();
+
+      const text = wrapper.text();
+      // Should have dashes for empty variable sections
+      expect(text).toContain("-");
+    });
+  });
+
+  describe("Time Display", () => {
+    it("should display start time", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("Start Time");
+      expect(wrapper.text()).toContain("1640995200000");
+    });
+
+    it("should display end time", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("End Time");
+      expect(wrapper.text()).toContain("1641081600000");
     });
   });
 });

--- a/web/src/components/dashboards/QueryInspector.vue
+++ b/web/src/components/dashboards/QueryInspector.vue
@@ -1,112 +1,357 @@
 <template>
-  <q-card style="min-width: 700px">
-    <q-card-section class="q-pt-md">
-      <div class="row items-center">
-        <div class="text-bold text-h6 q-pb-lg">Query Inspector</div>
-        <q-space />
-        <q-btn icon="close" class="q-mb-lg" flat round dense v-close-popup = "true" data-test="query-inspector-close-btn"/>
+  <q-card
+    class="tw:min-w-[850px] tw:max-w-[80vw] tw:max-h-[90vh] tw:flex tw:flex-col tw:rounded-xl tw:shadow-2xl tw:overflow-hidden tw:bg-[var(--o2-card-bg)] tw:text-[var(--o2-text-primary)]">
+    <!-- Header -->
+    <div
+      class="tw:flex tw:items-center tw:justify-between tw:px-6 tw:py-4 tw:bg-[var(--o2-card-bg)] tw:border-b tw:border-[var(--o2-border-color)]">
+      <div class="tw:flex tw:flex-col">
+        <div class="tw:text-xl tw:font-bold tw:m-0 tw:flex tw:items-center tw:gap-2">
+          Query Inspector
+        </div>
+        <div class="tw:text-[var(--o2-text-secondary)] tw:text-sm tw:font-bold tw:mt-1 tw:flex tw:items-center tw:gap-3">
+          <span>Panel : {{ dataTitle }}</span>
+          <span class="tw:w-1 tw:h-1 tw:bg-[var(--o2-text-secondary)] tw:rounded-full"></span>
+          <span>Total Queries: {{ totalQueries }}</span>
+        </div>
       </div>
-      <div class="text-bold q-pb-sm">Panel : {{ dataTitle }}</div>
-      <div class="text-bold">Total Query(s) Executed: {{ totalQueries }}</div>
-      <div v-for="(query, index) in ((metaData as any)?.queries ?? [])" :key="query?.originalQuery">
-        <div class="text-bold q-py-sm">Query: {{ index + 1 }}</div>
-            <q-table class="my-sticky-virtscroll-table" virtual-scroll  v-model:pagination="pagination"
-              :rows-per-page-options="[0]" :virtual-scroll-sticky-size-start="48" dense :rows="getRows(query)"
-              hide-bottom hide-header row-key="index" wrap-cells data-test="query-inspector">
-            </q-table>
+
+      <div class="tw:flex tw:items-center tw:gap-4">
+        <div class="tw:relative tw:w-50">
+          <q-input v-model="searchQuery" placeholder="Search keywords..." dense color="primary"
+            :dark="store.state.theme === 'dark'">
+            <template v-slot:prepend>
+              <q-icon name="search" size="xs" />
+            </template>
+          </q-input>
+        </div>
+        <q-btn icon="close" flat round dense v-close-popup="true"
+          class="tw:text-[var(--o2-text-muted)] hover:tw:text-[var(--o2-text-primary)]"
+          data-test="query-inspector-close-btn" />
+      </div>
+    </div>
+
+    <!-- Body -->
+    <q-card-section class="tw:flex-1 tw:max-h-[60vh] tw:overflow-y-auto tw:p-6">
+      <div v-if="queryData.length === 0"
+        class="tw:flex tw:flex-col tw:items-center tw:justify-center tw:h-64 tw:text-[var(--o2-text-muted)]">
+        <q-icon name="info" size="48px" />
+        <p class="tw:mt-2">No queries executed for this panel.</p>
+      </div>
+
+      <div v-else class="tw:space-y-4">
+        <div v-for="(query, index) in queryData" :key="query?.originalQuery + index"
+          class="tw:bg-[var(--o2-card-bg)] tw:rounded-xl tw:border tw:border-[var(--o2-border-color)] tw:shadow-sm tw:overflow-hidden">
+          <!-- Query Header -->
+          <div
+            class="tw:p-2 tw:gap-3 tw:bg-[var(--o2-body-primary-bg)] tw:border-b tw:border-[var(--o2-border-color)] tw:flex tw:items-start tw:justify-start">
+           
+              <span
+                class="tw:text-sm tw:font-bold tw:rounded-md">
+                Query {{ index + 1 }}
+              </span>
+              <span
+                class="tw:bg-[var(--o2-body-primary-bg)] tw:border tw:border-[var(--o2-border-color)] tw:text-[var(--o2-text-secondary)] tw:text-[10px] tw:font-bold tw:px-2 tw:py-0.5 tw:rounded-md">
+                 {{ getQueryTypeDisplay(query.queryType) }}
+              </span>
+          </div>
+
+          <!-- Query Content -->
+          <div class="tw:p-3 tw:space-y-4">
+            <!-- Original Query -->
+            <div v-if="query.originalQuery">
+              <div class="tw:flex tw:items-center tw:justify-between">
+                <label
+                  class="tw:text-xs tw:font-bold tw:tracking-wider">Original
+                  Query</label>
+                <q-btn flat dense no-caps color="primary" size="sm" class="tw:rounded-md tw:px-2"
+                  @click="copyText(query.originalQuery)">
+                  <q-icon name="content_copy" size="14px" class="tw:mr-2" />
+                  Copy
+                </q-btn>
+              </div>
+              <div class="tw:relative tw:group">
+                <div
+                  class="tw:p-2 tw:rounded-lg tw:bg-[var(--o2-body-primary-bg)] tw:border tw:border-[var(--o2-border-color)] tw:font-mono tw:text-sm tw:max-h-40 tw:overflow-y-auto tw:whitespace-pre-wrap tw:break-all inspector-query-editor"
+                  v-html="highlightSearch(
+                    colorizedQueries[`${index}-Original Query`] ||
+                    query.originalQuery,
+                  )
+                    "></div>
+              </div>
+            </div>
+
+            <!-- Executed Query -->
+            <div>
+              <div class="tw:flex tw:items-center tw:justify-between">
+                <label
+                  class="tw:text-xs tw:font-bold tw:tracking-wider">Executed
+                  Query</label>
+                <q-btn flat dense no-caps color="primary" size="sm" class="tw:rounded-md tw:px-2"
+                  @click="copyText(query.query)">
+                  <q-icon name="content_copy" size="14px" class="tw:mr-2" />
+                  Copy
+                </q-btn>
+              </div>
+              <div class="tw:relative tw:group">
+                <div
+                  class="tw:p-2 tw:rounded-lg tw:bg-[var(--o2-body-primary-bg)] tw:border tw:border-[var(--o2-border-color)] tw:font-mono tw:text-sm tw:max-h-40 tw:overflow-y-auto tw:whitespace-pre-wrap tw:break-all inspector-query-editor"
+                  v-html="highlightSearch(
+                    colorizedQueries[`${index}-Query`] || query.query,
+                  )
+                    "></div>
+              </div>
+            </div>
+
+            <!-- Time Metadata -->
+            <div class="tw:grid tw:grid-cols-2 tw:gap-4 tw:border-t tw:border-[var(--o2-border-color)] tw:pt-2">
+              <div class="tw:space-y-1">
+                <label
+                  class="tw:text-xs tw:font-bold tw:tracking-wider">Start
+                  Time</label>
+                <div
+                  class="tw:text-xs tw:text-[var(--o2-text-secondary)] tw:font-medium tw:flex tw:items-center tw:gap-2">
+                  <q-icon name="login" size="14px" class="tw:text-[var(--o2-text-muted)]" />
+                  {{ formatTimestamp(query.startTime) }}
+                </div>
+              </div>
+              <div class="tw:space-y-1">
+                <label class="tw:text-xs tw:font-bold tw:tracking-wider">End
+                  Time</label>
+                <div
+                  class="tw:text-xs tw:text-[var(--o2-text-secondary)] tw:font-medium tw:flex tw:items-center tw:gap-2">
+                  <q-icon name="logout" size="14px" class="tw:text-[var(--o2-text-muted)]" />
+                  {{ formatTimestamp(query.endTime) }}
+                </div>
+              </div>
+            </div>
+
+            <!-- Variables List (Row by Row) -->
+            <div class="tw:space-y-3 tw:border-t tw:border-[var(--o2-border-color)]">
+              <!-- Standard Variables -->
+              <div class="tw:pt-2">
+                <label
+                  class="tw:text-xs tw:font-bold tw:tracking-wider">Variable(s)</label>
+                <div class="tw:flex tw:flex-wrap tw:gap-2">
+                  <template v-if="getVariablesByType(query, 'variable').length">
+                    <div v-for="v in getVariablesByType(query, 'variable')" :key="v.name"
+                      class="tw:flex tw:items-center tw:gap-2 tw:p-1 tw:rounded-md tw:border tw:border-[var(--o2-border-color)] tw:bg-[var(--o2-card-bg)] tw:text-xs">
+                      <span class="tw:font-bold tw:text-[var(--o2-text-primary)]">{{ v.name }}</span>
+                      <span class="tw:text-[var(--o2-text-muted)]">:</span>
+                      <span class="tw:text-[var(--o2-text-secondary)] tw:italic">{{
+                        v.value
+                      }}</span>
+                    </div>
+                  </template>
+                  <span v-else class="tw:text-xs tw:text-[var(--o2-text-muted)]">-</span>
+                </div>
+              </div>
+
+              <!-- Fixed Variables -->
+              <div>
+                <label
+                  class="tw:text-xs tw:font-bold tw:tracking-wider">Fixed
+                  Variable(s)</label>
+                <div class="tw:flex tw:flex-wrap tw:gap-2">
+                  <template v-if="getVariablesByType(query, 'fixed').length">
+                    <div v-for="v in getVariablesByType(query, 'fixed')" :key="v.name"
+                      class="tw:flex tw:items-center tw:gap-2 tw:p-1 tw:rounded-md tw:border tw:border-[var(--o2-border-color)] tw:bg-[var(--o2-card-bg)] tw:text-xs">
+                      <span class="tw:font-bold tw:text-[var(--o2-text-primary)]">{{ v.name }}</span>
+                      <span class="tw:text-[var(--o2-text-muted)]">:</span>
+                      <span class="tw:text-[var(--o2-text-secondary)] tw:italic">{{
+                        v.value
+                      }}</span>
+                    </div>
+                  </template>
+                  <span v-else class="tw:text-xs tw:text-[var(--o2-text-muted)]">-</span>
+                </div>
+              </div>
+
+              <!-- Dynamic Variables -->
+              <div>
+                <label
+                  class="tw:text-xs tw:font-bold tw:tracking-wider">Dynamic
+                  Variable(s)</label>
+                <div class="tw:flex tw:flex-wrap tw:gap-2">
+                  <template v-if="getVariablesByType(query, 'dynamicVariable').length">
+                    <div v-for="v in getVariablesByType(query, 'dynamicVariable')" :key="v.name"
+                      class="tw:flex tw:items-center tw:gap-2 tw:p-1 tw:rounded-md tw:border tw:border-[var(--o2-border-color)] tw:bg-[var(--o2-card-bg)] tw:text-xs">
+                      <span class="tw:font-bold tw:text-[var(--o2-text-primary)]">{{ v.name }}</span>
+                      <span class="tw:text-[var(--o2-text-muted)]">{{ v.operator }}</span>
+                      <span class="tw:text-[var(--o2-text-secondary)] tw:italic">{{
+                        v.value
+                      }}</span>
+                    </div>
+                  </template>
+                  <span v-else class="tw:text-xs tw:text-[var(--o2-text-muted)]">-</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </q-card-section>
   </q-card>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from "vue";
+import { computed, defineComponent, ref, watch, onMounted } from "vue";
 import { timestampToTimezoneDate } from "@/utils/zincutils";
 import { useStore } from "vuex";
+import { colorizeQuery } from "@/utils/query/colorizeQuery";
 
 export default defineComponent({
   name: "QueryInspector",
   props: {
     metaData: {
-      validator: value => {
-        // Custom validation logic
-        return typeof value == 'object' || typeof value == undefined;
-      },
-      required: true
+      type: Object,
+      required: true,
     },
     data: {
       type: Object,
-      required: true
-    }
+      required: true,
+    },
   },
   setup(props: any) {
-    const queryData = props.metaData?.queries || [] ;
     const store = useStore();
-    
-    const getRows = (query: any) => {
-      
-      const timestampOfStartTime = query?.startTime;
-      const formattedStartTime = timestampToTimezoneDate(
-        timestampOfStartTime / 1000,
-        store.state.timezone,
-        "yyyy-MM-dd HH:mm:ss.SSS"
-      );
-      const startTimeEntry = `${timestampOfStartTime} (${formattedStartTime} ${store.state.timezone})`;
+    const queryData = computed(() => props.metaData?.queries || []);
+    const searchQuery = ref("");
+    const colorizedQueries = ref<Record<string, string>>({});
 
-      const timestampOfEndTime = query?.endTime;
-      const formattedEndTime = timestampToTimezoneDate(
-        timestampOfEndTime / 1000,
-        store.state.timezone,
-        "yyyy-MM-dd HH:mm:ss.SSS"
-      );
-      const endTimeEntry = `${timestampOfEndTime} (${formattedEndTime} ${store.state.timezone})`;
-
-      const rows: any[] = [
-        ["Original Query", query?.originalQuery],
-        ["Query", query?.query],
-        ["Start Time", startTimeEntry],
-        ["End Time", endTimeEntry],
-        ["Query Type", query?.queryType],
-        ["Variable(s)", ],
-        ["Fixed Variable(s)",],
-        ["Dynamic Variable(s)",],
-      ];
-
-      const variableRows: any[] = [];
-      const fixedVariableRows: any[] = [];
-      const dynamicVariableRows: any[] = [];
-
-      query?.variables?.forEach((variable: any) => {
-        if (variable.type === 'variable') {
-          variableRows.push(`${variable.name}: ${variable.value}`);
-        } else if (variable.type === 'fixed') {
-          fixedVariableRows.push(`${variable.name}: ${variable.value}`);
-        } else if (variable.type === 'dynamicVariable') {
-          dynamicVariableRows.push(`${variable.name} ${variable.operator} ${variable.value}`);
-        }
-      });
-
-      rows[5][1] = variableRows.length > 0 ? variableRows.join(', ') : '-';
-      rows[6][1] = fixedVariableRows.length > 0 ? fixedVariableRows.join(', ') : '-';
-      rows[7][1] = dynamicVariableRows.length > 0 ? dynamicVariableRows.join(', ') : '-';
-
-
-      return rows;
-    };
-    const totalQueries = computed(() => queryData.length);
+    const totalQueries = computed(() => queryData.value.length);
     const dataTitle = computed(() => props.data.title);
 
+    const formatTimestamp = (ts: number) => {
+      if (!ts) return "-";
+      const formatted = timestampToTimezoneDate(
+        ts / 1000,
+        store.state.timezone,
+        "yyyy-MM-dd HH:mm:ss.SSS",
+      );
+      return `${ts} (${formatted} ${store.state.timezone})`;
+    };
+
+
+    const getVariablesByType = (query: any, type: string) => {
+      return (query.variables || []).filter((v: any) => v.type === type);
+    };
+
+    const updateColorizedQueries = async () => {
+      const newColorized: Record<string, string> = {};
+      for (const [index, query] of queryData.value.entries()) {
+        const lang = query.queryType?.toLowerCase() || "sql";
+
+        // Original Query
+        if (query.originalQuery) {
+          newColorized[`${index}-Original Query`] = await colorizeQuery(
+            query.originalQuery,
+            lang,
+          );
+        }
+
+        // Executed Query
+        if (query.query) {
+          newColorized[`${index}-Query`] = await colorizeQuery(
+            query.query,
+            lang,
+          );
+        }
+      }
+      colorizedQueries.value = newColorized;
+    };
+
+    const highlightSearch = (html: string) => {
+      if (!searchQuery.value || !html) return html;
+
+      try {
+        const escapedSearch = searchQuery.value.replace(
+          /[.*+?^${}()|[\]\\]/g,
+          "\\$&",
+        );
+        const regex = new RegExp(`(?![^<]*>)(${escapedSearch})`, "gi");
+
+        return html.replace(
+          regex,
+          (match) =>
+            `<mark class="tw:bg-yellow-400 tw:text-black tw:rounded-sm tw:shadow-sm">${match}</mark>`,
+        );
+      } catch (e) {
+        return html;
+      }
+    };
+
+    const getQueryTypeDisplay = (queryType: string) => {
+      if (!queryType) return "SQL";
+      const type = queryType.toLowerCase();
+      if (type === "sql") return "SQL";
+      if (type === "promql" || type === "metrics") return "PromQL";
+      return queryType.toUpperCase();
+    };
+
+    const copyText = (text: string) => {
+      if (!text) return;
+      navigator.clipboard.writeText(text);
+    };
+
+    watch(
+      () => props.metaData,
+      updateColorizedQueries,
+      { deep: true, immediate: true }
+    );
+
     return {
+      store,
       queryData,
-      getRows,
       totalQueries,
       dataTitle,
-      pagination: ref({
-        rowsPerPage: 0,
-      }),
+      searchQuery,
+      colorizedQueries,
+      formatTimestamp,
+      getVariablesByType,
+      getQueryTypeDisplay,
+      highlightSearch,
+      copyText,
     };
   },
 });
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.inspector-query-editor {
+
+  /* Custom scrollbar styling */
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(128, 128, 128, 0.2);
+    border-radius: 10px;
+
+    &:hover {
+      background: rgba(128, 128, 128, 0.4);
+    }
+  }
+
+  /* Firefox scrollbar styling */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(128, 128, 128, 0.2) transparent;
+}
+
+:deep(mark) {
+  all: unset;
+  background-color: #facc15;
+  color: black;
+  border-radius: 2px;
+  padding: 0;
+}
+
+// Ensure Monaco colorized content looks good
+:deep(.mtk1) {
+  color: inherit;
+}
+</style>

--- a/web/src/utils/query/colorizeQuery.spec.ts
+++ b/web/src/utils/query/colorizeQuery.spec.ts
@@ -1,0 +1,490 @@
+// Copyright 2023 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
+
+// Mock monaco-editor
+vi.mock("monaco-editor/esm/vs/editor/editor.api", () => ({
+  editor: {
+    colorize: vi.fn(),
+  },
+  languages: {
+    register: vi.fn(),
+    setMonarchTokensProvider: vi.fn(),
+  },
+}));
+
+// Mock SQL contribution
+vi.mock("monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js", () => ({}));
+
+// Mock VRL language definition
+vi.mock("@/utils/query/vrlLanguageDefinition", () => ({
+  vrlLanguageDefinition: {
+    tokenizer: {
+      root: [],
+    },
+  },
+}));
+
+import { colorizeQuery } from "./colorizeQuery";
+import { editor } from "monaco-editor/esm/vs/editor/editor.api";
+
+describe("colorizeQuery", () => {
+  const mockColorize = vi.mocked(editor.colorize);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockColorize.mockResolvedValue("<span>colorized</span>");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Basic Functionality", () => {
+    it("should return empty string for empty query", async () => {
+      const result = await colorizeQuery("", "sql");
+      expect(result).toBe("");
+    });
+
+    it("should return empty string for null query", async () => {
+      const result = await colorizeQuery(null as any, "sql");
+      expect(result).toBe("");
+    });
+
+    it("should return empty string for undefined query", async () => {
+      const result = await colorizeQuery(undefined as any, "sql");
+      expect(result).toBe("");
+    });
+
+    it("should colorize valid SQL query", async () => {
+      const query = "SELECT * FROM logs WHERE level = 'error'";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should colorize valid PromQL query", async () => {
+      const query = "rate(http_requests[5m])";
+      const result = await colorizeQuery(query, "promql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "promql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should colorize valid VRL query", async () => {
+      const query = ".level = \"error\"";
+      const result = await colorizeQuery(query, "vrl");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "vrl", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+  });
+
+  describe("Language Registration", () => {
+    it("should call colorize after registration", async () => {
+      const result = await colorizeQuery("test query", "promql");
+
+      // Language registration happens once at module level
+      // What we care about is that colorization works
+      expect(mockColorize).toHaveBeenCalledWith("test query", "promql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should call colorize for VRL language", async () => {
+      const result = await colorizeQuery("test query", "vrl");
+
+      // Language registration happens once at module level
+      // What we care about is that colorization works
+      expect(mockColorize).toHaveBeenCalledWith("test query", "vrl", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle multiple calls with same language", async () => {
+      // First call
+      await colorizeQuery("query1", "sql");
+      const firstCallCount = mockColorize.mock.calls.length;
+
+      // Second call
+      await colorizeQuery("query2", "sql");
+      const secondCallCount = mockColorize.mock.calls.length;
+
+      // Should colorize both times
+      expect(secondCallCount).toBeGreaterThan(firstCallCount);
+    });
+
+    it("should import SQL contribution and colorize", async () => {
+      await colorizeQuery("SELECT * FROM logs", "sql");
+
+      // SQL contribution should be imported and colorization should work
+      expect(mockColorize).toHaveBeenCalled();
+    });
+  });
+
+  describe("Language Case Handling", () => {
+    it("should handle uppercase language names", async () => {
+      const query = "SELECT * FROM logs";
+      const result = await colorizeQuery(query, "SQL");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle mixed case language names", async () => {
+      const query = "SELECT * FROM logs";
+      const result = await colorizeQuery(query, "SqL");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle lowercase language names", async () => {
+      const query = "rate(http_requests[5m])";
+      const result = await colorizeQuery(query, "promql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "promql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+  });
+
+  describe("Different Query Types", () => {
+    it("should colorize simple SELECT query", async () => {
+      const query = "SELECT id, name FROM users";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should colorize complex SQL query with joins", async () => {
+      const query = `
+        SELECT u.id, u.name, o.order_id
+        FROM users u
+        LEFT JOIN orders o ON u.id = o.user_id
+        WHERE u.status = 'active'
+      `;
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should colorize SQL query with aggregations", async () => {
+      const query = "SELECT COUNT(*), AVG(price), MAX(quantity) FROM products GROUP BY category";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should colorize PromQL range query", async () => {
+      const query = "rate(http_requests_total[5m])";
+      const result = await colorizeQuery(query, "promql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "promql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should colorize PromQL aggregation query", async () => {
+      const query = "sum by (instance) (rate(http_requests_total[5m]))";
+      const result = await colorizeQuery(query, "promql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "promql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should colorize VRL transformation", async () => {
+      const query = `.level = downcase(.level)\n.timestamp = parse_timestamp(.timestamp, "%Y-%m-%d")`;
+      const result = await colorizeQuery(query, "vrl");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "vrl", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+  });
+
+  describe("Special Characters and Edge Cases", () => {
+    it("should handle query with special characters", async () => {
+      const query = "SELECT * FROM logs WHERE message LIKE '%error%' AND status != 'ok'";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle query with newlines", async () => {
+      const query = "SELECT *\nFROM logs\nWHERE level = 'error'";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle query with tabs", async () => {
+      const query = "SELECT\t*\tFROM\tlogs";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle query with single quotes", async () => {
+      const query = "SELECT * FROM logs WHERE message = 'it''s working'";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle query with double quotes", async () => {
+      const query = 'SELECT * FROM "my_table" WHERE "column_name" = "value"';
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle query with backticks", async () => {
+      const query = "SELECT * FROM `logs` WHERE `level` = 'error'";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle query with comments", async () => {
+      const query = "SELECT * FROM logs -- This is a comment\nWHERE level = 'error'";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle query with multi-line comments", async () => {
+      const query = "SELECT * FROM logs /* This is a\nmulti-line comment */ WHERE level = 'error'";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle very long queries", async () => {
+      const query = "SELECT * FROM logs WHERE " + "condition AND ".repeat(100) + "final_condition";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle queries with unicode characters", async () => {
+      const query = "SELECT * FROM logs WHERE message = '日本語テスト'";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle queries with emojis", async () => {
+      const query = "SELECT * FROM logs WHERE message LIKE '%🔥%'";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("should return original query when colorization fails", async () => {
+      const query = "SELECT * FROM logs";
+      const error = new Error("Colorization failed");
+      mockColorize.mockRejectedValueOnce(error);
+
+      const result = await colorizeQuery(query, "sql");
+
+      expect(result).toBe(query);
+    });
+
+    it("should handle Monaco editor errors gracefully", async () => {
+      const query = "SELECT * FROM logs";
+      mockColorize.mockRejectedValueOnce(new Error("Monaco not available"));
+
+      const result = await colorizeQuery(query, "sql");
+
+      expect(result).toBe(query);
+    });
+
+    it("should handle internal errors gracefully", async () => {
+      const query = "test query";
+
+      // Mock colorization error
+      mockColorize.mockRejectedValueOnce(new Error("Internal error"));
+
+      // Should return original query on error
+      const result = await colorizeQuery(query, "sql");
+      expect(result).toBe(query);
+    });
+
+    it("should handle unknown language gracefully", async () => {
+      const query = "some query in unknown language";
+      const result = await colorizeQuery(query, "unknownlang");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "unknownlang", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should return original query on syntax errors", async () => {
+      const query = "INVALID SQL SYNTAX HERE!!!";
+      mockColorize.mockRejectedValueOnce(new Error("Syntax error"));
+
+      const result = await colorizeQuery(query, "sql");
+
+      expect(result).toBe(query);
+    });
+  });
+
+  describe("Performance and Caching", () => {
+    it("should handle multiple concurrent colorization requests", async () => {
+      const queries = [
+        "SELECT * FROM logs",
+        "SELECT * FROM metrics",
+        "SELECT * FROM traces",
+      ];
+
+      const results = await Promise.all(
+        queries.map((q) => colorizeQuery(q, "sql"))
+      );
+
+      expect(results).toHaveLength(3);
+      results.forEach((result) => {
+        expect(result).toBe("<span>colorized</span>");
+      });
+      expect(mockColorize).toHaveBeenCalledTimes(3);
+    });
+
+    it("should handle sequential colorization calls", async () => {
+      await colorizeQuery("query1", "sql");
+      await colorizeQuery("query2", "sql");
+      await colorizeQuery("query3", "sql");
+
+      expect(mockColorize).toHaveBeenCalledTimes(3);
+    });
+
+    it("should handle same query colorized multiple times", async () => {
+      const query = "SELECT * FROM logs";
+
+      await colorizeQuery(query, "sql");
+      await colorizeQuery(query, "sql");
+      await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("Integration Scenarios", () => {
+    it("should handle switching between different languages", async () => {
+      await colorizeQuery("SELECT * FROM logs", "sql");
+      await colorizeQuery("rate(http_requests[5m])", "promql");
+      await colorizeQuery(".level = \"error\"", "vrl");
+
+      expect(mockColorize).toHaveBeenCalledTimes(3);
+      expect(mockColorize).toHaveBeenNthCalledWith(1, "SELECT * FROM logs", "sql", {});
+      expect(mockColorize).toHaveBeenNthCalledWith(2, "rate(http_requests[5m])", "promql", {});
+      expect(mockColorize).toHaveBeenNthCalledWith(3, ".level = \"error\"", "vrl", {});
+    });
+
+    it("should preserve HTML entities in colorized output", async () => {
+      mockColorize.mockResolvedValueOnce("<span>&lt;test&gt;</span>");
+
+      const query = "SELECT * FROM logs WHERE html = '<test>'";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(result).toBe("<span>&lt;test&gt;</span>");
+    });
+
+    it("should handle empty options object", async () => {
+      const query = "SELECT * FROM logs";
+      await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+    });
+  });
+
+  describe("Language-Specific Features", () => {
+    it("should colorize SQL keywords", async () => {
+      const query = "SELECT COUNT(*) FROM logs WHERE timestamp BETWEEN 1000 AND 2000";
+      await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+    });
+
+    it("should colorize PromQL operators", async () => {
+      const query = "http_requests_total > 100 and rate(errors[5m]) < 0.01";
+      await colorizeQuery(query, "promql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "promql", {});
+    });
+
+    it("should colorize VRL functions", async () => {
+      const query = `.message = parse_json(.message)\n.level = downcase(.level)`;
+      await colorizeQuery(query, "vrl");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "vrl", {});
+    });
+  });
+
+  describe("Whitespace Handling", () => {
+    it("should preserve leading whitespace", async () => {
+      const query = "    SELECT * FROM logs";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should preserve trailing whitespace", async () => {
+      const query = "SELECT * FROM logs    ";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should preserve internal whitespace", async () => {
+      const query = "SELECT  *  FROM  logs";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+  });
+
+  describe("Single Character Queries", () => {
+    it("should handle single character query", async () => {
+      const query = "*";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+
+    it("should handle single space query", async () => {
+      const query = " ";
+      const result = await colorizeQuery(query, "sql");
+
+      expect(mockColorize).toHaveBeenCalledWith(query, "sql", {});
+      expect(result).toBe("<span>colorized</span>");
+    });
+  });
+});

--- a/web/src/utils/query/colorizeQuery.ts
+++ b/web/src/utils/query/colorizeQuery.ts
@@ -1,0 +1,41 @@
+import { editor, languages } from "monaco-editor/esm/vs/editor/editor.api";
+import { vrlLanguageDefinition } from "@/utils/query/vrlLanguageDefinition";
+
+let languagesRegistered = false;
+
+const registerLanguages = async () => {
+  if (languagesRegistered) return;
+
+  // Register PromQL
+  languages.register({ id: "promql" });
+
+  // Register VRL
+  languages.register({ id: "vrl" });
+  languages.setMonarchTokensProvider("vrl", vrlLanguageDefinition as any);
+
+  // Load standard languages (SQL, JSON, etc.)
+  // We explicitly import SQL contribution for ensuring it's available
+  await import("monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js");
+
+  // You might want to add other language contributions here if needed
+  // await import("monaco-editor/esm/vs/basic-languages/python/python.contribution.js");
+
+  languagesRegistered = true;
+};
+
+export const colorizeQuery = async (query: string, language: string): Promise<string> => {
+  if (!query) return "";
+
+  await registerLanguages();
+
+  const lang = language.toLowerCase();
+
+  try {
+    // Determine language ID to pass to Monaco
+    // Some basic languages might need specific IDs or are auto-handled if loaded
+    const colorized = await editor.colorize(query, lang, {});
+    return colorized;
+  } catch (e) {
+    return query;
+  }
+};


### PR DESCRIPTION
### **User description**
Enhancement

___
- Add Monaco-based query colorization utility

- Redesign QueryInspector component UI layout

- Implement search highlighting and copy notifications

- Make colorization reactive on mount and data changes

___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>colorizeQuery.ts</strong><dd><code>Add query colorization utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/query/colorizeQuery.ts

<ul><li>Register PromQL, VRL, and SQL languages<br> <li> Implement async <code>colorizeQuery</code> function<br> <li> Prevent duplicate language registrations<br> <li> Handle colorization errors gracefully</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10249/files#diff-58f1e967db31a700d3ad2387bd4c9330a14995f4e6f48bcaf0ee5074816c2c8f">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>QueryInspector.vue</strong><dd><code>Redesign QueryInspector UI and logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

web/src/components/dashboards/QueryInspector.vue

<ul><li>Revamp UI with styled layout and search input<br> <li> Integrate <code>colorizeQuery</code> for syntax highlighting<br> <li> Add search-term highlighting and copy notifications<br> <li> Reactively update colorization on mount/watch<br> <li> Include custom scrollbar styling</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10249/files#diff-ffe50532d3e00a45f4fd570bf0e852658b382fc05982f6c0afca2a7e8940316d">+318/-73</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

---------


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Redesign Query Inspector UI layout

- Add Monaco-based query syntax colorization

- Add search highlighting and copy actions

- Update unit and Playwright test selectors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ui["`QueryInspector.vue` redesigned UI + actions"]
  util["`colorizeQuery.ts` Monaco colorization helper"]
  unit["Unit tests (`QueryInspector.spec.ts`)"]
  utiltests["Utility tests (`colorizeQuery.spec.ts`)"]
  e2e["Playwright UI tests selector updates"]
  ui -- "calls" --> util
  unit -- "mocks & asserts" --> ui
  utiltests -- "validates" --> util
  e2e -- "asserts rendered queries" --> ui
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>QueryInspector.vue</strong><dd><code>Redesign inspector UI with search and colorization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10445/files#diff-ffe50532d3e00a45f4fd570bf0e852658b382fc05982f6c0afca2a7e8940316d">+318/-73</a></td>

</tr>

<tr>
  <td><strong>colorizeQuery.ts</strong><dd><code>Add Monaco-based query colorization helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10445/files#diff-58f1e967db31a700d3ad2387bd4c9330a14995f4e6f48bcaf0ee5074816c2c8f">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>colorizeQuery.spec.ts</strong><dd><code>Add comprehensive tests for colorizeQuery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10445/files#diff-d412906d0d1f2e543d32976f533542253e48493b49c358c58419ed259ede44d1">+490/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>QueryInspector.spec.ts</strong><dd><code>Update QueryInspector unit tests for redesign</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10445/files#diff-5db282f1e123d731ab4ed83d9500a87bbdd968f28c2c9f11179eaebed4f6bef6">+715/-264</a></td>

</tr>

<tr>
  <td><strong>visualise.js</strong><dd><code>Wait for inspector via close button locator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10445/files#diff-c14ac1db3e4aa86190d7525e8e38c410bcbbae7f46b01890e74937cc11be67e6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dashboard-filter.spec.js</strong><dd><code>Assert query text via `.inspector-query-editor`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10445/files#diff-0b36e0f7bb97e53ba43466ae6666f04e2b3015f5760243493a058ad3df6fbef9">+55/-71</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dashboard-multi-y-axis.spec.js</strong><dd><code>Update inspector assertions to new DOM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10445/files#diff-2c0ab4d43c3e915a4e00f2a729234e7c1c975a7a8bc9483fff2ba0a4660f0f83">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dashboard-variables-null-handling.spec.js</strong><dd><code>Verify executed query using editor container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10445/files#diff-e42ab503059a687ceb4fa2edeed0888a47591e0a61680c10448eaf68b4e6bbd8">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>visualize.spec.js</strong><dd><code>Switch inspector query checks to editor selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10445/files#diff-28874b05126e014a74c04029ea47a8797f936827a0b7196bd543b91f7389d0c1">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

