### PR TITLE
fix: dimensions not visible issue on incident detail 60

### DIFF
--- a/web/src/components/alerts/IncidentDetailDrawer.vue
+++ b/web/src/components/alerts/IncidentDetailDrawer.vue
@@ -709,7 +709,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <div
                 class="el-border el-border-radius o2-incident-card-bg tw:flex tw:flex-col tw:overflow-hidden"
                 :style="{
-                  height: (incidentDetails?.topology_context?.nodes?.length && triggers.length > 0)
+                  height: (sortedAlertsByTriggerCount?.length)
                     ? 'calc(35% - 5.6px)'
                     : 'calc(65% - 2px)',
                   minHeight: 0,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix dimensions panel height condition


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["IncidentDetailDrawer dimensions panel"] --> B["Use `sortedAlertsByTriggerCount?.length` condition"]
  B["Use `sortedAlertsByTriggerCount?.length` condition"] --> C["Correct height when triggers absent"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IncidentDetailDrawer.vue</strong><dd><code>Fix dimensions panel height trigger detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentDetailDrawer.vue

<ul><li>Switch height logic to <code>sortedAlertsByTriggerCount?.length</code><br> <li> Remove dependency on topology nodes and <code>triggers.length</code><br> <li> Ensure dimensions panel uses correct height mode</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10450/files#diff-6973d58a5f49658b07d3533d4db5d32cc6430433b51732481e7497243dadb0b0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

