### PR TITLE
fix: dimensions not visible for incident detail main

### DIFF
--- a/web/src/components/alerts/IncidentDetailDrawer.vue
+++ b/web/src/components/alerts/IncidentDetailDrawer.vue
@@ -709,7 +709,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <div
                 class="el-border el-border-radius o2-incident-card-bg tw:flex tw:flex-col tw:overflow-hidden"
                 :style="{
-                  height: (incidentDetails?.topology_context?.nodes?.length && triggers.length > 0)
+                  height: (sortedAlertsByTriggerCount?.length)
                     ? 'calc(35% - 5.6px)'
                     : 'calc(65% - 2px)',
                   minHeight: 0,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Use `sortedAlertsByTriggerCount` to drive Dimensions height

- Ensure Dimensions visible when triggers absent


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["IncidentDetailDrawer layout"] --> B["Height condition logic"]
  B -- "checks" --> C["sortedAlertsByTriggerCount length"]
  C -- "sets" --> D["Dimensions panel height"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IncidentDetailDrawer.vue</strong><dd><code>Correct Dimensions panel height conditional</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/alerts/IncidentDetailDrawer.vue

<ul><li>Replace topology/triggers check with <br><code>sortedAlertsByTriggerCount?.length</code><br> <li> Prevent incorrect sizing hiding Dimensions panel</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10451/files#diff-6973d58a5f49658b07d3533d4db5d32cc6430433b51732481e7497243dadb0b0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

