### PR TITLE
fix: enabled logs key highlighting

### DIFF
--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -162,8 +162,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             style="opacity: 0.7"
           >
             <div class="text-subtitle2 text-weight-bold bg-warning">
-              <q-icon size="xs"
-name="warning" class="q-mr-xs" />
+              <q-icon size="xs" name="warning" class="q-mr-xs" />
               {{ errMsg }}
             </div>
           </td>
@@ -546,14 +545,18 @@ watch(
 
     await nextTick();
 
-    if (props.columns?.length && tableRows.value?.length) {
+    if (
+      props.columns?.length &&
+      tableRows.value?.length &&
+      window.shouldHighlight
+    ) {
       processHitsInChunks(
         tableRows.value,
         props.columns,
         true,
         props.highlightQuery,
         200,
-        selectedStreamFtsKeys.value
+        selectedStreamFtsKeys.value,
       );
     }
 
@@ -572,14 +575,18 @@ watch(
 
     await nextTick();
 
-    if (props.columns?.length && tableRows.value?.length) {
+    if (
+      props.columns?.length &&
+      tableRows.value?.length &&
+      window.shouldHighlight
+    ) {
       processHitsInChunks(
         tableRows.value,
         props.columns,
         false,
         props.highlightQuery,
         100,
-        selectedStreamFtsKeys.value
+        selectedStreamFtsKeys.value,
       );
     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Render log keys with dedicated styling

- Reduce chunk delay for faster rendering

- Skip/trim highlighting for oversized payloads

- Gate table highlighting behind `window.shouldHighlight`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TenstackTable watchers"] 
  B["processHitsInChunks execution"]
  C["useLogsHighlighter colorization"]
  D["Key styling: `.log-key` spans"]
  E["Perf guards: size estimate + truncation"]
  F["Progressive rendering for detail views"]
  A -- "if `window.shouldHighlight`" --> B
  B -- "render cells" --> C
  C -- "wrap keys" --> D
  C -- "avoid freezes" --> E
  C -- "optional incremental output" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useLogsHighlighter.ts</strong><dd><code>Improve highlighting performance and key rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/useLogsHighlighter.ts

<ul><li>Add <code>estimateSize</code> to avoid stringify costs<br> <li> Truncate >50KB content; skip highlighting<br> <li> Render object keys via <code>.log-key</code> spans<br> <li> Add progressive colorization for huge logs</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10457/files#diff-ad7744a2edc4764be1c7d67feb7fe1473536af245821898a9136256b3aeb0342">+270/-47</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TenstackTable.vue</strong><dd><code>Gate table highlighting and minor formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/plugins/logs/TenstackTable.vue

<ul><li>Run <code>processHitsInChunks</code> only when enabled<br> <li> Add <code>window.shouldHighlight</code> to watchers<br> <li> Reformat <code><q-icon></code> markup for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10457/files#diff-bc3c669f5ab65a42ae378df1f7d6b35014c9c220790bdcc72b47f55d1385dc22">+13/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

