### PR TITLE
fix: for errors when saving prebuilt destinations, show the message on UI

### DIFF
--- a/web/src/composables/usePrebuiltDestinations.ts
+++ b/web/src/composables/usePrebuiltDestinations.ts
@@ -522,8 +522,7 @@ export function usePrebuiltDestinations() {
       console.error('Failed to create prebuilt destination:', error);
       $q.notify({
         type: 'negative',
-        message: t('alerts.destinations.saveError'),
-        caption: error.message
+        message: error.response?.data?.error || error.response?.data?.message || error.message,
       });
       throw error;
     } finally {
@@ -634,8 +633,7 @@ export function usePrebuiltDestinations() {
       console.error('Failed to update prebuilt destination:', error);
       $q.notify({
         type: 'negative',
-        message: t('alerts.destinations.saveError'),
-        caption: error.message
+        message: error.response?.data?.error || error.response?.data?.message || error.message,
       });
       throw error;
     } finally {
@@ -727,8 +725,7 @@ export function usePrebuiltDestinations() {
       console.error('Failed to convert destination:', error);
       $q.notify({
         type: 'negative',
-        message: t('alerts.prebuilt.conversionError'),
-        caption: error.message
+        message: error.response?.data?.error || error.response?.data?.message || error.message,
       });
       throw error;
     } finally {


### PR DESCRIPTION
### **User description**
Currently when there is any error when saving a pre-built type destination, the error popup message on UI is not correct, it does not show the actual error message. This pr adds the error message to the popup.


___

### **PR Type**
Bug fix


___

### **Description**
- Show backend error details in notifications

- Normalize error message selection across flows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ui["Prebuilt destination create/update/convert"]
  apiErr["API error response payload"]
  pick["Select error text (error/message/fallback)"]
  notify["Quasar negative notification"]
  ui -- "request fails" --> apiErr
  apiErr -- "extract error fields" --> pick
  pick -- "display" --> notify
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usePrebuiltDestinations.ts</strong><dd><code>Use API error text in UI notifications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/usePrebuiltDestinations.ts

<ul><li>Replace generic i18n save/conversion errors<br> <li> Prefer <code>response.data.error</code>, then <code>response.data.message</code><br> <li> Fallback to <code>error.message</code> when needed<br> <li> Apply consistent logic to create/update/convert</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10461/files#diff-2c90b706aae7486541bbee80d2c67c9de18504b90e1d9618ba130e017d0a5246">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

