### PR TITLE
fix: table chart print mode css issue

### DIFF
--- a/web/src/components/dashboards/panels/TableRenderer.vue
+++ b/web/src/components/dashboards/panels/TableRenderer.vue
@@ -495,4 +495,18 @@ export default defineComponent({
     opacity: 1;
   }
 }
+
+.table-wrapper {
+  height: 100%;
+  width: 100%;
+  position: relative;
+}
+
+@media print {
+  .table-wrapper {
+    overflow: hidden !important;
+    max-height: 100% !important;
+    page-break-inside: avoid;
+  }
+}
 </style>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix table panel print overflow clipping

- Prevent table wrapper page break inside


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TableRenderer styles"] 
  B["Add .table-wrapper sizing/positioning"] 
  C["Print media overflow/max-height rules"] 
  A -- "introduce wrapper styles" --> B
  A -- "apply print-specific constraints" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TableRenderer.vue</strong><dd><code>Add print-safe styling for table wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/panels/TableRenderer.vue

<ul><li>Add <code>.table-wrapper</code> full-size relative layout<br> <li> Add <code>@media print</code> rules to hide overflow<br> <li> Constrain print height and avoid page breaks</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10462/files#diff-794706ea9da3a70012a0327c0464f9fd16802f78ece26055fe951716c2d73d59">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

