### PR TITLE
fix(test): resolve SDR multi-pattern timing failure and enforce POM compliance

### DIFF
--- a/tests/ui-testing/pages/sdrPages/sdrVerificationPage.js
+++ b/tests/ui-testing/pages/sdrPages/sdrVerificationPage.js
@@ -112,7 +112,7 @@ export class SDRVerificationPage {
 
     expect(logText, 'No logs found in the stream after multiple retries').not.toBeNull();
 
-    testLogger.info(`Latest log text (first 300 chars): ${logText.substring(0, 300)}...`);
+    testLogger.info(`Latest log text (first 300 chars): ${logText?.substring(0, 300)}...`);
 
     // Check if field exists in the log
     const fieldAsJsonKey = `"${fieldName}":`;


### PR DESCRIPTION
### **User description**
## Summary
- Fix CI timing failure in `multipleSDRPatterns.spec.js` where `Field multi_data not found in log` occurred due to slow indexing
- Add retry loop with incremental backoff (5 retries) and Loading... indicator wait to `SDRVerificationPage`
- Replace all `throw new Error()` with proper Playwright `expect()` assertions
- Remove raw selectors from spec file — all UI interactions now go through `SDRVerificationPage` page object

## Test plan
- [x] All 3 tests pass locally (setup, 10-step sequential verification, cleanup)
- [ ] CI run passes on this branch

## Related
- Fixes flaky failure in: https://github.com/openobserve/o2-enterprise/actions/runs/21890212046/job/63196712500


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Add retry-based log verification for CI

- Move log UI logic into page object

- Replace thrown errors with Playwright expects

- Stabilize timing, tagging, and cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["multipleSDRPatterns.spec.js: SDR multi-pattern test"] 
  B["SDRVerificationPage.verifySingleFieldInLatestLog()"] 
  C["Retry loop + refresh + loading wait"] 
  D["Assertions via Playwright expect()"] 
  E["More reliable CI execution"] 
  A -- "delegates verification to" --> B
  B -- "adds" --> C
  B -- "uses" --> D
  C -- "reduces flakiness in" --> E
  D -- "improves failure diagnostics in" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sdrVerificationPage.js</strong><dd><code>Add robust log verification retries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/pages/sdrPages/sdrVerificationPage.js

<ul><li>Import <code>expect</code> and assert via Playwright<br> <li> Add <code>waitForLoadingToDisappear()</code> helper<br> <li> Add <code>getLogEntries()</code> with locator fallback<br> <li> Retry refresh/indexing before verifying fields</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10476/files#diff-cdbdaa86cda3a764a369728d276b21b06f3b13c6ef815b29fc7a024b270e2bec">+60/-42</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>multipleSDRPatterns.spec.js</strong><dd><code>Refactor spec to use page object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ui-testing/playwright-tests/SDR/multipleSDRPatterns.spec.js

<ul><li>Increase post-ingestion wait to 5s<br> <li> Remove inline log-verification helper functions<br> <li> Use <code>pm.sdrVerificationPage.verifySingleFieldInLatestLog()</code><br> <li> Rename tag to <code>@sdrMultiPattern</code> and assert cleanup count</ul>


</details>


  </td>
  <td><a href="https://github.com/openobserve/openobserve/pull/10476/files#diff-27c612d13221447d0f5ee4b26066288ae498f189967c5ed6ab7bff07a0caad6b">+14/-91</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

