### PR TITLE
fix: dashboard support custom type variables as parents in variable dependencies (#10481)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -248,6 +248,7 @@ jobs:
                 "dashboard-variables-url-sync.spec.js",
                 "dashboard-variables-creation-scopes.spec.js",
                 "dashboard-variables-default-values-chain.spec.js",
+                "dashboard-variables-custom-parents.spec.js"
               ]
     steps:
       - name: Clone the current repo

--- a/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-variables-scoped.js
@@ -1189,4 +1189,495 @@ export default class DashboardVariablesScoped {
       variableName: variableName
     };
   }
+
+  /**
+   * Add a custom type variable
+   * @param {string} name - Variable name
+   * @param {string[]} values - Array of custom values (can also be objects with {label, value})
+   * @param {Object} options - Additional options
+   * @param {string} options.label - Display label (defaults to name)
+   * @param {string} options.scope - Variable scope: 'global', 'tabs', 'panels'
+   * @param {string[]} options.assignedTabs - Tab IDs if scope is 'tabs'
+   * @param {string[]} options.assignedPanels - Panel IDs if scope is 'panels'
+   * @param {boolean} options.multiSelect - Enable multi-select (default: false)
+   * @returns {Promise<void>}
+   */
+  async addCustomVariable(name, values = [], options = {}) {
+    const {
+      label = name,
+      scope = "global",
+      assignedTabs = [],
+      assignedPanels = [],
+      multiSelect = false,
+    } = options;
+
+    // Wait for settings panel and variable tab
+    const variableTab = this.page.locator('[data-test="dashboard-settings-variable-tab"]');
+    await variableTab.waitFor({ state: "visible", timeout: 10000 });
+
+    // Only click if not already active
+    const isActive = await variableTab.getAttribute('aria-selected');
+    if (isActive !== 'true') {
+      await variableTab.click();
+      await this.page.waitForTimeout(500);
+    } else {
+      await this.page.waitForTimeout(300);
+    }
+
+    // Click Add Variable button
+    await this.page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
+    await this.page.waitForTimeout(500);
+
+    // Select scope first (before filling other fields)
+    const normalizedScope = scope === 'panel' ? 'panels' : (scope === 'tab' ? 'tabs' : scope);
+    const scopeUIText = {
+      'global': 'Global',
+      'tabs': 'Selected Tabs',
+      'panels': 'Selected Panels'
+    };
+
+    await this.page.locator('[data-test="dashboard-variable-scope-select"]').click();
+    await this.page.getByRole("option", { name: scopeUIText[normalizedScope] || normalizedScope, exact: true }).click();
+
+    // Assign to tabs if needed
+    if (normalizedScope === "tabs" && assignedTabs.length > 0) {
+      const tabsSelect = this.page.locator('[data-test="dashboard-variable-tabs-select"]');
+      await tabsSelect.waitFor({ state: "visible", timeout: 10000 });
+      await tabsSelect.click();
+      await this.page.waitForTimeout(500);
+
+      for (const tabId of assignedTabs) {
+        const tabLabel = tabId === 'default' ? 'Default' : tabId.charAt(0).toUpperCase() + tabId.slice(1);
+        const tabItem = this.page.locator('.q-item').filter({ hasText: new RegExp(`^${tabLabel}$`) });
+        await tabItem.waitFor({ state: "visible", timeout: 5000 });
+        await tabItem.click();
+      }
+
+      await this.page.keyboard.press('Escape');
+      await this.page.waitForTimeout(300);
+    }
+
+    // Assign to panels if needed
+    if (normalizedScope === "panels") {
+      const tabsToSelect = assignedTabs.length > 0 ? assignedTabs : ['default'];
+
+      const tabsSelect = this.page.locator('[data-test="dashboard-variable-tabs-select"]');
+      await tabsSelect.waitFor({ state: "visible", timeout: 10000 });
+      await tabsSelect.click();
+      await this.page.waitForTimeout(500);
+
+      for (const tabId of tabsToSelect) {
+        const tabLabel = tabId === 'default' ? 'Default' : tabId.charAt(0).toUpperCase() + tabId.slice(1);
+        const tabItem = this.page.locator('.q-item').filter({ hasText: new RegExp(`^${tabLabel}$`) });
+        await tabItem.waitFor({ state: "visible", timeout: 5000 });
+        await tabItem.click();
+      }
+
+      await this.page.keyboard.press('Escape');
+      await this.page.waitForTimeout(300);
+
+      if (assignedPanels.length > 0) {
+        const panelsSelect = this.page.locator('[data-test="dashboard-variable-panels-select"]');
+        await panelsSelect.waitFor({ state: "visible", timeout: 10000 });
+        await panelsSelect.click();
+        await this.page.waitForTimeout(1000);
+
+        await this.page.waitForSelector('.q-item', { state: "visible", timeout: 5000 });
+
+        for (const panelName of assignedPanels) {
+          const panelItem = this.page.locator('.q-item').filter({ hasText: new RegExp(`^${panelName}$`) });
+          await panelItem.waitFor({ state: "visible", timeout: 5000 });
+          await panelItem.click();
+          await this.page.waitForTimeout(500);
+        }
+
+        await this.page.keyboard.press('Escape');
+        await this.page.waitForTimeout(500);
+      }
+    }
+
+    // Select variable type - Custom
+    await this.page.locator('[data-test="dashboard-variable-type-select"]').click();
+    await this.page.getByRole("option", { name: "Custom", exact: true }).click();
+    await this.page.waitForTimeout(500);
+
+    // Fill name and label
+    await this.page.locator('[data-test="dashboard-variable-name"]').fill(name);
+    await this.page.locator('[data-test="dashboard-variable-label"]').fill(label);
+
+    // Add custom options - the first option already exists by default
+    if (values.length > 0) {
+      for (let i = 0; i < values.length; i++) {
+        const value = values[i];
+        const valueLabel = typeof value === 'string' ? value : value.label;
+        const valueValue = typeof value === 'string' ? value : value.value;
+        const isDefault = typeof value === 'object' && value.selected === true;
+
+        // If this is not the first item, add a new option
+        if (i > 0) {
+          await this.page.locator('button:has-text("Add Option")').click();
+          await this.page.waitForTimeout(300);
+        }
+
+        // Fill label and value for this option
+        await this.page.locator(`[data-test="dashboard-custom-variable-${i}-label"]`).fill(valueLabel);
+        await this.page.locator(`[data-test="dashboard-custom-variable-${i}-value"]`).fill(valueValue);
+
+        // Set as default if specified
+        if (isDefault) {
+          const checkbox = this.page.locator(`[data-test="dashboard-custom-variable-${i}-checkbox"]`);
+          const isChecked = await checkbox.isChecked();
+          if (!isChecked) {
+            await checkbox.click();
+          }
+        }
+      }
+    }
+
+    // Enable multi-select if requested
+    if (multiSelect) {
+      await this.page.locator('[data-test="dashboard-query_values-show_multiple_values"]').click();
+    }
+
+    // Save variable
+    const saveBtn = this.page.locator('[data-test="dashboard-variable-save-btn"]');
+    await saveBtn.waitFor({ state: "visible", timeout: 10000 });
+    await saveBtn.click();
+
+    // Wait for save to complete
+    await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+
+    const addVariableBtn = this.page.locator('[data-test="dashboard-add-variable-btn"]');
+    const editBtn = this.page.locator(`[data-test="dashboard-edit-variable-${name}"]`);
+
+    try {
+      await Promise.race([
+        addVariableBtn.waitFor({ state: "visible", timeout: 8000 }),
+        editBtn.waitFor({ state: "visible", timeout: 8000 })
+      ]);
+    } catch (e) {
+      await this.page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
+      await this.page.waitForTimeout(500);
+    }
+  }
+
+  /**
+   * Add a constant type variable
+   * @param {string} name - Variable name
+   * @param {string} value - Constant value
+   * @param {Object} options - Additional options
+   * @param {string} options.label - Display label (defaults to name)
+   * @param {string} options.scope - Variable scope: 'global', 'tabs', 'panels'
+   * @param {string[]} options.assignedTabs - Tab IDs if scope is 'tabs'
+   * @param {string[]} options.assignedPanels - Panel IDs if scope is 'panels'
+   * @returns {Promise<void>}
+   */
+  async addConstantVariable(name, value, options = {}) {
+    const {
+      label = name,
+      scope = "global",
+      assignedTabs = [],
+      assignedPanels = [],
+    } = options;
+
+    // Wait for settings panel and variable tab
+    const variableTab = this.page.locator('[data-test="dashboard-settings-variable-tab"]');
+    await variableTab.waitFor({ state: "visible", timeout: 10000 });
+
+    // Only click if not already active
+    const isActive = await variableTab.getAttribute('aria-selected');
+    if (isActive !== 'true') {
+      await variableTab.click();
+      await this.page.waitForTimeout(500);
+    } else {
+      await this.page.waitForTimeout(300);
+    }
+
+    // Click Add Variable button
+    await this.page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
+    await this.page.waitForTimeout(500);
+
+    // Select scope first
+    const normalizedScope = scope === 'panel' ? 'panels' : (scope === 'tab' ? 'tabs' : scope);
+    const scopeUIText = {
+      'global': 'Global',
+      'tabs': 'Selected Tabs',
+      'panels': 'Selected Panels'
+    };
+
+    await this.page.locator('[data-test="dashboard-variable-scope-select"]').click();
+    await this.page.getByRole("option", { name: scopeUIText[normalizedScope] || normalizedScope, exact: true }).click();
+
+    // Assign to tabs if needed
+    if (normalizedScope === "tabs" && assignedTabs.length > 0) {
+      const tabsSelect = this.page.locator('[data-test="dashboard-variable-tabs-select"]');
+      await tabsSelect.waitFor({ state: "visible", timeout: 10000 });
+      await tabsSelect.click();
+      await this.page.waitForTimeout(500);
+
+      for (const tabId of assignedTabs) {
+        const tabLabel = tabId === 'default' ? 'Default' : tabId.charAt(0).toUpperCase() + tabId.slice(1);
+        const tabItem = this.page.locator('.q-item').filter({ hasText: new RegExp(`^${tabLabel}$`) });
+        await tabItem.waitFor({ state: "visible", timeout: 5000 });
+        await tabItem.click();
+      }
+
+      await this.page.keyboard.press('Escape');
+      await this.page.waitForTimeout(300);
+    }
+
+    // Assign to panels if needed
+    if (normalizedScope === "panels") {
+      const tabsToSelect = assignedTabs.length > 0 ? assignedTabs : ['default'];
+
+      const tabsSelect = this.page.locator('[data-test="dashboard-variable-tabs-select"]');
+      await tabsSelect.waitFor({ state: "visible", timeout: 10000 });
+      await tabsSelect.click();
+      await this.page.waitForTimeout(500);
+
+      for (const tabId of tabsToSelect) {
+        const tabLabel = tabId === 'default' ? 'Default' : tabId.charAt(0).toUpperCase() + tabId.slice(1);
+        const tabItem = this.page.locator('.q-item').filter({ hasText: new RegExp(`^${tabLabel}$`) });
+        await tabItem.waitFor({ state: "visible", timeout: 5000 });
+        await tabItem.click();
+      }
+
+      await this.page.keyboard.press('Escape');
+      await this.page.waitForTimeout(300);
+
+      if (assignedPanels.length > 0) {
+        const panelsSelect = this.page.locator('[data-test="dashboard-variable-panels-select"]');
+        await panelsSelect.waitFor({ state: "visible", timeout: 10000 });
+        await panelsSelect.click();
+        await this.page.waitForTimeout(1000);
+
+        await this.page.waitForSelector('.q-item', { state: "visible", timeout: 5000 });
+
+        for (const panelName of assignedPanels) {
+          const panelItem = this.page.locator('.q-item').filter({ hasText: new RegExp(`^${panelName}$`) });
+          await panelItem.waitFor({ state: "visible", timeout: 5000 });
+          await panelItem.click();
+          await this.page.waitForTimeout(500);
+        }
+
+        await this.page.keyboard.press('Escape');
+        await this.page.waitForTimeout(500);
+      }
+    }
+
+    // Select variable type - Constant
+    await this.page.locator('[data-test="dashboard-variable-type-select"]').click();
+    await this.page.getByRole("option", { name: "Constant", exact: true }).click();
+    await this.page.waitForTimeout(500);
+
+    // Fill name and label
+    await this.page.locator('[data-test="dashboard-variable-name"]').fill(name);
+    await this.page.locator('[data-test="dashboard-variable-label"]').fill(label);
+
+    // Set constant value
+    await this.page.locator('[data-test="dashboard-variable-constant-value"]').fill(value);
+
+    // Save variable
+    const saveBtn = this.page.locator('[data-test="dashboard-variable-save-btn"]');
+    await saveBtn.waitFor({ state: "visible", timeout: 10000 });
+    await saveBtn.click();
+
+    // Wait for save to complete
+    await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+
+    const addVariableBtn = this.page.locator('[data-test="dashboard-add-variable-btn"]');
+    const editBtn = this.page.locator(`[data-test="dashboard-edit-variable-${name}"]`);
+
+    try {
+      await Promise.race([
+        addVariableBtn.waitFor({ state: "visible", timeout: 8000 }),
+        editBtn.waitFor({ state: "visible", timeout: 8000 })
+      ]);
+    } catch (e) {
+      await this.page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
+      await this.page.waitForTimeout(500);
+    }
+  }
+
+  /**
+   * Add a textbox type variable
+   * @param {string} name - Variable name
+   * @param {string} defaultValue - Default textbox value
+   * @param {Object} options - Additional options
+   * @param {string} options.label - Display label (defaults to name)
+   * @param {string} options.scope - Variable scope: 'global', 'tabs', 'panels'
+   * @param {string[]} options.assignedTabs - Tab IDs if scope is 'tabs'
+   * @param {string[]} options.assignedPanels - Panel IDs if scope is 'panels'
+   * @returns {Promise<void>}
+   */
+  async addTextboxVariable(name, defaultValue = "", options = {}) {
+    const {
+      label = name,
+      scope = "global",
+      assignedTabs = [],
+      assignedPanels = [],
+    } = options;
+
+    // Wait for settings panel and variable tab
+    const variableTab = this.page.locator('[data-test="dashboard-settings-variable-tab"]');
+    await variableTab.waitFor({ state: "visible", timeout: 10000 });
+
+    // Only click if not already active
+    const isActive = await variableTab.getAttribute('aria-selected');
+    if (isActive !== 'true') {
+      await variableTab.click();
+      await this.page.waitForTimeout(500);
+    } else {
+      await this.page.waitForTimeout(300);
+    }
+
+    // Click Add Variable button
+    await this.page.locator(SELECTORS.ADD_VARIABLE_BTN).click();
+    await this.page.waitForTimeout(500);
+
+    // Select scope first
+    const normalizedScope = scope === 'panel' ? 'panels' : (scope === 'tab' ? 'tabs' : scope);
+    const scopeUIText = {
+      'global': 'Global',
+      'tabs': 'Selected Tabs',
+      'panels': 'Selected Panels'
+    };
+
+    await this.page.locator('[data-test="dashboard-variable-scope-select"]').click();
+    await this.page.getByRole("option", { name: scopeUIText[normalizedScope] || normalizedScope, exact: true }).click();
+
+    // Assign to tabs if needed
+    if (normalizedScope === "tabs" && assignedTabs.length > 0) {
+      const tabsSelect = this.page.locator('[data-test="dashboard-variable-tabs-select"]');
+      await tabsSelect.waitFor({ state: "visible", timeout: 10000 });
+      await tabsSelect.click();
+      await this.page.waitForTimeout(500);
+
+      for (const tabId of assignedTabs) {
+        const tabLabel = tabId === 'default' ? 'Default' : tabId.charAt(0).toUpperCase() + tabId.slice(1);
+        const tabItem = this.page.locator('.q-item').filter({ hasText: new RegExp(`^${tabLabel}$`) });
+        await tabItem.waitFor({ state: "visible", timeout: 5000 });
+        await tabItem.click();
+      }
+
+      await this.page.keyboard.press('Escape');
+      await this.page.waitForTimeout(300);
+    }
+
+    // Assign to panels if needed
+    if (normalizedScope === "panels") {
+      const tabsToSelect = assignedTabs.length > 0 ? assignedTabs : ['default'];
+
+      const tabsSelect = this.page.locator('[data-test="dashboard-variable-tabs-select"]');
+      await tabsSelect.waitFor({ state: "visible", timeout: 10000 });
+      await tabsSelect.click();
+      await this.page.waitForTimeout(500);
+
+      for (const tabId of tabsToSelect) {
+        const tabLabel = tabId === 'default' ? 'Default' : tabId.charAt(0).toUpperCase() + tabId.slice(1);
+        const tabItem = this.page.locator('.q-item').filter({ hasText: new RegExp(`^${tabLabel}$`) });
+        await tabItem.waitFor({ state: "visible", timeout: 5000 });
+        await tabItem.click();
+      }
+
+      await this.page.keyboard.press('Escape');
+      await this.page.waitForTimeout(300);
+
+      if (assignedPanels.length > 0) {
+        const panelsSelect = this.page.locator('[data-test="dashboard-variable-panels-select"]');
+        await panelsSelect.waitFor({ state: "visible", timeout: 10000 });
+        await panelsSelect.click();
+        await this.page.waitForTimeout(1000);
+
+        await this.page.waitForSelector('.q-item', { state: "visible", timeout: 5000 });
+
+        for (const panelName of assignedPanels) {
+          const panelItem = this.page.locator('.q-item').filter({ hasText: new RegExp(`^${panelName}$`) });
+          await panelItem.waitFor({ state: "visible", timeout: 5000 });
+          await panelItem.click();
+          await this.page.waitForTimeout(500);
+        }
+
+        await this.page.keyboard.press('Escape');
+        await this.page.waitForTimeout(500);
+      }
+    }
+
+    // Select variable type - Textbox
+    await this.page.locator('[data-test="dashboard-variable-type-select"]').click();
+    await this.page.getByRole("option", { name: "Textbox", exact: true }).click();
+    await this.page.waitForTimeout(500);
+
+    // Fill name and label
+    await this.page.locator('[data-test="dashboard-variable-name"]').fill(name);
+    await this.page.locator('[data-test="dashboard-variable-label"]').fill(label);
+
+    // Set default value
+    if (defaultValue) {
+      await this.page.locator('[data-test="dashboard-variable-textbox-default-value"]').fill(defaultValue);
+    }
+
+    // Save variable
+    const saveBtn = this.page.locator('[data-test="dashboard-variable-save-btn"]');
+    await saveBtn.waitFor({ state: "visible", timeout: 10000 });
+    await saveBtn.click();
+
+    // Wait for save to complete
+    await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+
+    const addVariableBtn = this.page.locator('[data-test="dashboard-add-variable-btn"]');
+    const editBtn = this.page.locator(`[data-test="dashboard-edit-variable-${name}"]`);
+
+    try {
+      await Promise.race([
+        addVariableBtn.waitFor({ state: "visible", timeout: 8000 }),
+        editBtn.waitFor({ state: "visible", timeout: 8000 })
+      ]);
+    } catch (e) {
+      await this.page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
+      await this.page.waitForTimeout(500);
+    }
+  }
+
+
+  /**
+   * Change textbox variable value (clear, fill, submit)
+   * @param {string} variableName - Variable name
+   * @param {string} newValue - New value to set
+   */
+  async changeTextboxVariableValue(variableName, newValue) {
+    const selector = await this.waitForVariableSelectorVisible(variableName);
+    await selector.clear();
+    await selector.fill(newValue);
+    await this.page.keyboard.press('Enter');
+  }
+
+  /**
+   * Verify variable has loaded options (is not empty)
+   * @param {string} variableName - Variable name
+   * @param {Object} options - Options
+   * @param {number} options.timeout - Timeout in ms
+   * @returns {Promise<number>} Number of options found
+   */
+  async verifyVariableHasOptions(variableName, options = {}) {
+    const { timeout = 10000 } = options;
+
+    // Open variable dropdown
+    const selector = this.page.locator(`[data-test="variable-selector-${variableName}"]`);
+    await selector.click();
+
+    // Wait for dropdown menu
+    await this.page.locator(SELECTORS.MENU).waitFor({ state: "visible", timeout: 5000 });
+
+    // Wait for and count options
+    const dropdown = this.page.locator(`${SELECTORS.MENU} ${SELECTORS.MENU_ITEM}`);
+    await dropdown.first().waitFor({ state: "visible", timeout });
+    const count = await dropdown.count();
+
+    // Close dropdown
+    await this.page.keyboard.press('Escape');
+    await this.page.locator(SELECTORS.MENU).waitFor({ state: "hidden", timeout: 3000 });
+
+    return count;
+  }
 }

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-custom-parents.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-variables-custom-parents.spec.js
@@ -1,0 +1,387 @@
+/**
+ * Dashboard Variables - Custom/Constant/Textbox as Parents Test Suite
+ * Tests that custom, constant, and textbox type variables can be used as parents
+ * for query_values variables (e.g., in stream/field names or filters)
+ */
+
+const { test, expect, navigateToBase } = require("../utils/enhanced-baseFixtures.js");
+import { ingestion } from "./utils/dashIngestion.js";
+import PageManager from "../../pages/page-manager.js";
+import DashboardVariablesScoped from "../../pages/dashboardPages/dashboard-variables-scoped.js";
+import { waitForDashboardPage, deleteDashboard, reopenDashboardFromList } from "./utils/dashCreation.js";
+import { monitorVariableAPICalls } from "../utils/variable-helpers.js";
+const { safeWaitForNetworkIdle } = require("../utils/wait-helpers.js");
+const testLogger = require("../utils/test-logger.js");
+
+test.describe.configure({ mode: "parallel" });
+
+test.describe("Dashboard Variables - Custom/Constant/Textbox as Parents", { tag: ['@dashboards', '@dashboardVariables', '@customParents', '@P1'] }, () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToBase(page);
+    await ingestion(page);
+  });
+
+  test("1-should load query_values child when custom type parent has initial value", async ({ page }) => {
+    const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
+    const dashboardName = `Dashboard_CustomParent_${Date.now()}`;
+    const customVar = `custom_stream_${Date.now()}`;
+    const queryVar = `query_field_${Date.now()}`;
+
+    await pm.dashboardList.menuItem("dashboards-item");
+    await waitForDashboardPage(page);
+    await pm.dashboardCreate.waitForDashboardUIStable();
+    await pm.dashboardCreate.createDashboard(dashboardName);
+    await scopedVars.waitForAddPanelBtn();
+
+    // Open settings
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+
+    testLogger.debug("Creating custom variable as parent");
+    await scopedVars.addCustomVariable(customVar, ["ziox", "kube-system"], {
+      label: "Stream Name",
+      scope: "global"
+    });
+
+    // Close and reopen settings for next variable
+    await pm.dashboardSetting.closeSettingWindow();
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    // Wait for the custom variable to be visible in the list
+    await scopedVars.waitForEditVariableBtnVisible(customVar);
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    testLogger.debug("Creating query_values child with filter using custom parent");
+    await scopedVars.addScopedVariable(
+      queryVar,
+      "logs",
+      "e2e_automate", // Fixed stream name
+      "kubernetes_container_name",
+      {
+        scope: "global",
+        dependsOn: customVar, // Create filter dependency on custom variable
+        dependsOnField: "kubernetes_namespace_name" // Filter by namespace
+      }
+    );
+
+    await pm.dashboardSetting.closeSettingWindow();
+    await scopedVars.waitForDialogHidden({ timeout: 5000 });
+
+    testLogger.debug("Going back to dashboard list and reopening to test initial load");
+
+    // Go back to dashboard list
+    await pm.dashboardCreate.backToDashboardList();
+    await scopedVars.waitForDashboardSearch();
+
+    testLogger.debug("Monitoring API calls during dashboard reopen (initial load)");
+
+    // Start monitoring for API calls BEFORE reopening dashboard
+    const apiMonitorPromise = monitorVariableAPICalls(page, {
+      expectedCount: 1, // Child variable should make 1 API call on initial load
+      timeout: 15000
+    });
+
+    // Reopen the dashboard to test true initial load
+    await reopenDashboardFromList(page, dashboardName);
+
+    testLogger.debug("Verifying child variable loaded on initial dashboard open");
+
+    // Both variables should be visible
+    await scopedVars.waitForVariableSelectorVisible(customVar);
+    await scopedVars.waitForVariableSelectorVisible(queryVar);
+
+    // Verify API call happened during initial load (not when dropdown opens)
+    const apiResult = await apiMonitorPromise;
+    testLogger.debug(`Child variable made ${apiResult.actualCount} API call(s) on initial load`);
+    expect(apiResult.actualCount).toBeGreaterThanOrEqual(1);
+
+    // Now verify the variable has loaded options
+    const optionCount = await scopedVars.verifyVariableHasOptions(queryVar);
+    testLogger.debug(`Child variable has ${optionCount} options`);
+    expect(optionCount).toBeGreaterThan(0);
+
+    // Cleanup
+    await pm.dashboardCreate.backToDashboardList();
+    // Wait for dashboard list to be fully loaded
+    await scopedVars.waitForDashboardSearch();
+    await deleteDashboard(page, dashboardName);
+  });
+
+  test("2-should reload query_values child when constant type parent is used in filter", async ({ page }) => {
+    const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
+    const dashboardName = `Dashboard_ConstantParent_${Date.now()}`;
+    const constantVar = `constant_filter_${Date.now()}`;
+    const queryVar = `query_dependent_${Date.now()}`;
+
+    await pm.dashboardList.menuItem("dashboards-item");
+    await waitForDashboardPage(page);
+    await pm.dashboardCreate.waitForDashboardUIStable();
+    await pm.dashboardCreate.createDashboard(dashboardName);
+    await scopedVars.waitForAddPanelBtn();
+
+    // Open settings
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+
+    testLogger.debug("Creating constant variable as parent");
+    await scopedVars.addConstantVariable(constantVar, "ziox", {
+      label: "Namespace Filter",
+      scope: "global"
+    });
+
+    // Close and reopen settings for next variable
+    await pm.dashboardSetting.closeSettingWindow();
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    // Wait for the constant variable to be visible in the list
+    await scopedVars.waitForEditVariableBtnVisible(constantVar);
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    testLogger.debug("Creating query_values child with filter using constant parent");
+    await scopedVars.addScopedVariable(
+      queryVar,
+      "logs",
+      "e2e_automate",
+      "kubernetes_container_name",
+      {
+        scope: "global",
+        dependsOn: constantVar,
+        dependsOnField: "kubernetes_namespace_name"
+      }
+    );
+
+    await pm.dashboardSetting.closeSettingWindow();
+    await scopedVars.waitForDialogHidden({ timeout: 5000 });
+
+    testLogger.debug("Going back to dashboard list and reopening to test initial load");
+
+    // Go back to dashboard list
+    await pm.dashboardCreate.backToDashboardList();
+    await scopedVars.waitForDashboardSearch();
+
+    testLogger.debug("Monitoring API calls during dashboard reopen (initial load)");
+
+    // Start monitoring for API calls BEFORE reopening dashboard
+    const apiMonitorPromise = monitorVariableAPICalls(page, {
+      expectedCount: 1, // Child variable should make 1 API call on initial load
+      timeout: 15000
+    });
+
+    // Reopen the dashboard to test true initial load
+    await reopenDashboardFromList(page, dashboardName);
+
+    testLogger.debug("Verifying child variable loaded with constant parent filter");
+
+    // Both variables should be visible
+    await scopedVars.waitForVariableSelectorVisible(constantVar);
+    await scopedVars.waitForVariableSelectorVisible(queryVar);
+
+    // Verify API call happened during initial load (not when dropdown opens)
+    const apiResult = await apiMonitorPromise;
+    testLogger.debug(`Child variable made ${apiResult.actualCount} API call(s) on initial load`);
+    expect(apiResult.actualCount).toBeGreaterThanOrEqual(1);
+
+    // Now verify the variable has loaded options
+    const optionCount = await scopedVars.verifyVariableHasOptions(queryVar);
+    testLogger.debug(`Child variable has ${optionCount} options with constant filter`);
+    expect(optionCount).toBeGreaterThan(0);
+
+    // Cleanup
+    await pm.dashboardCreate.backToDashboardList();
+    // Wait for dashboard list to be fully loaded
+    await scopedVars.waitForDashboardSearch();
+    await deleteDashboard(page, dashboardName);
+  });
+
+  test("3-should handle textbox type parent in stream/field names", async ({ page }) => {
+    const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
+    const dashboardName = `Dashboard_TextboxParent_${Date.now()}`;
+    const textboxVar = `textbox_stream_${Date.now()}`;
+    const queryVar = `query_textbox_child_${Date.now()}`;
+
+    await pm.dashboardList.menuItem("dashboards-item");
+    await waitForDashboardPage(page);
+    await pm.dashboardCreate.waitForDashboardUIStable();
+    await pm.dashboardCreate.createDashboard(dashboardName);
+    await scopedVars.waitForAddPanelBtn();
+
+    // Open settings
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+
+    testLogger.debug("Creating textbox variable as parent");
+    await scopedVars.addTextboxVariable(textboxVar, "e2e_automate", {
+      label: "Stream Input",
+      scope: "global"
+    });
+
+    // Close and reopen settings for next variable
+    await pm.dashboardSetting.closeSettingWindow();
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    // Wait for the textbox variable to be visible in the list
+    await scopedVars.waitForEditVariableBtnVisible(textboxVar);
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    testLogger.debug("Creating query_values child using textbox parent in stream");
+    await scopedVars.addScopedVariable(
+      queryVar,
+      "logs",
+      `e2e_automate`,
+      "kubernetes_namespace_name",
+      { scope: "global" }
+    );
+
+    await pm.dashboardSetting.closeSettingWindow();
+    await scopedVars.waitForDialogHidden({ timeout: 5000 });
+
+    testLogger.debug("Going back to dashboard list and reopening to test initial load");
+
+    // Go back to dashboard list
+    await pm.dashboardCreate.backToDashboardList();
+    await scopedVars.waitForDashboardSearch();
+
+    testLogger.debug("Monitoring API calls during dashboard reopen (initial load)");
+
+    // Start monitoring for API calls BEFORE reopening dashboard
+    const apiMonitorPromise = monitorVariableAPICalls(page, {
+      expectedCount: 1, // Child variable should make 1 API call on initial load
+      timeout: 15000
+    });
+
+    // Reopen the dashboard to test true initial load
+    await reopenDashboardFromList(page, dashboardName);
+
+    testLogger.debug("Verifying child variable loaded with textbox parent");
+
+    // Both variables should be visible
+    await scopedVars.waitForVariableSelectorVisible(textboxVar);
+    await scopedVars.waitForVariableSelectorVisible(queryVar);
+
+    // Verify API call happened during initial load (not when dropdown opens)
+    const apiResult = await apiMonitorPromise;
+    testLogger.debug(`Child variable made ${apiResult.actualCount} API call(s) on initial load`);
+    expect(apiResult.actualCount).toBeGreaterThanOrEqual(1);
+
+    // Now verify the variable has loaded options
+    const optionCount = await scopedVars.verifyVariableHasOptions(queryVar);
+    testLogger.debug(`Child variable has ${optionCount} options with textbox parent`);
+    expect(optionCount).toBeGreaterThan(0);
+
+    testLogger.debug("Changing textbox value and verifying child reloads");
+
+    // Change textbox value and verify child reloads
+    await scopedVars.changeTextboxVariableValue(textboxVar, "default");
+
+    // Wait for child to reload
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    // Verify child still has options (might be different stream)
+    const newOptionCount = await scopedVars.verifyVariableHasOptions(queryVar);
+    testLogger.debug(`Child variable has ${newOptionCount} options after textbox change`);
+    expect(newOptionCount).toBeGreaterThanOrEqual(0); // May be 0 if stream doesn't exist
+
+    // Cleanup
+    await pm.dashboardCreate.backToDashboardList();
+    // Wait for dashboard list to be fully loaded
+    await scopedVars.waitForDashboardSearch();
+    await deleteDashboard(page, dashboardName);
+  });
+
+  test("4-should not reload child when parent dropdown opens without value change", async ({ page }) => {
+    const pm = new PageManager(page);
+    const scopedVars = new DashboardVariablesScoped(page);
+    const dashboardName = `Dashboard_NoReload_${Date.now()}`;
+    const customVar = `custom_no_reload_${Date.now()}`;
+    const queryVar = `query_no_reload_${Date.now()}`;
+
+    await pm.dashboardList.menuItem("dashboards-item");
+    await waitForDashboardPage(page);
+    await pm.dashboardCreate.waitForDashboardUIStable();
+    await pm.dashboardCreate.createDashboard(dashboardName);
+    await scopedVars.waitForAddPanelBtn();
+
+    // Open settings
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+
+    testLogger.debug("Creating custom parent and query_values child");
+    await scopedVars.addCustomVariable(customVar, ["e2e_automate"], {
+      scope: "global"
+    });
+
+    // Close and reopen settings for next variable
+    await pm.dashboardSetting.closeSettingWindow();
+    await pm.dashboardSetting.openSetting();
+    await pm.dashboardSetting.openVariables();
+    // Wait for the custom variable to be visible in the list
+    await scopedVars.waitForEditVariableBtnVisible(customVar);
+    await safeWaitForNetworkIdle(page, { timeout: 3000 });
+
+    await scopedVars.addScopedVariable(
+      queryVar,
+      "logs",
+      `e2e_automate`,
+      "kubernetes_namespace_name",
+      { scope: "global" }
+    );
+
+    await pm.dashboardSetting.closeSettingWindow();
+    await scopedVars.waitForDialogHidden({ timeout: 5000 });
+
+    testLogger.debug("Going back to dashboard list and reopening to test initial load");
+
+    // Go back to dashboard list
+    await pm.dashboardCreate.backToDashboardList();
+    await scopedVars.waitForDashboardSearch();
+
+    testLogger.debug("Monitoring API calls during dashboard reopen (initial load)");
+
+    // Start monitoring for API calls BEFORE reopening dashboard
+    const initialApiMonitorPromise = monitorVariableAPICalls(page, {
+      expectedCount: 1, // Child variable should make 1 API call on initial load
+      timeout: 15000
+    });
+
+    // Reopen the dashboard to test true initial load
+    await reopenDashboardFromList(page, dashboardName);
+
+    // Verify child loaded on initial page load
+    const initialApiResult = await initialApiMonitorPromise;
+    testLogger.debug(`Child variable made ${initialApiResult.actualCount} API call(s) on initial load`);
+    expect(initialApiResult.actualCount).toBeGreaterThanOrEqual(1);
+
+    testLogger.debug("Monitoring API calls when opening parent dropdown without changing value");
+
+    // Now test that opening dropdown WITHOUT changing value doesn't trigger additional API calls
+    const apiMonitorPromise = monitorVariableAPICalls(page, {
+      expectedCount: 0,
+      timeout: 3000
+    });
+
+    // Open parent dropdown (this should NOT trigger child reload)
+    const parentSelector = await scopedVars.waitForVariableSelectorVisible(customVar);
+    await parentSelector.click();
+
+    // Wait a bit and close dropdown without selecting
+    await page.waitForTimeout(2000);
+    await page.keyboard.press('Escape');
+
+    // Check API monitoring result
+    const apiResult = await apiMonitorPromise;
+    testLogger.debug(`Total child API calls after parent dropdown open: ${apiResult.actualCount}`);
+
+    // Child should NOT have reloaded (0 API calls expected)
+    // This verifies the race condition fix is working
+    expect(apiResult.actualCount).toBe(0);
+
+    // Cleanup
+    await pm.dashboardCreate.backToDashboardList();
+    // Wait for dashboard list to be fully loaded
+    await scopedVars.waitForDashboardSearch();
+    await deleteDashboard(page, dashboardName);
+  });
+});

--- a/web/src/composables/dashboard/useVariablesManager.spec.ts
+++ b/web/src/composables/dashboard/useVariablesManager.spec.ts
@@ -294,12 +294,13 @@ describe("useVariablesManager", () => {
 
       await manager.initialize(config, {});
 
-      // Parent (constant type) should be immediately ready
+      // Parent (constant type) should be immediately ready and marked as pending to load
       expect(manager.variablesData.global[0].isVariablePartialLoaded).toBe(true);
+      expect(manager.variablesData.global[0].isVariableLoadingPending).toBe(true);
 
-      // Child (query_values type) has a dependency so it won't be marked as pending initially
-      // Only independent query_values variables are marked as pending during initialization
-      expect(manager.variablesData.global[1].isVariableLoadingPending).toBe(false);
+      // Child (query_values type) depends on a non-API type parent (constant)
+      // With the fix, children of non-API parents are now marked as pending during initialization
+      expect(manager.variablesData.global[1].isVariableLoadingPending).toBe(true);
       expect(manager.variablesData.global[1].isVariablePartialLoaded).toBe(false);
 
       // Verify dependency graph is correct

--- a/web/src/composables/dashboard/useVariablesManager.ts
+++ b/web/src/composables/dashboard/useVariablesManager.ts
@@ -483,9 +483,13 @@ export const useVariablesManager = () => {
     });
 
     independentGlobalVars.forEach((v) => {
-      // Mark as pending so selector will fire API
-      // Skip custom and "all" variables during initial load - they don't need API calls
-      if (v.type === "query_values") {
+      // Mark as pending so selector will load them
+      // Non-API types (custom, constant, textbox) need to load to notify manager
+      // query_values types without custom/all need API calls
+      if (v.type === "custom" || v.type === "constant" || v.type === "textbox") {
+        // Non-API types still need to load to set values and notify manager
+        v.isVariableLoadingPending = true;
+      } else if (v.type === "query_values") {
         const hasCustomOrAllDefault =
           v.selectAllValueForMultiSelect === "custom" ||
           v.selectAllValueForMultiSelect === "all";
@@ -509,8 +513,11 @@ export const useVariablesManager = () => {
         const key = getVariableKey(v.name, v.scope);
         const parentKeys = dependencyGraph.value[key]?.parents || [];
 
-        // Check if all parents are custom/all variables (and thus already loaded)
-        const allParentsAreCustomOrAll = parentKeys.every((parentKey) => {
+        // Check if all parents are non-API types (don't require API calls to load)
+        // These variables are treated the same: they load synchronously without API calls
+        // 1. Custom type variables: custom, constant, textbox, dynamic_filters
+        // 2. Query_values with custom/all defaults (values set from config, not API)
+        const allParentsAreNonAPITypes = parentKeys.every((parentKey) => {
           const parentVar = globalVars.find((gv) => {
             const gvKey = getVariableKey(gv.name, gv.scope);
             return gvKey === parentKey;
@@ -518,16 +525,23 @@ export const useVariablesManager = () => {
 
           if (!parentVar) return false;
 
-          const parentIsCustomOrAll =
-            parentVar.type === "query_values" &&
-            (parentVar.selectAllValueForMultiSelect === "custom" ||
-              parentVar.selectAllValueForMultiSelect === "all");
+          // Parent is non-API type if:
+          // - It's a custom type variable (custom, constant, textbox, dynamic_filters)
+          // - OR it's a query_values with custom/all default (no API call needed)
+          const parentIsNonAPIType =
+            parentVar.type === "custom" ||
+            parentVar.type === "constant" ||
+            parentVar.type === "textbox" ||
+            parentVar.type === "dynamic_filters" ||
+            (parentVar.type === "query_values" &&
+              (parentVar.selectAllValueForMultiSelect === "custom" ||
+                parentVar.selectAllValueForMultiSelect === "all"));
 
-          return parentIsCustomOrAll;
+          return parentIsNonAPIType;
         });
 
-        // If all parents are custom/all, mark this child as pending to load
-        if (allParentsAreCustomOrAll && parentKeys.length > 0) {
+        // If all parents are non-API types, mark this child as pending to load
+        if (allParentsAreNonAPITypes && parentKeys.length > 0) {
           v.isVariableLoadingPending = true;
         }
       }


### PR DESCRIPTION


When using custom type variables (custom, constant, textbox) as parent variables for query_values variables (e.g., using custom variables for query_values), the dependent children weren't loading on initial page load.

Root cause:
1. Custom type variables weren't marked as pending during initialization
2. Manager didn't recognize custom types as non-API variables that load synchronously
3. finalizeVariableLoading wasn't notifying manager on completion

Fixes:
1. Mark custom/constant/textbox variables as pending so they load and notify the manager
2. Expand non-API type detection to include custom type variables, not just query_values with custom/all defaults
3. Add manager notification in finalizeVariableLoading, but only on first load to avoid triggering children on dropdown reopens
4. Pass isInitialLoad to finalizePartialVariableLoading for proper child loading

___
Bug fix

___
- Mark custom-type variables as pending

- Treat non-API parents as preloaded

- Notify manager only on first load

- Pass `isInitialLoad` to partial finalize

___

```mermaid
flowchart LR
  A["Variables initialization"] --> B["Mark non-API variables pending"]
  B --> C["VariablesValueSelector loads values"]
  C --> D["Finalize partial loading (initial-load aware)"]
  D --> E["Notify manager on first load"]
  E --> F["Trigger dependent children loading"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>useVariablesManager.ts</strong><dd><code>Load non-API variable types during initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/composables/dashboard/useVariablesManager.ts

<ul><li>Mark
<code>custom</code>/<code>constant</code>/<code>textbox</code> as pending<br> <li> Expand “non-API parent” detection logic<br> <li> Include <code>dynamic_filters</code> as non-API parent<br> <li> Enable child pending when all parents non-API</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10481/files#diff-95f6bdeb96f8454bdff53bb60cafe6851b0cda450591813dd4dfb2038c4f3d50">+27/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>VariablesValueSelector.vue</strong><dd><code>Gate manager notifications to first load</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/dashboards/VariablesValueSelector.vue

<ul><li>Pass <code>isInitialLoad</code> into
<code>finalizePartialVariableLoading</code><br> <li> Compute <code>isFirstLoad</code> from partial-loaded state<br> <li> Notify manager only on initial successful load<br> <li> Avoid triggering children on dropdown reopen</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/10481/files#diff-5c6e3bcb87cb64f25bf8157a541604b7a4904c1282acf662cab5d76a5be6bd56">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

---------