### PR TITLE
fix: table chart number column alignment issue caused by copy cell button (#9843)

### DIFF
--- a/web/src/components/dashboards/panels/TableRenderer.vue
+++ b/web/src/components/dashboards/panels/TableRenderer.vue
@@ -37,7 +37,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   >
     <template v-slot:body-cell="props">
       <q-td :props="props" :style="getStyle(props)" class="copy-cell-td">
-        <div class="flex items-center no-wrap copy-cell-content">
+        <!-- Copy button on left for numeric/right-aligned columns -->
+        <q-btn
+          v-if="props.col.align === 'right' && shouldShowCopyButton(props.value)"
+          :icon="
+            isCellCopied(props.rowIndex, props.col.name)
+              ? 'check'
+              : 'content_copy'
+          "
+          dense
+          size="xs"
+          no-caps
+          flat
+          class="copy-btn q-mr-xs"
+          @click.stop="
+            copyCellContent(props.value, props.rowIndex, props.col.name)
+          "
+        >
+        </q-btn>
           <!-- Use JsonFieldRenderer if column is marked as JSON -->
           <JsonFieldRenderer
             v-if="props.col.showFieldAsJson"
@@ -45,17 +62,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           />
           <!-- Otherwise show normal value -->
           <template v-else>
-            <span class="q-mr-xs">
               {{
-                props.value == "undefined" || props.value === null
+                props.value === "undefined" || props.value === null
                   ? ""
                   : props.col.format
                     ? props.col.format(props.value, props.row)
                     : props.value
               }}
-            </span>
           </template>
+        <!-- Copy button on right for non-numeric columns -->
           <q-btn
+            v-if="props.col.align !== 'right' && shouldShowCopyButton(props.value)"
             :icon="
               isCellCopied(props.rowIndex, props.col.name)
                 ? 'check'
@@ -64,13 +81,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             dense
             size="xs"
             no-caps
-            class="copy-btn"
+            flat
+            class="copy-btn q-ml-xs"
             @click.stop="
               copyCellContent(props.value, props.rowIndex, props.col.name)
             "
           >
           </q-btn>
-        </div>
       </q-td>
     </template>
 
@@ -266,6 +283,13 @@ export default defineComponent({
       return copiedCells.value.has(`${rowIndex}_${colName}`);
     };
 
+    const shouldShowCopyButton = (value: any) => {
+      if (value === null || value === undefined) return false;
+      if (value === "undefined") return false;
+      const stringValue = String(value).trim();
+      return stringValue !== "";
+    };
+
     const copyCellContent = (value: any, rowIndex: number, colName: string) => {
       if (value === null || value === undefined) return;
 
@@ -307,6 +331,7 @@ export default defineComponent({
       store,
       copyCellContent,
       isCellCopied,
+      shouldShowCopyButton,
     };
   },
 });
@@ -372,13 +397,6 @@ export default defineComponent({
     white-space: normal !important;
   }
 
-  // also ensure the inner content (which uses flex and a 'no-wrap' utility) allows wrapping
-  :deep(.copy-cell-content) {
-    white-space: normal !important;
-    overflow-wrap: break-word;
-    word-break: break-word;
-    flex-wrap: wrap !important;
-  }
 }
 
 .copy-cell-td {


### PR DESCRIPTION
Bug fix

___
- Add conditional copy button placement based on alignment

- Show copy icon only when cell has value

- Remove obsolete wrapper and CSS styling

___

```mermaid
flowchart LR
  Cell["Table cell"]
  Cell -- "align right" --> BtnLeft["Copy button left"]
  BtnLeft --> Value["Cell value"]
  Cell -- "non-right align" --> Value2["Cell value"]
  Value2 --> BtnRight["Copy button right"]
```

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>TableRenderer.vue</strong><dd><code>Conditional copy button placement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

web/src/components/dashboards/panels/TableRenderer.vue

<ul><li>Added conditional copy buttons based on column alignment<br> <li> Placed button left for right-aligned columns<br> <li> Placed button right for other columns<br> <li> Removed wrapper div and copy-cell-content CSS</ul>

</details>

  </td>
<td><a
href="https://github.com/openobserve/openobserve/pull/9843/files#diff-794706ea9da3a70012a0327c0464f9fd16802f78ece26055fe951716c2d73d59">+22/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___