### PR TITLE
fix: correct hit truncation limit in partitioned streaming search

### DIFF
--- a/src/service/search/streaming/execution.rs
+++ b/src/service/search/streaming/execution.rs
@@ -182,7 +182,8 @@ pub async fn do_partitioned_search(
                 log::info!(
                     "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), truncating results",
                 );
-                search_res.hits.truncate(req_size as usize);
+                let allowed = (req_size - (curr_res_size - total_hits)) as usize;
+                search_res.hits.truncate(allowed);
                 search_res.total = search_res.hits.len();
             }
         }


### PR DESCRIPTION
When a query with LIMIT spans multiple partitions, the truncation at
the limit boundary used `req_size` (the total limit, e.g. 230) as the
truncation target instead of the remaining slots for the current
partition (`req_size - hits_already_returned`).

For example with limit=230:
- Partition 0: 43 hits returned → accumulated = 43
- Partition 1: 198 hits returned by DB, but only 187 slots remain
  (230 - 43). `truncate(230)` was a no-op since 198 < 230, so all
  198 hits passed through → total = 241 (exceeds limit by 11)

Fix: compute `allowed = req_size - (curr_res_size - total_hits)` which
is the number of remaining slots before this partition's hits are added,
then truncate to that value.


Fixes Issues:
https://github.com/openobserve/openobserve/issues/10602
