### PR TITLE
fix: WAL runtime worker configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6911,7 +6911,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openobserve"
-version = "0.60.0"
+version = "0.80.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = [
 license = "AGPL-3.0"
 name = "openobserve"
 repository = "https://github.com/openobserve/openobserve/"
-version = "0.60.0"
+version = "0.80.0"
 publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1493,6 +1493,8 @@ pub struct Limit {
     pub job_runtime_blocking_worker_num: usize, // equals to 512 if 0
     #[env_config(name = "ZO_JOB_RUNTIME_SHUTDOWN_TIMEOUT", default = 10)] // seconds
     pub job_runtime_shutdown_timeout: u64,
+    #[env_config(name = "ZO_WAL_RUNTIME_WORKER_NUM", default = 0)]
+    pub wal_runtime_worker_num: usize, // equals to mem_table_bucket_num if 0
     #[env_config(name = "ZO_CALCULATE_STATS_INTERVAL", default = 600)] // seconds
     pub calculate_stats_interval: u64,
     #[env_config(name = "ZO_CALCULATE_STATS_STEP_LIMIT_SECS", default = 600)] // seconds

--- a/src/infra/src/runtime/mod.rs
+++ b/src/infra/src/runtime/mod.rs
@@ -30,3 +30,35 @@ pub static DATAFUSION_RUNTIME: Lazy<Arc<Runtime>> = Lazy::new(|| {
             .unwrap(),
     )
 });
+
+pub static WAL_RUNTIME: Lazy<Option<Arc<Runtime>>> = Lazy::new(|| {
+    let cfg = get_config();
+
+    if !cfg.common.wal_dedicated_runtime_enabled {
+        return None;
+    }
+
+    let total_cpus = cfg.limit.cpu_num;
+    // Security Check: At least 2 CPU cores are required for isolation (1 for HTTP, 1 for WAL)
+    if total_cpus < 2 {
+        return None;
+    }
+
+    // Worker number strategy for WAL runtime
+    let thread_num = if cfg.limit.wal_runtime_worker_num > 0 {
+        cfg.limit.wal_runtime_worker_num
+    } else {
+        cfg.limit.mem_table_bucket_num
+    };
+    // Ensure the number of worker threads less than the total number of CPU cores
+    let thread_num = thread_num.min(total_cpus);
+
+    tokio::runtime::Builder::new_multi_thread()
+        .thread_name("wal-runtime")
+        .worker_threads(thread_num)
+        .thread_stack_size(16 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .ok()
+        .map(Arc::new)
+});

--- a/src/ingester/src/writer.rs
+++ b/src/ingester/src/writer.rs
@@ -30,6 +30,7 @@ use config::{
     stats::MemorySize,
     utils::hash::{Sum64, gxhash},
 };
+use infra::runtime::WAL_RUNTIME;
 use once_cell::sync::Lazy;
 use snafu::ResultExt;
 use tokio::sync::{RwLock, mpsc};
@@ -52,26 +53,6 @@ static WRITERS: Lazy<Vec<RwMap<WriterKey, Arc<Writer>>>> = Lazy::new(|| {
         writers.push(RwMap::default());
     }
     writers
-});
-
-static WAL_RUNTIME: Lazy<Option<Arc<tokio::runtime::Runtime>>> = Lazy::new(|| {
-    let cfg = get_config();
-    if !cfg.common.wal_dedicated_runtime_enabled {
-        return None;
-    }
-
-    match create_shared_wal_runtime() {
-        Some(rt) => {
-            log::info!("[INGESTER:RUNTIME] Created single shared WAL runtime successfully");
-            Some(rt)
-        }
-        None => {
-            log::warn!(
-                "[INGESTER:RUNTIME] Failed to create shared WAL runtime, falling back to default runtime"
-            );
-            None
-        }
-    }
 });
 
 pub struct Writer {
@@ -703,95 +684,6 @@ impl Writer {
     }
 }
 
-fn create_shared_wal_runtime() -> Option<Arc<tokio::runtime::Runtime>> {
-    let cfg = get_config();
-
-    if !cfg.common.wal_dedicated_runtime_enabled {
-        return None;
-    }
-
-    let total_cpus = cfg.limit.cpu_num;
-    // Security Check: At least 2 CPU cores are required for isolation (1 for HTTP, 1 for WAL)
-    if total_cpus < 2 {
-        log::warn!(
-            "[INGESTER:RUNTIME] Cannot enable dedicated runtime: need at least 2 CPUs, got {total_cpus}"
-        );
-        return None;
-    }
-
-    // CPU reservation strategy for shared runtime:
-    // - Small systems (<= 8 CPU cores): Reserve 1 CPU core with 1 worker thread
-    // - Medium systems (9-32 CPU cores): Reserve max(1, total_cpus / 8) CPU cores
-    // - Large systems (> 32 CPU cores): Reserve max(4, total_cpus / 8) CPU cores
-    let reserved_cpus_for_wal = if total_cpus <= 8 {
-        1
-    } else if total_cpus <= 32 {
-        std::cmp::max(1, total_cpus / 8)
-    } else {
-        std::cmp::max(4, total_cpus / 8)
-    };
-    // Ensure the number of reserved CPU cores is reasonable (no more than half of the total)
-    let reserved_cpus_for_wal = std::cmp::min(reserved_cpus_for_wal, total_cpus / 2);
-
-    // WAL runtime uses the last few CPU cores
-    // Example: 8-core system with 1 reserved core -> WAL uses CPU 7
-    // 32-core system with 4 reserved cores -> WAL uses CPUs 28-31
-    let wal_cpu_start = total_cpus - reserved_cpus_for_wal;
-
-    log::info!(
-        "[INGESTER:RUNTIME] Creating shared WAL runtime with {} worker threads on CPU cores {}-{} (total CPUs: {}, HTTP can use: 0-{})",
-        reserved_cpus_for_wal,
-        wal_cpu_start,
-        total_cpus - 1,
-        total_cpus,
-        wal_cpu_start - 1
-    );
-
-    // Create CPU affinity list for the worker threads
-    let cpu_ids: Vec<usize> = (wal_cpu_start..total_cpus).collect();
-    let cpu_ids_for_log = cpu_ids.clone();
-
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(reserved_cpus_for_wal)
-        .thread_name("wal-runtime")
-        .on_thread_start(move || {
-            if let Some(core_ids) = core_affinity::get_core_ids() {
-                // Get current thread index by parsing thread name or use round-robin
-                // Since we can't easily get thread index here, bind to the first available CPU in the range
-                // The OS scheduler will distribute threads across the reserved CPUs
-                for &cpu_id in &cpu_ids {
-                    if cpu_id < core_ids.len()
-                        && core_affinity::set_for_current(core_ids[cpu_id]) {
-                            log::info!(
-                                "[INGESTER:RUNTIME] Successfully bound WAL worker thread to CPU core {cpu_id}"
-                            );
-                            break;
-                        }
-                }
-            } else {
-                log::warn!("[INGESTER:RUNTIME] Failed to get CPU core IDs for binding");
-            }
-        })
-        .enable_all()
-        .build();
-
-    match runtime {
-        Ok(rt) => {
-            log::info!(
-                "[INGESTER:RUNTIME] Created shared WAL runtime successfully with {} threads on CPUs: {:?}",
-                reserved_cpus_for_wal,
-                cpu_ids_for_log
-            );
-            Some(Arc::new(rt))
-        }
-        Err(e) => {
-            log::error!(
-                "[INGESTER:RUNTIME] Failed to create shared WAL runtime: {e}, falling back to default runtime"
-            );
-            None
-        }
-    }
-}
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub(crate) struct WriterKey {
     pub(crate) org_id: Arc<str>,


### PR DESCRIPTION
There is a problem that `WAL_RUNTIME` always use single thread working.

- Introduced `ZO_WAL_RUNTIME_WORKER_NUM` to `Limit` struct for configurable worker threads.
- Updated CPU reservation logic in `create_shared_wal_runtime` to utilize the new configuration, ensuring better resource management based on user-defined settings.