### PR TITLE
test: Streams cloud compatibility for alpha1 E2E (Set3)

### DIFF
--- a/tests/ui-testing/pages/streamsPages/streamsPage.js
+++ b/tests/ui-testing/pages/streamsPages/streamsPage.js
@@ -546,7 +546,7 @@ export class StreamsPage {
                     catch { return { status: r.status, data: text }; }
                 }, { orgId, streamName, streamType, payload });
 
-                if (result.status === 200 && result.data?.code === 200) {
+                if (result.status === 200) {
                     testLogger.info('Stream created successfully (cloud)', { streamName });
                 } else {
                     testLogger.warn('Stream creation returned non-200 (cloud)', { streamName, status: result.status });

--- a/tests/ui-testing/utils/apiUtils.js
+++ b/tests/ui-testing/utils/apiUtils.js
@@ -22,7 +22,7 @@ export const getHeaders = () => {
         };
       }
     } catch (e) {
-      // Fall through to password-based auth
+      console.warn('[apiUtils] Failed to read cloud-config.json, falling back to password auth:', e.message);
     }
   }
 


### PR DESCRIPTION
## Summary
- **apiUtils.js**: `getHeaders()` now reads `cloud-config.json` for `email:passcode` auth when `IS_CLOUD=true`, with caching
- **streamsPage.js**: `deleteStreamViaAPI`, `createStream`, `verifyStreamExists` use `page.evaluate(fetch())` on cloud for OIDC cookie auth on management APIs (node-fetch can't send session cookies)
- All 5 Streams spec files (30 tests) passing on alpha1 cloud

## Test plan
- [x] All 5 Streams specs pass locally against alpha1 (headless)
- [x] CI run passed: https://github.com/openobserve/o2-enterprise/actions/runs/22906826643
- [ ] Full regression with all shards uncommented after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)