### PR TITLE
fix: dual encoding of vrl while saving alert (#10734)

### DIFF
--- a/web/src/components/alerts/AddAlert.vue
+++ b/web/src/components/alerts/AddAlert.vue
@@ -447,6 +447,7 @@ import {
   getUUID,
   getTimezoneOffset,
   b64DecodeUnicode,
+  smartDecodeVrlFunction,
   isValidResourceName,
   getTimezonesByOffset,
 } from "@/utils/zincutils";
@@ -760,11 +761,9 @@ export default defineComponent({
       if (!formData.value.query_condition.vrl_function) {
         return "";
       }
-      try {
-        return b64DecodeUnicode(formData.value.query_condition.vrl_function);
-      } catch (e) {
-        return formData.value.query_condition.vrl_function;
-      }
+      // formData already has decoded VRL (decoded at load time in created() hook)
+      // Just return it directly, no need to decode again
+      return formData.value.query_condition.vrl_function;
     });
 
     const editorData = ref("");
@@ -2351,7 +2350,8 @@ export default defineComponent({
 
       if (this.formData.query_condition.vrl_function) {
         this.showVrlFunction = true;
-        this.formData.query_condition.vrl_function = b64DecodeUnicode(
+        // Use smart decoder to handle both single and double-encoded VRL (backwards compatibility)
+        this.formData.query_condition.vrl_function = smartDecodeVrlFunction(
           this.formData.query_condition.vrl_function,
         );
       }

--- a/web/src/components/alerts/PreviewAlert.vue
+++ b/web/src/components/alerts/PreviewAlert.vue
@@ -45,7 +45,7 @@ import { cloneDeep } from "lodash-es";
 import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
 import searchService from "@/services/search";
-import { b64EncodeUnicode, b64DecodeUnicode } from "@/utils/zincutils";
+import { b64EncodeUnicode, b64DecodeUnicode, smartDecodeVrlFunction } from "@/utils/zincutils";
 import { logsUtils } from "@/composables/useLogs/logsUtils";
 
 const getDefaultDashboardPanelData: any = () => ({
@@ -187,11 +187,8 @@ const getDecodedVrlFunction = (): string | null => {
   if (!props.formData.query_condition?.vrl_function) {
     return null;
   }
-  try {
-    return b64DecodeUnicode(props.formData.query_condition.vrl_function);
-  } catch (e) {
-    return props.formData.query_condition.vrl_function;
-  }
+  // Use smart decoder to handle both single and double-encoded VRL
+  return smartDecodeVrlFunction(props.formData.query_condition.vrl_function);
 };
 
 onBeforeMount(() => {

--- a/web/src/components/alerts/QueryEditorDialog.vue
+++ b/web/src/components/alerts/QueryEditorDialog.vue
@@ -675,8 +675,7 @@ const updatePromqlQuery = (value: string) => {
 
 const updateVrlFunction = (value: string) => {
   vrlFunctionContent.value = value;
-  const encoded = b64EncodeUnicode(value);
-  emit("update:vrlFunction", encoded);
+  emit("update:vrlFunction", value);
 };
 
 const onBlurQueryEditor = debounce(() => {

--- a/web/src/components/alerts/steps/QueryConfig.vue
+++ b/web/src/components/alerts/steps/QueryConfig.vue
@@ -673,9 +673,9 @@ export default defineComponent({
 
 
     // Handler for VRL function updates from QueryEditorDialog
-    // The dialog emits the encoded value, so we just pass it through
-    const handleVrlFunctionUpdate = (encodedValue: string) => {
-      emit("update:vrlFunction", encodedValue);
+    // The dialog now emits plain text VRL (encoding happens once at save time)
+    const handleVrlFunctionUpdate = (vrlValue: string) => {
+      emit("update:vrlFunction", vrlValue);
     };
 
     // Handler for SQL validation from QueryEditorDialog

--- a/web/src/utils/alerts/alertValidation.ts
+++ b/web/src/utils/alerts/alertValidation.ts
@@ -518,7 +518,7 @@ export const validateSqlQuery = async (
   query.query.sql = formData.query_condition.sql;
 
   if (formData.query_condition.vrl_function)
-    query.query.query_fn = formData.query_condition.vrl_function
+    query.query.query_fn = b64EncodeUnicode(formData.query_condition.vrl_function)
 
   validateSqlQueryPromise.value = new Promise((resolve, reject) => {
     searchService

--- a/web/src/utils/zincutils.spec.ts
+++ b/web/src/utils/zincutils.spec.ts
@@ -17,6 +17,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import {
   b64EncodeUnicode,
   b64DecodeUnicode,
+  smartDecodeVrlFunction,
   b64EncodeStandard,
   b64DecodeStandard,
   validateEmail,
@@ -148,6 +149,225 @@ describe("zincutils", () => {
       it("should handle invalid base64", () => {
         const result = b64DecodeUnicode("invalid-base64");
         expect(result).toBeUndefined();
+      });
+    });
+
+    describe("smartDecodeVrlFunction", () => {
+      // Test data setup
+      const plainTextVrl = ".field1 = \"value1\"\n.field2 = \"value2\"";
+      const singleEncodedVrl = b64EncodeUnicode(plainTextVrl);
+      const doubleEncodedVrl = b64EncodeUnicode(singleEncodedVrl as string);
+
+      describe("Normal Case: Single-Encoded VRL", () => {
+        it("should decode single-encoded VRL correctly", () => {
+          const result = smartDecodeVrlFunction(singleEncodedVrl);
+          expect(result).toBe(plainTextVrl);
+        });
+
+        it("should handle single-encoded VRL with special characters", () => {
+          const specialVrl = ".message = \"Hello @user! Cost: $50.00\"";
+          const encoded = b64EncodeUnicode(specialVrl);
+          const result = smartDecodeVrlFunction(encoded);
+          expect(result).toBe(specialVrl);
+        });
+
+        it("should handle single-encoded VRL with newlines", () => {
+          const multilineVrl = ".field1 = \"line1\"\n.field2 = \"line2\"\n.field3 = \"line3\"";
+          const encoded = b64EncodeUnicode(multilineVrl);
+          const result = smartDecodeVrlFunction(encoded);
+          expect(result).toBe(multilineVrl);
+        });
+
+        it("should handle single-encoded VRL with unicode characters", () => {
+          const unicodeVrl = ".message = \"Hello 世界! 🌍\"";
+          const encoded = b64EncodeUnicode(unicodeVrl);
+          const result = smartDecodeVrlFunction(encoded);
+          expect(result).toBe(unicodeVrl);
+        });
+      });
+
+      describe("Legacy v0.40 Case: Double-Encoded VRL", () => {
+        it("should detect and decode double-encoded VRL", () => {
+          const result = smartDecodeVrlFunction(doubleEncodedVrl);
+          expect(result).toBe(plainTextVrl);
+        });
+
+        it("should handle double-encoded VRL with special characters", () => {
+          const specialVrl = ".msg = \"Test @#$%^&*()\"";
+          const doubleEncoded = b64EncodeUnicode(
+            b64EncodeUnicode(specialVrl) as string
+          );
+          const result = smartDecodeVrlFunction(doubleEncoded);
+          expect(result).toBe(specialVrl);
+        });
+
+        it("should handle real-world double-encoded VRL scenario", () => {
+          // Simulate v0.40 bug: VRL gets encoded in QueryEditorDialog, then encoded again in getAlertPayload
+          const originalVrl = ".severity = \"error\"\n.status_code = 500";
+          const firstEncode = b64EncodeUnicode(originalVrl); // QueryEditorDialog encoding
+          const secondEncode = b64EncodeUnicode(firstEncode as string); // getAlertPayload encoding
+
+          const result = smartDecodeVrlFunction(secondEncode);
+          expect(result).toBe(originalVrl);
+        });
+      });
+
+      describe("Edge Cases", () => {
+        it("should return empty string for null input", () => {
+          const result = smartDecodeVrlFunction(null);
+          expect(result).toBe("");
+        });
+
+        it("should return empty string for undefined input", () => {
+          const result = smartDecodeVrlFunction(undefined);
+          expect(result).toBe("");
+        });
+
+        it("should return empty string for empty string input", () => {
+          const result = smartDecodeVrlFunction("");
+          expect(result).toBe("");
+        });
+
+        it("should handle plain text VRL (not encoded) gracefully", () => {
+          // If someone manually enters plain VRL in JSON editor
+          const plainVrl = ".field = \"value\"";
+          const result = smartDecodeVrlFunction(plainVrl);
+          // Should attempt to decode and fail gracefully, returning original
+          expect(result).toBe(plainVrl);
+        });
+
+        it("should handle invalid base64 gracefully", () => {
+          const invalidBase64 = "!!!invalid!!!";
+          const result = smartDecodeVrlFunction(invalidBase64);
+          expect(result).toBe(invalidBase64);
+        });
+
+        it("should handle partially encoded text", () => {
+          const partiallyEncoded = "plain text with some SGVsbG8= base64";
+          const result = smartDecodeVrlFunction(partiallyEncoded);
+          // Should return original since it's not fully base64 encoded
+          expect(result).toBe(partiallyEncoded);
+        });
+      });
+
+      describe("Backwards Compatibility", () => {
+        it("should handle alerts from v0.40 with double-encoded VRL", () => {
+          // Simulate: Backend returns double-encoded VRL from legacy v0.40 alert
+          const originalVrl = ".parse_json(.message)";
+          const legacyDoubleEncoded = b64EncodeUnicode(
+            b64EncodeUnicode(originalVrl) as string
+          );
+
+          // Smart decoder should detect and fix
+          const result = smartDecodeVrlFunction(legacyDoubleEncoded);
+          expect(result).toBe(originalVrl);
+        });
+
+        it("should handle alerts saved correctly (single-encoded)", () => {
+          // Simulate: Backend returns properly single-encoded VRL from new alerts
+          const originalVrl = ".parse_json(.message)";
+          const properlyEncoded = b64EncodeUnicode(originalVrl);
+
+          // Should decode once
+          const result = smartDecodeVrlFunction(properlyEncoded);
+          expect(result).toBe(originalVrl);
+        });
+
+        it("should handle migration scenario: fixing double-encoded on save", () => {
+          // Simulate: User loads old double-encoded alert, edits, saves
+          const originalVrl = ".status = 200";
+          const oldDoubleEncoded = b64EncodeUnicode(
+            b64EncodeUnicode(originalVrl) as string
+          );
+
+          // Load: Smart decoder fixes it
+          const decoded = smartDecodeVrlFunction(oldDoubleEncoded);
+          expect(decoded).toBe(originalVrl);
+
+          // Save: Re-encode (should be single-encoded now)
+          const reEncoded = b64EncodeUnicode(decoded);
+
+          // Load again: Should still decode correctly
+          const finalDecoded = smartDecodeVrlFunction(reEncoded);
+          expect(finalDecoded).toBe(originalVrl);
+        });
+      });
+
+      describe("Complex VRL Examples", () => {
+        it("should handle complex VRL with nested functions", () => {
+          const complexVrl = `
+.parsed = parse_json!(.message)
+.severity = .parsed.level
+if .severity == "error" {
+  .alert = true
+}
+.timestamp = to_timestamp!(.time)
+`;
+          const encoded = b64EncodeUnicode(complexVrl);
+          const result = smartDecodeVrlFunction(encoded);
+          expect(result).toBe(complexVrl);
+        });
+
+        it("should handle VRL with arrays and objects", () => {
+          const vrlWithArrays = '.tags = ["production", "api", "critical"]';
+          const encoded = b64EncodeUnicode(vrlWithArrays);
+          const result = smartDecodeVrlFunction(encoded);
+          expect(result).toBe(vrlWithArrays);
+        });
+
+        it("should handle VRL with regex patterns", () => {
+          const vrlWithRegex = '.is_error = match!(.message, r"error|fail|exception")';
+          const encoded = b64EncodeUnicode(vrlWithRegex);
+          const result = smartDecodeVrlFunction(encoded);
+          expect(result).toBe(vrlWithRegex);
+        });
+      });
+
+      describe("Performance and Safety", () => {
+        it("should handle very long VRL functions", () => {
+          const longVrl = ".field = \"" + "a".repeat(10000) + "\"";
+          const encoded = b64EncodeUnicode(longVrl);
+          const result = smartDecodeVrlFunction(encoded);
+          expect(result).toBe(longVrl);
+        });
+
+        it("should not throw errors for any input", () => {
+          const testInputs = [
+            null,
+            undefined,
+            "",
+            "plain text",
+            "123456",
+            "SGVsbG8=",
+            "!!!",
+            b64EncodeUnicode("test"),
+            b64EncodeUnicode(b64EncodeUnicode("test") as string),
+          ];
+
+          testInputs.forEach((input) => {
+            expect(() => smartDecodeVrlFunction(input as any)).not.toThrow();
+          });
+        });
+
+        it("should handle concurrent decode operations", () => {
+          const vrl1 = ".field1 = \"value1\"";
+          const vrl2 = ".field2 = \"value2\"";
+          const vrl3 = ".field3 = \"value3\"";
+
+          const encoded1 = b64EncodeUnicode(vrl1);
+          const encoded2 = b64EncodeUnicode(vrl2);
+          const encoded3 = b64EncodeUnicode(vrl3);
+
+          const results = [
+            smartDecodeVrlFunction(encoded1),
+            smartDecodeVrlFunction(encoded2),
+            smartDecodeVrlFunction(encoded3),
+          ];
+
+          expect(results[0]).toBe(vrl1);
+          expect(results[1]).toBe(vrl2);
+          expect(results[2]).toBe(vrl3);
+        });
       });
     });
 

--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -204,6 +204,62 @@ export const b64DecodeUnicode = (str: string) => {
   }
 };
 
+/**
+ * Helper function to check if a string is base64 encoded
+ * Used to detect double-encoded VRL functions from v0.40 legacy data
+ */
+const isBase64Encoded = (str: string): boolean => {
+  if (!str || typeof str !== 'string') return false;
+
+  // Check if string looks like base64 (url-safe format used by OpenObserve)
+  // Base64 pattern: alphanumeric + "-" + "_" + "."
+  const base64Pattern = /^[A-Za-z0-9\-_\.]+$/;
+
+  if (!base64Pattern.test(str)) return false;
+
+  // Try to decode - if it succeeds without error, it's likely base64
+  try {
+    const decoded = b64DecodeUnicode(str);
+    return decoded !== undefined && decoded !== null && decoded !== str;
+  } catch (e) {
+    return false;
+  }
+};
+
+/**
+ * Smart VRL function decoder that handles backwards compatibility
+ * - Detects if VRL is single or double-encoded (legacy v0.40 bug)
+ * - Decodes once, checks if still encoded, decodes again if needed
+ * - Ensures clean decoded VRL for display/editing
+ *
+ * @param vrlFunction - VRL function string (may be single or double encoded)
+ * @returns Fully decoded VRL function
+ */
+export const smartDecodeVrlFunction = (vrlFunction: string | null | undefined): string => {
+  if (!vrlFunction) return "";
+
+  try {
+    // First decode
+    const firstDecode = b64DecodeUnicode(vrlFunction);
+
+    if (!firstDecode) return vrlFunction;
+
+    // Check if result is still base64 encoded (double-encoded case from legacy bug)
+    if (isBase64Encoded(firstDecode)) {
+      // Decode again for double-encoded VRL
+      const secondDecode = b64DecodeUnicode(firstDecode);
+      return secondDecode || firstDecode;
+    }
+
+    // Single-encoded (normal case)
+    return firstDecode;
+  } catch (e) {
+    // If decode fails, return original value
+    console.error("Error decoding VRL function:", e);
+    return vrlFunction;
+  }
+};
+
 export const b64EncodeStandard = (str: string) => {
   try {
     return btoa(


### PR DESCRIPTION
1. This PR fixes the issue which is when saving alert we are encoding the vrl function 2 times which is not correct and should only be 1 time .