### PR TITLE
perf: Batch schema evolution checks in handle_otlp_request

### DIFF
--- a/src/service/metrics/otlp.rs
+++ b/src/service/metrics/otlp.rs
@@ -152,7 +152,6 @@ pub async fn handle_otlp_request(
 
     let mut metric_data_map: HashMap<String, HashMap<String, SchemaRecords>> = HashMap::new();
     let mut metric_schema_map: HashMap<String, SchemaCache> = HashMap::new();
-    let mut schema_evolved: HashMap<String, bool> = HashMap::new();
     let mut stream_partitioning_map: HashMap<String, Vec<StreamPartition>> = HashMap::new();
 
     // Start get user defined schema
@@ -473,6 +472,20 @@ pub async fn handle_otlp_request(
             .unwrap_or_default();
         let partition_time_level = get_partition_time_level(StreamType::Metrics);
 
+        // check for schema evolution
+        let min_timestamp = batch_min_timestamp(&json_data, Utc::now().timestamp_micros());
+
+        let _ = check_for_schema(
+            org_id,
+            &local_metric_name,
+            StreamType::Metrics,
+            &mut metric_schema_map,
+            json_data.iter().collect(),
+            min_timestamp,
+            false, // is_derived is false for metrics
+        )
+        .await?;
+
         for val_map in json_data {
             let timestamp = val_map
                 .get(TIMESTAMP_COL_NAME)
@@ -480,40 +493,6 @@ pub async fn handle_otlp_request(
                 .unwrap_or(Utc::now().timestamp_micros());
 
             let value_str = json::to_string(&val_map).unwrap();
-
-            // check for schema evolution
-            let schema_fields = match metric_schema_map.get(&local_metric_name) {
-                Some(schema) => schema
-                    .schema()
-                    .fields()
-                    .iter()
-                    .map(|f| f.name())
-                    .collect::<HashSet<_>>(),
-                None => HashSet::default(),
-            };
-            let mut need_schema_check = !schema_evolved.contains_key(&local_metric_name);
-            for key in val_map.keys() {
-                if !schema_fields.contains(&key) {
-                    need_schema_check = true;
-                    break;
-                }
-            }
-            drop(schema_fields);
-            if need_schema_check {
-                let (schema_evolution, _infer_schema) = check_for_schema(
-                    org_id,
-                    &local_metric_name,
-                    StreamType::Metrics,
-                    &mut metric_schema_map,
-                    vec![&val_map],
-                    timestamp,
-                    false, // is_derived is false for metrics
-                )
-                .await?;
-                if schema_evolution.is_schema_changed {
-                    schema_evolved.insert(local_metric_name.to_owned(), true);
-                }
-            }
 
             let buf = metric_data_map
                 .entry(local_metric_name.to_owned())
@@ -648,6 +627,23 @@ pub async fn handle_otlp_request(
     }
 
     format_response(partial_success, req_type)
+}
+
+fn batch_min_timestamp(
+    json_data: &[serde_json::Map<String, serde_json::Value>],
+    default: i64,
+) -> i64 {
+    let first = json_data
+        .first()
+        .and_then(|v| v.get(TIMESTAMP_COL_NAME)?.as_i64());
+    let last = json_data
+        .last()
+        .and_then(|v| v.get(TIMESTAMP_COL_NAME)?.as_i64());
+
+    match (first, last) {
+        (Some(f), Some(l)) => f.min(l),
+        (f, l) => f.or(l).unwrap_or(default),
+    }
 }
 
 fn process_gauge(
@@ -1640,6 +1636,31 @@ mod tests {
         // This should handle empty data gracefully
         // The actual behavior depends on the implementation
         assert!(empty_metric.data.is_none());
+    }
+
+    #[test]
+    fn test_batch_min_timestamp() {
+        // min of multiple values
+        let json_data = vec![
+            serde_json::Map::from_iter([(TIMESTAMP_COL_NAME.to_string(), json!(1i64))]),
+            serde_json::Map::from_iter([(TIMESTAMP_COL_NAME.to_string(), json!(2i64))]),
+            serde_json::Map::from_iter([(TIMESTAMP_COL_NAME.to_string(), json!(3i64))]),
+        ];
+        assert_eq!(batch_min_timestamp(&json_data, 42), 1i64);
+
+        // first element doesn't have a timestamp, returns the last
+        let json_data_with_one_timestamp = vec![
+            serde_json::Map::from_iter([("value".to_string(), json!(1))]),
+            serde_json::Map::from_iter([(TIMESTAMP_COL_NAME.to_string(), json!(2i64))]),
+        ];
+        assert_eq!(batch_min_timestamp(&json_data_with_one_timestamp, 42), 2i64);
+
+        // no records have a timestamp, returns default
+        let json_data_with_no_timestamp = vec![
+            serde_json::Map::from_iter([("value".to_string(), json!(1))]),
+            serde_json::Map::from_iter([("value".to_string(), json!(2))]),
+        ];
+        assert_eq!(batch_min_timestamp(&json_data_with_no_timestamp, 42), 42i64);
     }
 
     mod protobuf_json_tests {


### PR DESCRIPTION
# Description 

`handle_otlp_request` runs schema evolution checks on each record of a batch using `check_for_schema`. `check_for_schema` has a lot of per call overhead because it needs to infer the schema of the record on each call. 

This PR performs the schema evolution check on a batch of records by passing the full batch to `check_for_schema`, this amoritizes the schema inference time over the batch.

I'm very new to this codebase so maybe  this isn't a safe change to make, here are some of my assumptions from reading the  code

- It is ok for keys to be missing in the schema, batching the records unions the schema so we won't know if a particular record is missing a key.
- It is ok for types to be coerced in the schema, schema inference will coerce compatible types across the batch so we compare the final type coerced schema when we do schema evolution checking.
- I use the min timestamp for the whole batch, not exactly sure what the timestamp is used for.

# Results

I made a very basic benchmark where I send a batch of 100 records and saw a ~30% latency improvement in `handle_otlp_request` on my machine.

### Before Change

```
otlp/otlp_metrics_write time:   [2.3513 ms 2.3796 ms 2.4106 ms]
                        thrpt:  [41.483 Kelem/s 42.024 Kelem/s 42.530 Kelem/s]
```

### After Change

```
otlp/otlp_metrics_write time:   [1.5964 ms 1.6188 ms 1.6424 ms]
                        thrpt:  [60.885 Kelem/s 61.774 Kelem/s 62.641 Kelem/s]
```