### PR TITLE
feat: add configuration option for field values in FST logs page

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -809,6 +809,12 @@ pub struct Common {
     pub timestamp_compression_disabled: bool,
     #[env_config(name = "ZO_FEATURE_INGESTER_NONE_COMPRESSION", default = false)]
     pub feature_ingester_none_compression: bool,
+    #[env_config(
+        name = "ZO_FEATURE_FIELD_VALUES_FOR_FST",
+        default = false,
+        help = "Show field values dropdown for full text search (FST) fields in the logs page field list"
+    )]
+    pub field_values_for_fst: bool,
     #[env_config(name = "ZO_FEATURE_FULLTEXT_EXTRA_FIELDS", default = "")]
     pub feature_fulltext_extra_fields: String,
     #[env_config(name = "ZO_FEATURE_INDEX_EXTRA_FIELDS", default = "")]

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -162,6 +162,7 @@ struct ConfigResponse<'a> {
     #[cfg(not(feature = "enterprise"))]
     fqn_priority_dimensions: Vec<String>,
     enable_cross_linking: bool,
+    field_values_for_fst: bool,
 }
 
 #[derive(Serialize, serde::Deserialize)]
@@ -443,6 +444,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         #[cfg(not(feature = "enterprise"))]
         fqn_priority_dimensions: vec![],
         enable_cross_linking: cfg.common.enable_cross_linking,
+        field_values_for_fst: cfg.common.field_values_for_fst,
     }))
 }
 

--- a/web/src/components/common/sidebar/FieldList.vue
+++ b/web/src/components/common/sidebar/FieldList.vue
@@ -35,7 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <q-td :props="props" class="field_list">
               <!-- TODO OK : Repeated code make separate component to display field  -->
               <div
-                v-if="props.row.ftsKey || !props.row.showValues"
+                v-if="(props.row.ftsKey && !fieldValuesForFst) || !props.row.showValues"
                 class="field-container flex content-center ellipsis q-pl-lg q-pr-sm"
                 :title="props.row.name"
               >
@@ -255,7 +255,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, type Ref } from "vue";
+import { computed, defineComponent, ref, type Ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useStore } from "vuex";
 import { useQuasar } from "quasar";
@@ -320,6 +320,10 @@ export default defineComponent({
         values: { key: string; count: string }[];
       };
     }> = ref({});
+
+    const fieldValuesForFst = computed(
+      () => store.state.zoConfig?.field_values_for_fst ?? false,
+    );
 
     const filterFieldFn = (rows: any, terms: any) => {
       var filtered = [];
@@ -405,6 +409,7 @@ export default defineComponent({
       outlinedAdd,
       filterFieldValue,
       copyContentValue,
+      fieldValuesForFst,
     };
   },
 });

--- a/web/src/plugins/traces/IndexList.vue
+++ b/web/src/plugins/traces/IndexList.vue
@@ -75,7 +75,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             >
               <!-- TODO OK : Repeated code make separate component to display field  -->
               <div
-                v-if="props.row.ftsKey || !props.row.showValues"
+                v-if="(props.row.ftsKey && !fieldValuesForFst) || !props.row.showValues"
                 class="field-container flex content-center ellipsis q-pl-lg q-pr-sm hover:!tw-bg-[var(--o2-hover-accent)]"
                 :title="props.row.label || props.row.name"
               >
@@ -138,7 +138,7 @@ style="opacity: 0.7">
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from "vue";
+import { computed,defineComponent, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
@@ -146,7 +146,6 @@ import useTraces from "../../composables/useTraces";
 import { getImageURL } from "../../utils/zincutils";
 import { outlinedAdd } from "@quasar/extras/material-icons-outlined";
 import BasicValuesFilter from "./fields-sidebar/BasicValuesFilter.vue";
-import { computed } from "vue";
 
 export default defineComponent({
   name: "ComponentSearchIndexSelect",
@@ -177,6 +176,10 @@ export default defineComponent({
         max: 100000,
       },
     });
+
+    const fieldValuesForFst = computed(
+      () => store.state.zoConfig?.field_values_for_fst ?? false,
+    );
 
     const fnMarkerLabel = computed(() => {
       const markers = [];
@@ -247,6 +250,7 @@ export default defineComponent({
       fnMarkerLabel,
       duration,
       onStreamChange,
+      fieldValuesForFst,
     };
   },
 });


### PR DESCRIPTION
Design at: #10951

## Summary
- Add `ZO_FEATURE_FIELD_VALUES_FOR_FST` env var (default: `false`) to backend config
- Expose the value via `/api/config` endpoint to the frontend
- When `false` (default): FST fields in the logs page field list render without a values dropdown (existing behavior)
- When `true`: FST fields show the expandable values dropdown like regular fields
