### PR TITLE
fix: show non-timestamp and JSON render options in Custom mode

### DIFF
--- a/web/src/components/dashboards/addPanel/dynamicFunction/DynamicFunctionPopUp.vue
+++ b/web/src/components/dashboards/addPanel/dynamicFunction/DynamicFunctionPopUp.vue
@@ -135,23 +135,24 @@
           />
         </div>
       </div>
-      <div v-if="chartType === 'table'" class="q-mt-sm q-mb-sm">
-        <div>
-          <q-checkbox
-            v-model="fields.treatAsNonTimestamp"
-            :label="'Mark this field as non-timestamp'"
-            dense
-            data-test="dynamic-function-popup-treat-as-non-timestamp"
-          />
-        </div>
-        <div class="q-mt-xs">
-          <q-checkbox
-            v-model="fields.showFieldAsJson"
-            :label="'Render Data as JSON / Array'"
-            dense
-            data-test="dynamic-function-popup-show-field-as-json"
-          />
-        </div>
+    </div>
+
+    <div v-if="chartType === 'table'" class="q-mt-sm q-mb-sm">
+      <div>
+        <q-checkbox
+          v-model="fields.treatAsNonTimestamp"
+          :label="'Mark this field as non-timestamp'"
+          dense
+          data-test="dynamic-function-popup-treat-as-non-timestamp"
+        />
+      </div>
+      <div class="q-mt-xs">
+        <q-checkbox
+          v-model="fields.showFieldAsJson"
+          :label="'Render Data as JSON / Array'"
+          dense
+          data-test="dynamic-function-popup-show-field-as-json"
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Move the 'Mark this field as non-timestamp' and 'Render Data as JSON / Array' checkboxes outside the Build-mode-only conditional block so they are visible in both Build and Custom modes for table charts.

Fixes #10953