### PR TITLE
chore: enable service graph by default, drop runtime config knobs

### DIFF
--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -185,7 +185,6 @@ struct ConfigResponse<'a> {
     log_page_default_field_list: String,
     query_values_default_num: i64,
     alert_preview_timerange_minutes: i64,
-    service_graph_enabled: bool,
     incidents_enabled: bool,
     service_streams_enabled: bool,
     anomaly_detection_enabled: bool,
@@ -325,7 +324,6 @@ pub async fn zo_config() -> impl IntoResponse {
     let custom_hide_menus = enterprise_value!("", &o2cfg.common.custom_hide_menus);
     let custom_hide_self_logo = enterprise_value!(false, o2cfg.common.custom_hide_self_logo);
     let ai_enabled = enterprise_value!(false, o2cfg.ai.enabled);
-    let service_graph_enabled = enterprise_value!(false, o2cfg.service_graph.enabled);
     let incidents_enabled = enterprise_value!(false, o2cfg.incidents.enabled);
     let service_streams_enabled = enterprise_value!(false, o2cfg.service_streams.enabled);
     // Anomaly detection is always on when the enterprise feature is compiled in — no runtime flag.
@@ -426,7 +424,6 @@ pub async fn zo_config() -> impl IntoResponse {
         ingestion_history,
         query_values_default_num: cfg.limit.query_values_default_num,
         alert_preview_timerange_minutes: cfg.limit.alert_preview_timerange_minutes,
-        service_graph_enabled,
         incidents_enabled,
         service_streams_enabled,
         anomaly_detection_enabled,

--- a/src/job/service_graph.rs
+++ b/src/job/service_graph.rs
@@ -19,11 +19,6 @@ use o2_enterprise::enterprise::common::config::get_config as get_o2_config;
 pub async fn run() -> Result<(), anyhow::Error> {
     #[cfg(feature = "enterprise")]
     {
-        if !get_o2_config().service_graph.enabled {
-            log::info!("[SERVICE_GRAPH::JOB] Service graph is disabled");
-            return Ok(());
-        }
-
         // Service graph processor writes data via ingestion pipeline
         // and must run on ingester nodes only
         if !LOCAL_NODE.is_ingester() {

--- a/src/service/traces/service_graph/api.rs
+++ b/src/service/traces/service_graph/api.rs
@@ -70,10 +70,7 @@ pub async fn get_current_topology(
             (start, end)
         } else {
             let now = chrono::Utc::now().timestamp_micros();
-            let window_minutes = o2_enterprise::enterprise::common::config::get_config()
-                .service_graph
-                .query_time_range_minutes;
-            let window_micros = window_minutes * 60 * 1_000_000;
+            let window_micros = super::DEFAULT_QUERY_WINDOW_MINUTES * 60 * 1_000_000;
             (now - window_micros, now)
         };
 
@@ -231,12 +228,8 @@ pub async fn query_edges_from_stream_internal(
         if let (Some(start), Some(end)) = (custom_start_time, custom_end_time) {
             (start, end)
         } else {
-            // Use configured time range (same as processor)
             let now = chrono::Utc::now().timestamp_micros();
-            let window_minutes = o2_enterprise::enterprise::common::config::get_config()
-                .service_graph
-                .query_time_range_minutes;
-            let window_micros = window_minutes * 60 * 1_000_000;
+            let window_micros = super::DEFAULT_QUERY_WINDOW_MINUTES * 60 * 1_000_000;
             (now - window_micros, now)
         };
 

--- a/src/service/traces/service_graph/mod.rs
+++ b/src/service/traces/service_graph/mod.rs
@@ -18,6 +18,10 @@
 //! Daemon-based service graph that queries traces periodically.
 //! No inline processing during trace ingestion.
 
+/// Default window (in minutes) used when no explicit time range is provided.
+/// The UI has its own time range picker, so this only applies as the server-side fallback.
+pub const DEFAULT_QUERY_WINDOW_MINUTES: i64 = 60;
+
 // OSS modules
 pub mod aggregator;
 pub mod api;

--- a/src/service/traces/service_graph/processor.rs
+++ b/src/service/traces/service_graph/processor.rs
@@ -29,14 +29,9 @@ use o2_enterprise::enterprise::common::config::get_config as get_o2_config;
 /// Called by compactor job
 #[cfg(feature = "enterprise")]
 pub async fn process_service_graph() -> Result<(), anyhow::Error> {
-    let cfg = get_o2_config();
-    if !cfg.service_graph.enabled {
-        return Ok(());
-    }
-    // Process last hour of traces (configurable window)
+    // Process last hour of traces
     let now = Utc::now().timestamp_micros();
-    let window_minutes = get_o2_config().service_graph.query_time_range_minutes;
-    let window_micros = window_minutes * 60 * 1_000_000;
+    let window_micros = super::DEFAULT_QUERY_WINDOW_MINUTES * 60 * 1_000_000;
     let start_time = now - window_micros;
 
     log::debug!(

--- a/web/src/plugins/traces/Index.spec.ts
+++ b/web/src/plugins/traces/Index.spec.ts
@@ -198,6 +198,10 @@ const mockSearchObj = {
   runQuery: false,
 };
 
+vi.mock("@/aws-exports", () => ({
+  default: { isCloud: "false", isEnterprise: "true" },
+}));
+
 vi.mock("@/composables/useTraces", () => ({
   default: () => ({
     searchObj: mockSearchObj,
@@ -412,9 +416,7 @@ describe("Index.vue (Main Traces Page)", () => {
   });
 
   describe("Tab Navigation", () => {
-    it("should switch to service-graph tab when service graph is enabled", async () => {
-      // Enable service graph in store
-      store.state.zoConfig.service_graph_enabled = true;
+    it("should switch to service-graph tab on enterprise", async () => {
 
       routerCurrentRouteSpy.mockReturnValue({
         value: {
@@ -444,41 +446,7 @@ describe("Index.vue (Main Traces Page)", () => {
       expect(wrapper.vm.activeTab).toBe("service-graph");
     });
 
-    it("should default to search tab when service graph is disabled", async () => {
-      // Disable service graph
-      store.state.zoConfig.service_graph_enabled = false;
-
-      routerCurrentRouteSpy.mockReturnValue({
-        value: {
-          query: { tab: "service-graph" },
-          name: "traces",
-          path: "/traces",
-        },
-      } as any);
-
-      wrapper = mount(Index, {
-        attachTo: node,
-        global: {
-          plugins: [i18n, router],
-          provide: { store: store },
-          stubs: {
-            "search-bar": true,
-            "index-list": true,
-            "search-result": true,
-            "service-graph": true,
-            SanitizedHtmlRenderer: true,
-          },
-        },
-      });
-
-      await flushPromises();
-
-      expect(wrapper.vm.activeTab).toBe("search");
-    });
-
     it("should update URL when tab changes", async () => {
-      store.state.zoConfig.service_graph_enabled = true;
-
       wrapper = mount(Index, {
         attachTo: node,
         global: {
@@ -1063,7 +1031,6 @@ describe("Index.vue (Main Traces Page)", () => {
 
   describe("Service Graph Integration", () => {
     it("should switch to search tab when viewing traces from service graph", async () => {
-      store.state.zoConfig.service_graph_enabled = true;
       wrapper = mount(Index, {
         attachTo: node,
         global: {

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -44,10 +44,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       <!-- Service Graph Tab Content -->
       <div
-        v-if="
-          activeTab === 'service-graph' &&
-          store.state.zoConfig.service_graph_enabled
-        "
+        v-if="activeTab === 'service-graph' && config.isEnterprise == 'true'"
         class="tw:px-[0.625rem] tw:pb-[0.625rem] tw:h-[calc(100vh-90px)] tw:overflow-hidden"
       >
         <service-graph
@@ -1293,14 +1290,8 @@ onBeforeMount(async () => {
   restoreUrlQueryParams();
   // Restore active tab from URL query params
   const queryParams = router.currentRoute.value.query;
-  if (queryParams.tab === "service-graph") {
-    // Only allow service-graph tab if service graph is enabled
-    if (store.state.zoConfig.service_graph_enabled) {
-      activeTab.value = "service-graph";
-    } else {
-      // If service graph is disabled, default to search tab
-      activeTab.value = "search";
-    }
+  if (queryParams.tab === "service-graph" && config.isEnterprise == "true") {
+    activeTab.value = "service-graph";
   }
   await importSqlParser();
   if (!searchObj.loading) {
@@ -1809,14 +1800,7 @@ watch(updateSelectedColumns, () => {
 watch(activeTab, (newTab) => {
   const query = { ...router.currentRoute.value.query };
   if (newTab === "service-graph") {
-    // Only set service-graph tab if service graph is enabled
-    if (store.state.zoConfig.service_graph_enabled) {
-      query.tab = "service-graph";
-    } else {
-      // If service graph is disabled, force back to search tab
-      activeTab.value = "search";
-      delete query.tab;
-    }
+    query.tab = "service-graph";
   } else {
     delete query.tab;
   }

--- a/web/src/plugins/traces/SearchBar.spec.ts
+++ b/web/src/plugins/traces/SearchBar.spec.ts
@@ -34,7 +34,7 @@ vi.mock("@/services/segment_analytics", () => ({
 }));
 
 vi.mock("@/aws-exports", () => ({
-  default: { isCloud: "false" },
+  default: { isCloud: "false", isEnterprise: "true" },
 }));
 
 // getImageURL is called by the metricsIcon computed; stub to avoid asset loading.
@@ -332,9 +332,6 @@ describe("SearchBar", () => {
     // Fresh searchObj per test — mutations cannot bleed across tests.
     searchObjInstance = makeSearchObj();
 
-    // Ensure store flag is reset.
-    store.state.zoConfig.service_graph_enabled = true;
-
     // Spy on router so updateDateTime's route guard does not early-return.
     vi.spyOn(router, "currentRoute", "get").mockReturnValue({
       value: {
@@ -362,8 +359,7 @@ describe("SearchBar", () => {
 
   // -------------------------------------------------------------------------
   describe("tab toggle visibility", () => {
-    it("should render tab toggle buttons when service_graph_enabled is true", async () => {
-      store.state.zoConfig.service_graph_enabled = true;
+    it("should render tab toggle buttons on enterprise", async () => {
       wrapper = mountSearchBar();
       await flushPromises();
 
@@ -376,19 +372,6 @@ describe("SearchBar", () => {
       expect(
         wrapper.find('[data-test="traces-service-graph-toggle"]').exists(),
       ).toBe(true);
-    });
-
-    it("should not render tab toggle buttons when service_graph_enabled is false", async () => {
-      store.state.zoConfig.service_graph_enabled = false;
-      wrapper = mountSearchBar();
-      await flushPromises();
-
-      expect(wrapper.find('[data-test="traces-search-toggle"]').exists()).toBe(
-        false,
-      );
-      expect(
-        wrapper.find('[data-test="traces-service-graph-toggle"]').exists(),
-      ).toBe(false);
     });
   });
 
@@ -722,12 +705,12 @@ describe("SearchBar", () => {
       expect(wrapper.emitted("searchdata")).toHaveLength(1);
     });
 
-    it("should be disabled when isLoading prop is true", async () => {
+    it("should show cancel button when isLoading prop is true on enterprise", async () => {
       wrapper = mountSearchBar({ isLoading: true });
       await flushPromises();
 
-      const runBtn = wrapper.find('[data-test="logs-search-bar-refresh-btn"]');
-      expect(runBtn.classes()).toContain("disabled");
+      expect(wrapper.find('[data-test="traces-search-bar-cancel-btn"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="logs-search-bar-refresh-btn"]').exists()).toBe(false);
     });
 
     it("should not emit searchdata when searchObj.loading is true", async () => {
@@ -1205,15 +1188,17 @@ describe("SearchBar", () => {
       expect(wrapper.props("fieldValues")).toHaveProperty("service_name");
     });
 
-    it("should disable the run query button when isLoading changes to true", async () => {
+    it("should switch to cancel button when isLoading changes to true on enterprise", async () => {
       wrapper = mountSearchBar({ isLoading: false });
       await flushPromises();
+
+      expect(wrapper.find('[data-test="logs-search-bar-refresh-btn"]').exists()).toBe(true);
 
       await wrapper.setProps({ isLoading: true });
       await flushPromises();
 
-      const runBtn = wrapper.find('[data-test="logs-search-bar-refresh-btn"]');
-      expect(runBtn.classes()).toContain("disabled");
+      expect(wrapper.find('[data-test="traces-search-bar-cancel-btn"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="logs-search-bar-refresh-btn"]').exists()).toBe(false);
     });
   });
 });

--- a/web/src/plugins/traces/SearchBar.vue
+++ b/web/src/plugins/traces/SearchBar.vue
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div class="float-right col flex items-center">
         <!-- Tab Toggle Buttons -->
         <div
-          v-if="store.state.zoConfig.service_graph_enabled"
+          v-if="config.isEnterprise == 'true'"
           class="button-group logs-visualize-toggle element-box-shadow tw:mr-[0.375rem]"
         >
           <div class="row">

--- a/web/src/test/unit/helpers/store.ts
+++ b/web/src/test/unit/helpers/store.ts
@@ -90,7 +90,6 @@ const store = createStore({
       all_fields_name: "_all",
       default_secondary_index_fields: ["level"],
       default_quick_mode_fields: [],
-      service_graph_enabled: true,
     },
     organizationData: {
       organizationPasscode: "",


### PR DESCRIPTION
Remove O2_SERVICE_GRAPH_ENABLED and O2_SERVICE_GRAPH_QUERY_TIME_RANGE_MINUTES. Service graph now runs unconditionally on enterprise ingester nodes. Query window defaults to 60m constant; UI time range picker controls actual queries.

Also remove checks for this on the UI. Keep only enterprise level checks.