### PR TITLE
fix: alert history sidebar changes (#10950)

### DIFF
--- a/web/src/components/alerts/AlertHistoryDrawer.spec.ts
+++ b/web/src/components/alerts/AlertHistoryDrawer.spec.ts
@@ -570,42 +570,34 @@ describe("AlertHistoryDrawer.vue", () => {
       expect(vm.formatTimestamp(null)).toBe("N/A");
     });
 
-    it("formatTimestamp should format recent timestamps as relative", async () => {
+    it("formatTimestamp should format recent timestamps as ISO datetime", async () => {
       await mountComponent();
       const vm = wrapper.vm as any;
       // 5 minutes ago in microseconds
       const fiveMinAgo = (Date.now() - 5 * 60 * 1000) * 1000;
-      expect(vm.formatTimestamp(fiveMinAgo)).toMatch(/\d+ min ago/);
+      expect(vm.formatTimestamp(fiveMinAgo)).toMatch(
+        /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+      );
     });
 
-    it("formatTimestamp should format hours-old timestamps", async () => {
+    it("formatTimestamp should format hours-old timestamps as ISO datetime", async () => {
       await mountComponent();
       const vm = wrapper.vm as any;
       // 3 hours ago in microseconds
       const threeHoursAgo = (Date.now() - 3 * 3600 * 1000) * 1000;
-      expect(vm.formatTimestamp(threeHoursAgo)).toMatch(/\d+h ago/);
+      expect(vm.formatTimestamp(threeHoursAgo)).toMatch(
+        /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+      );
     });
 
-    it("formatTimestamp should format days-old timestamps", async () => {
+    it("formatTimestamp should format days-old timestamps as ISO datetime", async () => {
       await mountComponent();
       const vm = wrapper.vm as any;
       // 3 days ago in microseconds
       const threeDaysAgo = (Date.now() - 3 * 86400 * 1000) * 1000;
-      expect(vm.formatTimestamp(threeDaysAgo)).toMatch(/\d+d ago/);
-    });
-
-    it("formatTimestampFull should return N/A for falsy timestamps", async () => {
-      await mountComponent();
-      const vm = wrapper.vm as any;
-      expect(vm.formatTimestampFull(0)).toBe("N/A");
-      expect(vm.formatTimestampFull(null)).toBe("N/A");
-    });
-
-    it("formatTimestampFull should return full date string", async () => {
-      await mountComponent();
-      const vm = wrapper.vm as any;
-      const result = vm.formatTimestampFull(1699900000000000);
-      expect(result).toMatch(/\w+ \d{2}, \d{4} \d{2}:\d{2}:\d{2}/);
+      expect(vm.formatTimestamp(threeDaysAgo)).toMatch(
+        /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+      );
     });
   });
 

--- a/web/src/components/alerts/AlertHistoryDrawer.vue
+++ b/web/src/components/alerts/AlertHistoryDrawer.vue
@@ -39,28 +39,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             size="18px"
             :color="store.state.theme === 'dark' ? 'blue-4' : 'primary'"
           />
-          <span class="tw-font-semibold tw-text-[15px] tw-whitespace-nowrap">{{
-            t("alert_list.alert_history")
-          }}</span>
-          <q-icon
-            name="chevron_right"
-            size="16px"
-            color="grey-5"
-            class="tw-shrink-0"
-          />
-          <!-- Alert Name Badge -->
+          <!-- Alert Name -->
           <span
-            v-if="alertDetails"
             :class="[
-              'tw-font-medium tw-text-[13px] tw-px-2 tw-py-0.5 tw-rounded tw-truncate tw-max-w-[220px] tw-inline-block',
-              store.state.theme === 'dark'
-                ? 'tw-text-blue-300 tw-bg-blue-900/40'
-                : 'tw-text-blue-700 tw-bg-blue-50',
+              'tw-font-semibold tw-text-[15px] tw-truncate tw-max-w-[220px] tw-inline-block',
             ]"
           >
-            {{ alertDetails.name }}
+            {{ alertDetails?.name ?? t("alert_list.alert_history") }}
             <q-tooltip
-              v-if="alertDetails.name && alertDetails.name.length > 28"
+              v-if="alertDetails?.name && alertDetails.name.length > 28"
               class="tw-text-xs"
             >
               {{ alertDetails.name }}
@@ -283,12 +270,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         </div>
                       </template>
                       <template v-else-if="col.name === 'timestamp'">
-                        <span class="tw-text-[13px]">{{
+                        <span class="tw-text-[13px] tw-tabular-nums">{{
                           formatTimestamp(props.row.timestamp)
                         }}</span>
-                        <q-tooltip class="tw-text-xs">
-                          {{ formatTimestampFull(props.row.timestamp) }}
-                        </q-tooltip>
                       </template>
                       <template v-else-if="col.name === 'evaluation_time'">
                         <span class="tw-text-[13px] tw-tabular-nums">
@@ -366,82 +350,123 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <div
             class="tw-flex tw-flex-col tw-flex-1 tw-overflow-hidden tw-px-2 tw-pt-2 tw-pb-2"
           >
-            <div
-              class="code-block tw-flex tw-flex-col tw-flex-1 tw-overflow-hidden"
-              :class="
-                store.state.theme === 'dark'
-                  ? 'code-block-dark'
-                  : 'code-block-light'
-              "
-            >
-              <!-- Code block header bar — stays fixed -->
+            <!-- Outer flex column — condition area + VRL area split 50/50 when VRL present -->
+            <div class="tw-flex tw-flex-col tw-flex-1 tw-overflow-hidden tw-gap-2">
+
+              <!-- ── Condition area (main + optional PromQL) ── -->
               <div
-                class="code-block-header tw-shrink-0"
-                :class="
-                  store.state.theme === 'dark'
-                    ? 'code-block-header-dark'
-                    : 'code-block-header-light'
-                "
+                class="tw-flex tw-flex-col tw-overflow-hidden tw-gap-2"
+                :class="hasVRL ? 'tw-flex-1 tw-min-h-0' : 'tw-flex-1'"
               >
-                <div class="tw-flex tw-items-center tw-gap-1.5">
+                <!-- Main condition block -->
+                <div
+                  class="code-block tw-flex tw-flex-col tw-overflow-hidden"
+                  :class="[
+                    store.state.theme === 'dark' ? 'code-block-dark' : 'code-block-light',
+                    showSeparatePromQL ? 'tw-flex-1 tw-min-h-0' : 'tw-flex-1',
+                  ]"
+                >
+                  <div
+                    class="code-block-header tw-shrink-0"
+                    :class="store.state.theme === 'dark' ? 'code-block-header-dark' : 'code-block-header-light'"
+                  >
+                    <span
+                      class="tw-text-[11px] tw-font-medium"
+                      :class="store.state.theme === 'dark' ? 'tw-text-gray-400' : 'tw-text-gray-500'"
+                    >
+                      {{
+                        alertDetails.type === "sql"
+                          ? "SQL"
+                          : alertDetails.type === "promql"
+                            ? "PromQL"
+                            : "Conditions"
+                      }}
+                    </span>
+                    <q-btn
+                      v-if="alertDetails.conditions && alertDetails.conditions !== '' && alertDetails.conditions !== '--'"
+                      @click="copyToClipboard(
+                        alertDetails.conditions,
+                        alertDetails.type === 'sql'
+                          ? t('alerts.alertDetails.sqlQuery')
+                          : alertDetails.type === 'promql'
+                            ? t('alerts.alertDetails.promqlQuery')
+                            : t('alerts.alertDetails.conditions'),
+                      )"
+                      flat dense size="xs" icon="content_copy"
+                      :color="store.state.theme === 'dark' ? 'grey-5' : 'grey-7'"
+                      data-test="alert-details-copy-conditions-btn"
+                    >
+                      <q-tooltip>{{ t("alerts.alertDetails.copy") }}</q-tooltip>
+                    </q-btn>
+                  </div>
+                  <pre
+                    class="code-block-content tw-text-[13px] tw-m-0 tw-leading-relaxed tw-flex-1 tw-overflow-y-auto"
+                  >{{
+                    alertDetails.conditions !== "" && alertDetails.conditions !== "--"
+                      ? alertDetails.type === "sql" || alertDetails.type === "promql"
+                        ? alertDetails.conditions
+                        : alertDetails.conditions.length !== 2
+                          ? `if ${alertDetails.conditions}`
+                          : t("alerts.alertDetails.noCondition")
+                      : t("alerts.alertDetails.noCondition")
+                  }}</pre>
+                </div>
+
+                <!-- Separate PromQL block (only when rawCondition has promql and type isn't promql) -->
+                <div
+                  v-if="showSeparatePromQL"
+                  class="code-block tw-flex tw-flex-col tw-flex-1 tw-min-h-0 tw-overflow-hidden"
+                  :class="store.state.theme === 'dark' ? 'code-block-dark' : 'code-block-light'"
+                >
+                  <div
+                    class="code-block-header tw-shrink-0"
+                    :class="store.state.theme === 'dark' ? 'code-block-header-dark' : 'code-block-header-light'"
+                  >
+                    <span
+                      class="tw-text-[11px] tw-font-medium"
+                      :class="store.state.theme === 'dark' ? 'tw-text-gray-400' : 'tw-text-gray-500'"
+                    >PromQL</span>
+                    <q-btn
+                      @click="copyToClipboard(rawPromQL!, t('alerts.alertDetails.promqlQuery'))"
+                      flat dense size="xs" icon="content_copy"
+                      :color="store.state.theme === 'dark' ? 'grey-5' : 'grey-7'"
+                    >
+                      <q-tooltip>{{ t("alerts.alertDetails.copy") }}</q-tooltip>
+                    </q-btn>
+                  </div>
+                  <pre
+                    class="code-block-content tw-text-[13px] tw-m-0 tw-leading-relaxed tw-flex-1 tw-overflow-y-auto"
+                  >{{ rawPromQL }}</pre>
+                </div>
+              </div>
+
+              <!-- ── VRL block (only when hasVRL) — takes equal half ── -->
+              <div
+                v-if="hasVRL"
+                class="code-block tw-flex tw-flex-col tw-flex-1 tw-min-h-0 tw-overflow-hidden"
+                :class="store.state.theme === 'dark' ? 'code-block-dark' : 'code-block-light'"
+              >
+                <div
+                  class="code-block-header tw-shrink-0"
+                  :class="store.state.theme === 'dark' ? 'code-block-header-dark' : 'code-block-header-light'"
+                >
                   <span
                     class="tw-text-[11px] tw-font-medium"
-                    :class="
-                      store.state.theme === 'dark'
-                        ? 'tw-text-gray-400'
-                        : 'tw-text-gray-500'
-                    "
+                    :class="store.state.theme === 'dark' ? 'tw-text-gray-400' : 'tw-text-gray-500'"
+                  >VRL Function</span>
+                  <q-btn
+                    @click="copyToClipboard(rawVRL!, 'VRL Function')"
+                    flat dense size="xs" icon="content_copy"
+                    :color="store.state.theme === 'dark' ? 'grey-5' : 'grey-7'"
                   >
-                    {{
-                      alertDetails.type === "sql"
-                        ? "SQL"
-                        : alertDetails.type === "promql"
-                          ? "PromQL"
-                          : "Conditions"
-                    }}
-                  </span>
+                    <q-tooltip>{{ t("alerts.alertDetails.copy") }}</q-tooltip>
+                  </q-btn>
                 </div>
-                <q-btn
-                  v-if="
-                    alertDetails.conditions &&
-                    alertDetails.conditions !== '' &&
-                    alertDetails.conditions !== '--'
-                  "
-                  @click="
-                    copyToClipboard(
-                      alertDetails.conditions,
-                      alertDetails.type === 'sql'
-                        ? t('alerts.alertDetails.sqlQuery')
-                        : alertDetails.type === 'promql'
-                          ? t('alerts.alertDetails.promqlQuery')
-                          : t('alerts.alertDetails.conditions'),
-                    )
-                  "
-                  flat
-                  dense
-                  size="xs"
-                  icon="content_copy"
-                  :color="store.state.theme === 'dark' ? 'grey-5' : 'grey-7'"
-                  data-test="alert-details-copy-conditions-btn"
-                >
-                  <q-tooltip>{{ t("alerts.alertDetails.copy") }}</q-tooltip>
-                </q-btn>
+                <pre
+                  class="code-block-content tw-text-[13px] tw-m-0 tw-leading-relaxed tw-flex-1 tw-overflow-y-auto"
+                >{{ rawVRL }}</pre>
               </div>
-              <!-- Code content — scrolls internally -->
-              <pre
-                class="code-block-content tw-text-[13px] tw-m-0 tw-leading-relaxed tw-flex-1 tw-overflow-y-auto"
-                >{{
-                  alertDetails.conditions !== "" &&
-                  alertDetails.conditions !== "--"
-                    ? alertDetails.type === "sql" ||
-                      alertDetails.type === "promql"
-                      ? alertDetails.conditions
-                      : alertDetails.conditions.length !== 2
-                        ? `if ${alertDetails.conditions}`
-                        : t("alerts.alertDetails.noCondition")
-                    : t("alerts.alertDetails.noCondition")
-                }}</pre
-              >
+
             </div>
 
             <!-- Description (only show if exists) -->
@@ -476,13 +501,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref, watch, computed } from "vue";
 import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
 import { useQuasar, date } from "quasar";
 import DateTime from "@/components/DateTime.vue";
 import QTablePagination from "@/components/shared/grid/Pagination.vue";
 import alertsService from "@/services/alerts";
+import { b64DecodeUnicode } from "@/utils/zincutils";
 import type { Ref } from "vue";
 
 // Composables
@@ -499,6 +525,24 @@ interface Props {
 const props = defineProps<Props>();
 
 const emit = defineEmits(["edit"]);
+
+// PromQL from rawCondition (shown separately only when the alert type isn't already promql)
+const rawPromQL = computed(() => {
+  const rc = props.alertDetails?.rawCondition;
+  if (!rc?.promql) return null;
+  if (props.alertDetails?.type === "promql") return null; // already shown as main condition
+  return rc.promql;
+});
+
+// VRL function (URL-safe base64-decoded, matches b64EncodeUnicode encoding used on save)
+const rawVRL = computed(() => {
+  const encoded = props.alertDetails?.rawCondition?.vrl_function;
+  if (!encoded) return null;
+  return b64DecodeUnicode(encoded) ?? null;
+});
+
+const hasVRL = computed(() => !!rawVRL.value);
+const showSeparatePromQL = computed(() => !!rawPromQL.value);
 
 const resultTotal = ref(0);
 
@@ -686,27 +730,7 @@ const formatStatus = (status: string) => {
 
 const formatTimestamp = (timestamp: number) => {
   if (!timestamp) return "N/A";
-  const now = Date.now() * 1000; // microseconds
-  const diff = now - timestamp;
-
-  if (diff < 3600000000) {
-    const minutes = Math.floor(diff / 60000000);
-    return `${minutes} min ago`;
-  }
-  if (diff < 86400000000) {
-    const hours = Math.floor(diff / 3600000000);
-    return `${hours}h ago`;
-  }
-  if (diff < 604800000000) {
-    const days = Math.floor(diff / 86400000000);
-    return `${days}d ago`;
-  }
-  return date.formatDate(timestamp / 1000, "MMM DD, HH:mm");
-};
-
-const formatTimestampFull = (timestamp: number) => {
-  if (!timestamp) return "N/A";
-  return date.formatDate(timestamp / 1000, "MMM DD, YYYY HH:mm:ss");
+  return date.formatDate(timestamp / 1000, "YYYY-MM-DD HH:mm:ss");
 };
 
 // Main Functions


### PR DESCRIPTION
- Remove the highlighted part in the alert history sidebar. The phrase was obvious and was consuming space.

<img width="1434" height="71" alt="image"
src="https://github.com/user-attachments/assets/b632d8d5-8f95-45f5-a65b-7c72abc38a53" />

Now it looks like this.

<img width="1029" height="56" alt="image"
src="https://github.com/user-attachments/assets/4dbe6320-0067-45f0-ac4e-d8e6b8310187" />

- add support to view VRL & SQL both in split-view
- add support for regular conditions as well
- display absolute timestamp in timezone-aware ISO format, not `X units ago`