### PR TITLE
fix: check trigger again next week when pipeline is disabled similar to alerts

### DIFF
--- a/src/infra/src/cache/file_data/disk.rs
+++ b/src/infra/src/cache/file_data/disk.rs
@@ -857,7 +857,7 @@ async fn gc() -> Result<(), anyhow::Error> {
 
     for file in FILES.iter() {
         let r = file.read().await;
-        if r.cur_size + cfg.disk_cache.release_size < r.max_size {
+        if r.cur_size == 0 || r.cur_size + cfg.disk_cache.release_size < r.max_size {
             continue;
         }
         drop(r);
@@ -872,7 +872,7 @@ async fn gc() -> Result<(), anyhow::Error> {
     );
     for file in RESULT_FILES.iter() {
         let r = file.read().await;
-        if r.cur_size + release_size < r.max_size {
+        if r.cur_size == 0 || r.cur_size + release_size < r.max_size {
             drop(r);
             continue;
         }
@@ -891,7 +891,7 @@ async fn gc() -> Result<(), anyhow::Error> {
     );
     for file in AGGREGATION_FILES.iter() {
         let r = file.read().await;
-        if r.cur_size + release_size < r.max_size {
+        if r.cur_size == 0 || r.cur_size + release_size < r.max_size {
             drop(r);
             continue;
         }

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -1538,7 +1538,7 @@ async fn handle_derived_stream_triggers(
     if !pipeline.enabled {
         // Pipeline not enabled, check again next week
         let msg = format!(
-            "Pipeline associated with trigger not enabled: {org_id}/{stream_type}/{pipeline_name}/{pipeline_id}. Checking after 5 mins."
+            "Pipeline associated with trigger not enabled: {org_id}/{stream_type}/{pipeline_name}/{pipeline_id}. Checking after 7 days."
         );
         // update trigger, check on next week
         new_trigger.next_run_at += Duration::try_days(7).unwrap().num_microseconds().unwrap();


### PR DESCRIPTION
Currently, when a pipeline is disabled, the scheduled job we don't delete, but we check after 5mins. 5mins is too frequent to check this, instead we should follow the same like alerts and reports that checks again after a week.