### PR TITLE
fix(ci): pass PR target branch in enterprise build dispatch payload

### DIFF
--- a/.github/workflows/dispatch-event-enterprise.yml
+++ b/.github/workflows/dispatch-event-enterprise.yml
@@ -43,7 +43,7 @@ jobs:
           TOKEN: ${{ steps.generate_token.outputs.token }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
-          token: ${{ env.TOKEN }} # GitHub App installation access token
+          token: ${{ env.TOKEN }} # access token
           repository: openobserve/o2-enterprise
           event-type: initiate-enterprise-build
           client-payload: '{"o2_enterprise_repo": "${{ env.BRANCH_NAME }}", "o2_opensource_repo": "${{ env.BRANCH_NAME }}" ,"o2_commit_id": "${{ env.SHORT_COMMIT_ID }}", "o2_full_commit":"${{env.COMMIT_ID}}", "o2_target_branch": "${{ github.event.pull_request.base.ref }}"}'


### PR DESCRIPTION
When the enterprise build check falls back because the feature branch
doesn't exist in o2-enterprise, it currently defaults to main. This
sends the PR's target branch so o2-enterprise can fall back to it first.
