### PR TITLE
fix(dashboard): display '(empty)' for empty breakdown values in chart legends

### DIFF
--- a/web/src/utils/dashboard/sql/shared/seriesBuilder.ts
+++ b/web/src/utils/dashboard/sql/shared/seriesBuilder.ts
@@ -221,11 +221,12 @@ export function createSeriesBuilders(deps: SeriesDeps) {
         panelSchema.type == "h-stacked") &&
         panelSchema.queries[0].fields.breakdown?.length)
     ) {
+      // Display "(empty)" for empty breakdown values instead of falling
+      // through to the y-axis label, which produces misleading legends
+      const displayKey = xAXisKey === "" ? "(empty)" : xAXisKey;
       return yAxisKeys.length === 1
-        ? xAXisKey !== ""
-          ? xAXisKey
-          : label
-        : `${xAXisKey} (${label})`;
+        ? displayKey
+        : `${displayKey} (${label})`;
     }
 
     return label;


### PR DESCRIPTION
## Summary

Fixes #10780

When a breakdown field contains an empty value (`""`), the chart legend displayed the y-axis label (e.g., `"count"`) as the series name. This made the legend misleading because the empty-breakdown series was indistinguishable from the metric name.

### Root Cause

In `seriesBuilder.ts`, `getYAxisLabel()` checked `xAXisKey !== ""` and fell through to the raw y-axis `label` for empty breakdown values. For multi-y-axis charts, it produced `" (count)"` with a leading space and no breakdown identifier.

### Fix

Normalize empty breakdown values to `"(empty)"` before building the display label, consistent with how `sqlProcessData.ts` already treats null/undefined/empty breakdown values as a single group.

**Before:** empty breakdown → series labeled `"count"` (misleading)  
**After:** empty breakdown → series labeled `"(empty)"` (clear)

## Changes

- `web/src/utils/dashboard/sql/shared/seriesBuilder.ts` — 1 file, ~5 lines changed

## Test Plan

- [ ] Create a dashboard panel with a breakdown field that contains empty string values
- [ ] Verify the chart legend shows `"(empty)"` instead of the y-axis field name
- [ ] Verify non-empty breakdown values still display correctly
- [ ] Verify multi-y-axis panels show `"(empty) (metricName)"` format