### PR TITLE
ci: add merge_group trigger to CI workflows for merge queue support

### DIFF
--- a/.github/workflows/api-testing.yml
+++ b/.github/workflows/api-testing.yml
@@ -18,7 +18,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/db-testing.yml
+++ b/.github/workflows/db-testing.yml
@@ -10,7 +10,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/js-license-checker.yml
+++ b/.github/workflows/js-license-checker.yml
@@ -18,7 +18,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,7 +18,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Add merge_group event trigger to all required CI workflows so they run
when PRs enter the merge queue. Fix github.event.pull_request references
in dispatch-event-enterprise.yml to handle merge_group context.
