### PR TITLE
fix: do not strip base uri prefix in rum enpoints

### DIFF
--- a/src/handler/http/auth/validator.rs
+++ b/src/handler/http/auth/validator.rs
@@ -802,10 +802,13 @@ pub async fn validator_gcp(req_data: &RequestData) -> Result<AuthValidationResul
 
 /// Validates RUM requests
 pub async fn validator_rum(req_data: &RequestData) -> Result<AuthValidationResult, AuthError> {
+    // By the time this middleware runs, axum's nested router has already stripped
+    // both the base_uri prefix (outer nest) and the "/rum" prefix (inner nest),
+    // so the path is always "/v1/{org_id}/{endpoint}" regardless of base_uri.
     let path = req_data
         .uri
         .path()
-        .strip_prefix(format!("{}/v1/", get_config().common.base_uri).as_str())
+        .strip_prefix("/v1/")
         .unwrap_or(req_data.uri.path());
 
     // After this previous path clean we should get only the


### PR DESCRIPTION
When `ZO_BASE_URI` is set, the rum endpoints get broken. This is because when we strip prefix in the `validator_rum` functiom, it checks for `{base_uri}/v1` endpoint. But axum already strips the nesting path when the `req_data.uri()` is called. 

The routing tree for a sub-path deployment `(base_uri = "/openobserve")` is:

```
nest("/openobserve", app)          ← outer: strips /openobserve
  └── merge(other_service_routes())
        └── nest("/rum", rum_routes)  ← inner: strips /rum
              └── layer(rum_auth_middleware)  ← middleware runs here
```