### PR TITLE
fix: compute search job inspector timeline bar widths from all events

### DIFF
--- a/web/src/plugins/logs/SearchJobInspector.vue
+++ b/web/src/plugins/logs/SearchJobInspector.vue
@@ -640,9 +640,21 @@ export default defineComponent({
     });
 
     const maxDuration = computed(() => {
-      if (!hierarchicalEvents.value || hierarchicalEvents.value.length === 0) return 1;
-      const max = Math.max(...hierarchicalEvents.value.map((e: any) => e.duration));
-      return max || 1;
+      if (!profileData.value?.events) return 1;
+
+      const findMax = (events: ProfileEvent[]): number => {
+        let max = 0;
+        for (const event of events) {
+          if (event.duration > max) max = event.duration;
+          if (event.events && event.events.length > 0) {
+            const childMax = findMax(event.events);
+            if (childMax > max) max = childMax;
+          }
+        }
+        return max;
+      };
+
+      return findMax(profileData.value.events) || 1;
     });
 
     // Calculate maximum depth in the hierarchy


### PR DESCRIPTION
## Summary

`maxDuration` was computed from `hierarchicalEvents`, which only includes currently visible (expanded) rows. When nodes are collapsed or expanded, the max changes and timeline bar widths shift incorrectly.

## Root Cause

In `web/src/plugins/logs/SearchJobInspector.vue`, the `maxDuration` computed property derived its value from the flattened `hierarchicalEvents` array. That array is filtered by expansion state — collapsed children are excluded. So expanding/collapsing nodes changed the denominator used to calculate bar widths, making them jump around.

## Fix

Compute `maxDuration` by recursively traversing **all** events from the original profile data events tree, independent of which nodes are currently expanded. This gives a stable maximum that does not change based on UI state.

## Changes

| File | Change |
|------|--------|
| `web/src/plugins/logs/SearchJobInspector.vue` | Rewrite `maxDuration` to recurse over all profile events instead of only visible rows |

Fixes #11129
