### PR TITLE
fix: restore per-query query_fn for VRL apply in alerts (#11167)

### DIFF
--- a/web/src/components/alerts/QueryEditorDialog.vue
+++ b/web/src/components/alerts/QueryEditorDialog.vue
@@ -747,7 +747,7 @@ const onFunctionClear = () => {
 };
 
 // Build multi-window query - includes all multi-windows automatically
-const buildMultiWindowQuery = (sql: string, periodInMicroseconds: number) => {
+const buildMultiWindowQuery = (sql: string, fn: boolean, periodInMicroseconds: number) => {
   const queryToSend: any[] = [];
 
   // Guard: If multiTimeRange is null, undefined, or empty, return empty array
@@ -783,6 +783,7 @@ const buildMultiWindowQuery = (sql: string, periodInMicroseconds: number) => {
       individualQuery.start_time = startTime - periodInMicroseconds;
       individualQuery.end_time = startTime;
       individualQuery.sql = sql;
+      individualQuery.query_fn = fn ? b64EncodeUnicode(vrlFunctionContent.value) : null;
       queryToSend.push(individualQuery);
     } else {
       console.warn("Invalid format:", date);
@@ -821,12 +822,13 @@ const triggerQuery = async (fn = false) => {
         start_time: startTime,
         end_time: endTime,
         sql: queryReq.query.sql,
+        query_fn: fn ? b64EncodeUnicode(vrlFunctionContent.value) : null,
       }
     ];
     console.log('[QueryEditorDialog] Initial queryToSend:', queryToSend);
 
     console.log('[QueryEditorDialog] Step 5: Calling buildMultiWindowQuery...');
-    const multiWindowQueries = buildMultiWindowQuery(queryReq.query.sql, periodInMicroseconds);
+    const multiWindowQueries = buildMultiWindowQuery(queryReq.query.sql, fn, periodInMicroseconds);
     console.log('[QueryEditorDialog] Multi-window queries:', multiWindowQueries);
 
     queryToSend.push(...multiWindowQueries);


### PR DESCRIPTION
The query_fn was removed from individual query objects in commit abe71fe5e and moved to only the top-level queryReq.query.query_fn. However, the backend's to_query_req() for new-format queries reads query_fn from each individual query object, not the top-level. Additionally, the handler only falls back to the top-level query_fn when per_query_response is false, but the frontend sets it to true. This caused VRL to never be applied when clicking Apply in alerts.

Fix: add query_fn back to each individual query in the SQL array (initial query and multi-window queries).

fixes #11167
