### PR TITLE
fix: add explicit wait for pattern card template visibility

### DIFF
--- a/tests/ui-testing/playwright-tests/Logs/searchPatterns.spec.js
+++ b/tests/ui-testing/playwright-tests/Logs/searchPatterns.spec.js
@@ -615,6 +615,9 @@ test.describe("Search Patterns Feature", { tag: ['@enterprise', '@searchPatterns
         // Get all pattern templates
         const patternTemplates = [];
         for (let i = 0; i < cardCount; i++) {
+            // Wait for the template element to be visible before getting its text
+            const templateLocator = page.locator(`[data-test="pattern-card-${i}-template"]`);
+            await templateLocator.waitFor({ state: 'visible', timeout: 10000 });
             const template = await pm.logsPage.getPatternCardTemplateText(i);
             patternTemplates.push(template);
         }


### PR DESCRIPTION
Fixed race condition in duplicate patterns test where pattern-card-6-template element was not yet rendered when getPatternCardTemplateText was called.

The test now waits for each template element to be visible before attempting to read its text content, preventing TimeoutError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)