### PR TITLE
fix: extract path without query for query route by body matching

### DIFF
--- a/src/config/src/router.rs
+++ b/src/config/src/router.rs
@@ -98,8 +98,14 @@ pub fn is_querier_route(path: &str) -> bool {
 
 #[inline]
 pub fn is_querier_route_by_body(path: &str) -> bool {
-    let path = remove_base_uri(path);
+    let path = extract_path_without_query(remove_base_uri(path));
     QUERIER_ROUTES_BY_BODY.iter().any(|x| path.ends_with(x))
+}
+
+/// Extracts the path without query string.
+pub fn extract_path_without_query(path: &str) -> &str {
+    let query_start = path.find('?').unwrap_or(path.len());
+    &path[..query_start]
 }
 
 #[inline]
@@ -152,8 +158,17 @@ mod tests {
     #[test]
     fn test_is_querier_route_by_body() {
         assert!(is_querier_route_by_body("/_search"));
+        assert!(is_querier_route_by_body("/_search?foo=bar"));
         assert!(is_querier_route_by_body("/_search_stream"));
+        assert!(is_querier_route_by_body("/_search_stream?foo=bar"));
         assert!(is_querier_route_by_body("/_values_stream"));
+        assert!(is_querier_route_by_body("/_values_stream?foo=bar"));
+        assert!(is_querier_route_by_body("/_search_multi_stream"));
+        assert!(is_querier_route_by_body("/_search_multi_stream?foo=bar"));
+        assert!(is_querier_route_by_body("/_search_partition"));
+        assert!(is_querier_route_by_body("/_search_partition?foo=bar"));
+        assert!(is_querier_route_by_body("/_search_multi"));
+        assert!(is_querier_route_by_body("/_search_multi?foo=bar"));
         assert!(is_querier_route_by_body("/prometheus/api/v1/query_range"));
         assert!(is_querier_route_by_body(
             "/prometheus/api/v1/query_exemplars"
@@ -163,6 +178,16 @@ mod tests {
         // _search_history must NOT match /_search (was the root cause bug)
         assert!(!is_querier_route_by_body("/_search_history"));
         assert!(!is_querier_route_by_body("/api/org1/_search_history"));
+    }
+
+    #[test]
+    fn test_extract_path_without_query() {
+        assert_eq!(extract_path_without_query("/api/test?foo=bar"), "/api/test");
+        assert_eq!(extract_path_without_query("/api/test"), "/api/test");
+        assert_eq!(
+            extract_path_without_query("/api/test?foo=bar&baz=qux"),
+            "/api/test"
+        );
     }
 
     #[test]

--- a/src/router/http/mod.rs
+++ b/src/router/http/mod.rs
@@ -25,7 +25,10 @@ use ::config::{
             SearchPartitionRequest, ValuesRequest,
         },
     },
-    router::{is_fixed_querier_route, is_querier_route, is_querier_route_by_body},
+    router::{
+        extract_path_without_query, is_fixed_querier_route, is_querier_route,
+        is_querier_route_by_body,
+    },
     utils::{json, rand::get_rand_element},
 };
 use actix_web::{
@@ -685,6 +688,7 @@ fn build_response_headers(
 const STREAMING_ENDPOINTS: &[&str] = &[
     "/_search_stream",
     "/_values_stream",
+    "/_search_multi_stream",
     "/ai/chat_stream",
     "/prometheus/api/v1/query_range",
 ];
@@ -692,12 +696,6 @@ const STREAMING_ENDPOINTS: &[&str] = &[
 /// Checks if the request path is for a streaming endpoint.
 fn is_streaming_endpoint(path: &str) -> bool {
     STREAMING_ENDPOINTS.iter().any(|&ep| path.ends_with(ep))
-}
-
-/// Extracts the path without query string.
-fn extract_path_without_query(path: &str) -> &str {
-    let query_start = path.find('?').unwrap_or(path.len());
-    &path[..query_start]
 }
 
 /// Reads payload bytes with error handling.
@@ -750,22 +748,13 @@ mod tests {
     fn test_is_streaming_endpoint() {
         assert!(is_streaming_endpoint("/api/org/_search_stream"));
         assert!(is_streaming_endpoint("/api/org/_values_stream"));
+        assert!(is_streaming_endpoint("/api/org/_search_multi_stream"));
         assert!(is_streaming_endpoint("/api/org/ai/chat_stream"));
         assert!(is_streaming_endpoint(
             "/api/org/prometheus/api/v1/query_range"
         ));
         assert!(!is_streaming_endpoint("/api/org/_search"));
         assert!(!is_streaming_endpoint("/api/org/logs"));
-    }
-
-    #[test]
-    fn test_extract_path_without_query() {
-        assert_eq!(extract_path_without_query("/api/test?foo=bar"), "/api/test");
-        assert_eq!(extract_path_without_query("/api/test"), "/api/test");
-        assert_eq!(
-            extract_path_without_query("/api/test?foo=bar&baz=qux"),
-            "/api/test"
-        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Currently the hashing of sql query for routing to specific queriers for result cache is broken, because the `is_querier_route_by_body` function uses `ends_with` on a path that contains query params. Hence, it always returns false and same sql query does not reach same querier where the result cache is present.