### PR TITLE
fix: update auto-resolve condition in incidents job to prevent negative values

### DIFF
--- a/src/job/incidents.rs
+++ b/src/job/incidents.rs
@@ -30,9 +30,9 @@ pub async fn run() -> Result<(), anyhow::Error> {
             return Ok(());
         }
 
-        if config.incidents.auto_resolve_after_minutes < 0 {
+        if config.incidents.auto_resolve_after_minutes <= 0 {
             log::info!(
-                "[INCIDENTS::JOB] Auto-resolve is disabled (auto_resolve_after_minutes=-1), only manual resolution allowed"
+                "[INCIDENTS::JOB] Auto-resolve is disabled (auto_resolve_after_minutes=0), only manual resolution allowed"
             );
             return Ok(());
         }


### PR DESCRIPTION
Changed the condition for auto-resolve in the incidents job to disable it when the value is less than or equal to zero, ensuring clearer logging and behavior.