### PR TITLE
fix: use gRPC endpoint to ingest service graph

### DIFF
--- a/src/service/traces/service_graph/aggregator.rs
+++ b/src/service/traces/service_graph/aggregator.rs
@@ -18,8 +18,13 @@
 //! Aggregates raw edges into minute-bucketed summaries for stream storage.
 //! Used by the service graph daemon (not inline with trace ingestion).
 
-/// Write SQL-aggregated edge records directly to stream
-/// Used when SQL query already performed aggregation
+/// Write SQL-aggregated edge records to the _o2_service_graph stream.
+///
+/// Forwards to an ingester via gRPC using the internal token — no root
+/// credentials required. Works in all deployment topologies:
+/// - Single-node: the local node registers itself in the NODES cache on startup (even in local
+///   mode), so the gRPC lookup finds it and the call loops back to the same process.
+/// - Distributed / cloud: routes to a separate ingester node.
 #[cfg(feature = "enterprise")]
 pub async fn write_sql_aggregated_edges(
     org_id: &str,
@@ -30,106 +35,60 @@ pub async fn write_sql_aggregated_edges(
         return Ok(());
     }
 
+    let record_count = aggregated_records.len();
     log::info!(
         "[ServiceGraph] Writing {} SQL-aggregated edges for {}/{}",
-        aggregated_records.len(),
+        record_count,
         org_id,
         stream_name
     );
 
-    // Build bulk request body
-    let mut bulk_body = String::new();
-    let record_count = aggregated_records.len();
-
-    for record in aggregated_records {
-        // Transform SQL result to match expected schema
-        let enriched_record = if let Some(obj) = record.as_object() {
-            // Map SQL field names to storage schema using json! macro
-            // Use 'end' timestamp so edges are recent and queryable by API
+    // Transform SQL results to storage schema and collect as a JSON array.
+    let enriched: Vec<serde_json::Value> = aggregated_records
+        .into_iter()
+        .filter_map(|v| match v {
+            serde_json::Value::Object(o) => Some(o),
+            _ => None,
+        })
+        .map(|mut obj| {
             config::utils::json::json!({
-                "_timestamp": obj.get("end").cloned().unwrap_or(serde_json::json!(0)),
+                "_timestamp": obj.remove("end").unwrap_or(serde_json::json!(0)),
                 "org_id": org_id,
                 "trace_stream_name": stream_name,
-                "client_service": obj.get("client").cloned().unwrap_or(serde_json::json!(null)),
-                "server_service": obj.get("server").cloned().unwrap_or(serde_json::json!("")),
-                "total_requests": obj.get("total_requests").cloned().unwrap_or(serde_json::json!(0)),
-                "failed_requests": obj.get("errors").cloned().unwrap_or(serde_json::json!(0)),
-                "error_rate": obj.get("error_rate").cloned().unwrap_or(serde_json::json!(0.0)),
-                "p50_latency_ns": obj.get("p50").cloned().unwrap_or(serde_json::json!(0)),
-                "p95_latency_ns": obj.get("p95").cloned().unwrap_or(serde_json::json!(0)),
-                "p99_latency_ns": obj.get("p99").cloned().unwrap_or(serde_json::json!(0)),
+                "client_service": obj.remove("client").unwrap_or(serde_json::json!(null)),
+                "server_service": obj.remove("server").unwrap_or(serde_json::json!("")),
+                "total_requests": obj.remove("total_requests").unwrap_or(serde_json::json!(0)),
+                "failed_requests": obj.remove("errors").unwrap_or(serde_json::json!(0)),
+                "error_rate": obj.remove("error_rate").unwrap_or(serde_json::json!(0.0)),
+                "p50_latency_ns": obj.remove("p50").unwrap_or(serde_json::json!(0)),
+                "p95_latency_ns": obj.remove("p95").unwrap_or(serde_json::json!(0)),
+                "p99_latency_ns": obj.remove("p99").unwrap_or(serde_json::json!(0)),
             })
-        } else {
-            record
-        };
+        })
+        .collect();
 
-        // Add bulk action line
-        let action = config::utils::json::json!({"index": {"_index": "_o2_service_graph"}});
-        bulk_body.push_str(&serde_json::to_string(&action)?);
-        bulk_body.push('\n');
-
-        // Add data line
-        bulk_body.push_str(&serde_json::to_string(&enriched_record)?);
-        bulk_body.push('\n');
-    }
-
-    // Write to stream via HTTP POST to an ingester node.
-    // The alertmanager is not an ingester so we cannot call logs::bulk::ingest
-    // directly — forward the write to an online ingester instead (same pattern
-    // as write_anomalies_to_stream in anomaly_detection.rs).
-    if !bulk_body.is_empty() {
-        let ingester = infra::cluster::get_cached_online_ingester_nodes()
-            .await
-            .and_then(|nodes| nodes.into_iter().next())
-            .ok_or_else(|| {
-                anyhow::anyhow!("No online ingester node available to write _o2_service_graph")
-            })?;
-
-        let cfg = config::get_config();
-        let url = format!(
-            "{}{}/api/{org_id}/_bulk",
-            ingester.http_addr, cfg.common.base_uri,
-        );
-
-        let client = reqwest::Client::new();
-        let resp = client
-            .post(&url)
-            .header("Content-Type", "application/x-ndjson")
-            .header(
-                "Authorization",
-                format!(
-                    "Basic {}",
-                    base64::Engine::encode(
-                        &base64::engine::general_purpose::STANDARD,
-                        format!(
-                            "{}:{}",
-                            cfg.auth.root_user_email, cfg.auth.root_user_password
-                        )
-                    )
-                ),
-            )
-            .body(bulk_body)
-            .send()
-            .await
-            .map_err(|e| anyhow::anyhow!("HTTP request to ingester failed: {e}"))
-            .inspect_err(|e| {
-                log::error!("[ServiceGraph] Failed to write SQL-aggregated edges: {e}");
-            })?;
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            let e = anyhow::anyhow!("Ingester returned {status} writing _o2_service_graph: {body}");
+    use proto::cluster_rpc;
+    let req = cluster_rpc::IngestionRequest {
+        org_id: org_id.to_string(),
+        stream_type: config::meta::stream::StreamType::ServiceGraph
+            .as_str()
+            .to_string(),
+        stream_name: "_o2_service_graph".to_string(),
+        data: Some(cluster_rpc::IngestionData {
+            data: serde_json::to_vec(&enriched)?,
+        }),
+        ingestion_type: Some(cluster_rpc::IngestionType::Json as i32),
+        metadata: None,
+    };
+    crate::service::ingestion::ingestion_service::ingest(req)
+        .await
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("{e}"))
+        .inspect_err(|e| {
             log::error!("[ServiceGraph] Failed to write SQL-aggregated edges: {e}");
-            return Err(e);
-        }
-    }
+        })?;
 
-    log::info!(
-        "[ServiceGraph] Wrote {} SQL-aggregated edge summaries for {}",
-        record_count,
-        org_id
-    );
+    log::info!("[ServiceGraph] Wrote {record_count} SQL-aggregated edge summaries for {org_id}");
     Ok(())
 }
 

--- a/web/src/plugins/traces/ServiceGraph.vue
+++ b/web/src/plugins/traces/ServiceGraph.vue
@@ -18,6 +18,7 @@
           borderless
           emit-value
           map-options
+          :dark="$q.dark.isActive"
           class="tw:w-[auto] tw:flex-shrink-0 tw:bg-[var(--o2-primary-background)] tw:rounded"
           @update:model-value="onStreamFilterChange"
           :disable="availableStreams.length === 0"
@@ -34,6 +35,7 @@
           v-model="searchFilter"
           borderless
           dense
+          :dark="$q.dark.isActive"
           class="no-border tw:w-[14rem]! tw:h-[36px] tw:bg-[var(--o2-primary-background)] tw:rounded tw:border tw:border-[var(--o2-border-color)]!"
           placeholder="Search Services"
           debounce="300"
@@ -1712,6 +1714,7 @@ code {
   font-family: "Courier New", monospace;
   font-size: 0.9em;
 }
+
 </style>
 
 <!-- Flowing edge animation — non-scoped so it reaches inside ECharts SVG output -->
@@ -1734,5 +1737,10 @@ code {
 .graph-container svg path[style*="stroke-dasharray"] {
   animation: sg-edge-flow 0.5s linear infinite;
   animation-fill-mode: both;
+}
+
+.body--dark [data-test="service-graph-stream-selector"] .q-field,
+.body--dark [data-test="service-graph-search-input"] .q-field {
+  background: var(--o2-primary-background);
 }
 </style>

--- a/web/src/styles/_variables.scss
+++ b/web/src/styles/_variables.scss
@@ -434,7 +434,7 @@ $json-object-dark: #D1D5DB;         // Light gray
 .body--dark {
   --o2-theme-mode: #{$dark-theme-mode};
   // Backgrounds
-  --o2-primary-background: #{$o2-dark-gray-1400};  // Dark mode background
+  --o2-primary-background: #{$o2-dark-gray-200};  // Dark mode background
   --o2-secondary-background: #{$o2-dark-gray-1300}; // Secondary background
   --o2-muted-background: #{$o2-dark-gray-1100};    // Muted background
   


### PR DESCRIPTION
In a recent change, service graph ingestion was moved from ingesters to alert managers. Since alertmanager cannot run bulk::ingest, we switched to HTTP API using root credentials.

This created a side effect wherein environments without root credentials, such as cloud started throwing 401.

To mitigate this, we switched to gRPC API, which is also used for various other internal calls.

- also fix dark mode on service graph's stream selector