### PR TITLE
fix: propagate partial_err via dedicated flight message

### DIFF
--- a/src/flight/src/common.rs
+++ b/src/flight/src/common.rs
@@ -81,6 +81,7 @@ pub enum CustomMessage {
     ScanStats(ScanStats),
     Metrics(Vec<Metrics>),
     PeakMemory(usize),
+    PartialErr(String),
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -103,6 +104,10 @@ pub enum PreCustomMessage {
     MetricsRef(Vec<Arc<Mutex<Vec<Metrics>>>>),
     // use for storing memory pool reference to extract peak later
     PeakMemoryRef(Option<Arc<AtomicUsize>>),
+    // sent before first batch (early signal for fast-failing nodes)
+    PartialErrRefEarly(Option<Arc<Mutex<String>>>),
+    // sent after all batches (final accumulated value)
+    PartialErrRef(Option<Arc<Mutex<String>>>),
 }
 
 pub struct MetricsInfo {
@@ -115,7 +120,9 @@ impl PreCustomMessage {
     pub fn is_scan_stats(&self) -> bool {
         matches!(
             self,
-            PreCustomMessage::ScanStats(_) | PreCustomMessage::ScanStatsRef(_)
+            PreCustomMessage::ScanStats(_)
+                | PreCustomMessage::ScanStatsRef(_)
+                | PreCustomMessage::PartialErrRefEarly(_)
         )
     }
 
@@ -135,6 +142,15 @@ impl PreCustomMessage {
             PreCustomMessage::PeakMemoryRef(peak_memory_ref) => peak_memory_ref
                 .as_ref()
                 .map(|peak| CustomMessage::PeakMemory(peak.load(Ordering::Relaxed))),
+            PreCustomMessage::PartialErrRefEarly(ref_opt)
+            | PreCustomMessage::PartialErrRef(ref_opt) => ref_opt.as_ref().and_then(|r| {
+                let err = r.lock().clone();
+                if err.is_empty() {
+                    None
+                } else {
+                    Some(CustomMessage::PartialErr(err))
+                }
+            }),
         }
     }
 }

--- a/src/flight/src/common.rs
+++ b/src/flight/src/common.rs
@@ -117,7 +117,7 @@ pub struct MetricsInfo {
 }
 
 impl PreCustomMessage {
-    pub fn is_scan_stats(&self) -> bool {
+    pub fn is_early_emit(&self) -> bool {
         matches!(
             self,
             PreCustomMessage::ScanStats(_)
@@ -220,29 +220,29 @@ mod tests {
     }
 
     #[test]
-    fn test_pre_custom_message_is_scan_stats() {
+    fn test_pre_custom_message_is_early_emit() {
         let scan_stats = create_test_scan_stats();
 
         // Test ScanStats variant
         let pre_msg = PreCustomMessage::ScanStats(scan_stats);
-        assert!(pre_msg.is_scan_stats());
+        assert!(pre_msg.is_early_emit());
 
         // Test ScanStatsRef variant with Some
         let stats_ref = Arc::new(Mutex::new(scan_stats));
         let pre_msg = PreCustomMessage::ScanStatsRef(Some(stats_ref));
-        assert!(pre_msg.is_scan_stats());
+        assert!(pre_msg.is_early_emit());
 
         // Test ScanStatsRef variant with None
         let pre_msg = PreCustomMessage::ScanStatsRef(None);
-        assert!(pre_msg.is_scan_stats());
+        assert!(pre_msg.is_early_emit());
 
         // Test Metrics variant (should be false)
         let pre_msg = PreCustomMessage::Metrics(None);
-        assert!(!pre_msg.is_scan_stats());
+        assert!(!pre_msg.is_early_emit());
 
         // Test MetricsRef variant (should be false)
         let pre_msg = PreCustomMessage::MetricsRef(vec![]);
-        assert!(!pre_msg.is_scan_stats());
+        assert!(!pre_msg.is_early_emit());
     }
 
     #[test]

--- a/src/handler/grpc/flight/mod.rs
+++ b/src/handler/grpc/flight/mod.rs
@@ -48,7 +48,8 @@ use crate::{
         flight::{
             stream::FlightEncoderStreamBuilder,
             visitor::{
-                get_cluster_metrics, get_peak_memory, get_peak_memory_from_ctx, get_scan_stats,
+                get_cluster_metrics, get_partial_err, get_peak_memory, get_peak_memory_from_ctx,
+                get_scan_stats,
             },
         },
     },
@@ -208,6 +209,7 @@ impl FlightService for FlightServiceImpl {
         let scan_stats_ref = get_scan_stats(&physical_plan);
         let metrics_ref = get_cluster_metrics(&physical_plan);
         let peak_memory_ref = get_peak_memory(&physical_plan);
+        let partial_err_ref = get_partial_err(&physical_plan);
 
         let stream = execute_stream(physical_plan, ctx.task_ctx().clone()).map_err(|e| {
             // clear session data
@@ -229,6 +231,10 @@ impl FlightService for FlightServiceImpl {
             .with_custom_message(PreCustomMessage::MetricsRef(metrics_ref))
             .with_custom_message(PreCustomMessage::PeakMemoryRef(Some(peak_memory)))
             .with_custom_message(PreCustomMessage::PeakMemoryRef(peak_memory_ref))
+            .with_custom_message(PreCustomMessage::PartialErrRefEarly(
+                partial_err_ref.clone(),
+            ))
+            .with_custom_message(PreCustomMessage::PartialErrRef(partial_err_ref))
             .build(stream, span);
 
         let stream = async_stream::stream! {

--- a/src/handler/grpc/flight/stream.rs
+++ b/src/handler/grpc/flight/stream.rs
@@ -146,7 +146,7 @@ impl FlightEncoderStream {
         let custom_messages = std::mem::take(&mut self.custom_messages);
         let mut remainder_messages = Vec::new();
         for message in custom_messages.into_iter() {
-            if message.is_scan_stats() {
+            if message.is_early_emit() {
                 let message = message.get_custom_message();
                 if let Some(message) = message {
                     let flight_data = self.encoder.encode_custom(&message)?;

--- a/src/handler/grpc/flight/visitor.rs
+++ b/src/handler/grpc/flight/visitor.rs
@@ -93,6 +93,36 @@ impl<'n> TreeNodeVisitor<'n> for MetricsVisitor {
     }
 }
 
+pub fn get_partial_err(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<Mutex<String>>> {
+    let mut visitor = PartialErrVisitor::new();
+    let _ = plan.visit(&mut visitor);
+    visitor.partial_err
+}
+
+struct PartialErrVisitor {
+    partial_err: Option<Arc<Mutex<String>>>,
+}
+
+impl PartialErrVisitor {
+    pub fn new() -> Self {
+        Self { partial_err: None }
+    }
+}
+
+impl<'n> TreeNodeVisitor<'n> for PartialErrVisitor {
+    type Node = Arc<dyn ExecutionPlan>;
+
+    fn f_up(&mut self, node: &'n Self::Node) -> Result<TreeNodeRecursion> {
+        if node.name() == "RemoteScanExec" {
+            let remote_scan_exec = node.as_any().downcast_ref::<RemoteScanExec>().unwrap();
+            self.partial_err = Some(remote_scan_exec.partial_err());
+            Ok(TreeNodeRecursion::Stop)
+        } else {
+            Ok(TreeNodeRecursion::Continue)
+        }
+    }
+}
+
 pub fn get_peak_memory(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<AtomicUsize>> {
     let mut visitor = PeakMemoryVisitor::new();
     let _ = plan.visit(&mut visitor);

--- a/src/service/search/datafusion/distributed_plan/common.rs
+++ b/src/service/search/datafusion/distributed_plan/common.rs
@@ -151,7 +151,7 @@ pub fn get_empty_stream(empty_stream: EmptyStream) -> SendableRecordBatchStream 
     if let Some(e) = e
         && e.code() != tonic::Code::Ok
     {
-        log::info!(
+        log::error!(
             "[trace_id {trace_id}] flight->search: response node: {grpc_addr}, is_querier: {is_querier}, err: {e:?}, took: {} ms",
             start.elapsed().as_millis(),
         );

--- a/src/service/search/datafusion/distributed_plan/decoder_stream.rs
+++ b/src/service/search/datafusion/distributed_plan/decoder_stream.rs
@@ -72,6 +72,17 @@ impl FlightDecoderStream {
                     .peak_memory
                     .fetch_max(peak_memory, Ordering::Relaxed);
             }
+            CustomMessage::PartialErr(err) => {
+                if !err.is_empty() {
+                    let mut guard = self.query_context.partial_err.lock();
+                    if guard.is_empty() {
+                        *guard = err;
+                    } else if !guard.contains(&err) {
+                        guard.push_str(" \n ");
+                        guard.push_str(&err);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Sub-cluster internal node failures (h2 errors) were silently dropped —
partial_err was never transmitted to the super cluster leader, causing
degraded results to be cached as if they were complete.

Adds PreCustomMessage::PartialErrRefEarly + PartialErrRef to carry
partial_err over the flight wire independently of ScanStats (which can
be disabled at deployment level).

Sent twice for reliability: once before first batch (catches fast-failing
nodes), once after all batches (final accumulated value). Decoder dedupes
on receive.

Also elevates node gRPC error log from info → error.