### PR TITLE
fix(e2e): use clipboard paste for Monaco editor to prevent auto-close bracket corruption

### DIFF
--- a/tests/ui-testing/pages/functionsPages/functionsPage.js
+++ b/tests/ui-testing/pages/functionsPages/functionsPage.js
@@ -109,12 +109,21 @@ class FunctionsPage {
     await textarea.focus();
     await this.page.waitForTimeout(300);
 
-    // Clear existing content and type new code
+    // Clear existing content
     const selectAll = process.platform === 'darwin' ? 'Meta+A' : 'Control+A';
     await this.page.keyboard.press(selectAll);
     await this.page.keyboard.press('Backspace');
     await this.page.waitForTimeout(200);
-    await this.page.keyboard.type(code);
+
+    // IMPORTANT: Use clipboard paste instead of keyboard.type() to avoid Monaco
+    // auto-close bracket interference. keyboard.type() types char-by-char, causing
+    // Monaco to auto-insert } after every {, corrupting multi-line code with nested blocks.
+    const pasteShortcut = process.platform === 'darwin' ? 'Meta+V' : 'Control+V';
+    await this.page.evaluate(async (text) => {
+      await navigator.clipboard.writeText(text);
+    }, code);
+    await this.page.keyboard.press(pasteShortcut);
+
     // Wait longer than the Monaco editor's 500ms debounce so formData syncs via v-model
     await this.page.waitForTimeout(1000);
   }

--- a/tests/ui-testing/pages/functionsPages/functionsPage.js
+++ b/tests/ui-testing/pages/functionsPages/functionsPage.js
@@ -115,9 +115,7 @@ class FunctionsPage {
     await this.page.keyboard.press('Backspace');
     await this.page.waitForTimeout(200);
 
-    // IMPORTANT: Use clipboard paste instead of keyboard.type() to avoid Monaco
-    // auto-close bracket interference. keyboard.type() types char-by-char, causing
-    // Monaco to auto-insert } after every {, corrupting multi-line code with nested blocks.
+    // Paste via clipboard to avoid Monaco auto-close bracket corruption
     const pasteShortcut = process.platform === 'darwin' ? 'Meta+V' : 'Control+V';
     await this.page.evaluate(async (text) => {
       await navigator.clipboard.writeText(text);


### PR DESCRIPTION
## Summary
- **Root cause**: `keyboard.type()` types code char-by-char into Monaco editor. When typing `{`, Monaco auto-inserts `}`. With nested blocks (3 levels in JS row-expansion code), this creates 3 extra closing braces → invalid JS → QuickJS compilation failure.
- **Fix**: Replace `keyboard.type()` with clipboard paste (`navigator.clipboard.writeText` + `Ctrl+V`) in `enterFunctionCode()`. Pasting inserts text as a single operation, bypassing Monaco's auto-close bracket behavior.
- All 6 row-expansion tests pass locally after this fix.

## Test plan
- [x] Run `row-expansion.spec.js` locally — all 6 tests pass
- [ ] CI passes on this PR