### PR TITLE
test: fix search patterns details icon selector and empty state timing

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -280,7 +280,7 @@ export class LogsPage {
         this.patternCardPercentage = (index) => `[data-test="pattern-card-${index}-percentage"]`;
         this.patternCardIncludeBtn = (index) => `[data-test="pattern-card-${index}-include-btn"]`;
         this.patternCardExcludeBtn = (index) => `[data-test="pattern-card-${index}-exclude-btn"]`;
-        this.patternCardDetailsIcon = (index) => `[data-test="pattern-card-${index}-details-icon"]`;
+        this.patternCardDetailsIcon = (index) => `[data-test="pattern-card-${index}"]`;
         // Pattern details dialog
         this.closePatternDialog = '[data-test="close-pattern-dialog"]';
         this.patternDetailPreviousBtn = '[data-test="pattern-detail-previous-btn"]';
@@ -5971,6 +5971,9 @@ export class LogsPage {
         const remainingTimeout = Math.max(timeout - (Date.now() - startTime), 5000);
         const checkInterval = 500;
         const maxChecks = Math.ceil(remainingTimeout / checkInterval);
+        // Grace period: don't accept "empty" until at least 15s have elapsed, because
+        // the backend may return "No patterns found" before async extraction completes.
+        const emptyGracePeriodMs = 15000;
 
         for (let i = 0; i < maxChecks; i++) {
             // Check each state synchronously to avoid Promise.race resource leaks
@@ -5983,8 +5986,10 @@ export class LogsPage {
                 return 'patterns';
             }
             if (await this.page.locator(this.patternEmptyState).isVisible().catch(() => false)) {
-                testLogger.info('Patterns loading result: empty');
-                return 'empty';
+                if (Date.now() - startTime >= emptyGracePeriodMs) {
+                    testLogger.info('Patterns loading result: empty');
+                    return 'empty';
+                }
             }
 
             if (i < maxChecks - 1) {


### PR DESCRIPTION
## Summary
- Fixed `patternCardDetailsIcon` selector in the page object — the details icon button was removed from `PatternCard.vue` in PR #11314, so the test now clicks the card row itself (`pattern-card-N`) which is the current UX for opening pattern details.
- Added a 15-second grace period in `waitForPatternsToLoad` before accepting "empty" as the final result. The backend can return "No patterns found" before async pattern extraction completes, causing the P0 duplicate-patterns test to fail when patterns exist but haven't been extracted yet.

## Test plan
- [x] Ran `searchPatterns.spec.js` full suite locally — **15/15 passed** (was 10 passed, 1 failed, 4 skipped)
- [x] Ran failing test individually — passes
- [x] Verified no regressions in other tests using `clickPatternDetailsIcon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)