### PR TITLE
fix: adjust partition ordering in trace processing

### DIFF
--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -1072,7 +1072,14 @@ async fn process_latest_traces_stream(
     let total_partitions = partitions.len();
     // Partitions from search_partition are already in DESC order (newest-first) by default,
     // since the partition SQL has no ORDER BY and the default is OrderBy::Desc.
-    let partitions_desc = partitions;
+    let partitions_desc = if sql_order_expr == "zo_sql_timestamp DESC" {
+        partitions
+    } else if sql_order_expr == "zo_sql_timestamp ASC" {
+        partitions.into_iter().rev().collect::<Vec<_>>()
+    } else {
+        // order by other fields can't be multiple partitions
+        vec![[partition_req.start_time, partition_req.end_time]]
+    };
 
     // `from` is a global offset: skip the first `from` hits across all partitions,
     // then deliver `size` hits. We track how many we've seen and delivered so far.


### PR DESCRIPTION
Fixed #11339 
Updated the logic for ordering partitions based on the SQL order expression. If the expression is "zo_sql_timestamp DESC", partitions remain unchanged. For "zo_sql_timestamp ASC", partitions are reversed. For other fields, a single partition is returned, ensuring compatibility with the new ordering requirements.