### PR TITLE
ci: Add Issue Audit workflow for retrospective test coverage enforcement

### DIFF
--- a/.github/workflows/ISSUE_AUDIT.md
+++ b/.github/workflows/ISSUE_AUDIT.md
@@ -1,0 +1,283 @@
+# Issue Audit Workflow
+
+Automated retrospective audit of open bug issues to ensure they have both fix + test coverage.
+
+## What It Does
+
+This workflow audits all open issues labeled with `bug` and categorizes them:
+
+1. **✅ Ready to Close**: Has merged fix PR + test with `@bug-{issue#}` tag → **Auto-closes**
+2. **⚠️ Needs Test**: Has merged fix PR but no test → **Comments asking for test**
+3. **⚠️ Needs Fix**: Has test but no merged PR → **Reports** (weird case)
+4. **❌ Needs Both**: No fix and no test → **Reports only**
+
+## How It Works
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Trigger: Manual or Weekly (Monday)                     │
+└─────────────────────────────────────────────────────────┘
+                         ↓
+┌─────────────────────────────────────────────────────────┐
+│ 1. Fetch All Open Bug Issues                           │
+│    - Only issues with "bug" label                      │
+│    - Excludes PRs                                       │
+└─────────────────────────────────────────────────────────┘
+                         ↓
+┌─────────────────────────────────────────────────────────┐
+│ 2. For Each Issue:                                      │
+│    a) Check for merged PR with closing keywords        │
+│       - Searches timeline for "Closes #X", "Fixes #X"  │
+│       - Verifies PR is merged                          │
+│    b) Check for test with @bug-{issue#} tag            │
+│       - Greps test directory                           │
+└─────────────────────────────────────────────────────────┘
+                         ↓
+┌─────────────────────────────────────────────────────────┐
+│ 3. Categorize and Take Action:                         │
+│                                                         │
+│  ✅ Fix + Test → Auto-close with comment               │
+│  ⚠️  Fix only → Post comment asking for test           │
+│  ⚠️  Test only → Report (no action)                    │
+│  ❌ Neither → Report (no action)                       │
+└─────────────────────────────────────────────────────────┘
+                         ↓
+┌─────────────────────────────────────────────────────────┐
+│ 4. Generate Report                                      │
+│    - Summary table                                      │
+│    - Details for each category                         │
+│    - Saved as downloadable artifact                    │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Triggers
+
+### Manual Trigger
+```bash
+# Via GitHub UI
+Go to: Actions → Issue Audit → Run workflow
+
+# Via gh CLI
+gh workflow run issue-audit.yml
+```
+
+### Scheduled Trigger
+- **When**: Every Monday at midnight UTC
+- **Frequency**: Weekly
+- **Customize**: Edit `cron:` in the workflow file
+
+## Example Outputs
+
+### Auto-Closed Issue Comment
+```markdown
+## ✅ Issue Resolved - Auto-Closed by Issue Audit
+
+This issue has been automatically closed because:
+- ✅ **Fix merged**: PR #11357 (https://github.com/.../pull/11357)
+- ✅ **Test coverage**: `tests/ui-testing/playwright-tests/RegressionSet/dashboards-11357.spec.js`
+
+The fix has been implemented and proper test coverage exists with the `@bug-11357` tag.
+
+---
+🤖 Automated by Issue Audit Workflow
+```
+
+### Needs Test Comment
+```markdown
+## ⚠️  Missing Test Coverage
+
+**Status**: This issue has been fixed but lacks E2E test coverage.
+
+- ✅ **Fix merged**: PR #11234 (https://github.com/.../pull/11234)
+- ❌ **No test found**: Missing `@bug-11234` tag
+
+**Action needed**:
+Please add an E2E test with proper tags:
+```javascript
+test("Test description @bug-11234 @regression", async ({ page }) => {
+  // Test implementation
+});
+```
+
+Place the test in `tests/ui-testing/playwright-tests/RegressionSet/`
+
+---
+🤖 Detected by Issue Audit Workflow
+```
+
+### Audit Report
+```markdown
+# Issue Audit Report
+
+**Run ID**: 123456789
+**Date**: 2026-04-21T18:00:00.000Z
+
+---
+
+## Summary
+
+| Category | Count |
+|----------|-------|
+| ✅ Auto-closed (fix + test) | 5 |
+| ⚠️  Needs test | 12 |
+| ⚠️  Needs fix | 2 |
+| ❌ Needs both | 23 |
+| **Total audited** | **42** |
+
+## ✅ Auto-Closed Issues (5)
+
+- #11357: Dashboard table chart copy cell format
+  - Fix: PR #11358
+  - Test: `tests/ui-testing/playwright-tests/RegressionSet/dashboards-11357.spec.js`
+
+...
+
+## ⚠️  Issues Needing Tests (12)
+
+- #11234: Fix dashboard filter bug
+  - Fix: PR #11235 (merged 2026-04-15)
+  - Missing test with @bug-11234 tag
+
+...
+```
+
+## Configuration
+
+### Change Schedule
+Edit `.github/workflows/issue-audit.yml`:
+
+```yaml
+schedule:
+  - cron: '0 0 * * 1'  # Weekly on Monday
+  # Examples:
+  # - cron: '0 0 * * *'  # Daily at midnight
+  # - cron: '0 0 1 * *'  # Monthly on 1st
+```
+
+### Change Issue Label
+```yaml
+labels: 'bug',  # Only audit bug issues
+# Or use multiple labels:
+# labels: ['bug', 'regression']
+```
+
+### Disable Auto-Closing
+Remove or comment out the "Auto-close issues" step.
+
+## Requirements
+
+- **GitHub Token**: Auto-provided (`GITHUB_TOKEN`)
+- **Permissions**:
+  - `issues: write` - To close issues and post comments
+  - `pull-requests: read` - To check PR status
+  - `contents: read` - To search test files
+
+## Monitoring
+
+### View Run Results
+```
+GitHub → Actions → Issue Audit → Click run
+```
+
+### Download Report
+1. Go to completed workflow run
+2. Scroll to "Artifacts"
+3. Download `issue-audit-report`
+
+### Check Logs
+Each step shows detailed logs:
+- Issue fetching
+- PR checking
+- Test coverage checking
+- Categorization results
+
+## Benefits
+
+### For QA
+✅ **Automatic cleanup** - Issues with fix + test auto-close
+✅ **Missing test alerts** - Proactive comments on issues
+✅ **Coverage visibility** - Weekly reports
+
+### For Developers
+✅ **Clear action items** - Know which issues need tests
+✅ **Reduced manual checking** - Automated audit
+✅ **Audit trail** - All actions logged in GitHub
+
+### For Project
+✅ **Test coverage enforcement** - Can't close without test
+✅ **Issue hygiene** - Automatic cleanup of resolved issues
+✅ **Quality metrics** - Track test coverage over time
+
+## Troubleshooting
+
+### Issue: Workflow doesn't find merged PRs
+
+**Check**:
+1. PR body uses closing keywords: "Closes #1234", "Fixes #1234", "Resolves #1234"
+2. PR is actually merged (not just closed)
+3. PR references the issue correctly
+
+### Issue: Test not detected
+
+**Check**:
+1. Test file has `@bug-{issue#}` tag
+2. Test file is in `tests/ui-testing/playwright-tests/` directory
+3. File extension is `.spec.js`
+
+### Issue: Too many issues audited
+
+**Solution**:
+Add more specific labels or date filters:
+```yaml
+# Only recent issues
+const cutoffDate = new Date();
+cutoffDate.setMonth(cutoffDate.getMonth() - 3);  // Last 3 months
+const issues = allIssues.filter(i => new Date(i.created_at) > cutoffDate);
+```
+
+## Customization Examples
+
+### Only Auto-Close Issues Older Than 30 Days
+```javascript
+if (hasFix && hasTest) {
+  const issueAge = Date.now() - new Date(issue.created_at);
+  const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+
+  if (issueAge > thirtyDays) {
+    results.ready_to_close.push(result);
+  }
+}
+```
+
+### Require Specific Test Location
+```javascript
+const hasTest = searchResult && searchResult.includes('RegressionSet/');
+```
+
+### Send Slack Notification
+Add a step:
+```yaml
+- name: Send Slack notification
+  if: steps.audit.outputs.ready_to_close_count > 0
+  uses: slackapi/slack-github-action@v1
+  with:
+    payload: |
+      {
+        "text": "Issue Audit: Closed ${{ steps.audit.outputs.ready_to_close_count }} issues"
+      }
+  env:
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+---
+
+## Next Steps
+
+1. ✅ Workflow is created and committed
+2. ⏳ Trigger manual run to test
+3. ⏳ Review first audit report
+4. ⏳ Adjust settings as needed
+
+---
+
+*Issue Audit Workflow - Retrospective test coverage enforcement* 🔍

--- a/.github/workflows/issue-audit.yml
+++ b/.github/workflows/issue-audit.yml
@@ -2,6 +2,17 @@ name: Issue Audit - Check Fix & Test Coverage
 
 on:
   workflow_dispatch:  # Manual trigger
+    inputs:
+      test_mode:
+        description: 'Test mode - limit to specific issues (comma-separated issue numbers, or "all" for full audit)'
+        required: false
+        default: 'all'
+        type: string
+      dry_run:
+        description: 'Dry run - do not close issues or post comments, only generate report'
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: '0 0 * * 1'  # Weekly on Monday at midnight UTC
 
@@ -54,7 +65,18 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const issues = JSON.parse('${{ steps.fetch-issues.outputs.issues }}');
+            let issues = JSON.parse('${{ steps.fetch-issues.outputs.issues }}');
+
+            // Apply test mode filter if specified
+            const testMode = '${{ inputs.test_mode }}' || 'all';
+            if (testMode !== 'all' && testMode !== '') {
+              const testIssueNumbers = testMode.split(',').map(n => parseInt(n.trim())).filter(n => !isNaN(n));
+              if (testIssueNumbers.length > 0) {
+                console.log(`\n🧪 TEST MODE: Filtering to issues: ${testIssueNumbers.join(', ')}`);
+                issues = issues.filter(i => testIssueNumbers.includes(i.number));
+                console.log(`Filtered to ${issues.length} issue(s)\n`);
+              }
+            }
 
             const results = {
               ready_to_close: [],      // Has fix + test
@@ -175,7 +197,7 @@ jobs:
             core.setOutput('ready_to_close_count', results.ready_to_close.length);
 
       - name: Auto-close issues with fix + test
-        if: steps.audit.outputs.ready_to_close_count > 0
+        if: ${{ steps.audit.outputs.ready_to_close_count > 0 && !inputs.dry_run }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -221,6 +243,7 @@ The fix has been implemented and proper test coverage exists with the \`@bug-${i
             }
 
       - name: Comment on issues needing tests
+        if: ${{ !inputs.dry_run }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -287,10 +310,19 @@ Place the test in \`tests/ui-testing/playwright-tests/RegressionSet/\`
           script: |
             const results = JSON.parse('${{ steps.audit.outputs.results }}');
 
+            const dryRun = '${{ inputs.dry_run }}' === 'true';
+            const testMode = '${{ inputs.test_mode }}' || 'all';
+
             let report = `# Issue Audit Report\n\n`;
             report += `**Run ID**: ${context.runId}\n`;
-            report += `**Date**: ${new Date().toISOString()}\n\n`;
-            report += `---\n\n`;
+            report += `**Date**: ${new Date().toISOString()}\n`;
+            if (dryRun) {
+              report += `**Mode**: 🧪 DRY RUN (no actions taken)\n`;
+            }
+            if (testMode !== 'all') {
+              report += `**Test Mode**: Issues ${testMode}\n`;
+            }
+            report += `\n---\n\n`;
 
             // Summary table
             report += `## Summary\n\n`;

--- a/.github/workflows/issue-audit.yml
+++ b/.github/workflows/issue-audit.yml
@@ -1,7 +1,7 @@
 name: Issue Audit - Check Fix & Test Coverage
 
 on:
-  workflow_dispatch:  # Manual trigger
+  workflow_dispatch:  # Manual trigger only
     inputs:
       test_mode:
         description: 'Test mode - limit to specific issues (comma-separated issue numbers, or "all" for full audit)'
@@ -13,8 +13,6 @@ on:
         required: false
         default: false
         type: boolean
-  schedule:
-    - cron: '0 0 * * 1'  # Weekly on Monday at midnight UTC
 
 permissions:
   issues: write

--- a/.github/workflows/issue-audit.yml
+++ b/.github/workflows/issue-audit.yml
@@ -1,0 +1,354 @@
+name: Issue Audit - Check Fix & Test Coverage
+
+on:
+  workflow_dispatch:  # Manual trigger
+  schedule:
+    - cron: '0 0 * * 1'  # Weekly on Monday at midnight UTC
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  audit-issues:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all open issues
+        id: fetch-issues
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'bug',  // Only audit bug issues
+              per_page: 100
+            });
+
+            // Filter out PRs (GitHub API returns both)
+            const bugIssues = issues.filter(issue => !issue.pull_request);
+
+            core.setOutput('count', bugIssues.length);
+            core.setOutput('issues', JSON.stringify(bugIssues.map(i => ({
+              number: i.number,
+              title: i.title,
+              url: i.html_url,
+              created_at: i.created_at
+            }))));
+
+            console.log(`Found ${bugIssues.length} open bug issues to audit`);
+
+      - name: Audit each issue for fix + test coverage
+        id: audit
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issues = JSON.parse('${{ steps.fetch-issues.outputs.issues }}');
+
+            const results = {
+              ready_to_close: [],      // Has fix + test
+              needs_test: [],          // Has fix, no test
+              needs_fix: [],           // Has test, no fix (weird case)
+              needs_both: []           // No fix, no test
+            };
+
+            for (const issue of issues) {
+              console.log(`\n=== Auditing Issue #${issue.number}: ${issue.title} ===`);
+
+              // 1. Check for merged PR that fixes this issue
+              let hasFix = false;
+              let fixPR = null;
+
+              try {
+                const timeline = await github.rest.issues.listEventsForTimeline({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  per_page: 100
+                });
+
+                // Look for "referenced" events from merged PRs
+                for (const event of timeline.data) {
+                  if (event.event === 'referenced' && event.source?.type === 'issue') {
+                    // Check if the referencing PR is merged
+                    const prNumber = event.source.issue.number;
+                    const pr = await github.rest.pulls.get({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: prNumber
+                    });
+
+                    if (pr.data.merged) {
+                      // Check if PR body mentions this issue with closing keywords
+                      const prBody = (pr.data.body || '').toLowerCase();
+                      const issueRef = `#${issue.number}`;
+                      const closingKeywords = ['closes', 'fixes', 'resolves', 'fixed', 'close', 'resolve'];
+
+                      if (closingKeywords.some(keyword =>
+                        prBody.includes(`${keyword} ${issueRef}`) ||
+                        prBody.includes(`${keyword}: ${issueRef}`)
+                      )) {
+                        hasFix = true;
+                        fixPR = {
+                          number: pr.data.number,
+                          title: pr.data.title,
+                          url: pr.data.html_url,
+                          merged_at: pr.data.merged_at
+                        };
+                        console.log(`  ✓ Found fix: PR #${fixPR.number}`);
+                        break;
+                      }
+                    }
+                  }
+                }
+              } catch (error) {
+                console.log(`  ⚠️  Error checking PRs: ${error.message}`);
+              }
+
+              // 2. Check for test with @bug-{issue#} tag
+              const { execSync } = require('child_process');
+              let hasTest = false;
+              let testFile = null;
+
+              try {
+                const searchResult = execSync(
+                  `grep -r "@bug-${issue.number}" tests/ui-testing/playwright-tests/ --include="*.spec.js" -l || true`,
+                  { encoding: 'utf-8' }
+                ).trim();
+
+                if (searchResult) {
+                  hasTest = true;
+                  testFile = searchResult.split('\n')[0];  // Take first match
+                  console.log(`  ✓ Found test: ${testFile}`);
+                } else {
+                  console.log(`  ✗ No test found with @bug-${issue.number}`);
+                }
+              } catch (error) {
+                console.log(`  ⚠️  Error checking tests: ${error.message}`);
+              }
+
+              // 3. Categorize the issue
+              const result = {
+                issue: issue,
+                hasFix: hasFix,
+                hasTest: hasTest,
+                fixPR: fixPR,
+                testFile: testFile
+              };
+
+              if (hasFix && hasTest) {
+                console.log(`  → Category: READY TO CLOSE`);
+                results.ready_to_close.push(result);
+              } else if (hasFix && !hasTest) {
+                console.log(`  → Category: NEEDS TEST`);
+                results.needs_test.push(result);
+              } else if (!hasFix && hasTest) {
+                console.log(`  → Category: NEEDS FIX (has test but no merged PR)`);
+                results.needs_fix.push(result);
+              } else {
+                console.log(`  → Category: NEEDS BOTH`);
+                results.needs_both.push(result);
+              }
+            }
+
+            // Log summary
+            console.log(`\n=== AUDIT SUMMARY ===`);
+            console.log(`Total issues audited: ${issues.length}`);
+            console.log(`Ready to close: ${results.ready_to_close.length}`);
+            console.log(`Needs test: ${results.needs_test.length}`);
+            console.log(`Needs fix: ${results.needs_fix.length}`);
+            console.log(`Needs both: ${results.needs_both.length}`);
+
+            // Save results
+            core.setOutput('results', JSON.stringify(results));
+            core.setOutput('ready_to_close_count', results.ready_to_close.length);
+
+      - name: Auto-close issues with fix + test
+        if: steps.audit.outputs.ready_to_close_count > 0
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const results = JSON.parse('${{ steps.audit.outputs.results }}');
+
+            for (const item of results.ready_to_close) {
+              const issue = item.issue;
+              const fixPR = item.fixPR;
+              const testFile = item.testFile;
+
+              console.log(`Closing issue #${issue.number}: ${issue.title}`);
+
+              // Post closing comment
+              const comment = `## ✅ Issue Resolved - Auto-Closed by Issue Audit
+
+This issue has been automatically closed because:
+- ✅ **Fix merged**: PR #${fixPR.number} (${fixPR.url})
+- ✅ **Test coverage**: \`${testFile}\`
+
+The fix has been implemented and proper test coverage exists with the \`@bug-${issue.number}\` tag.
+
+---
+*🤖 Automated by [Issue Audit Workflow](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})*`;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: comment
+              });
+
+              // Close the issue
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+
+              console.log(`  ✓ Closed issue #${issue.number}`);
+            }
+
+      - name: Comment on issues needing tests
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const results = JSON.parse('${{ steps.audit.outputs.results }}');
+
+            for (const item of results.needs_test) {
+              const issue = item.issue;
+              const fixPR = item.fixPR;
+
+              console.log(`Commenting on issue #${issue.number}: needs test`);
+
+              // Check if we already posted this comment
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number
+              });
+
+              const alreadyCommented = comments.data.some(c =>
+                c.body.includes('Issue Audit Workflow') &&
+                c.body.includes('needs test coverage')
+              );
+
+              if (alreadyCommented) {
+                console.log(`  → Already commented, skipping`);
+                continue;
+              }
+
+              const comment = `## ⚠️  Missing Test Coverage
+
+**Status**: This issue has been fixed but lacks E2E test coverage.
+
+- ✅ **Fix merged**: PR #${fixPR.number} (${fixPR.url})
+- ❌ **No test found**: Missing \`@bug-${issue.number}\` tag
+
+**Action needed**:
+Please add an E2E test with proper tags:
+\`\`\`javascript
+test("Test description @bug-${issue.number} @regression", async ({ page }) => {
+  // Test implementation
+});
+\`\`\`
+
+Place the test in \`tests/ui-testing/playwright-tests/RegressionSet/\`
+
+---
+*🤖 Detected by [Issue Audit Workflow](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})*`;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: comment
+              });
+
+              console.log(`  ✓ Posted comment on issue #${issue.number}`);
+            }
+
+      - name: Generate audit report
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const results = JSON.parse('${{ steps.audit.outputs.results }}');
+
+            let report = `# Issue Audit Report\n\n`;
+            report += `**Run ID**: ${context.runId}\n`;
+            report += `**Date**: ${new Date().toISOString()}\n\n`;
+            report += `---\n\n`;
+
+            // Summary table
+            report += `## Summary\n\n`;
+            report += `| Category | Count |\n`;
+            report += `|----------|-------|\n`;
+            report += `| ✅ Auto-closed (fix + test) | ${results.ready_to_close.length} |\n`;
+            report += `| ⚠️  Needs test | ${results.needs_test.length} |\n`;
+            report += `| ⚠️  Needs fix | ${results.needs_fix.length} |\n`;
+            report += `| ❌ Needs both | ${results.needs_both.length} |\n`;
+            report += `| **Total audited** | **${results.ready_to_close.length + results.needs_test.length + results.needs_fix.length + results.needs_both.length}** |\n\n`;
+
+            // Details
+            if (results.ready_to_close.length > 0) {
+              report += `## ✅ Auto-Closed Issues (${results.ready_to_close.length})\n\n`;
+              results.ready_to_close.forEach(item => {
+                report += `- #${item.issue.number}: ${item.issue.title}\n`;
+                report += `  - Fix: PR #${item.fixPR.number}\n`;
+                report += `  - Test: \`${item.testFile}\`\n\n`;
+              });
+            }
+
+            if (results.needs_test.length > 0) {
+              report += `## ⚠️  Issues Needing Tests (${results.needs_test.length})\n\n`;
+              results.needs_test.forEach(item => {
+                report += `- #${item.issue.number}: ${item.issue.title}\n`;
+                report += `  - Fix: PR #${item.fixPR.number} (merged ${item.fixPR.merged_at})\n`;
+                report += `  - Missing test with @bug-${item.issue.number} tag\n\n`;
+              });
+            }
+
+            if (results.needs_fix.length > 0) {
+              report += `## ⚠️  Issues with Tests but No Fix (${results.needs_fix.length})\n\n`;
+              results.needs_fix.forEach(item => {
+                report += `- #${item.issue.number}: ${item.issue.title}\n`;
+                report += `  - Test exists: \`${item.testFile}\`\n`;
+                report += `  - No merged PR found\n\n`;
+              });
+            }
+
+            if (results.needs_both.length > 0) {
+              report += `## ❌ Issues Needing Both Fix and Test (${results.needs_both.length})\n\n`;
+              results.needs_both.forEach(item => {
+                report += `- #${item.issue.number}: ${item.issue.title}\n`;
+              });
+            }
+
+            report += `\n---\n`;
+            report += `*Generated by Issue Audit Workflow*\n`;
+
+            console.log(report);
+
+            // Save report as artifact
+            const fs = require('fs');
+            fs.writeFileSync('issue-audit-report.md', report);
+
+      - name: Upload audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: issue-audit-report
+          path: issue-audit-report.md
+          retention-days: 90

--- a/scripts/test-issue-audit.sh
+++ b/scripts/test-issue-audit.sh
@@ -35,7 +35,7 @@ if [ -n "$MERGED_COMMITS" ]; then
   # Check if any commit message has closing keywords
   while IFS= read -r line; do
     COMMIT_MSG=$(echo "$line" | cut -d' ' -f2-)
-    if echo "$COMMIT_MSG" | grep -qiE "(close|fix|resolve)(s|d|)( |:)#${TEST_ISSUE}"; then
+    if echo "$COMMIT_MSG" | grep -qiE "(closes|close|fixed|fixes|fix|resolved|resolves|resolve)( |:)#${TEST_ISSUE}"; then
       HAS_FIX=true
       FIX_PR=$(echo "$line" | grep -oE "\(#[0-9]+\)" | grep -oE "[0-9]+" || echo "unknown")
       echo "✓ Found fix: Commit mentions 'closes/fixes/resolves #${TEST_ISSUE}'"

--- a/scripts/test-issue-audit.sh
+++ b/scripts/test-issue-audit.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# Local test script for Issue Audit workflow
+# Tests the core logic without running the full GitHub Action
+
+set -e
+
+echo "=========================================="
+echo "Issue Audit - Local Test"
+echo "=========================================="
+echo ""
+
+# Test a specific issue number or default to a known issue
+TEST_ISSUE="${1:-11357}"
+
+echo "Testing issue #$TEST_ISSUE"
+echo ""
+
+# Step 1: Check if issue has a merged PR with closing keywords
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "STEP 1: Check for Merged Fix PR"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+HAS_FIX=false
+FIX_PR=""
+
+# Search git log for merged commits mentioning this issue
+MERGED_COMMITS=$(git log --all --grep="#${TEST_ISSUE}" --oneline --no-merges | head -5)
+
+if [ -n "$MERGED_COMMITS" ]; then
+  echo "Found commits mentioning issue #${TEST_ISSUE}:"
+  echo "$MERGED_COMMITS"
+  echo ""
+
+  # Check if any commit message has closing keywords
+  while IFS= read -r line; do
+    COMMIT_MSG=$(echo "$line" | cut -d' ' -f2-)
+    if echo "$COMMIT_MSG" | grep -qiE "(close|fix|resolve)(s|d|)( |:)#${TEST_ISSUE}"; then
+      HAS_FIX=true
+      FIX_PR=$(echo "$line" | grep -oE "\(#[0-9]+\)" | grep -oE "[0-9]+" || echo "unknown")
+      echo "✓ Found fix: Commit mentions 'closes/fixes/resolves #${TEST_ISSUE}'"
+      break
+    fi
+  done <<< "$MERGED_COMMITS"
+fi
+
+if [ "$HAS_FIX" = false ]; then
+  echo "✗ No merged fix found for issue #${TEST_ISSUE}"
+fi
+
+echo ""
+
+# Step 2: Check for test with @bug-{issue#} tag
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "STEP 2: Check for Test Coverage"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+HAS_TEST=false
+TEST_FILE=""
+
+# Search for @bug-{issue#} tag in test files
+if grep -r "@bug-${TEST_ISSUE}" tests/ui-testing/playwright-tests/ --include="*.spec.js" -l 2>/dev/null | head -1 | read -r found_file; then
+  HAS_TEST=true
+  TEST_FILE="$found_file"
+  echo "✓ Found test: $TEST_FILE"
+
+  # Show the test description
+  echo ""
+  echo "Test content preview:"
+  grep -A 2 "@bug-${TEST_ISSUE}" "$TEST_FILE" | head -5
+else
+  echo "✗ No test found with @bug-${TEST_ISSUE} tag"
+fi
+
+echo ""
+
+# Step 3: Categorize the issue
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "STEP 3: Categorize Issue"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$HAS_FIX" = true ] && [ "$HAS_TEST" = true ]; then
+  echo "Category: ✅ READY TO CLOSE"
+  echo ""
+  echo "Action: Would auto-close with comment:"
+  echo "┌─────────────────────────────────────────────────────┐"
+  echo "│ ## ✅ Issue Resolved - Auto-Closed by Issue Audit  │"
+  echo "│                                                     │"
+  echo "│ This issue has been automatically closed because:  │"
+  echo "│ - ✅ Fix merged: PR #${FIX_PR}                      │"
+  echo "│ - ✅ Test coverage: ${TEST_FILE}                    │"
+  echo "└─────────────────────────────────────────────────────┘"
+
+elif [ "$HAS_FIX" = true ] && [ "$HAS_TEST" = false ]; then
+  echo "Category: ⚠️  NEEDS TEST"
+  echo ""
+  echo "Action: Would post comment asking for test:"
+  echo "┌─────────────────────────────────────────────────────┐"
+  echo "│ ## ⚠️  Missing Test Coverage                        │"
+  echo "│                                                     │"
+  echo "│ Status: Issue has been fixed but lacks E2E test.   │"
+  echo "│ - ✅ Fix merged: PR #${FIX_PR}                      │"
+  echo "│ - ❌ No test found: Missing @bug-${TEST_ISSUE} tag │"
+  echo "│                                                     │"
+  echo "│ Action needed: Add E2E test with proper tags       │"
+  echo "└─────────────────────────────────────────────────────┘"
+
+elif [ "$HAS_FIX" = false ] && [ "$HAS_TEST" = true ]; then
+  echo "Category: ⚠️  NEEDS FIX (has test but no merged PR)"
+  echo ""
+  echo "Action: Would report only (weird case)"
+  echo "  - Test exists: $TEST_FILE"
+  echo "  - No merged PR found"
+
+else
+  echo "Category: ❌ NEEDS BOTH"
+  echo ""
+  echo "Action: Would report only"
+  echo "  - No fix found"
+  echo "  - No test found"
+fi
+
+echo ""
+
+# Summary
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "TEST SUMMARY"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Issue #${TEST_ISSUE}:"
+echo "  Has Fix: $HAS_FIX"
+echo "  Has Test: $HAS_TEST"
+echo ""
+echo "To test other issues, run:"
+echo "  $0 <issue-number>"
+echo ""
+echo "Examples:"
+echo "  $0 11357  # Test issue #11357"
+echo "  $0 10769  # Test issue #10769"
+echo ""


### PR DESCRIPTION
- Audits all open bug issues for fix + test coverage
- Auto-closes issues with both merged PR and @bug-{issue#} test
- Comments on issues needing tests (fix exists, test missing)
- Generates detailed audit report as artifact
- Runs weekly (Monday) or manually on-demand

Audit categories:
✅ Fix + Test → Auto-close
⚠️  Fix only → Comment asking for test
⚠️  Test only → Report (no action)
❌ Neither → Report (no action)

This is a retrospective cleanup tool that ensures existing open issues have proper test coverage before closing them.

🤖 Generated with Claude Code