### PR TITLE
fix: added tooltips for formatted span and error count

### DIFF
--- a/web/src/components/traces/FlameGraphView.spec.ts
+++ b/web/src/components/traces/FlameGraphView.spec.ts
@@ -168,7 +168,7 @@ describe("FlameGraphView", () => {
       expect(wrapper.vm.totalSpans).toBe(3);
     });
 
-    it("should calculate max depth correctly", () => {
+    it("should calculate depth correctly", () => {
       wrapper = mount(FlameGraphView, {
         props: {
           spans: mockSpans,
@@ -180,7 +180,7 @@ describe("FlameGraphView", () => {
       expect(wrapper.vm.maxDepth).toBe(1);
     });
 
-    it("should return 0 for max depth when no spans", () => {
+    it("should return 0 for depth when no spans", () => {
       wrapper = mount(FlameGraphView, {
         props: {
           spans: [],
@@ -243,7 +243,7 @@ describe("FlameGraphView", () => {
       expect(wrapper.text()).toContain("spans");
     });
 
-    it("should display max depth", () => {
+    it("should display depth", () => {
       wrapper = mount(FlameGraphView, {
         props: {
           spans: mockSpans,
@@ -253,7 +253,7 @@ describe("FlameGraphView", () => {
       });
 
       expect(wrapper.text()).toContain("1");
-      expect(wrapper.text()).toContain("max depth");
+      expect(wrapper.text()).toContain("depth");
     });
 
     it("should show empty state when no data", () => {

--- a/web/src/components/traces/FlameGraphView.vue
+++ b/web/src/components/traces/FlameGraphView.vue
@@ -14,13 +14,18 @@
       <div class="tw:flex tw:items-center tw:space-x-4">
         <div class="tw:text-xs tw:font-bold tw:text-[var(--o2-text-secondary)]">
           <template v-if="isTruncated">
-            <span class="tw:text-orange-500">{{ totalSpans }}</span><span class="tw:text-[var(--o2-text-primary)]">/{{ totalSpanCount }}</span>
+            <span class="tw:text-orange-500">{{ totalSpans }}</span
+            ><span class="tw:text-[var(--o2-text-primary)]"
+              >/{{ totalSpanCount }}</span
+            >
           </template>
-          <span v-else class="tw:text-[var(--o2-text-primary)]">{{ totalSpans }}</span>
+          <span v-else class="tw:text-[var(--o2-text-primary)]">{{
+            totalSpans
+          }}</span>
           spans
           <span class="tw:mx-2">•</span>
           <span class="tw:text-[var(--o2-text-primary)]">{{ maxDepth }}</span>
-          max depth
+          depth
         </div>
       </div>
     </div>

--- a/web/src/components/traces/FlameGraphView.vue
+++ b/web/src/components/traces/FlameGraphView.vue
@@ -13,15 +13,7 @@
     >
       <div class="tw:flex tw:items-center tw:space-x-4">
         <div class="tw:text-xs tw:font-bold tw:text-[var(--o2-text-secondary)]">
-          <template v-if="isTruncated">
-            <span class="tw:text-orange-500">{{ totalSpans }}</span
-            ><span class="tw:text-[var(--o2-text-primary)]"
-              >/{{ totalSpanCount }}</span
-            >
-          </template>
-          <span v-else class="tw:text-[var(--o2-text-primary)]">{{
-            totalSpans
-          }}</span>
+          <span class="tw:text-[var(--o2-text-primary)]">{{ totalSpans }}</span>
           spans
           <span class="tw:mx-2">•</span>
           <span class="tw:text-[var(--o2-text-primary)]">{{ maxDepth }}</span>
@@ -147,14 +139,10 @@ interface Props {
   spans: EnrichedSpan[];
   selectedSpanId?: string | null;
   traceDuration: number;
-  isTruncated?: boolean;
-  totalSpanCount?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   selectedSpanId: null,
-  isTruncated: false,
-  totalSpanCount: 0,
 });
 
 // Emits

--- a/web/src/composables/useTraces.ts
+++ b/web/src/composables/useTraces.ts
@@ -157,8 +157,6 @@ const defaultObject = {
       } | null,
       traceId: "",
       spanList: [],
-      spansTruncated: false,
-      totalSpanCount: 0,
       isLoadingTraceMeta: false,
       isLoadingTraceDetails: false,
       selectedSpanId: "" as String | null,

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -1591,6 +1591,7 @@ export default defineComponent({
     const buildTraceSearchQuery = (trace: any) => {
       const req = getDefaultRequest();
       req.query.from = 0;
+      // Set -1 to get all spans of trace
       req.query.size = -1;
       req.query.start_time = trace.from;
       req.query.end_time = trace.to;

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -143,6 +143,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     formatLargeNumber(effectiveSpanList.length)
                   }}</template>
                   {{ t("traces.spansLabel") }}
+                  <q-tooltip
+                    >{{ effectiveSpanList.length }}
+                    {{ t("traces.spansLabel") }}</q-tooltip
+                  >
                 </span>
                 <q-tooltip
                   v-if="searchObj.data.traceDetails.spansTruncated"
@@ -170,6 +174,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <span
                   >{{ formatLargeNumber(errorSpansCount) }}
                   {{ t("traces.errorsLabel") }}</span
+                >
+                <q-tooltip
+                  >{{ errorSpansCount }}
+                  {{ t("traces.errorsLabel") }}</q-tooltip
                 >
               </div>
             </div>

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -125,41 +125,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 class="tw:flex tw:items-center tw:ml-[0rem] tw:space-x-1 tw:px-[0.625rem] tw:py-[0.1rem] tw:rounded tw:text-[0.75rem] tw:text-[var(--o2-text-4)] tw:bg-[var(--o2-tag-grey-1)]"
               >
                 <span data-test="span-count-text">
-                  <template v-if="searchObj.data.traceDetails.spansTruncated">
-                    <span
-                      v-if="
-                        searchObj.data.traceDetails.totalSpanCount >
-                        traceSpanLimit
-                      "
-                      >Showing {{ traceSpanLimit }} out of
-                    </span>
-                    <span class="tw:pl-[0.25rem]">{{
-                      formatLargeNumber(
-                        searchObj.data.traceDetails.totalSpanCount,
-                      )
-                    }}</span>
-                  </template>
-                  <template v-else>{{
-                    formatLargeNumber(effectiveSpanList.length)
-                  }}</template>
+                  {{ formatLargeNumber(effectiveSpanList.length) }}
                   {{ t("traces.spansLabel") }}
                   <q-tooltip
                     >{{ effectiveSpanList.length }}
                     {{ t("traces.spansLabel") }}</q-tooltip
                   >
                 </span>
-                <q-tooltip
-                  v-if="searchObj.data.traceDetails.spansTruncated"
-                  anchor="bottom middle"
-                  self="top middle"
-                >
-                  {{
-                    t("traces.spansTruncatedWarning", {
-                      count: effectiveSpanList.length,
-                      total: searchObj.data.traceDetails.totalSpanCount,
-                    })
-                  }}
-                </q-tooltip>
               </div>
 
               <div
@@ -612,8 +584,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 :spans="flatSpans"
                 :selected-span-id="selectedSpanId"
                 :trace-duration="traceMetadata?.duration_ms || 0"
-                :is-truncated="searchObj.data.traceDetails.spansTruncated"
-                :total-span-count="searchObj.data.traceDetails.totalSpanCount"
                 @span-selected="updateSelectedSpan"
               />
             </div>
@@ -1078,11 +1048,6 @@ export default defineComponent({
       const sidebarWidthPx = Math.max(remainingWidth * 0.84, 300); // Minimum 300px
       return `${sidebarWidthPx}px`;
     });
-
-    /** Maximum number of spans fetched per trace. Truncation warning is shown when this limit is hit. */
-    const MAX_SPANS_PER_TRACE = 20000;
-
-    const traceSpanLimit = ref(MAX_SPANS_PER_TRACE);
 
     const serviceColorIndex = ref(0);
     const colors = ref(getAllSpanColors());
@@ -1623,26 +1588,10 @@ export default defineComponent({
     const sanitizeTraceId = (id: string): string =>
       String(id).replace(/['"\\]/g, "");
 
-    const buildTraceCountQuery = (trace: any) => {
-      const req = getDefaultRequest();
-      req.query.from = 0;
-      req.query.size = 1;
-      req.query.start_time = trace.from;
-      req.query.end_time = trace.to;
-      req.query.sql = b64EncodeUnicode(
-        `SELECT COUNT(*) as total FROM "${trace.stream}" WHERE trace_id = '${sanitizeTraceId(trace.trace_id)}'`,
-      ) as string;
-      return req;
-    };
-
     const buildTraceSearchQuery = (trace: any) => {
       const req = getDefaultRequest();
       req.query.from = 0;
-      // Prefer operator-configured limit from backend config; fall back to the
-      // frontend default. When the backend exposes max_spans_per_trace via /config
-      // it is picked up automatically without any code changes.
-      req.query.size =
-        store.state.zoConfig.max_spans_per_trace ?? MAX_SPANS_PER_TRACE;
+      req.query.size = -1;
       req.query.start_time = trace.from;
       req.query.end_time = trace.to;
 
@@ -1796,12 +1745,8 @@ export default defineComponent({
       try {
         searchObj.data.traceDetails.isLoadingTraceDetails = true;
         searchObj.data.traceDetails.spanList = [];
-        searchObj.data.traceDetails.spansTruncated = false;
-        searchObj.data.traceDetails.totalSpanCount = 0;
         const req = buildTraceSearchQuery(data);
-        const countReq = buildTraceCountQuery(data);
 
-        // Fetch trace spans, total span count, and RUM events in parallel
         const tracePromise = searchService.search(
           {
             org_identifier: router.currentRoute.value.query
@@ -1812,53 +1757,21 @@ export default defineComponent({
           "ui",
         );
 
-        const countPromise = searchService.search(
-          {
-            org_identifier: router.currentRoute.value.query
-              ?.org_identifier as string,
-            query: countReq,
-            page_type: "traces",
-          },
-          "ui",
-        );
-
-        // Fetch RUM events with matching trace_id
         const rumPromise = fetchRumEventsForTrace(
           data.trace_id,
           req.query.start_time,
           req.query.end_time,
         );
 
-        // Wait for all requests to complete
-        Promise.all([tracePromise, countPromise, rumPromise])
-          .then(([traceRes, countRes, rumEvents]) => {
+        Promise.all([tracePromise, rumPromise])
+          .then(([traceRes, rumEvents]) => {
             if (!traceRes.data?.hits?.length) {
               showTraceDetailsError();
               return;
             }
 
-            // Combine trace spans and RUM events
             const traceSpans = traceRes.data?.hits || [];
             const rumSpans = formatRumEventsAsSpans(rumEvents);
-            const limit =
-              store.state.zoConfig.max_spans_per_trace ?? MAX_SPANS_PER_TRACE;
-            traceSpanLimit.value = limit;
-            const totalFromCount: number =
-              countRes.data?.hits?.[0]?.total ?? traceSpans.length;
-            searchObj.data.traceDetails.totalSpanCount = totalFromCount;
-            searchObj.data.traceDetails.spansTruncated =
-              totalFromCount > traceSpans.length;
-            if (searchObj.data.traceDetails.spansTruncated) {
-              $q.notify({
-                type: "warning",
-                message: t("traces.spansTruncatedWarning", {
-                  count: traceSpans.length,
-                  total: totalFromCount,
-                }),
-                timeout: 0,
-                actions: [{ icon: "close", color: "black", round: false }],
-              });
-            }
             searchObj.data.traceDetails.spanList = [...rumSpans, ...traceSpans];
             updateServiceColors();
             buildTracesTree();
@@ -2856,7 +2769,6 @@ export default defineComponent({
       fetchEvalPipeline,
       fetchEvalData,
       formatLargeNumber,
-      traceSpanLimit,
     };
   },
 });


### PR DESCRIPTION
1. Added tooltips displaying the actual counts for spans and formatted error counts.
2. Removed unused code related to max spans in the trace tree.