### PR TITLE
fix: validate multi-stream SQL join query fields against correct stream schema

### DIFF
--- a/src/handler/http/request/search/utils.rs
+++ b/src/handler/http/request/search/utils.rs
@@ -13,13 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashSet;
-
 #[cfg(feature = "enterprise")]
 use axum::response::Response;
 use config::{
     ALL_VALUES_COL_NAME, ID_COL_NAME, INDEX_FIELD_NAME_FOR_ALL, ORIGINAL_DATA_COL_NAME,
-    TIMESTAMP_COL_NAME, meta::stream::StreamType,
+    TIMESTAMP_COL_NAME,
+    meta::{sql::TableReferenceExt, stream::StreamType},
 };
 use hashbrown::HashMap;
 use infra::errors::{Error, ErrorCodes};
@@ -138,25 +137,40 @@ pub async fn validate_query_fields(
 
     let sql = Sql::new_with_options(&search_query, org_id, stream_type, None, false).await?;
 
-    // Step 2: Get schema and UDS fields (from cache)
-    let schema = infra::schema::get(org_id, stream_name, stream_type)
-        .await
-        .map_err(|_| Error::ErrorCode(ErrorCodes::SearchStreamNotFound(stream_name.to_string())))?;
+    // Step 2: Resolve which stream and fields to validate.
+    //
+    // For multi-stream CTE queries sql.stream_names lists every real stream referenced
+    // (e.g. ["default", "k8s_events"]). Each stream has its own set of fields in
+    // sql.columns. Look up the entry matching stream_name so that fields belonging to
+    // a different stream are not incorrectly checked against stream_name's schema.
+    let (target_stream, target_fields) = sql
+        .stream_names
+        .iter()
+        .find(|r| r.stream_name() == stream_name)
+        .map(|r| {
+            let fields = sql.columns.get(r).cloned().unwrap_or_default();
+            (stream_name.to_string(), fields)
+        })
+        .unwrap_or_else(|| {
+            // stream_name not found in sql.stream_names (aliased or unresolved table).
+            // Fall back to original behaviour: all tracked columns against stream_name.
+            let fields = sql.columns.values().flatten().cloned().collect();
+            (stream_name.to_string(), fields)
+        });
 
-    let settings = infra::schema::get_settings(org_id, stream_name, stream_type).await;
+    // Step 3: Validate target stream's fields against its own schema and UDS.
+    let schema = infra::schema::get(org_id, &target_stream, stream_type)
+        .await
+        .map_err(|_| Error::ErrorCode(ErrorCodes::SearchStreamNotFound(target_stream.clone())))?;
+
+    let settings = infra::schema::get_settings(org_id, &target_stream, stream_type).await;
     let uds_fields = infra::schema::get_stream_setting_defined_schema_fields(&settings);
 
-    // Step 3: Get fields used in query
-    let used_fields: HashSet<String> = sql.columns.values().flatten().cloned().collect();
-
-    // Step 4: Validate each field
-    for field in used_fields {
-        // Skip system fields
+    for field in target_fields {
         if is_system_field(&field) {
             continue;
         }
 
-        // Check 1: Field must exist in schema
         if schema.field_with_name(&field).is_err() {
             return Err(Error::ErrorCode(ErrorCodes::SearchFieldNotFound(format!(
                 "{}. Field not found in stream schema.",
@@ -164,7 +178,6 @@ pub async fn validate_query_fields(
             ))));
         }
 
-        // Check 2: If UDS is defined, field must be in UDS
         if !uds_fields.is_empty() && !uds_fields.contains(&field) {
             return Err(Error::ErrorCode(ErrorCodes::SearchFieldNotFound(format!(
                 "{field}. Field exists but not in User-Defined Schema (UDS)",
@@ -868,5 +881,104 @@ JOIN "test1" AS b ON a._timestamp = b._timestamp"#;
                 "Should fail when complex query uses field not in UDS"
             );
         }
+    }
+}
+
+// ============================================================================
+// Regression test: CTE multi-stream field validation
+//
+// Bug: validate_query_fields flattened ALL streams' columns and checked them
+// against ONE stream's schema. Fields from stream B (e.g. body_type in
+// k8s_events) were rejected when validating stream A (default), producing a
+// false SearchFieldNotFound error.
+//
+// This test FAILS on the unfixed code and PASSES after the fix.
+// ============================================================================
+#[cfg(test)]
+mod test_cte_multi_stream_regression {
+    use arrow_schema::{DataType, Field, Schema};
+    use config::meta::stream::{StreamSettings, StreamType};
+    use infra::schema::{STREAM_SCHEMAS_LATEST, STREAM_SETTINGS, SchemaCache};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cte_join_cross_stream_field_not_rejected() {
+        let org_id = "test_cte_regression";
+        let st = StreamType::Logs;
+
+        // default stream: pod/container logs — does NOT have body_type
+        let default_schema = Schema::new(vec![
+            Field::new(config::TIMESTAMP_COL_NAME, DataType::Int64, false),
+            Field::new("k8s_cluster", DataType::Utf8, true),
+            Field::new("k8s_namespace_name", DataType::Utf8, true),
+            Field::new("k8s_pod_name", DataType::Utf8, true),
+            Field::new("severity", DataType::Utf8, true),
+        ]);
+
+        // k8s_events stream: has body_type — the field the old code falsely rejected
+        let k8s_events_schema = Schema::new(vec![
+            Field::new(config::TIMESTAMP_COL_NAME, DataType::Int64, false),
+            Field::new("body_type", DataType::Utf8, true),
+            Field::new("event_name", DataType::Utf8, true),
+            Field::new("k8s_cluster", DataType::Utf8, true),
+            Field::new("k8s_namespace_name", DataType::Utf8, true),
+        ]);
+
+        let key_default = format!("{org_id}/{st}/default");
+        let key_k8s = format!("{org_id}/{st}/k8s_events");
+
+        {
+            let mut w = STREAM_SCHEMAS_LATEST.write().await;
+            w.insert(key_default.clone(), SchemaCache::new(default_schema));
+            w.insert(key_k8s.clone(), SchemaCache::new(k8s_events_schema));
+        }
+        {
+            let mut w = STREAM_SETTINGS.write().await;
+            w.insert(key_default.clone(), StreamSettings::default());
+            w.insert(key_k8s.clone(), StreamSettings::default());
+            let mut atomic = hashbrown::HashMap::new();
+            atomic.insert(key_default.clone(), StreamSettings::default());
+            atomic.insert(key_k8s.clone(), StreamSettings::default());
+            infra::schema::set_stream_settings_atomic(atomic);
+        }
+
+        // Exact query shape that triggered the bug in alerts validation
+        let sql = r#"
+WITH pod_logs AS (
+    SELECT DISTINCT k8s_pod_name, k8s_namespace_name, k8s_cluster
+    FROM "default"
+    WHERE severity = '0'
+),
+k8s_events_agg AS (
+    SELECT e.k8s_cluster, e.k8s_namespace_name, e.event_name, e.body_type
+    FROM "k8s_events" e
+    INNER JOIN pod_logs p
+        ON e.k8s_cluster = p.k8s_cluster
+        AND e.k8s_namespace_name = p.k8s_namespace_name
+)
+SELECT k8s_cluster, k8s_namespace_name, event_name, body_type
+FROM k8s_events_agg"#;
+
+        let result = validate_query_fields(org_id, "default", st, sql).await;
+
+        {
+            let mut w = STREAM_SCHEMAS_LATEST.write().await;
+            w.remove(&key_default);
+            w.remove(&key_k8s);
+        }
+        {
+            let mut w = STREAM_SETTINGS.write().await;
+            w.remove(&key_default);
+            w.remove(&key_k8s);
+        }
+
+        // OLD code: body_type (k8s_events field) checked against default schema → Err
+        // FIXED:    only default's fields validated against default schema → Ok
+        assert!(
+            result.is_ok(),
+            "body_type belongs to k8s_events, not default — must not be rejected \
+             when validating the default stream. Got: {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Bug

Alert queries using SQL that joins two streams (CTE, direct JOIN, subquery, UNION) fail
validation with a false `SearchFieldNotFound (20004)` error — even though the same query
runs fine in Logs UI.

**Example error:**
```
Search field not found: body_type. Field not found in stream schema.
```

The query works in `_search` / `_search_stream` but fails when alerts calls
`_search?validate=true` or `_search_multi?validate=true` before saving.

---

## Root Cause

`validate_query_fields` in `src/handler/http/request/search/utils.rs` flattened fields
from **all** streams into one set, then validated every field against the schema of the
**single primary stream** passed in (`stream_name`).

For a query joining `default` + `k8s_events`, `body_type` (which lives only in
`k8s_events`) was checked against `default`'s schema — where it doesn't exist — producing
a false negative.

---

## Behaviour Diagram

### Before (broken)

```
SQL joining "default" + "k8s_events"
                │
                ▼
    Sql::new_with_options() — parses SQL, loads both schemas
                │
                ▼
          ColumnVisitor assigns fields per stream:
          ┌──────────────────────────────────────┐
          │ sql.columns                          │
          │  "default"    → {k8s_pod_name, ...}  │
          │  "k8s_events" → {body_type, ...}     │
          └──────────────────────────────────────┘
                │
                ▼  ← BUG
    flatten ALL streams into one set
    {k8s_pod_name, body_type, event_name, ...}
                │
                ▼
    validate every field against "default" schema only
                │
        ┌───────┴────────┐
        │                │
   k8s_pod_name ✅   body_type ❌  ← only in k8s_events
                         │
                         ▼
            SearchFieldNotFound (20004)
```

### After (fixed)

```
SQL joining "default" + "k8s_events"
                │
                ▼
    Sql::new_with_options() — parses SQL, loads both schemas
                │
                ▼
          ColumnVisitor assigns fields per stream:
          ┌──────────────────────────────────────┐
          │ sql.columns                          │
          │  "default"    → {k8s_pod_name, ...}  │
          │  "k8s_events" → {body_type, ...}     │
          └──────────────────────────────────────┘
                │
                ▼
    find entry where stream_name == "default"
    target_fields = {k8s_pod_name, ...}
                │
                ▼
    validate ONLY "default" fields against "default" schema
                │
        ┌───────┴────────┐
        │                │
   k8s_pod_name ✅   body_type → not in target_fields, skipped ✅
                │
                ▼
              Ok(())
```

---

## Affected Query Shapes

All four patterns hit the same bug — any SQL that produces `sql.columns` with keys for
more than one stream:

```sql
-- CTE + JOIN
WITH x AS (SELECT ... FROM "default") SELECT b.body_type FROM "k8s_events" b JOIN x ...

-- Direct JOIN
SELECT a.col, b.body_type FROM "default" a JOIN "k8s_events" b ON ...

-- Subquery
SELECT col FROM "default" WHERE id IN (SELECT id FROM "k8s_events")

-- UNION
SELECT col FROM "default" UNION SELECT body_type FROM "k8s_events"
```

---

## How `validate_query_fields` is meant to behave

The function validates **one stream at a time**. The handler calls it once per stream in
the request — full coverage comes from all the calls combined, not from a single call.

### `_search_multi` (multi-stream, correct path)

```
_search_multi?validate=true  with streams: ["default", "k8s_events"]
        │
        ├── validate_query_fields(org_id, "default",    sql)
        │       → checks default's fields ✅
        │       → body_type skipped (belongs to k8s_events) ✅
        │
        └── validate_query_fields(org_id, "k8s_events", sql)
                → checks k8s_events' fields including body_type ✅
```

Every stream's fields are validated against their own schema. No false rejections, no gaps.

### `_search` (single-stream endpoint)

```
_search?validate=true  (primary stream: "default")
        │
        └── validate_query_fields(org_id, "default", sql)
                → checks default's fields ✅
                → body_type skipped (belongs to k8s_events) ✅
                → k8s_events fields: not checked ⚠️
```

`k8s_events` fields go unvalidated at pre-check time. This is a **pre-existing
limitation**, not introduced by this fix. Runtime execution (DataFusion) still validates
them — if `body_type` doesn't exist in `k8s_events` at query time, the query fails then
with a clear error. `_search_multi` is the correct API for multi-stream queries and
provides full pre-validation coverage.

### `_search_stream`

Never calls `validate_query_fields` — goes straight to execution. Multi-stream joins
work because DataFusion resolves all streams at runtime.

---

## Fix

Look up the `sql.columns` entry that matches `stream_name` and validate only that
stream's fields against its own schema. Fields from other streams in the query are
validated separately when the handler calls `validate_query_fields` for each stream.

```rust
// Before
let used_fields: HashSet<String> = sql.columns.values().flatten().cloned().collect();

// After
let (target_stream, target_fields) = sql
    .stream_names
    .iter()
    .find(|r| r.stream_name() == stream_name)
    .map(|r| {
        let fields = sql.columns.get(r).cloned().unwrap_or_default();
        (stream_name.to_string(), fields)
    })
    .unwrap_or_else(|| {
        // fallback: aliased or unresolved table — original behaviour
        let fields = sql.columns.values().flatten().cloned().collect();
        (stream_name.to_string(), fields)
    });
```

**File:** `src/handler/http/request/search/utils.rs` — `validate_query_fields()`

---

## Tests

Added `test_cte_multi_stream_regression` module in `utils.rs`:

- `test_cte_join_cross_stream_field_not_rejected` — regression test for the exact bug:
  sets up `default` schema (no `body_type`) + `k8s_events` schema (has `body_type`),
  runs a CTE join query, asserts `validate_query_fields` returns `Ok(())` for `default`.
  Fails on old code, passes after fix.
