### PR TITLE
fix: disable partitioning for ORDER BY on non-timestamp column

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1559,6 +1559,8 @@ pub struct Limit {
     pub query_values_default_num: i64,
     #[env_config(name = "ZO_QUERY_PARTITION_BY_SECS", default = 1)] // seconds
     pub query_partition_by_secs: usize,
+    #[env_config(name = "ZO_DISABLE_PARTITIONS_FOR_NON_TS_ORDER_BY", default = false)]
+    pub disable_partitions_for_non_ts_order_by: bool,
     #[env_config(name = "ZO_QUERY_GROUP_BASE_SPEED", default = 768)] // MB/s/core
     pub query_group_base_speed: usize,
     // Default Config: Run Query Recommendation Analysis for last one hour for every hour

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -946,7 +946,7 @@ pub async fn search_partition(
     if part_num * cfg.limit.query_partition_by_secs < total_secs {
         part_num += 1;
     }
-    
+
     // if the partition number is too large, we limit it to 1000
     if part_num > 1000 {
         part_num = 1000;

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -946,6 +946,7 @@ pub async fn search_partition(
     if part_num * cfg.limit.query_partition_by_secs < total_secs {
         part_num += 1;
     }
+    part_num = 3;
     // if the partition number is too large, we limit it to 1000
     if part_num > 1000 {
         part_num = 1000;
@@ -1017,7 +1018,7 @@ pub async fn search_partition(
             .first()
             .map(|(field, _)| {
                 field.as_str() != TIMESTAMP_COL_NAME
-                    && ts_column.as_deref().map_or(true, |ts| field.as_str() != ts)
+                    && (ts_column.as_deref() != Some(field.as_str()))
             })
             .unwrap_or(false)
     {

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -1009,6 +1009,25 @@ pub async fn search_partition(
         })
         .unwrap_or(OrderBy::Desc);
 
+    if cfg.limit.disable_partitions_for_non_ts_order_by
+        && !is_aggregate
+        && !is_histogram
+        && sql
+            .order_by
+            .first()
+            .map(|(field, _)| {
+                field.as_str() != TIMESTAMP_COL_NAME
+                    && ts_column.as_deref().map_or(true, |ts| field.as_str() != ts)
+            })
+            .unwrap_or(false)
+    {
+        log::info!(
+            "[trace_id {trace_id}] search_partition: ORDER BY on non-timestamp column, disabling partitioning"
+        );
+        resp.partitions = vec![[req.start_time, req.end_time]];
+        return Ok(resp);
+    }
+
     log::debug!(
         "[trace_id {trace_id}] total_secs: {}, partition_num: {}, step: {}, min_step: {}, is_histogram: {}",
         total_secs,

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -946,7 +946,7 @@ pub async fn search_partition(
     if part_num * cfg.limit.query_partition_by_secs < total_secs {
         part_num += 1;
     }
-    part_num = 3;
+    
     // if the partition number is too large, we limit it to 1000
     if part_num > 1000 {
         part_num = 1000;


### PR DESCRIPTION
When ORDER BY is on a non-timestamp column (e.g. duration), each partition returns its own local top-N rows. Merging those produces incorrect global sort order since globally highest values may not appear in any partition's local top-N.

Add `ZO_DISABLE_PARTITIONS_FOR_NON_TS_ORDER_BY` env var (default false). When true, non-aggregate non-histogram queries with ORDER BY on a non-timestamp field return a single full-range partition instead.