### PR TITLE
fix: split metrics into Node, Pod, Network, and Other tabs in Traces

### DIFF
--- a/web/src/locales/languages/de.json
+++ b/web/src/locales/languages/de.json
@@ -3274,7 +3274,8 @@
     "metricsErrorDetails": "Beim Abrufen der Metrikdaten ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
     "noMetricsDescription": "Für diese Korrelation wurden im ausgewählten Zeitraum keine Metriken gefunden.",
     "errorRetrievingTraces": "Beim Abrufen der Spuren ist ein Fehler aufgetreten.",
-    "serviceGroupProtected": "Die Dienstgruppe kann nicht entfernt werden. Sie können nur die zugewiesenen Felder ändern."
+    "serviceGroupProtected": "Die Dienstgruppe kann nicht entfernt werden. Sie können nur die zugewiesenen Felder ändern.",
+    "noDataFound": "Keine Daten gefunden"
   },
   "sreChat": {
     "emptyMessage": "Fragen Sie mich alles über Ihre Warnungen und Vorfälle",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -3412,6 +3412,7 @@
     },
     "loadingLogs": "Loading logs...",
     "noLogsFound": "No Logs Found",
+    "noDataFound": "No Data Found",
     "noLogsDescription": "No logs found for this correlation in the selected time range.",
     "service": "Service: {service}",
     "tracesPlaceholder": "Traces will be implemented here",

--- a/web/src/locales/languages/es.json
+++ b/web/src/locales/languages/es.json
@@ -3272,7 +3272,8 @@
     "metricsErrorDetails": "Se ha producido un error al obtener los datos de las métricas. Por favor, inténtalo de nuevo.",
     "noMetricsDescription": "No se han encontrado métricas para esta correlación en el intervalo de tiempo seleccionado.",
     "errorRetrievingTraces": "Se ha producido un error al recuperar los rastros.",
-    "serviceGroupProtected": "No se puede eliminar el grupo de servicios. Solo puede modificar los campos mapeados."
+    "serviceGroupProtected": "No se puede eliminar el grupo de servicios. Solo puede modificar los campos mapeados.",
+    "noDataFound": "No se han encontrado datos"
   },
   "sreChat": {
     "emptyMessage": "Pregúntame cualquier cosa sobre tus alertas e incidencias",

--- a/web/src/locales/languages/fr.json
+++ b/web/src/locales/languages/fr.json
@@ -3274,7 +3274,8 @@
     "metricsErrorDetails": "Une erreur s'est produite lors de la récupération des données des métriques. Veuillez réessayer.",
     "noMetricsDescription": "Aucune métrique n'a été trouvée pour cette corrélation dans la plage de temps sélectionnée.",
     "errorRetrievingTraces": "Une erreur s'est produite lors de la récupération des traces.",
-    "serviceGroupProtected": "Le groupe de services ne peut pas être supprimé. Vous ne pouvez modifier que les champs mappés."
+    "serviceGroupProtected": "Le groupe de services ne peut pas être supprimé. Vous ne pouvez modifier que les champs mappés.",
+    "noDataFound": "Aucune donnée trouvée"
   },
   "sreChat": {
     "emptyMessage": "Demandez-moi tout ce que vous voulez savoir sur vos alertes et incidents",

--- a/web/src/locales/languages/it.json
+++ b/web/src/locales/languages/it.json
@@ -3283,7 +3283,8 @@
     "metricsErrorDetails": "Si è verificato un errore durante il recupero dei dati delle metriche. Riprova.",
     "noMetricsDescription": "Nessuna metrica trovata per questa correlazione nell'intervallo di tempo selezionato.",
     "errorRetrievingTraces": "Si è verificato un errore durante il recupero delle tracce.",
-    "serviceGroupProtected": "Il gruppo di servizi non può essere rimosso. È possibile modificare solo i campi mappati."
+    "serviceGroupProtected": "Il gruppo di servizi non può essere rimosso. È possibile modificare solo i campi mappati.",
+    "noDataFound": "Nessun dato trovato"
   },
   "sreChat": {
     "emptyMessage": "Chiedimi qualcosa sui tuoi avvisi e incidenti",

--- a/web/src/locales/languages/ja.json
+++ b/web/src/locales/languages/ja.json
@@ -3274,7 +3274,8 @@
     "metricsErrorDetails": "メトリックスデータの取得中にエラーが発生しました。もう一度試してください。",
     "noMetricsDescription": "選択した時間範囲では、この相関の指標は見つかりませんでした。",
     "errorRetrievingTraces": "トレースの取得中にエラーが発生しました。",
-    "serviceGroupProtected": "サービスグループは削除できません。変更できるのはマップされたフィールドだけです。"
+    "serviceGroupProtected": "サービスグループは削除できません。変更できるのはマップされたフィールドだけです。",
+    "noDataFound": "データが見つかりません"
   },
   "sreChat": {
     "emptyMessage": "アラートやインシデントについて何でも聞いてください",

--- a/web/src/locales/languages/ko.json
+++ b/web/src/locales/languages/ko.json
@@ -3285,7 +3285,8 @@
     "metricsErrorDetails": "지표 데이터를 가져오는 동안 오류가 발생했습니다.다시 시도해 주세요.",
     "noMetricsDescription": "선택한 시간 범위에서 이 상관 관계에 대한 메트릭을 찾을 수 없습니다.",
     "errorRetrievingTraces": "추적을 가져오는 동안 오류가 발생했습니다.",
-    "serviceGroupProtected": "서비스 그룹은 제거할 수 없습니다.매핑된 필드만 수정할 수 있습니다."
+    "serviceGroupProtected": "서비스 그룹은 제거할 수 없습니다.매핑된 필드만 수정할 수 있습니다.",
+    "noDataFound": "데이터를 찾을 수 없음"
   },
   "sreChat": {
     "emptyMessage": "경고 및 사고에 대해 무엇이든 물어보세요.",

--- a/web/src/locales/languages/nl.json
+++ b/web/src/locales/languages/nl.json
@@ -3285,7 +3285,8 @@
     "metricsErrorDetails": "Er is een fout opgetreden tijdens het ophalen van metrische gegevens. Probeer het nog eens.",
     "noMetricsDescription": "Er zijn geen statistieken gevonden voor deze correlatie in het geselecteerde tijdbereik.",
     "errorRetrievingTraces": "Er is een fout opgetreden bij het ophalen van sporen.",
-    "serviceGroupProtected": "De servicegroep kan niet worden verwijderd. U kunt alleen de toegewezen velden wijzigen."
+    "serviceGroupProtected": "De servicegroep kan niet worden verwijderd. U kunt alleen de toegewezen velden wijzigen.",
+    "noDataFound": "Geen gegevens gevonden"
   },
   "sreChat": {
     "emptyMessage": "Vraag me alles over je meldingen en incidenten",

--- a/web/src/locales/languages/pt.json
+++ b/web/src/locales/languages/pt.json
@@ -3274,7 +3274,8 @@
     "metricsErrorDetails": "Ocorreu um erro ao buscar dados de métricas. Por favor, tente novamente.",
     "noMetricsDescription": "Nenhuma métrica encontrada para essa correlação no intervalo de tempo selecionado.",
     "errorRetrievingTraces": "Ocorreu um erro ao recuperar os traços.",
-    "serviceGroupProtected": "O grupo de serviços não pode ser removido. Você só pode modificar os campos mapeados."
+    "serviceGroupProtected": "O grupo de serviços não pode ser removido. Você só pode modificar os campos mapeados.",
+    "noDataFound": "Nenhum dado encontrado"
   },
   "sreChat": {
     "emptyMessage": "Pergunte-me qualquer coisa sobre seus alertas e incidentes",

--- a/web/src/locales/languages/tr.json
+++ b/web/src/locales/languages/tr.json
@@ -3285,7 +3285,8 @@
     "metricsErrorDetails": "Metrik verileri alınırken bir hata oluştu. Lütfen tekrar deneyin.",
     "noMetricsDescription": "Seçilen zaman aralığında bu korelasyon için hiçbir metrik bulunamadı.",
     "errorRetrievingTraces": "İzler alınırken hata oluştu.",
-    "serviceGroupProtected": "Hizmet grubu kaldırılamaz. Yalnızca eşlenen alanları değiştirebilirsiniz."
+    "serviceGroupProtected": "Hizmet grubu kaldırılamaz. Yalnızca eşlenen alanları değiştirebilirsiniz.",
+    "noDataFound": "Veri Bulunamadı"
   },
   "sreChat": {
     "emptyMessage": "Uyarılarınız ve olaylarınız hakkında bana herhangi bir şey sorun",

--- a/web/src/locales/languages/zh.json
+++ b/web/src/locales/languages/zh.json
@@ -3278,7 +3278,8 @@
     "metricsErrorDetails": "获取指标数据时出错。请再试一次。",
     "noMetricsDescription": "在所选时间范围内未找到此关联的指标。",
     "errorRetrievingTraces": "检索跟踪时出错。",
-    "serviceGroupProtected": "无法删除服务组。您只能修改映射的字段。"
+    "serviceGroupProtected": "无法删除服务组。您只能修改映射的字段。",
+    "noDataFound": "未找到任何数据"
   },
   "sreChat": {
     "emptyMessage": "向我询问有关您的告警和事件的任何信息",

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
@@ -1264,6 +1264,7 @@ import {
 import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import {
   groupMetricsByCategory,
+  getDefaultMetricSelections,
   type MetricGroupDefinition,
   DEFAULT_METRIC_GROUP_DEFINITIONS,
 } from "@/utils/metrics/metricGrouping";
@@ -1591,11 +1592,18 @@ const uniqueMetricStreams = computed(() => {
   return getUniqueStreams(props.metricStreams);
 });
 
-// Selected metric streams (default to first 6 unique streams)
-// Apply SELECT_ALL_VALUE defaults for unstable dimensions
+// Selected metric streams — prefer curated defaults from group definitions,
+// fall back to first 6 unique streams for non-OTel deployments.
+// Apply SELECT_ALL_VALUE defaults for unstable dimensions.
 const selectedMetricStreams = ref<StreamInfo[]>(
   applyUnstableDimensionDefaults(
-    getUniqueStreams(props.metricStreams).slice(0, 6),
+    (() => {
+      const unique = getUniqueStreams(props.metricStreams);
+      const defs =
+        props.metricGroupDefinitions ?? DEFAULT_METRIC_GROUP_DEFINITIONS;
+      const defaults = getDefaultMetricSelections(defs, unique);
+      return defaults.length > 0 ? defaults : unique.slice(0, 6);
+    })(),
   ),
 );
 

--- a/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
+++ b/web/src/plugins/correlation/TelemetryCorrelationDashboard.vue
@@ -200,7 +200,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               >
                 <!-- Search -->
                 <div
-                  class="tw:p-[0.625rem] tw:border-b tw:border-solid tw:border-[var(--o2-border-color)]"
+                  class="dimension-sidebar-search-container tw:p-[0.625rem] tw:border-b tw:border-solid tw:border-[var(--o2-border-color)]"
                 >
                   <q-input
                     v-model="metricSearchText"
@@ -702,7 +702,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             >
               <!-- Search -->
               <div
-                class="tw:p-[0.625rem] tw:border-b tw:border-solid tw:border-[var(--o2-border-color)]"
+                class="dimension-sidebar-search-container tw:p-[0.625rem] tw:border-b tw:border-solid tw:border-[var(--o2-border-color)]"
               >
                 <q-input
                   v-model="metricSearchText"
@@ -1563,7 +1563,9 @@ const applyUnstableDimensionDefaults = (
     const notMatchedKeys: string[] = [];
 
     // For each filter in the stream, check if it maps to an unstable dimension
-    for (const [filterKey, filterValue] of Object.entries(stream.filters ?? {})) {
+    for (const [filterKey, filterValue] of Object.entries(
+      stream.filters ?? {},
+    )) {
       // Look up the semantic dimension ID for this field name
       const dimensionId = fieldToDimensionId.get(filterKey);
 
@@ -1893,7 +1895,9 @@ const applyDimensionChanges = () => {
 
     // For each filter in the stream, find its semantic dimension ID
     // and update with the new value from activeDimensions
-    for (const [filterKey, _filterValue] of Object.entries(stream.filters ?? {})) {
+    for (const [filterKey, _filterValue] of Object.entries(
+      stream.filters ?? {},
+    )) {
       const dimensionId = fieldToDimensionId.get(filterKey);
       if (dimensionId && activeDimensions.value[dimensionId] !== undefined) {
         const newValue = activeDimensions.value[dimensionId];

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
@@ -617,6 +617,34 @@ describe("ServiceGraphNodeSidePanel", () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // metricGroupResources ref
+  // -------------------------------------------------------------------------
+
+  describe("metricGroupResources", () => {
+    beforeEach(() => {
+      wrapper = mountPanel();
+    });
+
+    it("should expose exactly 3 metric group entries", () => {
+      expect(wrapper.vm.metricGroupResources).toHaveLength(3);
+    });
+
+    it("should have IDs in order: pods, nodes, others", () => {
+      const ids = wrapper.vm.metricGroupResources.map(
+        (g: { id: string }) => g.id,
+      );
+      expect(ids).toEqual(["pods", "nodes", "others"]);
+    });
+
+    it("should have the expected id and label for each group", () => {
+      const groups = wrapper.vm.metricGroupResources;
+      expect(groups[0]).toMatchObject({ id: "pods", label: "Pods" });
+      expect(groups[1]).toMatchObject({ id: "nodes", label: "Nodes" });
+      expect(groups[2]).toMatchObject({ id: "others", label: "Others" });
+    });
+  });
+
   describe("viewRelatedLogs — valid logs stream found", () => {
     beforeEach(() => {
       vi.mocked(correlateStreams).mockResolvedValue({

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
@@ -626,22 +626,23 @@ describe("ServiceGraphNodeSidePanel", () => {
       wrapper = mountPanel();
     });
 
-    it("should expose exactly 3 metric group entries", () => {
-      expect(wrapper.vm.metricGroupResources).toHaveLength(3);
+    it("should expose exactly 4 metric group entries", () => {
+      expect(wrapper.vm.metricGroupResources).toHaveLength(4);
     });
 
-    it("should have IDs in order: pods, nodes, others", () => {
+    it("should have IDs in order: pods, nodes, network, others", () => {
       const ids = wrapper.vm.metricGroupResources.map(
         (g: { id: string }) => g.id,
       );
-      expect(ids).toEqual(["pods", "nodes", "others"]);
+      expect(ids).toEqual(["pods", "nodes", "network", "others"]);
     });
 
     it("should have the expected id and label for each group", () => {
       const groups = wrapper.vm.metricGroupResources;
       expect(groups[0]).toMatchObject({ id: "pods", label: "Pods" });
       expect(groups[1]).toMatchObject({ id: "nodes", label: "Nodes" });
-      expect(groups[2]).toMatchObject({ id: "others", label: "Others" });
+      expect(groups[2]).toMatchObject({ id: "network", label: "Network" });
+      expect(groups[3]).toMatchObject({ id: "others", label: "Others" });
     });
   });
 

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -974,6 +974,7 @@ export default defineComponent({
     const metricGroupResources = ref<MetricGroupDefinition[]>([
       { id: "pods", label: "Pods", icon: DeployedCode },
       { id: "nodes", label: "Nodes", icon: "dns" },
+      { id: "network", label: "Network", icon: "wifi" },
       { id: "others", label: "Others", icon: "category" },
     ]);
 

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -646,7 +646,10 @@ import {
 } from "@/utils/zincutils";
 import { convertDashboardSchemaVersion } from "@/utils/dashboard/convertDashboardSchemaVersion";
 import metrics from "./metrics/metrics.json";
-import { type MetricGroupDefinition } from "@/utils/metrics/metricGrouping";
+import {
+  type MetricGroupDefinition,
+  K8S_METRIC_GROUP_DEFINITIONS,
+} from "@/utils/metrics/metricGrouping";
 import DeployedCode from "@/components/icons/DeployedCode.vue";
 import { useI18n } from "vue-i18n";
 
@@ -968,15 +971,14 @@ export default defineComponent({
       navigateToTraces({ errorsOnly, minDurationMicros, maxDurationMicros });
     };
 
-    // Metric group definitions — controls which category tabs appear in the metrics dashboard.
-    // Defaults to pods + nodes + others for service-graph workloads. Consumers can extend
-    // this list by pushing entries whose ids are registered in METRIC_GROUP_PATTERNS.
-    const metricGroupResources = ref<MetricGroupDefinition[]>([
-      { id: "pods", label: "Pods", icon: DeployedCode },
-      { id: "nodes", label: "Nodes", icon: "dns" },
-      { id: "network", label: "Network", icon: "wifi" },
-      { id: "others", label: "Others", icon: "category" },
-    ]);
+    // Metric group definitions — controls which category tabs and default selections
+    // appear in the metrics dashboard. Uses K8S_METRIC_GROUP_DEFINITIONS for OTel
+    // semantic defaults; overrides the pods icon with the project-specific component.
+    const metricGroupResources = ref<MetricGroupDefinition[]>(
+      K8S_METRIC_GROUP_DEFINITIONS.map((g) =>
+        g.id === "pods" ? { ...g, icon: DeployedCode } : g,
+      ),
+    );
 
     // Metrics Correlation State
     const showTelemetryDialog = ref(false);

--- a/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
+++ b/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
@@ -28,7 +28,9 @@ import { installQuasar } from "@/test/unit/helpers/install-quasar-plugin";
 import * as quasar from "quasar";
 
 vi.mock("@/utils/traces/convertTraceData", () => ({
-  getServiceIconDataUrl: vi.fn().mockReturnValue("data:image/svg+xml;base64,ICON"),
+  getServiceIconDataUrl: vi
+    .fn()
+    .mockReturnValue("data:image/svg+xml;base64,ICON"),
 }));
 
 vi.mock("@/composables/useTraces", () => ({
@@ -264,9 +266,9 @@ describe("TraceDetailsSidebar", async () => {
 
     it("should call getServiceIconDataUrl with the span service name", () => {
       expect(
-        vi.mocked(getServiceIconDataUrl).mock.calls.some(
-          (call) => call[0] === mockSpan.service_name,
-        ),
+        vi
+          .mocked(getServiceIconDataUrl)
+          .mock.calls.some((call) => call[0] === mockSpan.service_name),
       ).toBe(true);
     });
   });
@@ -442,7 +444,9 @@ describe("TraceDetailsSidebar", async () => {
         '[data-test="trace-details-sidebar-attributes-table"]',
       );
       expect(attributesTable.exists()).toBe(true);
-      expect(attributesTable.text()).toContain("dev2-openobserve-alertmanager-1");
+      expect(attributesTable.text()).toContain(
+        "dev2-openobserve-alertmanager-1",
+      );
     });
   });
 
@@ -977,7 +981,7 @@ describe("TraceDetailsSidebar", async () => {
       correlationWrapper?.unmount();
     });
 
-    it("should set correlationError to noLogsFound message when findRelatedTelemetry returns null", async () => {
+    it("should set correlationError to noDataFound message when findRelatedTelemetry returns null", async () => {
       const metricsTab = correlationWrapper.find(
         '[data-test="trace-details-sidebar-tabs-correlated-metrics"]',
       );

--- a/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
+++ b/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
@@ -986,7 +986,7 @@ describe("TraceDetailsSidebar", async () => {
       await metricsTab.trigger("click");
       await flushPromises();
 
-      expect(correlationWrapper.vm.correlationError).toContain("No Logs Found");
+      expect(correlationWrapper.vm.correlationError).toContain("No Data Found");
     });
   });
 

--- a/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
+++ b/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
@@ -39,6 +39,19 @@ vi.mock("@/composables/useTraces", () => ({
   }),
 }));
 
+vi.mock("@/aws-exports", () => ({
+  default: {
+    isEnterprise: "true",
+    isCloud: "false",
+  },
+}));
+
+vi.mock("@/composables/useServiceCorrelation", () => ({
+  useServiceCorrelation: () => ({
+    findRelatedTelemetry: vi.fn().mockResolvedValue(null),
+  }),
+}));
+
 import { getServiceIconDataUrl } from "@/utils/traces/convertTraceData";
 import TraceDetailsSidebar from "@/plugins/traces/TraceDetailsSidebar.vue";
 import i18n from "@/locales";
@@ -919,6 +932,61 @@ describe("TraceDetailsSidebar", async () => {
       expect(Array.isArray(newWrapper.vm.spanLinks)).toBe(true);
 
       newWrapper.unmount();
+    });
+  });
+
+  describe("correlateForMetrics — no data found", () => {
+    let correlationWrapper: any;
+
+    beforeEach(async () => {
+      correlationWrapper = mount(TraceDetailsSidebar, {
+        attachTo: "#app",
+        props: {
+          span: mockSpan,
+          baseTracePosition: mockBaseTracePosition,
+          searchQuery: "",
+          streamName: "default",
+          serviceStreamsEnabled: true,
+        },
+        global: {
+          plugins: [i18n, router],
+          provide: {
+            store: mockStore,
+          },
+          stubs: {
+            "q-resize-observer": true,
+            "q-virtual-scroll": {
+              template: `
+                <div>
+                  <slot name="before"></slot>
+                  <div v-for="(item, index) in items" :key="index">
+                    <slot :item="item" :index="index"></slot>
+                  </div>
+                </div>
+              `,
+              props: ["items"],
+            },
+          },
+        },
+      });
+
+      await correlationWrapper.vm.$nextTick();
+    });
+
+    afterEach(() => {
+      correlationWrapper?.unmount();
+    });
+
+    it("should set correlationError to noLogsFound message when findRelatedTelemetry returns null", async () => {
+      const metricsTab = correlationWrapper.find(
+        '[data-test="trace-details-sidebar-tabs-correlated-metrics"]',
+      );
+      expect(metricsTab.exists()).toBe(true);
+
+      await metricsTab.trigger("click");
+      await flushPromises();
+
+      expect(correlationWrapper.vm.correlationError).toContain("No Logs Found");
     });
   });
 

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -915,6 +915,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :fts-fields="correlationProps.ftsFields"
           :time-range="correlationProps.timeRange"
           :hide-dimension-filters="true"
+          :metric-group-definitions="metricGroupResources"
           @close="activeTab = 'attributes'"
         />
         <!-- Loading/Empty state when no data -->
@@ -972,6 +973,8 @@ import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import type { TelemetryContext } from "@/utils/telemetryCorrelation";
 import config from "@/aws-exports";
 import { SPAN_KIND_MAP } from "@/utils/traces/constants";
+import { type MetricGroupDefinition } from "@/utils/metrics/metricGrouping";
+import DeployedCode from "@/components/icons/DeployedCode.vue";
 import { getServiceIconDataUrl } from "@/utils/traces/convertTraceData";
 import LLMContentRenderer from "@/plugins/traces/LLMContentRenderer.vue";
 import TenstackTable from "@/components/TenstackTable.vue";
@@ -1028,6 +1031,7 @@ export default defineComponent({
     EqualIcon,
     NotEqualIcon,
     AttributeValueCell,
+    DeployedCode,
   },
   emits: [
     "close",
@@ -1698,6 +1702,14 @@ export default defineComponent({
       }
     });
 
+    // Metric group definitions — controls which category tabs appear in the metrics dashboard.
+    const metricGroupResources = ref<MetricGroupDefinition[]>([
+      { id: "pods", label: "Pods", icon: DeployedCode },
+      { id: "nodes", label: "Nodes", icon: "dns" },
+      { id: "network", label: "Network", icon: "wifi" },
+      { id: "others", label: "Others", icon: "category" },
+    ]);
+
     // Correlation state
     const correlationLoading = ref(false);
     const correlationError = ref<string | null>(null);
@@ -2133,6 +2145,7 @@ export default defineComponent({
       correlationLoading,
       correlationError,
       correlationProps,
+      metricGroupResources,
       config,
       // LLM
       isLLMSpan,

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -916,6 +916,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :time-range="correlationProps.timeRange"
           :hide-dimension-filters="true"
           :metric-group-definitions="metricGroupResources"
+          :panelHeight="12"
+          :panelWidth="96"
           @close="activeTab = 'attributes'"
         />
         <!-- Loading/Empty state when no data -->
@@ -973,7 +975,10 @@ import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import type { TelemetryContext } from "@/utils/telemetryCorrelation";
 import config from "@/aws-exports";
 import { SPAN_KIND_MAP } from "@/utils/traces/constants";
-import { type MetricGroupDefinition } from "@/utils/metrics/metricGrouping";
+import {
+  type MetricGroupDefinition,
+  K8S_METRIC_GROUP_DEFINITIONS,
+} from "@/utils/metrics/metricGrouping";
 import DeployedCode from "@/components/icons/DeployedCode.vue";
 import { getServiceIconDataUrl } from "@/utils/traces/convertTraceData";
 import LLMContentRenderer from "@/plugins/traces/LLMContentRenderer.vue";
@@ -1702,13 +1707,14 @@ export default defineComponent({
       }
     });
 
-    // Metric group definitions — controls which category tabs appear in the metrics dashboard.
-    const metricGroupResources = ref<MetricGroupDefinition[]>([
-      { id: "pods", label: "Pods", icon: DeployedCode },
-      { id: "nodes", label: "Nodes", icon: "dns" },
-      { id: "network", label: "Network", icon: "wifi" },
-      { id: "others", label: "Others", icon: "category" },
-    ]);
+    // Metric group definitions — controls which category tabs and default selections
+    // appear in the metrics dashboard. Uses K8S_METRIC_GROUP_DEFINITIONS for OTel
+    // semantic defaults; overrides the pods icon with the project-specific component.
+    const metricGroupResources = ref<MetricGroupDefinition[]>(
+      K8S_METRIC_GROUP_DEFINITIONS.map((g) =>
+        g.id === "pods" ? { ...g, icon: DeployedCode } : g,
+      ),
+    );
 
     // Correlation state
     const correlationLoading = ref(false);

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -883,7 +883,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             />
             <div
               v-else-if="correlationError"
-              class="tw:text-base tw:text-red-500"
+              class="tw:text-base tw:text-[0.875rem] tw:font-bold"
             >
               {{ correlationError }}
             </div>
@@ -937,7 +937,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             />
             <div
               v-else-if="correlationError"
-              class="tw:text-base tw:text-red-500"
+              class="tw:text-base tw:text-[0.875rem] tw:font-bold"
             >
               {{ correlationError }}
             </div>
@@ -1900,7 +1900,7 @@ export default defineComponent({
             },
           };
         } else {
-          correlationError.value = t("correlation.noLogsFound");
+          correlationError.value = t("correlation.noDataFound");
         }
       } catch (err: any) {
         console.error("[TraceDetailsSidebar] Correlation failed:", err);
@@ -2177,6 +2177,23 @@ export default defineComponent({
 :deep(.traces-correlated-metrics-container) {
   .q-splitter--vertical .q-splitter__separator {
     height: 100% !important;
+  }
+
+  .q-card {
+    box-shadow: none !important;
+    border: 1px solid var(--o2-border) !important;
+  }
+
+  .card-container {
+    box-shadow: none !important;
+  }
+
+  .dimension-sidebar {
+    padding-left: 0.25rem;
+  }
+
+  .dimension-sidebar-search-container {
+    padding: 0.375rem 0.2rem !important;
   }
 }
 

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -883,7 +883,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             />
             <div
               v-else-if="correlationError"
-              class="tw:text-base tw:text-[0.875rem] tw:font-bold"
+              class="tw:text-[0.875rem] tw:font-bold tw:text-red-500"
             >
               {{ correlationError }}
             </div>
@@ -939,7 +939,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             />
             <div
               v-else-if="correlationError"
-              class="tw:text-base tw:text-[0.875rem] tw:font-bold"
+              class="tw:text-[0.875rem] tw:font-bold tw:text-red-500"
             >
               {{ correlationError }}
             </div>

--- a/web/src/utils/metrics/metricGrouping.spec.ts
+++ b/web/src/utils/metrics/metricGrouping.spec.ts
@@ -17,7 +17,9 @@ import { describe, it, expect } from "vitest";
 import {
   classifyMetric,
   groupMetricsByCategory,
+  getDefaultMetricSelections,
   DEFAULT_METRIC_GROUP_DEFINITIONS,
+  K8S_METRIC_GROUP_DEFINITIONS,
   type MetricGroupDefinition,
   type MetricGroupConfig,
 } from "./metricGrouping";
@@ -592,6 +594,186 @@ describe("groupMetricsByCategory — custom groupDefs", () => {
     const podsGroup = result.groups.find((g) => g.id === "pods");
     expect(podsGroup?.label).toBe("Pods");
     expect(podsGroup?.icon).toBe("bubble_chart");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// K8S_METRIC_GROUP_DEFINITIONS
+// ---------------------------------------------------------------------------
+
+describe("K8S_METRIC_GROUP_DEFINITIONS", () => {
+  it("should contain exactly 4 entries in order: pods, nodes, network, others", () => {
+    expect(K8S_METRIC_GROUP_DEFINITIONS).toHaveLength(4);
+    expect(K8S_METRIC_GROUP_DEFINITIONS.map((d) => d.id)).toEqual([
+      "pods",
+      "nodes",
+      "network",
+      "others",
+    ]);
+  });
+
+  it("should have label and icon for every entry", () => {
+    for (const def of K8S_METRIC_GROUP_DEFINITIONS) {
+      expect(def.label).toBeTruthy();
+      expect(def.icon).toBeTruthy();
+    }
+  });
+
+  it("should have defaultMetrics defined for pods, nodes, and network groups", () => {
+    const pods = K8S_METRIC_GROUP_DEFINITIONS.find((d) => d.id === "pods");
+    const nodes = K8S_METRIC_GROUP_DEFINITIONS.find((d) => d.id === "nodes");
+    const network = K8S_METRIC_GROUP_DEFINITIONS.find(
+      (d) => d.id === "network",
+    );
+    expect(pods?.defaultMetrics?.length).toBeGreaterThan(0);
+    expect(nodes?.defaultMetrics?.length).toBeGreaterThan(0);
+    expect(network?.defaultMetrics?.length).toBeGreaterThan(0);
+  });
+
+  it("should have no defaultMetrics on the others group", () => {
+    const others = K8S_METRIC_GROUP_DEFINITIONS.find((d) => d.id === "others");
+    expect(others?.defaultMetrics ?? []).toHaveLength(0);
+  });
+
+  it("should list all 6 expected pod CPU/memory stream names", () => {
+    const pods = K8S_METRIC_GROUP_DEFINITIONS.find((d) => d.id === "pods");
+    const names = pods!.defaultMetrics!.map((m) => m.streamName);
+    expect(names).toContain("k8s_pod_cpu_usage");
+    expect(names).toContain("k8s_pod_memory_usage");
+    expect(names).toContain("k8s_pod_cpu_request_utilization");
+    expect(names).toContain("k8s_pod_memory_request_utilization");
+    expect(names).toContain("k8s_pod_cpu_limit_utilization");
+    expect(names).toContain("k8s_pod_memory_limit_utilization");
+  });
+
+  it("should list k8s_node_cpu_usage and k8s_node_memory_rss in nodes defaults", () => {
+    const nodes = K8S_METRIC_GROUP_DEFINITIONS.find((d) => d.id === "nodes");
+    const names = nodes!.defaultMetrics!.map((m) => m.streamName);
+    expect(names).toContain("k8s_node_cpu_usage");
+    expect(names).toContain("k8s_node_memory_rss");
+  });
+
+  it("should have 4 network defaults with direction filters", () => {
+    const network = K8S_METRIC_GROUP_DEFINITIONS.find(
+      (d) => d.id === "network",
+    );
+    expect(network!.defaultMetrics).toHaveLength(4);
+    const receiveEntries = network!.defaultMetrics!.filter(
+      (m) => m.filters?.direction === "receive",
+    );
+    const transmitEntries = network!.defaultMetrics!.filter(
+      (m) => m.filters?.direction === "transmit",
+    );
+    expect(receiveEntries).toHaveLength(2);
+    expect(transmitEntries).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDefaultMetricSelections
+// ---------------------------------------------------------------------------
+
+describe("getDefaultMetricSelections", () => {
+  function makeStream(
+    stream_name: string,
+    filters: Record<string, string> = {},
+  ): StreamInfo {
+    return { stream_name, stream_type: "metrics", filters };
+  }
+
+  it("should return an empty array when no group has defaultMetrics", () => {
+    const defs: MetricGroupDefinition[] = [
+      { id: "others", label: "Others", icon: "category" },
+    ];
+    const streams = [makeStream("k8s_pod_cpu_usage")];
+    expect(getDefaultMetricSelections(defs, streams)).toEqual([]);
+  });
+
+  it("should return an empty array when none of the default streams are available", () => {
+    const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, []);
+    expect(result).toEqual([]);
+  });
+
+  it("should match a default metric by stream_name alone when no filters defined", () => {
+    const streams = [makeStream("k8s_pod_cpu_usage")];
+    const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, streams);
+    expect(result).toHaveLength(1);
+    expect(result[0].stream_name).toBe("k8s_pod_cpu_usage");
+  });
+
+  it("should match all 6 pod CPU/memory defaults when all are present", () => {
+    const podStreams = [
+      "k8s_pod_cpu_usage",
+      "k8s_pod_memory_usage",
+      "k8s_pod_cpu_request_utilization",
+      "k8s_pod_memory_request_utilization",
+      "k8s_pod_cpu_limit_utilization",
+      "k8s_pod_memory_limit_utilization",
+    ].map((n) => makeStream(n));
+    const result = getDefaultMetricSelections(
+      K8S_METRIC_GROUP_DEFINITIONS,
+      podStreams,
+    );
+    expect(result).toHaveLength(6);
+  });
+
+  it("should skip defaults whose stream_name is not in availableStreams", () => {
+    const streams = [makeStream("k8s_pod_cpu_usage")];
+    const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, streams);
+    // Only 1 of many defaults is available
+    expect(result).toHaveLength(1);
+    expect(result[0].stream_name).toBe("k8s_pod_cpu_usage");
+  });
+
+  it("should require all declared filters to match when filters are specified", () => {
+    const streams = [
+      makeStream("k8s_pod_network_io", { direction: "receive" }),
+      makeStream("k8s_pod_network_io", { direction: "transmit" }),
+    ];
+    const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, streams);
+    expect(result).toHaveLength(2);
+    const directions = result.map((s) => s.filters?.direction);
+    expect(directions).toContain("receive");
+    expect(directions).toContain("transmit");
+  });
+
+  it("should not match a stream when its filters do not satisfy the default config filters", () => {
+    // Only transmit is available; receive is declared as a default but absent
+    const streams = [makeStream("k8s_pod_network_io", { direction: "transmit" })];
+    const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, streams);
+    // Only transmit matches; receive default finds no match
+    const matched = result.filter((s) => s.stream_name === "k8s_pod_network_io");
+    expect(matched).toHaveLength(1);
+    expect(matched[0].filters?.direction).toBe("transmit");
+  });
+
+  it("should return streams in group definition order (pods → nodes → network)", () => {
+    const streams = [
+      makeStream("k8s_node_cpu_usage"),
+      makeStream("k8s_pod_cpu_usage"),
+      makeStream("k8s_pod_network_io", { direction: "receive" }),
+    ];
+    const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, streams);
+    expect(result[0].stream_name).toBe("k8s_pod_cpu_usage"); // pods group first
+    expect(result[1].stream_name).toBe("k8s_node_cpu_usage"); // nodes group second
+    expect(result[2].stream_name).toBe("k8s_pod_network_io"); // network group last
+  });
+
+  it("should return the same StreamInfo reference from availableStreams", () => {
+    const stream = makeStream("k8s_pod_cpu_usage");
+    const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, [stream]);
+    expect(result[0]).toBe(stream);
+  });
+
+  it("should not include duplicates when the same stream appears multiple times in availableStreams", () => {
+    const streams = [
+      makeStream("k8s_pod_cpu_usage"),
+      makeStream("k8s_pod_cpu_usage"),
+    ];
+    const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, streams);
+    // getDefaultMetricSelections uses Array.find — picks first match per default entry
+    const cpuMatches = result.filter((s) => s.stream_name === "k8s_pod_cpu_usage");
+    expect(cpuMatches).toHaveLength(1);
   });
 });
 

--- a/web/src/utils/metrics/metricGrouping.spec.ts
+++ b/web/src/utils/metrics/metricGrouping.spec.ts
@@ -619,15 +619,13 @@ describe("K8S_METRIC_GROUP_DEFINITIONS", () => {
     }
   });
 
-  it("should have defaultMetrics defined for pods, nodes, and network groups", () => {
+  it("should have defaultMetrics defined for pods and nodes but not for network", () => {
     const pods = K8S_METRIC_GROUP_DEFINITIONS.find((d) => d.id === "pods");
     const nodes = K8S_METRIC_GROUP_DEFINITIONS.find((d) => d.id === "nodes");
-    const network = K8S_METRIC_GROUP_DEFINITIONS.find(
-      (d) => d.id === "network",
-    );
+    const network = K8S_METRIC_GROUP_DEFINITIONS.find((d) => d.id === "network");
     expect(pods?.defaultMetrics?.length).toBeGreaterThan(0);
     expect(nodes?.defaultMetrics?.length).toBeGreaterThan(0);
-    expect(network?.defaultMetrics?.length).toBeGreaterThan(0);
+    expect(network?.defaultMetrics ?? []).toHaveLength(0);
   });
 
   it("should have no defaultMetrics on the others group", () => {
@@ -635,7 +633,7 @@ describe("K8S_METRIC_GROUP_DEFINITIONS", () => {
     expect(others?.defaultMetrics ?? []).toHaveLength(0);
   });
 
-  it("should list all 6 expected pod CPU/memory stream names", () => {
+  it("should list all 6 pod CPU/memory metrics and pod network IO in pods defaults", () => {
     const pods = K8S_METRIC_GROUP_DEFINITIONS.find((d) => d.id === "pods");
     const names = pods!.defaultMetrics!.map((m) => m.streamName);
     expect(names).toContain("k8s_pod_cpu_usage");
@@ -644,28 +642,23 @@ describe("K8S_METRIC_GROUP_DEFINITIONS", () => {
     expect(names).toContain("k8s_pod_memory_request_utilization");
     expect(names).toContain("k8s_pod_cpu_limit_utilization");
     expect(names).toContain("k8s_pod_memory_limit_utilization");
+    expect(names).toContain("k8s_pod_network_io");
   });
 
-  it("should list k8s_node_cpu_usage and k8s_node_memory_rss in nodes defaults", () => {
+  it("should list k8s_node_cpu_usage, k8s_node_memory_rss, and k8s_node_network_io in nodes defaults", () => {
     const nodes = K8S_METRIC_GROUP_DEFINITIONS.find((d) => d.id === "nodes");
     const names = nodes!.defaultMetrics!.map((m) => m.streamName);
     expect(names).toContain("k8s_node_cpu_usage");
     expect(names).toContain("k8s_node_memory_rss");
+    expect(names).toContain("k8s_node_network_io");
   });
 
-  it("should have 4 network defaults with direction filters", () => {
-    const network = K8S_METRIC_GROUP_DEFINITIONS.find(
-      (d) => d.id === "network",
-    );
-    expect(network!.defaultMetrics).toHaveLength(4);
-    const receiveEntries = network!.defaultMetrics!.filter(
-      (m) => m.filters?.direction === "receive",
-    );
-    const transmitEntries = network!.defaultMetrics!.filter(
-      (m) => m.filters?.direction === "transmit",
-    );
-    expect(receiveEntries).toHaveLength(2);
-    expect(transmitEntries).toHaveLength(2);
+  it("should have no direction filters on any default metric config", () => {
+    for (const group of K8S_METRIC_GROUP_DEFINITIONS) {
+      for (const m of group.defaultMetrics ?? []) {
+        expect(m.filters?.direction).toBeUndefined();
+      }
+    }
   });
 });
 
@@ -725,38 +718,58 @@ describe("getDefaultMetricSelections", () => {
     expect(result[0].stream_name).toBe("k8s_pod_cpu_usage");
   });
 
-  it("should require all declared filters to match when filters are specified", () => {
-    const streams = [
-      makeStream("k8s_pod_network_io", { direction: "receive" }),
-      makeStream("k8s_pod_network_io", { direction: "transmit" }),
-    ];
+  it("should match k8s_pod_network_io without requiring any direction filter", () => {
+    // K8S_METRIC_GROUP_DEFINITIONS has no direction filter — any network_io stream matches
+    const streams = [makeStream("k8s_pod_network_io")];
     const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, streams);
-    expect(result).toHaveLength(2);
-    const directions = result.map((s) => s.filters?.direction);
-    expect(directions).toContain("receive");
-    expect(directions).toContain("transmit");
-  });
-
-  it("should not match a stream when its filters do not satisfy the default config filters", () => {
-    // Only transmit is available; receive is declared as a default but absent
-    const streams = [makeStream("k8s_pod_network_io", { direction: "transmit" })];
-    const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, streams);
-    // Only transmit matches; receive default finds no match
     const matched = result.filter((s) => s.stream_name === "k8s_pod_network_io");
     expect(matched).toHaveLength(1);
-    expect(matched[0].filters?.direction).toBe("transmit");
   });
 
-  it("should return streams in group definition order (pods → nodes → network)", () => {
+  it("should require all declared filters to match when a custom definition uses filters", () => {
+    const defs: MetricGroupDefinition[] = [
+      {
+        id: "custom",
+        label: "Custom",
+        icon: "star",
+        defaultMetrics: [{ streamName: "my_metric", filters: { env: "prod" } }],
+      },
+    ];
+    const streams = [
+      makeStream("my_metric", { env: "staging" }),
+      makeStream("my_metric", { env: "prod" }),
+    ];
+    const result = getDefaultMetricSelections(defs, streams);
+    expect(result).toHaveLength(1);
+    expect(result[0].filters?.env).toBe("prod");
+  });
+
+  it("should return no match when a custom filter requirement is not satisfied by any stream", () => {
+    const defs: MetricGroupDefinition[] = [
+      {
+        id: "custom",
+        label: "Custom",
+        icon: "star",
+        defaultMetrics: [{ streamName: "my_metric", filters: { env: "prod" } }],
+      },
+    ];
+    const streams = [makeStream("my_metric", { env: "staging" })];
+    const result = getDefaultMetricSelections(defs, streams);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should return streams in group definition order (pods → nodes)", () => {
     const streams = [
       makeStream("k8s_node_cpu_usage"),
       makeStream("k8s_pod_cpu_usage"),
-      makeStream("k8s_pod_network_io", { direction: "receive" }),
+      makeStream("k8s_pod_network_io"),
     ];
     const result = getDefaultMetricSelections(K8S_METRIC_GROUP_DEFINITIONS, streams);
-    expect(result[0].stream_name).toBe("k8s_pod_cpu_usage"); // pods group first
-    expect(result[1].stream_name).toBe("k8s_node_cpu_usage"); // nodes group second
-    expect(result[2].stream_name).toBe("k8s_pod_network_io"); // network group last
+    // pods group is first: k8s_pod_cpu_usage (first pod default) then k8s_pod_network_io (last pod default)
+    expect(result[0].stream_name).toBe("k8s_pod_cpu_usage");
+    expect(result[1].stream_name).toBe("k8s_pod_network_io");
+    // nodes group is second
+    expect(result[2].stream_name).toBe("k8s_node_cpu_usage");
   });
 
   it("should return the same StreamInfo reference from availableStreams", () => {

--- a/web/src/utils/metrics/metricGrouping.ts
+++ b/web/src/utils/metrics/metricGrouping.ts
@@ -220,19 +220,10 @@ export const K8S_METRIC_GROUP_DEFINITIONS: MetricGroupDefinition[] = [
     defaultMetrics: [
       { streamName: "k8s_node_cpu_usage" },
       { streamName: "k8s_node_memory_rss" },
+      { streamName: "k8s_node_network_io" },
     ],
   },
-  {
-    id: "network",
-    label: "Network",
-    icon: "wifi",
-    defaultMetrics: [
-      { streamName: "k8s_pod_network_io", filters: { direction: "receive" } },
-      { streamName: "k8s_pod_network_io", filters: { direction: "transmit" } },
-      { streamName: "k8s_node_network_io", filters: { direction: "receive" } },
-      { streamName: "k8s_node_network_io", filters: { direction: "transmit" } },
-    ],
-  },
+  { id: "network", label: "Network", icon: "wifi" },
   { id: "others", label: "Others", icon: "category" },
 ];
 

--- a/web/src/utils/metrics/metricGrouping.ts
+++ b/web/src/utils/metrics/metricGrouping.ts
@@ -31,10 +31,16 @@ import type { StreamInfo } from "@/services/service_streams";
 
 export type MetricGroupId = string;
 
+export interface DefaultMetricConfig {
+  streamName: string;
+  filters?: Record<string, string>;
+}
+
 export interface MetricGroupDefinition {
   id: string;
   label: string;
   icon: string | {};
+  defaultMetrics?: DefaultMetricConfig[];
 }
 
 export interface MetricGroupConfig {
@@ -183,6 +189,85 @@ export const DEFAULT_METRIC_GROUP_DEFINITIONS: MetricGroupDefinition[] = [
   { id: "infra", label: "Infra", icon: "dns" },
   { id: "others", label: "Others", icon: "category" },
 ];
+
+/**
+ * Group definitions for Kubernetes-instrumented deployments using OTel semantic
+ * naming conventions (kubeletstats / cluster receiver).
+ *
+ * Splits pod and node metrics into dedicated tabs and pre-selects the most
+ * operationally relevant streams by default. Falls back to slice(0,6) for
+ * deployments that use Prometheus-style naming (no OTel k8s_* metrics present).
+ */
+export const K8S_METRIC_GROUP_DEFINITIONS: MetricGroupDefinition[] = [
+  {
+    id: "pods",
+    label: "Pods",
+    icon: "view_in_ar",
+    defaultMetrics: [
+      { streamName: "k8s_pod_cpu_usage" },
+      { streamName: "k8s_pod_memory_usage" },
+      { streamName: "k8s_pod_cpu_request_utilization" },
+      { streamName: "k8s_pod_memory_request_utilization" },
+      { streamName: "k8s_pod_cpu_limit_utilization" },
+      { streamName: "k8s_pod_memory_limit_utilization" },
+      { streamName: "k8s_pod_network_io" },
+    ],
+  },
+  {
+    id: "nodes",
+    label: "Nodes",
+    icon: "computer",
+    defaultMetrics: [
+      { streamName: "k8s_node_cpu_usage" },
+      { streamName: "k8s_node_memory_rss" },
+    ],
+  },
+  {
+    id: "network",
+    label: "Network",
+    icon: "wifi",
+    defaultMetrics: [
+      { streamName: "k8s_pod_network_io", filters: { direction: "receive" } },
+      { streamName: "k8s_pod_network_io", filters: { direction: "transmit" } },
+      { streamName: "k8s_node_network_io", filters: { direction: "receive" } },
+      { streamName: "k8s_node_network_io", filters: { direction: "transmit" } },
+    ],
+  },
+  { id: "others", label: "Others", icon: "category" },
+];
+
+/**
+ * Return the ordered list of streams that match the defaultMetrics declared on
+ * each group definition. Only streams present in `availableStreams` are included.
+ *
+ * Matching rules:
+ * - stream_name must equal DefaultMetricConfig.streamName
+ * - every key/value in DefaultMetricConfig.filters must match the stream's filters
+ *
+ * Returns an empty array when no group has defaultMetrics configured, allowing
+ * the caller to apply a fallback (e.g. slice(0, 6)).
+ */
+export function getDefaultMetricSelections(
+  groupDefs: MetricGroupDefinition[],
+  availableStreams: StreamInfo[],
+): StreamInfo[] {
+  const results: StreamInfo[] = [];
+  for (const group of groupDefs) {
+    if (!group.defaultMetrics?.length) continue;
+    for (const def of group.defaultMetrics) {
+      const match = availableStreams.find(
+        (s) =>
+          s.stream_name === def.streamName &&
+          (!def.filters ||
+            Object.entries(def.filters).every(
+              ([k, v]) => s.filters?.[k] === v,
+            )),
+      );
+      if (match) results.push(match);
+    }
+  }
+  return results;
+}
 
 /**
  * Classify a single metric stream name into a group.


### PR DESCRIPTION
#11360 