### PR TITLE
test: add data-test attribute to anomaly filter row for E2E tests

### DIFF
--- a/web/src/components/anomaly_detection/steps/AnomalyDetectionConfig.vue
+++ b/web/src/components/anomaly_detection/steps/AnomalyDetectionConfig.vue
@@ -53,6 +53,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               v-for="(filter, idx) in config.filters"
               :key="idx"
               class="tw:flex tw:items-center tw:gap-2 tw:mb-2"
+              data-test="anomaly-filter-row"
             >
               <q-select
                 v-model="filter.field"


### PR DESCRIPTION
This fixes the failing anomaly detection E2E test in enterprise that was looking for the data-test="anomaly-filter-row" selector. The test was failing with:

Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
Locator: locator('[data-test="anomaly-filter-row"]').filter({ hasText: 'status' })

The test spec at playwright-tests/Alerts/alerts-anomaly-detection.spec.js:667 uses the page object method expectFilterRowWithField() which relies on this data-test attribute to verify filter rows in builder mode.

🤖 Generated with Claude Code