### PR TITLE
ci: auto-assign metadata to PRs and issues

### DIFF
--- a/.github/workflows/auto-assign-metadata.yml
+++ b/.github/workflows/auto-assign-metadata.yml
@@ -48,11 +48,14 @@ jobs:
             [.[] | select(.title != "Backlog")] |
             map({
               title: .title,
+              due_ts: (if .due_on then (.due_on | fromdateiso8601) else null end),
               sort_key: ([.title | scan("[0-9]+")] | map(tonumber))
             }) |
             map(select(.sort_key | length > 0)) |
-            sort_by(.sort_key) |
-            .[0].title // empty')
+            . as $ms |
+            (($ms | map(select(.due_ts == null or .due_ts >= now)) | sort_by(.sort_key) | .[0].title) //
+             ($ms | sort_by(.due_ts) | .[-1].title) //
+             empty)')
 
           if [ -n "$MILESTONE" ]; then
             gh pr edit "$NUMBER" -m "$MILESTONE" \
@@ -120,11 +123,14 @@ jobs:
             [.[] | select(.title != "Backlog")] |
             map({
               title: .title,
+              due_ts: (if .due_on then (.due_on | fromdateiso8601) else null end),
               sort_key: ([.title | scan("[0-9]+")] | map(tonumber))
             }) |
             map(select(.sort_key | length > 0)) |
-            sort_by(.sort_key) |
-            .[0].title // empty')
+            . as $ms |
+            (($ms | map(select(.due_ts == null or .due_ts >= now)) | sort_by(.sort_key) | .[0].title) //
+             ($ms | sort_by(.due_ts) | .[-1].title) //
+             empty)')
 
           if [ -n "$MILESTONE" ]; then
             gh issue edit "$NUMBER" -m "$MILESTONE" \


### PR DESCRIPTION
## Summary

- Auto-assigns the PR creator as assignee when a PR is opened or marked ready for review
- Auto-assigns the issue creator if no assignee is set when an issue is opened
- Adds both PRs and issues to org Project (number 19)
- Sets the lowest open milestone on PRs (non-draft) and issues that don't already have one set

**Milestone selection logic:**
- Prefers the lowest semver milestone whose due date has not yet passed (milestones with no due date are treated as not expired)
- If all milestones are past due, falls back to the most recently expired one

Uses `ORG_ADMIN_TOKEN` (fine-grained PAT) for all operations. Workflow uses `pull_request_target` so fork PRs also get metadata without needing checkout.

## Test plan
- [ ] Open a non-draft PR → creator assigned, lowest non-expired milestone set, added to project
- [ ] Open a PR when all milestones are past due → least-recently-expired milestone is set
- [ ] Open a PR that already has a milestone → milestone not overwritten
- [ ] Open an issue with no assignee → creator assigned, milestone set, added to project
- [ ] Open an issue with an existing assignee → assignee not overwritten