### PR TITLE
fix: show include or exlcude fro timestamp field

### DIFF
--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
@@ -278,7 +278,7 @@ test.describe("Dashboard Table Chart - Core Features", () => {
     }
   );
 
-  test(
+  test.skip(
     "should display VRL-created field as column when dynamic columns enabled",
     { tag: ["@tableChart", "@functional", "@P1"] },
     async ({ page }) => {

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
@@ -278,7 +278,7 @@ test.describe("Dashboard Table Chart - Core Features", () => {
     }
   );
 
-  test.skip(
+  test(
     "should display VRL-created field as column when dynamic columns enabled",
     { tag: ["@tableChart", "@functional", "@P1"] },
     async ({ page }) => {

--- a/web/src/composables/useLogs/useStreamFields.ts
+++ b/web/src/composables/useLogs/useStreamFields.ts
@@ -368,13 +368,16 @@ export const useStreamFields = () => {
             let UDSFieldCount = 0;
             // Build type map in a single pass over the schema array
             const schemaTypeMap: Record<string, string> = {};
+            const definedFields = stream.settings?.defined_schema_fields || [];
+            const tsCol = store.state.zoConfig?.timestamp_column;
+            const allCol = store.state.zoConfig?.all_fields_name;
             const fields: [string] =
               stream.settings?.defined_schema_fields &&
               searchObj.meta.useUserDefinedSchemas === "user_defined_schema"
                 ? [
-                    store.state.zoConfig?.timestamp_column,
-                    ...stream.settings?.defined_schema_fields,
-                    store.state.zoConfig?.all_fields_name,
+                    ...(definedFields.includes(tsCol) ? [] : [tsCol]),
+                    ...definedFields,
+                    ...(definedFields.includes(allCol) ? [] : [allCol]),
                   ]
                 : stream.schema.map((obj: any) => {
                     schemaTypeMap[obj.name] = obj.type;


### PR DESCRIPTION
This pr fixes the issue #11450 

We observed that during auto UDF execution, the _timestamp field was being included both in the schema and the user-defined schema. The UI was not designed to handle this duplication. This issue does not occur when users manually add fields through the Stream page, as _timestamp is not added to the user-defined schema in that flow. We have now handled this scenario.