### PR TITLE
fix: clear UDS when only _timestamp remains after deletion

### DIFF
--- a/web/src/components/logstream/schema.vue
+++ b/web/src/components/logstream/schema.vue
@@ -2223,6 +2223,17 @@ export default defineComponent({
             (field) => !selectedFieldsSet.has(field),
           );
 
+        // _timestamp cannot be deselected from the UI, so if it's the only
+        // remaining field after deletion, clear the UDS entirely. An empty
+        // defined_schema_fields is treated by the backend as UDS disabled.
+        if (
+          indexData.value.defined_schema_fields.length === 1 &&
+          indexData.value.defined_schema_fields[0] ===
+            store.state.zoConfig.timestamp_column
+        ) {
+          indexData.value.defined_schema_fields = [];
+        }
+
         if (!indexData.value.defined_schema_fields.length) {
           activeTab.value = "allFields";
         }


### PR DESCRIPTION
## Summary
- When auto-UDS kicks in and the user removes UDS fields via the schema UI, `_timestamp` is hidden from selection so it can never be deselected.
- That left `defined_schema_fields = [\"_timestamp\"]` after a full UDS cleanup, which the backend still treats as UDS enabled — blocking UDS from being disabled (the original report happens after raising `ZO_SCHEMA_MAX_FIELDS_TO_ENABLE_UDS` too).
- Fix: in the schemaFields delete path, if only `_timestamp` remains after the filter, clear `defined_schema_fields` so the save request disables UDS.

Refs: openobserve/o2-enterprise#1570

## Test plan
- [ ] On a stream where auto-UDS is enabled, open Schema settings.
- [ ] Switch to the User Defined Schema tab, select all UDS fields and delete them.
- [ ] Save and confirm UDS is now disabled (stream falls back to all fields, no `_timestamp`-only UDS lingering).
- [ ] Re-add fields to UDS and confirm the normal add path still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)