### PR TITLE
fix: clear UDS when only _timestamp remains after removal

### DIFF
--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -665,6 +665,14 @@ pub async fn update_stream_settings(
         settings
             .defined_schema_fields
             .retain(|field| !new_settings.defined_schema_fields.remove.contains(field));
+        // _timestamp cannot be deselected from the UI, so when the user removes every
+        // UDS field they can see, _timestamp may be the only one left. Treat that as a
+        // request to disable UDS entirely.
+        if settings.defined_schema_fields.len() == 1
+            && settings.defined_schema_fields[0] == TIMESTAMP_COL_NAME
+        {
+            settings.defined_schema_fields.clear();
+        }
     }
     if !settings.defined_schema_fields.is_empty() {
         // check fields with stream type


### PR DESCRIPTION
## Summary
- When auto-UDS is triggered, the persisted `defined_schema_fields` includes `_timestamp`. The UI hides `_timestamp` from the UDS selector so the user can never deselect it.
- A "remove all UDS fields" action from the frontend therefore leaves `defined_schema_fields = [\"_timestamp\"]` on the backend, which is still treated as UDS enabled — making it impossible to disable UDS through the UI even after raising `ZO_SCHEMA_MAX_FIELDS_TO_ENABLE_UDS`.
- Fix: in `update_stream_settings`, after applying the remove diff, if only `_timestamp` is left, clear `defined_schema_fields` so UDS is disabled.

Refs: openobserve/o2-enterprise#1570

## Test plan
- [x] On a stream where auto-UDS is enabled, open Schema settings and switch to the User Defined Schema tab.
- [x] Select all visible UDS fields and delete them, then save.
- [x] Verify the response/stored settings have `defined_schema_fields = []` and the stream falls back to all fields (no `_timestamp`-only UDS lingering).
- [x] Re-add fields to UDS and confirm the normal add path still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)