### PR TITLE
refactor: make detect_llm_stream accept a key-lookup closure

### DIFF
--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -369,10 +369,7 @@ pub async fn handle_otlp_request(
                     );
 
                     // check if we have any LLM related attributes
-                    if !is_llm_stream
-                        && (span_att_map.contains_key(otel::attributes::O2Attributes::INPUT)
-                            || span_att_map.contains_key(otel::attributes::O2Attributes::OUTPUT))
-                    {
+                    if !is_llm_stream && detect_llm_stream(|k| span_att_map.contains_key(k)) {
                         is_llm_stream = true;
                         need_mark_llm_stream = true;
                     }
@@ -739,10 +736,7 @@ pub async fn ingest_json(
         };
 
         // check if we have any LLM related attributes
-        if !is_llm_stream
-            && (record_val.contains_key(otel::attributes::O2Attributes::INPUT)
-                || record_val.contains_key(otel::attributes::O2Attributes::OUTPUT))
-        {
+        if !is_llm_stream && detect_llm_stream(|k| record_val.contains_key(k)) {
             is_llm_stream = true;
             need_mark_llm_stream = true;
         }
@@ -1135,6 +1129,20 @@ async fn write_traces(
     evaluate_trigger(triggers).await;
 
     Ok(req_stats)
+}
+
+fn detect_llm_stream(contains_key: impl Fn(&str) -> bool) -> bool {
+    let keys = [
+        otel::attributes::GenAiAttributes::USAGE_INPUT_TOKENS,
+        otel::attributes::GenAiAttributes::USAGE_OUTPUT_TOKENS,
+        otel::attributes::GenAiAttributes::INPUT_MESSAGES,
+        otel::attributes::GenAiAttributes::OUTPUT_MESSAGES,
+        otel::attributes::O2Attributes::INPUT,
+        otel::attributes::O2Attributes::OUTPUT,
+        otel::attributes::LangfuseAttributes::INPUT,
+        otel::attributes::LangfuseAttributes::OUTPUT,
+    ];
+    keys.iter().any(|k| contains_key(k))
 }
 
 #[cfg(test)]
@@ -1801,5 +1809,105 @@ mod tests {
             span_att_map.get(super::ATTR_STATUS_MESSAGE).unwrap(),
             "Internal server error"
         );
+    }
+
+    #[test]
+    fn test_detect_llm_stream_empty() {
+        let map: std::collections::HashMap<String, config::utils::json::Value> =
+            std::collections::HashMap::new();
+        assert!(!super::detect_llm_stream(|k| map.contains_key(k)));
+
+        let obj = config::utils::json::Map::new();
+        assert!(!super::detect_llm_stream(|k| obj.contains_key(k)));
+    }
+
+    #[test]
+    fn test_detect_llm_stream_no_match() {
+        let mut map: std::collections::HashMap<String, config::utils::json::Value> =
+            std::collections::HashMap::new();
+        map.insert("http.method".to_string(), json!("GET"));
+        map.insert("service.name".to_string(), json!("api"));
+        assert!(!super::detect_llm_stream(|k| map.contains_key(k)));
+    }
+
+    #[test]
+    fn test_detect_llm_stream_hashmap_gen_ai() {
+        use crate::service::traces::otel::attributes::GenAiAttributes;
+
+        let keys = [
+            GenAiAttributes::USAGE_INPUT_TOKENS,
+            GenAiAttributes::USAGE_OUTPUT_TOKENS,
+            GenAiAttributes::INPUT_MESSAGES,
+            GenAiAttributes::OUTPUT_MESSAGES,
+        ];
+        for key in keys {
+            let mut map: std::collections::HashMap<String, config::utils::json::Value> =
+                std::collections::HashMap::new();
+            map.insert(key.to_string(), json!("value"));
+            assert!(
+                super::detect_llm_stream(|k| map.contains_key(k)),
+                "expected detection for key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_llm_stream_hashmap_o2_attrs() {
+        use crate::service::traces::otel::attributes::O2Attributes;
+
+        let mut map: std::collections::HashMap<String, config::utils::json::Value> =
+            std::collections::HashMap::new();
+        map.insert(O2Attributes::INPUT.to_string(), json!("prompt"));
+        assert!(super::detect_llm_stream(|k| map.contains_key(k)));
+
+        let mut map: std::collections::HashMap<String, config::utils::json::Value> =
+            std::collections::HashMap::new();
+        map.insert(O2Attributes::OUTPUT.to_string(), json!("completion"));
+        assert!(super::detect_llm_stream(|k| map.contains_key(k)));
+    }
+
+    #[test]
+    fn test_detect_llm_stream_hashmap_langfuse() {
+        use crate::service::traces::otel::attributes::LangfuseAttributes;
+
+        let mut map: std::collections::HashMap<String, config::utils::json::Value> =
+            std::collections::HashMap::new();
+        map.insert(LangfuseAttributes::INPUT.to_string(), json!("prompt"));
+        assert!(super::detect_llm_stream(|k| map.contains_key(k)));
+
+        let mut map: std::collections::HashMap<String, config::utils::json::Value> =
+            std::collections::HashMap::new();
+        map.insert(LangfuseAttributes::OUTPUT.to_string(), json!("completion"));
+        assert!(super::detect_llm_stream(|k| map.contains_key(k)));
+    }
+
+    #[test]
+    fn test_detect_llm_stream_json_map() {
+        use crate::service::traces::otel::attributes::GenAiAttributes;
+
+        let mut obj = config::utils::json::Map::new();
+        obj.insert("service.name".to_string(), json!("api"));
+        assert!(!super::detect_llm_stream(|k| obj.contains_key(k)));
+
+        obj.insert(
+            GenAiAttributes::USAGE_INPUT_TOKENS.to_string(),
+            json!(42),
+        );
+        assert!(super::detect_llm_stream(|k| obj.contains_key(k)));
+    }
+
+    #[test]
+    fn test_detect_llm_stream_mixed_attrs_match_first() {
+        use crate::service::traces::otel::attributes::GenAiAttributes;
+
+        let mut map: std::collections::HashMap<String, config::utils::json::Value> =
+            std::collections::HashMap::new();
+        map.insert("http.method".to_string(), json!("POST"));
+        map.insert("service.name".to_string(), json!("llm-api"));
+        map.insert(
+            GenAiAttributes::OUTPUT_MESSAGES.to_string(),
+            json!("response"),
+        );
+        assert!(super::detect_llm_stream(|k| map.contains_key(k)));
     }
 }

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -1889,10 +1889,7 @@ mod tests {
         obj.insert("service.name".to_string(), json!("api"));
         assert!(!super::detect_llm_stream(|k| obj.contains_key(k)));
 
-        obj.insert(
-            GenAiAttributes::USAGE_INPUT_TOKENS.to_string(),
-            json!(42),
-        );
+        obj.insert(GenAiAttributes::USAGE_INPUT_TOKENS.to_string(), json!(42));
         assert!(super::detect_llm_stream(|k| obj.contains_key(k)));
     }
 


### PR DESCRIPTION
## Summary
- Change `detect_llm_stream` to accept `impl Fn(&str) -> bool` instead of `&HashMap<String, json::Value>`, so the same helper works for both `HashMap` (span attributes path) and `json::Map` (JSON ingest path) without cloning or wrapping.
- Update the two callers in `src/service/traces/mod.rs` to pass `|k| map.contains_key(k)`.
- Add unit tests covering empty input, no-match, and each LLM attribute family (GenAi, O2, Langfuse) for both `HashMap` and `json::Map`.

## Test plan
- [x] `cargo check -p openobserve`
- [x] `cargo test -p openobserve --lib service::traces::tests::test_detect_llm_stream` (7 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)