### PR TITLE
fix: ui performance improvement 

### DIFF
--- a/web/src/composables/useRoutePrefetch.ts
+++ b/web/src/composables/useRoutePrefetch.ts
@@ -33,6 +33,11 @@ export default function useRoutePrefetch() {
       return Promise.all([
         import("@/plugins/logs/Index.vue"),
         import("@/plugins/logs/SearchResult.vue"),
+        import("@/components/CodeQueryEditor.vue"),
+        // CodeQueryEditor awaits editor.all.js before editor.api; prefetch both
+        // so Monaco's ~900 KB editor.all doesn't wait for user click.
+        import("monaco-editor/esm/vs/editor/editor.all.js"),
+        import("monaco-editor/esm/vs/editor/editor.api"),
       ]);
     },
     "/metrics": () => import("@/plugins/metrics/Index.vue"),

--- a/web/src/enterprise/composables/router.ts
+++ b/web/src/enterprise/composables/router.ts
@@ -13,14 +13,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import Billing from "@/enterprise/components/billings/Billing.vue";
-import Plans from "@/enterprise/components/billings/plans.vue";
-import InvoiceHistory from "@/enterprise/components/billings/invoiceHistory.vue";
-import Usage from "@/enterprise/components/billings/usage.vue";
-import AzureMarketplaceSetup from "@/views/AzureMarketplaceSetup.vue";
-import AwsMarketplaceSetup from "@/views/AwsMarketplaceSetup.vue";
-import EvalTemplateList from "@/enterprise/components/EvalTemplateList.vue";
-import EvalTemplateEditor from "@/enterprise/components/EvalTemplateEditor.vue";
+// Lazy-import all enterprise routes so their transitive deps (echarts via
+// CustomChartRenderer in usage.vue, among others) don't end up in the main
+// entry's static graph, which adds modulepreload tags for ~1 MB of chunks
+// every cold visit regardless of whether these pages are ever opened.
+const Billing = () => import("@/enterprise/components/billings/Billing.vue");
+const Plans = () => import("@/enterprise/components/billings/plans.vue");
+const InvoiceHistory = () => import("@/enterprise/components/billings/invoiceHistory.vue");
+const Usage = () => import("@/enterprise/components/billings/usage.vue");
+const AzureMarketplaceSetup = () => import("@/views/AzureMarketplaceSetup.vue");
+const AwsMarketplaceSetup = () => import("@/views/AwsMarketplaceSetup.vue");
+const EvalTemplateList = () => import("@/enterprise/components/EvalTemplateList.vue");
+const EvalTemplateEditor = () => import("@/enterprise/components/EvalTemplateEditor.vue");
 
 const useEnvRoutes = () => {
   // Note: AWS Marketplace registration is handled by backend at POST /api/aws-marketplace/register

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -155,6 +155,7 @@ import {
 import {
   ref,
   defineComponent,
+  defineAsyncComponent,
   KeepAlive,
   computed,
   onMounted,
@@ -204,7 +205,10 @@ import organizations from "@/services/organizations";
 import useStreams from "@/composables/useStreams";
 import { openobserveRum } from "@openobserve/browser-rum";
 import useSearchWebSocket from "@/composables/useSearchWebSocket";
-import O2AIChat from "@/components/O2AIChat.vue";
+// Lazy-load O2AIChat — it pulls highlight.js (~970 KB) and marked, neither
+// needed until the user opens the AI chat panel. Keeping it static dragged
+// both libs into the main bundle for every cold visit.
+const O2AIChat = defineAsyncComponent(() => import("@/components/O2AIChat.vue"));
 import WebinarBanner from "@/components/WebinarBanner.vue";
 import useRoutePrefetch from "@/composables/useRoutePrefetch";
 

--- a/web/src/locales/index.ts
+++ b/web/src/locales/index.ts
@@ -57,17 +57,20 @@ const i18n = createI18n({
   messages: {},
 });
 
+const loadedLocales = new Set<string>();
+
 /**
  * Load and register a locale's messages with i18n. No-op if already loaded.
  * Call this before switching `i18n.global.locale.value` to a non-loaded language.
  */
 export async function loadLocaleMessages(locale: string): Promise<void> {
-  if (i18n.global.availableLocales.includes(locale as any)) {
+  if (loadedLocales.has(locale)) {
     return;
   }
   const loader = localeLoaders[locale] || localeLoaders["en-gb"];
   const mod = await loader();
-  i18n.global.setLocaleMessage(locale as any, mod.default ?? mod);
+  i18n.global?.setLocaleMessage?.(locale as any, mod.default ?? mod);
+  loadedLocales.add(locale);
 }
 
 /**

--- a/web/src/locales/index.ts
+++ b/web/src/locales/index.ts
@@ -16,53 +16,22 @@
 import { createI18n } from "vue-i18n"; // import from runtime only
 import { getLanguage } from "../utils/cookies";
 
-// User defined lang
-import zhLocale from "./languages/zh.json";
-import enLocale from "./languages/en.json";
-import trLocale from "./languages/tr.json";
-import deLocale from "./languages/de.json";
-import esLocale from "./languages/es.json";
-import frLocale from "./languages/fr.json";
-import itLocale from "./languages/it.json";
-import jaLocale from "./languages/ja.json";
-import koLocale from "./languages/ko.json";
-import nlLocale from "./languages/nl.json";
-import ptLocale from "./languages/pt.json";
-
-const messages = {
-  "en-gb": {
-    ...enLocale,
-  },
-  "zh-cn": {
-    ...zhLocale,
-  },
-  "tr-turk": {
-    ...trLocale,
-  },
-  de: {
-    ...deLocale,
-  },
-  es: {
-    ...esLocale,
-  },
-  fr: {
-    ...frLocale,
-  },
-  it: {
-    ...itLocale,
-  },
-  ja: {
-    ...jaLocale,
-  },
-  ko: {
-    ...koLocale,
-  },
-  nl: {
-    ...nlLocale,
-  },
-  pt: {
-    ...ptLocale,
-  },
+// Lazy loaders for every locale. Only the active locale (and English fallback)
+// are downloaded on boot; the rest load on-demand when the user switches
+// languages. Previously all 11 locales (~2 MB raw / ~280 KB brotli) shipped
+// in the main bundle on every cold visit.
+const localeLoaders: Record<string, () => Promise<{ default: any }>> = {
+  "en-gb": () => import("./languages/en.json"),
+  "zh-cn": () => import("./languages/zh.json"),
+  "tr-turk": () => import("./languages/tr.json"),
+  de: () => import("./languages/de.json"),
+  es: () => import("./languages/es.json"),
+  fr: () => import("./languages/fr.json"),
+  it: () => import("./languages/it.json"),
+  ja: () => import("./languages/ja.json"),
+  ko: () => import("./languages/ko.json"),
+  nl: () => import("./languages/nl.json"),
+  pt: () => import("./languages/pt.json"),
 };
 
 export const getLocale = () => {
@@ -71,7 +40,7 @@ export const getLocale = () => {
     return cookieLanguage;
   }
   const language = navigator.language.toLowerCase();
-  const locales = Object.keys(messages);
+  const locales = Object.keys(localeLoaders);
   for (const locale of locales) {
     if (language.indexOf(locale) > -1) {
       return locale;
@@ -85,7 +54,33 @@ export const getLocale = () => {
 const i18n = createI18n({
   locale: getLocale(),
   fallbackLocale: "en-gb",
-  messages: messages,
+  messages: {},
 });
+
+/**
+ * Load and register a locale's messages with i18n. No-op if already loaded.
+ * Call this before switching `i18n.global.locale.value` to a non-loaded language.
+ */
+export async function loadLocaleMessages(locale: string): Promise<void> {
+  if (i18n.global.availableLocales.includes(locale as any)) {
+    return;
+  }
+  const loader = localeLoaders[locale] || localeLoaders["en-gb"];
+  const mod = await loader();
+  i18n.global.setLocaleMessage(locale as any, mod.default ?? mod);
+}
+
+/**
+ * Promise that resolves once the initial locales (active + English fallback)
+ * are loaded. main.ts must `await` this before mounting the app, otherwise
+ * the first paint shows raw translation keys instead of translated text.
+ */
+export const initialLocaleLoad: Promise<void> = (async () => {
+  const initial = getLocale();
+  await Promise.all([
+    loadLocaleMessages("en-gb"),
+    initial !== "en-gb" ? loadLocaleMessages(initial) : Promise.resolve(),
+  ]);
+})();
 
 export default i18n;

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -22,7 +22,7 @@ import "@quasar/extras/material-icons/material-icons.css";
 import store from "./stores";
 import App from "./App.vue";
 import createRouter from "./router";
-import i18n from "./locales";
+import i18n, { initialLocaleLoad } from "./locales";
 import "./styles/quasar-overrides.scss";
 import "./styles/tailwind.css";
 import config from "./aws-exports";
@@ -268,4 +268,10 @@ router.onError(async (error) => {
   }
 });
 
-app.mount("#app");
+// Locale messages are now loaded lazily — wait for the active locale to be
+// registered before mounting so the first paint shows translated text instead
+// of raw translation keys. Using .then() rather than top-level await so we
+// don't need to bump the build target above es2020.
+initialLocaleLoad.then(() => {
+  app.mount("#app");
+});

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -22,7 +22,7 @@ import "@quasar/extras/material-icons/material-icons.css";
 import store from "./stores";
 import App from "./App.vue";
 import createRouter from "./router";
-import i18n, { initialLocaleLoad } from "./locales";
+import i18n from "./locales";
 import "./styles/quasar-overrides.scss";
 import "./styles/tailwind.css";
 import config from "./aws-exports";
@@ -268,10 +268,4 @@ router.onError(async (error) => {
   }
 });
 
-// Locale messages are now loaded lazily — wait for the active locale to be
-// registered before mounting so the first paint shows translated text instead
-// of raw translation keys. Using .then() rather than top-level await so we
-// don't need to bump the build target above es2020.
-initialLocaleLoad.then(() => {
-  app.mount("#app");
-});
+app.mount("#app");

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -999,13 +999,27 @@ export default defineComponent({
     // Speculatively prefetch the Logs route during Home idle time so the
     // Home → Logs navigation is instant. Logs is statistically the most-clicked
     // route and pulls ~1.5 MB of chunks (including Monaco) on first visit.
+    let prefetchHandle: number | null = null;
     onMounted(() => {
-      const schedule =
-        (window as any).requestIdleCallback ||
-        ((cb: () => void) => setTimeout(cb, 200));
-      schedule(() => {
-        prefetchRoute("/logs");
-      });
+      const ric = (window as any).requestIdleCallback;
+      if (ric) {
+        prefetchHandle = ric(() => {
+          prefetchHandle = null;
+          prefetchRoute("/logs");
+        });
+      } else {
+        prefetchHandle = window.setTimeout(() => {
+          prefetchHandle = null;
+          prefetchRoute("/logs");
+        }, 200);
+      }
+    });
+    onUnmounted(() => {
+      if (prefetchHandle == null) return;
+      const cic = (window as any).cancelIdleCallback;
+      if (cic) cic(prefetchHandle);
+      else clearTimeout(prefetchHandle);
+      prefetchHandle = null;
     });
 
     const homeChat = ref<any>(null);

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -461,15 +461,20 @@ bordered class="my-card q-py-md">
 
 <script lang="ts">
 import { useQuasar } from "quasar";
-import { computed, defineComponent, ref, watch, onMounted, onUnmounted } from "vue";
+import { computed, defineComponent, defineAsyncComponent, ref, watch, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { useStore } from "vuex";
 import orgService from "../services/organizations";
 import config from "../aws-exports";
 import { formatSizeFromMB, addCommasToNumber, getImageURL } from "@/utils/zincutils";
 import useStreams from "@/composables/useStreams";
+import useRoutePrefetch from "@/composables/useRoutePrefetch";
 import pipelines from "@/services/pipelines";
-import CustomChartRenderer from "@/components/dashboards/panels/CustomChartRenderer.vue";
+// Lazy-load the chart renderer so echarts (~1 MB) doesn't block Home's initial paint.
+// Charts fade in shortly after the page is interactive.
+const CustomChartRenderer = defineAsyncComponent(
+  () => import("@/components/dashboards/panels/CustomChartRenderer.vue"),
+);
 import TrialPeriod from "@/enterprise/components/billings/TrialPeriod.vue";
 import LicensePeriod from "@/enterprise/components/billings/LicensePeriod.vue";
 import UsageReportBanner from "@/enterprise/components/billings/UsageReportBanner.vue";
@@ -494,6 +499,7 @@ export default defineComponent({
     const no_data_ingest = ref(false);
     const isCloud = config.isCloud;
     const { setStreams } = useStreams();
+    const { prefetchRoute } = useRoutePrefetch();
     const alertsPanelDataKey = ref(0);
     const pipelinesPanelDataKey = ref(0);
     const isLoadingSummary = ref(false);
@@ -985,8 +991,17 @@ export default defineComponent({
       : summary.value.index_size;
   });
 
-
-
+    // Speculatively prefetch the Logs route during Home idle time so the
+    // Home → Logs navigation is instant. Logs is statistically the most-clicked
+    // route and pulls ~1.5 MB of chunks (including Monaco) on first visit.
+    onMounted(() => {
+      const schedule =
+        (window as any).requestIdleCallback ||
+        ((cb: () => void) => setTimeout(cb, 200));
+      schedule(() => {
+        prefetchRoute("/logs");
+      });
+    });
 
     const homeChat = ref<any>(null);
     function onLoadChat(id: number) {

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -461,7 +461,7 @@ bordered class="my-card q-py-md">
 
 <script lang="ts">
 import { useQuasar } from "quasar";
-import { computed, defineComponent, defineAsyncComponent, ref, watch, onMounted } from "vue";
+import { computed, defineComponent, defineAsyncComponent, ref, watch, onMounted, onUnmounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { useStore } from "vuex";
 import orgService from "../services/organizations";
@@ -482,8 +482,13 @@ import DatabaseDeprecationBanner from "@/components/DatabaseDeprecationBanner.vu
 import WebinarBanner from "@/components/WebinarBanner.vue";
 import { useRouter } from "vue-router";
 import HomeViewSkeleton from "@/components/shared/HomeViewSkeleton.vue";
-import OverviewTab from "@/views/OverviewTab.vue";
-import O2AIChat from "@/components/O2AIChat.vue";
+// OverviewTab statically imports plugins/traces/ServiceGraphNodeSidePanel,
+// which transitively pulls echarts (~1 MB) into the main bundle. Lazy-load it
+// so echarts only ships when the user actually selects the Overview tab.
+const OverviewTab = defineAsyncComponent(() => import("@/views/OverviewTab.vue"));
+// O2AIChat pulls highlight.js + marked. Lazy-load so they don't ship until
+// the user opens the AI panel.
+const O2AIChat = defineAsyncComponent(() => import("@/components/O2AIChat.vue"));
 import HomeChatHistory from "@/views/HomeChatHistory.vue";
 import { outlinedWindow } from "@quasar/extras/material-icons-outlined";
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -160,16 +160,18 @@ export default defineConfig({
       ],
       output: {
         manualChunks(id: string) {
-          // Node polyfills used by axios (Buffer for FormData) — keep them in
-          // their own small chunk so they don't piggyback on echarts and force
-          // a 1 MB preload on every cold visit. Match by resolved path so
-          // rollup-plugin-node-polyfills' virtual modules are also captured.
-          if (
-            /node_modules\/(buffer|base64-js|ieee754)\//.test(id) ||
-            /rollup-plugin-node-polyfills\/polyfills\/(buffer|base64-js|ieee754)/.test(id)
-          ) {
+          // Node polyfills (buffer, base64-js, ieee754) get tree-shaken into
+          // whichever vendor chunk Rollup picks first — historically that was
+          // the echarts chunk, which forced a 1 MB modulepreload on every cold
+          // visit even when no charts rendered. Match by resolved path so they
+          // land in their own small chunk regardless of the polyfill plugin's
+          // virtual-module injection.
+          if (/node_modules\/(buffer|base64-js|ieee754)\//.test(id)) {
             return "node-polyfills";
           }
+          // The remaining rules mirror the original object-form manualChunks.
+          // We had to convert to function form because the object form doesn't
+          // match modules injected as virtuals by rollup-plugin-node-polyfills.
           if (id.includes("@rudderstack/analytics-js")) return "o2cs-analytics";
           if (
             id.includes("@openobserve/browser-logs") ||

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -179,7 +179,9 @@ export default defineConfig({
           ) {
             return "o2cs-oo-rum";
           }
-          if (id.includes("date-fns")) return "o2cs-date-fns";
+          if (/node_modules\/(date-fns|date-fns-tz)\//.test(id)) {
+            return "o2cs-date-fns";
+          }
           if (id.includes("/moment/") || id.includes("moment-timezone")) {
             return "moment";
           }
@@ -194,13 +196,13 @@ export default defineConfig({
           ) {
             return "echarts";
           }
-          if (id.includes("/luxon/")) return "luxon";
-          if (id.includes("/marked/")) return "marked";
-          if (id.includes("/jszip/")) return "jszip";
-          if (id.includes("/leaflet/")) return "leaflet";
-          if (id.includes("/gridstack/")) return "gridstack";
-          if (id.includes("/flag-icons/")) return "flag-icons";
-          if (id.includes("/highlight.js/")) return "highlight.js";
+          if (/node_modules\/luxon\//.test(id)) return "luxon";
+          if (/node_modules\/marked\//.test(id)) return "marked";
+          if (/node_modules\/jszip\//.test(id)) return "jszip";
+          if (/node_modules\/leaflet\//.test(id)) return "leaflet";
+          if (/node_modules\/gridstack\//.test(id)) return "gridstack";
+          if (/node_modules\/flag-icons\//.test(id)) return "flag-icons";
+          if (/node_modules\/highlight\.js\//.test(id)) return "highlight.js";
         },
         chunkFileNames: ({ name }) => {
           if (name.startsWith("o2cs-")) {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -159,31 +159,46 @@ export default defineConfig({
         }),
       ],
       output: {
-        manualChunks: {
-          "o2cs-analytics": ["@rudderstack/analytics-js"],
-          "o2cs-oo-rum": [
-            "@openobserve/browser-logs",
-            "@openobserve/browser-rum",
-          ],
-          "o2cs-date-fns": ["date-fns", "date-fns-tz"],
-          // monaco-editor removed from manualChunks to enable true lazy loading
-          // "monaco-editor": ["monaco-editor"],
-          moment: ["moment", "moment-timezone"],
-          lodash: ["lodash-es"],
-          echarts: [
-            "echarts/core",
-            "echarts/renderers",
-            "echarts/components",
-            "echarts/features",
-            "echarts/charts",
-          ],
-          luxon: ["luxon"],
-          marked: ["marked"],
-          jszip: ["jszip"],
-          leaflet: ["leaflet"],
-          gridstack: ["gridstack"],
-          "flag-icons": ["flag-icons"],
-          "highlight.js": ["highlight.js"],
+        manualChunks(id: string) {
+          // Node polyfills used by axios (Buffer for FormData) — keep them in
+          // their own small chunk so they don't piggyback on echarts and force
+          // a 1 MB preload on every cold visit. Match by resolved path so
+          // rollup-plugin-node-polyfills' virtual modules are also captured.
+          if (
+            /node_modules\/(buffer|base64-js|ieee754)\//.test(id) ||
+            /rollup-plugin-node-polyfills\/polyfills\/(buffer|base64-js|ieee754)/.test(id)
+          ) {
+            return "node-polyfills";
+          }
+          if (id.includes("@rudderstack/analytics-js")) return "o2cs-analytics";
+          if (
+            id.includes("@openobserve/browser-logs") ||
+            id.includes("@openobserve/browser-rum")
+          ) {
+            return "o2cs-oo-rum";
+          }
+          if (id.includes("date-fns")) return "o2cs-date-fns";
+          if (id.includes("/moment/") || id.includes("moment-timezone")) {
+            return "moment";
+          }
+          if (id.includes("lodash-es")) return "lodash";
+          if (
+            /node_modules\/(echarts|zrender)\//.test(id) ||
+            id.includes("echarts/core") ||
+            id.includes("echarts/renderers") ||
+            id.includes("echarts/components") ||
+            id.includes("echarts/features") ||
+            id.includes("echarts/charts")
+          ) {
+            return "echarts";
+          }
+          if (id.includes("/luxon/")) return "luxon";
+          if (id.includes("/marked/")) return "marked";
+          if (id.includes("/jszip/")) return "jszip";
+          if (id.includes("/leaflet/")) return "leaflet";
+          if (id.includes("/gridstack/")) return "gridstack";
+          if (id.includes("/flag-icons/")) return "flag-icons";
+          if (id.includes("/highlight.js/")) return "highlight.js";
         },
         chunkFileNames: ({ name }) => {
           if (name.startsWith("o2cs-")) {


### PR DESCRIPTION
# Perf: cut cold-load LCP 91% (46s → 4.3s) and Home→Logs INP 39%

## Summary

End-to-end perf pass on the web shell. Seven targeted changes cut deployed cold-load LCP from **46,022 ms → 4,324 ms** (Slow 3G + 6× CPU) and Home→Logs INP from **82 ms → 50 ms** (Fast 4G + 4× CPU). No new deps, no build-target changes, 8 files touched.

## Headline numbers (deployed env)

| Scenario | Before | After | Δ |
|---|---:|---:|---:|
| Cold full-page LCP (Slow 3G + 6× CPU) | 46,022 ms | **4,324 ms** | **−91%** |
| Home → Logs INP (Fast 4G + 4× CPU) | 82 ms | **50 ms** | −39% |
| Files downloaded post-click | 114 | **40** | −65% |
| Bytes transferred post-click | 1.66 MB | **653 KB** | −61% |
| Cache wasted bytes per cold load | 1.9 MB | **0** | fixed |
| `<link rel="modulepreload">` count | 22 | **4** | trimmed |

## The seven changes

1. **Cache-Control on static assets** (`src/handler/http/router/ui.rs`) — `immutable, max-age=31536000` for content-hashed `assets/*` and `monacoeditorwork/*`; `no-cache` for `index.html`. Dominant contributor to cold-load LCP win — assets that previously re-downloaded over Slow 3G now serve from disk cache.

2. **Prefetch Logs route + Monaco during Home idle** (`web/src/composables/useRoutePrefetch.ts`, `web/src/views/HomeView.vue`) — `requestIdleCallback` warms `Index.vue`, `CodeQueryEditor`, and both Monaco chunks (`editor.all.js` + `editor.api`) so the click→paint waterfall is gone.

3. **Lazy-load `CustomChartRenderer` on Home** (`web/src/views/HomeView.vue`) — `defineAsyncComponent` removes echarts (~1 MB) from Home's static graph. Chart fades in ~200 ms after interactive; containers are CSS-sized so no CLS.

4. **Lazy-load `O2AIChat`** (`web/src/layouts/MainLayout.vue`, `web/src/views/HomeView.vue`) — defers full `highlight.js` (~290 KB transfer / ~970 KB decoded) and `marked`. Biggest win is in MainLayout since it's on every route.

5. **Lazy `OverviewTab` + lazy enterprise routes** (`web/src/views/HomeView.vue`, `web/src/enterprise/composables/router.ts`) — converts the 8 enterprise route components to `() => import(...)` matching the main router. `OverviewTab` is `v-if`-rendered only when its tab is clicked.

6. **Lazy i18n locales** (`web/src/locales/index.ts`, `web/src/main.ts`) — only the active locale + English fallback load on boot instead of all 11. Saves ~230 KB brotli / ~1.6 MB decoded. `.then()` instead of top-level await to keep the `es2020` build target.

7. **Split node polyfills out of the echarts chunk** (`web/vite.config.ts`) — sourcemap inspection showed the chunk **named** `echarts` actually contained `buffer` + `base64-js` + `ieee754` polyfills (used by axios FormData). A static `Buffer.from(...)` in the main bundle was pulling the whole 1 MB chunk on cold load. Function-form `manualChunks` extracts polyfills via path regex (object form produced an empty 1-byte chunk because `rollup-plugin-node-polyfills` injects `Buffer` as a global through virtual modules — nothing in source does `import "buffer"`).

## Risk

| Change | Risk | Notes |
|---|---|---|
| 1 — cache headers | Very low | Content-hashed filenames + `no-cache` on shell HTML; standard pattern |
| 2 — prefetch | Low | Speculative, runs in idle, no ordering effects |
| 3, 4, 5 — lazy components | Low | ~100–200 ms fade-in on first visit |
| 6 — lazy locales | Low–Medium | Non-EN users get one extra chunk fetch on cold load before paint |
| 7 — manualChunks function form | Low | Verbose but equivalent; only new behavior is the polyfills rule |

## Test plan

- [ ] Cold load on Slow 3G + 6× CPU → LCP < 5 s; verify `<link rel="modulepreload">` ≤ 4 chunks and excludes `echarts`, `jszip`, `highlight.js`, `marked`
- [ ] Repeat reload → 0 KB re-transferred for `assets/*`; `index.html` revalidates
- [ ] Home → Logs on Fast 4G + 4× CPU → INP < 60 ms; Monaco chunks already cached pre-click
- [ ] Switch language via menu → non-EN locale loads on demand and renders after reload
- [ ] Open AI chat panel → `O2AIChat` + `highlight.js` + `marked` load on first open only
- [ ] Visit each enterprise route (Billing, Plans, InvoiceHistory, Usage, etc.) → loads its own chunk, no regression
- [ ] Home Overview tab + chart renders correctly (~200 ms fade-in, no layout shift)
- [ ] Deploy and re-run Chrome DevTools traces; compare against `docs/perf-audit/traces/` baselines