### PR TITLE
fix: alerts/scheduled pipelines should follow cron when created/updated or enabled

### DIFF
--- a/src/service/alerts/derived_streams.rs
+++ b/src/service/alerts/derived_streams.rs
@@ -141,23 +141,24 @@ pub async fn save(
         };
     }
 
-    let next_run_at =
-        if derived_stream.trigger_condition.frequency_type == FrequencyType::Cron {
-            match derived_stream
-                .trigger_condition
-                .get_next_trigger_time(false, derived_stream.tz_offset, false, None)
-            {
-                Ok(t) => t,
-                Err(e) => {
-                    log::error!(
-                        "Failed to compute next trigger time for DerivedStream {trigger_module_key}: {e}"
-                    );
-                    chrono::Utc::now().timestamp_micros()
-                }
+    let next_run_at = if derived_stream.trigger_condition.frequency_type == FrequencyType::Cron {
+        match derived_stream.trigger_condition.get_next_trigger_time(
+            false,
+            derived_stream.tz_offset,
+            false,
+            None,
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                log::error!(
+                    "Failed to compute next trigger time for DerivedStream {trigger_module_key}: {e}"
+                );
+                chrono::Utc::now().timestamp_micros()
             }
-        } else {
-            chrono::Utc::now().timestamp_micros()
-        };
+        }
+    } else {
+        chrono::Utc::now().timestamp_micros()
+    };
     // Save the trigger to db
     match db::scheduler::get(
         &derived_stream.org_id,

--- a/src/service/alerts/derived_streams.rs
+++ b/src/service/alerts/derived_streams.rs
@@ -141,7 +141,23 @@ pub async fn save(
         };
     }
 
-    let next_run_at = chrono::Utc::now().timestamp_micros();
+    let next_run_at =
+        if derived_stream.trigger_condition.frequency_type == FrequencyType::Cron {
+            match derived_stream
+                .trigger_condition
+                .get_next_trigger_time(false, derived_stream.tz_offset, false, None)
+            {
+                Ok(t) => t,
+                Err(e) => {
+                    log::error!(
+                        "Failed to compute next trigger time for DerivedStream {trigger_module_key}: {e}"
+                    );
+                    chrono::Utc::now().timestamp_micros()
+                }
+            }
+        } else {
+            chrono::Utc::now().timestamp_micros()
+        };
     // Save the trigger to db
     match db::scheduler::get(
         &derived_stream.org_id,

--- a/src/service/db/alerts/alert.rs
+++ b/src/service/db/alerts/alert.rs
@@ -17,7 +17,10 @@ use std::{collections::HashSet, str::FromStr};
 
 use config::{
     meta::{
-        alerts::{FrequencyType, alert::{Alert, ListAlertsParams}},
+        alerts::{
+            FrequencyType,
+            alert::{Alert, ListAlertsParams},
+        },
         folder::{DEFAULT_FOLDER, Folder},
         stream::StreamType,
     },
@@ -78,23 +81,24 @@ pub async fn set(org_id: &str, alert: Alert, create: bool) -> Result<Alert, infr
             }
 
             let schedule_key = scheduler_key(alert.id);
-            let next_run_at =
-                if alert.trigger_condition.frequency_type == FrequencyType::Cron {
-                    match alert
-                        .trigger_condition
-                        .get_next_trigger_time(true, alert.tz_offset, false, None)
-                    {
-                        Ok(t) => t,
-                        Err(e) => {
-                            log::error!(
-                                "Failed to compute next trigger time for alert {schedule_key}: {e}"
-                            );
-                            now_micros()
-                        }
+            let next_run_at = if alert.trigger_condition.frequency_type == FrequencyType::Cron {
+                match alert.trigger_condition.get_next_trigger_time(
+                    true,
+                    alert.tz_offset,
+                    false,
+                    None,
+                ) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        log::error!(
+                            "Failed to compute next trigger time for alert {schedule_key}: {e}"
+                        );
+                        now_micros()
                     }
-                } else {
-                    now_micros()
-                };
+                }
+            } else {
+                now_micros()
+            };
             // Get the trigger from scheduler
             let mut trigger = db::scheduler::Trigger {
                 org: org_id.to_string(),
@@ -182,9 +186,7 @@ pub async fn create<C: TransactionTrait>(
         {
             Ok(t) => t,
             Err(e) => {
-                log::error!(
-                    "Failed to compute next trigger time for alert {schedule_key}: {e}"
-                );
+                log::error!("Failed to compute next trigger time for alert {schedule_key}: {e}");
                 now_micros()
             }
         }
@@ -229,9 +231,7 @@ pub async fn update<C: ConnectionTrait + TransactionTrait>(
         {
             Ok(t) => t,
             Err(e) => {
-                log::error!(
-                    "Failed to compute next trigger time for alert {schedule_key}: {e}"
-                );
+                log::error!("Failed to compute next trigger time for alert {schedule_key}: {e}");
                 now_micros()
             }
         }

--- a/src/service/db/alerts/alert.rs
+++ b/src/service/db/alerts/alert.rs
@@ -17,7 +17,7 @@ use std::{collections::HashSet, str::FromStr};
 
 use config::{
     meta::{
-        alerts::alert::{Alert, ListAlertsParams},
+        alerts::{FrequencyType, alert::{Alert, ListAlertsParams}},
         folder::{DEFAULT_FOLDER, Folder},
         stream::StreamType,
     },
@@ -78,11 +78,28 @@ pub async fn set(org_id: &str, alert: Alert, create: bool) -> Result<Alert, infr
             }
 
             let schedule_key = scheduler_key(alert.id);
+            let next_run_at =
+                if alert.trigger_condition.frequency_type == FrequencyType::Cron {
+                    match alert
+                        .trigger_condition
+                        .get_next_trigger_time(true, alert.tz_offset, false, None)
+                    {
+                        Ok(t) => t,
+                        Err(e) => {
+                            log::error!(
+                                "Failed to compute next trigger time for alert {schedule_key}: {e}"
+                            );
+                            now_micros()
+                        }
+                    }
+                } else {
+                    now_micros()
+                };
             // Get the trigger from scheduler
             let mut trigger = db::scheduler::Trigger {
                 org: org_id.to_string(),
                 module_key: schedule_key.clone(),
-                next_run_at: now_micros(),
+                next_run_at,
                 is_realtime: alert.is_real_time,
                 is_silenced: false,
                 ..Default::default()
@@ -158,10 +175,26 @@ pub async fn create<C: TransactionTrait>(
     #[cfg(feature = "enterprise")]
     super_cluster::emit_create_event(org_id, folder_id, alert.clone()).await?;
 
+    let next_run_at = if alert.trigger_condition.frequency_type == FrequencyType::Cron {
+        match alert
+            .trigger_condition
+            .get_next_trigger_time(true, alert.tz_offset, false, None)
+        {
+            Ok(t) => t,
+            Err(e) => {
+                log::error!(
+                    "Failed to compute next trigger time for alert {schedule_key}: {e}"
+                );
+                now_micros()
+            }
+        }
+    } else {
+        now_micros()
+    };
     let trigger = db::scheduler::Trigger {
         org: org_id.to_string(),
         module_key: schedule_key.clone(),
-        next_run_at: now_micros(),
+        next_run_at,
         is_realtime: alert.is_real_time,
         is_silenced: false,
         ..Default::default()
@@ -189,10 +222,26 @@ pub async fn update<C: ConnectionTrait + TransactionTrait>(
     #[cfg(feature = "enterprise")]
     super_cluster::emit_update_event(org_id, folder_id, alert.clone()).await?;
 
+    let next_run_at = if alert.trigger_condition.frequency_type == FrequencyType::Cron {
+        match alert
+            .trigger_condition
+            .get_next_trigger_time(true, alert.tz_offset, false, None)
+        {
+            Ok(t) => t,
+            Err(e) => {
+                log::error!(
+                    "Failed to compute next trigger time for alert {schedule_key}: {e}"
+                );
+                now_micros()
+            }
+        }
+    } else {
+        now_micros()
+    };
     let mut trigger = db::scheduler::Trigger {
         org: org_id.to_string(),
         module_key: schedule_key.clone(),
-        next_run_at: now_micros(),
+        next_run_at,
         is_realtime: alert.is_real_time,
         is_silenced: false,
         ..Default::default()

--- a/src/service/db/dashboards/reports.rs
+++ b/src/service/db/dashboards/reports.rs
@@ -79,7 +79,8 @@ pub async fn update<C: ConnectionTrait + TransactionTrait>(
 ) -> Result<(), anyhow::Error> {
     let org_id = report.org_id.clone();
     let next_run_at = if report.frequency.frequency_type == ReportFrequencyType::Cron {
-        let tz_offset = FixedOffset::east_opt(report.tz_offset * 60).unwrap_or(FixedOffset::east_opt(0).unwrap());
+        let tz_offset = FixedOffset::east_opt(report.tz_offset * 60)
+            .unwrap_or(FixedOffset::east_opt(0).unwrap());
         match Schedule::from_str(&report.frequency.cron) {
             Ok(schedule) => schedule
                 .upcoming(tz_offset)

--- a/src/service/db/dashboards/reports.rs
+++ b/src/service/db/dashboards/reports.rs
@@ -55,7 +55,23 @@ pub async fn create<C: ConnectionTrait + TransactionTrait>(
     report: Report,
 ) -> Result<String, anyhow::Error> {
     let org = report.org_id.clone();
-    let next_run_at = report.start;
+    let next_run_at = if report.frequency.frequency_type == ReportFrequencyType::Cron {
+        let tz_offset = FixedOffset::east_opt(report.tz_offset * 60)
+            .unwrap_or(FixedOffset::east_opt(0).unwrap());
+        match Schedule::from_str(&report.frequency.cron) {
+            Ok(schedule) => schedule
+                .upcoming(tz_offset)
+                .next()
+                .map(|t| t.timestamp_micros())
+                .unwrap_or(report.start),
+            Err(e) => {
+                log::error!("Failed to parse cron expression for report: {e}");
+                report.start
+            }
+        }
+    } else {
+        report.start
+    };
 
     let report_id = create_without_updating_trigger(conn, folder_snowflake_id, report).await?;
     let trigger = db::scheduler::Trigger {
@@ -189,7 +205,23 @@ pub async fn update_by_id<C: ConnectionTrait + TransactionTrait>(
     report: Report,
 ) -> Result<(), anyhow::Error> {
     let org_id = report.org_id.clone();
-    let next_run_at = report.start;
+    let next_run_at = if report.frequency.frequency_type == ReportFrequencyType::Cron {
+        let tz_offset = FixedOffset::east_opt(report.tz_offset * 60)
+            .unwrap_or(FixedOffset::east_opt(0).unwrap());
+        match Schedule::from_str(&report.frequency.cron) {
+            Ok(schedule) => schedule
+                .upcoming(tz_offset)
+                .next()
+                .map(|t| t.timestamp_micros())
+                .unwrap_or(report.start),
+            Err(e) => {
+                log::error!("Failed to parse cron expression for report: {e}");
+                report.start
+            }
+        }
+    } else {
+        report.start
+    };
 
     let id =
         update_by_id_without_updating_trigger(conn, report_id, new_folder_snowflake_id, report)

--- a/src/service/db/dashboards/reports.rs
+++ b/src/service/db/dashboards/reports.rs
@@ -13,10 +13,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::str::FromStr;
+
+use chrono::FixedOffset;
 use config::meta::{
-    dashboards::reports::{ListReportsParams, Report},
+    dashboards::reports::{ListReportsParams, Report, ReportFrequencyType},
     folder::{DEFAULT_FOLDER, Folder, FolderType},
 };
+use cron::Schedule;
 use infra::table;
 use sea_orm::{ConnectionTrait, TransactionTrait};
 
@@ -74,7 +78,22 @@ pub async fn update<C: ConnectionTrait + TransactionTrait>(
     report: Report,
 ) -> Result<(), anyhow::Error> {
     let org_id = report.org_id.clone();
-    let next_run_at = report.start;
+    let next_run_at = if report.frequency.frequency_type == ReportFrequencyType::Cron {
+        let tz_offset = FixedOffset::east_opt(report.tz_offset * 60).unwrap_or(FixedOffset::east_opt(0).unwrap());
+        match Schedule::from_str(&report.frequency.cron) {
+            Ok(schedule) => schedule
+                .upcoming(tz_offset)
+                .next()
+                .map(|t| t.timestamp_micros())
+                .unwrap_or(report.start),
+            Err(e) => {
+                log::error!("Failed to parse cron expression for report: {e}");
+                report.start
+            }
+        }
+    } else {
+        report.start
+    };
 
     let report_id =
         update_without_updating_trigger(conn, folder_snowflake_id, new_folder_snowflake_id, report)


### PR DESCRIPTION
Currently alerts/reports/scheduled pipelines get triggered immediately when updated or enabled or created. Instead, it should follow the cron expression (if given) instead of triggering immediately.