### PR TITLE
fix: skip milestone on PRs not targeting main branch

### DIFF
--- a/.github/workflows/auto-assign-metadata.yml
+++ b/.github/workflows/auto-assign-metadata.yml
@@ -32,7 +32,7 @@ jobs:
 
       # ── PR: add lowest open milestone (skip drafts) ──
       - name: Add milestone to PR
-        if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main'
         env:
           GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Adds `github.event.pull_request.base.ref == 'main'` guard to the "Add milestone to PR" step
- PRs opened against non-main branches (feature, release, etc.) will no longer receive auto-assigned milestones
- Issue milestone logic is unchanged (issues don't have a target branch)

## Test plan
- [ ] PR opened against `main` → milestone is assigned (existing behavior preserved)
- [ ] PR opened against a non-`main` branch (e.g., `feature/xyz`) → milestone step is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)