### PR TITLE
fix: load previously used filters

### DIFF
--- a/web/src/composables/useCorrelationDefaultSlug.spec.ts
+++ b/web/src/composables/useCorrelationDefaultSlug.spec.ts
@@ -1,0 +1,327 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  extractCorrelationFilters,
+  saveCorrelationFilters,
+  loadCorrelationFilters,
+  clearCorrelationFilters,
+  buildCorrelationWhereClause,
+  clearCorrelationCache,
+  getCorrelationFieldNames,
+  useCorrelationFilters,
+  type SavedFilter,
+} from "./useCorrelationDefaultSlug";
+
+vi.mock("@/utils/identityConfig", () => ({
+  loadIdentityConfig: vi.fn(),
+}));
+
+vi.mock("@/services/service_streams", () => ({
+  default: {
+    getSemanticGroups: vi.fn(),
+  },
+}));
+
+import { loadIdentityConfig } from "@/utils/identityConfig";
+import serviceStreamsApi from "@/services/service_streams";
+
+// ── localStorage helpers ──────────────────────────────────────────────────────
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(globalThis, "localStorage", { value: localStorageMock });
+
+beforeEach(() => {
+  localStorageMock.clear();
+  vi.clearAllMocks();
+  clearCorrelationCache();
+});
+
+// ── extractCorrelationFilters ─────────────────────────────────────────────────
+
+describe("extractCorrelationFilters", () => {
+  it("returns empty array for empty query", () => {
+    expect(extractCorrelationFilters("", ["host"])).toEqual([]);
+  });
+
+  it("returns empty array for empty tracked fields", () => {
+    expect(extractCorrelationFilters("host = 'web-01'", [])).toEqual([]);
+  });
+
+  it("extracts a single matching field", () => {
+    const result = extractCorrelationFilters("host = 'web-01'", ["host"]);
+    expect(result).toEqual([{ field: "host", value: "web-01" }]);
+  });
+
+  it("ignores fields not in tracked list", () => {
+    const result = extractCorrelationFilters("host = 'web-01' AND region = 'us'", ["host"]);
+    expect(result).toEqual([{ field: "host", value: "web-01" }]);
+  });
+
+  it("extracts multiple tracked fields", () => {
+    const result = extractCorrelationFilters(
+      "host = 'web-01' AND region = 'us-east'",
+      ["host", "region"],
+    );
+    expect(result).toEqual([
+      { field: "host", value: "web-01" },
+      { field: "region", value: "us-east" },
+    ]);
+  });
+
+  it("strips SQL WHERE prefix before parsing", () => {
+    const result = extractCorrelationFilters(
+      "SELECT * FROM \"logs\" WHERE host = 'web-01'",
+      ["host"],
+    );
+    expect(result).toEqual([{ field: "host", value: "web-01" }]);
+  });
+
+  it("updates existing field when it appears twice (last value wins)", () => {
+    const result = extractCorrelationFilters(
+      "host = 'web-01' AND host = 'web-02'",
+      ["host"],
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe("web-02");
+  });
+});
+
+// ── saveCorrelationFilters / loadCorrelationFilters ───────────────────────────
+
+describe("saveCorrelationFilters", () => {
+  it("stores filters in localStorage", () => {
+    const filters: SavedFilter[] = [{ field: "host", value: "web-01" }];
+    saveCorrelationFilters("org1", "logs", "mystream", filters);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      "oo_correlation_filters_org1_logs_mystream",
+      JSON.stringify(filters),
+    );
+  });
+
+  it("does nothing when filters array is empty", () => {
+    saveCorrelationFilters("org1", "logs", "mystream", []);
+    expect(localStorageMock.setItem).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when orgId is missing", () => {
+    saveCorrelationFilters("", "logs", "mystream", [{ field: "host", value: "x" }]);
+    expect(localStorageMock.setItem).not.toHaveBeenCalled();
+  });
+});
+
+describe("loadCorrelationFilters", () => {
+  it("returns stored filters", () => {
+    const filters: SavedFilter[] = [{ field: "host", value: "web-01" }];
+    saveCorrelationFilters("org1", "logs", "mystream", filters);
+    expect(loadCorrelationFilters("org1", "logs", "mystream")).toEqual(filters);
+  });
+
+  it("returns empty array when key does not exist", () => {
+    expect(loadCorrelationFilters("org1", "logs", "missing")).toEqual([]);
+  });
+
+  it("returns empty array on malformed JSON", () => {
+    localStorageMock.getItem.mockReturnValueOnce("not-json{{{");
+    expect(loadCorrelationFilters("org1", "logs", "mystream")).toEqual([]);
+  });
+});
+
+// ── clearCorrelationFilters ───────────────────────────────────────────────────
+
+describe("clearCorrelationFilters", () => {
+  it("removes the localStorage key", () => {
+    const filters: SavedFilter[] = [{ field: "host", value: "web-01" }];
+    saveCorrelationFilters("org1", "logs", "mystream", filters);
+    clearCorrelationFilters("org1", "logs", "mystream");
+    expect(loadCorrelationFilters("org1", "logs", "mystream")).toEqual([]);
+  });
+});
+
+// ── buildCorrelationWhereClause ───────────────────────────────────────────────
+
+describe("buildCorrelationWhereClause", () => {
+  it("returns empty string for empty filters", () => {
+    expect(buildCorrelationWhereClause([])).toBe("");
+  });
+
+  it("builds a single condition", () => {
+    expect(buildCorrelationWhereClause([{ field: "host", value: "web-01" }])).toBe(
+      "host = 'web-01'",
+    );
+  });
+
+  it("joins multiple conditions with AND", () => {
+    const result = buildCorrelationWhereClause([
+      { field: "host", value: "web-01" },
+      { field: "region", value: "us-east" },
+    ]);
+    expect(result).toBe("host = 'web-01' AND region = 'us-east'");
+  });
+
+  it("escapes single quotes in values", () => {
+    const result = buildCorrelationWhereClause([{ field: "name", value: "o'brien" }]);
+    expect(result).toBe("name = 'o''brien'");
+  });
+});
+
+// ── getCorrelationFieldNames ──────────────────────────────────────────────────
+
+describe("getCorrelationFieldNames", () => {
+  it("returns empty array when loadIdentityConfig throws", async () => {
+    vi.mocked(loadIdentityConfig).mockRejectedValueOnce(new Error("network"));
+    const result = await getCorrelationFieldNames("org1", "mystream", [{ name: "host" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when no tracked alias ids", async () => {
+    vi.mocked(loadIdentityConfig).mockResolvedValueOnce({ tracked_alias_ids: [] });
+    const result = await getCorrelationFieldNames("org1", "mystream", [{ name: "host" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("resolves aliasId directly when not in semantic groups but present in schema", async () => {
+    vi.mocked(loadIdentityConfig).mockResolvedValueOnce({ tracked_alias_ids: ["host"] });
+    vi.mocked(serviceStreamsApi.getSemanticGroups).mockResolvedValueOnce({ data: [] });
+    const result = await getCorrelationFieldNames("org1", "stream1", [{ name: "host" }]);
+    expect(result).toEqual(["host"]);
+  });
+
+  it("resolves fields via semantic group mapping", async () => {
+    vi.mocked(loadIdentityConfig).mockResolvedValueOnce({ tracked_alias_ids: ["alias1"] });
+    vi.mocked(serviceStreamsApi.getSemanticGroups).mockResolvedValueOnce({
+      data: [{ id: "alias1", fields: ["host", "ip"] }],
+    });
+    const result = await getCorrelationFieldNames("org1", "stream2", [
+      { name: "host" },
+      { name: "region" },
+    ]);
+    expect(result).toEqual(["host"]);
+  });
+
+  it("caches results on second call", async () => {
+    vi.mocked(loadIdentityConfig).mockResolvedValue({ tracked_alias_ids: ["host"] });
+    vi.mocked(serviceStreamsApi.getSemanticGroups).mockResolvedValue({ data: [] });
+    await getCorrelationFieldNames("org1", "cached-stream", [{ name: "host" }]);
+    await getCorrelationFieldNames("org1", "cached-stream", [{ name: "host" }]);
+    expect(loadIdentityConfig).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── useCorrelationFilters composable ─────────────────────────────────────────
+
+describe("useCorrelationFilters", () => {
+  const makeOpts = (overrides: Partial<Parameters<typeof useCorrelationFilters>[0]> = {}) => {
+    let query = "";
+    return {
+      orgId: () => "org1",
+      streamType: () => "logs",
+      streamName: () => "mystream",
+      streamSchemaFields: () => [{ name: "host" }],
+      getQuery: () => query,
+      setQuery: vi.fn((q: string) => { query = q; }),
+      ...overrides,
+    };
+  };
+
+  describe("save / sync", () => {
+    it("clears filters when query is empty", async () => {
+      vi.mocked(loadIdentityConfig).mockResolvedValueOnce({ tracked_alias_ids: ["host"] });
+      vi.mocked(serviceStreamsApi.getSemanticGroups).mockResolvedValueOnce({ data: [] });
+
+      saveCorrelationFilters("org1", "logs", "mystream", [{ field: "host", value: "old" }]);
+      const opts = makeOpts({ getQuery: () => "" });
+      const { save } = useCorrelationFilters(opts);
+      await save();
+      expect(loadCorrelationFilters("org1", "logs", "mystream")).toEqual([]);
+    });
+
+    it("saves matched filters from query", async () => {
+      vi.mocked(loadIdentityConfig).mockResolvedValueOnce({ tracked_alias_ids: ["host"] });
+      vi.mocked(serviceStreamsApi.getSemanticGroups).mockResolvedValueOnce({ data: [] });
+
+      const opts = makeOpts({ getQuery: () => "host = 'web-01'" });
+      const { save } = useCorrelationFilters(opts);
+      await save();
+      expect(loadCorrelationFilters("org1", "logs", "mystream")).toEqual([
+        { field: "host", value: "web-01" },
+      ]);
+    });
+
+    it("clears filters when no tracked fields match query", async () => {
+      vi.mocked(loadIdentityConfig).mockResolvedValueOnce({ tracked_alias_ids: ["host"] });
+      vi.mocked(serviceStreamsApi.getSemanticGroups).mockResolvedValueOnce({ data: [] });
+
+      saveCorrelationFilters("org1", "logs", "mystream", [{ field: "host", value: "old" }]);
+      const opts = makeOpts({ getQuery: () => "region = 'us-east'" });
+      const { save } = useCorrelationFilters(opts);
+      await save();
+      expect(loadCorrelationFilters("org1", "logs", "mystream")).toEqual([]);
+    });
+
+    it("does nothing when orgId is missing", async () => {
+      const opts = makeOpts({ orgId: () => "", getQuery: () => "host = 'x'" });
+      const { save } = useCorrelationFilters(opts);
+      await save();
+      expect(loadIdentityConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("restore", () => {
+    it("sets query from saved filters", () => {
+      saveCorrelationFilters("org1", "logs", "mystream", [{ field: "host", value: "web-01" }]);
+      const setQuery = vi.fn();
+      const opts = makeOpts({ getQuery: () => "", setQuery });
+      const { restore } = useCorrelationFilters(opts);
+      restore();
+      expect(setQuery).toHaveBeenCalledWith("host = 'web-01'");
+    });
+
+    it("does not overwrite existing query", () => {
+      saveCorrelationFilters("org1", "logs", "mystream", [{ field: "host", value: "web-01" }]);
+      const setQuery = vi.fn();
+      const opts = makeOpts({ getQuery: () => "existing query", setQuery });
+      const { restore } = useCorrelationFilters(opts);
+      restore();
+      expect(setQuery).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when no saved filters", () => {
+      const setQuery = vi.fn();
+      const opts = makeOpts({ getQuery: () => "", setQuery });
+      const { restore } = useCorrelationFilters(opts);
+      restore();
+      expect(setQuery).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when orgId is missing", () => {
+      const setQuery = vi.fn();
+      const opts = makeOpts({ orgId: () => "", getQuery: () => "", setQuery });
+      const { restore } = useCorrelationFilters(opts);
+      restore();
+      expect(setQuery).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/composables/useCorrelationDefaultSlug.ts
+++ b/web/src/composables/useCorrelationDefaultSlug.ts
@@ -1,0 +1,252 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { loadIdentityConfig } from "@/utils/identityConfig";
+import serviceStreamsApi from "@/services/service_streams";
+import type { FieldAlias } from "@/services/service_streams";
+
+// ── Cache ────────────────────────────────────────────────────────────────────
+
+const fieldNamesCache = new Map<string, string[]>();
+const semanticGroupsCache = new Map<string, FieldAlias[]>();
+
+async function loadSemanticGroups(orgId: string): Promise<FieldAlias[]> {
+  if (semanticGroupsCache.has(orgId)) return semanticGroupsCache.get(orgId)!;
+  try {
+    const response = await serviceStreamsApi.getSemanticGroups(orgId);
+    const groups: FieldAlias[] = response.data ?? [];
+    semanticGroupsCache.set(orgId, groups);
+    return groups;
+  } catch {
+    return [];
+  }
+}
+
+// ── Field resolution ─────────────────────────────────────────────────────────
+
+export async function getCorrelationFieldNames(
+  orgId: string,
+  streamName: string,
+  streamSchemaFields: { name: string }[],
+): Promise<string[]> {
+  const key = `${orgId}/${streamName}`;
+  if (fieldNamesCache.has(key)) return fieldNamesCache.get(key)!;
+
+  let identityConfig: any;
+  try {
+    identityConfig = await loadIdentityConfig(orgId);
+  } catch {
+    return [];
+  }
+
+  const trackedIds: string[] = identityConfig?.tracked_alias_ids;
+  if (!trackedIds?.length) return [];
+
+  const semanticGroups = await loadSemanticGroups(orgId);
+  const idToFields = new Map<string, string[]>();
+  for (const group of semanticGroups) idToFields.set(group.id, group.fields);
+
+  const schemaFieldNames = new Set(streamSchemaFields.map((f) => f.name));
+  const matched: string[] = [];
+  for (const aliasId of trackedIds) {
+    const fieldNames = idToFields.get(aliasId);
+    if (fieldNames) {
+      for (const fieldName of fieldNames) {
+        if (schemaFieldNames.has(fieldName)) matched.push(fieldName);
+      }
+    } else if (schemaFieldNames.has(aliasId)) {
+      matched.push(aliasId);
+    }
+  }
+
+  fieldNamesCache.set(key, matched);
+  return matched;
+}
+
+// ── Storage ───────────────────────────────────────────────────────────────────
+
+const STORAGE_PREFIX = "oo_correlation_filters";
+
+function storageKey(orgId: string, streamType: string, streamName: string): string {
+  return `${STORAGE_PREFIX}_${orgId}_${streamType}_${streamName}`;
+}
+
+export interface SavedFilter {
+  field: string;
+  value: string;
+}
+
+export function extractCorrelationFilters(
+  queryStr: string,
+  trackedFieldNames: string[],
+): SavedFilter[] {
+  if (!queryStr || !trackedFieldNames.length) return [];
+
+  const trackedSet = new Set(trackedFieldNames);
+  const filters: SavedFilter[] = [];
+
+  // Strip SELECT ... FROM "stream" WHERE prefix for SQL mode queries
+  let whereClause = queryStr;
+  const whereIdx = queryStr.search(/WHERE\s+/i);
+  if (whereIdx !== -1) {
+    whereClause = queryStr.slice(whereIdx).replace(/^WHERE\s+/i, "");
+  }
+
+  const conditionRegex = /(\w+)\s*=\s*'([^']+)'/gi;
+  let m;
+  while ((m = conditionRegex.exec(whereClause)) !== null) {
+    if (trackedSet.has(m[1])) {
+      const existing = filters.findIndex((f) => f.field === m[1]);
+      if (existing >= 0) {
+        filters[existing].value = m[2];
+      } else {
+        filters.push({ field: m[1], value: m[2] });
+      }
+    }
+  }
+
+  return filters;
+}
+
+export function saveCorrelationFilters(
+  orgId: string,
+  streamType: string,
+  streamName: string,
+  filters: SavedFilter[],
+): void {
+  if (!orgId || !streamType || !streamName || !filters.length) return;
+
+  localStorage.setItem(
+    storageKey(orgId, streamType, streamName),
+    JSON.stringify(filters),
+  );
+}
+
+export function loadCorrelationFilters(
+  orgId: string,
+  streamType: string,
+  streamName: string,
+): SavedFilter[] {
+  try {
+    const raw = localStorage.getItem(storageKey(orgId, streamType, streamName));
+    if (!raw) return [];
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+export function buildCorrelationWhereClause(filters: SavedFilter[]): string {
+  if (!filters.length) return "";
+  return filters
+    .map((f) => `${f.field} = '${f.value.replace(/'/g, "''")}'`)
+    .join(" AND ");
+}
+
+export function clearCorrelationFilters(
+  orgId: string,
+  streamType: string,
+  streamName: string,
+): void {
+  localStorage.removeItem(storageKey(orgId, streamType, streamName));
+}
+
+export function clearCorrelationCache(): void {
+  fieldNamesCache.clear();
+  semanticGroupsCache.clear();
+}
+
+// ── Generic composable ────────────────────────────────────────────────────────
+
+import { watch, type WatchSource } from "vue";
+
+export interface CorrelationFiltersOptions {
+  orgId: () => string;
+  streamType: () => string;
+  streamName: () => string;
+  streamSchemaFields: () => { name: string }[];
+  getQuery: () => string;
+  setQuery: (whereClause: string) => void;
+  /** Reactive source to watch for query changes (e.g. () => searchObj.data.query) */
+  querySource?: WatchSource<string>;
+}
+
+export function useCorrelationFilters(opts: CorrelationFiltersOptions) {
+  const sync = async (queryStr: string): Promise<void> => {
+    try {
+      const orgId = opts.orgId();
+      const streamType = opts.streamType();
+      const streamName = opts.streamName();
+      if (!orgId || !streamType || !streamName) return;
+
+      if (!queryStr) {
+        clearCorrelationFilters(orgId, streamType, streamName);
+        return;
+      }
+
+      const trackedFields = await getCorrelationFieldNames(
+        orgId,
+        streamName,
+        opts.streamSchemaFields(),
+      );
+      if (!trackedFields.length) return;
+
+      const filters = extractCorrelationFilters(queryStr, trackedFields);
+      if (filters.length) {
+        saveCorrelationFilters(orgId, streamType, streamName, filters);
+      } else {
+        clearCorrelationFilters(orgId, streamType, streamName);
+      }
+    } catch (e) {
+      console.error("[correlation:sync] error:", e);
+    }
+  };
+
+  const save = (): Promise<void> => sync(opts.getQuery());
+
+  const restore = (): void => {
+    try {
+      const orgId = opts.orgId();
+      const streamType = opts.streamType();
+      const streamName = opts.streamName();
+      if (!orgId || !streamType || !streamName) return;
+
+      if (opts.getQuery()) return;
+
+      const saved = loadCorrelationFilters(orgId, streamType, streamName);
+      if (!saved.length) return;
+
+      const whereClause = buildCorrelationWhereClause(saved);
+      if (!whereClause) return;
+
+      opts.setQuery(whereClause);
+    } catch (e) {
+      console.error("[correlation:restore] error:", e);
+    }
+  };
+
+  // Sets up a watcher so localStorage stays in sync as user edits the query bar.
+  // Debounced to avoid firing on every keystroke.
+  const watchQuery = (): void => {
+    if (!opts.querySource) return;
+    let timer: ReturnType<typeof setTimeout>;
+    watch(opts.querySource, (newQuery: string) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => sync(newQuery), 600);
+    });
+  };
+
+  return { save, restore, watchQuery };
+}

--- a/web/src/composables/useCorrelationDefaultSlug.ts
+++ b/web/src/composables/useCorrelationDefaultSlug.ts
@@ -21,6 +21,19 @@ import type { FieldAlias } from "@/services/service_streams";
 
 const fieldNamesCache = new Map<string, string[]>();
 const semanticGroupsCache = new Map<string, FieldAlias[]>();
+let lastSeenOrgId: string | null = null;
+
+function evictOrgCacheIfSwitched(orgId: string): void {
+  if (lastSeenOrgId !== null && lastSeenOrgId !== orgId) {
+    // Org switched — remove all cached entries for the previous org so stale
+    // identity config and semantic groups are not reused.
+    for (const key of fieldNamesCache.keys()) {
+      if (key.startsWith(`${lastSeenOrgId}/`)) fieldNamesCache.delete(key);
+    }
+    semanticGroupsCache.delete(lastSeenOrgId);
+  }
+  lastSeenOrgId = orgId;
+}
 
 async function loadSemanticGroups(orgId: string): Promise<FieldAlias[]> {
   if (semanticGroupsCache.has(orgId)) return semanticGroupsCache.get(orgId)!;
@@ -41,6 +54,7 @@ export async function getCorrelationFieldNames(
   streamName: string,
   streamSchemaFields: { name: string }[],
 ): Promise<string[]> {
+  evictOrgCacheIfSwitched(orgId);
   const key = `${orgId}/${streamName}`;
   if (fieldNamesCache.has(key)) return fieldNamesCache.get(key)!;
 
@@ -104,15 +118,17 @@ export function extractCorrelationFilters(
     whereClause = queryStr.slice(whereIdx).replace(/^WHERE\s+/i, "");
   }
 
-  const conditionRegex = /(\w+)\s*=\s*'([^']+)'/gi;
+  // Match field = 'value' where value may contain SQL-escaped single quotes ('')
+  const conditionRegex = /(\w+)\s*=\s*'((?:[^']|'')*)'/gi;
   let m;
   while ((m = conditionRegex.exec(whereClause)) !== null) {
     if (trackedSet.has(m[1])) {
+      const value = m[2].replace(/''/g, "'");
       const existing = filters.findIndex((f) => f.field === m[1]);
       if (existing >= 0) {
-        filters[existing].value = m[2];
+        filters[existing].value = value;
       } else {
-        filters.push({ field: m[1], value: m[2] });
+        filters.push({ field: m[1], value });
       }
     }
   }
@@ -166,6 +182,7 @@ export function clearCorrelationFilters(
 export function clearCorrelationCache(): void {
   fieldNamesCache.clear();
   semanticGroupsCache.clear();
+  lastSeenOrgId = null;
 }
 
 // ── Generic composable ────────────────────────────────────────────────────────

--- a/web/src/composables/useLogs.ts
+++ b/web/src/composables/useLogs.ts
@@ -185,16 +185,16 @@ const useLogs = () => {
     }
   };
 
-  const processPostPaginationData = () => {
+  const processPostPaginationData = async () => {
     updateFieldValues();
 
     //extract fields from query response
-    extractFields();
+    await extractFields();
 
     //update grid columns
     updateGridColumns();
 
-    filterHitsColumns();
+    await filterHitsColumns();
     searchObj.data.histogram.chartParams.title = getHistogramTitle();
   };
 

--- a/web/src/composables/useLogs/searchAround.ts
+++ b/web/src/composables/useLogs/searchAround.ts
@@ -181,7 +181,7 @@ export const useSearchAround = () => {
           is_multistream: searchObj.data.stream.selectedStream.length > 1,
           traceparent,
         })
-        .then((res: { data: SearchAroundResponse }) => {
+        .then(async (res: { data: SearchAroundResponse }) => {
           searchObj.loading = false;
           searchObj.data.histogram.chartParams.title = "";
           if (res.data.from > 0) {
@@ -193,12 +193,12 @@ export const useSearchAround = () => {
             searchObj.data.queryResults = res.data;
           }
           //extract fields from query response
-          extractFields();
+          await extractFields();
           generateHistogramSkeleton();
           generateHistogramData();
           //update grid columns
           updateGridColumns();
-          filterHitsColumns();
+          await filterHitsColumns();
 
           if (searchObj.meta.showHistogram) {
             searchObj.meta.showHistogram = false;

--- a/web/src/composables/useLogs/usePagination.ts
+++ b/web/src/composables/useLogs/usePagination.ts
@@ -497,16 +497,16 @@ export const usePagination = () => {
     });
   };
 
-  const processPostPaginationData = () => {
+  const processPostPaginationData = async () => {
     updateFieldValues();
 
     //extract fields from query response
-    extractFields();
+    await extractFields();
 
     //update grid columns
     updateGridColumns();
 
-    filterHitsColumns();
+    await filterHitsColumns();
     searchObj.data.histogram.chartParams.title = getHistogramTitle();
   };
 

--- a/web/src/composables/useLogs/useSearchResponseHandler.ts
+++ b/web/src/composables/useLogs/useSearchResponseHandler.ts
@@ -220,11 +220,11 @@ export const useSearchResponseHandler = () => {
     processPostPaginationData();
   };
 
-  const processPostPaginationData = () => {
+  const processPostPaginationData = async () => {
     updateFieldValues();
-    extractFields();
+    await extractFields();
     updateGridColumns();
-    filterHitsColumns();
+    await filterHitsColumns();
     searchObj.data.histogram.chartParams.title = getHistogramTitle();
   };
 

--- a/web/src/composables/useLogs/useSearchResponseHandler.ts
+++ b/web/src/composables/useLogs/useSearchResponseHandler.ts
@@ -173,7 +173,7 @@ export const useSearchResponseHandler = () => {
     }
   };
 
-  const handleStreamingHits = (
+  const handleStreamingHits = async (
     payload: WebSocketSearchPayload,
     response: WebSocketSearchResponse,
     isPagination: boolean,
@@ -217,7 +217,7 @@ export const useSearchResponseHandler = () => {
     }
 
     refreshPagination(true);
-    processPostPaginationData();
+    await processPostPaginationData();
   };
 
   const processPostPaginationData = async () => {

--- a/web/src/composables/useLogs/useStreamFields.ts
+++ b/web/src/composables/useLogs/useStreamFields.ts
@@ -31,6 +31,7 @@ import {
   convertToCamelCase,
   deepCopy,
 } from "@/utils/zincutils";
+import { useCorrelationFilters } from "@/composables/useCorrelationDefaultSlug";
 
 import { logsUtils } from "@/composables/useLogs/logsUtils";
 
@@ -51,6 +52,21 @@ export const useStreamFields = () => {
   } = searchState();
 
   const { fnParsedSQL, getColumnWidth } = logsUtils();
+
+  const correlationFilters = useCorrelationFilters({
+    orgId: () => store.state.selectedOrganization.identifier,
+    streamType: () => searchObj.data.stream.streamType,
+    streamName: () => searchObj.data.stream.selectedStream[0],
+    streamSchemaFields: () => searchObj.data.stream.selectedStreamFields,
+    getQuery: () => searchObj.data.query || searchObj.data.editorValue,
+    setQuery: (whereClause: string) => {
+      searchObj.data.query = whereClause;
+      searchObj.data.editorValue = whereClause;
+      searchObj.meta.sqlMode = false;
+    },
+    querySource: () => searchObj.data.query,
+  });
+  correlationFilters.watchQuery();
 
   const updateFieldValues = () => {
     try {
@@ -753,6 +769,9 @@ export const useStreamFields = () => {
 
         createFieldIndexMapping();
       }
+
+      correlationFilters.restore();
+
       searchObjDebug["extractFieldsEndTime"] = performance.now();
     } catch (e: any) {
       searchObj.loadingStream = false;
@@ -1112,6 +1131,7 @@ export const useStreamFields = () => {
       }
 
       extractFTSFields();
+      correlationFilters.restore();
     } catch (e: any) {
       searchObj.loadingStream = false;
       notificationMsg.value = "Error while updating table columns.";
@@ -1135,7 +1155,7 @@ export const useStreamFields = () => {
     }
   };
 
-  const filterHitsColumns = () => {
+  const filterHitsColumns = async () => {
     searchObj.data.queryResults.filteredHit = [];
     let itemHits: any = {};
     if (searchObj.data.stream.selectedFields.length > 0) {
@@ -1155,7 +1175,10 @@ export const useStreamFields = () => {
       searchObj.data.queryResults.filteredHit =
         searchObj.data.queryResults.hits;
     }
+
+    await correlationFilters.save();
   };
+
 
   return {
     updateFieldValues,

--- a/web/src/composables/useLogs/useStreamFields.ts
+++ b/web/src/composables/useLogs/useStreamFields.ts
@@ -1131,7 +1131,6 @@ export const useStreamFields = () => {
       }
 
       extractFTSFields();
-      correlationFilters.restore();
     } catch (e: any) {
       searchObj.loadingStream = false;
       notificationMsg.value = "Error while updating table columns.";

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -986,7 +986,7 @@ async function getQueryData(
         org_id: searchObj.organizationIdentifier,
       },
       {
-        data: async (_payload: any, response: any) => {
+        data: (_payload: any, response: any) => {
           // Each metadata event signals a new backend partition — advance the counter
           if (response.type === "search_response_metadata") {
             tracesPartitionMap[searchTraceId].partition++;
@@ -1068,7 +1068,9 @@ async function getQueryData(
             ) {
               loadLocalLogFilterField(searchObj.meta.searchMode);
               rebuildColumns();
-              await correlationFilters.save();
+              correlationFilters.save().catch((e) =>
+                console.error("[correlation:save] error:", e),
+              );
             }
           }
         },

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -309,6 +309,7 @@ import { useTracesTableColumns } from "./composables/useTracesTableColumns";
 import type { TraceSearchMode } from "@/ts/interfaces/traces/trace.types";
 import { isLLMTrace } from "@/utils/llmUtils";
 import { saveTracesStream, restoreTracesStream } from "@/utils/streamPersist";
+import { useCorrelationFilters } from "@/composables/useCorrelationDefaultSlug";
 
 const SearchBar = defineAsyncComponent(() => import("./SearchBar.vue"));
 const IndexList = defineAsyncComponent(() => import("./IndexList.vue"));
@@ -336,6 +337,20 @@ const {
   updatedLocalLogFilterField,
 } = useTraces();
 const { fnParsedSQL } = logsUtils();
+
+const correlationFilters = useCorrelationFilters({
+  orgId: () => store.state.selectedOrganization.identifier,
+  streamType: () => "traces",
+  streamName: () => searchObj.data.stream.selectedStream.value,
+  streamSchemaFields: () => searchObj.data.stream.selectedStreamFields,
+  getQuery: () => searchObj.data.editorValue,
+  setQuery: (whereClause: string) => {
+    searchObj.data.editorValue = whereClause;
+  },
+  querySource: () => searchObj.data.editorValue,
+});
+correlationFilters.watchQuery();
+
 let refreshIntervalID = 0;
 const searchResultRef = ref(null);
 const searchBarRef = ref(null);
@@ -461,6 +476,7 @@ async function getStreamList() {
         }
 
         await extractFields();
+        correlationFilters.restore();
 
         if (
           searchObj.data.editorValue &&
@@ -1052,6 +1068,7 @@ async function getQueryData(
             ) {
               loadLocalLogFilterField(searchObj.meta.searchMode);
               rebuildColumns();
+              correlationFilters.save();
             }
           }
         },

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -476,7 +476,10 @@ async function getStreamList() {
         }
 
         await extractFields();
+        const queryBeforeRestore = searchObj.data.editorValue;
         correlationFilters.restore();
+        const filterWasRestored =
+          !queryBeforeRestore && !!searchObj.data.editorValue;
 
         if (
           searchObj.data.editorValue &&
@@ -484,6 +487,7 @@ async function getStreamList() {
         )
           nextTick(() => {
             restoreFilters(searchObj.data.editorValue);
+            if (filterWasRestored) searchData();
           });
       })
       .catch((e) => {

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -1068,9 +1068,6 @@ async function getQueryData(
             ) {
               loadLocalLogFilterField(searchObj.meta.searchMode);
               rebuildColumns();
-              correlationFilters.save().catch((e) =>
-                console.error("[correlation:save] error:", e),
-              );
             }
           }
         },
@@ -1102,6 +1099,9 @@ async function getQueryData(
           if (!isPagination) {
             fetchTracesCount();
           }
+          correlationFilters.save().catch((e) =>
+            console.error("[correlation:save] error:", e),
+          );
         },
         reset: (_payload: any) => {
           searchObj.data.queryResults = {};
@@ -1821,9 +1821,9 @@ const getMoreData = () => {
   }
 };
 
-const onChangeStream = () => {
+const onChangeStream = async () => {
+  await extractFields();
   runQueryFn();
-  extractFields();
 };
 
 const collapseFieldList = () => {

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -986,7 +986,7 @@ async function getQueryData(
         org_id: searchObj.organizationIdentifier,
       },
       {
-        data: (_payload: any, response: any) => {
+        data: async (_payload: any, response: any) => {
           // Each metadata event signals a new backend partition — advance the counter
           if (response.type === "search_response_metadata") {
             tracesPartitionMap[searchTraceId].partition++;
@@ -1068,7 +1068,7 @@ async function getQueryData(
             ) {
               loadLocalLogFilterField(searchObj.meta.searchMode);
               rebuildColumns();
-              correlationFilters.save();
+              await correlationFilters.save();
             }
           }
         },


### PR DESCRIPTION
- load filter used by users in last session for logs and traces
- we only use keys from co-relation settings