### PR TITLE
feat: add llm_input and llm_output as default full text search fields

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -106,8 +106,17 @@ pub const STREAM_NAME_LABEL: &str = "o2_stream_name";
 pub const STREAM_NAME_LABEL_OLD: &str = "stream_name";
 pub const DEFAULT_STREAM_NAME: &str = "default";
 
-const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 8] = [
-    "log", "message", "msg", "content", "data", "body", "json", "error",
+const _DEFAULT_SQL_FULL_TEXT_SEARCH_FIELDS: [&str; 10] = [
+    "log",
+    "message",
+    "msg",
+    "content",
+    "data",
+    "body",
+    "json",
+    "error",
+    "llm_input",
+    "llm_output",
 ];
 pub static SQL_FULL_TEXT_SEARCH_FIELDS: Lazy<Vec<String>> = Lazy::new(|| {
     let mut fields = chain(


### PR DESCRIPTION
Design at: #11518

## Summary
- Add `llm_input` and `llm_output` to the default SQL full text search field list so LLM-related streams get FTS out of the box without needing to set `feature_fulltext_extra_fields`.

## Test plan
- [x] Verify a stream with `llm_input` / `llm_output` columns is searchable via `match_all` without extra config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)