### PR TITLE
fix: allow updating LLM stream setting

### DIFF
--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -777,6 +777,8 @@ pub struct UpdateStreamSettings {
     #[serde(default)]
     pub enable_log_patterns_extraction: Option<bool>,
     #[serde(default)]
+    pub is_llm_stream: Option<bool>,
+    #[serde(default)]
     pub cross_links: UpdateSettingsWrapper<CrossLink>,
     #[serde(default)]
     pub storage_type: Option<StorageType>,
@@ -1367,6 +1369,18 @@ mod tests {
         let rpc_meta = cluster_rpc::FileMeta::from(&file_meta);
         let resp = FileMeta::from(&rpc_meta);
         assert_eq!(file_meta, resp);
+    }
+
+    #[test]
+    fn test_update_stream_settings_accepts_is_llm_stream() {
+        let settings: UpdateStreamSettings = json::from_str(r#"{"is_llm_stream":false}"#).unwrap();
+        assert_eq!(settings.is_llm_stream, Some(false));
+    }
+
+    #[test]
+    fn test_stream_settings_from_preserves_is_llm_stream() {
+        let settings = StreamSettings::from(r#"{"is_llm_stream":true}"#);
+        assert!(settings.is_llm_stream);
     }
 
     #[test]

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -871,6 +871,10 @@ pub async fn update_stream_settings(
         settings.enable_log_patterns_extraction = enable_log_patterns_extraction;
     }
 
+    if let Some(is_llm_stream) = new_settings.is_llm_stream {
+        settings.is_llm_stream = is_llm_stream;
+    }
+
     if let Some(storage_type) = new_settings.storage_type {
         if storage_type.is_compliance() {
             let effective_retention = new_settings


### PR DESCRIPTION
## Summary

- Allow stream settings updates to accept `is_llm_stream`.
- Persist `is_llm_stream` changes in `update_stream_settings`.
- Add focused tests for deserializing update payloads and preserving stored stream settings.

## Why

`StreamSettings` already stores and serializes `is_llm_stream`, but `UpdateStreamSettings` does not expose the field. As a result, requests such as `PUT /api/{org_id}/streams/{stream_name}/settings?type=traces` with `{ "is_llm_stream": false }` can be accepted while silently leaving the stored setting unchanged.

This makes it hard to correct streams that were marked as LLM streams by ingestion detection but need to be reverted through the settings API.

## Testing

- `cargo fmt --check`
- `git diff --check`

I also attempted `CARGO_NET_OFFLINE=true cargo test -p config is_llm_stream`, but the local environment is missing the `vortex` git dependency cache, so the test could not be executed offline.
