### PR TITLE
fix: updating is_llm_stream via UpdateStreamSettings

### DIFF
--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -780,6 +780,8 @@ pub struct UpdateStreamSettings {
     pub cross_links: UpdateSettingsWrapper<CrossLink>,
     #[serde(default)]
     pub storage_type: Option<StorageType>,
+    #[serde(default)]
+    pub is_llm_stream: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -885,6 +885,10 @@ pub async fn update_stream_settings(
         settings.storage_type = storage_type;
     }
 
+    if let Some(is_llm_stream) = new_settings.is_llm_stream {
+        settings.is_llm_stream = is_llm_stream;
+    }
+
     if !new_settings.full_text_search_keys.add.is_empty() {
         let mut add = new_settings.full_text_search_keys.add;
         add.sort();


### PR DESCRIPTION
fixed #11490 
## Summary
- Add optional `is_llm_stream` field to `UpdateStreamSettings` so the stream settings update API can toggle the flag.
- Apply the value in `update_stream_settings` alongside the other boolean toggles.

## Why
`StreamSettings` already exposes `is_llm_stream`, but the update API had no way to change it. This brings the update payload in line with the underlying setting so callers can flip the flag without going through a different code path.

## Test plan
- [x] `cargo check` passes (verified locally)
- [x] PATCH stream settings with `{"is_llm_stream": true}` updates the stored value
- [x] Omitting `is_llm_stream` leaves the existing value unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)