### PR TITLE
fix: support updating is_llm_stream via UpdateStreamSettings

### DIFF
--- a/src/config/src/meta/stream.rs
+++ b/src/config/src/meta/stream.rs
@@ -780,6 +780,8 @@ pub struct UpdateStreamSettings {
     pub cross_links: UpdateSettingsWrapper<CrossLink>,
     #[serde(default)]
     pub storage_type: Option<StorageType>,
+    #[serde(default)]
+    pub is_llm_stream: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -856,6 +856,10 @@ pub async fn update_stream_settings(
         settings.storage_type = storage_type;
     }
 
+    if let Some(is_llm_stream) = new_settings.is_llm_stream {
+        settings.is_llm_stream = is_llm_stream;
+    }
+
     if !new_settings.full_text_search_keys.add.is_empty() {
         settings
             .full_text_search_keys


### PR DESCRIPTION
Adds an optional is_llm_stream field to UpdateStreamSettings so the stream settings update API can toggle the flag, matching how other boolean settings (e.g. store_original_data, approx_partition) are handled.