### PR TITLE
feat: add super cluster sync support for anomaly detection

### DIFF
--- a/src/infra/src/errors/mod.rs
+++ b/src/infra/src/errors/mod.rs
@@ -135,6 +135,8 @@ pub enum DbError {
     TemplateError(#[from] TemplateError),
     #[error("PutAlert# {0}")]
     PutAlert(#[from] PutAlertError),
+    #[error("PutAnomalyConfig# {0}")]
+    PutAnomalyConfig(#[from] PutAnomalyConfigError),
 }
 
 #[derive(ThisError, Debug)]
@@ -155,6 +157,12 @@ pub enum PutDashboardError {
     MissingOwner,
     #[error("error putting dashboard with missing inner data for version {0}")]
     MissingInnerData(i32),
+}
+
+#[derive(ThisError, Debug)]
+pub enum PutAnomalyConfigError {
+    #[error("error creating anomaly config with folder that does not exist")]
+    FolderDoesNotExist,
 }
 
 #[derive(ThisError, Debug)]

--- a/src/infra/src/table/anomaly_detection/config.rs
+++ b/src/infra/src/table/anomaly_detection/config.rs
@@ -1,0 +1,397 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Table-level CRUD for `anomaly_detection_config`.
+//!
+//! The critical invariant: every function that writes to an existing row
+//! **fetches the row first** so the primary key is `Unchanged` in the
+//! resulting `ActiveModel`. This guarantees SeaORM generates a correct
+//! `UPDATE … WHERE anomaly_id = ?` rather than silently updating 0 rows.
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter,
+    QueryOrder, Set, TransactionTrait,
+};
+
+use crate::{
+    errors::{self, Error},
+    table::entity::anomaly_detection_config,
+};
+
+type Model = anomaly_detection_config::Model;
+type Result<T> = std::result::Result<T, Error>;
+
+/// Returns a config by its primary key, scoped to `org_id`.
+pub async fn get_by_id<C: ConnectionTrait>(
+    conn: &C,
+    org_id: &str,
+    anomaly_id: &str,
+) -> Result<Option<Model>> {
+    let _lock = super::super::get_lock().await;
+    let model = anomaly_detection_config::Entity::find_by_id(anomaly_id)
+        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
+        .one(conn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+    Ok(model)
+}
+
+/// Lists all configs for an organisation, ordered by `created_at` descending.
+pub async fn list_by_org<C: ConnectionTrait>(conn: &C, org_id: &str) -> Result<Vec<Model>> {
+    let _lock = super::super::get_lock().await;
+    let models = anomaly_detection_config::Entity::find()
+        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
+        .order_by_desc(anomaly_detection_config::Column::CreatedAt)
+        .all(conn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+    Ok(models)
+}
+
+/// Lists all enabled configs across all organisations.
+/// Used by startup recovery to re-create any missing detection triggers.
+pub async fn list_all_enabled<C: ConnectionTrait>(conn: &C) -> Result<Vec<Model>> {
+    let _lock = super::super::get_lock().await;
+    let models = anomaly_detection_config::Entity::find()
+        .filter(anomaly_detection_config::Column::Enabled.eq(true))
+        .all(conn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+    Ok(models)
+}
+
+/// Inserts a new config row.
+///
+/// Returns an error if a row with the same primary key already exists.
+/// Use `create_if_not_exists` for idempotent inserts.
+pub async fn create<C: ConnectionTrait>(conn: &C, config: Model) -> Result<Model> {
+    let _lock = super::super::get_lock().await;
+    let anomaly_id = config.anomaly_id.clone();
+    log::info!("[anomaly_detection_config] create: inserting id={anomaly_id}");
+    let result = anomaly_detection_config::Entity::insert(into_active_model(config))
+        .exec_with_returning(conn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+    log::info!("[anomaly_detection_config] create: inserted id={anomaly_id}");
+    Ok(result)
+}
+
+/// Inserts a new config row. Skips silently if a row with the same primary key
+/// already exists (idempotent — matches the alerts Create handler behaviour).
+pub async fn create_if_not_exists<C: TransactionTrait + ConnectionTrait>(
+    conn: &C,
+    config: Model,
+) -> Result<()> {
+    let _lock = super::super::get_lock().await;
+    let txn = conn.begin().await?;
+
+    let anomaly_id = config.anomaly_id.clone();
+    let exists = anomaly_detection_config::Entity::find_by_id(&anomaly_id)
+        .one(&txn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?
+        .is_some();
+
+    if exists {
+        log::debug!(
+            "[anomaly_detection_config] create_if_not_exists: skipping, row already exists id={anomaly_id}"
+        );
+    } else {
+        anomaly_detection_config::Entity::insert(into_active_model(config))
+            .exec(&txn)
+            .await
+            .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+        log::debug!("[anomaly_detection_config] create_if_not_exists: inserted id={anomaly_id}");
+    }
+
+    txn.commit().await?;
+    Ok(())
+}
+
+/// Updates an existing config row with all fields from `incoming`.
+///
+/// Fetches the current DB row first so the `ActiveModel` PK is `Unchanged`,
+/// guaranteeing SeaORM generates `UPDATE … WHERE anomaly_id = ?`.
+///
+/// Returns an error if the row does not exist.
+pub async fn update<C: TransactionTrait + ConnectionTrait>(
+    conn: &C,
+    incoming: Model,
+) -> Result<Model> {
+    let _lock = super::super::get_lock().await;
+    let txn = conn.begin().await?;
+
+    let existing = anomaly_detection_config::Entity::find_by_id(&incoming.anomaly_id)
+        .one(&txn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?
+        .ok_or_else(|| {
+            Error::DbError(errors::DbError::SeaORMError(format!(
+                "anomaly config not found: {}",
+                incoming.anomaly_id
+            )))
+        })?;
+
+    let mut active = existing.into_active_model();
+    patch_all_fields(&mut active, incoming);
+
+    let updated: Model = active
+        .update(&txn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+
+    txn.commit().await?;
+    Ok(updated)
+}
+
+/// Stores a config row — updates if it exists, inserts if it doesn't.
+/// Matches HTTP PUT semantics: "store this resource regardless of whether it
+/// already exists." Used by the super-cluster ConfigUpdate handler to stay in
+/// sync even when the ConfigCreate message was never received.
+pub async fn put<C: TransactionTrait + ConnectionTrait>(
+    conn: &C,
+    incoming: Model,
+) -> Result<Model> {
+    let _lock = super::super::get_lock().await;
+    let txn = conn.begin().await?;
+
+    let anomaly_id = incoming.anomaly_id.clone();
+    let existing = anomaly_detection_config::Entity::find_by_id(&anomaly_id)
+        .one(&txn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+
+    let result: Model = if let Some(existing) = existing {
+        log::debug!("[anomaly_detection_config] put: updating existing row id={anomaly_id}");
+        let mut active = existing.into_active_model();
+        patch_all_fields(&mut active, incoming);
+        let updated = active
+            .update(&txn)
+            .await
+            .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+        log::debug!("[anomaly_detection_config] put: update done id={anomaly_id}");
+        updated
+    } else {
+        log::debug!("[anomaly_detection_config] put: row not found, inserting id={anomaly_id}");
+        let inserted = anomaly_detection_config::Entity::insert(into_active_model(incoming))
+            .exec_with_returning(&txn)
+            .await
+            .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+        log::debug!("[anomaly_detection_config] put: insert done id={anomaly_id}");
+        inserted
+    };
+
+    txn.commit().await?;
+    Ok(result)
+}
+
+/// Deletes a config by `anomaly_id` + `org_id`.
+pub async fn delete<C: ConnectionTrait>(conn: &C, org_id: &str, anomaly_id: &str) -> Result<()> {
+    let _lock = super::super::get_lock().await;
+    anomaly_detection_config::Entity::delete_many()
+        .filter(anomaly_detection_config::Column::AnomalyId.eq(anomaly_id))
+        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
+        .exec(conn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Overwrites every non-PK field of `active` with the values from `src`.
+/// `created_at` is intentionally excluded — it must never be overwritten.
+fn patch_all_fields(active: &mut anomaly_detection_config::ActiveModel, src: Model) {
+    active.org_id = Set(src.org_id);
+    active.stream_name = Set(src.stream_name);
+    active.stream_type = Set(src.stream_type);
+    active.enabled = Set(src.enabled);
+    active.name = Set(src.name);
+    active.description = Set(src.description);
+    active.query_mode = Set(src.query_mode);
+    active.filters = Set(src.filters);
+    active.custom_sql = Set(src.custom_sql);
+    active.detection_function = Set(src.detection_function);
+    active.histogram_interval = Set(src.histogram_interval);
+    active.schedule_interval = Set(src.schedule_interval);
+    active.detection_window_seconds = Set(src.detection_window_seconds);
+    active.training_window_days = Set(src.training_window_days);
+    active.retrain_interval_days = Set(src.retrain_interval_days);
+    active.threshold = Set(src.threshold);
+    active.seasonality = Set(src.seasonality);
+    active.is_trained = Set(src.is_trained);
+    active.training_started_at = Set(src.training_started_at);
+    active.training_completed_at = Set(src.training_completed_at);
+    active.last_error = Set(src.last_error);
+    active.last_processed_timestamp = Set(src.last_processed_timestamp);
+    active.current_model_version = Set(src.current_model_version);
+    active.rcf_num_trees = Set(src.rcf_num_trees);
+    active.rcf_tree_size = Set(src.rcf_tree_size);
+    active.rcf_shingle_size = Set(src.rcf_shingle_size);
+    active.alert_enabled = Set(src.alert_enabled);
+    active.alert_destinations = Set(src.alert_destinations);
+    active.folder_id = Set(src.folder_id);
+    active.owner = Set(src.owner);
+    active.status = Set(src.status);
+    active.retries = Set(src.retries);
+    active.last_updated = Set(src.last_updated);
+    active.updated_at = Set(src.updated_at);
+    // created_at is NOT patched — it is set once at insert time and never changed.
+}
+
+/// Converts a `Model` into a fully-`Set` `ActiveModel` for inserts.
+fn into_active_model(m: Model) -> anomaly_detection_config::ActiveModel {
+    // For inserts the PK must be Set (it is not auto-increment).
+    // `into_active_model()` sets every field including PK as Set, which is
+    // correct for INSERT — only UPDATE requires the PK to be Unchanged.
+    m.into_active_model()
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::IntoActiveModel;
+
+    use super::*;
+
+    fn make_model(anomaly_id: &str, org_id: &str) -> Model {
+        Model {
+            anomaly_id: anomaly_id.to_string(),
+            org_id: org_id.to_string(),
+            stream_name: "default".to_string(),
+            stream_type: "logs".to_string(),
+            enabled: true,
+            name: "test-config".to_string(),
+            description: None,
+            query_mode: "sql".to_string(),
+            filters: None,
+            custom_sql: None,
+            detection_function: "rcf".to_string(),
+            histogram_interval: "1h".to_string(),
+            schedule_interval: "5m".to_string(),
+            detection_window_seconds: 3600,
+            training_window_days: 7,
+            retrain_interval_days: 1,
+            threshold: 95,
+            seasonality: "none".to_string(),
+            is_trained: false,
+            training_started_at: None,
+            training_completed_at: None,
+            last_error: None,
+            last_processed_timestamp: None,
+            current_model_version: 0,
+            rcf_num_trees: 50,
+            rcf_tree_size: 256,
+            rcf_shingle_size: 8,
+            alert_enabled: false,
+            alert_destinations: None,
+            folder_id: "folder-1".to_string(),
+            owner: None,
+            status: 0,
+            retries: 0,
+            last_updated: 0,
+            created_at: 1_000_000,
+            updated_at: 1_000_000,
+        }
+    }
+
+    #[test]
+    fn test_patch_all_fields_overwrites_org_id() {
+        let original = make_model("anom-1", "org-original");
+        let mut active = original.into_active_model();
+        let replacement = make_model("anom-1", "org-replaced");
+        patch_all_fields(&mut active, replacement);
+        assert_eq!(active.org_id.unwrap(), "org-replaced");
+    }
+
+    #[test]
+    fn test_patch_all_fields_does_not_change_created_at() {
+        let original = make_model("anom-1", "org");
+        let created_at_before = original.created_at;
+        let mut active = original.into_active_model();
+        let mut replacement = make_model("anom-1", "org");
+        replacement.created_at = 9_999_999;
+        patch_all_fields(&mut active, replacement);
+        // created_at must remain as the original value (not patched)
+        assert_eq!(active.created_at.unwrap(), created_at_before);
+    }
+
+    #[test]
+    fn test_patch_all_fields_updates_enabled_and_status() {
+        let original = make_model("anom-1", "org");
+        let mut active = original.into_active_model();
+        let mut replacement = make_model("anom-1", "org");
+        replacement.enabled = false;
+        replacement.status = 3;
+        patch_all_fields(&mut active, replacement);
+        assert!(!active.enabled.unwrap());
+        assert_eq!(active.status.unwrap(), 3);
+    }
+
+    #[test]
+    fn test_into_active_model_sets_pk() {
+        let m = make_model("anom-pk", "org");
+        let active = into_active_model(m);
+        assert_eq!(active.anomaly_id.unwrap(), "anom-pk");
+    }
+
+    #[test]
+    fn test_patch_all_fields_updates_numeric_params() {
+        let original = make_model("anom-1", "org");
+        let mut active = original.into_active_model();
+        let mut replacement = make_model("anom-1", "org");
+        replacement.threshold = 99;
+        replacement.rcf_num_trees = 100;
+        replacement.rcf_tree_size = 512;
+        replacement.rcf_shingle_size = 16;
+        replacement.training_window_days = 30;
+        replacement.retrain_interval_days = 7;
+        patch_all_fields(&mut active, replacement);
+        assert_eq!(active.threshold.unwrap(), 99);
+        assert_eq!(active.rcf_num_trees.unwrap(), 100);
+        assert_eq!(active.rcf_tree_size.unwrap(), 512);
+        assert_eq!(active.rcf_shingle_size.unwrap(), 16);
+        assert_eq!(active.training_window_days.unwrap(), 30);
+        assert_eq!(active.retrain_interval_days.unwrap(), 7);
+    }
+
+    #[test]
+    fn test_patch_all_fields_updates_string_fields() {
+        let original = make_model("anom-1", "org");
+        let mut active = original.into_active_model();
+        let mut replacement = make_model("anom-1", "org");
+        replacement.stream_name = "new-stream".to_string();
+        replacement.stream_type = "metrics".to_string();
+        replacement.seasonality = "daily".to_string();
+        replacement.detection_function = "zscore".to_string();
+        patch_all_fields(&mut active, replacement);
+        assert_eq!(active.stream_name.unwrap(), "new-stream");
+        assert_eq!(active.stream_type.unwrap(), "metrics");
+        assert_eq!(active.seasonality.unwrap(), "daily");
+        assert_eq!(active.detection_function.unwrap(), "zscore");
+    }
+
+    #[test]
+    fn test_into_active_model_sets_all_fields() {
+        let m = make_model("anom-all", "org-all");
+        let active = into_active_model(m);
+        assert_eq!(active.anomaly_id.unwrap(), "anom-all");
+        assert_eq!(active.org_id.unwrap(), "org-all");
+        assert_eq!(active.stream_name.unwrap(), "default");
+        assert_eq!(active.enabled.unwrap(), true);
+        assert_eq!(active.threshold.unwrap(), 95);
+    }
+}

--- a/src/infra/src/table/anomaly_detection/config.rs
+++ b/src/infra/src/table/anomaly_detection/config.rs
@@ -27,7 +27,7 @@ use sea_orm::{
 
 use crate::{
     errors::{self, Error},
-    table::entity::anomaly_detection_config,
+    table::entity::{anomaly_detection_config, folders},
 };
 
 type Model = anomaly_detection_config::Model;
@@ -74,16 +74,36 @@ pub async fn list_all_enabled<C: ConnectionTrait>(conn: &C) -> Result<Vec<Model>
 
 /// Inserts a new config row.
 ///
-/// Returns an error if a row with the same primary key already exists.
-/// Use `create_if_not_exists` for idempotent inserts.
-pub async fn create<C: ConnectionTrait>(conn: &C, config: Model) -> Result<Model> {
+/// Verifies the referenced folder exists inside the same transaction, matching
+/// the pattern used by `alerts::create` and `dashboards::create`.
+///
+/// Returns an error if the folder does not exist or if a row with the same
+/// primary key already exists. Use `create_if_not_exists` for idempotent inserts.
+pub async fn create<C: TransactionTrait + ConnectionTrait>(
+    conn: &C,
+    config: Model,
+) -> Result<Model> {
     let _lock = super::super::get_lock().await;
+    let txn = conn.begin().await?;
+
+    let folder_exists = folders::Entity::find_by_id(&config.folder_id)
+        .one(&txn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?
+        .is_some();
+    if !folder_exists {
+        return Err(Error::DbError(errors::DbError::PutAnomalyConfig(
+            errors::PutAnomalyConfigError::FolderDoesNotExist,
+        )));
+    }
+
     let anomaly_id = config.anomaly_id.clone();
     log::info!("[anomaly_detection_config] create: inserting id={anomaly_id}");
     let result = anomaly_detection_config::Entity::insert(into_active_model(config))
-        .exec_with_returning(conn)
+        .exec_with_returning(&txn)
         .await
         .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+    txn.commit().await?;
     log::info!("[anomaly_detection_config] create: inserted id={anomaly_id}");
     Ok(result)
 }
@@ -143,6 +163,20 @@ pub async fn update<C: TransactionTrait + ConnectionTrait>(
                 incoming.anomaly_id
             )))
         })?;
+
+    // If folder is changing, verify the new folder exists — matches alerts::update behaviour.
+    if existing.folder_id != incoming.folder_id {
+        let folder_exists = folders::Entity::find_by_id(&incoming.folder_id)
+            .one(&txn)
+            .await
+            .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?
+            .is_some();
+        if !folder_exists {
+            return Err(Error::DbError(errors::DbError::PutAnomalyConfig(
+                errors::PutAnomalyConfigError::FolderDoesNotExist,
+            )));
+        }
+    }
 
     let mut active = existing.into_active_model();
     patch_all_fields(&mut active, incoming);

--- a/src/infra/src/table/anomaly_detection/mod.rs
+++ b/src/infra/src/table/anomaly_detection/mod.rs
@@ -1,0 +1,24 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Table-level CRUD for anomaly detection.
+//!
+//! Two sub-modules mirror the two database tables:
+//!
+//! * [`config`] — `anomaly_detection_config` (one row per anomaly detector)
+//! * [`models`] — `anomaly_detection_models` (one row per trained model version)
+
+pub mod config;
+pub mod models;

--- a/src/infra/src/table/anomaly_detection/models.rs
+++ b/src/infra/src/table/anomaly_detection/models.rs
@@ -1,0 +1,82 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Table-level CRUD for `anomaly_detection_models`.
+//!
+//! Composite PK: (`anomaly_id`, `version`).  Rows are written once at
+//! training completion and never mutated — only inserted and deleted.
+
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder,
+};
+
+use crate::{
+    errors::{self, Error},
+    table::entity::anomaly_detection_models,
+};
+
+type Model = anomaly_detection_models::Model;
+type Result<T> = std::result::Result<T, Error>;
+
+/// Inserts a new model-metadata row.
+///
+/// Called once per training run after the serialised model has been written to
+/// object storage.  Returns the inserted row so callers can inspect the stored
+/// values.
+pub async fn insert<C: ConnectionTrait>(conn: &C, model: Model) -> Result<Model> {
+    let _lock = super::super::get_lock().await;
+    let anomaly_id = model.anomaly_id.clone();
+    let version = model.version;
+    log::info!("[anomaly_detection_models] insert: anomaly_id={anomaly_id} version={version}");
+    let result = anomaly_detection_models::Entity::insert(model.into_active_model())
+        .exec_with_returning(conn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+    Ok(result)
+}
+
+/// Returns all model-metadata rows for a config, sorted by `version`
+/// descending (newest first).
+///
+/// Used by the training cleanup routine to find and delete old versions.
+pub async fn list_by_anomaly_id_desc<C: ConnectionTrait>(
+    conn: &C,
+    anomaly_id: &str,
+) -> Result<Vec<Model>> {
+    let _lock = super::super::get_lock().await;
+    let models = anomaly_detection_models::Entity::find()
+        .filter(anomaly_detection_models::Column::AnomalyId.eq(anomaly_id))
+        .order_by_desc(anomaly_detection_models::Column::Version)
+        .all(conn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+    Ok(models)
+}
+
+/// Deletes a single model-metadata row by its composite primary key.
+pub async fn delete_by_key<C: ConnectionTrait>(
+    conn: &C,
+    anomaly_id: &str,
+    version: i64,
+) -> Result<()> {
+    let _lock = super::super::get_lock().await;
+    anomaly_detection_models::Entity::delete_many()
+        .filter(anomaly_detection_models::Column::AnomalyId.eq(anomaly_id))
+        .filter(anomaly_detection_models::Column::Version.eq(version))
+        .exec(conn)
+        .await
+        .map_err(|e| Error::DbError(errors::DbError::SeaORMError(e.to_string())))?;
+    Ok(())
+}

--- a/src/infra/src/table/migration/m20260504_000001_add_anomaly_detection_config_folder_fk.rs
+++ b/src/infra/src/table/migration/m20260504_000001_add_anomaly_detection_config_folder_fk.rs
@@ -18,6 +18,11 @@
 //! `alerts` and `dashboards` both define this FK at table-creation time. This migration
 //! retrofits the same referential-integrity guarantee for anomaly detection configs.
 //!
+//! Before adding the constraint, any rows whose `folder_id` no longer exists in `folders`
+//! (orphaned due to folder deletion after m20260317 ran) are re-pointed to the org's default
+//! Alerts folder — auto-creating that folder if needed. This mirrors m20260317's approach and
+//! ensures `ALTER TABLE ADD CONSTRAINT` never encounters an orphaned row.
+//!
 //! - No `ON DELETE` action → defaults to RESTRICT (same as alerts, dashboards). Folder deletion is
 //!   blocked while any anomaly configs still reference it.
 //!
@@ -28,6 +33,7 @@
 
 use sea_orm::{ConnectionTrait, Statement};
 use sea_orm_migration::prelude::*;
+use svix_ksuid::{Ksuid, KsuidLike};
 
 const FK_NAME: &str = "fk_anomaly_config_folder_id";
 
@@ -37,42 +43,104 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        match manager.get_database_backend() {
-            sea_orm::DbBackend::Sqlite => {
-                // SQLite does not support ALTER TABLE ADD CONSTRAINT FOREIGN KEY.
-            }
-            sea_orm::DbBackend::Postgres => {
-                if !fk_exists(manager).await? {
-                    manager
-                        .get_connection()
-                        .execute_unprepared(&format!(
-                            "ALTER TABLE anomaly_detection_config \
-                             ADD CONSTRAINT {FK_NAME} \
-                             FOREIGN KEY (folder_id) REFERENCES folders(id)"
-                        ))
-                        .await?;
-                }
-            }
-            sea_orm::DbBackend::MySql => {}
+        if manager.get_database_backend() == sea_orm::DbBackend::Sqlite {
+            return Ok(());
         }
+
+        // Repair any orphaned folder_id values before adding the FK constraint.
+        // Postgres rejects ALTER TABLE ADD CONSTRAINT FOREIGN KEY if any existing row
+        // has a folder_id that doesn't exist in folders.
+        repair_orphaned_folder_ids(manager).await?;
+
+        if !fk_exists(manager).await? {
+            manager
+                .get_connection()
+                .execute_unprepared(&format!(
+                    "ALTER TABLE anomaly_detection_config \
+                     ADD CONSTRAINT {FK_NAME} \
+                     FOREIGN KEY (folder_id) REFERENCES folders(id)"
+                ))
+                .await?;
+        }
+
         Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        match manager.get_database_backend() {
-            sea_orm::DbBackend::Sqlite | sea_orm::DbBackend::MySql => {}
-            sea_orm::DbBackend::Postgres => {
-                manager
-                    .get_connection()
-                    .execute_unprepared(&format!(
-                        "ALTER TABLE anomaly_detection_config \
-                         DROP CONSTRAINT IF EXISTS {FK_NAME}"
-                    ))
-                    .await?;
-            }
+        if manager.get_database_backend() == sea_orm::DbBackend::Sqlite {
+            return Ok(());
         }
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "ALTER TABLE anomaly_detection_config \
+                 DROP CONSTRAINT IF EXISTS {FK_NAME}"
+            ))
+            .await?;
         Ok(())
     }
+}
+
+/// Re-points any `anomaly_detection_config` rows whose `folder_id` no longer exists in
+/// `folders` to the org's default Alerts folder (type = 1, folder_id = 'default').
+/// Auto-creates the default folder for any org that is missing one.
+async fn repair_orphaned_folder_ids(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let db = manager.get_connection();
+    let db_backend = manager.get_database_backend();
+
+    // Find all orgs that have at least one orphaned anomaly config row.
+    let orphaned_orgs = db
+        .query_all(Statement::from_string(
+            db_backend,
+            "SELECT DISTINCT ac.org_id \
+             FROM anomaly_detection_config ac \
+             WHERE NOT EXISTS (\
+               SELECT 1 FROM folders f WHERE f.id = ac.folder_id\
+             )",
+        ))
+        .await?;
+
+    for row in orphaned_orgs {
+        let org_id: String = row.try_get("", "org_id")?;
+        let org_id_escaped = org_id.replace('\'', "''");
+
+        // Ensure the org has a default Alerts folder (type = 1).
+        let existing_folder = db
+            .query_one(Statement::from_string(
+                db_backend,
+                format!(
+                    "SELECT id FROM folders \
+                     WHERE org = '{org_id_escaped}' \
+                     AND folder_id = 'default' AND type = 1 LIMIT 1"
+                ),
+            ))
+            .await?;
+
+        let default_folder_id = if let Some(r) = existing_folder {
+            r.try_get::<String>("", "id")?
+        } else {
+            let ksuid = Ksuid::new(None, None).to_string();
+            db.execute_unprepared(&format!(
+                "INSERT INTO folders (id, org, folder_id, name, type) \
+                 VALUES ('{ksuid}', '{org_id_escaped}', 'default', 'Default', 1)"
+            ))
+            .await?;
+            ksuid
+        };
+
+        // Re-point all orphaned rows for this org to the default folder.
+        db.execute_unprepared(&format!(
+            "UPDATE anomaly_detection_config \
+             SET folder_id = '{default_folder_id}' \
+             WHERE org_id = '{org_id_escaped}' \
+             AND NOT EXISTS (\
+               SELECT 1 FROM folders f WHERE f.id = anomaly_detection_config.folder_id\
+             )"
+        ))
+        .await?;
+    }
+
+    Ok(())
 }
 
 async fn fk_exists(manager: &SchemaManager<'_>) -> Result<bool, DbErr> {

--- a/src/infra/src/table/migration/m20260504_000001_add_anomaly_detection_config_folder_fk.rs
+++ b/src/infra/src/table/migration/m20260504_000001_add_anomaly_detection_config_folder_fk.rs
@@ -1,0 +1,93 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Adds the missing FOREIGN KEY constraint on `anomaly_detection_config.folder_id → folders.id`.
+//!
+//! `alerts` and `dashboards` both define this FK at table-creation time. This migration
+//! retrofits the same referential-integrity guarantee for anomaly detection configs.
+//!
+//! - No `ON DELETE` action → defaults to RESTRICT (same as alerts, dashboards). Folder deletion is
+//!   blocked while any anomaly configs still reference it.
+//!
+//! - SQLite: cannot add FK constraints to existing tables via ALTER TABLE. SQLite is dev-only; this
+//!   migration is a no-op there.
+//!
+//! - Idempotent: checks `information_schema.table_constraints` before adding.
+
+use sea_orm::{ConnectionTrait, Statement};
+use sea_orm_migration::prelude::*;
+
+const FK_NAME: &str = "fk_anomaly_config_folder_id";
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            sea_orm::DbBackend::Sqlite => {
+                // SQLite does not support ALTER TABLE ADD CONSTRAINT FOREIGN KEY.
+            }
+            sea_orm::DbBackend::Postgres => {
+                if !fk_exists(manager).await? {
+                    manager
+                        .get_connection()
+                        .execute_unprepared(&format!(
+                            "ALTER TABLE anomaly_detection_config \
+                             ADD CONSTRAINT {FK_NAME} \
+                             FOREIGN KEY (folder_id) REFERENCES folders(id)"
+                        ))
+                        .await?;
+                }
+            }
+            sea_orm::DbBackend::MySql => {}
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            sea_orm::DbBackend::Sqlite | sea_orm::DbBackend::MySql => {}
+            sea_orm::DbBackend::Postgres => {
+                manager
+                    .get_connection()
+                    .execute_unprepared(&format!(
+                        "ALTER TABLE anomaly_detection_config \
+                         DROP CONSTRAINT IF EXISTS {FK_NAME}"
+                    ))
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn fk_exists(manager: &SchemaManager<'_>) -> Result<bool, DbErr> {
+    let row = manager
+        .get_connection()
+        .query_one(Statement::from_string(
+            sea_orm::DbBackend::Postgres,
+            format!(
+                "SELECT COUNT(*) AS cnt FROM information_schema.table_constraints \
+                 WHERE constraint_name = '{FK_NAME}' \
+                 AND table_name = 'anomaly_detection_config'"
+            ),
+        ))
+        .await?;
+    Ok(row
+        .map(|r| r.try_get::<i64>("", "cnt").unwrap_or(0) > 0)
+        .unwrap_or(false))
+}

--- a/src/infra/src/table/migration/mod.rs
+++ b/src/infra/src/table/migration/mod.rs
@@ -114,6 +114,7 @@ mod m20260414_000001_add_is_system_to_cipher_keys;
 mod m20260414_000002_create_org_ai_toolsets;
 mod m20260415_000001_create_model_pricing_table;
 mod m20260415_000002_add_source_to_model_pricing;
+mod m20260504_000001_add_anomaly_detection_config_folder_fk;
 
 pub struct Migrator;
 
@@ -217,6 +218,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260414_000002_create_org_ai_toolsets::Migration),
             Box::new(m20260415_000001_create_model_pricing_table::Migration),
             Box::new(m20260415_000002_add_source_to_model_pricing::Migration),
+            Box::new(m20260504_000001_add_anomaly_detection_config_folder_fk::Migration),
         ]
     }
 }

--- a/src/infra/src/table/mod.rs
+++ b/src/infra/src/table/mod.rs
@@ -25,6 +25,7 @@ use crate::{
 pub mod action_scripts;
 pub mod alert_incidents;
 pub mod alerts;
+pub mod anomaly_detection;
 pub mod backfill_jobs;
 pub mod cipher;
 pub mod compactor_manual_jobs;

--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -89,8 +89,7 @@ async fn handle_anomaly_detection_triggers(
     mut trigger: db::scheduler::Trigger,
 ) -> Result<(), anyhow::Error> {
     use config::utils::time::now_micros;
-    use infra::table::entity::anomaly_detection_config;
-    use sea_orm::EntityTrait;
+    use infra::table::anomaly_detection::config as anomaly_config_table;
 
     let anomaly_id = trigger.module_key.clone();
 
@@ -103,18 +102,24 @@ async fn handle_anomaly_detection_triggers(
         .get()
         .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
 
-    let config = anomaly_detection_config::Entity::find_by_id(&anomaly_id)
-        .one(db)
-        .await?;
+    let config = anomaly_config_table::get_by_id(db, &trigger.org, &anomaly_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
-    // If config was deleted, clean up the trigger.
+    // If config is not found locally, it may not have synced yet from the primary
+    // region (super cluster race: trigger row arrives before ConfigCreate NATS message).
+    // Reschedule instead of deleting so detection can proceed once the config syncs.
+    // The trigger is cleaned up via ConfigDelete in the super cluster queue, not here.
     let Some(config) = config else {
-        db::scheduler::delete(
-            &trigger.org,
-            db::scheduler::TriggerModule::AnomalyDetection,
-            &anomaly_id,
-        )
-        .await?;
+        log::warn!(
+            "[anomaly_detection] config not found locally for id={anomaly_id} org={} — \
+             trigger row arrived before ConfigCreate synced; rescheduling +60s. \
+             If this persists the ConfigCreate NATS message may have been lost.",
+            trigger.org
+        );
+        trigger.next_run_at = now_micros() + 60 * 1_000_000;
+        trigger.status = db::scheduler::TriggerStatus::Waiting;
+        db::scheduler::update_trigger(trigger, false, "").await?;
         return Ok(());
     };
 
@@ -220,9 +225,8 @@ async fn handle_anomaly_detection_triggers(
     if trigger_status == TriggerDataStatus::Completed && config.is_trained {
         use o2_enterprise::enterprise::anomaly_detection::types::Status as AnomalyStatus;
         if config.status != AnomalyStatus::Active.to_i32() {
-            use infra::table::entity::anomaly_detection_config;
-            use sea_orm::{ActiveModelTrait, Set};
-            let mut active: anomaly_detection_config::ActiveModel = config.into();
+            use sea_orm::{ActiveModelTrait, IntoActiveModel, Set};
+            let mut active = config.into_active_model();
             active.status = Set(AnomalyStatus::Active.to_i32());
             active.updated_at = Set(run_end_us);
             if let Err(e) = active.update(db).await {
@@ -4021,5 +4025,273 @@ mod tests {
 
         // The final timestamp should be adjusted based on the logic
         assert!(final_timestamp >= supposed_to_run_at);
+    }
+
+    // ── parse_detection_interval_to_micros ───────────────────────────────────
+
+    #[test]
+    fn test_parse_detection_interval_minutes() {
+        // "5m" → 5 * 60 * 1_000_000
+        let result = parse_detection_interval_to_micros("5m");
+        assert_eq!(result, 5 * 60 * 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_hours() {
+        // "2h" → 2 * 3600 * 1_000_000
+        let result = parse_detection_interval_to_micros("2h");
+        assert_eq!(result, 2 * 3600 * 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_one_hour() {
+        let result = parse_detection_interval_to_micros("1h");
+        assert_eq!(result, 3600 * 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_ten_minutes() {
+        let result = parse_detection_interval_to_micros("10m");
+        assert_eq!(result, 10 * 60 * 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_bare_number_treated_as_minutes() {
+        // Bare number has no suffix → treated as minutes via the fallback branch
+        let result = parse_detection_interval_to_micros("15");
+        assert_eq!(result, 15 * 60 * 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_invalid_suffix_defaults_to_five_minutes() {
+        // Unknown suffix falls through to the bare-number branch which tries parse().
+        // "abc" parse fails → unwrap_or(5) * 60 * 1_000_000
+        let result = parse_detection_interval_to_micros("abcm");
+        // "abcm".strip_suffix('m') = Some("abc"), parse::<i64>() fails → unwrap_or(5)
+        assert_eq!(result, 5 * 60 * 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_invalid_hour_defaults_to_one_hour() {
+        // "xh" → strip_suffix('h') = Some("x"), parse fails → unwrap_or(1) * 3600
+        let result = parse_detection_interval_to_micros("xh");
+        assert_eq!(result, 1 * 3600 * 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_empty_string_defaults() {
+        // Empty string: no suffix matches, parse fails → unwrap_or(5) * 60
+        let result = parse_detection_interval_to_micros("");
+        assert_eq!(result, 5 * 60 * 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_whitespace_trimmed() {
+        // Surrounding whitespace is trimmed before parsing
+        let result = parse_detection_interval_to_micros("  3m  ");
+        assert_eq!(result, 3 * 60 * 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_whitespace_with_hour() {
+        let result = parse_detection_interval_to_micros("  4h  ");
+        assert_eq!(result, 4 * 3600 * 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_zero_minutes() {
+        // "0m" → 0 * 60 * 1_000_000 = 0
+        let result = parse_detection_interval_to_micros("0m");
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_zero_hours() {
+        let result = parse_detection_interval_to_micros("0h");
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_parse_detection_interval_large_value() {
+        let result = parse_detection_interval_to_micros("100m");
+        assert_eq!(result, 100 * 60 * 1_000_000);
+    }
+
+    // ── get_pipeline_info_from_module_key additional edge cases ──────────────
+
+    #[test]
+    fn test_get_pipeline_info_pipeline_name_with_slash() {
+        // pipeline_name contains a '/' – the function takes columns[2] as the name
+        // and columns[last] as the id, so intermediate slashes become part of the name.
+        let module_key = "logs/org1/my/pipeline/name/actual_id";
+        let result = get_pipeline_info_from_module_key(module_key);
+        assert!(result.is_ok());
+        let (org_id, stream_type, pipeline_name, pipeline_id) = result.unwrap();
+        assert_eq!(org_id, "org1");
+        assert_eq!(stream_type, StreamType::Logs);
+        assert_eq!(pipeline_name, "my"); // columns[2]
+        assert_eq!(pipeline_id, "actual_id"); // columns[last]
+    }
+
+    #[test]
+    fn test_get_pipeline_info_metrics_stream_type() {
+        let module_key = "metrics/metrics_org/pipe/id999";
+        let result = get_pipeline_info_from_module_key(module_key);
+        assert!(result.is_ok());
+        let (org_id, stream_type, _, pipeline_id) = result.unwrap();
+        assert_eq!(org_id, "metrics_org");
+        assert_eq!(stream_type, StreamType::Metrics);
+        assert_eq!(pipeline_id, "id999");
+    }
+
+    #[test]
+    fn test_get_pipeline_info_traces_stream_type() {
+        let module_key = "traces/trace_org/trace_pipe/trace_id";
+        let result = get_pipeline_info_from_module_key(module_key);
+        assert!(result.is_ok());
+        let (_, stream_type, ..) = result.unwrap();
+        assert_eq!(stream_type, StreamType::Traces);
+    }
+
+    #[test]
+    fn test_get_pipeline_info_too_few_parts_one() {
+        let result = get_pipeline_info_from_module_key("onlyonepart");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid module_key")
+        );
+    }
+
+    #[test]
+    fn test_get_pipeline_info_too_few_parts_two() {
+        let result = get_pipeline_info_from_module_key("logs/org");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_pipeline_info_too_few_parts_three() {
+        let result = get_pipeline_info_from_module_key("logs/org/pipeline");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_pipeline_info_exactly_four_parts() {
+        let module_key = "logs/org/pipe/id";
+        let result = get_pipeline_info_from_module_key(module_key);
+        assert!(result.is_ok());
+        let (org_id, _, pipeline_name, pipeline_id) = result.unwrap();
+        assert_eq!(org_id, "org");
+        assert_eq!(pipeline_name, "pipe");
+        assert_eq!(pipeline_id, "id");
+    }
+
+    #[test]
+    fn test_get_pipeline_info_unknown_stream_type_falls_back() {
+        // Unknown stream type strings fall through to the From<&str> impl which
+        // is expected to produce a value (likely a default).  The important
+        // thing is the function does NOT return Err just because the type is unknown.
+        let module_key = "unknown_type/some_org/some_pipe/some_id";
+        let result = get_pipeline_info_from_module_key(module_key);
+        // Should succeed (no length check failure)
+        assert!(result.is_ok());
+        let (org_id, _, pipeline_name, pipeline_id) = result.unwrap();
+        assert_eq!(org_id, "some_org");
+        assert_eq!(pipeline_name, "some_pipe");
+        assert_eq!(pipeline_id, "some_id");
+    }
+
+    #[test]
+    fn test_get_destination_stream_excludes_source_node() {
+        use config::meta::pipeline::{
+            Pipeline,
+            components::{Node, PipelineSource},
+        };
+
+        let source_node = Node::new(
+            "source".to_string(),
+            NodeData::Stream(StreamParams::new("org", "input-stream", StreamType::Logs)),
+            0.0,
+            0.0,
+            "input".to_string(),
+        );
+        let output_node = Node::new(
+            "output-1".to_string(),
+            NodeData::Stream(StreamParams::new("org", "output-stream", StreamType::Logs)),
+            100.0,
+            0.0,
+            "output".to_string(),
+        );
+        let pipeline = Pipeline {
+            id: "p1".to_string(),
+            version: 0,
+            enabled: true,
+            org: "org".to_string(),
+            name: "test".to_string(),
+            description: String::new(),
+            source: PipelineSource::default(),
+            nodes: vec![source_node, output_node],
+            edges: vec![],
+        };
+
+        let result = get_destination_stream_from_pipeline(&pipeline).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].stream_name.as_str(), "output-stream");
+    }
+
+    #[test]
+    fn test_get_destination_stream_no_stream_nodes_returns_error() {
+        use config::meta::pipeline::{
+            Pipeline,
+            components::{FunctionParams, Node, PipelineSource},
+        };
+
+        let func_node = Node::new(
+            "func-1".to_string(),
+            NodeData::Function(FunctionParams {
+                name: "my_func".to_string(),
+                after_flatten: false,
+                num_args: 0,
+            }),
+            0.0,
+            0.0,
+            "default".to_string(),
+        );
+        let pipeline = Pipeline {
+            id: "p2".to_string(),
+            version: 0,
+            enabled: true,
+            org: "org".to_string(),
+            name: "test".to_string(),
+            description: String::new(),
+            source: PipelineSource::default(),
+            nodes: vec![func_node],
+            edges: vec![],
+        };
+
+        let result = get_destination_stream_from_pipeline(&pipeline);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_destination_stream_empty_pipeline_returns_error() {
+        use config::meta::pipeline::{Pipeline, components::PipelineSource};
+
+        let pipeline = Pipeline {
+            id: "p3".to_string(),
+            version: 0,
+            enabled: true,
+            org: "org".to_string(),
+            name: "test".to_string(),
+            description: String::new(),
+            source: PipelineSource::default(),
+            nodes: vec![],
+            edges: vec![],
+        };
+
+        let result = get_destination_stream_from_pipeline(&pipeline);
+        assert!(result.is_err());
     }
 }

--- a/src/service/anomaly_detection.rs
+++ b/src/service/anomaly_detection.rs
@@ -24,11 +24,8 @@ use config::{
     },
     utils::time::now_micros,
 };
-use infra::{db::ORM_CLIENT, table::entity::anomaly_detection_config};
-use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, ModelTrait, QueryFilter,
-    QueryOrder, Set,
-};
+use infra::{db::ORM_CLIENT, table::anomaly_detection::config as anomaly_config_table};
+use sea_orm::{ActiveModelTrait, IntoActiveModel, Set};
 use svix_ksuid::KsuidLike;
 
 use crate::{
@@ -129,11 +126,9 @@ pub async fn list_configs(
         .get()
         .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
 
-    let configs = anomaly_detection_config::Entity::find()
-        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
-        .order_by_desc(anomaly_detection_config::Column::CreatedAt)
-        .all(db)
-        .await?;
+    let configs = anomaly_config_table::list_by_org(db, org_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
     // Build a map of anomaly_id → trigger for O(1) lookups.
     let trigger_map: std::collections::HashMap<String, _> =
@@ -247,10 +242,9 @@ pub async fn get_config(org_id: &str, anomaly_id: &str) -> Result<Option<serde_j
         .get()
         .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
 
-    let config = anomaly_detection_config::Entity::find_by_id(anomaly_id)
-        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
-        .one(db)
-        .await?;
+    let config = anomaly_config_table::get_by_id(db, org_id, anomaly_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
     match config {
         None => Ok(None),
@@ -290,69 +284,89 @@ pub async fn create_config(
         .await
         .ok_or_else(|| anyhow::anyhow!("Folder '{}' not found", folder_name))?;
 
-    let new_config = anomaly_detection_config::ActiveModel {
-        anomaly_id: Set(anomaly_id.clone()),
-        org_id: Set(org_id.to_string()),
-        stream_name: Set(req.stream_name.clone()),
-        stream_type: Set(req.stream_type.clone()),
-        enabled: Set(req.enabled.unwrap_or(true)),
-        name: Set(req.name.clone()),
-        description: Set(req.description.clone()),
-        query_mode: Set(req.query_mode.clone()),
-        filters: Set(req.filters.clone()),
-        custom_sql: Set(req.custom_sql.clone()),
-        detection_function: Set(combine_detection_fn(
+    use infra::table::entity::anomaly_detection_config::Model as ConfigModel;
+    let new_config = ConfigModel {
+        anomaly_id: anomaly_id.clone(),
+        org_id: org_id.to_string(),
+        stream_name: req.stream_name.clone(),
+        stream_type: req.stream_type.clone(),
+        enabled: req.enabled.unwrap_or(true),
+        name: req.name.clone(),
+        description: req.description.clone(),
+        query_mode: req.query_mode.clone(),
+        filters: req.filters.clone(),
+        custom_sql: req.custom_sql.clone(),
+        detection_function: combine_detection_fn(
             &req.detection_function,
             req.detection_function_field.as_deref(),
-        )),
-        histogram_interval: Set(req.histogram_interval.clone()),
-        schedule_interval: Set(req.schedule_interval.clone()),
-        detection_window_seconds: Set(req.detection_window_seconds),
-        training_window_days: Set(req.training_window_days.unwrap_or(7)),
-        retrain_interval_days: Set(req.retrain_interval_days.unwrap_or(7)),
+        ),
+        histogram_interval: req.histogram_interval.clone(),
+        schedule_interval: req.schedule_interval.clone(),
+        detection_window_seconds: req.detection_window_seconds,
+        training_window_days: req.training_window_days.unwrap_or(7),
+        retrain_interval_days: req.retrain_interval_days.unwrap_or(7),
         // Store percentile as i32 (e.g. 97.0 → 97). Whole-number percentiles are
         // sufficient; the valid range is 50–99 and we clamp at the model level.
-        threshold: Set(req.percentile.unwrap_or(97.0).clamp(50.0, 99.9) as i32),
-        is_trained: Set(false),
-        training_started_at: Set(None),
-        training_completed_at: Set(None),
-        last_error: Set(None),
-        last_processed_timestamp: Set(None),
-        current_model_version: Set(0),
-        rcf_num_trees: Set(req.rcf_num_trees.unwrap_or(
+        threshold: req.percentile.unwrap_or(97.0).clamp(50.0, 99.9) as i32,
+        is_trained: false,
+        training_started_at: None,
+        training_completed_at: None,
+        last_error: None,
+        last_processed_timestamp: None,
+        current_model_version: 0,
+        rcf_num_trees: req.rcf_num_trees.unwrap_or(
             o2_enterprise::enterprise::common::config::get_config()
                 .anomaly_detection
                 .rcf_num_trees as i32,
-        )),
-        rcf_tree_size: Set(req.rcf_tree_size.unwrap_or(
+        ),
+        rcf_tree_size: req.rcf_tree_size.unwrap_or(
             o2_enterprise::enterprise::common::config::get_config()
                 .anomaly_detection
                 .rcf_tree_size as i32,
-        )),
+        ),
         // shingle_size default comes from O2_ANOMALY_RCF_SHINGLE_SIZE env var (default=4).
         // 4 consecutive time-buckets gives the RCF model enough temporal context.
-        rcf_shingle_size: Set(req.rcf_shingle_size.unwrap_or(
+        rcf_shingle_size: req.rcf_shingle_size.unwrap_or(
             o2_enterprise::enterprise::common::config::get_config()
                 .anomaly_detection
                 .rcf_shingle_size as i32,
-        )),
-        alert_enabled: Set(req.alert_enabled.unwrap_or(true)),
-        alert_destinations: Set(Some(
+        ),
+        alert_enabled: req.alert_enabled.unwrap_or(true),
+        alert_destinations: Some(
             serde_json::to_value(&req.alert_destinations).unwrap_or(serde_json::json!([])),
-        )),
-        folder_id: Set(folder_pk),
-        owner: Set(req.owner.clone()),
-        status: Set(0i32), // 0 = waiting
-        retries: Set(0),
-        last_updated: Set(now_us),
+        ),
+        folder_id: folder_pk,
+        owner: req.owner.clone(),
+        status: 0i32, // 0 = waiting
+        retries: 0,
+        last_updated: now_us,
         // Seasonality is auto-determined at training time from training_window_days;
         // initialise to "none" as a placeholder until the first training run.
-        seasonality: Set("none".to_string()),
-        created_at: Set(now_us),
-        updated_at: Set(now_us),
+        seasonality: "none".to_string(),
+        created_at: now_us,
+        updated_at: now_us,
     };
 
-    let result = new_config.insert(db).await?;
+    let result = anomaly_config_table::create(db, new_config)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    // Broadcast config creation to all super cluster regions for API-read consistency.
+    #[cfg(feature = "enterprise")]
+    if o2_enterprise::enterprise::common::config::get_config()
+        .super_cluster
+        .enabled
+        && !config::get_config().common.local_mode
+        && let Err(e) =
+            o2_enterprise::enterprise::super_cluster::queue::anomaly_config_create(result.clone())
+                .await
+    {
+        log::warn!(
+            "[anomaly_detection {}] failed to broadcast ConfigCreate to super cluster: {e}",
+            result.anomaly_id
+        );
+    }
+
     let folder_name_owned = folder_name.to_string();
 
     // Register a detection trigger in the shared scheduler so it is driven by the
@@ -414,14 +428,14 @@ pub async fn update_config(
         .get()
         .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
 
-    // Fetch existing config
-    let existing = anomaly_detection_config::Entity::find_by_id(anomaly_id)
-        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
-        .one(db)
-        .await?
+    // Fetch existing config — into_active_model() on a DB-fetched model sets the PK as
+    // Unchanged, which is required for SeaORM to generate UPDATE … WHERE anomaly_id = ?
+    let existing = anomaly_config_table::get_by_id(db, org_id, anomaly_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?
         .ok_or_else(|| anyhow::anyhow!("Config not found"))?;
 
-    let mut active_model: anomaly_detection_config::ActiveModel = existing.into_active_model();
+    let mut active_model = existing.into_active_model();
 
     // Update only provided fields
     // Track whether we need to push a trigger after the DB save (see below).
@@ -522,6 +536,37 @@ pub async fn update_config(
 
     let updated = active_model.update(db).await?;
 
+    // Evict any cached model for this config — training params may have changed,
+    // so the next detection run should load a fresh model from S3.
+    #[cfg(feature = "enterprise")]
+    o2_enterprise::enterprise::anomaly_detection::cache::invalidate_config(&updated.anomaly_id)
+        .await;
+
+    // Broadcast config update to all super cluster regions.
+    #[cfg(feature = "enterprise")]
+    {
+        let sc_enabled = o2_enterprise::enterprise::common::config::get_config()
+            .super_cluster
+            .enabled;
+        let local_mode = config::get_config().common.local_mode;
+        if sc_enabled && !local_mode {
+            log::debug!(
+                "[anomaly_detection {}] ConfigUpdate broadcast check: super_cluster.enabled={sc_enabled} local_mode={local_mode}",
+                updated.anomaly_id
+            );
+            if let Err(e) = o2_enterprise::enterprise::super_cluster::queue::anomaly_config_update(
+                updated.clone(),
+            )
+            .await
+            {
+                log::warn!(
+                    "[anomaly_detection {}] failed to broadcast ConfigUpdate to super cluster: {e}",
+                    updated.anomaly_id
+                );
+            }
+        }
+    }
+
     // Push the trigger AFTER the DB save so the scheduler always sees enabled=true
     // when it picks up the newly inserted trigger row.
     if push_trigger_after_save {
@@ -597,13 +642,31 @@ pub async fn delete_config(org_id: &str, anomaly_id: &str) -> Result<()> {
         .get()
         .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
 
-    let config = anomaly_detection_config::Entity::find_by_id(anomaly_id)
-        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
-        .one(db)
-        .await?
+    // Verify the config exists before deleting (returns 404 if missing).
+    anomaly_config_table::get_by_id(db, org_id, anomaly_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?
         .ok_or_else(|| anyhow::anyhow!("Config not found"))?;
 
-    config.delete(db).await?;
+    anomaly_config_table::delete(db, org_id, anomaly_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    // Broadcast config deletion to all super cluster regions.
+    #[cfg(feature = "enterprise")]
+    if o2_enterprise::enterprise::common::config::get_config()
+        .super_cluster
+        .enabled
+        && !config::get_config().common.local_mode
+        && let Err(e) = o2_enterprise::enterprise::super_cluster::queue::anomaly_config_delete(
+            org_id, anomaly_id,
+        )
+        .await
+    {
+        log::warn!(
+            "[anomaly_detection {anomaly_id}] failed to broadcast ConfigDelete to super cluster: {e}"
+        );
+    }
 
     // Remove the detection trigger from the shared scheduler.
     {
@@ -646,10 +709,9 @@ pub async fn clone_config(
         .get()
         .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
 
-    let src = anomaly_detection_config::Entity::find_by_id(anomaly_id)
-        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
-        .one(db)
-        .await?
+    let src = anomaly_config_table::get_by_id(db, org_id, anomaly_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?
         .ok_or_else(|| anyhow::anyhow!("Config not found"))?;
 
     let new_id = svix_ksuid::Ksuid::new(None, None).to_string();
@@ -665,46 +727,65 @@ pub async fn clone_config(
         src.folder_id.clone()
     };
 
-    let cloned = anomaly_detection_config::ActiveModel {
-        anomaly_id: Set(new_id.clone()),
-        org_id: Set(src.org_id.clone()),
-        stream_name: Set(src.stream_name.clone()),
-        stream_type: Set(src.stream_type.clone()),
-        enabled: Set(src.enabled),
-        name: Set(new_name.unwrap_or_else(|| format!("{}_copy", src.name))),
-        description: Set(src.description.clone()),
-        query_mode: Set(src.query_mode.clone()),
-        filters: Set(src.filters.clone()),
-        custom_sql: Set(src.custom_sql.clone()),
-        detection_function: Set(src.detection_function.clone()),
-        histogram_interval: Set(src.histogram_interval.clone()),
-        schedule_interval: Set(src.schedule_interval.clone()),
-        detection_window_seconds: Set(src.detection_window_seconds),
-        training_window_days: Set(src.training_window_days),
-        retrain_interval_days: Set(src.retrain_interval_days),
-        threshold: Set(src.threshold),
-        seasonality: Set(src.seasonality.clone()),
-        is_trained: Set(false),
-        training_started_at: Set(None),
-        training_completed_at: Set(None),
-        last_error: Set(None),
-        last_processed_timestamp: Set(None),
-        current_model_version: Set(0),
-        rcf_num_trees: Set(src.rcf_num_trees),
-        rcf_tree_size: Set(src.rcf_tree_size),
-        rcf_shingle_size: Set(src.rcf_shingle_size),
-        alert_enabled: Set(src.alert_enabled),
-        alert_destinations: Set(src.alert_destinations.clone()),
-        folder_id: Set(resolved_folder_id),
-        owner: Set(src.owner.clone()),
-        status: Set(0i32),
-        retries: Set(0),
-        last_updated: Set(now_us),
-        created_at: Set(now_us),
-        updated_at: Set(now_us),
+    use infra::table::entity::anomaly_detection_config::Model as ConfigModel;
+    let cloned = ConfigModel {
+        anomaly_id: new_id.clone(),
+        org_id: src.org_id.clone(),
+        stream_name: src.stream_name.clone(),
+        stream_type: src.stream_type.clone(),
+        enabled: src.enabled,
+        name: new_name.unwrap_or_else(|| format!("{}_copy", src.name)),
+        description: src.description.clone(),
+        query_mode: src.query_mode.clone(),
+        filters: src.filters.clone(),
+        custom_sql: src.custom_sql.clone(),
+        detection_function: src.detection_function.clone(),
+        histogram_interval: src.histogram_interval.clone(),
+        schedule_interval: src.schedule_interval.clone(),
+        detection_window_seconds: src.detection_window_seconds,
+        training_window_days: src.training_window_days,
+        retrain_interval_days: src.retrain_interval_days,
+        threshold: src.threshold,
+        seasonality: src.seasonality.clone(),
+        is_trained: false,
+        training_started_at: None,
+        training_completed_at: None,
+        last_error: None,
+        last_processed_timestamp: None,
+        current_model_version: 0,
+        rcf_num_trees: src.rcf_num_trees,
+        rcf_tree_size: src.rcf_tree_size,
+        rcf_shingle_size: src.rcf_shingle_size,
+        alert_enabled: src.alert_enabled,
+        alert_destinations: src.alert_destinations.clone(),
+        folder_id: resolved_folder_id,
+        owner: src.owner.clone(),
+        status: 0i32,
+        retries: 0,
+        last_updated: now_us,
+        created_at: now_us,
+        updated_at: now_us,
     };
 
-    let result = cloned.insert(db).await?;
+    let result = anomaly_config_table::create(db, cloned)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    // Broadcast cloned config to all super cluster regions for API-read consistency.
+    #[cfg(feature = "enterprise")]
+    if o2_enterprise::enterprise::common::config::get_config()
+        .super_cluster
+        .enabled
+        && !config::get_config().common.local_mode
+        && let Err(e) =
+            o2_enterprise::enterprise::super_cluster::queue::anomaly_config_create(result.clone())
+                .await
+    {
+        log::warn!(
+            "[anomaly_detection {}] failed to broadcast ConfigCreate (clone) to super cluster: {e}",
+            result.anomaly_id
+        );
+    }
 
     // Register detection trigger for the new config
     {
@@ -743,10 +824,9 @@ pub async fn cancel_training(org_id: &str, anomaly_id: &str) -> Result<()> {
         .get()
         .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
 
-    let config = anomaly_detection_config::Entity::find_by_id(anomaly_id)
-        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
-        .one(db)
-        .await?
+    let config = anomaly_config_table::get_by_id(db, org_id, anomaly_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?
         .ok_or_else(|| anyhow::anyhow!("Config not found"))?;
 
     let mut active = config.into_active_model();
@@ -767,10 +847,9 @@ pub async fn train_model(org_id: &str, anomaly_id: &str) -> Result<serde_json::V
     let db = ORM_CLIENT
         .get()
         .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
-    anomaly_detection_config::Entity::find_by_id(anomaly_id)
-        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
-        .one(db)
-        .await?
+    anomaly_config_table::get_by_id(db, org_id, anomaly_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?
         .ok_or_else(|| anyhow::anyhow!("Config not found"))?;
 
     #[cfg(feature = "enterprise")]
@@ -795,10 +874,9 @@ pub async fn detect_anomalies(org_id: &str, anomaly_id: &str) -> Result<serde_js
         .ok_or_else(|| anyhow::anyhow!("Database not initialized"))?;
 
     // Fetch config
-    let config = anomaly_detection_config::Entity::find_by_id(anomaly_id)
-        .filter(anomaly_detection_config::Column::OrgId.eq(org_id))
-        .one(db)
-        .await?
+    let config = anomaly_config_table::get_by_id(db, org_id, anomaly_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?
         .ok_or_else(|| anyhow::anyhow!("Config not found"))?;
 
     // Check if trained
@@ -1006,11 +1084,7 @@ pub async fn recover_detection_triggers_on_startup() {
         }
     };
 
-    let configs = match anomaly_detection_config::Entity::find()
-        .filter(anomaly_detection_config::Column::Enabled.eq(true))
-        .all(db)
-        .await
-    {
+    let configs = match anomaly_config_table::list_all_enabled(db).await {
         Ok(c) => c,
         Err(e) => {
             log::warn!(
@@ -1110,7 +1184,7 @@ fn parse_interval(interval: &str) -> Result<i64> {
 
 #[cfg(feature = "enterprise")]
 pub fn config_to_training_config(
-    config: &anomaly_detection_config::Model,
+    config: &infra::table::entity::anomaly_detection_config::Model,
 ) -> Result<o2_enterprise::enterprise::anomaly_detection::types::AnomalyConfig> {
     use o2_enterprise::enterprise::anomaly_detection::types::AnomalyConfig;
 
@@ -1575,4 +1649,273 @@ pub async fn send_anomaly_alert(
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handler::http::request::anomaly_detection::CreateAnomalyConfigRequest;
+
+    // ── combine_detection_fn ────────────────────────────────────────────────
+
+    #[test]
+    fn test_combine_already_has_parens() {
+        assert_eq!(combine_detection_fn("avg(cpu)", None), "avg(cpu)");
+    }
+
+    #[test]
+    fn test_combine_count_returns_star() {
+        assert_eq!(combine_detection_fn("count", None), "count(*)");
+        assert_eq!(combine_detection_fn("count", Some("ignored")), "count(*)");
+    }
+
+    #[test]
+    fn test_combine_other_with_field() {
+        assert_eq!(combine_detection_fn("avg", Some("cpu")), "avg(cpu)");
+        assert_eq!(combine_detection_fn("sum", Some("bytes")), "sum(bytes)");
+    }
+
+    #[test]
+    fn test_combine_other_no_field() {
+        assert_eq!(combine_detection_fn("avg", None), "avg");
+    }
+
+    #[test]
+    fn test_combine_other_empty_field() {
+        assert_eq!(combine_detection_fn("avg", Some("")), "avg");
+    }
+
+    // ── parse_interval ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_interval_hours() {
+        assert_eq!(parse_interval("1h").unwrap(), 3600);
+        assert_eq!(parse_interval("2h").unwrap(), 7200);
+        assert_eq!(parse_interval("0h").unwrap(), 0);
+    }
+
+    #[test]
+    fn test_parse_interval_minutes() {
+        assert_eq!(parse_interval("30m").unwrap(), 1800);
+        assert_eq!(parse_interval("5m").unwrap(), 300);
+    }
+
+    #[test]
+    fn test_parse_interval_invalid_suffix() {
+        assert!(parse_interval("10s").is_err());
+        assert!(parse_interval("10d").is_err());
+        assert!(parse_interval("abc").is_err());
+    }
+
+    #[test]
+    fn test_parse_interval_invalid_number() {
+        assert!(parse_interval("xh").is_err());
+        assert!(parse_interval("xm").is_err());
+    }
+
+    // ── validate_config_request ─────────────────────────────────────────────
+
+    fn make_valid_filters_req() -> CreateAnomalyConfigRequest {
+        CreateAnomalyConfigRequest {
+            name: "test".to_string(),
+            description: None,
+            stream_name: "logs".to_string(),
+            stream_type: "logs".to_string(),
+            query_mode: "filters".to_string(),
+            filters: Some(serde_json::json!([])),
+            custom_sql: None,
+            detection_function: "count".to_string(),
+            detection_function_field: None,
+            histogram_interval: "5m".to_string(),
+            schedule_interval: "1h".to_string(),
+            detection_window_seconds: 3600,
+            training_window_days: Some(7),
+            retrain_interval_days: Some(7),
+            percentile: Some(97.0),
+            rcf_num_trees: None,
+            rcf_tree_size: None,
+            rcf_shingle_size: None,
+            alert_enabled: None,
+            alert_destinations: vec![],
+            enabled: None,
+            folder_id: None,
+            owner: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_valid_filters_mode() {
+        assert!(validate_config_request(&make_valid_filters_req()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_valid_custom_sql_mode() {
+        let mut req = make_valid_filters_req();
+        req.query_mode = "custom_sql".to_string();
+        req.filters = None;
+        req.custom_sql = Some("SELECT count(*) FROM logs".to_string());
+        assert!(validate_config_request(&req).is_ok());
+    }
+
+    #[test]
+    fn test_validate_invalid_query_mode() {
+        let mut req = make_valid_filters_req();
+        req.query_mode = "invalid".to_string();
+        assert!(validate_config_request(&req).is_err());
+    }
+
+    #[test]
+    fn test_validate_filters_mode_missing_filters() {
+        let mut req = make_valid_filters_req();
+        req.filters = None;
+        assert!(validate_config_request(&req).is_err());
+    }
+
+    #[test]
+    fn test_validate_custom_sql_mode_missing_sql() {
+        let mut req = make_valid_filters_req();
+        req.query_mode = "custom_sql".to_string();
+        req.filters = None;
+        req.custom_sql = None;
+        assert!(validate_config_request(&req).is_err());
+    }
+
+    #[test]
+    fn test_validate_invalid_histogram_interval() {
+        let mut req = make_valid_filters_req();
+        req.histogram_interval = "10d".to_string();
+        assert!(validate_config_request(&req).is_err());
+    }
+
+    #[test]
+    fn test_validate_invalid_schedule_interval() {
+        let mut req = make_valid_filters_req();
+        req.schedule_interval = "bad".to_string();
+        assert!(validate_config_request(&req).is_err());
+    }
+
+    // ── model_to_api_json ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_model_to_api_json_replaces_integer_status() {
+        let val = serde_json::json!({"name": "test", "status": 0i64});
+        let result = model_to_api_json(val);
+        assert!(result["status"].is_string());
+    }
+
+    #[test]
+    fn test_model_to_api_json_no_status_field_unchanged() {
+        let val = serde_json::json!({"name": "test"});
+        let result = model_to_api_json(val);
+        assert!(result.get("status").is_none());
+        assert_eq!(result["name"], "test");
+    }
+
+    #[test]
+    fn test_model_to_api_json_non_object_unchanged() {
+        let val = serde_json::json!("just a string");
+        let result = model_to_api_json(val.clone());
+        assert_eq!(result, val);
+    }
+
+    // ── extract_timestamp_from_hit ──────────────────────────────────────────
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_timestamp_numeric_underscore_field() {
+        let hit = serde_json::json!({"_timestamp": 1_700_000_000_000_000i64});
+        assert_eq!(
+            extract_timestamp_from_hit(&hit).unwrap(),
+            1_700_000_000_000_000i64
+        );
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_timestamp_rfc3339_string() {
+        let hit = serde_json::json!({"timestamp": "2026-02-20T13:15:00Z"});
+        let ts = extract_timestamp_from_hit(&hit).unwrap();
+        assert!(ts > 0);
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_timestamp_naive_datetime_string() {
+        let hit = serde_json::json!({"time_bucket": "2026-02-20T13:15:00"});
+        let ts = extract_timestamp_from_hit(&hit).unwrap();
+        assert!(ts > 0);
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_timestamp_fractional_seconds() {
+        let hit = serde_json::json!({"time": "2026-02-20T13:15:00.000"});
+        let ts = extract_timestamp_from_hit(&hit).unwrap();
+        assert!(ts > 0);
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_timestamp_no_field_returns_error() {
+        let hit = serde_json::json!({"value": 42.0});
+        assert!(extract_timestamp_from_hit(&hit).is_err());
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_timestamp_non_numeric_non_string_value() {
+        let hit = serde_json::json!({"_timestamp": true});
+        assert!(extract_timestamp_from_hit(&hit).is_err());
+    }
+
+    // ── extract_value_from_hit ──────────────────────────────────────────────
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_value_from_hit_value_field_f64() {
+        let hit = serde_json::json!({"value": 3.14});
+        assert!((extract_value_from_hit(&hit).unwrap() - 3.14).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_value_from_hit_count_field_integer() {
+        let hit = serde_json::json!({"count": 42});
+        assert!((extract_value_from_hit(&hit).unwrap() - 42.0).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_value_from_hit_underscore_count_field() {
+        let hit = serde_json::json!({"_count": 7});
+        assert!((extract_value_from_hit(&hit).unwrap() - 7.0).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_value_from_hit_metric_field() {
+        let hit = serde_json::json!({"metric": 100.5});
+        assert!((extract_value_from_hit(&hit).unwrap() - 100.5).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_value_from_hit_result_field() {
+        let hit = serde_json::json!({"result": 0.0});
+        assert!((extract_value_from_hit(&hit).unwrap() - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_value_from_hit_no_value_field_returns_error() {
+        let hit = serde_json::json!({"other_field": 99.0});
+        assert!(extract_value_from_hit(&hit).is_err());
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn test_extract_value_from_hit_non_numeric_value_field_returns_error() {
+        let hit = serde_json::json!({"value": "not_a_number"});
+        assert!(extract_value_from_hit(&hit).is_err());
+    }
 }

--- a/src/super_cluster_queue/anomaly_detection.rs
+++ b/src/super_cluster_queue/anomaly_detection.rs
@@ -1,0 +1,118 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Super-cluster queue processor for anomaly detection config synchronization.
+//!
+//! Synchronizes anomaly detection configs across regions including:
+//! - Config creation, update, and deletion
+//! - Model training state updates (is_trained, version, training_completed_at)
+//!
+//! Only updates the local database for API reads. Training and detection run
+//! exclusively on the primary region (where the alert manager runs).
+
+use infra::{
+    db::{ORM_CLIENT, connect_to_orm},
+    errors::Result,
+    table::anomaly_detection::config as table,
+};
+use o2_enterprise::enterprise::super_cluster::queue::{AnomalyDetectionMessage, Message};
+
+pub(crate) async fn process(msg: Message) -> Result<()> {
+    let msg: AnomalyDetectionMessage = msg.try_into().map_err(|e| {
+        log::error!("[SUPER_CLUSTER:anomaly_detection] failed to deserialize message: {e}");
+        infra::errors::Error::Message(format!("[ANOMALY_DETECTION] Failed to deserialize: {e}"))
+    })?;
+    log::debug!(
+        "[SUPER_CLUSTER:anomaly_detection] deserialized message ok, dispatching to process_msg"
+    );
+    process_msg(msg).await
+}
+
+pub(crate) async fn process_msg(msg: AnomalyDetectionMessage) -> Result<()> {
+    let db = ORM_CLIENT.get_or_init(connect_to_orm).await;
+
+    match msg {
+        AnomalyDetectionMessage::ConfigCreate { config } => {
+            let anomaly_id = config.anomaly_id.clone();
+            log::info!(
+                "[SUPER_CLUSTER:anomaly_detection] ConfigCreate org={} id={} status={} is_trained={} updated_at={}",
+                config.org_id,
+                anomaly_id,
+                config.status,
+                config.is_trained,
+                config.updated_at,
+            );
+            table::create_if_not_exists(db, config).await.map_err(|e| {
+                log::error!(
+                    "[SUPER_CLUSTER:anomaly_detection] ConfigCreate failed id={}: {e}",
+                    anomaly_id
+                );
+                infra::errors::Error::Message(e.to_string())
+            })?;
+            log::debug!(
+                "[SUPER_CLUSTER:anomaly_detection] ConfigCreate done id={}",
+                anomaly_id
+            );
+        }
+        AnomalyDetectionMessage::ConfigUpdate { config } => {
+            let anomaly_id = config.anomaly_id.clone();
+            let updated_at = config.updated_at;
+            log::info!(
+                "[SUPER_CLUSTER:anomaly_detection] ConfigUpdate org={} id={} status={} is_trained={} schedule_interval={} updated_at={}",
+                config.org_id,
+                anomaly_id,
+                config.status,
+                config.is_trained,
+                config.schedule_interval,
+                updated_at,
+            );
+            table::put(db, config).await.map_err(|e| {
+                log::error!(
+                    "[SUPER_CLUSTER:anomaly_detection] ConfigUpdate failed id={}: {e}",
+                    anomaly_id
+                );
+                infra::errors::Error::Message(e.to_string())
+            })?;
+            log::debug!(
+                "[SUPER_CLUSTER:anomaly_detection] ConfigUpdate successfully wrote to DB id={} updated_at={}",
+                anomaly_id,
+                updated_at,
+            );
+            // Evict any cached model — training params may have changed on the primary.
+            #[cfg(feature = "enterprise")]
+            o2_enterprise::enterprise::anomaly_detection::cache::invalidate_config(&anomaly_id)
+                .await;
+        }
+        AnomalyDetectionMessage::ConfigDelete { org_id, config_id } => {
+            log::debug!(
+                "[SUPER_CLUSTER:anomaly_detection] ConfigDelete org={org_id} id={config_id}"
+            );
+            table::delete(db, &org_id, &config_id)
+                .await
+                .map_err(|e| infra::errors::Error::Message(e.to_string()))?;
+            // Clear any locally cached model entry on non-primary regions.
+            #[cfg(feature = "enterprise")]
+            o2_enterprise::enterprise::anomaly_detection::cache::invalidate_config(&config_id)
+                .await;
+        }
+        AnomalyDetectionMessage::ModelTrained { .. } => {
+            // Config state (is_trained, current_model_version, training_completed_at)
+            // arrives via the accompanying ConfigUpdate broadcast from trainer.rs.
+            // Non-primary regions do not run detection and do not need model metadata rows.
+        }
+    }
+
+    Ok(())
+}

--- a/src/super_cluster_queue/mod.rs
+++ b/src/super_cluster_queue/mod.rs
@@ -15,6 +15,7 @@
 
 mod action_scripts;
 mod alerts;
+mod anomaly_detection;
 mod cipher_keys;
 mod compactor_manual_jobs;
 mod dashboards;
@@ -79,6 +80,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
         on_scheduler_msg: scheduler::process,
         on_semantic_groups_msg: semantic_groups::process,
         on_incident_msg: incidents::process,
+        on_anomaly_detection_msg: anomaly_detection::process,
     };
     let scheduler_queue = SchedulerQueue {
         on_scheduler_msg: scheduler::process,

--- a/src/super_cluster_queue/scheduler.rs
+++ b/src/super_cluster_queue/scheduler.rs
@@ -210,13 +210,14 @@ async fn update(msg: Message) -> Result<()> {
         }
         TriggerModule::AnomalyDetection => {
             // Only sync if the anomaly detection config still exists in this region.
-            use infra::table::entity::anomaly_detection_config;
-            use sea_orm::EntityTrait;
-            if anomaly_detection_config::Entity::find_by_id(&trigger.module_key)
-                .one(conn)
-                .await
-                .unwrap_or(None)
-                .is_some()
+            if infra::table::anomaly_detection::config::get_by_id(
+                conn,
+                &trigger.org,
+                &trigger.module_key,
+            )
+            .await
+            .unwrap_or(None)
+            .is_some()
             {
                 scheduler::push(trigger.clone()).await.map_err(|e| {
                     let error_msg = format!(


### PR DESCRIPTION
design at: designs/anomaly-detection

## Summary

Adds super cluster sync support for anomaly detection configs and fixes a missing FK constraint on `anomaly_detection_config.folder_id`.

**Super cluster sync:**
- Add `infra::table::anomaly_detection` module with config CRUD ops (`create`, `create_if_not_exists`, `update`, `put`, `delete`, `get_by_id`, `list`)
- Add `super_cluster_queue::anomaly_detection` handler for `ConfigCreate`, `ConfigUpdate`, and `ConfigDelete` events
- Refactor `service::anomaly_detection` and `scheduler::handlers` to use the new table module instead of raw SeaORM entity queries
- Refactor `super_cluster_queue::scheduler` to use new table module
- Reschedule trigger instead of deleting when config not found locally — handles SC race where trigger row arrives before `ConfigCreate` NATS message is processed

**Migration / referential integrity fix:**
- Add migration `m20260504` to retrofit the missing `FOREIGN KEY (folder_id) REFERENCES folders(id)` constraint on `anomaly_detection_config` (alerts and dashboards have had this since creation; anomaly detection was missing it)
- Pre-migration repair: any rows whose `folder_id` no longer exists in `folders` (orphaned by folder deletion) are re-pointed to the org's default Alerts folder before the constraint is added — prevents migration failure on existing deployments
- Add folder existence check inside transaction in `create()` — eliminates TOCTOU race between folder lookup and INSERT
- Add folder existence check in `update()` when folder is changing — matches `alerts::update` behaviour
- Add `PutAnomalyConfigError::FolderDoesNotExist` error variant matching the alert/dashboard error pattern

## Files changed (11)

- `src/infra/src/table/anomaly_detection/` — new module (config.rs, mod.rs, models.rs)
- `src/super_cluster_queue/anomaly_detection.rs` — new SC queue handler
- `src/infra/src/table/mod.rs` — register new module
- `src/super_cluster_queue/mod.rs` — wire anomaly_detection handler
- `src/service/anomaly_detection.rs` — refactored to use new table module
- `src/service/alerts/scheduler/handlers.rs` — refactored; reschedule on missing config
- `src/super_cluster_queue/scheduler.rs` — refactored to use new table module
- `src/infra/src/errors/mod.rs` — add `PutAnomalyConfigError::FolderDoesNotExist`
- `src/infra/src/table/migration/m20260504_000001_add_anomaly_detection_config_folder_fk.rs` — new migration
- `src/infra/src/table/migration/mod.rs` — register migration

## Test plan

- [x] Anomaly config create/update/delete broadcasts appear in SC queue logs on primary region
- [x] Follower region receives and applies `ConfigCreate`, `ConfigUpdate`, `ConfigDelete`
- [x] Trigger reschedule (not delete) when config not yet synced to follower
- [x] Create with non-existent folder returns clean `FolderDoesNotExist` error
- [x] Update moving config to non-existent folder returns clean `FolderDoesNotExist` error
- [x] Migration runs clean on existing DB with no orphaned rows
- [x] Migration repairs orphaned `folder_id` rows before adding FK constraint
- [x] `cargo check --workspace` passes