### PR TITLE
fix: replace vue-json-pretty with CodeQueryEditor for LLM JSON rendering

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -75,7 +75,6 @@
     "vue-drag-resize": "^1.5.4",
     "vue-draggable-next": "^2.3.0",
     "vue-i18n": "^11.2.8",
-    "vue-json-pretty": "^2.6.0",
     "vue-router": "^4.6.4",
     "vuex": "^4.1.0"
   },

--- a/web/src/components/CodeQueryEditor.spec.ts
+++ b/web/src/components/CodeQueryEditor.spec.ts
@@ -586,7 +586,11 @@ describe("CodeQueryEditor", () => {
         .spyOn(document, "getElementById")
         .mockReturnValue(fakeEl);
       mount(CodeQueryEditor, {
-        props: { editorId: "test-editor", query: "SELECT * FROM logs", ...props },
+        props: {
+          editorId: "test-editor",
+          query: "SELECT * FROM logs",
+          ...props,
+        },
         global: { plugins: [store] },
       });
 
@@ -611,7 +615,11 @@ describe("CodeQueryEditor", () => {
     const callProvider = (fn: Function, text = "") => {
       const mockModel = {
         getValueInRange: vi.fn(() => text),
-        getWordUntilPosition: vi.fn(() => ({ word: "", startColumn: 1, endColumn: 1 })),
+        getWordUntilPosition: vi.fn(() => ({
+          word: "",
+          startColumn: 1,
+          endColumn: 1,
+        })),
       };
       return fn(mockModel, { lineNumber: 1, column: 1 });
     };
@@ -620,37 +628,96 @@ describe("CodeQueryEditor", () => {
       result.suggestions.some(
         (s: any) =>
           typeof s.label === "string" &&
-          (s.label.startsWith("match_all") || s.label.startsWith("fuzzy_match")),
+          (s.label.startsWith("match_all") ||
+            s.label.startsWith("fuzzy_match")),
       );
 
-    it.skip("includes function suggestions when suggestions prop is null (default)", { timeout: 20000 }, async () => {
-      const baselineIndex = await mountAndWait({ suggestions: null });
-      const fn = await captureProvideCompletionItems(baselineIndex);
-      const result = callProvider(fn);
-      expect(hasFunctionSuggestion(result)).toBe(true);
-    });
+    it.skip(
+      "includes function suggestions when suggestions prop is null (default)",
+      { timeout: 20000 },
+      async () => {
+        const baselineIndex = await mountAndWait({ suggestions: null });
+        const fn = await captureProvideCompletionItems(baselineIndex);
+        const result = callProvider(fn);
+        expect(hasFunctionSuggestion(result)).toBe(true);
+      },
+    );
 
-    it.skip("includes no function suggestions when suggestions prop is [] (explicit empty)", { timeout: 20000 }, async () => {
-      const baselineIndex = await mountAndWait({ suggestions: [] });
-      const fn = await captureProvideCompletionItems(baselineIndex);
-      const result = callProvider(fn);
-      expect(hasFunctionSuggestion(result)).toBe(false);
-    });
+    it.skip(
+      "includes no function suggestions when suggestions prop is [] (explicit empty)",
+      { timeout: 20000 },
+      async () => {
+        const baselineIndex = await mountAndWait({ suggestions: [] });
+        const fn = await captureProvideCompletionItems(baselineIndex);
+        const result = callProvider(fn);
+        expect(hasFunctionSuggestion(result)).toBe(false);
+      },
+    );
 
-    it.skip("includes provided suggestions when suggestions prop has items", { timeout: 20000 }, async () => {
-      const customSuggestion = {
-        label: (_kw: string) => `custom_fn('${_kw}')`,
-        kind: "Text",
-        insertText: (_kw: string) => `custom_fn('${_kw}')`,
-      };
-      const baselineIndex = await mountAndWait({ suggestions: [customSuggestion] });
-      const fn = await captureProvideCompletionItems(baselineIndex);
-      const result = callProvider(fn, "SELECT");
-      const found = result.suggestions.some(
-        (s: any) => typeof s.label === "string" && s.label.startsWith("custom_fn"),
-      );
-      expect(found).toBe(true);
-    });
+    it.skip(
+      "includes provided suggestions when suggestions prop has items",
+      { timeout: 20000 },
+      async () => {
+        const customSuggestion = {
+          label: (_kw: string) => `custom_fn('${_kw}')`,
+          kind: "Text",
+          insertText: (_kw: string) => `custom_fn('${_kw}')`,
+        };
+        const baselineIndex = await mountAndWait({
+          suggestions: [customSuggestion],
+        });
+        const fn = await captureProvideCompletionItems(baselineIndex);
+        const result = callProvider(fn, "SELECT");
+        const found = result.suggestions.some(
+          (s: any) =>
+            typeof s.label === "string" && s.label.startsWith("custom_fn"),
+        );
+        expect(found).toBe(true);
+      },
+    );
+    it(
+      "includes function suggestions when suggestions prop is null (default)",
+      { timeout: 20000 },
+      async () => {
+        const baselineIndex = await mountAndWait({ suggestions: null });
+        const fn = await captureProvideCompletionItems(baselineIndex);
+        const result = callProvider(fn);
+        expect(hasFunctionSuggestion(result)).toBe(true);
+      },
+    );
+
+    it(
+      "includes no function suggestions when suggestions prop is [] (explicit empty)",
+      { timeout: 20000 },
+      async () => {
+        const baselineIndex = await mountAndWait({ suggestions: [] });
+        const fn = await captureProvideCompletionItems(baselineIndex);
+        const result = callProvider(fn);
+        expect(hasFunctionSuggestion(result)).toBe(false);
+      },
+    );
+
+    it(
+      "includes provided suggestions when suggestions prop has items",
+      { timeout: 20000 },
+      async () => {
+        const customSuggestion = {
+          label: (_kw: string) => `custom_fn('${_kw}')`,
+          kind: "Text",
+          insertText: (_kw: string) => `custom_fn('${_kw}')`,
+        };
+        const baselineIndex = await mountAndWait({
+          suggestions: [customSuggestion],
+        });
+        const fn = await captureProvideCompletionItems(baselineIndex);
+        const result = callProvider(fn, "SELECT");
+        const found = result.suggestions.some(
+          (s: any) =>
+            typeof s.label === "string" && s.label.startsWith("custom_fn"),
+        );
+        expect(found).toBe(true);
+      },
+    );
   });
 
   // Tests for validateDoubleQuotes.
@@ -673,7 +740,9 @@ describe("CodeQueryEditor", () => {
     // ── double-quoted values ────────────────────────────────────────────────
 
     it('flags = "value"', () => {
-      expect(findInvalidQuotes(`WHERE http_endpoint = "test"`)).toEqual([`"test"`]);
+      expect(findInvalidQuotes(`WHERE http_endpoint = "test"`)).toEqual([
+        `"test"`,
+      ]);
     });
 
     it('flags != "value"', () => {
@@ -681,11 +750,15 @@ describe("CodeQueryEditor", () => {
     });
 
     it('flags LIKE "%value%"', () => {
-      expect(findInvalidQuotes(`WHERE msg LIKE "%error%"`)).toEqual([`"%error%"`]);
+      expect(findInvalidQuotes(`WHERE msg LIKE "%error%"`)).toEqual([
+        `"%error%"`,
+      ]);
     });
 
     it('flags NOT LIKE "value"', () => {
-      expect(findInvalidQuotes(`WHERE path NOT LIKE "%admin%"`)).toEqual([`"%admin%"`]);
+      expect(findInvalidQuotes(`WHERE path NOT LIKE "%admin%"`)).toEqual([
+        `"%admin%"`,
+      ]);
     });
 
     it('flags IN ("value")', () => {
@@ -706,7 +779,7 @@ describe("CodeQueryEditor", () => {
 
     // ── mismatched quotes ───────────────────────────────────────────────────
 
-    it('flags mismatched open-double close-single: = "value\'', () => {
+    it("flags mismatched open-double close-single: = \"value'", () => {
       expect(findInvalidQuotes(`WHERE field = "test'`)).toEqual([`"test'`]);
     });
 
@@ -717,14 +790,18 @@ describe("CodeQueryEditor", () => {
     // ── valid cases — must NOT be flagged ────────────────────────────────────
 
     it("does NOT flag single-quoted values", () => {
-      expect(findInvalidQuotes(`WHERE status = 'ok' AND env = 'prod'`)).toEqual([]);
+      expect(findInvalidQuotes(`WHERE status = 'ok' AND env = 'prod'`)).toEqual(
+        [],
+      );
     });
 
     it("does NOT flag numeric values", () => {
-      expect(findInvalidQuotes(`WHERE status = 200 AND code >= 400`)).toEqual([]);
+      expect(findInvalidQuotes(`WHERE status = 200 AND code >= 400`)).toEqual(
+        [],
+      );
     });
 
-    it('does NOT flag double-quoted table names in FROM clause', () => {
+    it("does NOT flag double-quoted table names in FROM clause", () => {
       expect(
         findInvalidQuotes(`SELECT * FROM "test_table" WHERE status = 200`),
       ).toEqual([]);

--- a/web/src/components/CodeQueryEditor.vue
+++ b/web/src/components/CodeQueryEditor.vue
@@ -112,6 +112,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    showLineNumbers: {
+      type: Boolean,
+      default: true,
+    },
     language: {
       type: String,
       default: "sql",
@@ -659,7 +663,7 @@ export default defineComponent({
         folding: enableCodeFolding.value,
         wordWrap: "on",
         automaticLayout: true,
-        lineNumbers: "on",
+        lineNumbers: props.showLineNumbers ? "on" : "off",
         lineNumbersMinChars: 0,
         overviewRulerLanes: 0,
         fixedOverflowWidgets: true,
@@ -840,6 +844,14 @@ export default defineComponent({
       () => props.readOnly,
       () => {
         editorObj?.updateOptions({ readOnly: props.readOnly });
+      },
+    );
+
+    // update lineNumbers when prop value changes
+    watch(
+      () => props.showLineNumbers,
+      () => {
+        editorObj?.updateOptions({ lineNumbers: props.showLineNumbers ? "on" : "off" });
       },
     );
 

--- a/web/src/components/CodeQueryEditor.vue
+++ b/web/src/components/CodeQueryEditor.vue
@@ -116,7 +116,7 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
-    stickScroll: {
+    stickyScroll: {
       type: Boolean,
       default: true,
     },
@@ -691,7 +691,7 @@ export default defineComponent({
         readOnly: props.readOnly,
         renderValidationDecorations: "on",
         stickyScroll: {
-          enabled: props.stickScroll,
+          enabled: props.stickyScroll,
         },
       });
 

--- a/web/src/components/CodeQueryEditor.vue
+++ b/web/src/components/CodeQueryEditor.vue
@@ -116,6 +116,10 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
+    stickScroll: {
+      type: Boolean,
+      default: true,
+    },
     language: {
       type: String,
       default: "sql",
@@ -686,6 +690,9 @@ export default defineComponent({
         minimap: { enabled: false },
         readOnly: props.readOnly,
         renderValidationDecorations: "on",
+        stickyScroll: {
+          enabled: props.stickScroll,
+        },
       });
 
       editorObj.onDidChangeModelContent(
@@ -851,7 +858,9 @@ export default defineComponent({
     watch(
       () => props.showLineNumbers,
       () => {
-        editorObj?.updateOptions({ lineNumbers: props.showLineNumbers ? "on" : "off" });
+        editorObj?.updateOptions({
+          lineNumbers: props.showLineNumbers ? "on" : "off",
+        });
       },
     );
 

--- a/web/src/plugins/traces/LLMContentRenderer.spec.ts
+++ b/web/src/plugins/traces/LLMContentRenderer.spec.ts
@@ -14,7 +14,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
+import DOMPurify from "dompurify";
+import { marked } from "marked";
 import { installQuasar } from "@/test/unit/helpers/install-quasar-plugin";
 import LLMContentRenderer from "@/plugins/traces/LLMContentRenderer.vue";
 
@@ -195,7 +197,7 @@ describe("LLMContentRenderer", () => {
       const toolContent = wrapper.vm.toolContent;
       expect(toolContent).toBeTruthy();
       // Check that it either unwrapped to the text or kept the structure
-      if (typeof toolContent === 'string') {
+      if (typeof toolContent === "string") {
         expect(toolContent).toBe("Nested text content");
       } else {
         expect(toolContent.content).toBeDefined();
@@ -278,7 +280,10 @@ describe("LLMContentRenderer", () => {
         props: {
           content: JSON.stringify([
             { type: "text", text: "Hello world" },
-            { type: "image_url", image_url: { url: "https://example.com/img.png" } },
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/img.png" },
+            },
           ]),
           viewMode: "formatted",
         },
@@ -384,7 +389,10 @@ describe("LLMContentRenderer", () => {
             role: "user",
             content: [
               { type: "text", text: "What is this?" },
-              { type: "image_url", image_url: { url: "https://example.com/img.png" } },
+              {
+                type: "image_url",
+                image_url: { url: "https://example.com/img.png" },
+              },
             ],
           }),
           viewMode: "formatted",
@@ -393,7 +401,9 @@ describe("LLMContentRenderer", () => {
 
       const messages = wrapper.vm.parsedMessages;
       expect(messages[0].content).toContain("What is this?");
-      expect(messages[0].content).toContain("[Image: https://example.com/img.png]");
+      expect(messages[0].content).toContain(
+        "[Image: https://example.com/img.png]",
+      );
     });
 
     it("should handle Anthropic image format", () => {
@@ -417,7 +427,10 @@ describe("LLMContentRenderer", () => {
 
   describe("Content Truncation", () => {
     it("should truncate long content", () => {
-      const longContent = Array.from({ length: 20 }, (_, i) => `Line ${i}`).join("\n");
+      const longContent = Array.from(
+        { length: 20 },
+        (_, i) => `Line ${i}`,
+      ).join("\n");
 
       wrapper = mount(LLMContentRenderer, {
         props: {
@@ -446,7 +459,10 @@ describe("LLMContentRenderer", () => {
     });
 
     it("should expand content when expand button is clicked", async () => {
-      const longContent = Array.from({ length: 20 }, (_, i) => `Line ${i}`).join("\n");
+      const longContent = Array.from(
+        { length: 20 },
+        (_, i) => `Line ${i}`,
+      ).join("\n");
 
       wrapper = mount(LLMContentRenderer, {
         props: {
@@ -466,7 +482,10 @@ describe("LLMContentRenderer", () => {
     });
 
     it("should collapse content when collapse button is clicked", async () => {
-      const longContent = Array.from({ length: 20 }, (_, i) => `Line ${i}`).join("\n");
+      const longContent = Array.from(
+        { length: 20 },
+        (_, i) => `Line ${i}`,
+      ).join("\n");
 
       wrapper = mount(LLMContentRenderer, {
         props: {
@@ -660,7 +679,8 @@ describe("LLMContentRenderer", () => {
     });
 
     it("should handle content with special characters", () => {
-      const specialContent = "Content with\ttabs\nand\rnewlines\r\nand unicode: 🎉";
+      const specialContent =
+        "Content with\ttabs\nand\rnewlines\r\nand unicode: 🎉";
 
       wrapper = mount(LLMContentRenderer, {
         props: {
@@ -696,7 +716,9 @@ describe("LLMContentRenderer", () => {
     it("should handle messages with missing role", () => {
       wrapper = mount(LLMContentRenderer, {
         props: {
-          content: JSON.stringify([{ role: undefined, content: "No role specified" }]),
+          content: JSON.stringify([
+            { role: undefined, content: "No role specified" },
+          ]),
           viewMode: "formatted",
         },
       });
@@ -746,7 +768,10 @@ describe("LLMContentRenderer", () => {
 
     it("should format image URLs in content", () => {
       const content = [
-        { type: "image_url", image_url: { url: "https://example.com/image.png" } },
+        {
+          type: "image_url",
+          image_url: { url: "https://example.com/image.png" },
+        },
       ];
 
       wrapper = mount(LLMContentRenderer, {
@@ -777,7 +802,7 @@ describe("LLMContentRenderer", () => {
 
   describe("XSS Prevention", () => {
     it("should sanitize HTML content through DOMPurify", () => {
-      const maliciousContent = '<img src=x onerror="alert(\'xss\')">';
+      const maliciousContent = "<img src=x onerror=\"alert('xss')\">";
 
       wrapper = mount(LLMContentRenderer, {
         props: {
@@ -887,6 +912,378 @@ describe("LLMContentRenderer", () => {
       });
 
       expect(wrapper.vm.parsedContent).toEqual({ key: "value" });
+    });
+  });
+
+  describe("instanceId & editorIdPrefix", () => {
+    it("should default instanceId to empty string", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: "test" },
+      });
+
+      expect(wrapper.props("instanceId")).toBe("");
+    });
+
+    it("should accept custom instanceId", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: "test", instanceId: "abc" },
+      });
+
+      expect(wrapper.props("instanceId")).toBe("abc");
+    });
+
+    it("should return 'abc-' when instanceId is 'abc'", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: "test", instanceId: "abc" },
+      });
+
+      expect(wrapper.vm.editorIdPrefix).toBe("abc-");
+    });
+
+    it("should return empty string when instanceId is empty string", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: "test", instanceId: "" },
+      });
+
+      expect(wrapper.vm.editorIdPrefix).toBe("");
+    });
+
+    it("should return empty string when instanceId is not provided", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: "test" },
+      });
+
+      expect(wrapper.vm.editorIdPrefix).toBe("");
+    });
+  });
+
+  describe("toolContentJson & parsedContentJson", () => {
+    it("should stringify toolContentJson for object content", () => {
+      const mockSpan = {
+        llm_tool_call_arguments: '{"key": "value"}',
+      };
+
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: null,
+          observationType: "TOOL",
+          contentType: "input",
+          span: mockSpan,
+        },
+      });
+
+      expect(wrapper.vm.toolContentJson).toBe('{\n  "key": "value"\n}');
+    });
+
+    it("should return empty string for toolContentJson when null", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: null,
+          observationType: "TOOL",
+          contentType: "input",
+          span: { llm_tool_call_arguments: "null" },
+        },
+      });
+
+      expect(wrapper.vm.toolContentJson).toBe("");
+    });
+
+    it("should stringify parsedContentJson for JSON object", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: '{"a": 1}', viewMode: "formatted" },
+      });
+
+      expect(wrapper.vm.parsedContentJson).toBe('{\n  "a": 1\n}');
+    });
+
+    it("should return empty string for parsedContentJson when null", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: null, viewMode: "formatted" },
+      });
+
+      expect(wrapper.vm.parsedContentJson).toBe("");
+    });
+  });
+
+  describe("Helper Functions", () => {
+    describe("isMessageJson", () => {
+      it("should return true for valid JSON", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.isMessageJson('{"key": "val"}')).toBe(true);
+      });
+
+      it("should return false for invalid JSON", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.isMessageJson("not json")).toBe(false);
+      });
+    });
+
+    describe("stringifyMessageContent", () => {
+      it("should return pretty-printed JSON", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        const result = wrapper.vm.stringifyMessageContent('{"b":2,"a":1}');
+        expect(result).toBe('{\n  "b": 2,\n  "a": 1\n}');
+      });
+    });
+
+    describe("roleColor", () => {
+      it("should return correct color for user role", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.roleColor("user")).toBe("rgba(25, 118, 210, 0.1)");
+      });
+
+      it("should return correct color for assistant role", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.roleColor("assistant")).toBe(
+          "rgba(76, 175, 80, 0.1)",
+        );
+      });
+
+      it("should return correct color for system role", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.roleColor("system")).toBe("rgba(255, 152, 0, 0.1)");
+      });
+
+      it("should return correct color for tool role", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.roleColor("tool")).toBe("rgba(156, 39, 176, 0.1)");
+      });
+
+      it("should return fallback color for unknown role", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.roleColor("unknown")).toBe(
+          "rgba(158, 158, 158, 0.1)",
+        );
+      });
+    });
+
+    describe("roleLabel", () => {
+      it("should return correct label for user role", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.roleLabel("user")).toBe("User");
+      });
+
+      it("should return correct label for assistant role", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.roleLabel("assistant")).toBe("Assistant");
+      });
+
+      it("should return correct label for system role", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.roleLabel("system")).toBe("System");
+      });
+
+      it("should return correct label for tool role", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.roleLabel("tool")).toBe("Tool");
+      });
+
+      it("should return role name as-is for unknown role", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        expect(wrapper.vm.roleLabel("custom-agent")).toBe("custom-agent");
+      });
+    });
+
+    describe("renderMarkdown", () => {
+      it("should replace [Image: URL] with markdown image syntax", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        const result = wrapper.vm.renderMarkdown(
+          "Check: [Image: https://example.com/img.png]",
+        );
+        expect(result).toContain("![Image](https://example.com/img.png)");
+      });
+
+      it("should call DOMPurify.sanitize with marked output", () => {
+        wrapper = mount(LLMContentRenderer, {
+          props: { content: "test" },
+        });
+
+        wrapper.vm.renderMarkdown("Hello world");
+        expect(DOMPurify.sanitize).toHaveBeenCalled();
+        expect(marked.parse).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("CodeQueryEditor Rendering", () => {
+    it("should render CodeQueryEditor stub for JSON content in formatted mode", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: '{"key": "value"}', viewMode: "formatted" },
+        global: {
+          stubs: {
+            CodeQueryEditor: {
+              template:
+                '<div data-test="code-query-editor">CodeQueryEditorStub</div>',
+            },
+          },
+        },
+      });
+
+      expect(wrapper.find('[data-test="code-query-editor"]').exists()).toBe(
+        true,
+      );
+    });
+
+    it("should render CodeQueryEditor stub in JSON view mode", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: { content: '{"key": "value"}', viewMode: "json" },
+        global: {
+          stubs: {
+            CodeQueryEditor: {
+              template:
+                '<div data-test="code-query-editor">CodeQueryEditorStub</div>',
+            },
+          },
+        },
+      });
+
+      expect(wrapper.find('[data-test="code-query-editor"]').exists()).toBe(
+        true,
+      );
+    });
+
+    it("should render CodeQueryEditor stub for tool content", () => {
+      const mockSpan = {
+        llm_tool_name: "test-tool",
+        llm_tool_call_id: "call-1",
+        llm_tool_call_arguments: '{"op": "add"}',
+      };
+
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: null,
+          observationType: "TOOL",
+          contentType: "input",
+          span: mockSpan,
+        },
+        global: {
+          stubs: {
+            CodeQueryEditor: {
+              template:
+                '<div data-test="code-query-editor">CodeQueryEditorStub</div>',
+            },
+          },
+        },
+      });
+
+      expect(wrapper.find('[data-test="code-query-editor"]').exists()).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("Inline Message Rendering", () => {
+    it("should render message items with role labels via v-for", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([
+            { role: "user", content: "Hello" },
+            { role: "assistant", content: "Hi there" },
+          ]),
+          viewMode: "formatted",
+        },
+      });
+
+      const messageItems = wrapper.findAll(".message-item");
+      expect(messageItems.length).toBe(2);
+
+      const roles = wrapper.findAll(".message-role");
+      expect(roles.length).toBe(2);
+      expect(roles[0].text()).toBe("User");
+      expect(roles[1].text()).toBe("Assistant");
+    });
+
+    it("should render markdown content when message content is not JSON", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([
+            { role: "assistant", content: "I am an assistant" },
+          ]),
+          viewMode: "formatted",
+        },
+      });
+
+      const markdownBody = wrapper.find(".markdown-body");
+      expect(markdownBody.exists()).toBe(true);
+    });
+
+    it("should render CodeQueryEditor stub when message content is JSON", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([
+            { role: "assistant", content: '{"inner": "json"}' },
+          ]),
+          viewMode: "formatted",
+        },
+        global: {
+          stubs: {
+            CodeQueryEditor: {
+              template:
+                '<div data-test="code-query-editor">CodeQueryEditorStub</div>',
+            },
+          },
+        },
+      });
+
+      const messageJson = wrapper.find(".message-content-json");
+      expect(messageJson.exists()).toBe(true);
+      expect(messageJson.find('[data-test="code-query-editor"]').exists()).toBe(
+        true,
+      );
+    });
+
+    it("should apply role-based background color to message items", () => {
+      wrapper = mount(LLMContentRenderer, {
+        props: {
+          content: JSON.stringify([{ role: "user", content: "Hello" }]),
+          viewMode: "formatted",
+        },
+      });
+
+      const roleDiv = wrapper.find(".message-role");
+      expect(roleDiv.attributes("style")).toContain("rgba(25, 118, 210, 0.1)");
     });
   });
 });

--- a/web/src/plugins/traces/LLMContentRenderer.spec.ts
+++ b/web/src/plugins/traces/LLMContentRenderer.spec.ts
@@ -34,6 +34,15 @@ vi.mock("marked", () => ({
   },
 }));
 
+// Mock CodeQueryEditor (Monaco wrapper, not needed in unit tests)
+vi.mock("@/components/CodeQueryEditor.vue", () => ({
+  default: {
+    name: "CodeQueryEditor",
+    template:
+      '<div class="code-query-editor-mock" data-test="code-query-editor">CodeQueryEditor</div>',
+  },
+}));
+
 describe("LLMContentRenderer", () => {
   let wrapper: any;
 

--- a/web/src/plugins/traces/LLMContentRenderer.vue
+++ b/web/src/plugins/traces/LLMContentRenderer.vue
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :read-only="true"
           :show-auto-complete="false"
           :show-line-numbers="false"
-          :stick-scroll="false"
+          :sticky-scroll="false"
           class="json-viewer-editor tw:max-h-full! tw:h-full!"
         />
       </div>
@@ -102,7 +102,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   :read-only="true"
                   :show-auto-complete="false"
                   :show-line-numbers="false"
-                  :stick-scroll="false"
+                  :sticky-scroll="false"
                   class="json-viewer-editor tw:max-h-full! tw:h-full!"
                 />
               </div>
@@ -125,7 +125,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :read-only="true"
               :show-auto-complete="false"
               :show-line-numbers="false"
-              :stick-scroll="false"
+              :sticky-scroll="false"
               class="json-viewer-editor tw:max-h-full! tw:h-full!"
             />
           </div>
@@ -140,7 +140,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :read-only="true"
             :show-auto-complete="false"
             :show-line-numbers="false"
-            :stick-scroll="false"
+            :sticky-scroll="false"
             class="json-viewer-editor tw:max-h-full! tw:h-full!"
           />
         </div>
@@ -204,7 +204,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   :read-only="true"
                   :show-auto-complete="false"
                   :show-line-numbers="false"
-                  :stick-scroll="false"
+                  :sticky-scroll="false"
                   class="json-viewer-editor tw:max-h-full! tw:h-full!"
                 />
               </div>
@@ -227,7 +227,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :read-only="true"
               :show-auto-complete="false"
               :show-line-numbers="false"
-              :stick-scroll="false"
+              :sticky-scroll="false"
               class="json-viewer-editor tw:max-h-full! tw:h-full"
             />
           </div>
@@ -242,7 +242,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :read-only="true"
             :show-auto-complete="false"
             :show-line-numbers="false"
-            :stick-scroll="false"
+            :sticky-scroll="false"
             class="json-viewer-editor"
           />
         </div>

--- a/web/src/plugins/traces/LLMContentRenderer.vue
+++ b/web/src/plugins/traces/LLMContentRenderer.vue
@@ -33,12 +33,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
       <div class="tool-data">
         <CodeQueryEditor
-          :editor-id="`tool-json-viewer-${span?.llm_tool_call_id || 'unknown'}`"
+          :editor-id="`${editorIdPrefix}tool-json-viewer-${span?.llm_tool_call_id || 'unknown'}`"
           :query="toolContentJson"
           language="json"
           :read-only="true"
           :show-auto-complete="false"
           :show-line-numbers="false"
+          :stick-scroll="false"
           class="json-viewer-editor tw:max-h-full! tw:h-full!"
         />
       </div>
@@ -75,12 +76,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 style="background-color: var(--o2-code-bg)"
               >
                 <CodeQueryEditor
-                  :editor-id="`msg-json-editor-${idx}`"
+                  :editor-id="`${editorIdPrefix}msg-json-editor-${idx}`"
                   :query="stringifyMessageContent(msg.content)"
                   language="json"
                   :read-only="true"
                   :show-auto-complete="false"
                   :show-line-numbers="false"
+                  :stick-scroll="false"
                   class="json-viewer-editor tw:max-h-full! tw:h-full!"
                 />
               </div>
@@ -97,12 +99,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
           <div v-else class="json-content">
             <CodeQueryEditor
-              editor-id="truncated-formatted-json-viewer"
+              :editor-id="`truncated-formatted-json-viewer-${editorIdPrefix}`"
               :query="parsedContentJson"
               language="json"
               :read-only="true"
               :show-auto-complete="false"
               :show-line-numbers="false"
+              :stick-scroll="false"
               class="json-viewer-editor tw:max-h-full! tw:h-full!"
             />
           </div>
@@ -111,12 +114,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <!-- JSON mode -->
         <div v-else class="json-content">
           <CodeQueryEditor
-            editor-id="truncated-json-mode-viewer"
+            :editor-id="`truncated-json-mode-viewer-${editorIdPrefix}`"
             :query="parsedContentJson"
             language="json"
             :read-only="true"
             :show-auto-complete="false"
             :show-line-numbers="false"
+            :stick-scroll="false"
             class="json-viewer-editor tw:max-h-full! tw:h-full!"
           />
         </div>
@@ -163,12 +167,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 style="background-color: var(--o2-code-bg)"
               >
                 <CodeQueryEditor
-                  :editor-id="`msg-json-editor-full-${idx}`"
+                  :editor-id="`${editorIdPrefix}msg-json-editor-full-${idx}`"
                   :query="stringifyMessageContent(msg.content)"
                   language="json"
                   :read-only="true"
                   :show-auto-complete="false"
                   :show-line-numbers="false"
+                  :stick-scroll="false"
                   class="json-viewer-editor tw:max-h-full! tw:h-full!"
                 />
               </div>
@@ -185,12 +190,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
           <div v-else class="json-content tw:h-full">
             <CodeQueryEditor
-              editor-id="full-formatted-json-viewer"
+              :editor-id="`full-formatted-json-viewer-${editorIdPrefix}`"
               :query="parsedContentJson"
               language="json"
               :read-only="true"
               :show-auto-complete="false"
               :show-line-numbers="false"
+              :stick-scroll="false"
               class="json-viewer-editor tw:max-h-full! tw:h-full"
             />
           </div>
@@ -199,12 +205,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <!-- JSON mode -->
         <div v-else class="json-content">
           <CodeQueryEditor
-            editor-id="full-json-mode-viewer"
+            :editor-id="`full-json-mode-viewer-${editorIdPrefix}`"
             :query="parsedContentJson"
             language="json"
             :read-only="true"
             :show-auto-complete="false"
             :show-line-numbers="false"
+            :stick-scroll="false"
             class="json-viewer-editor"
           />
         </div>
@@ -257,7 +264,15 @@ const props = defineProps({
     type: String as () => "formatted" | "json",
     default: "formatted",
   },
+  instanceId: {
+    type: String,
+    default: "",
+  },
 });
+
+const editorIdPrefix = computed(() =>
+  props.instanceId ? `${props.instanceId}-` : "",
+);
 
 const isExpanded = ref(false);
 

--- a/web/src/plugins/traces/LLMContentRenderer.vue
+++ b/web/src/plugins/traces/LLMContentRenderer.vue
@@ -15,42 +15,110 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div v-if="hasValidContent" class="llm-content-renderer">
+  <div v-if="hasValidContent" class="llm-content-renderer tw:h-full">
     <!-- Tool-specific rendering -->
     <div v-if="isToolObservation && toolContent !== null" class="tool-content">
       <div v-if="toolMetadata" class="tool-metadata q-mb-sm">
-        <q-badge v-if="toolMetadata.name" :label="`Tool: ${toolMetadata.name}`" color="orange" class="q-mr-sm" />
-        <q-badge v-if="toolMetadata.callId" :label="`Call ID: ${toolMetadata.callId}`" color="grey" />
+        <q-badge
+          v-if="toolMetadata.name"
+          :label="`Tool: ${toolMetadata.name}`"
+          color="orange"
+          class="q-mr-sm"
+        />
+        <q-badge
+          v-if="toolMetadata.callId"
+          :label="`Call ID: ${toolMetadata.callId}`"
+          color="grey"
+        />
       </div>
       <div class="tool-data">
-        <VueJsonPretty :data="toolContent" :deep="3" :showLength="true" />
+        <CodeQueryEditor
+          :editor-id="`tool-json-viewer-${span?.llm_tool_call_id || 'unknown'}`"
+          :query="toolContentJson"
+          language="json"
+          :read-only="true"
+          :show-auto-complete="false"
+          :show-line-numbers="false"
+          class="json-viewer-editor tw:max-h-full! tw:h-full!"
+        />
       </div>
     </div>
 
     <!-- Regular content rendering -->
-    <div v-else class="content-wrapper">
+    <div v-else class="content-wrapper tw:h-full">
       <!-- Truncated view -->
-      <div v-if="!isExpanded && contentStats.shouldTruncate">
+      <div v-if="!isExpanded && contentStats.shouldTruncate" class="tw:h-full!">
         <!-- Formatted mode -->
-        <div v-if="props.viewMode === 'formatted'">
-          <div v-if="shouldRenderAsMessages" class="messages-view">
-            <MessageItem
+        <div v-if="props.viewMode === 'formatted'" class="tw:h-full">
+          <div v-if="shouldRenderAsMessages" class="messages-view tw:h-full">
+            <div
               v-for="(msg, idx) in previewMessages"
               :key="idx"
-              :message="msg"
-            />
+              class="message-item q-mb-sm tw:h-full"
+              :style="{
+                border: '1px solid var(--o2-border)',
+                borderRadius: '8px',
+              }"
+            >
+              <div
+                class="message-role text-caption text-bold q-pa-sm tw:capitalize"
+                :style="{
+                  backgroundColor: roleColor(msg.role),
+                  borderBottom: '1px solid var(--o2-border)',
+                }"
+              >
+                {{ roleLabel(msg.role) }}
+              </div>
+              <div
+                v-if="isMessageJson(msg.content)"
+                class="message-content-json q-pa-sm tw:h-full"
+                style="background-color: var(--o2-code-bg)"
+              >
+                <CodeQueryEditor
+                  :editor-id="`msg-json-editor-${idx}`"
+                  :query="stringifyMessageContent(msg.content)"
+                  language="json"
+                  :read-only="true"
+                  :show-auto-complete="false"
+                  :show-line-numbers="false"
+                  class="json-viewer-editor tw:max-h-full! tw:h-full!"
+                />
+              </div>
+              <div
+                v-else
+                class="message-content markdown-body q-pa-sm"
+                style="background-color: var(--o2-code-bg)"
+                v-html="renderMarkdown(msg.content)"
+              />
+            </div>
           </div>
           <div v-else-if="isPlainText" class="text-content">
             <pre class="plain-text-content">{{ contentStats.previewText }}</pre>
           </div>
           <div v-else class="json-content">
-            <VueJsonPretty :data="parsedContent" :deep="3" :showLength="true" />
+            <CodeQueryEditor
+              editor-id="truncated-formatted-json-viewer"
+              :query="parsedContentJson"
+              language="json"
+              :read-only="true"
+              :show-auto-complete="false"
+              :show-line-numbers="false"
+              class="json-viewer-editor tw:max-h-full! tw:h-full!"
+            />
           </div>
         </div>
 
         <!-- JSON mode -->
         <div v-else class="json-content">
-          <VueJsonPretty :data="parsedContent" :deep="3" :showLength="true" />
+          <CodeQueryEditor
+            editor-id="truncated-json-mode-viewer"
+            :query="parsedContentJson"
+            language="json"
+            :read-only="true"
+            :show-auto-complete="false"
+            :show-line-numbers="false"
+            class="json-viewer-editor tw:max-h-full! tw:h-full!"
+          />
         </div>
 
         <div class="expand-indicator q-mt-sm">
@@ -67,27 +135,78 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
 
       <!-- Full content view -->
-      <div v-else>
+      <div v-else class="tw:h-full">
         <!-- Formatted mode -->
-        <div v-if="props.viewMode === 'formatted'">
-          <div v-if="shouldRenderAsMessages" class="messages-view">
-            <MessageItem
+        <div v-if="props.viewMode === 'formatted'" class="tw:h-full">
+          <div v-if="shouldRenderAsMessages" class="messages-view tw:h-full">
+            <div
               v-for="(msg, idx) in parsedMessages"
               :key="idx"
-              :message="msg"
-            />
+              class="message-item q-mb-sm tw:h-full"
+              :style="{
+                border: '1px solid var(--o2-border)',
+                borderRadius: '8px',
+              }"
+            >
+              <div
+                class="message-role text-caption text-bold q-pa-sm tw:capitalize"
+                :style="{
+                  backgroundColor: roleColor(msg.role),
+                  borderBottom: '1px solid var(--o2-border)',
+                }"
+              >
+                {{ roleLabel(msg.role) }}
+              </div>
+              <div
+                v-if="isMessageJson(msg.content)"
+                class="message-content-json q-pa-sm tw:h-full"
+                style="background-color: var(--o2-code-bg)"
+              >
+                <CodeQueryEditor
+                  :editor-id="`msg-json-editor-full-${idx}`"
+                  :query="stringifyMessageContent(msg.content)"
+                  language="json"
+                  :read-only="true"
+                  :show-auto-complete="false"
+                  :show-line-numbers="false"
+                  class="json-viewer-editor tw:max-h-full! tw:h-full!"
+                />
+              </div>
+              <div
+                v-else
+                class="message-content markdown-body q-pa-sm"
+                style="background-color: var(--o2-code-bg)"
+                v-html="renderMarkdown(msg.content)"
+              />
+            </div>
           </div>
           <div v-else-if="isPlainText" class="text-content">
             <pre class="plain-text-content">{{ fullText }}</pre>
           </div>
-          <div v-else class="json-content">
-            <VueJsonPretty :data="parsedContent" :deep="3" :showLength="true" />
+          <div v-else class="json-content tw:h-full">
+            <CodeQueryEditor
+              editor-id="full-formatted-json-viewer"
+              :query="parsedContentJson"
+              language="json"
+              :read-only="true"
+              :show-auto-complete="false"
+              :show-line-numbers="false"
+              class="json-viewer-editor tw:max-h-full! tw:h-full"
+            />
           </div>
         </div>
 
         <!-- JSON mode -->
         <div v-else class="json-content">
-          <VueJsonPretty :data="parsedContent" :deep="3" :showLength="true" />
+          <CodeQueryEditor
+            editor-id="full-json-mode-viewer"
+            :query="parsedContentJson"
+            language="json"
+            :read-only="true"
+            :show-auto-complete="false"
+            :show-line-numbers="false"
+            class="json-viewer-editor"
+          />
         </div>
 
         <div v-if="contentStats.shouldTruncate" class="collapse-btn q-mt-sm">
@@ -107,9 +226,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
-import VueJsonPretty from 'vue-json-pretty';
-import 'vue-json-pretty/lib/styles.css';
+import { computed, defineAsyncComponent, ref } from "vue";
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+
+const CodeQueryEditor = defineAsyncComponent(
+  () => import("@/components/CodeQueryEditor.vue"),
+);
 
 const INITIAL_LINE_LIMIT = 15;
 
@@ -120,19 +243,19 @@ const props = defineProps({
   },
   observationType: {
     type: String,
-    default: 'SPAN',
+    default: "SPAN",
   },
   contentType: {
-    type: String as () => 'input' | 'output',
-    default: 'input',
+    type: String as () => "input" | "output",
+    default: "input",
   },
   span: {
     type: Object,
     default: null,
   },
   viewMode: {
-    type: String as () => 'formatted' | 'json',
-    default: 'formatted',
+    type: String as () => "formatted" | "json",
+    default: "formatted",
   },
 });
 
@@ -140,7 +263,7 @@ const isExpanded = ref(false);
 
 // Tool observation type handling
 const isToolObservation = computed(() => {
-  return props.observationType === 'TOOL';
+  return props.observationType === "TOOL";
 });
 
 const toolMetadata = computed(() => {
@@ -156,7 +279,7 @@ const toolContent = computed(() => {
 
   let content = null;
   if (props.span) {
-    if (props.contentType === 'input') {
+    if (props.contentType === "input") {
       content = props.span.llm_tool_call_arguments;
     } else {
       content = props.span.llm_tool_call_result;
@@ -169,9 +292,9 @@ const toolContent = computed(() => {
   }
 
   // Check if content is the string "null"
-  if (typeof content === 'string') {
+  if (typeof content === "string") {
     const trimmed = content.trim();
-    if (trimmed.toLowerCase() === 'null' || trimmed === '') {
+    if (trimmed.toLowerCase() === "null" || trimmed === "") {
       return null;
     }
     // Try to parse string content as JSON
@@ -183,11 +306,15 @@ const toolContent = computed(() => {
   }
 
   // Handle nested content structure: {content: [{type: "text", text: "..."}]}
-  if (content && typeof content === 'object') {
+  if (content && typeof content === "object") {
     // Check if it has the Anthropic content format
-    if (content.content && Array.isArray(content.content) && content.content.length > 0) {
+    if (
+      content.content &&
+      Array.isArray(content.content) &&
+      content.content.length > 0
+    ) {
       const firstContent = content.content[0];
-      if (firstContent.type === 'text' && firstContent.text) {
+      if (firstContent.type === "text" && firstContent.text) {
         // Try to parse the inner text as JSON
         try {
           return JSON.parse(firstContent.text);
@@ -212,9 +339,9 @@ const hasValidContent = computed(() => {
   // For regular content
   if (!props.content) return false;
 
-  if (typeof props.content === 'string') {
+  if (typeof props.content === "string") {
     const trimmed = props.content.trim();
-    if (trimmed === '' || trimmed.toLowerCase() === 'null') return false;
+    if (trimmed === "" || trimmed.toLowerCase() === "null") return false;
   }
 
   return true;
@@ -225,10 +352,10 @@ const parsedContent = computed(() => {
   if (!props.content) return null;
 
   try {
-    if (typeof props.content === 'string') {
+    if (typeof props.content === "string") {
       // Check for explicit "null" string before parsing
       const trimmed = props.content.trim();
-      if (trimmed.toLowerCase() === 'null' || trimmed === '') {
+      if (trimmed.toLowerCase() === "null" || trimmed === "") {
         return null;
       }
       // Try to parse as JSON
@@ -241,11 +368,15 @@ const parsedContent = computed(() => {
     }
 
     // Handle nested content structure: {content: [{type: "text", text: "..."}]}
-    if (props.content && typeof props.content === 'object') {
+    if (props.content && typeof props.content === "object") {
       // Check if it has the Anthropic content format
-      if (props.content.content && Array.isArray(props.content.content) && props.content.content.length > 0) {
+      if (
+        props.content.content &&
+        Array.isArray(props.content.content) &&
+        props.content.content.length > 0
+      ) {
         const firstContent = props.content.content[0];
-        if (firstContent.type === 'text' && firstContent.text) {
+        if (firstContent.type === "text" && firstContent.text) {
           // Try to parse the inner text as JSON
           try {
             const innerParsed = JSON.parse(firstContent.text);
@@ -271,7 +402,7 @@ const isMessagesArray = computed(() => {
     Array.isArray(parsedContent.value) &&
     parsedContent.value.length > 0 &&
     parsedContent.value.every(
-      (item: any) => item && typeof item === 'object' && 'role' in item
+      (item: any) => item && typeof item === "object" && "role" in item,
     )
   );
 });
@@ -280,9 +411,9 @@ const isMessagesArray = computed(() => {
 const isSingleMessage = computed(() => {
   return (
     parsedContent.value &&
-    typeof parsedContent.value === 'object' &&
+    typeof parsedContent.value === "object" &&
     !Array.isArray(parsedContent.value) &&
-    'role' in parsedContent.value
+    "role" in parsedContent.value
   );
 });
 
@@ -295,21 +426,25 @@ const isContentPartsArray = computed(() => {
     parsedContent.value.every(
       (item: any) =>
         item &&
-        typeof item === 'object' &&
-        'type' in item &&
-        (item.type === 'text' || item.type === 'image_url' || item.type === 'image')
+        typeof item === "object" &&
+        "type" in item &&
+        (item.type === "text" ||
+          item.type === "image_url" ||
+          item.type === "image"),
     )
   );
 });
 
 // Check if content should be rendered as messages (any format)
 const shouldRenderAsMessages = computed(() => {
-  return isMessagesArray.value || isSingleMessage.value || isContentPartsArray.value;
+  return (
+    isMessagesArray.value || isSingleMessage.value || isContentPartsArray.value
+  );
 });
 
 const isPlainText = computed(() => {
   // If parsedContent is different from original content, it means we successfully parsed JSON
-  if (typeof props.content === 'string') {
+  if (typeof props.content === "string") {
     try {
       JSON.parse(props.content);
       return false; // It's valid JSON, not plain text
@@ -326,33 +461,45 @@ const formatContent = (content: any): string => {
   if (Array.isArray(content)) {
     const parts: string[] = [];
     for (const part of content) {
-      if (part.type === 'text' && part.text) {
+      if (part.type === "text" && part.text) {
         parts.push(part.text);
-      } else if (part.type === 'image_url' && part.image_url?.url) {
+      } else if (part.type === "image_url" && part.image_url?.url) {
         parts.push(`[Image: ${part.image_url.url}]`);
-      } else if (part.type === 'image' && part.source) {
+      } else if (part.type === "image" && part.source) {
         // Handle Anthropic-style image content
-        parts.push(`[Image: ${part.source.type || 'base64'}]`);
+        parts.push(`[Image: ${part.source.type || "base64"}]`);
       } else {
         // Fallback for unknown part types
         parts.push(JSON.stringify(part));
       }
     }
-    return parts.join('\n\n');
-  } else if (typeof content === 'string') {
+    return parts.join("\n\n");
+  } else if (typeof content === "string") {
     return content;
   } else if (content) {
     return JSON.stringify(content, null, 2);
   }
-  return '';
+  return "";
 };
+
+// Stringified versions for CodeQueryEditor (expects string query prop)
+const toolContentJson = computed(() => {
+  if (toolContent.value === null || toolContent.value === undefined) return "";
+  return JSON.stringify(toolContent.value, null, 2);
+});
+
+const parsedContentJson = computed(() => {
+  if (parsedContent.value === null || parsedContent.value === undefined)
+    return "";
+  return JSON.stringify(parsedContent.value, null, 2);
+});
 
 // Extract messages
 const parsedMessages = computed(() => {
   // Handle array of messages (input format)
   if (isMessagesArray.value) {
     return (parsedContent.value as any[]).map((msg: any) => ({
-      role: msg.role || 'unknown',
+      role: msg.role || "unknown",
       content: formatContent(msg.content),
     }));
   }
@@ -360,18 +507,22 @@ const parsedMessages = computed(() => {
   // Handle single message object (output format: {role: 'assistant', content: '...'})
   if (isSingleMessage.value) {
     const msg = parsedContent.value as any;
-    return [{
-      role: msg.role || 'assistant',
-      content: formatContent(msg.content),
-    }];
+    return [
+      {
+        role: msg.role || "assistant",
+        content: formatContent(msg.content),
+      },
+    ];
   }
 
   // Handle direct content parts array (output format: [{type: 'text', text: '...'}])
   if (isContentPartsArray.value) {
-    return [{
-      role: 'assistant',
-      content: formatContent(parsedContent.value),
-    }];
+    return [
+      {
+        role: "assistant",
+        content: formatContent(parsedContent.value),
+      },
+    ];
   }
 
   return [];
@@ -379,33 +530,33 @@ const parsedMessages = computed(() => {
 
 // Get text content for truncation
 const fullText = computed(() => {
-  if (typeof props.content === 'string') {
+  if (typeof props.content === "string") {
     return props.content;
   }
   if (props.content) {
     return JSON.stringify(props.content, null, 2);
   }
-  return '';
+  return "";
 });
 
 // Calculate content stats for truncation
 const contentStats = computed(() => {
-  let text = '';
+  let text = "";
 
   if (shouldRenderAsMessages.value) {
     // For messages, concatenate all message contents
     text = parsedMessages.value
       .map((m: any) => `${m.role}: ${m.content}`)
-      .join('\n');
+      .join("\n");
   } else {
     text = fullText.value;
   }
 
-  const lines = text.split('\n');
+  const lines = text.split("\n");
   const chars = text.length;
 
   const previewLines = lines.slice(0, INITIAL_LINE_LIMIT);
-  const previewText = previewLines.join('\n');
+  const previewText = previewLines.join("\n");
   const remainingChars = chars - previewText.length;
 
   return {
@@ -425,15 +576,18 @@ const previewMessages = computed(() => {
   const preview: any[] = [];
 
   for (const msg of parsedMessages.value) {
-    const msgLines = msg.content.split('\n').length;
+    const msgLines = msg.content.split("\n").length;
     if (lineCount + msgLines > INITIAL_LINE_LIMIT) {
       // Include partial message if possible
       const remainingLines = INITIAL_LINE_LIMIT - lineCount;
       if (remainingLines > 0) {
-        const truncatedContent = msg.content.split('\n').slice(0, remainingLines).join('\n');
+        const truncatedContent = msg.content
+          .split("\n")
+          .slice(0, remainingLines)
+          .join("\n");
         preview.push({
           ...msg,
-          content: truncatedContent + '...',
+          content: truncatedContent + "...",
         });
       }
       break;
@@ -444,141 +598,48 @@ const previewMessages = computed(() => {
 
   return preview;
 });
-</script>
 
-<script lang="ts">
-// Message Item Component - Renders message with markdown
-import { defineComponent, h } from 'vue';
-import VueJsonPretty from 'vue-json-pretty';
-import DOMPurify from 'dompurify';
-import { marked } from 'marked';
-
-// Convert content to markdown format
-const toMarkdown = (content: string): string => {
-  // Replace [Image: URL] markers with markdown image syntax
-  return content.replace(/\[Image: (https?:\/\/[^\]]+)\]/g, '![Image]($1)');
+// Message item helpers (was previously in MessageItem render function)
+const roleColor = (role: string) => {
+  const colors: Record<string, string> = {
+    user: "rgba(25, 118, 210, 0.1)",
+    assistant: "rgba(76, 175, 80, 0.1)",
+    system: "rgba(255, 152, 0, 0.1)",
+    tool: "rgba(156, 39, 176, 0.1)",
+  };
+  return colors[role] || "rgba(158, 158, 158, 0.1)";
 };
 
-const MessageItem = defineComponent({
-  name: 'MessageItem',
-  props: {
-    message: {
-      type: Object,
-      required: true,
-    },
-  },
-  setup(props) {
-    const roleColor = (role: string) => {
-      const colors: Record<string, string> = {
-        user: 'rgba(25, 118, 210, 0.1)',
-        assistant: 'rgba(76, 175, 80, 0.1)',
-        system: 'rgba(255, 152, 0, 0.1)',
-        tool: 'rgba(156, 39, 176, 0.1)',
-      };
-      return colors[role] || 'rgba(158, 158, 158, 0.1)';
-    };
+const roleLabel = (role: string) => {
+  const labels: Record<string, string> = {
+    user: "User",
+    assistant: "Assistant",
+    system: "System",
+    tool: "Tool",
+  };
+  return labels[role] || role;
+};
 
-    const roleLabel = (role: string) => {
-      const labels: Record<string, string> = {
-        user: 'User',
-        assistant: 'Assistant',
-        system: 'System',
-        tool: 'Tool',
-      };
-      return labels[role] || role;
-    };
+const toMarkdown = (content: string): string => {
+  return content.replace(/\[Image: (https?:\/\/[^\]]+)\]/g, "![Image]($1)");
+};
 
-    return () => {
-      const content = props.message.content;
+const isMessageJson = (content: string): boolean => {
+  try {
+    JSON.parse(content);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
-      // Try to parse as JSON for structured display
-      let isJson = false;
-      let jsonData = null;
-      try {
-        jsonData = JSON.parse(content);
-        isJson = true;
-      } catch {
-        isJson = false;
-      }
+const stringifyMessageContent = (content: string): string => {
+  return JSON.stringify(JSON.parse(content), null, 2);
+};
 
-      // If it's JSON, render with VueJsonPretty
-      if (isJson) {
-        return h(
-          'div',
-          {
-            class: 'message-item q-mb-sm',
-            style: {
-              border: '1px solid var(--o2-border-color)',
-              borderRadius: '8px',
-              overflow: 'hidden',
-            },
-          },
-          [
-            h('div', {
-              class: 'message-role text-caption text-bold q-pa-sm',
-              style: {
-                backgroundColor: roleColor(props.message.role),
-                borderBottom: '1px solid var(--o2-border-color)',
-                textTransform: 'capitalize',
-              },
-            }, roleLabel(props.message.role)),
-            h('div', {
-              class: 'message-content-json q-pa-sm',
-              style: {
-                backgroundColor: 'var(--o2-code-bg)',
-              },
-            }, [
-              h(VueJsonPretty, {
-                data: jsonData,
-                deep: 3,
-                showLength: true,
-              }),
-            ]),
-          ]
-        );
-      }
-
-      // Convert content to markdown and render
-      const markdownContent = toMarkdown(content);
-      const htmlContent = DOMPurify.sanitize(marked.parse(markdownContent) as string);
-
-      return h(
-        'div',
-        {
-          class: 'message-item q-mb-sm',
-          style: {
-            border: '1px solid var(--o2-border-color)',
-            borderRadius: '8px',
-            overflow: 'hidden',
-          },
-        },
-        [
-          h('div', {
-            class: 'message-role text-caption text-bold q-pa-sm',
-            style: {
-              backgroundColor: roleColor(props.message.role),
-              borderBottom: '1px solid var(--o2-border-color)',
-              textTransform: 'capitalize',
-            },
-          }, roleLabel(props.message.role)),
-          h('div', {
-            class: 'message-content markdown-body q-pa-sm',
-            style: {
-              backgroundColor: 'var(--o2-code-bg)',
-            },
-            innerHTML: htmlContent,
-          }),
-        ]
-      );
-    };
-  },
-});
-
-export default {
-  components: {
-    MessageItem,
-    VueJsonPretty,
-  },
+const renderMarkdown = (content: string): string => {
+  const markdownContent = toMarkdown(content);
+  return DOMPurify.sanitize(marked.parse(markdownContent) as string);
 };
 </script>
 
@@ -640,7 +701,8 @@ export default {
         padding: 0;
       }
 
-      :deep(ul), :deep(ol) {
+      :deep(ul),
+      :deep(ol) {
         margin: 8px 0;
         padding-left: 24px;
       }
@@ -670,7 +732,8 @@ export default {
         width: 100%;
         margin: 8px 0;
 
-        th, td {
+        th,
+        td {
           border: 1px solid var(--o2-border-color);
           padding: 6px 8px;
           text-align: left;
@@ -708,39 +771,13 @@ export default {
   text-align: center;
 }
 
-// vue-json-pretty customization
-:deep(.vjs-tree) {
-  font-size: 13px;
-  line-height: 1.5;
-
-  .vjs-key {
-    color: #0288d1; // Blue for keys
-    font-weight: 500;
-  }
-
-  .vjs-value-string {
-    color: var(--o2-text-primary); // Match main text color
-  }
-
-  .vjs-value-number {
-    color: #f57c00; // Orange for numbers
-  }
-
-  .vjs-value-boolean {
-    color: #7b1fa2; // Purple for booleans
-  }
-
-  .vjs-value-null {
-    color: #757575; // Gray for null
-  }
-
-  .vjs-tree-brackets {
-    color: #9ca3af;
-  }
-
-  .vjs-tree-content {
-    padding-left: 1em;
-  }
+.json-viewer-editor {
+  height: 300px;
+  max-height: 500px;
+  min-height: 100px;
+  width: 100%;
+  border-radius: 4px;
+  overflow: hidden;
 }
 </style>
 

--- a/web/src/plugins/traces/LLMContentRenderer.vue
+++ b/web/src/plugins/traces/LLMContentRenderer.vue
@@ -46,12 +46,32 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </div>
 
     <!-- Regular content rendering -->
-    <div v-else class="content-wrapper tw:h-full">
+    <div
+      v-else
+      class="content-wrapper"
+      :class="
+        props.viewMode === 'formatted' &&
+        !shouldRenderAsMessages &&
+        !isPlainText &&
+        'tw:h-full'
+      "
+    >
       <!-- Truncated view -->
-      <div v-if="!isExpanded && contentStats.shouldTruncate" class="tw:h-full!">
+      <div
+        v-if="!isExpanded && contentStats.shouldTruncate"
+        :class="
+          props.viewMode === 'formatted' &&
+          !shouldRenderAsMessages &&
+          !isPlainText &&
+          'tw:h-full'
+        "
+      >
         <!-- Formatted mode -->
-        <div v-if="props.viewMode === 'formatted'" class="tw:h-full">
-          <div v-if="shouldRenderAsMessages" class="messages-view tw:h-full">
+        <div
+          v-if="props.viewMode === 'formatted'"
+          :class="!shouldRenderAsMessages && !isPlainText && 'tw:h-full'"
+        >
+          <div v-if="shouldRenderAsMessages" class="messages-view">
             <div
               v-for="(msg, idx) in previewMessages"
               :key="idx"
@@ -88,7 +108,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </div>
               <div
                 v-else
-                class="message-content markdown-body q-pa-sm"
+                class="message-content markdown-body q-pa-sm tw:overflow-x-auto"
                 style="background-color: var(--o2-code-bg)"
                 v-html="renderMarkdown(msg.content)"
               />
@@ -112,7 +132,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
 
         <!-- JSON mode -->
-        <div v-else class="json-content">
+        <div v-else class="json-content tw:h-full!">
           <CodeQueryEditor
             :editor-id="`truncated-json-mode-viewer-${editorIdPrefix}`"
             :query="parsedContentJson"
@@ -139,10 +159,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
 
       <!-- Full content view -->
-      <div v-else class="tw:h-full">
+      <div
+        v-else
+        :class="
+          props.viewMode === 'formatted' &&
+          !shouldRenderAsMessages &&
+          !isPlainText &&
+          'tw:h-full'
+        "
+      >
         <!-- Formatted mode -->
-        <div v-if="props.viewMode === 'formatted'" class="tw:h-full">
-          <div v-if="shouldRenderAsMessages" class="messages-view tw:h-full">
+        <div
+          v-if="props.viewMode === 'formatted'"
+          :class="!shouldRenderAsMessages && !isPlainText && 'tw:h-full'"
+        >
+          <div v-if="shouldRenderAsMessages" class="messages-view">
             <div
               v-for="(msg, idx) in parsedMessages"
               :key="idx"
@@ -179,7 +210,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </div>
               <div
                 v-else
-                class="message-content markdown-body q-pa-sm"
+                class="message-content markdown-body q-pa-sm tw:overflow-x-auto"
                 style="background-color: var(--o2-code-bg)"
                 v-html="renderMarkdown(msg.content)"
               />

--- a/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
+++ b/web/src/plugins/traces/TraceDetailsSidebar.spec.ts
@@ -54,6 +54,7 @@ vi.mock("@/composables/useServiceCorrelation", () => ({
   }),
 }));
 
+import componentSource from "@/plugins/traces/TraceDetailsSidebar.vue?raw";
 import { getServiceIconDataUrl } from "@/utils/traces/convertTraceData";
 import TraceDetailsSidebar from "@/plugins/traces/TraceDetailsSidebar.vue";
 import i18n from "@/locales";
@@ -1006,7 +1007,9 @@ describe("TraceDetailsSidebar", async () => {
 
     it("should return the raw string start_time from props.span, not the formatted display string", async () => {
       const rawStartTime = "1700000000123456789";
-      await wrapper.setProps({ span: { ...mockSpan, start_time: rawStartTime } });
+      await wrapper.setProps({
+        span: { ...mockSpan, start_time: rawStartTime },
+      });
       const result = wrapper.vm.getFilterValue("start_time", "formatted-date");
       expect(result).toBe(rawStartTime);
     });
@@ -1048,16 +1051,28 @@ describe("TraceDetailsSidebar", async () => {
       const spanWithTsCol = { ...mockSpan, "@timestamp": rawTsValue };
       const tsWrapper = mount(TraceDetailsSidebar, {
         attachTo: "#app",
-        props: { span: spanWithTsCol, baseTracePosition: mockBaseTracePosition, searchQuery: "" },
+        props: {
+          span: spanWithTsCol,
+          baseTracePosition: mockBaseTracePosition,
+          searchQuery: "",
+        },
         global: {
           plugins: [i18n, router],
           provide: { store: mockStore },
-          stubs: { "q-resize-observer": true, "q-virtual-scroll": { template: "<div><slot /></div>", props: ["items"] } },
+          stubs: {
+            "q-resize-observer": true,
+            "q-virtual-scroll": {
+              template: "<div><slot /></div>",
+              props: ["items"],
+            },
+          },
         },
       });
       await tsWrapper.vm.$nextTick();
       const displayValue = "2025-07-14T10:14:52.843Z";
-      expect(tsWrapper.vm.getFilterValue("@timestamp", displayValue)).toBe(rawTsValue);
+      expect(tsWrapper.vm.getFilterValue("@timestamp", displayValue)).toBe(
+        rawTsValue,
+      );
       tsWrapper.unmount();
     });
 
@@ -1096,8 +1111,12 @@ describe("TraceDetailsSidebar", async () => {
       // The NS patching pipeline no longer injects _start_time_ns / _end_time_ns into spans.
       // mockSpan represents a normal span that does not carry those keys, so they must not
       // appear in the rendered attribute list.
-      expect(Object.prototype.hasOwnProperty.call(mockSpan, "_start_time_ns")).toBe(false);
-      expect(Object.prototype.hasOwnProperty.call(mockSpan, "_end_time_ns")).toBe(false);
+      expect(
+        Object.prototype.hasOwnProperty.call(mockSpan, "_start_time_ns"),
+      ).toBe(false);
+      expect(
+        Object.prototype.hasOwnProperty.call(mockSpan, "_end_time_ns"),
+      ).toBe(false);
 
       const attributesTable = wrapper.find(
         '[data-test="trace-details-sidebar-attributes-table"]',
@@ -1152,7 +1171,12 @@ describe("TraceDetailsSidebar", async () => {
             // Stub JsonPreview to render its #field-dropdown slot inline for each key
             // in `value`, so the q-item inside is immediately clickable without a popup.
             JsonPreview: {
-              props: ["value", "highlightQuery", "showCopyButton", "copyButtonClass"],
+              props: [
+                "value",
+                "highlightQuery",
+                "showCopyButton",
+                "copyButtonClass",
+              ],
               template: `
                 <div data-test="trace-details-sidebar-attributes-table">
                   <div
@@ -1281,6 +1305,150 @@ describe("TraceDetailsSidebar", async () => {
         // but we can verify the component didn't crash
         expect(wrapper.exists()).toBe(true);
       }
+    });
+  });
+
+  describe("LLM Preview tab — LLMContentRenderer instance-id", () => {
+    const LLM_SPAN_ID = "d9603ec7f76eb499";
+
+    const mockLLMSpan = {
+      _timestamp: 1752490492843047,
+      start_time: 1752490492843000000,
+      end_time: 1752490493164419300,
+      duration: 321372,
+      span_id: LLM_SPAN_ID,
+      trace_id: "6262666637a9ae45ad3e25f5111dd59f",
+      operation_name: "ChatCompletion",
+      service_name: "openai-service",
+      span_status: "UNSET",
+      span_kind: 2,
+      parent_id: "6702b0494b2b6e57",
+      events: "",
+      links: "",
+      llm_input: '{"messages": [{"role": "user", "content": "Hello"}]}',
+      llm_output: '{"choices": [{"message": {"content": "Hi there!"}}]}',
+      llm_observation_type: "LLM",
+      llm_model_name: "gpt-4",
+    };
+
+    let llmWrapper: any;
+
+    beforeEach(async () => {
+      llmWrapper = mount(TraceDetailsSidebar, {
+        attachTo: "#app",
+        props: {
+          span: mockLLMSpan,
+          baseTracePosition: mockBaseTracePosition,
+          searchQuery: "",
+        },
+        global: {
+          plugins: [i18n, router],
+          provide: { store: mockStore },
+          stubs: {
+            "q-resize-observer": true,
+            "q-virtual-scroll": {
+              template: `
+                <div>
+                  <slot name="before"></slot>
+                  <div v-for="(item, index) in items" :key="index">
+                    <slot :item="item" :index="index"></slot>
+                  </div>
+                </div>
+              `,
+              props: ["items"],
+            },
+            LLMContentRenderer: {
+              template: `<div :data-test="\`llm-content-renderer-\${contentType}\`" :data-instance-id="instanceId"><slot /></div>`,
+              props: [
+                "content",
+                "observationType",
+                "contentType",
+                "span",
+                "viewMode",
+                "instanceId",
+              ],
+            },
+            TenstackTable: true,
+            "q-expansion-item": true,
+            CodemirrorEditor: true,
+            CodeQueryEditor: true,
+          },
+        },
+      });
+
+      await llmWrapper.vm.$nextTick();
+    });
+
+    afterEach(() => {
+      llmWrapper?.unmount();
+    });
+
+    it("should render the preview tab by default for an LLM span", () => {
+      expect(llmWrapper.vm.activeTab).toBe("preview");
+    });
+
+    it("should render the input LLMContentRenderer when llm_input has content", () => {
+      const inputRenderer = llmWrapper.find(
+        '[data-test="llm-content-renderer-input"]',
+      );
+      expect(inputRenderer.exists()).toBe(true);
+    });
+
+    it("should render the output LLMContentRenderer when llm_output has content", () => {
+      const outputRenderer = llmWrapper.find(
+        '[data-test="llm-content-renderer-output"]',
+      );
+      expect(outputRenderer.exists()).toBe(true);
+    });
+
+    it("should pass instance-id ending with -input to the input LLMContentRenderer", () => {
+      const inputRenderer = llmWrapper.find(
+        '[data-test="llm-content-renderer-input"]',
+      );
+      expect(inputRenderer.exists()).toBe(true);
+      expect(inputRenderer.attributes("data-instance-id")).toBe(
+        `${LLM_SPAN_ID}-input`,
+      );
+    });
+
+    it("should pass instance-id ending with -output to the output LLMContentRenderer", () => {
+      const outputRenderer = llmWrapper.find(
+        '[data-test="llm-content-renderer-output"]',
+      );
+      expect(outputRenderer.exists()).toBe(true);
+      expect(outputRenderer.attributes("data-instance-id")).toBe(
+        `${LLM_SPAN_ID}-output`,
+      );
+    });
+
+    it("should include the span_id in the input instance-id", () => {
+      const inputRenderer = llmWrapper.find(
+        '[data-test="llm-content-renderer-input"]',
+      );
+      expect(inputRenderer.exists()).toBe(true);
+      expect(inputRenderer.attributes("data-instance-id")).toContain(
+        LLM_SPAN_ID,
+      );
+    });
+
+    it("should include the span_id in the output instance-id", () => {
+      const outputRenderer = llmWrapper.find(
+        '[data-test="llm-content-renderer-output"]',
+      );
+      expect(outputRenderer.exists()).toBe(true);
+      expect(outputRenderer.attributes("data-instance-id")).toContain(
+        LLM_SPAN_ID,
+      );
+    });
+  });
+
+  describe("CSS verification — .vjs-tree removal", () => {
+    it("should not reference .vjs-tree in component styles", () => {
+      // Verify that the removed .vjs-tree CSS selector is absent from the
+      // component's <style> blocks. The ?raw import returns the exact
+      // source content, so a regex scan confirms no style block targets
+      // .vjs-tree (the hover-suppression rules that were removed).
+      expect(componentSource).not.toMatch(/\.vjs-tree/);
     });
   });
 });

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -349,6 +349,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   content-type="input"
                   :span="span"
                   view-mode="formatted"
+                  :instance-id="`${span.span_id}-input`"
                 />
               </div>
             </div>
@@ -396,6 +397,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   content-type="output"
                   :span="span"
                   view-mode="formatted"
+                  :instance-id="`${span.span_id}-output`"
                 />
               </div>
             </div>

--- a/web/src/plugins/traces/TraceDetailsSidebar.vue
+++ b/web/src/plugins/traces/TraceDetailsSidebar.vue
@@ -2823,20 +2823,11 @@ body.body--dark {
     overflow-x: hidden;
     background-color: var(--o2-code-bg);
 
-    // Enhance hover visibility for code/text content (exclude VueJsonPretty)
+    // Enhance hover visibility for code/text content
     ::v-deep {
       .plain-text-content {
         &:hover {
           background-color: rgba(0, 0, 0, 0.04) !important;
-        }
-      }
-
-      // Don't apply hover to VueJsonPretty elements
-      .vjs-tree {
-        * {
-          &:hover {
-            background-color: transparent !important;
-          }
         }
       }
     }
@@ -2895,15 +2886,6 @@ body.body--dark {
       .plain-text-content {
         &:hover {
           background-color: rgba(255, 255, 255, 0.05) !important;
-        }
-      }
-
-      // Don't apply hover to VueJsonPretty elements in dark mode
-      .vjs-tree {
-        * {
-          &:hover {
-            background-color: transparent !important;
-          }
         }
       }
     }


### PR DESCRIPTION
## What changed

Replaced `VueJsonPretty` (`vue-json-pretty`) with `CodeQueryEditor.vue` (Monaco-based) for JSON rendering in `LLMContentRenderer.vue`. Inlined the `MessageItem` sub-component directly into the template with `CodeQueryEditor` for JSON message content. Added `showLineNumbers` and `stickyScroll` props to `CodeQueryEditor`. Removed the unused `vue-json-pretty` dependency from `package.json`. Passed unique editor IDs from `TraceDetailsSidebar` via a new `instanceId` prop to prevent Monaco editor ID collisions.

## Why

`vue-json-pretty` formats the entire JSON tree on initial render, causing lag on long JSON payloads. Monaco (via `CodeQueryEditor`) renders only visible viewport lines, making performance O(visible) instead of O(total).

## Approach

- Replaced all 7 `VueJsonPretty` instances in `LLMContentRenderer.vue` with `<CodeQueryEditor>` in read-only mode (`:read-only="true"`, `:show-line-numbers="false"`, `:sticky-scroll="false"`)
- Inlined the `MessageItem` sub-component as a `v-for` block with `CodeQueryEditor` for JSON message content and the existing `v-html` markdown renderer for non-JSON content
- Converted the component to `<script setup lang="ts">` with `defineAsyncComponent` for `CodeQueryEditor`
- Added `showLineNumbers` and `stickyScroll` props (both default `true`) to `CodeQueryEditor.vue` to support the JSON viewer use case
- Added a `watch` on `showLineNumbers` to dynamically toggle line numbers in Monaco
- Passed `instanceId` from `TraceDetailsSidebar` down to `LLMContentRenderer` to generate unique editor IDs like `trace-id-msg-json-editor-0`

## Considered & rejected

- **Render function approach with synchronous import of CodeQueryEditor** — rejected because it forced manual editor height computation and module-level counters for editor IDs. Inlining `MessageItem` as a template component was cleaner and consistent with the other 5 template `CodeQueryEditor` locations.
- **Retaining `MessageItem` as a separate component with render function** — rejected because the render function approach was over-engineering for what is now a simple `v-for` with conditional `CodeQueryEditor` / markdown branching.

## Risk

Medium. Monaco editor initialization has non-trivial overhead; rendering multiple editors on one page (e.g., many messages in a conversation) could impact initial render time. Reviewers should check that the `instanceId` prop is correctly wired from `TraceDetailsSidebar` to avoid duplicate Monaco editor IDs, and that the `tw:h-full` class application on content-wrapper divs doesn't break non-JSON (plain text / markdown) layouts.

