### PR TITLE
fix(logs): display aggregate SQL result columns instead of raw source JSON

### DIFF
--- a/web/src/composables/useLogs/useStreamFields.ts
+++ b/web/src/composables/useLogs/useStreamFields.ts
@@ -68,7 +68,7 @@ export const useStreamFields = () => {
     schemaRequestToken,
   } = searchState();
 
-  const { fnParsedSQL, getColumnWidth } = logsUtils();
+  const { fnParsedSQL, getColumnWidth, hasAggregation } = logsUtils();
 
   const correlationFilters = useCorrelationFilters({
     orgId: () => store.state.selectedOrganization.identifier,
@@ -1161,6 +1161,7 @@ export const useStreamFields = () => {
           if (
             searchObj.meta.sqlMode == true &&
             parsedSQL.hasOwnProperty("columns") &&
+            hasAggregation(parsedSQL.columns) &&
             searchObj.data.queryResults?.hits?.length > 0
           ) {
             const hitKeys = Object.keys(

--- a/web/src/composables/useLogs/useStreamFields.ts
+++ b/web/src/composables/useLogs/useStreamFields.ts
@@ -1155,20 +1155,59 @@ export const useStreamFields = () => {
         }
 
         if (selectedFields.length == 0) {
-          searchObj.data.resultGrid.columns.push({
-            name: "source",
-            id: "source",
-            accessorFn: (row: any) => JSON.stringify(row),
-            cell: (info: any) => info.getValue(),
-            header: "source",
-            sortable: true,
-            enableResizing: false,
-            meta: {
-              closable: false,
-              showWrap: false,
-              wrapContent: false,
-            },
-          });
+          // For SQL mode aggregate queries, derive columns from the first hit's keys
+          // so aliases like "cnt" in SELECT COUNT(*) as cnt show as proper columns.
+          let aggregateColumnsAdded = false;
+          if (
+            searchObj.meta.sqlMode == true &&
+            parsedSQL.hasOwnProperty("columns") &&
+            searchObj.data.queryResults?.hits?.length > 0
+          ) {
+            const hitKeys = Object.keys(
+              searchObj.data.queryResults.hits[0],
+            ).filter((key) => key !== store.state.zoConfig.timestamp_column);
+            if (hitKeys.length > 0) {
+              const aggCanvas = document.createElement("canvas");
+              const aggContext = aggCanvas.getContext("2d");
+              for (const field of hitKeys) {
+                searchObj.data.resultGrid.columns.push({
+                  name: field,
+                  id: field,
+                  accessorFn: (row: any) => row[field],
+                  header: field,
+                  sortable: true,
+                  enableResizing: true,
+                  meta: {
+                    closable: false,
+                    showWrap: true,
+                    wrapContent: false,
+                  },
+                  size: aggContext
+                    ? getColumnWidth(aggContext, field)
+                    : 150,
+                  maxSize: window.innerWidth,
+                });
+              }
+              aggregateColumnsAdded = true;
+            }
+          }
+
+          if (!aggregateColumnsAdded) {
+            searchObj.data.resultGrid.columns.push({
+              name: "source",
+              id: "source",
+              accessorFn: (row: any) => JSON.stringify(row),
+              cell: (info: any) => info.getValue(),
+              header: "source",
+              sortable: true,
+              enableResizing: false,
+              meta: {
+                closable: false,
+                showWrap: false,
+                wrapContent: false,
+              },
+            });
+          }
         }
       } else {
         if (

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :style="{
         minWidth: '100%',
         ...columnSizeVars,
-        minHeight: totalSize + 'px',
+        minHeight: (totalSize + 44) + 'px',
         width: !defaultColumns
           ? table.getCenterTotalSize() + 'px'
           : wrap


### PR DESCRIPTION
## What

When running aggregate SQL queries in the Logs view (e.g. `SELECT COUNT(*) as cnt FROM stream`), two compounding bugs make the result invisible:

1. The results table renders a single **`source`** column containing the raw JSON of each hit (`{"cnt":1}`) instead of the aliased columns from the SELECT.
2. Even with the columns derived correctly, a 1-row aggregate result is clipped underneath the sticky `<thead>` — so the value is not visible at all.

Reported in #2914 (open since 2024-03-08; screenshots there show the symptom).

## Why

**Bug 1 — wrong columns.** `updateGridColumns` (in `web/src/composables/useLogs/useStreamFields.ts`) falls through to a `source` JSON column whenever `selectedFields.length == 0`. Aggregate SQL results have no user-selected fields and no `_timestamp`, so they always hit this fallback and the actual query columns are never rendered.

**Bug 2 — row covered by header.** `TenstackTable.vue` sets `minHeight: totalSize`, where `totalSize` is the sum of row heights only. The sticky `<thead>` (44px) is layered on top inside the same scroll viewport, so for a 1-row result the only row sits behind the header and is invisible to the user.

## How

**Bug 1.** Before adding the `source` fallback:

1. Detect SQL mode + aggregate-shaped parsed SQL (has `columns`) with non-empty hits.
2. Derive column names from `Object.keys(hits[0])` minus the timestamp column.
3. Emit a proper named column per key, sized via the existing `getColumnWidth` helper. Guarded for null `2d` canvas context.

The `source` fallback is preserved as a single block for non-SQL mode and the all-keys-were-timestamp edge case.

**Bug 2.** Add the 44px header offset to `minHeight` so the table reserves space for both the sticky header and the rows underneath it.

Diff: 2 files, +54/−15.

## Test notes

This composable's existing spec (`useStreamFields.spec.ts`) is function-existence smoke tests — there is no harness today for invoking `updateGridColumns` with a realistic `searchObj` shape. Adding a meaningful unit test for the new branch would require bootstrapping mocks for `parsedSQL`, `queryResults`, `zoConfig`, etc. I left it out to keep this PR small and reviewable; happy to add it if the maintainers want it.

Verified manually in a deployed build against a real Logs aggregate query.

Fixes #2914