### PR TITLE
test: dedup alert threshold and tab switching for v3 UI

### DIFF
--- a/tests/ui-testing/pages/alertsPages/alertCreationWizard.js
+++ b/tests/ui-testing/pages/alertsPages/alertCreationWizard.js
@@ -690,24 +690,35 @@ export class AlertCreationWizard {
         await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
         await this.page.waitForTimeout(1000);
 
-        // Forcefully remove any remaining q-portal elements that intercept clicks
+        // Clean up any residual q-portal dialog overlays from the closed SQL Editor.
+        // The VRL Editor dialog portal often remains without aria-hidden and intercepts
+        // pointer events. Target only dialog portals (not menus/tooltips) and remove all.
         await this.page.evaluate(() => {
-            document.querySelectorAll('div[id^="q-portal"]').forEach(el => { if (el.getAttribute('aria-hidden') === 'true') el.style.display = 'none'; });
-        }).catch(e => testLogger.warn('Failed to remove q-portal elements', { error: e.message }));
+            document.querySelectorAll('div[id^="q-portal--dialog"]').forEach(el => { el.style.display = 'none'; });
+        }).catch(e => testLogger.warn('Failed to remove dialog portals', { error: e.message }));
         await this.page.waitForTimeout(300);
 
-        testLogger.info('Closed SQL Editor dialog');
+        testLogger.info('Closed SQL Editor dialog — portal cleaned up');
 
         // ==================== ALERT SETTINGS ====================
-        // In v3 UI, threshold operator + input are in QueryConfig as part of the "Alert if *" section
-        // For SQL mode, the condition row shows "Alert if No. of events *" (not "matching logs")
+        // In v3 UI, threshold operator + input are in the Alert Rules tab ("Alert if No. of events *")
         const thresholdSection = this.page.locator('.alert-condition-row').filter({ hasText: 'No. of events' }).first();
-        const thresholdOperator = thresholdSection.locator('.alert-v3-select').first();
+        await thresholdSection.waitFor({ state: 'visible', timeout: 10000 });
+        testLogger.info('Threshold section visible');
+
+        const thresholdOperator = thresholdSection.locator('.alert-v3-select, .q-select').first();
         await thresholdOperator.waitFor({ state: 'visible', timeout: 5000 });
-        await thresholdOperator.click({ force: true });
-        await this.page.waitForTimeout(500);
-        // Scope to visible menu to avoid strict mode violation (selected value + dropdown option)
-        await this.page.locator('.q-menu:visible').getByText('>=', { exact: true }).click();
+        // Click the q-field__control area to open the dropdown (more reliable than clicking the whole component)
+        await thresholdOperator.locator('.q-field__control, .q-field').first().click({ timeout: 5000 }).catch(async () => {
+            testLogger.info('q-field click failed, clicking main element with force');
+            await thresholdOperator.click({ force: true });
+        });
+        await this.page.waitForTimeout(1000);
+        // Use role-based option selection (bypasses q-portal visibility issues)
+        await this.page.getByRole('option', { name: '>=', exact: true }).click({ timeout: 5000 }).catch(async () => {
+            testLogger.warn('Role option not found, trying q-menu fallback');
+            await this.page.locator('.q-menu:visible').getByText('>=', { exact: true }).click({ timeout: 3000 });
+        });
         testLogger.info('Set threshold operator: >=');
 
         const thresholdInput = thresholdSection.locator('input[type="number"]').first();
@@ -1032,10 +1043,16 @@ export class AlertCreationWizard {
     }
 
     async _switchToTab(tabName) {
-        // The "Alert Rules" tab has required:true so text is "Alert Rules *"
-        const tab = this.page.locator('div.alert-v3-tabs > div').filter({ hasText: tabName }).first();
+        // v3 UI: tabs are inner divs within the tab header bar (first child of .alert-v3-tabs)
+        // e.g. <div>Alert Rules *</div> and <div>Advanced</div>
+        const tab = this.page.locator('.alert-v3-tabs > div:first-child > div').filter({ hasText: tabName }).first();
+        // Check if this tab is already active (has active-tab class)
+        const isActive = await tab.evaluate(el => el.classList.contains('active-tab')).catch(() => false);
+        if (isActive) {
+            testLogger.info('Tab already active, skipping click', { tabName });
+            return;
+        }
         await tab.waitFor({ state: 'visible', timeout: 5000 });
-        // Use force:true to bypass any residual q-portal overlays from closed dialogs
         await tab.click({ force: true });
         await this.page.waitForTimeout(500);
         testLogger.info('Switched to tab', { tabName });

--- a/tests/ui-testing/pages/alertsPages/alertCreationWizard.js
+++ b/tests/ui-testing/pages/alertsPages/alertCreationWizard.js
@@ -690,11 +690,15 @@ export class AlertCreationWizard {
         await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
         await this.page.waitForTimeout(1000);
 
-        // Clean up any residual q-portal dialog overlays from the closed SQL Editor.
-        // The VRL Editor dialog portal often remains without aria-hidden and intercepts
-        // pointer events. Target only dialog portals (not menus/tooltips) and remove all.
+        // Clean up residual q-portal dialog overlays from the closed SQL Editor,
+        // scoped to already-hidden portals and the Monaco editor's portal specifically
+        // so we don't hide any other legitimately open dialog.
         await this.page.evaluate(() => {
-            document.querySelectorAll('div[id^="q-portal--dialog"]').forEach(el => { el.style.display = 'none'; });
+            document.querySelectorAll('div[id^="q-portal--dialog"]').forEach(el => {
+                const isHidden = el.getAttribute('aria-hidden') === 'true';
+                const hasMonaco = el.querySelector('.monaco-editor');
+                if (isHidden || hasMonaco) el.style.display = 'none';
+            });
         }).catch(e => testLogger.warn('Failed to remove dialog portals', { error: e.message }));
         await this.page.waitForTimeout(300);
 
@@ -713,12 +717,20 @@ export class AlertCreationWizard {
             testLogger.info('q-field click failed, clicking main element with force');
             await thresholdOperator.click({ force: true });
         });
-        await this.page.waitForTimeout(1000);
+        // Wait for the dropdown menu to actually appear before selecting an option
+        await this.page.locator('[role="listbox"]:visible, .q-menu:visible').first().waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
         // Use role-based option selection (bypasses q-portal visibility issues)
-        await this.page.getByRole('option', { name: '>=', exact: true }).click({ timeout: 5000 }).catch(async () => {
+        // Use a flag to track success so the fallback error isn't silently swallowed
+        let operatorSelected = false;
+        try {
+            await this.page.getByRole('option', { name: '>=', exact: true }).click({ timeout: 5000 });
+            operatorSelected = true;
+        } catch {
             testLogger.warn('Role option not found, trying q-menu fallback');
+        }
+        if (!operatorSelected) {
             await this.page.locator('.q-menu:visible').getByText('>=', { exact: true }).click({ timeout: 3000 });
-        });
+        }
         testLogger.info('Set threshold operator: >=');
 
         const thresholdInput = thresholdSection.locator('input[type="number"]').first();


### PR DESCRIPTION
Three fixes in alertCreationWizard.js:
- Align threshold operator dropdown with working SQL method pattern (q-field__control click + role-based option + q-menu fallback)
- Narrow portal cleanup from all q-portal to q-portal--dialog only to avoid hiding new dropdown menus
- Fix _switchToTab to target v3 inner tab divs instead of wrapper