### PR TITLE
chore: upgrade build runners to ubicloud-standard-16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,17 @@ jobs:
       matrix:
         include:
           - arch: x86_64-unknown-linux-gnu
-            os: ubicloud-standard-8
+            os: ubicloud-standard-16
             features: "--features mimalloc"
             file_name: openobserve-${{ github.ref_name }}-linux-amd64
             file_ext: .tar.gz
           - arch: x86_64-unknown-linux-gnu
-            os: ubicloud-standard-8
+            os: ubicloud-standard-16
             features: "--features mimalloc"
             file_name: openobserve-${{ github.ref_name }}-linux-amd64-simd
             file_ext: .tar.gz
           - arch: x86_64-unknown-linux-musl
-            os: ubicloud-standard-8
+            os: ubicloud-standard-16
             features: "--features mimalloc"
             file_name: openobserve-${{ github.ref_name }}-linux-amd64-musl
             file_ext: .tar.gz


### PR DESCRIPTION
Upgrade x86 Linux build runners from `ubicloud-standard-8` to `ubicloud-standard-16` to fix OOM kills during release builds.