### PR TITLE
fix: check if slack url exists or not if exists then only use otherwise use default

### DIFF
--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -380,7 +380,7 @@ export default defineComponent({
     let slackURL = "https://short.openobserve.ai/community";
     if (
       config.isEnterprise == "true" &&
-      store.state.zoConfig.custom_slack_url != ""
+      store.state.zoConfig.custom_slack_url
     ) {
       slackURL = store.state.zoConfig.custom_slack_url;
     }


### PR DESCRIPTION
This Pr fixes the issue in #11604 