### PR TITLE
refactor(compactor): select old-data hours by file size, push merge filter to SQL (port of #11638 to v0.90.0)

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1907,8 +1907,6 @@ pub struct Compact {
     pub old_data_max_days: i64,
     #[env_config(name = "ZO_COMPACT_OLD_DATA_MIN_HOURS", default = 2)] // hours
     pub old_data_min_hours: i64,
-    #[env_config(name = "ZO_COMPACT_OLD_DATA_MIN_RECORDS", default = 100)] // records
-    pub old_data_min_records: i64,
     #[env_config(name = "ZO_COMPACT_OLD_DATA_MIN_FILES", default = 10)] // files
     pub old_data_min_files: i64,
     #[env_config(name = "ZO_COMPACT_DELETE_FILES_DELAY_HOURS", default = 2)] // hours
@@ -3258,9 +3256,6 @@ fn check_compact_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
     if cfg.compact.old_data_min_hours < 1 {
         cfg.compact.old_data_min_hours = 2;
     }
-    if cfg.compact.old_data_min_records < 1 {
-        cfg.compact.old_data_min_records = 100;
-    }
     if cfg.compact.old_data_min_files < 1 {
         cfg.compact.old_data_min_files = 10;
     }
@@ -3954,7 +3949,6 @@ mod tests {
         cfg.compact.old_data_interval = 0;
         cfg.compact.old_data_max_days = 0;
         cfg.compact.old_data_min_hours = 0;
-        cfg.compact.old_data_min_records = 0;
         cfg.compact.old_data_min_files = 0;
         cfg.compact.file_list_deleted_batch_size = 0;
         cfg.compact.batch_size = 0;
@@ -3966,7 +3960,6 @@ mod tests {
         assert_eq!(cfg.compact.old_data_interval, 3600);
         assert_eq!(cfg.compact.old_data_max_days, 7);
         assert_eq!(cfg.compact.old_data_min_hours, 2);
-        assert_eq!(cfg.compact.old_data_min_records, 100);
         assert_eq!(cfg.compact.old_data_min_files, 10);
         assert_eq!(cfg.compact.file_list_deleted_batch_size, 1000);
         assert_eq!(cfg.compact.batch_size, 100);

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -493,16 +493,19 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
             .with_label_values(&["query_for_merge", "file_list"])
             .inc();
 
+        let cfg = get_config();
+        let max_size = cfg.compact.max_file_size as i64 * 95 / 100;
         let sql = r#"
 SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
     FROM file_list
-    WHERE stream = $1 AND date >= $2 AND date <= $3;
+    WHERE stream = $1 AND date >= $2 AND date <= $3 AND original_size <= $4;
                 "#;
 
         let ret = sqlx::query_as::<_, super::FileRecord>(sql)
             .bind(stream_key)
             .bind(date_start)
             .bind(date_end)
+            .bind(max_size)
             .fetch_all(&pool)
             .await;
         let time = start.elapsed().as_secs_f64();
@@ -745,7 +748,7 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
         let sql = r#"
 SELECT date
     FROM file_list
-    WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4 AND records < $5 AND date >= $7 AND date < $8
+    WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4 AND original_size < $5 AND date >= $7 AND date < $8
     GROUP BY date HAVING count(*) >= $6;
             "#;
 
@@ -754,7 +757,7 @@ SELECT date
             .bind(time_start)
             .bind(max_ts_upper_bound)
             .bind(time_end)
-            .bind(cfg.compact.old_data_min_records)
+            .bind(cfg.compact.max_file_size as i64 / 2)
             .bind(cfg.compact.old_data_min_files)
             .bind(date_from)
             .bind(date_to)

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -748,7 +748,7 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
         let sql = r#"
 SELECT date
     FROM file_list
-    WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4 AND original_size < $5 AND date >= $7 AND date < $8
+    WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4 AND original_size <= $5 AND date >= $7 AND date < $8
     GROUP BY date HAVING count(*) >= $6;
             "#;
 

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -613,7 +613,7 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
         let sql = r#"
 SELECT date
     FROM file_list
-    WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4 AND original_size < $5
+    WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4 AND original_size <= $5
     GROUP BY date HAVING count(*) >= $6;
             "#;
 

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -404,16 +404,19 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
         let stream_key = format!("{org_id}/{stream_type}/{stream_name}");
 
         let pool = CLIENT_RO.clone();
+        let cfg = get_config();
+        let max_size = cfg.compact.max_file_size as i64 * 95 / 100;
         let ret = sqlx::query_as::<_, super::FileRecord>(
                 r#"
 SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, compressed_size, index_size, flattened
     FROM file_list
-    WHERE stream = $1 AND date >= $2 AND date <= $3;
+    WHERE stream = $1 AND date >= $2 AND date <= $3 AND original_size <= $4;
                 "#,
             )
             .bind(stream_key)
             .bind(date_start)
             .bind(date_end)
+            .bind(max_size)
             .fetch_all(&pool)
             .await;
         Ok(ret?.iter().map(|r| r.into()).collect())
@@ -610,7 +613,7 @@ SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, 
         let sql = r#"
 SELECT date
     FROM file_list
-    WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4 AND records < $5
+    WHERE stream = $1 AND max_ts >= $2 AND max_ts <= $3 AND min_ts <= $4 AND original_size < $5
     GROUP BY date HAVING count(*) >= $6;
             "#;
 
@@ -619,7 +622,7 @@ SELECT date
             .bind(time_start)
             .bind(max_ts_upper_bound)
             .bind(time_end)
-            .bind(cfg.compact.old_data_min_records)
+            .bind(cfg.compact.max_file_size as i64 / 2)
             .bind(cfg.compact.old_data_min_files)
             .fetch_all(&pool)
             .await?;

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -452,10 +452,6 @@ pub async fn merge_by_stream(
     // do partition by partition key
     let mut partition_files_with_size: HashMap<String, Vec<FileKey>> = HashMap::default();
     for file in files {
-        // skip the files which already reach the max_file_size * 95%
-        if file.meta.original_size > cfg.compact.max_file_size as i64 * 95 / 100 {
-            continue;
-        }
         let file_name = file.key.clone();
         let prefix = file_name[..file_name.rfind('/').unwrap()].to_string();
         let partition = partition_files_with_size.entry(prefix).or_default();


### PR DESCRIPTION
Port of #11638 to `branch-v0.90.0` (cherry-pick of commit 73c7f1ff1, clean — no conflicts).

> Note: original PR #11638 is still open against `main` at the time this port was opened.

## Summary (from #11638)

Two compactor optimizations focused on the historical (old-data) merge path:

1. **Replace `ZO_COMPACT_OLD_DATA_MIN_RECORDS` with a file-size check.** The hour-selection SQL in `query_old_data_hours` now uses `original_size < ZO_COMPACT_MAX_FILE_SIZE / 2` instead of `records < 100`. Record count is a weak proxy for "mergeable" — a file's size depends on schema width and compression, while the compactor's actual goal is to produce files near `max_file_size`. The size check directly answers the right question.

2. **Push the 95%-of-max-size filter into `query_for_merge` SQL.** Previously, every file in the target hour was fetched from `file_list`, then files at ≥95% of `max_file_size` were discarded in-process by the worker. The filter is now applied in the SQL (`AND original_size <= max_file_size * 95 / 100`), reducing the rowset shipped from the database — meaningful for healthy streams where most files are already compacted. The redundant in-process check in `merge.rs` was removed.

### Env var change (breaking)

- **Removed:** `ZO_COMPACT_OLD_DATA_MIN_RECORDS` (no replacement; the size threshold is derived from `ZO_COMPACT_MAX_FILE_SIZE`).
- Unchanged: `ZO_COMPACT_OLD_DATA_INTERVAL`, `ZO_COMPACT_OLD_DATA_STREAMS`, `ZO_COMPACT_OLD_DATA_MAX_DAYS`, `ZO_COMPACT_OLD_DATA_MIN_HOURS`, `ZO_COMPACT_OLD_DATA_MIN_FILES`.

## Test plan

- [ ] CI green on `branch-v0.90.0` base
- [ ] `cargo fmt && cargo clippy --all-targets` clean
- [ ] `cargo check --bin openobserve` succeeds
- [ ] `cargo test -p config` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)