### PR TITLE
perf: reduce compactor memory usage

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -3044,6 +3044,13 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
             "ZO_MEMORY_CACHE_MAX_SIZE is larger than total memory, please set a smaller value"
         ));
     }
+    let local_node_role: Vec<cluster::Role> = cfg
+        .common
+        .node_role
+        .clone()
+        .split(',')
+        .map(|s| s.parse().unwrap())
+        .collect();
     if cfg.memory_cache.datafusion_max_size == 0 {
         if local_node_role == [cluster::Role::Compactor] {
             cfg.memory_cache.datafusion_max_size = mem_total / cfg.limit.file_merge_thread_num;

--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -3045,7 +3045,9 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
         ));
     }
     if cfg.memory_cache.datafusion_max_size == 0 {
-        if cfg.common.local_mode {
+        if local_node_role == [cluster::Role::Compactor] {
+            cfg.memory_cache.datafusion_max_size = mem_total / cfg.limit.file_merge_thread_num;
+        } else if cfg.common.local_mode {
             cfg.memory_cache.datafusion_max_size = (mem_total - cfg.memory_cache.max_size) / 2; // 25%
         } else {
             cfg.memory_cache.datafusion_max_size = mem_total - cfg.memory_cache.max_size; // 50%

--- a/src/config/src/meta/user.rs
+++ b/src/config/src/meta/user.rs
@@ -428,8 +428,6 @@ mod tests {
         }
     }
 
-    use super::*;
-
     #[test]
     fn test_user_role_is_service_account() {
         assert!(UserRole::ServiceAccount.is_service_account());

--- a/src/config/src/utils/parquet.rs
+++ b/src/config/src/utils/parquet.rs
@@ -157,11 +157,11 @@ where
 
 pub async fn get_recordbatch_reader_from_bytes(
     file_format: FileFormat,
-    data: &bytes::Bytes,
+    data: bytes::Bytes,
 ) -> Result<(Arc<Schema>, RecordBatchStream), anyhow::Error> {
     match file_format {
         FileFormat::Parquet => {
-            let schema_reader = Cursor::new(data.clone());
+            let schema_reader = Cursor::new(data);
             let (schema, reader) = get_recordbatch_reader(schema_reader).await?;
             let stream: RecordBatchStream = Box::pin(reader.map_err(ArrowError::from));
             Ok((schema, stream))
@@ -218,7 +218,7 @@ pub async fn get_recordbatch_reader_from_bytes(
 // should not have such function in the config
 pub async fn read_recordbatch_from_bytes(
     file_format: FileFormat,
-    data: &bytes::Bytes,
+    data: bytes::Bytes,
 ) -> Result<(Arc<Schema>, Vec<RecordBatch>), anyhow::Error> {
     let (schema, reader) = get_recordbatch_reader_from_bytes(file_format, data).await?;
     let batches = reader.try_collect().await?;
@@ -474,7 +474,7 @@ mod tests {
 
         // Read back
         let (read_schema, read_batches) =
-            read_recordbatch_from_bytes(FileFormat::Parquet, &bytes::Bytes::from(data))
+            read_recordbatch_from_bytes(FileFormat::Parquet, bytes::Bytes::from(data))
                 .await
                 .unwrap();
 

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -987,11 +987,11 @@ async fn queue_services_from_parquet(
         let mut batches_sent = 0u64;
 
         let file_format = config::get_config().common.file_format;
-        let reader_result = get_recordbatch_reader_from_bytes(file_format, &parquet_bytes).await;
+        let reader_result = get_recordbatch_reader_from_bytes(file_format, parquet_bytes).await;
         let (_schema, mut reader) = match reader_result {
             Ok(r) => r,
             Err(e) => {
-                log::error!("[ServiceStreams] Failed to read parquet: {}", e);
+                log::error!("[ServiceStreams] Failed to read parquet: {e}");
                 return (records_sent, records_dropped);
             }
         };
@@ -1001,7 +1001,7 @@ async fn queue_services_from_parquet(
             let batch = match batch_result {
                 Ok(b) => b,
                 Err(e) => {
-                    log::error!("[ServiceStreams] Error reading batch: {}", e);
+                    log::error!("[ServiceStreams] Error reading batch: {e}");
                     continue;
                 }
             };
@@ -1020,14 +1020,12 @@ async fn queue_services_from_parquet(
                 Err(mpsc::error::TrySendError::Full(dropped_batch)) => {
                     let dropped = dropped_batch.num_rows() as u64;
                     records_dropped += dropped;
-                    log::debug!("[ServiceStreams] Channel full, dropped {} records", dropped);
+                    log::debug!("[ServiceStreams] Channel full, dropped {dropped} records");
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => {
                     // Consumer closed, stop producing
                     log::debug!(
-                        "[ServiceStreams] Consumer closed, stopping producer (sent {} batches, {} records)",
-                        batches_sent,
-                        records_sent
+                        "[ServiceStreams] Consumer closed, stopping producer (sent {batches_sent} batches, {records_sent} records)",
                     );
                     return (records_sent, records_dropped);
                 }
@@ -1035,10 +1033,7 @@ async fn queue_services_from_parquet(
         }
 
         log::debug!(
-            "[ServiceStreams] Producer finished: sent {} batches ({} records), dropped {} records",
-            batches_sent,
-            records_sent,
-            records_dropped
+            "[ServiceStreams] Producer finished: sent {batches_sent} batches ({records_sent} records), dropped {records_dropped} records",
         );
 
         (records_sent, records_dropped)

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -920,7 +920,7 @@ async fn merge_files(
 
     // generate tantivy inverted index and write to storage
     let file_format = config::get_config().common.file_format;
-    let (_, reader) = get_recordbatch_reader_from_bytes(file_format, &buf).await?;
+    let (_, reader) = get_recordbatch_reader_from_bytes(file_format, buf).await?;
     let index_size = create_tantivy_index(
         "INGESTER",
         &new_file_key,

--- a/src/service/compact/dump.rs
+++ b/src/service/compact/dump.rs
@@ -749,7 +749,7 @@ async fn calculate_dump_file_stats(account: &str, file_key: &str) -> Result<Stre
 
     // Parse the parquet file to get FileRecord list
     let file_format = FileFormat::from_extension(file_key).unwrap_or(FileFormat::Parquet);
-    let (_, mut reader) = get_recordbatch_reader_from_bytes(file_format, &file_data)
+    let (_, mut reader) = get_recordbatch_reader_from_bytes(file_format, file_data)
         .await
         .map_err(|e| format!("failed to parse dump file as parquet: {e}"))?;
 

--- a/src/service/compact/flatten.rs
+++ b/src/service/compact/flatten.rs
@@ -152,7 +152,7 @@ pub async fn generate_file(file: &FileKey) -> Result<(), anyhow::Error> {
 
     let data = storage::get_bytes(&file.account, &file.key).await?;
     let file_format = FileFormat::from_extension(&file.key).unwrap_or_default();
-    let (_, batches) = read_recordbatch_from_bytes(file_format, &data)
+    let (_, batches) = read_recordbatch_from_bytes(file_format, data)
         .await
         .map_err(|e| anyhow::anyhow!("read_recordbatch_from_bytes error: {}", e))?;
     let new_batches = generate_vertical_partition_recordbatch(&batches)

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -929,7 +929,7 @@ pub async fn merge_files(
                     &retain_file_list,
                     &mut new_file_meta,
                     latest_schema.clone(),
-                    &buf,
+                    buf,
                 )
                 .await?;
             }
@@ -975,7 +975,7 @@ pub async fn merge_files(
                         &retain_file_list,
                         &mut new_file_meta,
                         latest_schema.clone(),
-                        &buf,
+                        buf,
                     )
                     .await?;
                 }
@@ -1006,7 +1006,7 @@ async fn generate_inverted_index(
     retain_file_list: &[FileKey],
     new_file_meta: &mut FileMeta,
     latest_schema: Arc<Schema>,
-    buf: &Bytes,
+    buf: Bytes,
 ) -> Result<(), anyhow::Error> {
     let file_format = get_config().common.file_format;
     let (_, reader) = get_recordbatch_reader_from_bytes(file_format, buf).await?;

--- a/src/service/tantivy/mod.rs
+++ b/src/service/tantivy/mod.rs
@@ -105,19 +105,19 @@ pub(crate) async fn create_tantivy_index(
         return Ok(0);
     };
 
+    let buf = Bytes::from(puffin_bytes);
     let cfg = get_config();
     if cfg.cache_latest_files.enabled
         && cfg.cache_latest_files.cache_index
         && cfg.cache_latest_files.download_from_node
     {
-        infra::cache::file_data::disk::set(&idx_file_name, Bytes::from(puffin_bytes.clone()))
-            .await?;
+        infra::cache::file_data::disk::set(&idx_file_name, buf.clone()).await?;
         log::info!("file: {idx_file_name} file_data::disk::set success");
     }
 
     // the index file is stored in the same account as the parquet file
     let account = storage::get_account(parquet_file_name).unwrap_or_default();
-    match storage::put(&account, &idx_file_name, Bytes::from(puffin_bytes)).await {
+    match storage::put(&account, &idx_file_name, buf).await {
         Ok(_) => {
             log::info!(
                 "{caller} generated tantivy index file: {idx_file_name}, size {index_size}, took: {} ms",
@@ -416,7 +416,7 @@ mod tests {
         // Create stream from the buffer using the new API
         let bytes = bytes::Bytes::from(buffer);
         let (_schema, stream) =
-            config::utils::parquet::get_recordbatch_reader_from_bytes(FileFormat::Parquet, &bytes)
+            config::utils::parquet::get_recordbatch_reader_from_bytes(FileFormat::Parquet, bytes)
                 .await
                 .unwrap();
         stream

--- a/src/tantivy_utils/src/puffin_directory/writer.rs
+++ b/src/tantivy_utils/src/puffin_directory/writer.rs
@@ -23,7 +23,7 @@ use anyhow::{Context, Result};
 use hashbrown::HashSet;
 use tantivy::{
     HasLen,
-    directory::{Directory, RamDirectory, WatchCallback, WatchHandle, error::OpenReadError},
+    directory::{Directory, MmapDirectory, WatchCallback, WatchHandle, error::OpenReadError},
 };
 
 use super::{FOOTER_CACHE, footer_cache::build_footer_cache};
@@ -35,7 +35,7 @@ use crate::{
 /// Each tantivy file is stored as a blob in the puffin file, along with their file name.
 #[derive(Debug)]
 pub struct PuffinDirWriter {
-    ram_directory: Arc<RamDirectory>,
+    mmap_directory: Arc<MmapDirectory>,
     /// record all the files paths in the puffin file
     file_paths: Arc<RwLock<HashSet<PathBuf>>>,
 }
@@ -49,7 +49,7 @@ impl Default for PuffinDirWriter {
 impl Clone for PuffinDirWriter {
     fn clone(&self) -> Self {
         PuffinDirWriter {
-            ram_directory: self.ram_directory.clone(),
+            mmap_directory: self.mmap_directory.clone(),
             file_paths: self.file_paths.clone(),
         }
     }
@@ -58,7 +58,10 @@ impl Clone for PuffinDirWriter {
 impl PuffinDirWriter {
     pub fn new() -> Self {
         PuffinDirWriter {
-            ram_directory: Arc::new(RamDirectory::create()),
+            mmap_directory: Arc::new(
+                MmapDirectory::create_from_tempdir()
+                    .expect("failed to create temporary mmap directory"),
+            ),
             file_paths: Arc::new(RwLock::new(HashSet::default())),
         }
     }
@@ -98,7 +101,7 @@ impl PuffinDirWriter {
                 segment_id = path.file_stem().unwrap().to_str().unwrap().to_owned();
             }
 
-            let file_data = self.ram_directory.open_read(path)?;
+            let file_data = self.mmap_directory.open_read(path)?;
             log::debug!(
                 "Serializing file to puffin: len: {}, path: {}",
                 file_data.len(),
@@ -114,7 +117,7 @@ impl PuffinDirWriter {
         }
 
         // write footer cache
-        let meta_bytes = build_footer_cache(self.ram_directory.clone())?;
+        let meta_bytes = build_footer_cache(self.mmap_directory.clone())?;
         puffin_writer
             .add_blob(
                 &meta_bytes,
@@ -134,46 +137,46 @@ impl Directory for PuffinDirWriter {
         &self,
         path: &Path,
     ) -> Result<std::sync::Arc<dyn tantivy::directory::FileHandle>, OpenReadError> {
-        self.ram_directory.get_file_handle(path)
+        self.mmap_directory.get_file_handle(path)
     }
 
     fn delete(&self, path: &Path) -> Result<(), tantivy::directory::error::DeleteError> {
-        self.ram_directory.delete(path)
+        self.mmap_directory.delete(path)
     }
 
     fn exists(&self, path: &Path) -> Result<bool, OpenReadError> {
-        self.ram_directory.exists(path)
+        self.mmap_directory.exists(path)
     }
 
     fn open_write(
         &self,
         path: &Path,
     ) -> Result<tantivy::directory::WritePtr, tantivy::directory::error::OpenWriteError> {
-        // capture the files being written to ram directory
+        // capture the files being written to the mmap directory
         self.file_paths.write().unwrap().insert(path.to_path_buf());
-        self.ram_directory.open_write(path)
+        self.mmap_directory.open_write(path)
     }
 
     // this should read from the puffin source
     fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError> {
-        self.ram_directory.atomic_read(path)
+        self.mmap_directory.atomic_read(path)
     }
 
     fn atomic_write(&self, path: &Path, data: &[u8]) -> io::Result<()> {
-        // capture the files being written to ram directory
+        // capture the files being written to the mmap directory
         self.file_paths
             .write()
             .expect("poisoned lock")
             .insert(path.to_path_buf());
-        self.ram_directory.atomic_write(path, data)
+        self.mmap_directory.atomic_write(path, data)
     }
 
     fn sync_directory(&self) -> io::Result<()> {
-        self.ram_directory.sync_directory()
+        self.mmap_directory.sync_directory()
     }
 
     fn watch(&self, watch_callback: WatchCallback) -> tantivy::Result<WatchHandle> {
-        self.ram_directory.watch(watch_callback)
+        self.mmap_directory.watch(watch_callback)
     }
 }
 


### PR DESCRIPTION
- [x] replace the ram dir to mmap dir for tantivy generate 2GB->1.6GB
- [x] limit compactor parquet merge memory usage