### PR TITLE
test: skip TestDino upload and cache on green runs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -876,7 +876,7 @@ jobs:
           ls -lh playwright-results/report.json
 
       - name: Cache test failures to TestDino
-        if: always()
+        if: ${{ needs.ui_integration_tests.result == 'failure' }}
         env:
           TESTDINO_TOKEN: ${{ secrets.TESTDINO_API_TOKEN }}
         run: |
@@ -920,7 +920,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload to TestDino
-        if: ${{ (success() || failure()) && env.UPLOAD_TO_TESTDINO == 'true' }}
+        if: ${{ needs.ui_integration_tests.result == 'failure' && env.UPLOAD_TO_TESTDINO == 'true' }}
         run: |
           cd tests/ui-testing
 


### PR DESCRIPTION
## Summary
- Skip TestDino "Cache test failures" and "Upload to TestDino" steps when all tests pass
- Both steps now gate on `needs.ui_integration_tests.result == 'failure'` so they only run when at least one test shard failed
- The retry mechanism (`tdpw last-failed`) is unaffected — when there are failures the cache step still runs, and the re-run flow works as before

## Why
TestDino bills per test case uploaded. Running both steps on green builds wastes quota with zero value since the user only uses TestDino for failure analysis.

## Changes
- `merge_and_upload_reports` job: "Cache test failures" step condition changed from `always()` to `needs.ui_integration_tests.result == 'failure'`
- `merge_and_upload_reports` job: "Upload to TestDino" step condition changed from `(success() || failure())` to `needs.ui_integration_tests.result == 'failure'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)