### PR TITLE
fix: added default key log fields as columns in logs correaltion table

### DIFF
--- a/web/src/plugins/correlation/CorrelatedLogsTable.spec.ts
+++ b/web/src/plugins/correlation/CorrelatedLogsTable.spec.ts
@@ -46,6 +46,15 @@ vi.mock("@/composables/useCorrelatedLogs", () => ({
   })),
 }));
 
+// Mock useServiceCorrelation composable
+vi.mock("@/composables/useServiceCorrelation", () => ({
+  useServiceCorrelation: vi.fn(() => ({
+    loadKeyFields: vi.fn().mockResolvedValue({}),
+  })),
+  clearSemanticGroupsCaches: vi.fn(),
+  getSemanticGroupsCacheStatus: vi.fn(),
+}));
+
 // Mock TenstackTable component
 vi.mock("@/plugins/logs/TenstackTable.vue", () => ({
   default: {
@@ -178,9 +187,134 @@ describe("CorrelatedLogsTable.vue", () => {
       await nextTick();
       await flushPromises();
 
-      // Initially only timestamp should be visible
+      // Initially only timestamp should be visible (key fields mock returns empty)
       expect(wrapper.vm.visibleColumns.has("_timestamp")).toBe(true);
       expect(wrapper.vm.visibleColumns.size).toBe(1);
+    });
+
+    it("should include key fields in default columns when they match available fields", async () => {
+      // Mock loadKeyFields to return matching key fields for logs
+      const mockUseSC = await import("@/composables/useServiceCorrelation");
+      vi.mocked(mockUseSC.useServiceCorrelation).mockReturnValue({
+        loadKeyFields: vi.fn().mockResolvedValue({
+          logs: { fields: ["field1"], groups: [] },
+        }),
+        clearSemanticGroupsCaches: vi.fn(),
+        getSemanticGroupsCacheStatus: vi.fn(),
+      } as any);
+
+      const mockUseCorrelatedLogs = await import("@/composables/useCorrelatedLogs");
+      (mockUseCorrelatedLogs.useCorrelatedLogs as any).mockReturnValue({
+        ...mockUseCorrelatedLogs.useCorrelatedLogs(),
+        searchResults: {
+          value: [
+            { _timestamp: 1234567890, field1: "value1", field2: "value2" },
+          ],
+        },
+        hasResults: { value: true },
+      });
+
+      wrapper = createWrapper();
+      await nextTick();
+      await flushPromises();
+
+      expect(wrapper.vm.visibleColumns.has("_timestamp")).toBe(true);
+      expect(wrapper.vm.visibleColumns.has("field1")).toBe(true);
+      expect(wrapper.vm.visibleColumns.size).toBe(2);
+    });
+
+    it("should fall back to source column when no key fields match available fields", async () => {
+      // Mock loadKeyFields to return key fields that don't exist in data
+      const mockUseSC = await import("@/composables/useServiceCorrelation");
+      vi.mocked(mockUseSC.useServiceCorrelation).mockReturnValue({
+        loadKeyFields: vi.fn().mockResolvedValue({
+          logs: { fields: ["nonexistent_field"], groups: [] },
+        }),
+        clearSemanticGroupsCaches: vi.fn(),
+        getSemanticGroupsCacheStatus: vi.fn(),
+      } as any);
+
+      const mockUseCorrelatedLogs = await import("@/composables/useCorrelatedLogs");
+      (mockUseCorrelatedLogs.useCorrelatedLogs as any).mockReturnValue({
+        ...mockUseCorrelatedLogs.useCorrelatedLogs(),
+        searchResults: {
+          value: [
+            { _timestamp: 1234567890, field1: "value1" },
+          ],
+        },
+        hasResults: { value: true },
+      });
+
+      wrapper = createWrapper();
+      await nextTick();
+      await flushPromises();
+
+      // Should only have _timestamp (fallback to source column behavior)
+      expect(wrapper.vm.visibleColumns.has("_timestamp")).toBe(true);
+      expect(wrapper.vm.visibleColumns.has("field1")).toBe(false);
+      expect(wrapper.vm.visibleColumns.size).toBe(1);
+    });
+
+    it("should always include _timestamp in default columns", async () => {
+      const mockUseSC = await import("@/composables/useServiceCorrelation");
+      vi.mocked(mockUseSC.useServiceCorrelation).mockReturnValue({
+        loadKeyFields: vi.fn().mockResolvedValue({
+          logs: { fields: ["field1", "field2"], groups: [] },
+        }),
+        clearSemanticGroupsCaches: vi.fn(),
+        getSemanticGroupsCacheStatus: vi.fn(),
+      } as any);
+
+      const mockUseCorrelatedLogs = await import("@/composables/useCorrelatedLogs");
+      (mockUseCorrelatedLogs.useCorrelatedLogs as any).mockReturnValue({
+        ...mockUseCorrelatedLogs.useCorrelatedLogs(),
+        searchResults: {
+          value: [
+            { _timestamp: 1234567890, field1: "a", field2: "b", field3: "c" },
+          ],
+        },
+        hasResults: { value: true },
+      });
+
+      wrapper = createWrapper();
+      await nextTick();
+      await flushPromises();
+
+      // _timestamp should always be included
+      expect(wrapper.vm.visibleColumns.has("_timestamp")).toBe(true);
+    });
+
+    it("should not override user-customized columns when key fields load", async () => {
+      const mockUseSC = await import("@/composables/useServiceCorrelation");
+      vi.mocked(mockUseSC.useServiceCorrelation).mockReturnValue({
+        loadKeyFields: vi.fn().mockResolvedValue({
+          logs: { fields: ["field1"], groups: [] },
+        }),
+        clearSemanticGroupsCaches: vi.fn(),
+        getSemanticGroupsCacheStatus: vi.fn(),
+      } as any);
+
+      const mockUseCorrelatedLogs = await import("@/composables/useCorrelatedLogs");
+      (mockUseCorrelatedLogs.useCorrelatedLogs as any).mockReturnValue({
+        ...mockUseCorrelatedLogs.useCorrelatedLogs(),
+        searchResults: {
+          value: [
+            { _timestamp: 123, field1: "a", field2: "b" },
+          ],
+        },
+        hasResults: { value: true },
+      });
+
+      wrapper = createWrapper();
+      // Simulate user having previously customized columns (e.g., from localStorage)
+      wrapper.vm.visibleColumns = new Set(["_timestamp", "field2"]);
+      await nextTick();
+      await flushPromises();
+
+      // Should respect user's customization (field2), not replace with key fields (field1)
+      expect(wrapper.vm.visibleColumns.has("_timestamp")).toBe(true);
+      expect(wrapper.vm.visibleColumns.has("field2")).toBe(true);
+      expect(wrapper.vm.visibleColumns.has("field1")).toBe(false);
     });
 
     it("should toggle column visibility when toggleColumnVisibility is called", async () => {

--- a/web/src/plugins/correlation/CorrelatedLogsTable.vue
+++ b/web/src/plugins/correlation/CorrelatedLogsTable.vue
@@ -619,7 +619,8 @@ watch(
   (fields) => {
     if (fields.length === 0) return;
     
-    initializeVisibleColumns(fields);
+    // Added check for <=1 as _timestamp is also stored in localstorage, which is a bydefault column
+    if(visibleColumns.value.size <= 1) initializeVisibleColumns(fields);
 
     // Initialize column order if not set
     if (columnOrder.value.length === 0) {

--- a/web/src/plugins/correlation/CorrelatedLogsTable.vue
+++ b/web/src/plugins/correlation/CorrelatedLogsTable.vue
@@ -258,6 +258,7 @@ import OButton from "@/lib/core/Button/OButton.vue";
 import ODropdown from "@/lib/overlay/Dropdown/ODropdown.vue";
 import { useCorrelatedLogs } from "@/composables/useCorrelatedLogs";
 import type { CorrelatedLogsProps } from "@/composables/useCorrelatedLogs";
+import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import TenstackTable from "@/plugins/logs/TenstackTable.vue";
 import DimensionFiltersBar from "./DimensionFiltersBar.vue";
 import { date, copyToClipboard, useQuasar } from "quasar";
@@ -285,6 +286,7 @@ const store = useStore();
 const router = useRouter();
 const $q = useQuasar();
 const { searchObj } = searchState();
+const { loadKeyFields } = useServiceCorrelation();
 
 // Use correlated logs composable
 const {
@@ -315,6 +317,7 @@ const expandedRows = ref<any[]>([]);
 const selectedFields = ref<any[]>([]);
 const visibleColumns = ref<Set<string>>(new Set());
 const columnOrder = ref<string[]>([]);
+const defaultLogFields = ref<string[]>([]);
 const draggedIndex = ref<number | null>(null);
 let isSaving = false; // Prevent recursive saves
 let isUpdatingFromTable = false; // Prevent recursive updates from table
@@ -355,9 +358,16 @@ const saveColumnState = () => {
   }
 };
 
-// Load state on component mount
-onMounted(() => {
+// Load state and key fields config on component mount
+onMounted(async () => {
   loadColumnState();
+  try {
+    const keyFieldsConfig = await loadKeyFields();
+   let _defaultLogFields = keyFieldsConfig?.["logs"]?.fields ?? [];
+   defaultLogFields.value = _defaultLogFields;
+  } catch {
+    defaultLogFields.value = [];
+  }
 });
 
 // Watch for changes and save to localStorage
@@ -586,25 +596,52 @@ const areSomeColumnsSelected = computed(() => {
   return selectableFields.some((field) => visibleColumns.value.has(field));
 });
 
+// Initialize visibleColumns based on available fields and key fields config.
+// Shows _timestamp + any key fields that exist in the data.
+// Falls back to just _timestamp if no key fields match or key fields haven't loaded yet.
+const initializeVisibleColumns = (fields: string[]) => {
+  if (fields.length === 0) return;
+
+  const defaults = new Set<string>();
+  const timestampField = fields.find((f) => f === "_timestamp");
+  if (timestampField) defaults.add(timestampField);
+
+  for (const keyField of defaultLogFields.value) {
+    if (fields.includes(keyField)) defaults.add(keyField);
+  }
+
+  visibleColumns.value = defaults;
+};
+
 // Watch for new fields and initialize visibleColumns and columnOrder
-// By default, only show timestamp (which will trigger source column display)
 watch(
   availableFields,
   (fields) => {
-    if (fields.length > 0 && visibleColumns.value.size === 0) {
-      // Only show timestamp by default - this will display timestamp + source columns
-      const timestampField = fields.find((f) => f === "_timestamp");
-      if (timestampField) {
-        visibleColumns.value = new Set([timestampField]);
-      }
-    }
+    if (fields.length === 0) return;
+    
+    initializeVisibleColumns(fields);
+
     // Initialize column order if not set
-    if (fields.length > 0 && columnOrder.value.length === 0) {
+    if (columnOrder.value.length === 0) {
       columnOrder.value = [...fields];
     }
   },
   { immediate: true },
 );
+
+// If key fields load after availableFields, re-initialize to add matching key fields.
+// Only overrides when user hasn't customized columns (empty or only _timestamp).
+watch(defaultLogFields, (keyFields) => {
+  if (keyFields.length === 0 || availableFields.value.length === 0) return;
+
+  const isDefaultOrEmpty =
+    visibleColumns.value.size === 0 ||
+    (visibleColumns.value.size === 1 && visibleColumns.value.has("_timestamp"));
+
+  if (!isDefaultOrEmpty) return;
+
+  initializeVisibleColumns(availableFields.value);
+});
 
 // Generate table columns dynamically from visible fields in custom order
 const tableColumns = computed<ColumnDef<any>[]>(() => {


### PR DESCRIPTION
#11584 


## What changed

Updated `CorrelatedLogsTable.vue` to load key fields from the service correlation configuration and use them as default visible columns alongside `_timestamp`. Added 5 new test cases covering key field matching, fallback behavior, and user customization preservation.

## Why

The correlated logs table was only showing `_timestamp` by default, missing relevant log fields that should appear as columns. Key fields defined in the service correlation config (e.g., `field1`, `field2`) were not being surfaced unless the user manually customized columns.

## Approach

- Imported `useServiceCorrelation` composable and its `loadKeyFields` method
- On mount, fetch key fields config and store in `defaultLogFields` ref
- Added `initializeVisibleColumns()` that creates a default set from `_timestamp` + any key fields present in the available fields
- Updated the `availableFields` watcher to check `visibleColumns.size <= 1` (instead of `=== 0`) — accounts for `_timestamp` being persisted in localStorage
- Added a separate `watch` on `defaultLogFields` to re-initialize when key fields arrive after `availableFields`
- Both watchers skip re-initialization if the user has already customized columns (more than just `_timestamp`)

## Risk

Medium. The column initialization logic now runs in two watchers (`availableFields` and `defaultLogFields`). If `defaultLogFields` loads before `availableFields`, the first watcher applies (with an empty key fields list) and the second watcher skips because `visibleColumns.size` is already `> 1`. Reviewers should verify that the ordering of these watchers doesn't leave key fields unapplied in edge cases.