### PR TITLE
fix: service details operations table sorting

### DIFF
--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
@@ -750,4 +750,202 @@ describe("ServiceGraphNodeSidePanel", () => {
       );
     });
   });
+
+  // -------------------------------------------------------------------------
+  // isDurationColumn helper
+  // -------------------------------------------------------------------------
+
+  describe("isDurationColumn helper", () => {
+    beforeEach(() => {
+      wrapper = mountPanel();
+    });
+
+    it("should return true for p99", () => {
+      expect(wrapper.vm.isDurationColumn("p99")).toBe(true);
+    });
+
+    it("should return true for p95", () => {
+      expect(wrapper.vm.isDurationColumn("p95")).toBe(true);
+    });
+
+    it("should return true for p75", () => {
+      expect(wrapper.vm.isDurationColumn("p75")).toBe(true);
+    });
+
+    it("should return false for p50", () => {
+      expect(wrapper.vm.isDurationColumn("p50")).toBe(false);
+    });
+
+    it("should return false for requests", () => {
+      expect(wrapper.vm.isDurationColumn("requests")).toBe(false);
+    });
+
+    it("should return false for operation", () => {
+      expect(wrapper.vm.isDurationColumn("operation")).toBe(false);
+    });
+
+    it("should return false for empty string", () => {
+      expect(wrapper.vm.isDurationColumn("")).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // sortBy / sortOrder initial state
+  // -------------------------------------------------------------------------
+
+  describe("sort state initial defaults", () => {
+    beforeEach(() => {
+      wrapper = mountPanel();
+    });
+
+    it("should default sortBy to empty string", () => {
+      expect(wrapper.vm.sortBy).toBe("");
+    });
+
+    it("should default sortOrder to empty string", () => {
+      expect(wrapper.vm.sortOrder).toBe("");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleSortChange
+  // -------------------------------------------------------------------------
+
+  describe("handleSortChange", () => {
+    beforeEach(() => {
+      wrapper = mountPanel();
+    });
+
+    it("should set sortBy to the provided field when called with asc order", () => {
+      wrapper.vm.handleSortChange("p99", "asc");
+      expect(wrapper.vm.sortBy).toBe("p99");
+      expect(wrapper.vm.sortOrder).toBe("asc");
+    });
+
+    it("should set sortOrder to desc when provided", () => {
+      wrapper.vm.handleSortChange("requests", "desc");
+      expect(wrapper.vm.sortBy).toBe("requests");
+      expect(wrapper.vm.sortOrder).toBe("desc");
+    });
+
+    it("should update both sortBy and sortOrder when called multiple times", () => {
+      wrapper.vm.handleSortChange("operation", "asc");
+      expect(wrapper.vm.sortBy).toBe("operation");
+      expect(wrapper.vm.sortOrder).toBe("asc");
+
+      wrapper.vm.handleSortChange("p95", "desc");
+      expect(wrapper.vm.sortBy).toBe("p95");
+      expect(wrapper.vm.sortOrder).toBe("desc");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // sortedOperationsTableRows
+  // -------------------------------------------------------------------------
+
+  describe("sortedOperationsTableRows", () => {
+    const mockOperationsHits = [
+      {
+        operation_name: "GET /api/users",
+        request_count: 100,
+        error_count: 5,
+        p50_latency: 10000,
+        p75_latency: 20000,
+        p95_latency: 50000,
+        p99_latency: 80000,
+      },
+      {
+        operation_name: "POST /api/orders",
+        request_count: 200,
+        error_count: 10,
+        p50_latency: 5000,
+        p75_latency: 15000,
+        p95_latency: 30000,
+        p99_latency: 120000,
+      },
+      {
+        operation_name: "GET /api/products",
+        request_count: 50,
+        error_count: 0,
+        p50_latency: 20000,
+        p75_latency: 40000,
+        p95_latency: 80000,
+        p99_latency: 150000,
+      },
+    ];
+
+    describe("when operations are loaded", () => {
+      beforeEach(async () => {
+        vi.mocked(searchService.search).mockResolvedValue({
+          data: { hits: mockOperationsHits },
+        } as any);
+        wrapper = mountPanel({ streamFilter: "default" });
+        await flushPromises();
+      });
+
+      it("should return unsorted rows when sortBy is empty", () => {
+        const rows = wrapper.vm.sortedOperationsTableRows;
+        expect(rows).toHaveLength(3);
+        expect(rows[0].operation).toBe("GET /api/users");
+        expect(rows[1].operation).toBe("POST /api/orders");
+        expect(rows[2].operation).toBe("GET /api/products");
+      });
+
+      it("should sort by p99 ascending when sortBy is p99 and sortOrder is asc", () => {
+        wrapper.vm.handleSortChange("p99", "asc");
+        const rows = wrapper.vm.sortedOperationsTableRows;
+        expect(rows[0].p99).toBe(80000);
+        expect(rows[1].p99).toBe(120000);
+        expect(rows[2].p99).toBe(150000);
+      });
+
+      it("should sort by p99 descending when sortBy is p99 and sortOrder is desc", () => {
+        wrapper.vm.handleSortChange("p99", "desc");
+        const rows = wrapper.vm.sortedOperationsTableRows;
+        expect(rows[0].p99).toBe(150000);
+        expect(rows[1].p99).toBe(120000);
+        expect(rows[2].p99).toBe(80000);
+      });
+
+      it("should sort by operation alphabetically ascending", () => {
+        wrapper.vm.handleSortChange("operation", "asc");
+        const rows = wrapper.vm.sortedOperationsTableRows;
+        expect(rows[0].operation).toBe("GET /api/products");
+        expect(rows[1].operation).toBe("GET /api/users");
+        expect(rows[2].operation).toBe("POST /api/orders");
+      });
+
+      it("should sort by requests numerically descending", () => {
+        wrapper.vm.handleSortChange("requests", "desc");
+        const rows = wrapper.vm.sortedOperationsTableRows;
+        expect(rows[0].requests).toBe(200);
+        expect(rows[1].requests).toBe(100);
+        expect(rows[2].requests).toBe(50);
+      });
+
+      it("should sort by errors numerically ascending", () => {
+        wrapper.vm.handleSortChange("errors", "asc");
+        const rows = wrapper.vm.sortedOperationsTableRows;
+        expect(rows[0].errors).toBe(0);
+        expect(rows[1].errors).toBe(5);
+        expect(rows[2].errors).toBe(10);
+      });
+    });
+
+    describe("when operations are empty", () => {
+      beforeEach(async () => {
+        vi.mocked(searchService.search).mockResolvedValue({
+          data: { hits: [] },
+        } as any);
+        wrapper = mountPanel({ streamFilter: "default" });
+        await flushPromises();
+      });
+
+      it("should return an empty array without error when sortBy is set", () => {
+        wrapper.vm.handleSortChange("p99", "asc");
+        const rows = wrapper.vm.sortedOperationsTableRows;
+        expect(rows).toHaveLength(0);
+      });
+    });
+  });
 });

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -317,7 +317,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <template #cell-p99="{ item }">
                       <span
                         :class="
-                          item.p99 !== 'N/A'
+                          item.p99 > 0
                             ? 'tw:text-[var(--o2-latency-p99)]'
                             : ''
                         "
@@ -327,7 +327,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <template #cell-p95="{ item }">
                       <span
                         :class="
-                          item.p95 !== 'N/A'
+                          item.p95 > 0
                             ? 'tw:text-[var(--o2-latency-p95)]'
                             : ''
                         "
@@ -337,7 +337,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <template #cell-p75="{ item }">
                       <span
                         :class="
-                          item.p75 !== 'N/A'
+                          item.p75 > 0
                             ? 'tw:text-[var(--o2-latency-p75)]'
                             : ''
                         "
@@ -465,7 +465,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <template #cell-p99="{ item }">
                       <span
                         :class="
-                          item.p99 !== 'N/A'
+                          item.p99 > 0
                             ? 'tw:text-[var(--o2-latency-p99)]'
                             : ''
                         "
@@ -475,7 +475,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <template #cell-p95="{ item }">
                       <span
                         :class="
-                          item.p95 !== 'N/A'
+                          item.p95 > 0
                             ? 'tw:text-[var(--o2-latency-p95)]'
                             : ''
                         "
@@ -485,7 +485,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <template #cell-p75="{ item }">
                       <span
                         :class="
-                          item.p75 !== 'N/A'
+                          item.p75 > 0
                             ? 'tw:text-[var(--o2-latency-p75)]'
                             : ''
                         "

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -287,7 +287,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 >
                   <TenstackTable
                     :columns="operationsTableColumns"
-                    :rows="operationsTableRows"
+                    :rows="sortedOperationsTableRows"
+                    :sort-by="sortBy"
+                    :sort-order="sortOrder"
                     :loading="false"
                     :default-columns="false"
                     :enable-column-reorder="false"
@@ -296,6 +298,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     :enable-status-bar="false"
                     :enable-ai-context-button="false"
                     :row-height="28"
+                    @sort-change="handleSortChange"
                     @click:data-row="
                       (row: any) =>
                         navigateToTraces({ operationName: row._name })
@@ -318,7 +321,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             ? 'tw:text-[var(--o2-latency-p99)]'
                             : ''
                         "
-                        >{{ item.p99 }}</span
+                        >{{ formatOperationLatency(item.p99) }}</span
                       >
                     </template>
                     <template #cell-p95="{ item }">
@@ -328,7 +331,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             ? 'tw:text-[var(--o2-latency-p95)]'
                             : ''
                         "
-                        >{{ item.p95 }}</span
+                        >{{ formatOperationLatency(item.p95) }}</span
                       >
                     </template>
                     <template #cell-p75="{ item }">
@@ -338,7 +341,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             ? 'tw:text-[var(--o2-latency-p75)]'
                             : ''
                         "
-                        >{{ item.p75 }}</span
+                        >{{ formatOperationLatency(item.p75) }}</span
                       >
                     </template>
                     <template #cell-actions="{ row, column, active }">
@@ -412,7 +415,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 >
                   <TenstackTable
                     :columns="buildEntityTableColumns(cfg.colId, cfg.colLabel)"
-                    :rows="buildResourceTableRows(cfg)"
+                    :rows="sortResourceRows(buildResourceTableRows(cfg))"
+                    :sort-by="sortBy"
+                    :sort-order="sortOrder"
                     :loading="false"
                     :default-columns="false"
                     :enable-column-reorder="false"
@@ -421,6 +426,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     :enable-status-bar="false"
                     :enable-ai-context-button="false"
                     :row-height="28"
+                    @sort-change="handleSortChange"
                     @click:data-row="
                       (row: any) =>
                         navigateToTraces({
@@ -477,7 +483,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             ? 'tw:text-[var(--o2-latency-p99)]'
                             : ''
                         "
-                        >{{ item.p99 }}</span
+                        >{{ formatOperationLatency(item.p99) }}</span
                       >
                     </template>
                     <template #cell-p95="{ item }">
@@ -487,7 +493,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             ? 'tw:text-[var(--o2-latency-p95)]'
                             : ''
                         "
-                        >{{ item.p95 }}</span
+                        >{{ formatOperationLatency(item.p95) }}</span
                       >
                     </template>
                     <template #cell-p75="{ item }">
@@ -497,7 +503,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             ? 'tw:text-[var(--o2-latency-p75)]'
                             : ''
                         "
-                        >{{ item.p75 }}</span
+                        >{{ formatOperationLatency(item.p75) }}</span
                       >
                     </template>
                     <template #empty>
@@ -1435,6 +1441,52 @@ export default defineComponent({
       });
     };
 
+    // ── Sorting state ──────────────────────────────────────────────────────
+    const sortBy = ref<string>("errors");
+    const sortOrder = ref<"asc" | "desc">("desc");
+
+    function handleSortChange(field: string, order: "asc" | "desc") {
+      sortBy.value = field;
+      sortOrder.value = order;
+    }
+
+    const compareRows = (a: any, b: any, field: string): number => {
+      // For latency percentiles, sort by raw underscore-prefixed values
+      if (field === "p99" || field === "p95" || field === "p75") {
+        const rawKey = `${field}` as const;
+        return (a[rawKey] ?? 0) - (b[rawKey] ?? 0);
+      }
+      // For requests, sort by raw _requests value
+      if (field === "requests") {
+        return (a.requests ?? 0) - (b.requests ?? 0);
+      }
+      const va = a[field];
+      const vb = b[field];
+      if (typeof va === "number" && typeof vb === "number") {
+        return va - vb;
+      }
+      return String(va ?? "").localeCompare(String(vb ?? ""));
+    };
+
+    const sortedOperationsTableRows = computed(() => {
+      const rows = operationsTableRows.value;
+      if (!sortBy.value) return rows;
+      const order = sortOrder.value;
+      return [...rows].sort((a, b) => {
+        const result = compareRows(a, b, sortBy.value);
+        return order === "desc" ? -result : result;
+      });
+    });
+
+    const sortResourceRows = (rows: any[]) => {
+      if (!sortBy.value) return rows;
+      const order = sortOrder.value;
+      return [...rows].sort((a, b) => {
+        const result = compareRows(a, b, sortBy.value);
+        return order === "desc" ? -result : result;
+      });
+    };
+
     // Generic helper: builds table columns with a dynamic first (entity) column
     const buildEntityTableColumns = (
       entityId: string,
@@ -1445,41 +1497,48 @@ export default defineComponent({
         accessorKey: entityId,
         header: entityHeader,
         size: 220,
-        meta: { slot: false },
+        enableSorting: true,
+        meta: { slot: false, sortable: true },
       },
       {
         id: "requests",
-        accessorKey: "requests",
+        accessorFn: (row: any) => formatNumber(row.requests),
         header: "Requests",
         size: 100,
+        enableSorting: true,
+        meta: { sortable: true },
       },
       {
         id: "errors",
         accessorKey: "errors",
         header: "Errors",
         size: 80,
-        meta: { slot: true },
+        enableSorting: true,
+        meta: { slot: true, sortable: true },
       },
       {
         id: "p99",
         accessorKey: "p99",
         header: "P99",
         size: 80,
-        meta: { slot: true },
+        enableSorting: true,
+        meta: { slot: true, sortable: true },
       },
       {
         id: "p95",
         accessorKey: "p95",
         header: "P95",
         size: 80,
-        meta: { slot: true },
+        enableSorting: true,
+        meta: { slot: true, sortable: true },
       },
       {
         id: "p75",
         accessorKey: "p75",
         header: "P75",
         size: 80,
-        meta: { slot: true },
+        enableSorting: true,
+        meta: { slot: true, sortable: true },
       },
     ];
 
@@ -1492,16 +1551,12 @@ export default defineComponent({
     const operationsTableRows = computed(() =>
       recentOperations.value.map((op) => ({
         operation: op.name,
-        requests: formatNumber(op.requestCount),
+        requests: op.requestCount,
         errors: op.errorCount,
-        p99: formatOperationLatency(op.p99Latency),
-        p95: formatOperationLatency(op.p95Latency),
-        p75: formatOperationLatency(op.p75Latency),
-        p50: formatOperationLatency(op.p50Latency),
-        _name: op.name,
-        _p99: op.p99Latency,
-        _p95: op.p95Latency,
-        _p75: op.p75Latency,
+        p99: op.p99Latency,
+        p95: op.p95Latency,
+        p75: op.p75Latency,
+        p50: op.p50Latency,
       })),
     );
 
@@ -1798,16 +1853,12 @@ export default defineComponent({
     const buildResourceTableRows = (config: ResourceTabConfig) =>
       (resourceTabData.value[config.id] || []).map((row) => ({
         [config.colId]: row.name,
-        requests: formatNumber(row.requestCount),
+        requests: row.requestCount,
         errors: row.errorCount,
-        p99: formatOperationLatency(row.p99Latency),
-        p95: formatOperationLatency(row.p95Latency),
-        p75: formatOperationLatency(row.p75Latency),
-        p50: formatOperationLatency(row.p50Latency),
-        _name: row.name,
-        _p99: row.p99Latency,
-        _p95: row.p95Latency,
-        _p75: row.p75Latency,
+        p99: row.p99Latency,
+        p95: row.p95Latency,
+        p75: row.p75Latency,
+        p50: row.p50Latency,
       }));
 
     // Lazy-fetch resource tab data / metrics when their tab is activated
@@ -2067,6 +2118,12 @@ export default defineComponent({
       metricsCorrelationLoaded,
       fetchMetricsCorrelation,
       metricGroupResources,
+      sortedOperationsTableRows,
+      sortBy,
+      sortOrder,
+      handleSortChange,
+      sortResourceRows,
+      formatOperationLatency,
     };
   },
 });

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -355,7 +355,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           navigateToTraces({
                             operationName: row.operation,
                             errorsOnly: column.id === 'errors',
-                            minDurationMicros: row[column.id]
+                            minDurationMicros: isDurationColumn(column.id) ? row[column.id] : undefined
                           })
                         "
                       >
@@ -444,7 +444,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                               value: row[cfg.colId],
                             },
                             errorsOnly: column.id === 'errors',
-                            minDurationMicros: row[column.id]
+                            minDurationMicros: isDurationColumn(column.id) ? row[column.id] : undefined
                           })
                         "
                       >
@@ -1437,7 +1437,6 @@ export default defineComponent({
     }
 
     const compareRows = (a: any, b: any, field: string): number => {
-      // For latency percentiles, sort by raw underscore-prefixed values
       if (field === "p99" || field === "p95" || field === "p75") {
         return (a[field] ?? 0) - (b[field] ?? 0);
       }
@@ -2050,6 +2049,10 @@ export default defineComponent({
       return "status-critical";
     };
 
+    const isDurationColumn = (column: string) => {
+     return ['p99','p95','p75'].includes(column);
+    }
+
     return {
       t,
       serviceMetrics,
@@ -2109,6 +2112,7 @@ export default defineComponent({
       handleSortChange,
       sortResourceRows,
       formatOperationLatency,
+      isDurationColumn
     };
   },
 });

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -301,7 +301,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     @sort-change="handleSortChange"
                     @click:data-row="
                       (row: any) =>
-                        navigateToTraces({ operationName: row._name })
+                        navigateToTraces({ operationName: row.operation })
                     "
                   >
                     <template #cell-errors="{ item }">
@@ -353,16 +353,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         data-test="service-graph-side-panel-view-traces-btn"
                         @click.stop="
                           navigateToTraces({
-                            operationName: row._name,
+                            operationName: row.operation,
                             errorsOnly: column.id === 'errors',
-                            minDurationMicros:
-                              column.id === 'p99'
-                                ? row._p99
-                                : column.id === 'p95'
-                                  ? row._p95
-                                  : column.id === 'p75'
-                                    ? row._p75
-                                    : undefined,
+                            minDurationMicros: row[column.id]
                           })
                         "
                       >
@@ -432,7 +425,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         navigateToTraces({
                           resourceFilter: {
                             field: cfg.groupField,
-                            value: row._name,
+                            value: row[cfg.colId],
                           },
                         })
                     "
@@ -448,17 +441,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           navigateToTraces({
                             resourceFilter: {
                               field: cfg.groupField,
-                              value: row._name,
+                              value: row[cfg.colId],
                             },
                             errorsOnly: column.id === 'errors',
-                            minDurationMicros:
-                              column.id === 'p99'
-                                ? row._p99
-                                : column.id === 'p95'
-                                  ? row._p95
-                                  : column.id === 'p75'
-                                    ? row._p75
-                                    : undefined,
+                            minDurationMicros: row[cfg.colId]
                           })
                         "
                       >

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -847,8 +847,8 @@ export default defineComponent({
         panel.layout.h = 10;
 
         let query = panel.queries[0].query
-          .replace("[STREAM_NAME]", `"${streamName}"`)
-          .replace("[WHERE_CLAUSE]", whereClause);
+          .replace("[STREAM_NAME]", () => `"${streamName}"`)
+          .replace("[WHERE_CLAUSE]", () => whereClause);
 
         // Use count(*) instead of approx_distinct(trace_id)
         query = query

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -444,7 +444,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                               value: row[cfg.colId],
                             },
                             errorsOnly: column.id === 'errors',
-                            minDurationMicros: row[cfg.colId]
+                            minDurationMicros: row[column.id]
                           })
                         "
                       >
@@ -1428,8 +1428,8 @@ export default defineComponent({
     };
 
     // ── Sorting state ──────────────────────────────────────────────────────
-    const sortBy = ref<string>("errors");
-    const sortOrder = ref<"asc" | "desc">("desc");
+    const sortBy = ref<string>("");
+    const sortOrder = ref<"asc" | "desc">("");
 
     function handleSortChange(field: string, order: "asc" | "desc") {
       sortBy.value = field;
@@ -1439,8 +1439,7 @@ export default defineComponent({
     const compareRows = (a: any, b: any, field: string): number => {
       // For latency percentiles, sort by raw underscore-prefixed values
       if (field === "p99" || field === "p95" || field === "p75") {
-        const rawKey = `${field}` as const;
-        return (a[rawKey] ?? 0) - (b[rawKey] ?? 0);
+        return (a[field] ?? 0) - (b[field] ?? 0);
       }
       // For requests, sort by raw _requests value
       if (field === "requests") {

--- a/web/src/plugins/traces/ServicesCatalog.spec.ts
+++ b/web/src/plugins/traces/ServicesCatalog.spec.ts
@@ -780,6 +780,55 @@ describe("ServicesCatalog", () => {
 
       expect(wrapper.vm.filteredServices).toHaveLength(0);
     });
+
+    it("should handle null/undefined filterText gracefully when filterText is not initialized", async () => {
+      // Populate services via the streaming callback
+      mockFetchQueryDataWithHttpStream.mockImplementation(
+        (_req: any, callbacks: any) => {
+          const hits = mockServices.map((s) => ({
+            service_name: s.service_name,
+            total_requests: s.total_requests,
+            error_count: s.error_count,
+            error_rate: s.error_rate,
+            avg_duration_ns: s.avg_duration_ns,
+            max_duration_ns: s.max_duration_ns,
+            p50_latency_ns: s.p50_latency_ns,
+            p95_latency_ns: s.p95_latency_ns,
+            p99_latency_ns: s.p99_latency_ns,
+          }));
+
+          if (callbacks?.data) {
+            callbacks.data(null, {
+              type: "search_response_hits",
+              content: { results: { hits } },
+            });
+          }
+          if (callbacks?.complete) {
+            callbacks.complete(null, {});
+          }
+        },
+      );
+
+      wrapper = mountServicesCatalog();
+      await flushPromises();
+
+      // All 5 services should be present before setting filterText to null
+      expect(wrapper.vm.filteredServices).toHaveLength(5);
+
+      // Set filterText to null — the optional chaining filterText?.value?.trim()
+      // prevents a crash that would occur with filterText.value.trim()
+      wrapper.vm.filterText = null;
+      await flushPromises();
+
+      // Should return all services (no crash, empty-filter fallback)
+      expect(wrapper.vm.filteredServices).toHaveLength(5);
+
+      // Set filterText to undefined — same null-safety applies
+      wrapper.vm.filterText = undefined;
+      await flushPromises();
+
+      expect(wrapper.vm.filteredServices).toHaveLength(5);
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/web/src/plugins/traces/ServicesCatalog.vue
+++ b/web/src/plugins/traces/ServicesCatalog.vue
@@ -634,8 +634,8 @@ const statusCounts = computed(() => ({
 }));
 
 const filteredServices = computed(() => {
-  if (!filterText.value.trim()) return services.value;
-  const q = filterText.value.trim().toLowerCase();
+  if (!filterText?.value?.trim()) return services.value;
+  const q = filterText.value?.trim().toLowerCase();
   return services.value.filter((s) => s.service_name.toLowerCase().includes(q));
 });
 


### PR DESCRIPTION
#11590


## What changed

Fixed sorting on the operations and resource tables in the service details side panel. Previously, columns like P99, P95, and P75 sorted by their formatted string values (e.g., "1.23ms") instead of their raw numeric values, producing incorrect sort order. Sorting is now handled client-side via a custom sort function that compares raw latency values, and the TenstackTable receives explicit `sort-by`/`sort-order` props with a `sort-change` event handler.

## Why

The TenstackTable's built-in sorting handler sorted on the formatted display value, which is a string — making numeric sorting incorrect for latency percentile columns. The fix aligns with how sorting is handled in `ServicesCatalog.vue` (referenced implementation pattern).