### PR TITLE
feat: implement OToast component and provider for toast notifications

### DIFF
--- a/web/docs/toast.md
+++ b/web/docs/toast.md
@@ -1,0 +1,614 @@
+# OToast — Implementation Spec
+
+**Branch**: `feat/ux-notify`  
+**Replaces**: Quasar `useQuasar().notify()` / `Notify.create()`  
+**Headless base**: Reka UI `Toast*` primitives (already confirmed)  
+**Location**: `web/src/lib/feedback/Toast/`
+
+---
+
+## Why this work exists
+
+Quasar's `Notify` plugin is the last major blocker to removing `quasar` from `src/services/` and `src/utils/`. It is called in two fundamentally different contexts:
+
+1. **Inside Vue components / composables** — via `useQuasar().notify()`
+2. **Outside the Vue tree** — via `Notify.create()` in `main.ts`, `httpsearch.ts`, `http.ts`
+
+The replacement must work in **both** contexts. A standard `provide/inject` composable is not enough; the state store must live at module level.
+
+---
+
+## File Contract
+
+```
+web/src/lib/feedback/Toast/
+├── useToast.ts               ← Module-level singleton API (works outside Vue)
+├── useToast.spec.ts          ← Unit tests for the composable
+├── OToastProvider.vue        ← Mounted ONCE near app root — renders viewport + all toasts
+├── OToastProvider.types.ts
+├── OToastProvider.spec.ts
+├── OToast.vue                ← Single toast item (rendered by Provider internally)
+├── OToast.types.ts
+└── OToast.spec.ts
+```
+
+No `index.ts`. Import directly by path.
+
+---
+
+## Reka UI Primitives Used
+
+```ts
+import {
+  ToastProvider,
+  ToastViewport,
+  ToastRoot,
+  ToastTitle,
+  ToastDescription,
+  ToastAction,
+  ToastClose,
+} from "reka-ui"
+```
+
+> Reka UI is already in `package.json`. No install needed.
+
+`ToastProvider` manages the ARIA live region and swipe direction.  
+`ToastViewport` is the `Teleport` target — rendered inside `OToastProvider`.  
+`ToastRoot` is the individual toast shell — maps to `OToast`.  
+`ToastTitle` / `ToastDescription` carry the text content.  
+`ToastAction` renders an accessible action button inside the toast.  
+`ToastClose` renders the × dismiss button.
+
+---
+
+## 1 — `useToast.ts`
+
+### Public API
+
+```ts
+// Usage inside a Vue component or composable:
+import { useToast } from "@/lib/feedback/Toast/useToast"
+const { toast } = useToast()
+
+const dismiss = toast({ variant: "success", message: "Saved!" })
+dismiss()                                            // close it
+dismiss({ variant: "error", message: "Failed!" })   // close + show a new one
+
+// Usage OUTSIDE the Vue tree (services, main.ts):
+import { toast } from "@/lib/feedback/Toast/useToast"
+toast({ variant: "error", message: "Network error", position: "bottom-right" })
+```
+
+### Module-level store shape
+
+```ts
+// Internal — not exported
+interface ToastRecord {
+  id: string
+  variant: ToastVariant
+  message: string
+  title?: string
+  timeout: number        // ms; 0 = persistent
+  position: ToastPosition
+  open: boolean          // Reka controls enter/exit animation via this
+  action?: ToastAction
+}
+
+// Module-level — survives outside Vue lifecycle
+const toastRecords = reactive<ToastRecord[]>([])
+```
+
+### `toast()` return type
+
+```ts
+type DismissFn = (replacement?: Pick<ToastOptions, "variant" | "message" | "title">) => void
+```
+
+When `replacement` is provided, the function closes the current toast **and** immediately fires a new one.
+
+### `useToast()` return type
+
+```ts
+interface UseToastReturn {
+  toast: (options: ToastOptions) => DismissFn
+  toasts: ToastRecord[]     // readonly reactive — consumed by OToastProvider
+}
+```
+
+### Default timeout per variant
+
+| variant | default `timeout` |
+|---------|-------------------|
+| `"success"` | `3000` ms |
+| `"error"` | `5000` ms |
+| `"warning"` | `4000` ms |
+| `"info"` | `4000` ms |
+| `"loading"` | `0` (persistent — must be dismissed via `DismissFn`) |
+| `"default"` | `3000` ms |
+
+---
+
+## 2 — `OToast.types.ts`
+
+```ts
+export type ToastVariant =
+  | "success"
+  | "error"
+  | "warning"
+  | "info"
+  | "loading"
+  | "default"
+
+// Positions mirror Quasar's subset actually used in the codebase
+export type ToastPosition =
+  | "top-center"
+  | "top-right"
+  | "top-left"
+  | "bottom-center"
+  | "bottom-right"   // ← global default
+  | "bottom-left"
+
+export interface ToastAction {
+  label: string
+  handler: () => void
+}
+
+export interface ToastOptions {
+  /** Visual style + icon set */
+  variant?: ToastVariant
+  /** Primary message text — plain string only (no HTML) */
+  message: string
+  /** Optional bold title above message */
+  title?: string
+  /** Auto-dismiss delay in ms. 0 = persistent. Defaults per variant. */
+  timeout?: number
+  /** Where the toast appears on screen */
+  position?: ToastPosition
+  /** Optional action button rendered inside the toast */
+  action?: ToastAction
+}
+
+export interface ToastProps extends ToastOptions {
+  id: string
+  open: boolean
+}
+
+export interface ToastEmits {
+  (e: "openChange", value: boolean): void
+}
+```
+
+**Key decisions:**
+
+- `html` prop is **dropped** — plain strings only (security). The one `html: true` usage in `main.ts` will be rewritten to use `action: { label: "Refresh", handler: () => window.location.reload() }` with a plain `message`.
+- `color` / `textColor` props are **dropped** — baked into `variant`.
+- `spinner` prop is **dropped** — replaced by `variant: "loading"` which bakes in the spinner.
+- `multiLine` prop is **dropped** — text naturally wraps.
+- `classes` prop is **dropped** — the `stale-build-notification` class in `main.ts` is unnecessary after the redesign.
+- `progress` prop is **dropped** — a progress bar countdown is not part of the new visual design.
+
+---
+
+## 3 — `OToast.vue` (single item)
+
+Renders one `ToastRoot` using Reka UI. Consumes `ToastProps`.
+
+### Visual structure (per variant)
+
+```
+┌──────────────────────────────────────────────────┐
+│ [icon]  Title (optional)                   [  ×] │
+│         Message text                             │
+│         [Action Button] (optional)               │
+└──────────────────────────────────────────────────┘
+```
+
+### Icons per variant
+
+Use `lucide-vue-next` (already in project — confirmed safe):
+
+| variant | lucide icon |
+|---------|-------------|
+| `success` | `CheckCircle2` |
+| `error` | `XCircle` |
+| `warning` | `AlertTriangle` |
+| `info` | `Info` |
+| `loading` | `Loader2` with `tw:animate-spin` |
+| `default` | none |
+
+### Tailwind class map structure
+
+Follow the exact variant class-map pattern used in `OButton.vue`:
+
+```ts
+const variantClasses: Record<NonNullable<ToastVariant>, string> = {
+  success: [
+    "tw:bg-toast-success-bg tw:border tw:border-toast-success-border",
+    "tw:text-toast-fg",
+  ].join(" "),
+  error: [...].join(" "),
+  // ...
+}
+
+const iconColorClasses: Record<NonNullable<ToastVariant>, string> = {
+  success: "tw:text-toast-success-icon",
+  error:   "tw:text-toast-error-icon",
+  // ...
+}
+```
+
+### Accessibility requirements
+
+- `ToastRoot` gets `role="status"` for `success` / `info` / `loading`; `role="alert"` for `error` / `warning`
+- `ToastTitle` is always present (visually hidden if no `title` prop but `message` is set — assistive tech reads it)
+- `ToastClose` has `aria-label="Dismiss notification"`
+- Keyboard: `Escape` dismisses the focused toast (Reka handles this)
+- Swipe-to-dismiss: `swipeDirection="right"` on `ToastProvider`
+
+---
+
+## 4 — `OToastProvider.vue`
+
+Mounted **once** in `web/src/App.vue` (or the app root layout).
+
+```vue
+<template>
+  <!-- Reka wraps all toasts with the ARIA live region -->
+  <ToastProvider swipe-direction="right" :duration="0">
+
+    <!-- Render one OToast per active record -->
+    <OToast
+      v-for="t in toasts"
+      :key="t.id"
+      v-bind="t"
+      @open-change="(open) => handleOpenChange(t.id, open)"
+    />
+
+    <!-- One viewport per position bucket -->
+    <ToastViewport
+      v-for="pos in activePositions"
+      :key="pos"
+      :class="viewportPositionClasses[pos]"
+    />
+
+  </ToastProvider>
+</template>
+```
+
+**Position viewports**: Reka UI uses one `ToastViewport` for all toasts by default. To support multiple positions, render one `ToastViewport` per distinct position group and filter toasts per viewport. Toasts with different positions should render in the correct viewport.
+
+> **Simplification allowed**: For the initial implementation it is acceptable to use a single viewport positioned `bottom-right`. The position mapping can be added in a follow-up once the migration is complete. Document this decision in the PR.
+
+**`handleOpenChange`**: When Reka fires `openChange(false)` (after the exit animation finishes), remove the record from `toastRecords`.
+
+---
+
+## 5 — Design Tokens
+
+### Add to `web/src/lib/styles/tokens/component.css` — inside `:root { }`
+
+```css
+/* ── Toast ─────────────────────────────────────────────── */
+/* success */
+--color-toast-success-bg:     var(--color-success-50);
+--color-toast-success-border: var(--color-success-500);
+--color-toast-success-icon:   var(--color-success-700);
+
+/* error */
+--color-toast-error-bg:       var(--color-error-50);
+--color-toast-error-border:   var(--color-error-400);
+--color-toast-error-icon:     var(--color-error-600);
+
+/* warning */
+--color-toast-warning-bg:     var(--color-warning-50);
+--color-toast-warning-border: var(--color-warning-400);
+--color-toast-warning-icon:   var(--color-warning-600);
+
+/* info */
+--color-toast-info-bg:        var(--color-primary-50);
+--color-toast-info-border:    var(--color-primary-300);
+--color-toast-info-icon:      var(--color-primary-600);
+
+/* loading / default */
+--color-toast-loading-bg:     var(--color-surface-overlay);
+--color-toast-loading-border: var(--color-border-default);
+--color-toast-loading-icon:   var(--color-primary-600);
+--color-toast-default-bg:     var(--color-surface-overlay);
+--color-toast-default-border: var(--color-border-default);
+
+/* shared foreground */
+--color-toast-fg:             var(--color-text-primary);
+--color-toast-fg-secondary:   var(--color-text-secondary);
+--color-toast-action-text:    var(--color-primary-600);
+--color-toast-action-hover:   var(--color-primary-700);
+--shadow-toast:               var(--shadow-lg);
+```
+
+Also add the same tokens inside `@theme inline { }` in `component.css` (self-referencing, as all other component tokens do):
+
+```css
+--color-toast-success-bg:     var(--color-toast-success-bg);
+--color-toast-success-border: var(--color-toast-success-border);
+/* ... repeat for every token ... */
+```
+
+### Add to `web/src/lib/styles/tokens/dark.css` — inside `.dark { }`
+
+```css
+/* ── Toast (dark) ───────────────────────────────────────── */
+--color-toast-success-bg:     color-mix(in srgb, var(--color-success-700) 25%, var(--color-grey-900));
+--color-toast-success-border: var(--color-success-700);
+--color-toast-success-icon:   var(--color-success-500);
+
+--color-toast-error-bg:       color-mix(in srgb, var(--color-error-700) 25%, var(--color-grey-900));
+--color-toast-error-border:   var(--color-error-600);
+--color-toast-error-icon:     var(--color-error-400);
+
+--color-toast-warning-bg:     color-mix(in srgb, var(--color-warning-700) 20%, var(--color-grey-900));
+--color-toast-warning-border: var(--color-warning-500);
+--color-toast-warning-icon:   var(--color-warning-400);
+
+--color-toast-info-bg:        color-mix(in srgb, var(--color-primary-800) 40%, var(--color-grey-900));
+--color-toast-info-border:    var(--color-primary-700);
+--color-toast-info-icon:      var(--color-primary-400);
+
+--color-toast-loading-bg:     var(--color-surface-overlay);
+--color-toast-loading-border: var(--color-border-default);
+--color-toast-action-text:    var(--color-primary-400);
+--color-toast-action-hover:   var(--color-primary-300);
+```
+
+---
+
+## 6 — App.vue Change (one line)
+
+```vue
+<!-- web/src/App.vue — add near the bottom of the template, before </template> -->
+<OToastProvider />
+
+<!-- In <script setup>: -->
+import OToastProvider from "@/lib/feedback/Toast/OToastProvider.vue"
+```
+
+> `OToastProvider` must be mounted **outside** any conditional rendering (not inside `v-if`). Place it as a sibling of the router view, not nested inside a layout component.
+
+---
+
+## 7 — Migration: Call-Site Patterns
+
+### Pattern A — Simple one-shot toast
+
+```ts
+// BEFORE
+import { useQuasar } from "quasar"
+const $q = useQuasar()
+$q.notify({ type: "positive", message: "Saved!" })
+
+// AFTER
+import { useToast } from "@/lib/feedback/Toast/useToast"
+const { toast } = useToast()
+toast({ variant: "success", message: "Saved!" })
+```
+
+### Pattern B — Loading spinner + dismiss on complete
+
+```ts
+// BEFORE
+const dismiss = $q.notify({ spinner: true, message: "Loading...", timeout: 0 })
+// ... async work ...
+dismiss()
+// or:
+dismiss({ type: "positive", message: "Done!" })
+
+// AFTER
+const dismiss = toast({ variant: "loading", message: "Loading..." })
+// ... async work ...
+dismiss()
+// or:
+dismiss({ variant: "success", message: "Done!" })
+```
+
+### Pattern C — Static Notify.create() in service files
+
+```ts
+// BEFORE  (httpsearch.ts, main.ts, http.ts)
+import { Notify } from "quasar"
+Notify.create({ type: "negative", message: "Bad Request", position: "bottom-right" })
+
+// AFTER
+import { toast } from "@/lib/feedback/Toast/useToast"
+toast({ variant: "error", message: "Bad Request", position: "bottom-right" })
+```
+
+### Pattern D — main.ts chunk-load error (was using html: true + actions)
+
+```ts
+// AFTER — use action prop instead of html: true
+toast({
+  variant: "error",
+  message: i18n.global.t("common.chunkLoadErrorMsg"),
+  timeout: 0,
+  position: "top-center",
+  action: {
+    label: i18n.global.t("common.refresh"),
+    handler: () => window.location.reload(),
+  },
+})
+```
+
+### Type mapping — Quasar → O2
+
+| Quasar `type` | O2 `variant` |
+|---------------|-------------|
+| `"positive"` | `"success"` |
+| `"negative"` | `"error"` |
+| `"warning"` | `"warning"` |
+| `"info"` | `"info"` |
+| absent | `"default"` |
+| `spinner: true` | `"loading"` |
+
+### Position mapping
+
+| Quasar `position` | O2 `position` |
+|-------------------|--------------|
+| `"top"` | `"top-center"` |
+| `"bottom"` | `"bottom-center"` |
+| `"bottom-right"` | `"bottom-right"` |
+| absent | `"bottom-right"` (global default) |
+
+---
+
+## 8 — Migration Scope (all files that need updating)
+
+### Service / utility files (~6 call sites — do first, unblocks Quasar removal from these modules)
+
+| File | Change |
+|------|--------|
+| `src/main.ts` | `Notify.create(...)` → `toast(...)` — 1 call site, Pattern D |
+| `src/services/httpsearch.ts` | `Notify.create(...)` → `toast(...)` — 4 call sites, Pattern C |
+| `src/services/http.ts` | `useQuasar()` → `toast` — check call sites |
+| `src/test/__mocks__/http.ts` | Update mock to remove `Notify.create` usage |
+
+### Composables (~4 files)
+
+| File | Notes |
+|------|-------|
+| `src/composables/useTraces.ts` | Pattern A — 2 call sites |
+| `src/composables/useStreams.ts` | Pattern A / B — 2 call sites |
+| `src/composables/useActions.ts` | Pattern A |
+| `src/composables/useAlertForm.ts` | Pattern A — ~5 call sites |
+
+### Views — high density (~15 files)
+
+> Migrate one file at a time. Each PR should be a complete file migration, not a partial one.
+
+| File | Approx. call sites |
+|------|--------------------|
+| `src/views/Dashboards/Dashboards.vue` | ~10 |
+| `src/views/LogStream.vue` | ~8 |
+| `src/views/Ingestion.vue` | ~10 |
+| `src/views/RUM/UploadSourceMaps.vue` | ~5 |
+| `src/views/RUM/SourceMaps.vue` | ~2 |
+| `src/views/RUM/AppSessions.vue` | ~2 |
+| `src/views/RUM/AppErrors.vue` | ~1 |
+| `src/views/UsageTab.vue` | ~2 |
+| `src/views/About.vue` | ~1 |
+| `src/views/StreamExplorer.vue` | ~2 |
+| `src/views/Login.vue` | ~2 |
+| `src/views/PromQL/QueryBuilder.vue` | ~3 |
+| `src/views/AwsMarketplaceSetup.vue` | ~2 |
+| `src/views/AzureMarketplaceSetup.vue` | ~2 |
+| `src/views/AddAlertView.vue` | ~2 |
+| `src/views/MemberSubscription.vue` | ~1 |
+| `src/views/HomeChatHistory.vue` | uses `useQuasar` — check if `notify` is actually called |
+
+### Plugins (~6 files)
+
+| File | Approx. call sites |
+|------|--------------------|
+| `src/plugins/traces/Index.vue` | ~2 |
+| `src/plugins/traces/TraceDetails.vue` | ~3 |
+| `src/plugins/traces/TraceDetailsSidebar.vue` | ~4 |
+| `src/plugins/traces/ServiceGraphNodeSidePanel.vue` | ~3 |
+| `src/plugins/traces/SearchBar.vue` | ~1 |
+| `src/plugins/logs/SearchJobInspector.vue` | ~2 |
+
+### Components (~20+ files)
+
+Run this to get the full list before starting:
+```powershell
+grep -rl "useQuasar\|Notify\.create" web/src/components web/src/enterprise --include="*.vue" --include="*.ts"
+```
+
+### After all call sites are migrated
+
+1. Search for any remaining `import { useQuasar } from "quasar"` where `notify` was the **only** usage — remove the `useQuasar` import entirely.
+2. Search for any remaining `import { Notify } from "quasar"` — remove.
+3. If `useQuasar` is still needed in a file for non-notify purposes (e.g. `q.dialog`), leave the import and note it for the next Quasar removal sprint.
+
+---
+
+## 9 — eslint.config.js
+
+The Quasar notify API is not a template element, so no `no-restricted-syntax` template rule applies. Instead, add a **no-restricted-imports** entry to prevent future `Notify.create` imports:
+
+```js
+// web/eslint.config.js — inside the rules object
+"no-restricted-imports": [
+  "error",
+  {
+    paths: [
+      // existing entries...
+      {
+        name: "quasar",
+        importNames: ["Notify"],
+        message: 'Use toast() from "@/lib/feedback/Toast/useToast" instead of Quasar Notify.',
+      },
+    ],
+  },
+],
+```
+
+> Do not remove or modify existing entries — append only.
+
+---
+
+## 10 — Tests
+
+### `useToast.spec.ts`
+
+- `toast()` adds a record to `toastRecords`
+- `toast()` returns a `DismissFn`
+- Calling `DismissFn()` sets `open: false` on the record
+- Calling `DismissFn({ variant, message })` fires a new toast
+- Default `timeout` is applied correctly per variant
+- `timeout: 0` is respected (record stays open)
+- Generating multiple toasts produces unique `id` values
+
+### `OToast.spec.ts`
+
+- Renders `message` text
+- Renders `title` when provided
+- Renders the correct icon per `variant`
+- Does not render an icon for `variant="default"`
+- `loading` variant renders a spinning icon
+- Renders the action button when `action` prop is provided
+- Calls `action.handler` when action button is clicked
+- Emits `openChange(false)` when close button is clicked
+- ARIA: `role="alert"` for `error` / `warning`; `role="status"` for others
+
+### `OToastProvider.spec.ts`
+
+- Renders nothing when `toastRecords` is empty
+- Renders one `OToast` per record in `toastRecords`
+- Removes a record after `openChange(false)` fires
+
+---
+
+## 11 — Definition of Done
+
+- [ ] `useToast.ts` — module-level singleton, `toast()` function exported directly and via `useToast()`
+- [ ] `OToast.vue` — all 6 variants render correctly
+- [ ] `OToastProvider.vue` — mounted in `App.vue`, renders active toasts
+- [ ] Design tokens added to `component.css` (light) and `dark.css` (dark overrides)
+- [ ] All tokens verified visually in browser in **both** light and dark mode — icon colors must be fully visible at rest
+- [ ] `eslint.config.js` updated with `no-restricted-imports` for `Notify`
+- [ ] All tests pass — `useToast.spec`, `OToast.spec`, `OToastProvider.spec`
+- [ ] Service files migrated (`main.ts`, `httpsearch.ts`, `http.ts`) — these files no longer import from `quasar` for notification purposes
+- [ ] Composables migrated (`useTraces`, `useStreams`, `useActions`, `useAlertForm`)
+- [ ] All remaining `$q.notify` / `q.notify` call sites migrated (views, plugins, components, enterprise)
+- [ ] No `import { Notify } from "quasar"` remains in the codebase
+- [ ] Files that imported `useQuasar` **only** for `notify` no longer import `useQuasar`
+
+---
+
+## Reference Files
+
+| File | Purpose |
+|------|---------|
+| `web/src/lib/core/Button/OButton.vue` | Variant class-map pattern to follow |
+| `web/src/lib/core/Button/OButton.types.ts` | TypeScript types pattern |
+| `web/src/lib/styles/tokens/component.css` | Where to add new tokens |
+| `web/src/lib/styles/tokens/dark.css` | Where to add dark overrides |
+| `web/src/lib/styles/tailwind.css` | Tailwind entry — `prefix(tw)` defined here |
+| `web/src/App.vue` | Where to mount `<OToastProvider />` |

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -123,7 +123,19 @@ export default [
           element: 'q-btn-dropdown',
           message: 'Use <OButton> with <ODropdown> instead of <q-btn-dropdown>.'
         }
-      ]
+      ],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'quasar',
+              importNames: ['Notify'],
+              message: 'Use toast() from "@/lib/feedback/Toast/useToast" instead of Quasar Notify.',
+            },
+          ],
+        },
+      ],
     }
   },
   {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <router-view
     :class="store.state.theme === 'dark' ? 'dark-theme' : 'light-theme'"
   ></router-view>
+  <OToastProvider />
 </template>
 
 <script lang="ts">
@@ -26,8 +27,10 @@ import { useRouter } from "vue-router";
 import { onMounted, watch } from "vue";
 import config from "@/aws-exports";
 import { applyThemeColors } from "@/utils/theme";
+import OToastProvider from "@/lib/feedback/Toast/OToastProvider.vue";
 
 export default {
+  components: { OToastProvider },
   setup() {
     const store = useStore();
     const router = useRouter();

--- a/web/src/lib/feedback/Toast/OToast.spec.ts
+++ b/web/src/lib/feedback/Toast/OToast.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, afterEach, nextTick } from "vitest"
+import { mount } from "@vue/test-utils"
+import { h, nextTick as vueNextTick } from "vue"
+import { ToastProvider, ToastViewport } from "reka-ui"
+import OToast from "./OToast.vue"
+import type { ToastProps } from "./OToast.types"
+
+// ToastViewport uses Teleport to portal its <ol> into document.body.
+// We include a ToastViewport in the wrapper, mount with attachTo: document.body,
+// and query document.body for rendered content.
+function mountToast(props: ToastProps) {
+  return mount(
+    {
+      render() {
+        return h(ToastProvider, { duration: 0 }, () => [
+          h(OToast, props),
+          h(ToastViewport),
+        ])
+      },
+    },
+    { attachTo: document.body },
+  )
+}
+
+afterEach(() => {
+  document.body.innerHTML = ""
+})
+
+describe("OToast", () => {
+  it("renders message text", async () => {
+    mountToast({ id: "1", open: true, message: "Hello world" })
+    await vueNextTick()
+    expect(document.body.textContent).toContain("Hello world")
+  })
+
+  it("renders title when provided", async () => {
+    mountToast({ id: "1", open: true, message: "Body text", title: "My Title" })
+    await vueNextTick()
+    expect(document.body.textContent).toContain("My Title")
+    expect(document.body.textContent).toContain("Body text")
+  })
+
+  it("renders success icon for success variant", async () => {
+    mountToast({ id: "1", open: true, message: "Done", variant: "success" })
+    await vueNextTick()
+    expect(document.body.querySelector("svg")).not.toBeNull()
+  })
+
+  it("renders error icon for error variant", async () => {
+    mountToast({ id: "1", open: true, message: "Error", variant: "error" })
+    await vueNextTick()
+    expect(document.body.querySelector("svg")).not.toBeNull()
+  })
+
+  it("renders warning icon for warning variant", async () => {
+    mountToast({ id: "1", open: true, message: "Warn", variant: "warning" })
+    await vueNextTick()
+    expect(document.body.querySelector("svg")).not.toBeNull()
+  })
+
+  it("renders info icon for info variant", async () => {
+    mountToast({ id: "1", open: true, message: "FYI", variant: "info" })
+    await vueNextTick()
+    expect(document.body.querySelector("svg")).not.toBeNull()
+  })
+
+  it("does not render an icon for default variant", async () => {
+    mountToast({ id: "1", open: true, message: "Plain", variant: "default" })
+    await vueNextTick()
+    // default variant has no variant-icon div — only the dismiss button X renders
+    const toastEl = document.body.querySelector('[role="status"]')
+    expect(toastEl).not.toBeNull()
+    // The variant icon is wrapped in a <div aria-hidden="true">; close button X is not
+    expect(toastEl!.querySelector('div[aria-hidden="true"]')).toBeNull()
+  })
+
+  it("renders a spinning icon for loading variant", async () => {
+    mountToast({ id: "1", open: true, message: "Loading…", variant: "loading" })
+    await vueNextTick()
+    const svg = document.body.querySelector("svg")
+    expect(svg).not.toBeNull()
+    expect(svg!.classList.toString()).toContain("animate-spin")
+  })
+
+  it("renders action button when action prop is provided", async () => {
+    const handler = vi.fn()
+    mountToast({
+      id: "1",
+      open: true,
+      message: "Reload needed",
+      action: { label: "Refresh", handler },
+    })
+    await vueNextTick()
+    const btn = document.body.querySelector('button[type="button"]')
+    expect(btn).not.toBeNull()
+    expect(btn!.textContent).toContain("Refresh")
+  })
+
+  it("calls action.handler when action button is clicked", async () => {
+    const handler = vi.fn()
+    mountToast({
+      id: "1",
+      open: true,
+      message: "Reload needed",
+      action: { label: "Refresh", handler },
+    })
+    await vueNextTick()
+    const btn = document.body.querySelector<HTMLButtonElement>('button[type="button"]')
+    btn!.click()
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it("emits openChange(false) when close button is clicked", async () => {
+    const wrapper = mountToast({ id: "1", open: true, message: "Hello" })
+    await vueNextTick()
+    const closeBtn = document.body.querySelector<HTMLButtonElement>(
+      'button[aria-label="Dismiss notification"]',
+    )
+    expect(closeBtn).not.toBeNull()
+    closeBtn!.click()
+    await vueNextTick()
+    const emitted = wrapper.findComponent(OToast).emitted("openChange")
+    expect(emitted).toBeTruthy()
+    expect(emitted![0]).toEqual([false])
+  })
+
+  it("has role=alert for error variant", async () => {
+    mountToast({ id: "1", open: true, message: "Bad", variant: "error" })
+    await vueNextTick()
+    expect(document.body.querySelector('[role="alert"]')).not.toBeNull()
+  })
+
+  it("has role=alert for warning variant", async () => {
+    mountToast({ id: "1", open: true, message: "Careful", variant: "warning" })
+    await vueNextTick()
+    expect(document.body.querySelector('[role="alert"]')).not.toBeNull()
+  })
+
+  it("has role=status for success variant", async () => {
+    mountToast({ id: "1", open: true, message: "Great", variant: "success" })
+    await vueNextTick()
+    expect(document.body.querySelector('[role="status"]')).not.toBeNull()
+  })
+
+  it("has role=status for info variant", async () => {
+    mountToast({ id: "1", open: true, message: "Note", variant: "info" })
+    await vueNextTick()
+    expect(document.body.querySelector('[role="status"]')).not.toBeNull()
+  })
+})

--- a/web/src/lib/feedback/Toast/OToast.types.ts
+++ b/web/src/lib/feedback/Toast/OToast.types.ts
@@ -1,0 +1,45 @@
+export type ToastVariant =
+  | "success"
+  | "error"
+  | "warning"
+  | "info"
+  | "loading"
+  | "default"
+
+// Positions mirror Quasar's subset actually used in the codebase
+export type ToastPosition =
+  | "top-center"
+  | "top-right"
+  | "top-left"
+  | "bottom-center"
+  | "bottom-right" // ← global default
+  | "bottom-left"
+
+export interface ToastAction {
+  label: string
+  handler: () => void
+}
+
+export interface ToastOptions {
+  /** Visual style + icon set */
+  variant?: ToastVariant
+  /** Primary message text — plain string only (no HTML) */
+  message: string
+  /** Optional bold title above message */
+  title?: string
+  /** Auto-dismiss delay in ms. 0 = persistent. Defaults per variant. */
+  timeout?: number
+  /** Where the toast appears on screen */
+  position?: ToastPosition
+  /** Optional action button rendered inside the toast */
+  action?: ToastAction
+}
+
+export interface ToastProps extends ToastOptions {
+  id: string
+  open: boolean
+}
+
+export interface ToastEmits {
+  (e: "openChange", value: boolean): void
+}

--- a/web/src/lib/feedback/Toast/OToast.vue
+++ b/web/src/lib/feedback/Toast/OToast.vue
@@ -1,0 +1,182 @@
+<!-- Copyright 2026 OpenObserve Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<script setup lang="ts">
+import type { ToastProps, ToastEmits } from "./OToast.types"
+import { computed } from "vue"
+import {
+  ToastRoot,
+  ToastTitle,
+  ToastDescription,
+  ToastAction,
+  ToastClose,
+} from "reka-ui"
+import {
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Info,
+  Loader2,
+  X,
+} from "lucide-vue-next"
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(defineProps<ToastProps>(), {
+  variant: "default",
+  position: "bottom-right",
+  open: true,
+})
+
+const emit = defineEmits<ToastEmits>()
+
+// ── Variant class maps ───────────────────────────────────────────────────────
+
+const variantClasses: Record<NonNullable<ToastProps["variant"]>, string> = {
+  success: [
+    "tw:bg-toast-success-bg tw:border tw:border-toast-success-border",
+    "tw:text-toast-fg",
+  ].join(" "),
+  error: [
+    "tw:bg-toast-error-bg tw:border tw:border-toast-error-border",
+    "tw:text-toast-fg",
+  ].join(" "),
+  warning: [
+    "tw:bg-toast-warning-bg tw:border tw:border-toast-warning-border",
+    "tw:text-toast-fg",
+  ].join(" "),
+  info: [
+    "tw:bg-toast-info-bg tw:border tw:border-toast-info-border",
+    "tw:text-toast-fg",
+  ].join(" "),
+  loading: [
+    "tw:bg-toast-loading-bg tw:border tw:border-toast-loading-border",
+    "tw:text-toast-fg",
+  ].join(" "),
+  default: [
+    "tw:bg-toast-default-bg tw:border tw:border-toast-default-border",
+    "tw:text-toast-fg",
+  ].join(" "),
+}
+
+const iconColorClasses: Record<NonNullable<ToastProps["variant"]>, string> = {
+  success: "tw:text-toast-success-icon",
+  error: "tw:text-toast-error-icon",
+  warning: "tw:text-toast-warning-icon",
+  info: "tw:text-toast-info-icon",
+  loading: "tw:text-toast-loading-icon",
+  default: "tw:text-toast-fg",
+}
+
+// ── Computed ─────────────────────────────────────────────────────────────────
+
+const rootRole = computed<"alert" | "status">(() =>
+  props.variant === "error" || props.variant === "warning" ? "alert" : "status",
+)
+
+const hasIcon = computed(() => props.variant !== "default")
+
+const screenReaderTitle = computed(() =>
+  props.title ? props.title : props.message,
+)
+</script>
+
+<template>
+  <ToastRoot
+    :open="open"
+    :duration="0"
+    :class="[
+      'tw:flex tw:gap-3 tw:items-start tw:w-80 tw:max-w-sm tw:rounded-lg tw:p-4 tw:shadow-toast',
+      'tw:data-[state=open]:animate-in tw:data-[state=open]:fade-in-0 tw:data-[state=open]:slide-in-from-bottom-4',
+      'tw:data-[state=closed]:animate-out tw:data-[state=closed]:fade-out-0 tw:data-[state=closed]:slide-out-to-bottom-4',
+      variantClasses[variant ?? 'default'],
+    ]"
+    :role="rootRole"
+    @update:open="(val) => emit('openChange', val)"
+  >
+    <!-- Icon -->
+    <div
+      v-if="hasIcon"
+      :class="['tw:mt-0.5 tw:shrink-0', iconColorClasses[variant ?? 'default']]"
+      aria-hidden="true"
+    >
+      <Loader2
+        v-if="variant === 'loading'"
+        class="tw:size-5 tw:animate-spin"
+      />
+      <CheckCircle2
+        v-else-if="variant === 'success'"
+        class="tw:size-5"
+      />
+      <XCircle
+        v-else-if="variant === 'error'"
+        class="tw:size-5"
+      />
+      <AlertTriangle
+        v-else-if="variant === 'warning'"
+        class="tw:size-5"
+      />
+      <Info
+        v-else-if="variant === 'info'"
+        class="tw:size-5"
+      />
+    </div>
+
+    <!-- Content -->
+    <div class="tw:flex-1 tw:min-w-0">
+      <!-- Title (always present for screen readers) -->
+      <ToastTitle
+        :class="[
+          'tw:text-sm tw:font-semibold tw:text-toast-fg tw:leading-snug',
+          !title ? 'tw:sr-only' : ''
+        ]"
+      >
+        {{ title ?? screenReaderTitle }}
+      </ToastTitle>
+
+      <!-- Message (visible; hidden from SR when title is absent since title carries the text) -->
+      <ToastDescription
+        v-if="title"
+        class="tw:text-sm tw:text-toast-fg-secondary tw:mt-1 tw:leading-snug"
+      >
+        {{ message }}
+      </ToastDescription>
+
+      <!-- Action button -->
+      <ToastAction
+        v-if="action"
+        :alt-text="action.label"
+        as-child
+      >
+        <button
+          type="button"
+          class="tw:mt-2 tw:text-sm tw:font-medium tw:text-toast-action-text tw:hover:text-toast-action-hover tw:focus-visible:outline-none tw:focus-visible:underline"
+          @click="action.handler"
+        >
+          {{ action.label }}
+        </button>
+      </ToastAction>
+    </div>
+
+    <!-- Dismiss button -->
+    <ToastClose
+      class="tw:shrink-0 tw:mt-0.5 tw:rounded tw:p-0.5 tw:text-toast-fg-secondary tw:hover:text-toast-fg tw:focus-visible:outline-none tw:focus-visible:ring-2 tw:focus-visible:ring-toast-info-border"
+      aria-label="Dismiss notification"
+    >
+      <X class="tw:size-4" aria-hidden="true" />
+    </ToastClose>
+  </ToastRoot>
+</template>

--- a/web/src/lib/feedback/Toast/OToastProvider.spec.ts
+++ b/web/src/lib/feedback/Toast/OToastProvider.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { mount } from "@vue/test-utils"
+import { h, nextTick } from "vue"
+import OToastProvider from "./OToastProvider.vue"
+import { toastRecords, toast } from "./useToast"
+
+beforeEach(() => {
+  toastRecords.splice(0, toastRecords.length)
+})
+
+describe("OToastProvider", () => {
+  it("renders nothing (no OToast elements) when toastRecords is empty", () => {
+    const wrapper = mount(OToastProvider, { attachTo: document.body })
+    // No ToastRoot elements should be rendered
+    expect(wrapper.findAll('[role="status"], [role="alert"]')).toHaveLength(0)
+  })
+
+  it("renders one OToast per record in toastRecords", async () => {
+    toast({ variant: "success", message: "First", timeout: 0 })
+    toast({ variant: "error", message: "Second", timeout: 0 })
+
+    const wrapper = mount(OToastProvider, { attachTo: document.body })
+    await nextTick()
+
+    const toastElements = wrapper.findAll('[role="status"], [role="alert"]')
+    expect(toastElements).toHaveLength(2)
+  })
+
+  it("removes a record after openChange(false) fires", async () => {
+    toast({ variant: "info", message: "Temp", timeout: 0 })
+
+    const wrapper = mount(OToastProvider, { attachTo: document.body })
+    await nextTick()
+
+    expect(toastRecords).toHaveLength(1)
+
+    // Simulate Reka firing openChange(false) by directly calling the handler
+    const id = toastRecords[0].id
+    // Manually trigger handleOpenChange by emitting on the OToast child
+    const oToast = wrapper.findComponent({ name: "OToast" })
+    oToast.vm.$emit("openChange", false)
+    await nextTick()
+
+    expect(toastRecords).toHaveLength(0)
+  })
+})

--- a/web/src/lib/feedback/Toast/OToastProvider.types.ts
+++ b/web/src/lib/feedback/Toast/OToastProvider.types.ts
@@ -1,0 +1,32 @@
+import type { ToastPosition } from "./OToast.types"
+
+export interface ToastProviderProps {
+  // no public props — all state comes from the module-level store
+}
+
+export const viewportPositionClasses: Record<ToastPosition, string> = {
+  "top-center": [
+    "tw:fixed tw:top-4 tw:left-1/2 tw:-translate-x-1/2",
+    "tw:flex tw:flex-col tw:gap-2 tw:z-[9999]",
+  ].join(" "),
+  "top-right": [
+    "tw:fixed tw:top-4 tw:end-4",
+    "tw:flex tw:flex-col tw:gap-2 tw:z-[9999]",
+  ].join(" "),
+  "top-left": [
+    "tw:fixed tw:top-4 tw:start-4",
+    "tw:flex tw:flex-col tw:gap-2 tw:z-[9999]",
+  ].join(" "),
+  "bottom-center": [
+    "tw:fixed tw:bottom-4 tw:left-1/2 tw:-translate-x-1/2",
+    "tw:flex tw:flex-col-reverse tw:gap-2 tw:z-[9999]",
+  ].join(" "),
+  "bottom-right": [
+    "tw:fixed tw:bottom-4 tw:end-4",
+    "tw:flex tw:flex-col-reverse tw:gap-2 tw:z-[9999]",
+  ].join(" "),
+  "bottom-left": [
+    "tw:fixed tw:bottom-4 tw:start-4",
+    "tw:flex tw:flex-col-reverse tw:gap-2 tw:z-[9999]",
+  ].join(" "),
+}

--- a/web/src/lib/feedback/Toast/OToastProvider.vue
+++ b/web/src/lib/feedback/Toast/OToastProvider.vue
@@ -1,0 +1,68 @@
+<!-- Copyright 2026 OpenObserve Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { ToastProvider, ToastViewport } from "reka-ui"
+import { useToast } from "./useToast"
+import { toastRecords } from "./useToast"
+import { viewportPositionClasses } from "./OToastProvider.types"
+import type { ToastPosition } from "./OToast.types"
+import OToast from "./OToast.vue"
+
+const { toasts } = useToast()
+
+// Collect distinct positions from active toasts.
+// NOTE: For the initial implementation a single bottom-right viewport is used.
+// Multi-position support (one viewport per position bucket) will be added in a
+// follow-up once the full Quasar migration is complete. See toast.md § 4.
+const activePositions = computed<ToastPosition[]>(() => {
+  const seen = new Set<ToastPosition>()
+  for (const t of toasts) {
+    seen.add(t.position)
+  }
+  // Always show at least the default position so the viewport is mounted
+  seen.add("bottom-right")
+  return [...seen]
+})
+
+function handleOpenChange(id: string, open: boolean): void {
+  if (!open) {
+    // Remove the record after Reka's exit animation finishes
+    const idx = toastRecords.findIndex((r) => r.id === id)
+    if (idx !== -1) {
+      toastRecords.splice(idx, 1)
+    }
+  }
+}
+</script>
+
+<template>
+  <ToastProvider swipe-direction="right" :duration="0">
+    <OToast
+      v-for="t in toasts"
+      :key="t.id"
+      v-bind="t"
+      @open-change="(open) => handleOpenChange(t.id, open)"
+    />
+
+    <ToastViewport
+      v-for="pos in activePositions"
+      :key="pos"
+      :class="viewportPositionClasses[pos]"
+    />
+  </ToastProvider>
+</template>

--- a/web/src/lib/feedback/Toast/useToast.spec.ts
+++ b/web/src/lib/feedback/Toast/useToast.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { toast, useToast, toastRecords } from "./useToast"
+
+// Reset module state between tests
+beforeEach(() => {
+  // Clear all toasts between tests
+  toastRecords.splice(0, toastRecords.length)
+  vi.useFakeTimers()
+})
+
+describe("toast()", () => {
+  it("adds a record to toastRecords", () => {
+    toast({ variant: "success", message: "Saved!" })
+    expect(toastRecords).toHaveLength(1)
+    expect(toastRecords[0].message).toBe("Saved!")
+    expect(toastRecords[0].open).toBe(true)
+  })
+
+  it("returns a DismissFn", () => {
+    const dismiss = toast({ variant: "info", message: "Hello" })
+    expect(typeof dismiss).toBe("function")
+  })
+
+  it("calling DismissFn() sets open: false on the record", () => {
+    const dismiss = toast({ variant: "success", message: "Done" })
+    expect(toastRecords[0].open).toBe(true)
+    dismiss()
+    expect(toastRecords[0].open).toBe(false)
+  })
+
+  it("calling DismissFn with replacement closes current and fires new toast", () => {
+    const dismiss = toast({ variant: "loading", message: "Loading..." })
+    expect(toastRecords).toHaveLength(1)
+    dismiss({ variant: "success", message: "Done!" })
+    expect(toastRecords[0].open).toBe(false)
+    expect(toastRecords).toHaveLength(2)
+    expect(toastRecords[1].variant).toBe("success")
+    expect(toastRecords[1].message).toBe("Done!")
+  })
+
+  it("applies default timeout for success variant", () => {
+    toast({ variant: "success", message: "OK" })
+    expect(toastRecords[0].timeout).toBe(3000)
+  })
+
+  it("applies default timeout for error variant", () => {
+    toast({ variant: "error", message: "Fail" })
+    expect(toastRecords[0].timeout).toBe(5000)
+  })
+
+  it("applies default timeout for warning variant", () => {
+    toast({ variant: "warning", message: "Warn" })
+    expect(toastRecords[0].timeout).toBe(4000)
+  })
+
+  it("applies default timeout for info variant", () => {
+    toast({ variant: "info", message: "FYI" })
+    expect(toastRecords[0].timeout).toBe(4000)
+  })
+
+  it("applies timeout: 0 for loading variant (persistent)", () => {
+    toast({ variant: "loading", message: "Working..." })
+    expect(toastRecords[0].timeout).toBe(0)
+  })
+
+  it("applies default timeout for default variant", () => {
+    toast({ message: "Hello" })
+    expect(toastRecords[0].timeout).toBe(3000)
+  })
+
+  it("respects explicit timeout: 0 (persistent)", () => {
+    toast({ variant: "success", message: "Persistent", timeout: 0 })
+    vi.advanceTimersByTime(10000)
+    expect(toastRecords[0].open).toBe(true)
+  })
+
+  it("auto-dismisses after timeout", () => {
+    toast({ variant: "success", message: "Auto", timeout: 1000 })
+    expect(toastRecords[0].open).toBe(true)
+    vi.advanceTimersByTime(1000)
+    expect(toastRecords[0].open).toBe(false)
+  })
+
+  it("generates unique ids for multiple toasts", () => {
+    toast({ message: "A" })
+    toast({ message: "B" })
+    toast({ message: "C" })
+    const ids = toastRecords.map((r) => r.id)
+    const unique = new Set(ids)
+    expect(unique.size).toBe(3)
+  })
+})
+
+describe("useToast()", () => {
+  it("returns toast function and toasts array", () => {
+    const { toast: t, toasts } = useToast()
+    expect(typeof t).toBe("function")
+    expect(Array.isArray(toasts)).toBe(true)
+  })
+
+  it("toasts array is the same reactive store as toastRecords", () => {
+    const { toasts } = useToast()
+    toast({ message: "Hello" })
+    expect(toasts).toHaveLength(1)
+  })
+})

--- a/web/src/lib/feedback/Toast/useToast.ts
+++ b/web/src/lib/feedback/Toast/useToast.ts
@@ -1,0 +1,106 @@
+import { reactive } from "vue"
+import type { ToastVariant, ToastOptions, ToastPosition } from "./OToast.types"
+
+// ── Internal record shape ────────────────────────────────────────────────────
+
+interface ToastRecord {
+  id: string
+  variant: ToastVariant
+  message: string
+  title?: string
+  timeout: number // ms; 0 = persistent
+  position: ToastPosition
+  open: boolean // Reka controls enter/exit animation via this
+  action?: ToastOptions["action"]
+}
+
+// ── Default timeouts per variant ─────────────────────────────────────────────
+
+const defaultTimeouts: Record<ToastVariant, number> = {
+  success: 3000,
+  error: 5000,
+  warning: 4000,
+  info: 4000,
+  loading: 0,
+  default: 3000,
+}
+
+// ── Module-level singleton — survives outside Vue lifecycle ──────────────────
+
+const toastRecords = reactive<ToastRecord[]>([])
+
+let idCounter = 0
+
+// ── Public dismiss-function type ─────────────────────────────────────────────
+
+type DismissFn = (replacement?: Pick<ToastOptions, "variant" | "message" | "title">) => void
+
+// ── Core toast() function ────────────────────────────────────────────────────
+
+function toast(options: ToastOptions): DismissFn {
+  const variant: ToastVariant = options.variant ?? "default"
+  const position: ToastPosition = options.position ?? "bottom-right"
+  const timeout =
+    options.timeout !== undefined ? options.timeout : defaultTimeouts[variant]
+
+  const id = String(++idCounter)
+
+  const record: ToastRecord = {
+    id,
+    variant,
+    message: options.message,
+    title: options.title,
+    timeout,
+    position,
+    open: true,
+    action: options.action,
+  }
+
+  toastRecords.push(record)
+
+  // Auto-dismiss when timeout > 0
+  if (timeout > 0) {
+    setTimeout(() => {
+      dismiss(id)
+    }, timeout)
+  }
+
+  const dismissFn: DismissFn = (replacement) => {
+    dismiss(id)
+    if (replacement) {
+      toast({
+        variant: replacement.variant,
+        message: replacement.message,
+        title: replacement.title,
+        position,
+      })
+    }
+  }
+
+  return dismissFn
+}
+
+function dismiss(id: string): void {
+  const record = toastRecords.find((r) => r.id === id)
+  if (record) {
+    record.open = false
+  }
+}
+
+// ── useToast composable — for use inside Vue components ─────────────────────
+
+export interface UseToastReturn {
+  toast: (options: ToastOptions) => DismissFn
+  toasts: ToastRecord[]
+}
+
+export function useToast(): UseToastReturn {
+  return {
+    toast,
+    toasts: toastRecords,
+  }
+}
+
+// ── Direct export — for use outside Vue tree (services, main.ts) ─────────────
+export { toast, toastRecords }
+export type { ToastRecord, DismissFn }

--- a/web/src/lib/styles/tokens/component.css
+++ b/web/src/lib/styles/tokens/component.css
@@ -157,6 +157,41 @@
   --color-tabs-focus-ring: var(--color-primary-400);
   --spacing-tabs-height: var(--spacing-10);
   --spacing-tabs-height-dense: var(--spacing-8);
+
+  /* ── Toast ─────────────────────────────────────────────── */
+  /* success */
+  --color-toast-success-bg:     var(--color-success-50);
+  --color-toast-success-border: var(--color-success-500);
+  --color-toast-success-icon:   var(--color-success-700);
+
+  /* error */
+  --color-toast-error-bg:       var(--color-error-50);
+  --color-toast-error-border:   var(--color-error-400);
+  --color-toast-error-icon:     var(--color-error-600);
+
+  /* warning */
+  --color-toast-warning-bg:     var(--color-warning-50);
+  --color-toast-warning-border: var(--color-warning-400);
+  --color-toast-warning-icon:   var(--color-warning-600);
+
+  /* info */
+  --color-toast-info-bg:        var(--color-primary-50);
+  --color-toast-info-border:    var(--color-primary-300);
+  --color-toast-info-icon:      var(--color-primary-600);
+
+  /* loading / default */
+  --color-toast-loading-bg:     var(--color-surface-overlay);
+  --color-toast-loading-border: var(--color-border-default);
+  --color-toast-loading-icon:   var(--color-primary-600);
+  --color-toast-default-bg:     var(--color-surface-overlay);
+  --color-toast-default-border: var(--color-border-default);
+
+  /* shared foreground */
+  --color-toast-fg:             var(--color-text-primary);
+  --color-toast-fg-secondary:   var(--color-text-secondary);
+  --color-toast-action-text:    var(--color-primary-600);
+  --color-toast-action-hover:   var(--color-primary-700);
+  --shadow-toast:               var(--shadow-lg);
 }
 
 /* ToggleGroup — primary variant (colored tray) */
@@ -310,4 +345,28 @@
   --color-tabs-focus-ring: var(--color-tabs-focus-ring);
   --spacing-tabs-height: var(--spacing-tabs-height);
   --spacing-tabs-height-dense: var(--spacing-tabs-height-dense);
+
+  /* Toast */
+  --color-toast-success-bg: var(--color-toast-success-bg);
+  --color-toast-success-border: var(--color-toast-success-border);
+  --color-toast-success-icon: var(--color-toast-success-icon);
+  --color-toast-error-bg: var(--color-toast-error-bg);
+  --color-toast-error-border: var(--color-toast-error-border);
+  --color-toast-error-icon: var(--color-toast-error-icon);
+  --color-toast-warning-bg: var(--color-toast-warning-bg);
+  --color-toast-warning-border: var(--color-toast-warning-border);
+  --color-toast-warning-icon: var(--color-toast-warning-icon);
+  --color-toast-info-bg: var(--color-toast-info-bg);
+  --color-toast-info-border: var(--color-toast-info-border);
+  --color-toast-info-icon: var(--color-toast-info-icon);
+  --color-toast-loading-bg: var(--color-toast-loading-bg);
+  --color-toast-loading-border: var(--color-toast-loading-border);
+  --color-toast-loading-icon: var(--color-toast-loading-icon);
+  --color-toast-default-bg: var(--color-toast-default-bg);
+  --color-toast-default-border: var(--color-toast-default-border);
+  --color-toast-fg: var(--color-toast-fg);
+  --color-toast-fg-secondary: var(--color-toast-fg-secondary);
+  --color-toast-action-text: var(--color-toast-action-text);
+  --color-toast-action-hover: var(--color-toast-action-hover);
+  --shadow-toast: var(--shadow-toast);
 }

--- a/web/src/lib/styles/tokens/dark.css
+++ b/web/src/lib/styles/tokens/dark.css
@@ -103,3 +103,27 @@
     --color-toggle-item-active-bg: var(--color-primary-800);
     --color-toggle-item-active-text: var(--color-primary-200);
 }
+
+/* ── Toast (dark) ───────────────────────────────────────── */
+.dark {
+    --color-toast-success-bg:     color-mix(in srgb, var(--color-success-700) 25%, var(--color-grey-900));
+    --color-toast-success-border: var(--color-success-700);
+    --color-toast-success-icon:   var(--color-success-500);
+
+    --color-toast-error-bg:       color-mix(in srgb, var(--color-error-700) 25%, var(--color-grey-900));
+    --color-toast-error-border:   var(--color-error-600);
+    --color-toast-error-icon:     var(--color-error-400);
+
+    --color-toast-warning-bg:     color-mix(in srgb, var(--color-warning-700) 20%, var(--color-grey-900));
+    --color-toast-warning-border: var(--color-warning-500);
+    --color-toast-warning-icon:   var(--color-warning-400);
+
+    --color-toast-info-bg:        color-mix(in srgb, var(--color-primary-800) 40%, var(--color-grey-900));
+    --color-toast-info-border:    var(--color-primary-700);
+    --color-toast-info-icon:      var(--color-primary-400);
+
+    --color-toast-loading-bg:     var(--color-surface-overlay);
+    --color-toast-loading-border: var(--color-border-default);
+    --color-toast-action-text:    var(--color-primary-400);
+    --color-toast-action-hover:   var(--color-primary-300);
+}


### PR DESCRIPTION
- Added OToast component for displaying toast messages with various variants (success, error, warning, info, loading, default).
- Created OToastProvider to manage toast state and render multiple toasts.
- Introduced useToast composable for easier toast management within Vue components.
- Implemented toast records management with auto-dismiss functionality based on timeout.
- Added tests for OToast and OToastProvider to ensure correct rendering and behavior.
- Updated CSS variables for toast styling in light and dark themes.
- Enforced ESLint rule to restrict usage of Quasar Notify, encouraging the use of the new toast system.