### PR TITLE
fix: cloud deployment ran the same OFGA migration on multiple nodes

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -65,8 +65,10 @@ async fn patch_sre_readonly_eval_templates() {
 
     const MIGRATION_ORG: &str = "_migration";
     const FLAG_KEY: &str = "sre_readonly_eval_templates_v1";
+    const LOCK_KEY: &str = "/ofga/migration/sre_readonly_eval_templates_v1";
+    // Bounded wait: avoids hanging a startup thread forever if NATS has issues.
+    const LOCK_WAIT_SECS: u64 = 300;
 
-    // Already done — fast path, no cluster coordination needed
     if crate::service::kv::get(MIGRATION_ORG, FLAG_KEY)
         .await
         .is_ok()
@@ -74,21 +76,22 @@ async fn patch_sre_readonly_eval_templates() {
         return;
     }
 
-    // Only the node with the lowest id runs the migration.
-    // Sorting by id is stable across restarts and requires no locking infrastructure.
-    // If the chosen node is down the next-lowest will not run it either — but the
-    // KV flag is only set on success, so the migration will retry on next startup.
-    let is_leader = infra::cluster::get_cached_online_nodes()
-        .await
-        .and_then(|mut nodes| {
-            nodes.sort_by_key(|n| n.id);
-            nodes.into_iter().next()
-        })
-        .map(|first| first.id == LOCAL_NODE.id)
-        .unwrap_or(true); // single-node / no cluster info → always run
+    let locker = match infra::dist_lock::lock(LOCK_KEY, LOCK_WAIT_SECS).await {
+        Ok(l) => l,
+        Err(e) => {
+            log::error!("patch_sre_readonly_eval_templates: failed to acquire lock: {e}");
+            return;
+        }
+    };
 
-    if !is_leader {
-        log::debug!("patch_sre_readonly_eval_templates: not the lowest-id node, skipping");
+    // Re-check inside the lock — another node may have finished while we waited.
+    if crate::service::kv::get(MIGRATION_ORG, FLAG_KEY)
+        .await
+        .is_ok()
+    {
+        if let Err(e) = infra::dist_lock::unlock(&locker).await {
+            log::error!("patch_sre_readonly_eval_templates: dist_lock unlock failed: {e}");
+        }
         return;
     }
 
@@ -96,6 +99,9 @@ async fn patch_sre_readonly_eval_templates() {
         Ok(orgs) => orgs,
         Err(e) => {
             log::error!("Failed to list orgs for sre-readonly eval_templates patch: {e}");
+            if let Err(e) = infra::dist_lock::unlock(&locker).await {
+                log::error!("patch_sre_readonly_eval_templates: dist_lock unlock failed: {e}");
+            }
             return;
         }
     };
@@ -115,6 +121,9 @@ async fn patch_sre_readonly_eval_templates() {
 
     if failed {
         log::warn!("sre-readonly eval_templates patch had failures — will retry on next startup");
+        if let Err(e) = infra::dist_lock::unlock(&locker).await {
+            log::error!("patch_sre_readonly_eval_templates: dist_lock unlock failed: {e}");
+        }
         return;
     }
 
@@ -125,6 +134,10 @@ async fn patch_sre_readonly_eval_templates() {
     } else {
         log::info!("sre-readonly eval_templates patch complete");
     }
+
+    if let Err(e) = infra::dist_lock::unlock(&locker).await {
+        log::error!("patch_sre_readonly_eval_templates: dist_lock unlock failed: {e}");
+    }
 }
 
 #[cfg(feature = "enterprise")]
@@ -133,6 +146,8 @@ async fn patch_sre_readonly_alerts_incidents() {
 
     const MIGRATION_ORG: &str = "_migration";
     const FLAG_KEY: &str = "sre_readonly_afolder_incidents_v1";
+    const LOCK_KEY: &str = "/ofga/migration/sre_readonly_afolder_incidents_v1";
+    const LOCK_WAIT_SECS: u64 = 300;
 
     if crate::service::kv::get(MIGRATION_ORG, FLAG_KEY)
         .await
@@ -141,17 +156,22 @@ async fn patch_sre_readonly_alerts_incidents() {
         return;
     }
 
-    let is_leader = infra::cluster::get_cached_online_nodes()
-        .await
-        .and_then(|mut nodes| {
-            nodes.sort_by_key(|n| n.id);
-            nodes.into_iter().next()
-        })
-        .map(|first| first.id == LOCAL_NODE.id)
-        .unwrap_or(true);
+    let locker = match infra::dist_lock::lock(LOCK_KEY, LOCK_WAIT_SECS).await {
+        Ok(l) => l,
+        Err(e) => {
+            log::error!("patch_sre_readonly_alerts_incidents: failed to acquire lock: {e}");
+            return;
+        }
+    };
 
-    if !is_leader {
-        log::debug!("patch_sre_readonly_alerts_incidents: not the lowest-id node, skipping");
+    // Re-check inside the lock — another node may have finished while we waited.
+    if crate::service::kv::get(MIGRATION_ORG, FLAG_KEY)
+        .await
+        .is_ok()
+    {
+        if let Err(e) = infra::dist_lock::unlock(&locker).await {
+            log::error!("patch_sre_readonly_alerts_incidents: dist_lock unlock failed: {e}");
+        }
         return;
     }
 
@@ -159,6 +179,9 @@ async fn patch_sre_readonly_alerts_incidents() {
         Ok(orgs) => orgs,
         Err(e) => {
             log::error!("Failed to list orgs for sre-readonly alerts/incidents patch: {e}");
+            if let Err(e) = infra::dist_lock::unlock(&locker).await {
+                log::error!("patch_sre_readonly_alerts_incidents: dist_lock unlock failed: {e}");
+            }
             return;
         }
     };
@@ -179,6 +202,9 @@ async fn patch_sre_readonly_alerts_incidents() {
 
     if failed {
         log::warn!("sre-readonly alerts/incidents patch had failures — will retry on next startup");
+        if let Err(e) = infra::dist_lock::unlock(&locker).await {
+            log::error!("patch_sre_readonly_alerts_incidents: dist_lock unlock failed: {e}");
+        }
         return;
     }
 
@@ -189,25 +215,47 @@ async fn patch_sre_readonly_alerts_incidents() {
     } else {
         log::info!("sre-readonly alerts/incidents patch complete");
     }
+
+    if let Err(e) = infra::dist_lock::unlock(&locker).await {
+        log::error!("patch_sre_readonly_alerts_incidents: dist_lock unlock failed: {e}");
+    }
 }
 
 #[cfg(feature = "enterprise")]
 async fn backfill_sys_rca_agent_openfga_tuples() {
     use bytes::Bytes;
 
-    // Use a dedicated system org for migration flags, separate from user orgs.
     const MIGRATION_ORG: &str = "_migration";
     const FLAG_KEY: &str = "sys_rca_agent_openfga_migration_v1";
+    const LOCK_KEY: &str = "/ofga/migration/sys_rca_agent_openfga_migration_v1";
+    const LOCK_WAIT_SECS: u64 = 300;
 
-    // Check if already done via KV flag
     if crate::service::kv::get(MIGRATION_ORG, FLAG_KEY)
         .await
         .is_ok()
     {
-        return; // Already done
+        return;
     }
 
-    // Get all orgs and ensure SA exists (idempotent — creates OpenFGA tuples for existing DB rows)
+    let locker = match infra::dist_lock::lock(LOCK_KEY, LOCK_WAIT_SECS).await {
+        Ok(l) => l,
+        Err(e) => {
+            log::error!("backfill_sys_rca_agent_openfga_tuples: failed to acquire lock: {e}");
+            return;
+        }
+    };
+
+    // Re-check inside the lock — another node may have finished while we waited.
+    if crate::service::kv::get(MIGRATION_ORG, FLAG_KEY)
+        .await
+        .is_ok()
+    {
+        if let Err(e) = infra::dist_lock::unlock(&locker).await {
+            log::error!("backfill_sys_rca_agent_openfga_tuples: dist_lock unlock failed: {e}");
+        }
+        return;
+    }
+
     match crate::service::db::organization::list(None).await {
         Ok(orgs) => {
             for org in orgs {
@@ -220,7 +268,6 @@ async fn backfill_sys_rca_agent_openfga_tuples() {
                     );
                 }
             }
-            // Set flag so we don't run again
             if let Err(e) =
                 crate::service::kv::set(MIGRATION_ORG, FLAG_KEY, Bytes::from_static(b"done")).await
             {
@@ -232,6 +279,10 @@ async fn backfill_sys_rca_agent_openfga_tuples() {
         Err(e) => {
             log::error!("Failed to list orgs for OpenFGA backfill: {e}");
         }
+    }
+
+    if let Err(e) = infra::dist_lock::unlock(&locker).await {
+        log::error!("backfill_sys_rca_agent_openfga_tuples: dist_lock unlock failed: {e}");
     }
 }
 
@@ -464,9 +515,12 @@ pub async fn init() -> Result<(), anyhow::Error> {
         }
         // One-time OpenFGA migrations — dist_lock ensures only one node runs each
         // migration even in multi-node deployments. KV flag prevents re-runs.
-        backfill_sys_rca_agent_openfga_tuples().await;
-        patch_sre_readonly_eval_templates().await;
-        patch_sre_readonly_alerts_incidents().await;
+        // These run on a background thread to avoid blocking server startup.
+        tokio::task::spawn(async move {
+            backfill_sys_rca_agent_openfga_tuples().await;
+            patch_sre_readonly_eval_templates().await;
+            patch_sre_readonly_alerts_incidents().await;
+        });
     }
 
     tokio::task::spawn(promql_self_consume::run());


### PR DESCRIPTION
Two bugs:

  1. Racy leader election (mod.rs): get_cached_online_nodes() was called at startup before the cluster membership cache was populated. With unwrap_or(true) fallback, every node saw itself as "lowest-id" and ran.
  2. TOCTOU on KV flag: No atomicity between check flag → run → set flag. Multiple nodes could pass the "flag not set" gate before any of them wrote.
  3. Failure-mode amplifier (roles.rs): OFGA returned an error on the second writer's update (resource already modified), the loop set failed=true, KV flag never persisted → infinite retry loop on every restart.
  
 The Fix:
  - Concurrency: dist_lock serializes execution across nodes (replaces the unreliable lowest-id heuristic).
  - Recovery: OFGA idempotency check breaks the failure-retry loop you hit in production — duplicate writes become no-ops instead of errors that block the KV flag from being set.
  
  resolves https://github.com/openobserve/openobserve/issues/11559