### PR TITLE
fix: histogram cache returns duplicate hits when `stream_min_ts` falls mid-bucket

### DIFF
--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -61,28 +61,52 @@ pub async fn invalidate_cached_response_by_stream_min_ts(
     let stream_min_ts =
         infra::cache::stats::get_stream_stats(org_id, stream_name, stream_type).doc_time_min;
 
-    // For histogram queries, align stream_min_ts down to the bucket boundary.
-    // stream_min_ts is the first real document timestamp and may fall mid-bucket
-    // (e.g. 11:47 into a 1-day bucket). Using it raw pushes response_start_time
-    // past the bucket key, stranding the bucket inside the delta and causing
-    // sub-partitions to return the same cache hit as the main cache response.
-    let effective_min_ts = if histogram_interval > 0 {
-        (stream_min_ts / histogram_interval) * histogram_interval
+    let filtered_responses = if histogram_interval > 0 {
+        // For histogram queries, a bucket is only stale when its ENTIRE interval
+        // is before stream_min_ts — i.e. (bucket_key + interval) <= stream_min_ts.
+        //
+        // Example (1-day interval):
+        //   stream_min_ts  = Apr 16 11:47  (first live document)
+        //   bucket "Apr 16" covers Apr 16 00:00 → Apr 17 00:00
+        //   Apr 17 00:00 > Apr 16 11:47  →  bucket still has live data → KEEP
+        //   bucket "Jan 16" covers Jan 16 00:00 → Jan 17 00:00
+        //   Jan 17 00:00 > Apr 16 11:47  →  NO → fully expired → DROP
+        //
+        // Trimming response_start_time to stream_min_ts is wrong here because
+        // stream_min_ts can fall mid-bucket, pushing the effective cache start
+        // past the bucket key and corrupting delta computation.
+        // Instead: drop individual stale buckets and leave response_start_time
+        // untouched so deltas are computed from the real cache boundary.
+        responses
+            .iter()
+            .cloned()
+            .filter_map(|mut meta| {
+                meta.cached_response.hits.retain(|hit| {
+                    let hit_ts = get_ts_value(&meta.ts_column, hit);
+                    hit_ts + histogram_interval > stream_min_ts
+                });
+                if meta.cached_response.hits.is_empty() {
+                    None
+                } else {
+                    meta.cached_response.total = meta.cached_response.hits.len();
+                    Some(meta)
+                }
+            })
+            .collect()
     } else {
-        stream_min_ts
+        // For non-histogram queries, trim to stream_min_ts at the response level.
+        responses
+            .iter()
+            .filter(|meta| meta.response_end_time >= stream_min_ts)
+            .cloned()
+            .map(|mut meta| {
+                if meta.response_start_time < stream_min_ts {
+                    meta.response_start_time = stream_min_ts;
+                }
+                meta
+            })
+            .collect()
     };
-
-    let filtered_responses = responses
-        .iter()
-        .filter(|meta| meta.response_end_time >= stream_min_ts)
-        .cloned()
-        .map(|mut meta| {
-            if meta.response_start_time < effective_min_ts {
-                meta.response_start_time = effective_min_ts;
-            }
-            meta
-        })
-        .collect();
 
     Ok(filtered_responses)
 }

--- a/src/service/search/cache/cacher.rs
+++ b/src/service/search/cache/cacher.rs
@@ -46,6 +46,7 @@ use crate::{
 pub async fn invalidate_cached_response_by_stream_min_ts(
     file_path: &str,
     responses: &[CachedQueryResponse],
+    histogram_interval: i64, // microseconds; 0 for non-histogram queries
 ) -> Result<Vec<CachedQueryResponse>, String> {
     let components: Vec<&str> = file_path.split('/').collect();
     if components.len() < 3 {
@@ -60,13 +61,24 @@ pub async fn invalidate_cached_response_by_stream_min_ts(
     let stream_min_ts =
         infra::cache::stats::get_stream_stats(org_id, stream_name, stream_type).doc_time_min;
 
+    // For histogram queries, align stream_min_ts down to the bucket boundary.
+    // stream_min_ts is the first real document timestamp and may fall mid-bucket
+    // (e.g. 11:47 into a 1-day bucket). Using it raw pushes response_start_time
+    // past the bucket key, stranding the bucket inside the delta and causing
+    // sub-partitions to return the same cache hit as the main cache response.
+    let effective_min_ts = if histogram_interval > 0 {
+        (stream_min_ts / histogram_interval) * histogram_interval
+    } else {
+        stream_min_ts
+    };
+
     let filtered_responses = responses
         .iter()
         .filter(|meta| meta.response_end_time >= stream_min_ts)
         .cloned()
         .map(|mut meta| {
-            if meta.response_start_time < stream_min_ts {
-                meta.response_start_time = stream_min_ts;
+            if meta.response_start_time < effective_min_ts {
+                meta.response_start_time = effective_min_ts;
             }
             meta
         })
@@ -198,7 +210,13 @@ pub async fn check_cache(
         }
 
         // remove the cached response older than stream min ts
-        match invalidate_cached_response_by_stream_min_ts(file_path, &cached_responses).await {
+        match invalidate_cached_response_by_stream_min_ts(
+            file_path,
+            &cached_responses,
+            histogram_interval,
+        )
+        .await
+        {
             Ok(responses) => {
                 cached_responses = responses;
             }
@@ -274,8 +292,12 @@ pub async fn check_cache(
         {
             Some(mut cached_resp) => {
                 // remove the cached response older than stream min ts
-                match invalidate_cached_response_by_stream_min_ts(file_path, &[cached_resp.clone()])
-                    .await
+                match invalidate_cached_response_by_stream_min_ts(
+                    file_path,
+                    &[cached_resp.clone()],
+                    histogram_interval,
+                )
+                .await
                 {
                     Ok(responses) => {
                         // single cached query response is expected
@@ -1260,7 +1282,7 @@ mod tests {
         ];
 
         let file_path = "test_org/logs/test_stream";
-        let result = invalidate_cached_response_by_stream_min_ts(file_path, &responses).await;
+        let result = invalidate_cached_response_by_stream_min_ts(file_path, &responses, 0).await;
         assert!(result.is_ok());
         let filtered_responses = result.unwrap();
         assert_eq!(filtered_responses.len(), 2);


### PR DESCRIPTION
## Problem

When executing a histogram query with `use_cache=true`, the same result row was emitted **3 times** instead of once.

**Root cause:** `invalidate_cached_response_by_stream_min_ts` was designed for raw log retention but didn't account for histogram bucket boundaries. It trimmed `response_start_time` to `stream_min_ts` (the first live document timestamp), which can fall **mid-bucket**.

**Example:**
- Cache covers `Jan 15 → May 14`, contains 1 bucket: `Apr 16` (26,000 docs)
- `stream_min_ts = Apr 16 11:47` (first real document, mid-bucket)
- Old code pushed `response_start_time` to `Apr 16 11:47`, past the bucket key `Apr 16 00:00`
- This created a large delta `Jan 14 → Apr 16 11:47` that **contained the bucket key**
- Delta sub-partitions re-queried the cache and found the same bucket → 3× duplicates

## Fix

For histogram queries, instead of trimming `response_start_time`, check each bucket individually. A bucket is only stale when its **entire interval** is before `stream_min_ts`:

```
bucket "Apr 16": covers Apr 16 00:00 → Apr 17 00:00
stream_min_ts  :         Apr 16 11:47

Apr 17 00:00 > Apr 16 11:47  →  bucket still has live data → KEEP ✓

bucket "Jan 16": covers Jan 16 00:00 → Jan 17 00:00
Jan 17 00:00 > Apr 16 11:47  →  NO → fully expired → DROP ✓
```

`response_start_time` is left untouched (stays at `Jan 15`). The delta becomes `Jan 14 → Jan 15` — tiny, nowhere near the bucket key. No sub-partition can re-find the bucket. No duplicates.

## Changes

- `src/service/search/cache/cacher.rs` — `invalidate_cached_response_by_stream_min_ts`
  - Added `histogram_interval` parameter
  - For histogram queries: retain/drop individual buckets based on whether the full bucket interval has expired
  - For non-histogram queries: original behaviour unchanged