### PR TITLE
feat: add Guardian upgrade testing scripts with 18 entity types

### DIFF
--- a/tests/api-testing/tests/upgrade_state/guardian_cleanup.py
+++ b/tests/api-testing/tests/upgrade_state/guardian_cleanup.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Guardian Cleanup Phase: Delete all created entities in reverse dependency order."""
+
+import os
+import sys
+import json
+import time
+from pathlib import Path
+import requests
+from requests.auth import HTTPBasicAuth
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+EMAIL = os.environ.get("ZO_ROOT_USER_EMAIL", "root@example.com")
+PASSWORD = os.environ.get("ZO_ROOT_USER_PASSWORD", "changeme")
+
+# Determine which state file to use
+phase = sys.argv[1] if len(sys.argv) > 1 else "pre"
+state_file = Path(__file__).parent / f"devcluster2_default_{phase}_state.json"
+
+if not state_file.exists():
+    print(f"[GUARDIAN] State file not found: {state_file}")
+    print(f"[GUARDIAN] Nothing to clean up.")
+    sys.exit(0)
+
+with open(state_file) as f:
+    state = json.load(f)
+
+BASE_URL = state["base_url"]
+ORG_ID = state["org_id"]
+SUFFIX = state["suffix"]
+ENRICH_SUFFIX = state.get("enrichment_suffix", "")
+ENTITIES = state["entities"]
+
+session = requests.Session()
+session.auth = HTTPBasicAuth(EMAIL, PASSWORD)
+session.verify = False
+
+print(f"[GUARDIAN] Cleanup Phase - The Rest")
+print(f"[GUARDIAN] Env: {state['env']} | Org: {ORG_ID}")
+print(f"[GUARDIAN] Suffix: {SUFFIX}" + (f" | Enrich: {ENRICH_SUFFIX}" if ENRICH_SUFFIX else ""))
+print()
+
+deleted = 0
+failed = 0
+
+def delete(label, method, url, **kwargs):
+    global deleted, failed
+    try:
+        resp = method(url, **kwargs)
+        if resp.status_code in (200, 204):
+            deleted += 1
+            print(f"  [OK] {label}")
+        elif resp.status_code == 404:
+            deleted += 1  # already gone, that's fine
+            print(f"  [OK] {label} (already deleted)")
+        else:
+            failed += 1
+            print(f"  [FAIL] {label} (HTTP {resp.status_code}): {resp.text[:100]}")
+    except Exception as e:
+        failed += 1
+        print(f"  [FAIL] {label}: {e}")
+
+# Deletion order: reverse of creation
+# Reports → Timezone Alerts → Cron → RT → SQL → Standard → Extra Folder → Email Dest → Slack Dest → Email Tpl → Slack Tpl
+# → Saved Views → Time Shift Dash → Dashboards → MTR Alerts → VRL Trigger → VRL No-trigger
+# → Dash Folders → Alert Folders → Enrichments → Pipelines → Functions → Destinations → Templates
+
+# 1. Reports (scheduled + cached)
+print("[1] Deleting Reports...")
+report_names = []
+report_names += [r["name"] for r in ENTITIES.get("reports_scheduled", [])]
+report_names += [r["name"] for r in ENTITIES.get("reports_cached", [])]
+for name in report_names:
+    delete(f"report {name}", session.delete, f"{BASE_URL}api/{ORG_ID}/reports/{name}")
+print()
+
+# 2. Timezone Alerts
+print("[2] Deleting Timezone Alerts...")
+for entry in ENTITIES.get("alerts_timezone", []):
+    aid = entry.get("alert_id", entry.get("name"))
+    extra_folder = ENTITIES.get("alert_folder_extra", [])
+    fid = extra_folder[0]["folder_id"] if extra_folder else ""
+    delete(f"tz alert {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/alerts/{aid}?folder={fid}")
+print()
+
+# 3. Cron Alerts
+print("[3] Deleting Cron Alerts...")
+for entry in ENTITIES.get("alerts_cron", []):
+    aid = entry.get("alert_id", entry.get("name"))
+    extra_folder = ENTITIES.get("alert_folder_extra", [])
+    fid = extra_folder[0]["folder_id"] if extra_folder else ""
+    delete(f"cron alert {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/alerts/{aid}?folder={fid}")
+print()
+
+# 4. Real-Time Alerts
+print("[4] Deleting Real-Time Alerts...")
+for entry in ENTITIES.get("alerts_realtime", []):
+    aid = entry.get("alert_id", entry.get("name"))
+    extra_folder = ENTITIES.get("alert_folder_extra", [])
+    fid = extra_folder[0]["folder_id"] if extra_folder else ""
+    delete(f"rt alert {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/alerts/{aid}?folder={fid}")
+print()
+
+# 5. SQL Alerts
+print("[5] Deleting SQL Alerts...")
+for entry in ENTITIES.get("alerts_sql", []):
+    aid = entry.get("alert_id", entry.get("name"))
+    extra_folder = ENTITIES.get("alert_folder_extra", [])
+    fid = extra_folder[0]["folder_id"] if extra_folder else ""
+    delete(f"sql alert {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/alerts/{aid}?folder={fid}")
+print()
+
+# 6. Standard Alerts
+print("[6] Deleting Standard Alerts...")
+for entry in ENTITIES.get("alerts_standard", []):
+    aid = entry.get("alert_id", entry.get("name"))
+    extra_folder = ENTITIES.get("alert_folder_extra", [])
+    fid = extra_folder[0]["folder_id"] if extra_folder else ""
+    delete(f"standard alert {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/alerts/{aid}?folder={fid}")
+print()
+
+# 7. Email Destination
+print("[7] Deleting Email Destination...")
+for name in ENTITIES.get("email_destination", []) + ENTITIES.get("destinations_email", []):
+    if name: delete(f"email dest {name}", session.delete, f"{BASE_URL}api/{ORG_ID}/alerts/destinations/{name}")
+print()
+
+# 8. Slack Destination
+print("[8] Deleting Slack Destination...")
+for name in ENTITIES.get("slack_destination", []) + ENTITIES.get("destinations_slack", []):
+    if name: delete(f"slack dest {name}", session.delete, f"{BASE_URL}api/{ORG_ID}/alerts/destinations/{name}")
+print()
+
+# 9. Email Template
+print("[9] Deleting Email Template...")
+for name in ENTITIES.get("email_template", []) + ENTITIES.get("templates_email", []):
+    if name: delete(f"email tpl {name}", session.delete, f"{BASE_URL}api/{ORG_ID}/alerts/templates/{name}")
+print()
+
+# 10. Slack Template
+print("[10] Deleting Slack Template...")
+for name in ENTITIES.get("slack_template", []) + ENTITIES.get("templates_slack", []):
+    if name: delete(f"slack tpl {name}", session.delete, f"{BASE_URL}api/{ORG_ID}/alerts/templates/{name}")
+print()
+
+# 11. Extra Alert Folder
+print("[11] Deleting Extra Alert Folder...")
+for entry in ENTITIES.get("alert_folder_extra", []):
+    delete(f"extra folder {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/folders/alerts/{entry['folder_id']}")
+print()
+
+# 12. Saved Views
+print("[12] Deleting Saved Views...")
+for entry in ENTITIES.get("saved_views", []):
+    vid = entry.get("view_id", entry.get("name"))
+    delete(f"saved view {entry['name']}", session.delete, f"{BASE_URL}api/{ORG_ID}/savedviews/{vid}")
+print()
+
+# 13. Time Shift Dashboards
+print("[13] Deleting Time Shift Dashboards...")
+for entry in ENTITIES.get("dashboards_time_shift", []):
+    did = entry["dashboard_id"]
+    fid = entry["folder_id"]
+    delete(f"timeshift dash {entry['name']}", session.delete, f"{BASE_URL}api/{ORG_ID}/dashboards/{did}?folder={fid}")
+print()
+
+# 14. Dashboards
+print("[14] Deleting Dashboards...")
+for entry in ENTITIES.get("dashboards", []):
+    did = entry["dashboard_id"]
+    fid = entry["folder_id"]
+    delete(f"dashboard {entry['name']}", session.delete, f"{BASE_URL}api/{ORG_ID}/dashboards/{did}?folder={fid}")
+print()
+
+# 15. Multi Time Range Alerts
+print("[15] Deleting Multi Time Range Alerts...")
+for entry in ENTITIES.get("alerts_multi_time_range", []):
+    aid = entry["alert_id"]
+    fid = entry["folder_id"]
+    delete(f"mtr alert {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/alerts/{aid}?folder={fid}")
+print()
+
+# 16. VRL Alerts (trigger)
+print("[16] Deleting VRL Alerts (trigger)...")
+for entry in ENTITIES.get("alerts_vrl_trigger", []):
+    aid = entry["alert_id"]
+    fid = entry["folder_id"]
+    delete(f"vrl trigger {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/alerts/{aid}?folder={fid}")
+print()
+
+# 17. VRL Alerts (no-trigger)
+print("[17] Deleting VRL Alerts (no-trigger)...")
+for entry in ENTITIES.get("alerts_vrl_no_trigger", []):
+    aid = entry["alert_id"]
+    fid = entry["folder_id"]
+    delete(f"vrl no-trigger {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/alerts/{aid}?folder={fid}")
+print()
+
+# 18. Dashboard Folders
+print("[18] Deleting Dashboard Folders...")
+for entry in ENTITIES.get("dashboard_folders", []):
+    fid = entry["folder_id"]
+    delete(f"dash folder {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/folders/dashboards/{fid}")
+print()
+
+# 19. Alert Folders
+print("[19] Deleting Alert Folders...")
+for entry in ENTITIES.get("alert_folders", []):
+    fid = entry["folder_id"]
+    delete(f"alert folder {entry['name']}", session.delete, f"{BASE_URL}api/v2/{ORG_ID}/folders/alerts/{fid}")
+print()
+
+# 20. Enrichment Tables
+print("[20] Deleting Enrichment Tables...")
+for name in ENTITIES.get("enrichments", []):
+    delete(f"enrichment {name}", session.delete, f"{BASE_URL}api/{ORG_ID}/streams/{name}?type=enrichment_tables")
+print()
+
+# 21. Pipelines
+print("[21] Deleting Pipelines...")
+for entry in ENTITIES.get("pipelines", []):
+    pid = entry.get("pipeline_id", entry.get("name"))
+    delete(f"pipeline {entry['name']}", session.delete, f"{BASE_URL}api/{ORG_ID}/pipelines/{pid}")
+print()
+
+# 22. Functions
+print("[22] Deleting Functions...")
+for name in ENTITIES.get("functions", []):
+    delete(f"function {name}", session.delete, f"{BASE_URL}api/{ORG_ID}/functions/{name}")
+print()
+
+# 23. Destinations (original 5)
+print("[23] Deleting Destinations...")
+for name in ENTITIES.get("destinations", []):
+    delete(f"destination {name}", session.delete, f"{BASE_URL}api/{ORG_ID}/alerts/destinations/{name}")
+print()
+
+# 24. Templates (original 5)
+print("[24] Deleting Templates...")
+for name in ENTITIES.get("templates", []):
+    delete(f"template {name}", session.delete, f"{BASE_URL}api/{ORG_ID}/alerts/templates/{name}")
+print()
+
+# SUMMARY
+print("=" * 60)
+print("CLEANUP SUMMARY")
+print("=" * 60)
+print(f"  Deleted: {deleted}")
+print(f"  Failed: {failed}")
+print(f"  State file: {state_file}")
+print("=" * 60)
+
+# Optionally remove state file if all deleted
+if failed == 0:
+    print(f"\n[GUARDIAN] All entities cleaned up successfully.")
+    print(f"[GUARDIAN] State file preserved at: {state_file}")
+else:
+    print(f"\n[GUARDIAN] {failed} entities failed to delete. Check logs above.")

--- a/tests/api-testing/tests/upgrade_state/guardian_enrich.py
+++ b/tests/api-testing/tests/upgrade_state/guardian_enrich.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Guardian Post-Upgrade Enrichment: Add missing alert types, reports, Slack/Email destinations."""
+
+import os
+import sys
+import json
+import time
+import random
+from datetime import datetime
+from pathlib import Path
+import requests
+from requests.auth import HTTPBasicAuth
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# --- Add pages ---
+PAGES_DIR = Path(__file__).parent.parent / "pages"
+sys.path.insert(0, str(PAGES_DIR))
+
+from template_page import TemplatePage
+from destination_page import DestinationPage
+from alert_page import AlertPage
+from report_page import ReportPage
+
+# ============================================================
+# CONFIGURATION
+# ============================================================
+BASE_URL = os.environ.get("ZO_BASE_URL", "https://localhost:5080/")
+EMAIL = os.environ.get("ZO_ROOT_USER_EMAIL", "root@example.com")
+PASSWORD = os.environ.get("ZO_ROOT_USER_PASSWORD", "changeme")
+ORG_ID = os.environ.get("ORGNAME", "default")
+SLACK_WEBHOOK = os.environ.get("SLACK_WEBHOOK", "")
+REPORT_EMAIL = os.environ.get("REPORT_EMAIL", "user@example.com")
+REPORT_TITLE = os.environ.get("REPORT_TITLE", "upgrade-testing")
+
+session = requests.Session()
+session.auth = HTTPBasicAuth(EMAIL, PASSWORD)
+session.verify = False
+
+SUFFIX = f"guardian_extra_{datetime.now().strftime('%m%d')}_{random.randint(1000, 9999)}"
+
+# Load pre-upgrade state to get the stream and dashboards
+state_file = Path(__file__).parent / "devcluster2_default_pre_state.json"
+with open(state_file) as f:
+    state = json.load(f)
+
+STREAM_NAME = state["stream_name"]
+print(f"[GUARDIAN] Post-Upgrade Enrichment")
+print(f"[GUARDIAN] Base URL: {BASE_URL}")
+print(f"[GUARDIAN] Suffix: {SUFFIX}")
+print(f"[GUARDIAN] Stream: {STREAM_NAME}")
+print()
+
+# ============================================================
+# STEP 1: Create Slack + Email Templates
+# ============================================================
+print("[STEP 1] Creating Slack and Email templates...")
+template_page = TemplatePage(session, BASE_URL, ORG_ID)
+
+slack_template_name = f"template_slack_{SUFFIX}"
+try:
+    resp = template_page.create_template_webhook(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, slack_template_name)
+    print(f"  [OK] Slack template: {slack_template_name}")
+except Exception as e:
+    print(f"  [FAIL] Slack template: {e}")
+
+email_template_name = f"template_email_{SUFFIX}"
+try:
+    resp = template_page.create_template_email(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, email_template_name)
+    print(f"  [OK] Email template: {email_template_name}")
+except Exception as e:
+    print(f"  [FAIL] Email template: {e}")
+print()
+
+# ============================================================
+# STEP 2: Create Slack + Email Destinations
+# ============================================================
+print("[STEP 2] Creating Slack and Email destinations...")
+dest_page = DestinationPage(session, BASE_URL, ORG_ID)
+
+slack_dest_name = f"dest_slack_{SUFFIX}"
+try:
+    dest_page.create_destination_webhook(
+        session, BASE_URL, ORG_ID, EMAIL, PASSWORD,
+        slack_template_name, slack_dest_name,
+        webhook_url=SLACK_WEBHOOK, method="post"
+    )
+    print(f"  [OK] Slack destination: {slack_dest_name}")
+except Exception as e:
+    print(f"  [FAIL] Slack destination: {e}")
+
+email_dest_name = f"dest_email_{SUFFIX}"
+try:
+    dest_page.create_destination_email(
+        session, BASE_URL, ORG_ID, EMAIL, PASSWORD,
+        REPORT_EMAIL, email_template_name, email_dest_name
+    )
+    print(f"  [OK] Email destination: {email_dest_name}")
+except Exception as e:
+    print(f"  [FAIL] Email destination: {e}")
+print()
+
+# ============================================================
+# STEP 3: Create alert folder for new alerts
+# ============================================================
+print("[STEP 3] Creating alert folder for new alerts...")
+resp = session.post(
+    f"{BASE_URL}api/v2/{ORG_ID}/folders/alerts",
+    json={"description": f"extra_folder_{SUFFIX}", "folderId": "", "name": f"extra_folder_{SUFFIX}"},
+    headers={"Content-Type": "application/json"}
+)
+assert resp.status_code == 200, f"Failed to create folder: {resp.text}"
+ALERT_FOLDER_ID = resp.json()["folderId"]
+print(f"  [OK] Alert folder: extra_folder_{SUFFIX} (id: {ALERT_FOLDER_ID})")
+print()
+
+# ============================================================
+# STEP 4: Create additional alert types (5 each, 20 total)
+# ============================================================
+alert_page = AlertPage(session, BASE_URL, ORG_ID)
+
+# --- 4.1 Standard Alerts (custom type, template-based) ---
+print("[STEP 4.1] Creating 5 Standard Alerts (custom type)...")
+standard_alerts = []
+for i in range(5):
+    name = f"standard_{SUFFIX}_{i}"
+    try:
+        alert_page.create_standard_alert(
+            session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME,
+            slack_template_name, slack_dest_name, name
+        )
+        # Set folder_id via PUT since create_standard_alert doesn't accept folder_id
+        # Let's fetch the created alert and patch if needed
+        time.sleep(0.3)
+        alert_id = name  # fallback
+        resp = session.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts")
+        alist = resp.json().get("list", []) if resp.status_code == 200 else []
+        for a in alist:
+            if a.get("name") == name:
+                alert_id = a.get("alert_id", name)
+                break
+        standard_alerts.append({"name": name, "alert_id": alert_id})
+        print(f"  [OK] Standard Alert: {name} (id: {alert_id})")
+    except Exception as e:
+        print(f"  [FAIL] Standard Alert: {name} - {e}")
+print(f"[OK] Standard Alerts: {len(standard_alerts)}/5")
+print()
+
+# --- 4.2 Standard SQL Alerts ---
+print("[STEP 4.2] Creating 5 Standard SQL Alerts...")
+sql_alerts = []
+for i in range(5):
+    name = f"alert_sql_{SUFFIX}_{i}"
+    try:
+        alert_page.create_standard_alert_sql(
+            session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME,
+            slack_template_name, slack_dest_name, name
+        )
+        time.sleep(0.3)
+        resp = session.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts")
+        alist = resp.json().get("list", []) if resp.status_code == 200 else []
+        alert_id = name
+        for a in alist:
+            if a.get("name") == name:
+                alert_id = a.get("alert_id", name)
+                break
+        sql_alerts.append({"name": name, "alert_id": alert_id})
+        print(f"  [OK] SQL Alert: {name} (id: {alert_id})")
+    except Exception as e:
+        print(f"  [FAIL] SQL Alert: {name} - {e}")
+print(f"[OK] SQL Alerts: {len(sql_alerts)}/5")
+print()
+
+# --- 4.3 Real-Time Alerts ---
+print("[STEP 4.3] Creating 5 Real-Time Alerts...")
+rt_alerts = []
+for i in range(5):
+    name = f"alert_rt_{SUFFIX}_{i}"
+    try:
+        alert_page.create_real_time_alert(
+            session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME,
+            slack_template_name, slack_dest_name, name
+        )
+        time.sleep(0.3)
+        resp = session.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts")
+        alist = resp.json().get("list", []) if resp.status_code == 200 else []
+        alert_id = name
+        for a in alist:
+            if a.get("name") == name:
+                alert_id = a.get("alert_id", name)
+                break
+        rt_alerts.append({"name": name, "alert_id": alert_id})
+        print(f"  [OK] Real-Time Alert: {name} (id: {alert_id})")
+    except Exception as e:
+        print(f"  [FAIL] Real-Time Alert: {name} - {e}")
+print(f"[OK] Real-Time Alerts: {len(rt_alerts)}/5")
+print()
+
+# --- 4.4 Cron Alerts ---
+print("[STEP 4.4] Creating 5 Cron Alerts...")
+cron_alerts = []
+for i in range(5):
+    name = f"alert_cron_{SUFFIX}_{i}"
+    try:
+        alert_page.create_standard_alert_cron(
+            session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME,
+            slack_template_name, slack_dest_name, name
+        )
+        time.sleep(0.3)
+        resp = session.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts")
+        alist = resp.json().get("list", []) if resp.status_code == 200 else []
+        alert_id = name
+        for a in alist:
+            if a.get("name") == name:
+                alert_id = a.get("alert_id", name)
+                break
+        cron_alerts.append({"name": name, "alert_id": alert_id})
+        print(f"  [OK] Cron Alert: {name} (id: {alert_id})")
+    except Exception as e:
+        print(f"  [FAIL] Cron Alert: {name} - {e}")
+print(f"[OK] Cron Alerts: {len(cron_alerts)}/5")
+print()
+
+# ============================================================
+# STEP 5: Create Reports (5 scheduled + 5 cached)
+# ============================================================
+report_page = ReportPage(session, BASE_URL, ORG_ID)
+
+# Get dashboard IDs from pre-upgrade state
+dashboards = state["entities"]["dashboards"]
+dash_folder_ids = [d["folder_id"] for d in state["entities"]["dashboard_folders"]]
+
+# --- 5.1 Scheduled Reports (email to neha@openobserve) ---
+print("[STEP 5.1] Creating 5 Scheduled Reports (email to neha@openobserve)...")
+scheduled_reports = []
+for i in range(5):
+    name = f"report_scheduled_{SUFFIX}_{i}"
+    did = dashboards[i]["dashboard_id"]
+    fid = dash_folder_ids[i] if i < len(dash_folder_ids) else dash_folder_ids[0]
+    try:
+        # Use custom API call since the page object hardcodes the email
+        headers = {"Content-Type": "application/json"}
+        payload = {
+            "dashboards": [{
+                "folder": fid,
+                "dashboard": did,
+                "tabs": ["default"],
+                "variables": [],
+                "timerange": {"type": "relative", "period": "30m", "from": 0, "to": 0}
+            }],
+            "description": "",
+            "destinations": [{"email": REPORT_EMAIL}],
+            "enabled": True,
+            "media_type": "Pdf",
+            "name": name,
+            "title": REPORT_TITLE,
+            "message": "Guardian upgrade testing report",
+            "orgId": ORG_ID,
+            "start": int(datetime.now().timestamp() * 1000000),
+            "frequency": {"interval": 1, "type": "once", "cron": ""},
+            "user": "",
+            "password": "",
+            "timezone": "UTC",
+            "timezoneOffset": 0,
+            "owner": EMAIL,
+            "lastEditedBy": EMAIL,
+            "report_type": "PDF"
+        }
+        resp = session.post(f"{BASE_URL}api/{ORG_ID}/reports", json=payload, headers=headers)
+        assert resp.status_code == 200, f"Failed: {resp.text}"
+        scheduled_reports.append({"name": name})
+        print(f"  [OK] Scheduled Report: {name}")
+    except Exception as e:
+        print(f"  [FAIL] Scheduled Report: {name} - {e}")
+print(f"[OK] Scheduled Reports: {len(scheduled_reports)}/5")
+print()
+
+# --- 5.2 Cached Reports ---
+print("[STEP 5.2] Creating 5 Cached Reports...")
+cached_reports = []
+for i in range(5):
+    name = f"report_cached_{SUFFIX}_{i}"
+    did = dashboards[i]["dashboard_id"]
+    fid = dash_folder_ids[i] if i < len(dash_folder_ids) else dash_folder_ids[0]
+    try:
+        headers = {"Content-Type": "application/json"}
+        payload = {
+            "dashboards": [{
+                "folder": fid,
+                "dashboard": did,
+                "tabs": ["default"],
+                "variables": [],
+                "timerange": {"type": "relative", "period": "30m", "from": 0, "to": 0}
+            }],
+            "description": "",
+            "destinations": [],
+            "enabled": True,
+            "media_type": "Pdf",
+            "name": name,
+            "title": REPORT_TITLE,
+            "message": "Guardian upgrade testing cached report",
+            "orgId": ORG_ID,
+            "start": int(datetime.now().timestamp() * 1000000),
+            "frequency": {"interval": 1, "type": "once", "cron": ""},
+            "user": "",
+            "password": "",
+            "timezone": "UTC",
+            "timezoneOffset": 0,
+            "owner": EMAIL,
+            "lastEditedBy": EMAIL,
+            "report_type": "PDF"
+        }
+        resp = session.post(f"{BASE_URL}api/{ORG_ID}/reports", json=payload, headers=headers)
+        assert resp.status_code == 200, f"Failed: {resp.text}"
+        cached_reports.append({"name": name})
+        print(f"  [OK] Cached Report: {name}")
+    except Exception as e:
+        print(f"  [FAIL] Cached Report: {name} - {e}")
+print(f"[OK] Cached Reports: {len(cached_reports)}/5")
+print()
+
+# ============================================================
+# STEP 6: Save enriched state
+# ============================================================
+print("[STEP 6] Saving enriched state...")
+
+state["entities"]["templates_slack"] = [slack_template_name]
+state["entities"]["templates_email"] = [email_template_name]
+state["entities"]["destinations_slack"] = [slack_dest_name]
+state["entities"]["destinations_email"] = [email_dest_name]
+state["entities"]["alert_folder_extra"] = [{"name": f"extra_folder_{SUFFIX}", "folder_id": ALERT_FOLDER_ID}]
+state["entities"]["alerts_standard"] = standard_alerts
+state["entities"]["alerts_sql"] = sql_alerts
+state["entities"]["alerts_realtime"] = rt_alerts
+state["entities"]["alerts_cron"] = cron_alerts
+state["entities"]["reports_scheduled"] = scheduled_reports
+state["entities"]["reports_cached"] = cached_reports
+state["enrichment_suffix"] = SUFFIX
+state["enriched_at"] = datetime.now().isoformat()
+state["slack_webhook"] = SLACK_WEBHOOK
+state["report_email"] = REPORT_EMAIL
+
+enriched_file = Path(__file__).parent / "devcluster2_default_pre_state.json"
+with open(enriched_file, "w") as f:
+    json.dump(state, f, indent=2, default=str)
+print(f"[OK] State saved to: {enriched_file}")
+print()
+
+# ============================================================
+# SUMMARY
+# ============================================================
+print("=" * 60)
+print("POST-UPGRADE ENRICHMENT SUMMARY")
+print("=" * 60)
+print(f"  Slack template: 1")
+print(f"  Email template: 1")
+print(f"  Slack destination: 1 → Slack #alerts")
+print(f"  Email destination: 1 → {REPORT_EMAIL}")
+print(f"  Standard Alerts: {len(standard_alerts)}/5")
+print(f"  SQL Alerts: {len(sql_alerts)}/5")
+print(f"  Real-Time Alerts: {len(rt_alerts)}/5")
+print(f"  Cron Alerts: {len(cron_alerts)}/5")
+print(f"  Scheduled Reports: {len(scheduled_reports)}/5")
+print(f"  Cached Reports: {len(cached_reports)}/5")
+print(f"  ---")
+total = (len(standard_alerts) + len(sql_alerts) + len(rt_alerts) + len(cron_alerts) +
+         len(scheduled_reports) + len(cached_reports) + 4)  # +4 for templates/destinations
+print(f"  TOTAL NEW ENTITIES: {total}")
+print(f"  Suffix: {SUFFIX}")
+print("=" * 60)

--- a/tests/api-testing/tests/upgrade_state/guardian_post.py
+++ b/tests/api-testing/tests/upgrade_state/guardian_post.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Guardian Post-Upgrade Phase: Create ~100 entities across 18 types and save state."""
+
+import os
+import sys
+import io
+import json
+import time
+import uuid
+import random
+from datetime import datetime
+from pathlib import Path
+import requests
+from requests.auth import HTTPBasicAuth
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# --- Add pages directory to path ---
+PAGES_DIR = Path(__file__).parent.parent / "pages"
+sys.path.insert(0, str(PAGES_DIR))
+
+from template_page import TemplatePage
+from destination_page import DestinationPage
+from function_page import FunctionPage
+from pipeline_page import PipelinePage
+from enrichment_page import EnrichmentPage
+from folder_page import FolderPage
+from alertV2_page import AlertV2Page
+from alert_page import AlertPage
+from dashboard_page import DashboardPage
+from savedview_page import SavedViewPage
+
+# ============================================================
+# CONFIGURATION
+# ============================================================
+BASE_URL = os.environ.get("ZO_BASE_URL", "https://localhost:5080/")
+EMAIL = os.environ.get("ZO_ROOT_USER_EMAIL", "root@example.com")
+PASSWORD = os.environ.get("ZO_ROOT_USER_PASSWORD", "changeme")
+ORG_ID = os.environ.get("ORGNAME", "default")
+SLACK_WEBHOOK = os.environ.get("SLACK_WEBHOOK", "")
+REPORT_EMAIL = os.environ.get("REPORT_EMAIL", "user@example.com")
+REPORT_TITLE = os.environ.get("REPORT_TITLE", "upgrade-testing")
+
+session = requests.Session()
+session.auth = HTTPBasicAuth(EMAIL, PASSWORD)
+session.verify = False
+
+SUFFIX = f"guardian_{datetime.now().strftime('%m%d')}_{random.randint(1000, 9999)}"
+STREAM_NAME = f"guardian_stream_{SUFFIX}"
+
+print(f"[GUARDIAN] Post-Upgrade Phase - The Renewal")
+print(f"[GUARDIAN] Base URL: {BASE_URL}")
+print(f"[GUARDIAN] Org: {ORG_ID} | Suffix: {SUFFIX}")
+print(f"[GUARDIAN] Stream: {STREAM_NAME}")
+print()
+
+# ============================================================
+# STEP 1: Ingest 500 records spread over 6 months
+# ============================================================
+SIX_MONTHS_US = 180 * 24 * 60 * 60 * 1_000_000  # microseconds
+RECORD_COUNT = 500
+
+print(f"[1] Ingesting {RECORD_COUNT} records spread over 6 months...")
+namespaces = ["default", "kube-system", "monitoring", "logging", "app"]
+labels = ["nginx", "redis", "postgres", "app", "api"]
+levels = ["info", "warn", "error", "debug"]
+codes = [200, 201, 400, 404, 500, 502, 503]
+log_messages = [
+    "Request processed successfully", "Connection established", "Cache hit for key",
+    "Database query executed", "API response sent", "Authentication successful",
+    "Session created", "File uploaded", "Task completed", "Health check passed"
+]
+
+current_ts = int(time.time() * 1000000)
+logs = []
+for i in range(RECORD_COUNT):
+    offset = random.randint(0, SIX_MONTHS_US)
+    ts = current_ts - offset
+    logs.append({
+        "_timestamp": ts, "log": random.choice(log_messages),
+        "level": random.choice(levels),
+        "kubernetes_namespace_name": random.choice(namespaces),
+        "kubernetes_labels_name": random.choice(labels),
+        "code": random.choice(codes)
+    })
+
+# Sort by timestamp so data spans oldest to newest
+logs.sort(key=lambda x: x["_timestamp"])
+oldest_ts = logs[0]["_timestamp"]
+newest_ts = logs[-1]["_timestamp"]
+print(f"  Date range: {datetime.fromtimestamp(oldest_ts / 1_000_000)} → {datetime.fromtimestamp(newest_ts / 1_000_000)}")
+
+for batch_start in range(0, RECORD_COUNT, 100):
+    batch = logs[batch_start:batch_start + 100]
+    resp = session.post(f"{BASE_URL}api/{ORG_ID}/{STREAM_NAME}/_json", json=batch)
+    assert resp.status_code == 200, f"Ingest failed: {resp.text}"
+    print(f"  [OK] Batch {batch_start // 100 + 1}/{(RECORD_COUNT + 99) // 100}")
+print(f"[OK] {RECORD_COUNT} records ingested. Waiting 5s...")
+time.sleep(5)
+print()
+
+# ============================================================
+# STEP 2: Init page objects
+# ============================================================
+print("[2] Initializing page objects...")
+template_page = TemplatePage(session, BASE_URL, ORG_ID)
+dest_page = DestinationPage(session, BASE_URL, ORG_ID)
+func_page = FunctionPage(session, BASE_URL, ORG_ID)
+pipeline_page = PipelinePage(session, BASE_URL, ORG_ID)
+enrichment_page = EnrichmentPage(session, BASE_URL, ORG_ID)
+folder_page = FolderPage(session, BASE_URL, ORG_ID)
+alertv2_page = AlertV2Page(session, BASE_URL, ORG_ID)
+alert_page = AlertPage(session, BASE_URL, ORG_ID)
+dashboard_page = DashboardPage(session, BASE_URL, ORG_ID)
+savedview_page = SavedViewPage(session, BASE_URL, ORG_ID)
+print("[OK] Page objects initialized")
+print()
+
+# ============================================================
+# STATE
+# ============================================================
+state = {
+    "env": "devcluster2",
+    "org_id": ORG_ID,
+    "base_url": BASE_URL,
+    "created_at": datetime.now().isoformat(),
+    "suffix": SUFFIX,
+    "stream_name": STREAM_NAME,
+    "slack_webhook": SLACK_WEBHOOK,
+    "report_email": REPORT_EMAIL,
+    "report_title": REPORT_TITLE,
+    "entities": {
+        "templates": [], "destinations": [], "functions": [], "pipelines": [],
+        "enrichments": [], "alert_folders": [], "dashboard_folders": [],
+        "alerts_vrl_no_trigger": [], "alerts_vrl_trigger": [], "alerts_multi_time_range": [],
+        "dashboards": [], "dashboards_time_shift": [], "saved_views": [],
+        # NEW types
+        "slack_template": [], "email_template": [],
+        "slack_destination": [], "email_destination": [],
+        "alert_folder_extra": [],
+        "alerts_standard": [], "alerts_sql": [], "alerts_realtime": [], "alerts_cron": [],
+        "alerts_timezone": [],
+        "reports_scheduled": [], "reports_cached": [],
+    }
+}
+
+# Helper: fetch alert_id after creation
+def fetch_alert_id(folder_id, alert_name):
+    resp = session.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts?folder={folder_id}")
+    items = resp.json().get("list", []) if resp.status_code == 200 else []
+    for a in items:
+        if a.get("name") == alert_name:
+            return a.get("alert_id", alert_name)
+    # fallback: search all alerts
+    resp2 = session.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts")
+    items2 = resp2.json().get("list", []) if resp2.status_code == 200 else []
+    for a in items2:
+        if a.get("name") == alert_name:
+            return a.get("alert_id", alert_name)
+    return alert_name
+
+# ============================================================
+# STEP 3: Create 65 core entities (original 13 types)
+# ============================================================
+
+# 3.1 Templates (5)
+print("[3.1] Templates...")
+for i in range(5):
+    name = f"template_{SUFFIX}_{i}"
+    try:
+        template_page.create_template_webhook(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, name)
+        state["entities"]["templates"].append(name)
+        print(f"  [OK] {name}")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['templates'])}/5")
+print()
+
+# 3.2 Destinations (5)
+print("[3.2] Destinations...")
+for i in range(5):
+    name = f"dest_{SUFFIX}_{i}"
+    try:
+        dest_page.create_destination_webhook(session, BASE_URL, ORG_ID, EMAIL, PASSWORD, state["entities"]["templates"][i], name)
+        state["entities"]["destinations"].append(name)
+        print(f"  [OK] {name}")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['destinations'])}/5")
+print()
+
+# 3.3 Functions (5)
+print("[3.3] Functions...")
+for i in range(5):
+    name = f"func_{SUFFIX}_{i}"
+    try:
+        func_page.create_function(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, name)
+        state["entities"]["functions"].append(name)
+        print(f"  [OK] {name}")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['functions'])}/5")
+print()
+
+# 3.4 Pipelines (5)
+print("[3.4] Pipelines...")
+for i in range(5):
+    name = f"pipeline_{SUFFIX}_{i}"
+    try:
+        pipeline_page.create_realTime_pipeline(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, name)
+        time.sleep(0.5)
+        resp = session.get(f"{BASE_URL}api/{ORG_ID}/pipelines")
+        plist = resp.json().get("list", []) if resp.status_code == 200 else []
+        pid = name
+        for p in plist:
+            if p.get("name") == name: pid = p.get("pipeline_id", name); break
+        state["entities"]["pipelines"].append({"name": name, "pipeline_id": pid})
+        print(f"  [OK] {name} (id={pid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['pipelines'])}/5")
+print()
+
+# 3.5 Enrichments (5) — bypass cookie-based auth
+print("[3.5] Enrichments...")
+ENRICH_BOUNDARY = "----WebKitFormBoundaryaQgmYHuE6dQrlLss"
+
+def create_multipart(fields, boundary):
+    bs = f"--{boundary}"
+    lines = []
+    for k, v in fields.items():
+        if isinstance(v, tuple):
+            fname, fobj, ctype = v
+            lines.append(f"{bs}\r\nContent-Disposition: form-data; name=\"{k}\"; filename=\"{fname}\"\r\nContent-Type: {ctype}\r\n")
+            lines.append(fobj.read())
+        else:
+            lines.append(f"{bs}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}")
+    lines.append(f"{bs}--")
+    return b"\r\n".join(line if isinstance(line, bytes) else line.encode("utf-8") for line in lines)
+
+for i in range(5):
+    name = f"enrich_{SUFFIX}_{i}"
+    try:
+        csv_data = "protocol_number,keyword,protocol_description\n0,HOPOPT,IPv6 Hop-by-Hop Option\n1,ICMP,Internet Control Message\n2,IGMP,Internet Group Management"
+        fobj = io.BytesIO(csv_data.encode())
+        data = create_multipart({"file": ("protocols.csv", fobj, "text/csv")}, ENRICH_BOUNDARY)
+        headers = {"Content-Type": f"multipart/form-data; boundary={ENRICH_BOUNDARY}"}
+        resp = session.post(f"{BASE_URL}api/{ORG_ID}/enrichment_tables/{name}?append=false", headers=headers, data=data)
+        assert resp.status_code == 200, f"Failed: {resp.text}"
+        state["entities"]["enrichments"].append(name)
+        print(f"  [OK] {name}")
+        time.sleep(1)
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['enrichments'])}/5")
+print()
+
+# 3.6 Alert Folders (5)
+print("[3.6] Alert Folders...")
+for i in range(5):
+    name = f"alert_folder_{SUFFIX}_{i}"
+    try:
+        fid = folder_page.create_folder_alert_v2(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, name)
+        state["entities"]["alert_folders"].append({"name": name, "folder_id": fid})
+        print(f"  [OK] {name} (id={fid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alert_folders'])}/5")
+print()
+
+# 3.7 Dashboard Folders (5)
+print("[3.7] Dashboard Folders...")
+for i in range(5):
+    name = f"dash_folder_{SUFFIX}_{i}"
+    try:
+        fid = folder_page.create_folder_dashboard_v2(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, name)
+        state["entities"]["dashboard_folders"].append({"name": name, "folder_id": fid})
+        print(f"  [OK] {name} (id={fid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['dashboard_folders'])}/5")
+print()
+
+dest_names = state["entities"]["destinations"]
+alert_folder_ids = [f["folder_id"] for f in state["entities"]["alert_folders"]]
+dash_folder_ids = [f["folder_id"] for f in state["entities"]["dashboard_folders"]]
+
+# 3.8 VRL Alerts no-trigger (5)
+print("[3.8] VRL Alerts (no-trigger)...")
+for i in range(5):
+    name = f"alert_vrl_no_{SUFFIX}_{i}"
+    try:
+        alertv2_page.create_scheduled_sql_alert_vrl_no_trigger(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, dest_names[i], alert_folder_ids[i], name)
+        time.sleep(0.5)
+        aid = fetch_alert_id(alert_folder_ids[i], name)
+        state["entities"]["alerts_vrl_no_trigger"].append({"name": name, "alert_id": aid, "folder_id": alert_folder_ids[i]})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_vrl_no_trigger'])}/5")
+print()
+
+# 3.9 VRL Alerts trigger (5)
+print("[3.9] VRL Alerts (trigger)...")
+for i in range(5):
+    name = f"alert_vrl_trig_{SUFFIX}_{i}"
+    try:
+        alertv2_page.create_scheduled_sql_alert_vrl_trigger(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, dest_names[i], alert_folder_ids[i], name)
+        time.sleep(0.5)
+        aid = fetch_alert_id(alert_folder_ids[i], name)
+        state["entities"]["alerts_vrl_trigger"].append({"name": name, "alert_id": aid, "folder_id": alert_folder_ids[i]})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_vrl_trigger'])}/5")
+print()
+
+# 3.10 Multi Time Range Alerts (5) — offSet camelCase fix
+print("[3.10] Multi Time Range Alerts...")
+for i in range(5):
+    name = f"alert_mtr_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "name": name, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": False,
+            "query_condition": {"conditions": [], "sql": f"SELECT count(*) as count FROM {STREAM_NAME}",
+                "promql": "", "type": "sql", "aggregation": None, "promql_condition": None, "vrl_function": None,
+                "multi_time_range": [{"alias": "1h_ago", "offSet": "1h"}, {"alias": "1d_ago", "offSet": "1d"}, {"alias": "1w_ago", "offSet": "1w"}]},
+            "trigger_condition": {"period": 60, "operator": ">=", "frequency": 5, "cron": "", "threshold": 1,
+                "silence": 10, "frequency_type": "minutes", "timezone": "UTC"},
+            "destinations": [dest_names[i]], "context_attributes": {}, "enabled": True,
+            "owner": EMAIL, "lastEditedBy": EMAIL, "folder_id": alert_folder_ids[i]
+        }
+        resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?folder={alert_folder_ids[i]}", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+        time.sleep(0.5)
+        aid = fetch_alert_id(alert_folder_ids[i], name)
+        state["entities"]["alerts_multi_time_range"].append({"name": name, "alert_id": aid, "folder_id": alert_folder_ids[i]})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_multi_time_range'])}/5")
+print()
+
+# 3.11 Dashboards (5)
+print("[3.11] Dashboards...")
+for i in range(5):
+    name = f"dashboard_{SUFFIX}_{i}"
+    try:
+        did = dashboard_page.create_dashboard(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, dash_folder_ids[i], name)
+        state["entities"]["dashboards"].append({"name": name, "dashboard_id": did, "folder_id": dash_folder_ids[i]})
+        print(f"  [OK] {name} (id={did})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['dashboards'])}/5")
+print()
+
+# 3.12 Time Shift Dashboards (5)
+print("[3.12] Time Shift Dashboards...")
+for i in range(5):
+    name = f"dash_timeshift_{SUFFIX}_{i}"
+    try:
+        did = dashboard_page.create_dashboard_with_time_shift(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, dash_folder_ids[i], name)
+        state["entities"]["dashboards_time_shift"].append({"name": name, "dashboard_id": did, "folder_id": dash_folder_ids[i]})
+        print(f"  [OK] {name} (id={did})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['dashboards_time_shift'])}/5")
+print()
+
+# 3.13 Saved Views (5)
+print("[3.13] Saved Views...")
+for i in range(5):
+    name = f"savedview_{SUFFIX}_{i}"
+    try:
+        savedview_page.create_savedView(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, name)
+        time.sleep(0.5)
+        resp = session.get(f"{BASE_URL}api/{ORG_ID}/savedviews")
+        sv_items = resp.json().get("views", []) if resp.status_code == 200 else []
+        vid = name
+        for sv in sv_items:
+            if sv.get("view_name") == name: vid = sv.get("view_id", name); break
+        state["entities"]["saved_views"].append({"name": name, "view_id": vid})
+        print(f"  [OK] {name} (id={vid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['saved_views'])}/5")
+print()
+
+# ============================================================
+# STEP 4: NEW ENTITY TYPES — Slack/Email infra + more alerts + reports
+# ============================================================
+
+# 4.1 Slack template + destination
+print("[4.1] Slack template & destination...")
+slack_tpl = f"template_slack_{SUFFIX}"
+try:
+    template_page.create_template_webhook(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, slack_tpl)
+    state["entities"]["slack_template"].append(slack_tpl)
+    print(f"  [OK] Slack template: {slack_tpl}")
+    slack_dest = f"dest_slack_{SUFFIX}"
+    dest_page.create_destination_webhook(session, BASE_URL, ORG_ID, EMAIL, PASSWORD, slack_tpl, slack_dest, webhook_url=SLACK_WEBHOOK, method="post") if SLACK_WEBHOOK else \
+        dest_page.create_destination_webhook(session, BASE_URL, ORG_ID, EMAIL, PASSWORD, slack_tpl, slack_dest)
+    state["entities"]["slack_destination"].append(slack_dest)
+    print(f"  [OK] Slack destination: {slack_dest}")
+except Exception as e: print(f"  [FAIL] Slack infra: {e}")
+print()
+
+# 4.2 Email template + destination
+print("[4.2] Email template & destination...")
+email_tpl = f"template_email_{SUFFIX}"
+try:
+    template_page.create_template_email(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, email_tpl)
+    state["entities"]["email_template"].append(email_tpl)
+    print(f"  [OK] Email template: {email_tpl}")
+    email_dest = f"dest_email_{SUFFIX}"
+    dest_page.create_destination_email(session, BASE_URL, ORG_ID, EMAIL, PASSWORD, REPORT_EMAIL, email_tpl, email_dest)
+    state["entities"]["email_destination"].append(email_dest)
+    print(f"  [OK] Email destination: {email_dest}")
+except Exception as e: print(f"  [FAIL] Email infra: {e}")
+print()
+
+# 4.3 Extra alert folder
+print("[4.3] Extra alert folder...")
+extra_folder = f"extra_folder_{SUFFIX}"
+try:
+    resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/folders/alerts", json={"description": extra_folder, "folderId": "", "name": extra_folder}, headers={"Content-Type": "application/json"})
+    assert resp.status_code == 200, f"Failed: {resp.text}"
+    EXTRA_FID = resp.json()["folderId"]
+    state["entities"]["alert_folder_extra"].append({"name": extra_folder, "folder_id": EXTRA_FID})
+    print(f"  [OK] {extra_folder} (id={EXTRA_FID})")
+except Exception as e: print(f"  [FAIL] Extra folder: {e}")
+print()
+
+slack_dest_name = state["entities"]["slack_destination"][0] if state["entities"]["slack_destination"] else ""
+
+# 4.4 Standard Alerts (5) — custom condition on code >= 500
+print("[4.4] Standard Alerts (custom condition)...")
+for i in range(5):
+    name = f"standard_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "name": name, "row_template": slack_tpl, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": False,
+            "query_condition": {
+                "conditions": [{"column": "code", "operator": ">=", "value": 500, "type": None, "id": str(uuid.uuid4())}],
+                "search_event_type": "ui", "sql": "", "promql": "", "type": "custom",
+                "promql_condition": None, "vrl_function": None, "multi_time_range": []
+            },
+            "trigger_condition": {"period": 10, "operator": ">=", "frequency": 1, "cron": "", "threshold": 1, "silence": 5, "frequency_type": "minutes", "timezone": "UTC", "tolerance_in_secs": 0},
+            "org_id": ORG_ID, "destinations": [slack_dest_name], "enabled": True, "description": "Standard alert on error status codes"
+        }
+        resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?type=logs", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+        time.sleep(0.3)
+        aid = fetch_alert_id(EXTRA_FID, name)
+        state["entities"]["alerts_standard"].append({"name": name, "alert_id": aid})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_standard'])}/5")
+print()
+
+# 4.5 SQL Alerts (5)
+print("[4.5] SQL Alerts...")
+for i in range(5):
+    name = f"alert_sql_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "name": name, "row_template": slack_tpl, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": False,
+            "query_condition": {
+                "conditions": [{"column": "code", "operator": ">=", "value": 500, "type": None, "id": str(uuid.uuid4())}],
+                "search_event_type": "ui",
+                "sql": f"SELECT count(*) as count FROM \"{STREAM_NAME}\" WHERE code >= 500",
+                "promql": "", "type": "sql", "promql_condition": None, "vrl_function": None, "multi_time_range": []
+            },
+            "trigger_condition": {"period": 10, "operator": ">=", "frequency": 1, "cron": "", "threshold": 1, "silence": 5, "frequency_type": "minutes", "timezone": "UTC", "tolerance_in_secs": 0},
+            "org_id": ORG_ID, "destinations": [slack_dest_name], "enabled": True, "description": "SQL alert on error status codes"
+        }
+        resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?type=logs", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+        time.sleep(0.3)
+        aid = fetch_alert_id(EXTRA_FID, name)
+        state["entities"]["alerts_sql"].append({"name": name, "alert_id": aid})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_sql'])}/5")
+print()
+
+# 4.6 Real-Time Alerts (5) — condition on level=error (will trigger on ingest)
+print("[4.6] Real-Time Alerts...")
+for i in range(5):
+    name = f"alert_rt_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "name": name, "row_template": slack_tpl, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": True,
+            "query_condition": {
+                "conditions": [{"column": "level", "operator": "=", "value": "error", "type": None, "id": str(uuid.uuid4())}],
+                "search_event_type": "ui", "sql": "", "promql": "", "type": "custom",
+                "promql_condition": None, "vrl_function": None, "multi_time_range": []
+            },
+            "trigger_condition": {"period": 10, "operator": ">=", "frequency": 1, "cron": "", "threshold": 1, "silence": 5, "frequency_type": "minutes", "timezone": "UTC", "tolerance_in_secs": 0},
+            "org_id": ORG_ID, "destinations": [slack_dest_name], "enabled": True, "description": "Real-time alert on error logs"
+        }
+        resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?type=logs", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+        time.sleep(0.3)
+        aid = fetch_alert_id(EXTRA_FID, name)
+        state["entities"]["alerts_realtime"].append({"name": name, "alert_id": aid})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_realtime'])}/5")
+print()
+
+# 4.7 Cron Alerts (5)
+print("[4.7] Cron Alerts...")
+for i in range(5):
+    name = f"alert_cron_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "name": name, "row_template": slack_tpl, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": False,
+            "query_condition": {
+                "conditions": [{"column": "code", "operator": ">=", "value": 500, "type": None, "id": str(uuid.uuid4())}],
+                "search_event_type": "ui", "sql": "", "promql": "", "type": "custom",
+                "promql_condition": None, "vrl_function": None, "multi_time_range": []
+            },
+            "trigger_condition": {"period": 10, "operator": ">=", "frequency": 1, "cron": f"0 */{2+i} * * * *", "threshold": 1, "silence": 5, "frequency_type": "cron", "timezone": "UTC", "tz_offset": 0},
+            "org_id": ORG_ID, "destinations": [slack_dest_name], "enabled": True, "description": f"Cron alert every {2+i} minutes"
+        }
+        resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?type=logs", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+        time.sleep(0.3)
+        aid = fetch_alert_id(EXTRA_FID, name)
+        state["entities"]["alerts_cron"].append({"name": name, "alert_id": aid})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_cron'])}/5")
+print()
+
+# 4.8 Timezone Alert (1) — Asia/Calcutta
+print("[4.8] Timezone Alert (Asia/Calcutta)...")
+tz_name = f"alert_tz_calcutta_{SUFFIX}"
+try:
+    payload = {
+        "name": tz_name, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": False,
+        "query_condition": {"conditions": [], "sql": f"SELECT count(*) as count FROM {STREAM_NAME}",
+            "promql": "", "type": "sql", "aggregation": None, "promql_condition": None, "vrl_function": None, "multi_time_range": []},
+        "trigger_condition": {"period": 10, "operator": ">=", "frequency": 1, "cron": "", "threshold": 1, "silence": 5, "frequency_type": "minutes", "timezone": "Asia/Calcutta", "tz_offset": 330},
+        "destinations": [slack_dest_name], "context_attributes": {}, "enabled": True,
+        "owner": EMAIL, "lastEditedBy": EMAIL, "folder_id": EXTRA_FID
+    }
+    resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?folder={EXTRA_FID}", json=payload, headers={"Content-Type": "application/json"})
+    assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+    time.sleep(0.5)
+    aid = fetch_alert_id(EXTRA_FID, tz_name)
+    state["entities"]["alerts_timezone"].append({"name": tz_name, "alert_id": aid})
+    print(f"  [OK] {tz_name} (id={aid})")
+except Exception as e: print(f"  [FAIL] {tz_name}: {e}")
+print()
+
+# 4.9 Scheduled Reports (5) — email to REPORT_EMAIL
+print("[4.9] Scheduled Reports...")
+dash_ids = [d["dashboard_id"] for d in state["entities"]["dashboards"]]
+for i in range(5):
+    name = f"report_scheduled_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "dashboards": [{"folder": dash_folder_ids[i], "dashboard": dash_ids[i], "tabs": ["default"], "variables": [],
+                "timerange": {"type": "relative", "period": "30m", "from": 0, "to": 0}}],
+            "destinations": [{"email": REPORT_EMAIL}], "enabled": True, "media_type": "Pdf",
+            "name": name, "title": REPORT_TITLE, "message": "Guardian upgrade testing report", "orgId": ORG_ID,
+            "start": int(datetime.now().timestamp() * 1000000),
+            "frequency": {"interval": 1, "type": "once", "cron": ""},
+            "user": "", "password": "", "timezone": "UTC", "timezoneOffset": 0,
+            "owner": EMAIL, "lastEditedBy": EMAIL, "report_type": "PDF"
+        }
+        resp = session.post(f"{BASE_URL}api/{ORG_ID}/reports", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code == 200, f"Failed: {resp.text}"
+        state["entities"]["reports_scheduled"].append({"name": name})
+        print(f"  [OK] {name}")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['reports_scheduled'])}/5")
+print()
+
+# 4.10 Cached Reports (5)
+print("[4.10] Cached Reports...")
+for i in range(5):
+    name = f"report_cached_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "dashboards": [{"folder": dash_folder_ids[i], "dashboard": dash_ids[i], "tabs": ["default"], "variables": [],
+                "timerange": {"type": "relative", "period": "30m", "from": 0, "to": 0}}],
+            "destinations": [], "enabled": True, "media_type": "Pdf",
+            "name": name, "title": REPORT_TITLE, "message": "Guardian upgrade testing cached report", "orgId": ORG_ID,
+            "start": int(datetime.now().timestamp() * 1000000),
+            "frequency": {"interval": 1, "type": "once", "cron": ""},
+            "user": "", "password": "", "timezone": "UTC", "timezoneOffset": 0,
+            "owner": EMAIL, "lastEditedBy": EMAIL, "report_type": "PDF"
+        }
+        resp = session.post(f"{BASE_URL}api/{ORG_ID}/reports", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code == 200, f"Failed: {resp.text}"
+        state["entities"]["reports_cached"].append({"name": name})
+        print(f"  [OK] {name}")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['reports_cached'])}/5")
+print()
+
+# ============================================================
+# STEP 5: Save state
+# ============================================================
+print("[5] Saving state file...")
+state_file = Path(__file__).parent / "devcluster2_default_post_state.json"
+with open(state_file, "w") as f:
+    json.dump(state, f, indent=2, default=str)
+print(f"[OK] State saved to: {state_file}")
+print()
+
+# ============================================================
+# SUMMARY
+# ============================================================
+print("=" * 60)
+print("POST-UPGRADE CREATION SUMMARY")
+print("=" * 60)
+total = 0
+for entity_type, items in state["entities"].items():
+    count = len(items)
+    total += count
+    if count > 0: print(f"  {entity_type}: {count}")
+print(f"  TOTAL: {total} entities created")
+print(f"  Suffix: {SUFFIX}")
+print(f"  Stream: {STREAM_NAME}")
+print("=" * 60)

--- a/tests/api-testing/tests/upgrade_state/guardian_pre.py
+++ b/tests/api-testing/tests/upgrade_state/guardian_pre.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Guardian Pre-Upgrade Phase: Create ~100 entities across 18 types and save state."""
+
+import os
+import sys
+import io
+import json
+import time
+import uuid
+import random
+from datetime import datetime
+from pathlib import Path
+import requests
+from requests.auth import HTTPBasicAuth
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# --- Add pages directory to path ---
+PAGES_DIR = Path(__file__).parent.parent / "pages"
+sys.path.insert(0, str(PAGES_DIR))
+
+from template_page import TemplatePage
+from destination_page import DestinationPage
+from function_page import FunctionPage
+from pipeline_page import PipelinePage
+from enrichment_page import EnrichmentPage
+from folder_page import FolderPage
+from alertV2_page import AlertV2Page
+from alert_page import AlertPage
+from dashboard_page import DashboardPage
+from savedview_page import SavedViewPage
+
+# ============================================================
+# CONFIGURATION
+# ============================================================
+BASE_URL = os.environ.get("ZO_BASE_URL", "https://localhost:5080/")
+EMAIL = os.environ.get("ZO_ROOT_USER_EMAIL", "root@example.com")
+PASSWORD = os.environ.get("ZO_ROOT_USER_PASSWORD", "changeme")
+ORG_ID = os.environ.get("ORGNAME", "default")
+SLACK_WEBHOOK = os.environ.get("SLACK_WEBHOOK", "")
+REPORT_EMAIL = os.environ.get("REPORT_EMAIL", "user@example.com")
+REPORT_TITLE = os.environ.get("REPORT_TITLE", "upgrade-testing")
+
+session = requests.Session()
+session.auth = HTTPBasicAuth(EMAIL, PASSWORD)
+session.verify = False
+
+SUFFIX = f"guardian_{datetime.now().strftime('%m%d')}_{random.randint(1000, 9999)}"
+STREAM_NAME = f"guardian_stream_{SUFFIX}"
+
+print(f"[GUARDIAN] Pre-Upgrade Phase - The Watch Begins")
+print(f"[GUARDIAN] Base URL: {BASE_URL}")
+print(f"[GUARDIAN] Org: {ORG_ID} | Suffix: {SUFFIX}")
+print(f"[GUARDIAN] Stream: {STREAM_NAME}")
+print()
+
+# ============================================================
+# STEP 1: Ingest 500 records spread over 6 months
+# ============================================================
+SIX_MONTHS_US = 180 * 24 * 60 * 60 * 1_000_000  # microseconds
+RECORD_COUNT = 500
+
+print(f"[1] Ingesting {RECORD_COUNT} records spread over 6 months...")
+namespaces = ["default", "kube-system", "monitoring", "logging", "app"]
+labels = ["nginx", "redis", "postgres", "app", "api"]
+levels = ["info", "warn", "error", "debug"]
+codes = [200, 201, 400, 404, 500, 502, 503]
+log_messages = [
+    "Request processed successfully", "Connection established", "Cache hit for key",
+    "Database query executed", "API response sent", "Authentication successful",
+    "Session created", "File uploaded", "Task completed", "Health check passed"
+]
+
+current_ts = int(time.time() * 1000000)
+logs = []
+for i in range(RECORD_COUNT):
+    offset = random.randint(0, SIX_MONTHS_US)
+    ts = current_ts - offset
+    logs.append({
+        "_timestamp": ts, "log": random.choice(log_messages),
+        "level": random.choice(levels),
+        "kubernetes_namespace_name": random.choice(namespaces),
+        "kubernetes_labels_name": random.choice(labels),
+        "code": random.choice(codes)
+    })
+
+# Sort by timestamp so data spans oldest to newest
+logs.sort(key=lambda x: x["_timestamp"])
+oldest_ts = logs[0]["_timestamp"]
+newest_ts = logs[-1]["_timestamp"]
+print(f"  Date range: {datetime.fromtimestamp(oldest_ts / 1_000_000)} → {datetime.fromtimestamp(newest_ts / 1_000_000)}")
+
+for batch_start in range(0, RECORD_COUNT, 100):
+    batch = logs[batch_start:batch_start + 100]
+    resp = session.post(f"{BASE_URL}api/{ORG_ID}/{STREAM_NAME}/_json", json=batch)
+    assert resp.status_code == 200, f"Ingest failed: {resp.text}"
+    print(f"  [OK] Batch {batch_start // 100 + 1}/{(RECORD_COUNT + 99) // 100}")
+print(f"[OK] {RECORD_COUNT} records ingested. Waiting 5s...")
+time.sleep(5)
+print()
+
+# ============================================================
+# STEP 2: Init page objects
+# ============================================================
+print("[2] Initializing page objects...")
+template_page = TemplatePage(session, BASE_URL, ORG_ID)
+dest_page = DestinationPage(session, BASE_URL, ORG_ID)
+func_page = FunctionPage(session, BASE_URL, ORG_ID)
+pipeline_page = PipelinePage(session, BASE_URL, ORG_ID)
+enrichment_page = EnrichmentPage(session, BASE_URL, ORG_ID)
+folder_page = FolderPage(session, BASE_URL, ORG_ID)
+alertv2_page = AlertV2Page(session, BASE_URL, ORG_ID)
+alert_page = AlertPage(session, BASE_URL, ORG_ID)
+dashboard_page = DashboardPage(session, BASE_URL, ORG_ID)
+savedview_page = SavedViewPage(session, BASE_URL, ORG_ID)
+print("[OK] Page objects initialized")
+print()
+
+# ============================================================
+# STATE
+# ============================================================
+state = {
+    "env": "devcluster2",
+    "org_id": ORG_ID,
+    "base_url": BASE_URL,
+    "created_at": datetime.now().isoformat(),
+    "suffix": SUFFIX,
+    "stream_name": STREAM_NAME,
+    "slack_webhook": SLACK_WEBHOOK,
+    "report_email": REPORT_EMAIL,
+    "report_title": REPORT_TITLE,
+    "entities": {
+        "templates": [], "destinations": [], "functions": [], "pipelines": [],
+        "enrichments": [], "alert_folders": [], "dashboard_folders": [],
+        "alerts_vrl_no_trigger": [], "alerts_vrl_trigger": [], "alerts_multi_time_range": [],
+        "dashboards": [], "dashboards_time_shift": [], "saved_views": [],
+        # NEW types
+        "slack_template": [], "email_template": [],
+        "slack_destination": [], "email_destination": [],
+        "alert_folder_extra": [],
+        "alerts_standard": [], "alerts_sql": [], "alerts_realtime": [], "alerts_cron": [],
+        "alerts_timezone": [],
+        "reports_scheduled": [], "reports_cached": [],
+    }
+}
+
+# Helper: fetch alert_id after creation
+def fetch_alert_id(folder_id, alert_name):
+    resp = session.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts?folder={folder_id}")
+    items = resp.json().get("list", []) if resp.status_code == 200 else []
+    for a in items:
+        if a.get("name") == alert_name:
+            return a.get("alert_id", alert_name)
+    # fallback: search all alerts
+    resp2 = session.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts")
+    items2 = resp2.json().get("list", []) if resp2.status_code == 200 else []
+    for a in items2:
+        if a.get("name") == alert_name:
+            return a.get("alert_id", alert_name)
+    return alert_name
+
+# ============================================================
+# STEP 3: Create 65 core entities (original 13 types)
+# ============================================================
+
+# 3.1 Templates (5)
+print("[3.1] Templates...")
+for i in range(5):
+    name = f"template_{SUFFIX}_{i}"
+    try:
+        template_page.create_template_webhook(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, name)
+        state["entities"]["templates"].append(name)
+        print(f"  [OK] {name}")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['templates'])}/5")
+print()
+
+# 3.2 Destinations (5)
+print("[3.2] Destinations...")
+for i in range(5):
+    name = f"dest_{SUFFIX}_{i}"
+    try:
+        dest_page.create_destination_webhook(session, BASE_URL, ORG_ID, EMAIL, PASSWORD, state["entities"]["templates"][i], name)
+        state["entities"]["destinations"].append(name)
+        print(f"  [OK] {name}")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['destinations'])}/5")
+print()
+
+# 3.3 Functions (5)
+print("[3.3] Functions...")
+for i in range(5):
+    name = f"func_{SUFFIX}_{i}"
+    try:
+        func_page.create_function(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, name)
+        state["entities"]["functions"].append(name)
+        print(f"  [OK] {name}")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['functions'])}/5")
+print()
+
+# 3.4 Pipelines (5)
+print("[3.4] Pipelines...")
+for i in range(5):
+    name = f"pipeline_{SUFFIX}_{i}"
+    try:
+        pipeline_page.create_realTime_pipeline(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, name)
+        time.sleep(0.5)
+        resp = session.get(f"{BASE_URL}api/{ORG_ID}/pipelines")
+        plist = resp.json().get("list", []) if resp.status_code == 200 else []
+        pid = name
+        for p in plist:
+            if p.get("name") == name: pid = p.get("pipeline_id", name); break
+        state["entities"]["pipelines"].append({"name": name, "pipeline_id": pid})
+        print(f"  [OK] {name} (id={pid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['pipelines'])}/5")
+print()
+
+# 3.5 Enrichments (5) — bypass cookie-based auth
+print("[3.5] Enrichments...")
+ENRICH_BOUNDARY = "----WebKitFormBoundaryaQgmYHuE6dQrlLss"
+
+def create_multipart(fields, boundary):
+    bs = f"--{boundary}"
+    lines = []
+    for k, v in fields.items():
+        if isinstance(v, tuple):
+            fname, fobj, ctype = v
+            lines.append(f"{bs}\r\nContent-Disposition: form-data; name=\"{k}\"; filename=\"{fname}\"\r\nContent-Type: {ctype}\r\n")
+            lines.append(fobj.read())
+        else:
+            lines.append(f"{bs}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}")
+    lines.append(f"{bs}--")
+    return b"\r\n".join(line if isinstance(line, bytes) else line.encode("utf-8") for line in lines)
+
+for i in range(5):
+    name = f"enrich_{SUFFIX}_{i}"
+    try:
+        csv_data = "protocol_number,keyword,protocol_description\n0,HOPOPT,IPv6 Hop-by-Hop Option\n1,ICMP,Internet Control Message\n2,IGMP,Internet Group Management"
+        fobj = io.BytesIO(csv_data.encode())
+        data = create_multipart({"file": ("protocols.csv", fobj, "text/csv")}, ENRICH_BOUNDARY)
+        headers = {"Content-Type": f"multipart/form-data; boundary={ENRICH_BOUNDARY}"}
+        resp = session.post(f"{BASE_URL}api/{ORG_ID}/enrichment_tables/{name}?append=false", headers=headers, data=data)
+        assert resp.status_code == 200, f"Failed: {resp.text}"
+        state["entities"]["enrichments"].append(name)
+        print(f"  [OK] {name}")
+        time.sleep(1)
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['enrichments'])}/5")
+print()
+
+# 3.6 Alert Folders (5)
+print("[3.6] Alert Folders...")
+for i in range(5):
+    name = f"alert_folder_{SUFFIX}_{i}"
+    try:
+        fid = folder_page.create_folder_alert_v2(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, name)
+        state["entities"]["alert_folders"].append({"name": name, "folder_id": fid})
+        print(f"  [OK] {name} (id={fid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alert_folders'])}/5")
+print()
+
+# 3.7 Dashboard Folders (5)
+print("[3.7] Dashboard Folders...")
+for i in range(5):
+    name = f"dash_folder_{SUFFIX}_{i}"
+    try:
+        fid = folder_page.create_folder_dashboard_v2(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, name)
+        state["entities"]["dashboard_folders"].append({"name": name, "folder_id": fid})
+        print(f"  [OK] {name} (id={fid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['dashboard_folders'])}/5")
+print()
+
+dest_names = state["entities"]["destinations"]
+alert_folder_ids = [f["folder_id"] for f in state["entities"]["alert_folders"]]
+dash_folder_ids = [f["folder_id"] for f in state["entities"]["dashboard_folders"]]
+
+# 3.8 VRL Alerts no-trigger (5)
+print("[3.8] VRL Alerts (no-trigger)...")
+for i in range(5):
+    name = f"alert_vrl_no_{SUFFIX}_{i}"
+    try:
+        alertv2_page.create_scheduled_sql_alert_vrl_no_trigger(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, dest_names[i], alert_folder_ids[i], name)
+        time.sleep(0.5)
+        aid = fetch_alert_id(alert_folder_ids[i], name)
+        state["entities"]["alerts_vrl_no_trigger"].append({"name": name, "alert_id": aid, "folder_id": alert_folder_ids[i]})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_vrl_no_trigger'])}/5")
+print()
+
+# 3.9 VRL Alerts trigger (5)
+print("[3.9] VRL Alerts (trigger)...")
+for i in range(5):
+    name = f"alert_vrl_trig_{SUFFIX}_{i}"
+    try:
+        alertv2_page.create_scheduled_sql_alert_vrl_trigger(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, dest_names[i], alert_folder_ids[i], name)
+        time.sleep(0.5)
+        aid = fetch_alert_id(alert_folder_ids[i], name)
+        state["entities"]["alerts_vrl_trigger"].append({"name": name, "alert_id": aid, "folder_id": alert_folder_ids[i]})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_vrl_trigger'])}/5")
+print()
+
+# 3.10 Multi Time Range Alerts (5) — offSet camelCase fix
+print("[3.10] Multi Time Range Alerts...")
+for i in range(5):
+    name = f"alert_mtr_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "name": name, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": False,
+            "query_condition": {"conditions": [], "sql": f"SELECT count(*) as count FROM {STREAM_NAME}",
+                "promql": "", "type": "sql", "aggregation": None, "promql_condition": None, "vrl_function": None,
+                "multi_time_range": [{"alias": "1h_ago", "offSet": "1h"}, {"alias": "1d_ago", "offSet": "1d"}, {"alias": "1w_ago", "offSet": "1w"}]},
+            "trigger_condition": {"period": 60, "operator": ">=", "frequency": 5, "cron": "", "threshold": 1,
+                "silence": 10, "frequency_type": "minutes", "timezone": "UTC"},
+            "destinations": [dest_names[i]], "context_attributes": {}, "enabled": True,
+            "owner": EMAIL, "lastEditedBy": EMAIL, "folder_id": alert_folder_ids[i]
+        }
+        resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?folder={alert_folder_ids[i]}", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+        time.sleep(0.5)
+        aid = fetch_alert_id(alert_folder_ids[i], name)
+        state["entities"]["alerts_multi_time_range"].append({"name": name, "alert_id": aid, "folder_id": alert_folder_ids[i]})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_multi_time_range'])}/5")
+print()
+
+# 3.11 Dashboards (5)
+print("[3.11] Dashboards...")
+for i in range(5):
+    name = f"dashboard_{SUFFIX}_{i}"
+    try:
+        did = dashboard_page.create_dashboard(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, dash_folder_ids[i], name)
+        state["entities"]["dashboards"].append({"name": name, "dashboard_id": did, "folder_id": dash_folder_ids[i]})
+        print(f"  [OK] {name} (id={did})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['dashboards'])}/5")
+print()
+
+# 3.12 Time Shift Dashboards (5)
+print("[3.12] Time Shift Dashboards...")
+for i in range(5):
+    name = f"dash_timeshift_{SUFFIX}_{i}"
+    try:
+        did = dashboard_page.create_dashboard_with_time_shift(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, dash_folder_ids[i], name)
+        state["entities"]["dashboards_time_shift"].append({"name": name, "dashboard_id": did, "folder_id": dash_folder_ids[i]})
+        print(f"  [OK] {name} (id={did})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['dashboards_time_shift'])}/5")
+print()
+
+# 3.13 Saved Views (5)
+print("[3.13] Saved Views...")
+for i in range(5):
+    name = f"savedview_{SUFFIX}_{i}"
+    try:
+        savedview_page.create_savedView(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, STREAM_NAME, name)
+        time.sleep(0.5)
+        resp = session.get(f"{BASE_URL}api/{ORG_ID}/savedviews")
+        sv_items = resp.json().get("views", []) if resp.status_code == 200 else []
+        vid = name
+        for sv in sv_items:
+            if sv.get("view_name") == name: vid = sv.get("view_id", name); break
+        state["entities"]["saved_views"].append({"name": name, "view_id": vid})
+        print(f"  [OK] {name} (id={vid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['saved_views'])}/5")
+print()
+
+# ============================================================
+# STEP 4: NEW ENTITY TYPES — Slack/Email infra + more alerts + reports
+# ============================================================
+
+# 4.1 Slack template + destination
+print("[4.1] Slack template & destination...")
+slack_tpl = f"template_slack_{SUFFIX}"
+try:
+    template_page.create_template_webhook(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, slack_tpl)
+    state["entities"]["slack_template"].append(slack_tpl)
+    print(f"  [OK] Slack template: {slack_tpl}")
+    slack_dest = f"dest_slack_{SUFFIX}"
+    dest_page.create_destination_webhook(session, BASE_URL, ORG_ID, EMAIL, PASSWORD, slack_tpl, slack_dest, webhook_url=SLACK_WEBHOOK, method="post") if SLACK_WEBHOOK else \
+        dest_page.create_destination_webhook(session, BASE_URL, ORG_ID, EMAIL, PASSWORD, slack_tpl, slack_dest)
+    state["entities"]["slack_destination"].append(slack_dest)
+    print(f"  [OK] Slack destination: {slack_dest}")
+except Exception as e: print(f"  [FAIL] Slack infra: {e}")
+print()
+
+# 4.2 Email template + destination
+print("[4.2] Email template & destination...")
+email_tpl = f"template_email_{SUFFIX}"
+try:
+    template_page.create_template_email(session, BASE_URL, EMAIL, PASSWORD, ORG_ID, email_tpl)
+    state["entities"]["email_template"].append(email_tpl)
+    print(f"  [OK] Email template: {email_tpl}")
+    email_dest = f"dest_email_{SUFFIX}"
+    dest_page.create_destination_email(session, BASE_URL, ORG_ID, EMAIL, PASSWORD, REPORT_EMAIL, email_tpl, email_dest)
+    state["entities"]["email_destination"].append(email_dest)
+    print(f"  [OK] Email destination: {email_dest}")
+except Exception as e: print(f"  [FAIL] Email infra: {e}")
+print()
+
+# 4.3 Extra alert folder
+print("[4.3] Extra alert folder...")
+extra_folder = f"extra_folder_{SUFFIX}"
+try:
+    resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/folders/alerts", json={"description": extra_folder, "folderId": "", "name": extra_folder}, headers={"Content-Type": "application/json"})
+    assert resp.status_code == 200, f"Failed: {resp.text}"
+    EXTRA_FID = resp.json()["folderId"]
+    state["entities"]["alert_folder_extra"].append({"name": extra_folder, "folder_id": EXTRA_FID})
+    print(f"  [OK] {extra_folder} (id={EXTRA_FID})")
+except Exception as e: print(f"  [FAIL] Extra folder: {e}")
+print()
+
+slack_dest_name = state["entities"]["slack_destination"][0] if state["entities"]["slack_destination"] else ""
+
+# 4.4 Standard Alerts (5) — custom condition on code >= 500
+print("[4.4] Standard Alerts (custom condition)...")
+for i in range(5):
+    name = f"standard_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "name": name, "row_template": slack_tpl, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": False,
+            "query_condition": {
+                "conditions": [{"column": "code", "operator": ">=", "value": 500, "type": None, "id": str(uuid.uuid4())}],
+                "search_event_type": "ui", "sql": "", "promql": "", "type": "custom",
+                "promql_condition": None, "vrl_function": None, "multi_time_range": []
+            },
+            "trigger_condition": {"period": 10, "operator": ">=", "frequency": 1, "cron": "", "threshold": 1, "silence": 5, "frequency_type": "minutes", "timezone": "UTC", "tolerance_in_secs": 0},
+            "org_id": ORG_ID, "destinations": [slack_dest_name], "enabled": True, "description": "Standard alert on error status codes"
+        }
+        resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?type=logs", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+        time.sleep(0.3)
+        aid = fetch_alert_id(EXTRA_FID, name)
+        state["entities"]["alerts_standard"].append({"name": name, "alert_id": aid})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_standard'])}/5")
+print()
+
+# 4.5 SQL Alerts (5)
+print("[4.5] SQL Alerts...")
+for i in range(5):
+    name = f"alert_sql_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "name": name, "row_template": slack_tpl, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": False,
+            "query_condition": {
+                "conditions": [{"column": "code", "operator": ">=", "value": 500, "type": None, "id": str(uuid.uuid4())}],
+                "search_event_type": "ui",
+                "sql": f"SELECT count(*) as count FROM \"{STREAM_NAME}\" WHERE code >= 500",
+                "promql": "", "type": "sql", "promql_condition": None, "vrl_function": None, "multi_time_range": []
+            },
+            "trigger_condition": {"period": 10, "operator": ">=", "frequency": 1, "cron": "", "threshold": 1, "silence": 5, "frequency_type": "minutes", "timezone": "UTC", "tolerance_in_secs": 0},
+            "org_id": ORG_ID, "destinations": [slack_dest_name], "enabled": True, "description": "SQL alert on error status codes"
+        }
+        resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?type=logs", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+        time.sleep(0.3)
+        aid = fetch_alert_id(EXTRA_FID, name)
+        state["entities"]["alerts_sql"].append({"name": name, "alert_id": aid})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_sql'])}/5")
+print()
+
+# 4.6 Real-Time Alerts (5) — condition on level=error (will trigger on ingest)
+print("[4.6] Real-Time Alerts...")
+for i in range(5):
+    name = f"alert_rt_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "name": name, "row_template": slack_tpl, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": True,
+            "query_condition": {
+                "conditions": [{"column": "level", "operator": "=", "value": "error", "type": None, "id": str(uuid.uuid4())}],
+                "search_event_type": "ui", "sql": "", "promql": "", "type": "custom",
+                "promql_condition": None, "vrl_function": None, "multi_time_range": []
+            },
+            "trigger_condition": {"period": 10, "operator": ">=", "frequency": 1, "cron": "", "threshold": 1, "silence": 5, "frequency_type": "minutes", "timezone": "UTC", "tolerance_in_secs": 0},
+            "org_id": ORG_ID, "destinations": [slack_dest_name], "enabled": True, "description": "Real-time alert on error logs"
+        }
+        resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?type=logs", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+        time.sleep(0.3)
+        aid = fetch_alert_id(EXTRA_FID, name)
+        state["entities"]["alerts_realtime"].append({"name": name, "alert_id": aid})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_realtime'])}/5")
+print()
+
+# 4.7 Cron Alerts (5)
+print("[4.7] Cron Alerts...")
+for i in range(5):
+    name = f"alert_cron_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "name": name, "row_template": slack_tpl, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": False,
+            "query_condition": {
+                "conditions": [{"column": "code", "operator": ">=", "value": 500, "type": None, "id": str(uuid.uuid4())}],
+                "search_event_type": "ui", "sql": "", "promql": "", "type": "custom",
+                "promql_condition": None, "vrl_function": None, "multi_time_range": []
+            },
+            "trigger_condition": {"period": 10, "operator": ">=", "frequency": 1, "cron": f"0 */{2+i} * * * *", "threshold": 1, "silence": 5, "frequency_type": "cron", "timezone": "UTC", "tz_offset": 0},
+            "org_id": ORG_ID, "destinations": [slack_dest_name], "enabled": True, "description": f"Cron alert every {2+i} minutes"
+        }
+        resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?type=logs", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+        time.sleep(0.3)
+        aid = fetch_alert_id(EXTRA_FID, name)
+        state["entities"]["alerts_cron"].append({"name": name, "alert_id": aid})
+        print(f"  [OK] {name} (id={aid})")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['alerts_cron'])}/5")
+print()
+
+# 4.8 Timezone Alert (1) — Asia/Calcutta
+print("[4.8] Timezone Alert (Asia/Calcutta)...")
+tz_name = f"alert_tz_calcutta_{SUFFIX}"
+try:
+    payload = {
+        "name": tz_name, "stream_type": "logs", "stream_name": STREAM_NAME, "is_real_time": False,
+        "query_condition": {"conditions": [], "sql": f"SELECT count(*) as count FROM {STREAM_NAME}",
+            "promql": "", "type": "sql", "aggregation": None, "promql_condition": None, "vrl_function": None, "multi_time_range": []},
+        "trigger_condition": {"period": 10, "operator": ">=", "frequency": 1, "cron": "", "threshold": 1, "silence": 5, "frequency_type": "minutes", "timezone": "Asia/Calcutta", "tz_offset": 330},
+        "destinations": [slack_dest_name], "context_attributes": {}, "enabled": True,
+        "owner": EMAIL, "lastEditedBy": EMAIL, "folder_id": EXTRA_FID
+    }
+    resp = session.post(f"{BASE_URL}api/v2/{ORG_ID}/alerts?folder={EXTRA_FID}", json=payload, headers={"Content-Type": "application/json"})
+    assert resp.status_code in (200, 409), f"Failed: {resp.text}"
+    time.sleep(0.5)
+    aid = fetch_alert_id(EXTRA_FID, tz_name)
+    state["entities"]["alerts_timezone"].append({"name": tz_name, "alert_id": aid})
+    print(f"  [OK] {tz_name} (id={aid})")
+except Exception as e: print(f"  [FAIL] {tz_name}: {e}")
+print()
+
+# 4.9 Scheduled Reports (5) — email to REPORT_EMAIL
+print("[4.9] Scheduled Reports...")
+dash_ids = [d["dashboard_id"] for d in state["entities"]["dashboards"]]
+for i in range(5):
+    name = f"report_scheduled_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "dashboards": [{"folder": dash_folder_ids[i], "dashboard": dash_ids[i], "tabs": ["default"], "variables": [],
+                "timerange": {"type": "relative", "period": "30m", "from": 0, "to": 0}}],
+            "destinations": [{"email": REPORT_EMAIL}], "enabled": True, "media_type": "Pdf",
+            "name": name, "title": REPORT_TITLE, "message": "Guardian upgrade testing report", "orgId": ORG_ID,
+            "start": int(datetime.now().timestamp() * 1000000),
+            "frequency": {"interval": 1, "type": "once", "cron": ""},
+            "user": "", "password": "", "timezone": "UTC", "timezoneOffset": 0,
+            "owner": EMAIL, "lastEditedBy": EMAIL, "report_type": "PDF"
+        }
+        resp = session.post(f"{BASE_URL}api/{ORG_ID}/reports", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code == 200, f"Failed: {resp.text}"
+        state["entities"]["reports_scheduled"].append({"name": name})
+        print(f"  [OK] {name}")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['reports_scheduled'])}/5")
+print()
+
+# 4.10 Cached Reports (5)
+print("[4.10] Cached Reports...")
+for i in range(5):
+    name = f"report_cached_{SUFFIX}_{i}"
+    try:
+        payload = {
+            "dashboards": [{"folder": dash_folder_ids[i], "dashboard": dash_ids[i], "tabs": ["default"], "variables": [],
+                "timerange": {"type": "relative", "period": "30m", "from": 0, "to": 0}}],
+            "destinations": [], "enabled": True, "media_type": "Pdf",
+            "name": name, "title": REPORT_TITLE, "message": "Guardian upgrade testing cached report", "orgId": ORG_ID,
+            "start": int(datetime.now().timestamp() * 1000000),
+            "frequency": {"interval": 1, "type": "once", "cron": ""},
+            "user": "", "password": "", "timezone": "UTC", "timezoneOffset": 0,
+            "owner": EMAIL, "lastEditedBy": EMAIL, "report_type": "PDF"
+        }
+        resp = session.post(f"{BASE_URL}api/{ORG_ID}/reports", json=payload, headers={"Content-Type": "application/json"})
+        assert resp.status_code == 200, f"Failed: {resp.text}"
+        state["entities"]["reports_cached"].append({"name": name})
+        print(f"  [OK] {name}")
+    except Exception as e: print(f"  [FAIL] {name}: {e}")
+print(f"  => {len(state['entities']['reports_cached'])}/5")
+print()
+
+# ============================================================
+# STEP 5: Save state
+# ============================================================
+print("[5] Saving state file...")
+state_file = Path(__file__).parent / "devcluster2_default_pre_state.json"
+with open(state_file, "w") as f:
+    json.dump(state, f, indent=2, default=str)
+print(f"[OK] State saved to: {state_file}")
+print()
+
+# ============================================================
+# SUMMARY
+# ============================================================
+print("=" * 60)
+print("PRE-UPGRADE CREATION SUMMARY")
+print("=" * 60)
+total = 0
+for entity_type, items in state["entities"].items():
+    count = len(items)
+    total += count
+    if count > 0: print(f"  {entity_type}: {count}")
+print(f"  TOTAL: {total} entities created")
+print(f"  Suffix: {SUFFIX}")
+print(f"  Stream: {STREAM_NAME}")
+print("=" * 60)

--- a/tests/api-testing/tests/upgrade_state/guardian_verify.py
+++ b/tests/api-testing/tests/upgrade_state/guardian_verify.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Guardian Verify Phase: Check all pre-upgrade and post-upgrade entities still exist."""
+
+import os
+import sys
+import json
+from pathlib import Path
+import requests
+from requests.auth import HTTPBasicAuth
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+EMAIL = os.environ.get("ZO_ROOT_USER_EMAIL", "root@example.com")
+PASSWORD = os.environ.get("ZO_ROOT_USER_PASSWORD", "changeme")
+
+# Determine which state file to use (pre or post)
+phase = sys.argv[1] if len(sys.argv) > 1 else "pre"
+state_file = Path(__file__).parent / f"devcluster2_default_{phase}_state.json"
+with open(state_file) as f:
+    state = json.load(f)
+
+BASE_URL = state["base_url"]
+ORG_ID = state["org_id"]
+s = requests.Session()
+s.auth = HTTPBasicAuth(EMAIL, PASSWORD)
+s.verify = False
+
+print(f"[GUARDIAN] Verify Phase - The Vigil")
+print(f"[GUARDIAN] Env: {state['env']} | Org: {ORG_ID}")
+print(f"[GUARDIAN] Suffix: {state['suffix']} | Created: {state['created_at']}")
+if state.get("enriched_at"):
+    print(f"[GUARDIAN] Enriched: {state['enriched_at']} (suffix: {state.get('enrichment_suffix')})")
+print()
+
+results = {}
+total_ok, total_fail = 0, 0
+
+def check(label, url, expected_status=200):
+    resp = s.get(url)
+    ok = resp.status_code == expected_status
+    return ok, resp.status_code, resp.text[:200]
+
+# 1. Templates
+print("[1] Templates...")
+ok, fail = 0, 0
+for name in state["entities"].get("templates", []):
+    r_ok, code, _ = check(name, f"{BASE_URL}api/{ORG_ID}/alerts/templates/{name}")
+    if r_ok: ok += 1; print(f"  [OK] {name}")
+    else: fail += 1; print(f"  [FAIL] {name} (HTTP {code})")
+results["templates"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 2. Destinations
+print("[2] Destinations...")
+ok, fail = 0, 0
+for name in state["entities"].get("destinations", []):
+    r_ok, code, _ = check(name, f"{BASE_URL}api/{ORG_ID}/alerts/destinations/{name}")
+    if r_ok: ok += 1; print(f"  [OK] {name}")
+    else: fail += 1; print(f"  [FAIL] {name} (HTTP {code})")
+results["destinations"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 3. Functions
+print("[3] Functions...")
+ok, fail = 0, 0
+for name in state["entities"].get("functions", []):
+    r_ok, code, _ = check(name, f"{BASE_URL}api/{ORG_ID}/functions/{name}")
+    if r_ok: ok += 1; print(f"  [OK] {name}")
+    else: fail += 1; print(f"  [FAIL] {name} (HTTP {code})")
+results["functions"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 4. Pipelines (check via list API)
+print("[4] Pipelines...")
+ok, fail = 0, 0
+resp = s.get(f"{BASE_URL}api/{ORG_ID}/pipelines")
+pl_list = resp.json().get("list", []) if resp.status_code == 200 else []
+pl_names = {p["name"] for p in pl_list}
+for entry in state["entities"].get("pipelines", []):
+    name = entry["name"]
+    if name in pl_names: ok += 1; print(f"  [OK] {name}")
+    else: fail += 1; print(f"  [FAIL] {name}")
+results["pipelines"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 5. Enrichments (check via list API)
+print("[5] Enrichments...")
+ok, fail = 0, 0
+resp = s.get(f"{BASE_URL}api/{ORG_ID}/streams?type=enrichment_tables")
+et_list = resp.json().get("list", []) if resp.status_code == 200 else []
+et_names = {e.get("name", "") for e in et_list}
+for name in state["entities"].get("enrichments", []):
+    if name in et_names: ok += 1; print(f"  [OK] {name}")
+    else: fail += 1; print(f"  [FAIL] {name}")
+results["enrichments"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 6. Alert Folders (check via list API)
+print("[6] Alert Folders...")
+ok, fail = 0, 0
+resp = s.get(f"{BASE_URL}api/v2/{ORG_ID}/folders/alerts")
+af_list = resp.json().get("list", []) if resp.status_code == 200 else []
+af_ids = {f["folderId"] for f in af_list}
+# Regular alert folders
+for entry in state["entities"].get("alert_folders", []):
+    if entry["folder_id"] in af_ids: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+# Extra alert folder
+for entry in state["entities"].get("alert_folder_extra", []):
+    if entry["folder_id"] in af_ids: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["alert_folders"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 7. Dashboard Folders (check via list API)
+print("[7] Dashboard Folders...")
+ok, fail = 0, 0
+resp = s.get(f"{BASE_URL}api/v2/{ORG_ID}/folders/dashboards")
+df_list = resp.json().get("list", []) if resp.status_code == 200 else []
+df_ids = {f["folderId"] for f in df_list}
+for entry in state["entities"].get("dashboard_folders", []):
+    if entry["folder_id"] in df_ids: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["dashboard_folders"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 8. VRL Alerts no-trigger (check via list API by folder)
+print("[8] VRL Alerts (no-trigger)...")
+ok, fail = 0, 0
+for entry in state["entities"].get("alerts_vrl_no_trigger", []):
+    fid = entry["folder_id"]
+    resp = s.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts?folder={fid}")
+    alist = resp.json().get("list", []) if resp.status_code == 200 else []
+    a_names = {a["name"] for a in alist}
+    if entry["name"] in a_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["alerts_vrl_no_trigger"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 9. VRL Alerts trigger
+print("[9] VRL Alerts (trigger)...")
+ok, fail = 0, 0
+for entry in state["entities"].get("alerts_vrl_trigger", []):
+    fid = entry["folder_id"]
+    resp = s.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts?folder={fid}")
+    alist = resp.json().get("list", []) if resp.status_code == 200 else []
+    a_names = {a["name"] for a in alist}
+    if entry["name"] in a_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["alerts_vrl_trigger"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 10. Multi Time Range Alerts
+print("[10] Multi Time Range Alerts...")
+ok, fail = 0, 0
+for entry in state["entities"].get("alerts_multi_time_range", []):
+    fid = entry["folder_id"]
+    resp = s.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts?folder={fid}")
+    alist = resp.json().get("list", []) if resp.status_code == 200 else []
+    a_names = {a["name"] for a in alist}
+    if entry["name"] in a_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["alerts_multi_time_range"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 11. Dashboards (check by ID)
+print("[11] Dashboards...")
+ok, fail = 0, 0
+for entry in state["entities"].get("dashboards", []):
+    fid = entry["folder_id"]
+    did = entry["dashboard_id"]
+    r_ok, code, _ = check(entry["name"], f"{BASE_URL}api/{ORG_ID}/dashboards/{did}?folder={fid}")
+    if r_ok: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']} (HTTP {code})")
+results["dashboards"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 12. Time Shift Dashboards
+print("[12] Time Shift Dashboards...")
+ok, fail = 0, 0
+for entry in state["entities"].get("dashboards_time_shift", []):
+    fid = entry["folder_id"]
+    did = entry["dashboard_id"]
+    r_ok, code, _ = check(entry["name"], f"{BASE_URL}api/{ORG_ID}/dashboards/{did}?folder={fid}")
+    if r_ok: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']} (HTTP {code})")
+results["dashboards_time_shift"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 13. Saved Views (check via list API)
+print("[13] Saved Views...")
+ok, fail = 0, 0
+resp = s.get(f"{BASE_URL}api/{ORG_ID}/savedviews")
+sv_data = resp.json() if resp.status_code == 200 else {}
+sv_items = sv_data.get("views", [])
+sv_names = {v.get("view_name", "") for v in sv_items}
+for entry in state["entities"].get("saved_views", []):
+    if entry["name"] in sv_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["saved_views"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# --- NEW ENTITY TYPES ---
+
+# 14. Slack Templates
+print("[14] Slack Templates...")
+ok, fail = 0, 0
+for name in state["entities"].get("slack_template", []) + state["entities"].get("templates_slack", []):
+    if not name: continue
+    r_ok, code, _ = check(name, f"{BASE_URL}api/{ORG_ID}/alerts/templates/{name}")
+    if r_ok: ok += 1; print(f"  [OK] {name}")
+    else: fail += 1; print(f"  [FAIL] {name} (HTTP {code})")
+results["slack_templates"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 15. Email Templates
+print("[15] Email Templates...")
+ok, fail = 0, 0
+for name in state["entities"].get("email_template", []) + state["entities"].get("templates_email", []):
+    if not name: continue
+    r_ok, code, _ = check(name, f"{BASE_URL}api/{ORG_ID}/alerts/templates/{name}")
+    if r_ok: ok += 1; print(f"  [OK] {name}")
+    else: fail += 1; print(f"  [FAIL] {name} (HTTP {code})")
+results["email_templates"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 16. Slack Destinations
+print("[16] Slack Destinations...")
+ok, fail = 0, 0
+for name in state["entities"].get("slack_destination", []) + state["entities"].get("destinations_slack", []):
+    if not name: continue
+    r_ok, code, _ = check(name, f"{BASE_URL}api/{ORG_ID}/alerts/destinations/{name}")
+    if r_ok: ok += 1; print(f"  [OK] {name}")
+    else: fail += 1; print(f"  [FAIL] {name} (HTTP {code})")
+results["slack_destinations"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 17. Email Destinations
+print("[17] Email Destinations...")
+ok, fail = 0, 0
+for name in state["entities"].get("email_destination", []) + state["entities"].get("destinations_email", []):
+    if not name: continue
+    r_ok, code, _ = check(name, f"{BASE_URL}api/{ORG_ID}/alerts/destinations/{name}")
+    if r_ok: ok += 1; print(f"  [OK] {name}")
+    else: fail += 1; print(f"  [FAIL] {name} (HTTP {code})")
+results["email_destinations"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 18. Standard Alerts (check via list API by name)
+print("[18] Standard Alerts...")
+ok, fail = 0, 0
+resp = s.get(f"{BASE_URL}api/v2/{ORG_ID}/alerts")
+all_alerts = resp.json().get("list", []) if resp.status_code == 200 else []
+all_alert_names = {a["name"] for a in all_alerts}
+for entry in state["entities"].get("alerts_standard", []):
+    if entry["name"] in all_alert_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["alerts_standard"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 19. SQL Alerts
+print("[19] SQL Alerts...")
+ok, fail = 0, 0
+for entry in state["entities"].get("alerts_sql", []):
+    if entry["name"] in all_alert_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["alerts_sql"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 20. Real-Time Alerts
+print("[20] Real-Time Alerts...")
+ok, fail = 0, 0
+for entry in state["entities"].get("alerts_realtime", []):
+    if entry["name"] in all_alert_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["alerts_realtime"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 21. Cron Alerts
+print("[21] Cron Alerts...")
+ok, fail = 0, 0
+for entry in state["entities"].get("alerts_cron", []):
+    if entry["name"] in all_alert_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["alerts_cron"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 22. Timezone Alerts
+print("[22] Timezone Alerts...")
+ok, fail = 0, 0
+for entry in state["entities"].get("alerts_timezone", []):
+    if entry["name"] in all_alert_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["alerts_timezone"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# 23. Reports — Scheduled & Cached (check via list API)
+print("[23] Reports...")
+ok, fail = 0, 0
+resp = s.get(f"{BASE_URL}api/{ORG_ID}/reports")
+report_list = resp.json() if resp.status_code == 200 else []
+report_names = {r.get("name", "") for r in report_list}
+for entry in state["entities"].get("reports_scheduled", []):
+    if entry["name"] in report_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+for entry in state["entities"].get("reports_cached", []):
+    if entry["name"] in report_names: ok += 1; print(f"  [OK] {entry['name']}")
+    else: fail += 1; print(f"  [FAIL] {entry['name']}")
+results["reports"] = f"{ok}/{ok+fail}"; total_ok += ok; total_fail += fail
+
+# Summary
+print()
+print("=" * 60)
+print("VERIFICATION RESULTS")
+print("=" * 60)
+for label, result in results.items():
+    print(f"  {label}: {result}")
+print(f"  ---")
+print(f"  TOTAL: {total_ok}/{total_ok + total_fail} entities verified")
+if total_fail == 0:
+    print("  VERDICT: ALL ENTITIES SURVIVED ✅")
+else:
+    print(f"  VERDICT: {total_fail} ENTITIES LOST ❌")
+print("=" * 60)


### PR DESCRIPTION
## Summary
- `guardian_pre.py` / `guardian_post.py`: create ~100 entities across 18 types
- `guardian_verify.py`: verify 23 entity categories survive upgrades
- `guardian_cleanup.py`: delete all entities in reverse dependency order
- `guardian_enrich.py`: one-off enrichment for existing state
- Data ingested with 6-month backdating for MTR/trend alert coverage
- All config via env vars with safe defaults

## Related
- Guardian skill definition PR: https://github.com/openobserve/test_agents/pull/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)