### PR TITLE
fix: traces spans column sorting 

### DIFF
--- a/web/src/components/TenstackTable.spec.ts
+++ b/web/src/components/TenstackTable.spec.ts
@@ -1163,6 +1163,54 @@ describe("TenstackTable", () => {
       const [, rowIndex] = wrapper.emitted("click:dataRow")![0] as any[];
       expect(rowIndex).toBe(1);
     });
+
+    it("should emit click:dataRow with the correct sorted row data in virtual scroll mode with server-side sorting", async () => {
+      // This tests the bug where virtual scroll emits original unsorted data instead of sorted data
+      const sortableCols = [
+        { id: "name", accessorKey: "name", header: "NAME", size: 200, meta: { sortable: true } },
+        { id: "spans", accessorKey: "spans", header: "SPANS", size: 100, meta: { sortable: true } },
+      ];
+
+      // Original rows in default order
+      const originalRows = [
+        { _timestamp: 1000, name: "alpha", spans: 10 },
+        { _timestamp: 2000, name: "beta", spans: 5 },
+        { _timestamp: 3000, name: "gamma", spans: 20 },
+      ];
+
+      // When sorted by spans desc, the order should be: gamma(20), alpha(10), beta(5)
+      const sortedRows = [
+        { _timestamp: 3000, name: "gamma", spans: 20 },  // First after sorting
+        { _timestamp: 1000, name: "alpha", spans: 10 },
+        { _timestamp: 2000, name: "beta", spans: 5 },
+      ];
+
+      wrapper = mountTable({
+        columns: sortableCols,
+        rows: sortedRows,  // Pass the server-sorted rows
+        sortBy: "spans",   // Indicate we're sorted by spans
+        sortOrder: "desc", // Descending order
+        sortFieldMap: {},  // No field mapping needed
+        useVirtualScroll: true, // Use virtual scroll (default but explicit)
+      });
+
+      // Click on the first virtual row (should be gamma with 20 spans)
+      const firstVirtualRow = wrapper.find('[data-test="o2-table-detail-3000"]');
+      expect(firstVirtualRow.exists()).toBe(true);
+      await firstVirtualRow.trigger("click");
+
+      // Should emit the correct sorted row data, not the original row at index 0
+      expect(wrapper.emitted("click:dataRow")).toBeTruthy();
+      const [emittedRow] = wrapper.emitted("click:dataRow")![0] as any[];
+
+      // Should emit gamma (first in sorted order), not alpha (first in original order)
+      expect(emittedRow).toMatchObject({
+        _timestamp: 3000,
+        name: "gamma",
+        spans: 20
+      });
+      expect(emittedRow.name).not.toBe("alpha"); // Should NOT be the original first row
+    });
   });
 
   // ── rowClass prop ─────────────────────────────────────────────────────────

--- a/web/src/components/TenstackTable.vue
+++ b/web/src/components/TenstackTable.vue
@@ -596,7 +596,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           >
             <tr
               :data-test="`o2-table-detail-${
-                (tableRows[virtualRow.index] as any)[
+                (formattedRows[virtualRow.index]?.original as any)?.[
                   store.state.zoConfig.timestamp_column || '_timestamp'
                 ]
               }`"
@@ -617,7 +617,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   ?.isExpandedRow
                   ? 'tw:table-row'
                   : 'tw:flex',
-                (tableRows[virtualRow.index] as any)[
+                (formattedRows[virtualRow.index]?.original as any)?.[
                   store.state.zoConfig.timestamp_column
                 ] === highlightTimestamp &&
                 !(formattedRows[virtualRow.index]?.original as any)
@@ -629,14 +629,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 'table-row-hover',
                 !(formattedRows[virtualRow.index]?.original as any)
                   ?.isExpandedRow
-                  ? rowClass?.(tableRows[virtualRow.index] as any)
+                  ? rowClass?.(formattedRows[virtualRow.index]?.original as any)
                   : undefined,
               ]"
               @click="
                 !(formattedRows[virtualRow.index]?.original as any)
                   ?.isExpandedRow &&
                 handleDataRowClick(
-                  tableRows[virtualRow.index],
+                  formattedRows[virtualRow.index]?.original,
                   virtualRow.index,
                   $event,
                 )
@@ -652,7 +652,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 class="tw:absolute tw:left-0 tw:inset-y-0 tw:w-1 tw:z-10"
                 :style="{
                   backgroundColor: getRowStatusColor(
-                    tableRows[virtualRow.index],
+                    formattedRows[virtualRow.index]?.original,
                   ),
                 }"
               />
@@ -668,7 +668,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               >
                 <slot
                   name="expanded-row"
-                  :row="tableRows[virtualRow.index - 1]"
+                  :row="formattedRows[virtualRow.index - 1]?.original"
                   :index="calculateActualIndex(virtualRow.index - 1)"
                   :hide-field-options="hideExpandFieldOptions"
                 />


### PR DESCRIPTION
#11815 

## What changed

Fixed a bug in `TenstackTable.vue` where the virtual scroll row click handler used `tableRows[virtualRow.index]` instead of `formattedRows[virtualRow.index]?.original` to emit row data. When the table is sorted server-side, `tableRows` retains the original unsorted order while `formattedRows` reflects the sorted order, so clicking the first visible row emitted data from the wrong source row. Also added a regression test for the sorted virtual-scroll case.

## Why

When a user sorted the Traces search results by the spans column and clicked the first visible row, the `click:dataRow` event emitted the original unsorted row (e.g., "alpha" at index 0) instead of the sorted row (e.g., "gamma" at index 0 after sorting desc). This caused downstream consumers to receive incorrect row data.