### PR TITLE
fix: fixed duplicated traces search calls in live mode

### DIFF
--- a/web/src/plugins/traces/Index.spec.ts
+++ b/web/src/plugins/traces/Index.spec.ts
@@ -1065,7 +1065,7 @@ describe("Index.vue (Main Traces Page)", () => {
       expect(mockApplyFilters).toHaveBeenCalledWith([
         "duration >= 100",
         "service_name = 'test'",
-      ]);
+      ], false); // liveMode is undefined, so skipSearch = false
     });
 
     it("should append error filter to applyFilters call when showErrorOnly is enabled", async () => {
@@ -1079,7 +1079,7 @@ describe("Index.vue (Main Traces Page)", () => {
       expect(mockApplyFilters).toHaveBeenCalledWith([
         "duration >= 100",
         "span_status = 'ERROR'",
-      ]);
+      ], false); // liveMode is undefined, so skipSearch = false
     });
 
     it("should not duplicate error filter when it is already present in incoming filters", async () => {
@@ -1108,7 +1108,7 @@ describe("Index.vue (Main Traces Page)", () => {
       wrapper.vm.onErrorOnlyToggled(true);
       await flushPromises();
 
-      expect(mockApplyFilters).toHaveBeenCalledWith(["span_status = 'ERROR'"]);
+      expect(mockApplyFilters).toHaveBeenCalledWith(["span_status = 'ERROR'"], false); // liveMode is undefined, so skipSearch = false
     });
 
     it("should call removeFilterByField when error only toggle is turned off", async () => {
@@ -1119,6 +1119,68 @@ describe("Index.vue (Main Traces Page)", () => {
       await flushPromises();
 
       expect(mockRemoveFilterByField).toHaveBeenCalledWith("span_status");
+    });
+
+    it("should skip search when live mode is ON", async () => {
+      mockSearchObj.meta.liveMode = true;
+      wrapper = mountWithSearchBarStub();
+      await flushPromises();
+
+      const testFilters = ['duration > 100ms', 'service_name = "api"'];
+      wrapper.vm.onMetricsFiltersUpdated(testFilters);
+      await flushPromises();
+
+      expect(mockApplyFilters).toHaveBeenCalledWith(testFilters, true);
+    });
+
+    it("should not skip search when live mode is OFF", async () => {
+      mockSearchObj.meta.liveMode = false;
+      wrapper = mountWithSearchBarStub();
+      await flushPromises();
+
+      const testFilters = ['span_status = "ERROR"'];
+      wrapper.vm.onMetricsFiltersUpdated(testFilters);
+      await flushPromises();
+
+      expect(mockApplyFilters).toHaveBeenCalledWith(testFilters, false);
+    });
+
+    it("should handle undefined liveMode as false", async () => {
+      mockSearchObj.meta.liveMode = undefined;
+      wrapper = mountWithSearchBarStub();
+      await flushPromises();
+
+      const testFilters = ['http_method = "POST"'];
+      wrapper.vm.onMetricsFiltersUpdated(testFilters);
+      await flushPromises();
+
+      expect(mockApplyFilters).toHaveBeenCalledWith(testFilters, false);
+    });
+
+    it("should handle searchBarRef not available", async () => {
+      wrapper = mount(Index, {
+        attachTo: node,
+        global: {
+          plugins: [i18n, router],
+          provide: { store: store },
+          stubs: {
+            "search-bar": true, // No exposed methods
+            "index-list": true,
+            "search-result": true,
+            "service-graph": true,
+            SanitizedHtmlRenderer: true,
+          },
+        },
+      });
+      await flushPromises();
+
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      wrapper.vm.onMetricsFiltersUpdated(['test']);
+      await flushPromises();
+
+      expect(consoleSpy).toHaveBeenCalledWith("SearchBar not ready for filter application");
+      consoleSpy.mockRestore();
     });
   });
 

--- a/web/src/plugins/traces/Index.spec.ts
+++ b/web/src/plugins/traces/Index.spec.ts
@@ -1108,7 +1108,7 @@ describe("Index.vue (Main Traces Page)", () => {
       wrapper.vm.onErrorOnlyToggled(true);
       await flushPromises();
 
-      expect(mockApplyFilters).toHaveBeenCalledWith(["span_status = 'ERROR'"], false); // liveMode is undefined, so skipSearch = false
+      expect(mockApplyFilters).toHaveBeenCalledWith(["span_status = 'ERROR'"]);
     });
 
     it("should call removeFilterByField when error only toggle is turned off", async () => {

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -1740,7 +1740,15 @@ const onMetricsFiltersUpdated = (filters: string[]) => {
     allFilters.push("span_status = 'ERROR'");
   }
   // Apply each filter term independently so replace-or-append works per field
-  searchBarRef.value?.applyFilters(allFilters);
+  // Skip search only when live mode is ON (datetime trigger will handle it)
+  // Don't skip when live mode is OFF (datetime trigger won't fire)
+  const skipSearch = Boolean(searchObj.meta.liveMode);
+
+  if (searchBarRef.value?.applyFilters) {
+    searchBarRef.value.applyFilters(allFilters, skipSearch);
+  } else {
+    console.warn("SearchBar not ready for filter application");
+  }
 };
 
 // Handler for Error Only toggle — only adds/removes span_status condition,

--- a/web/src/plugins/traces/SearchBar.spec.ts
+++ b/web/src/plugins/traces/SearchBar.spec.ts
@@ -1461,4 +1461,61 @@ describe("SearchBar", () => {
       ).toBe(false);
     });
   });
+
+  // -------------------------------------------------------------------------
+  describe("applyFilters function", () => {
+    beforeEach(async () => {
+      // Setup auto-search enabled + live mode
+      store.state.zoConfig = { auto_query_enabled: true };
+      searchObjInstance.meta.liveMode = true;
+
+      wrapper = mountSearchBar();
+      await flushPromises();
+    });
+
+    it("should emit searchdata when skipSearch=false and auto-search enabled", async () => {
+      const testTerms = ["service_name = 'test-service'"];
+
+      wrapper.vm.applyFilters(testTerms, false);
+
+      expect(wrapper.emitted("searchdata")).toHaveLength(1);
+      expect(searchObjInstance.data.editorValue).toContain("service_name = 'test-service'");
+    });
+
+    it("should not emit searchdata when skipSearch=true", async () => {
+      const testTerms = ["duration > 100ms"];
+
+      wrapper.vm.applyFilters(testTerms, true);
+
+      expect(wrapper.emitted("searchdata")).toBeUndefined();
+      expect(searchObjInstance.data.editorValue).toContain("duration > 100ms");
+    });
+
+    it("should preserve existing behavior when skipSearch parameter omitted", async () => {
+      const testTerms = ["span_status = 'ERROR'"];
+
+      wrapper.vm.applyFilters(testTerms);
+
+      expect(wrapper.emitted("searchdata")).toHaveLength(1);
+      expect(searchObjInstance.data.editorValue).toContain("span_status = 'ERROR'");
+    });
+
+    it("should not emit searchdata when auto-search disabled", async () => {
+      store.state.zoConfig.auto_query_enabled = false;
+      const testTerms = ["service_name = 'test'"];
+
+      wrapper.vm.applyFilters(testTerms, false);
+
+      expect(wrapper.emitted("searchdata")).toBeUndefined();
+    });
+
+    it("should not emit searchdata when live mode is OFF", async () => {
+      searchObjInstance.meta.liveMode = false;
+      const testTerms = ["http_method = 'POST'"];
+
+      wrapper.vm.applyFilters(testTerms, false);
+
+      expect(wrapper.emitted("searchdata")).toBeUndefined();
+    });
+  });
 });

--- a/web/src/plugins/traces/SearchBar.vue
+++ b/web/src/plugins/traces/SearchBar.vue
@@ -833,7 +833,7 @@ export default defineComponent({
 
     // Apply multiple filter terms independently (replace-or-append per field).
     // Used by parent (Index.vue) for metrics brush selections and error toggle.
-    const applyFilters = (terms: string[]) => {
+    const applyFilters = (terms: string[], skipSearch = false) => {
       let current = searchObj.data.editorValue;
       for (const term of terms) {
         current = applyFilterTerm(term, current);
@@ -841,7 +841,8 @@ export default defineComponent({
       searchObj.data.editorValue = current;
       if (queryEditorRef.value?.setValue)
         queryEditorRef.value.setValue(current);
-      if (store.state.zoConfig?.auto_query_enabled && searchObj.meta.liveMode) {
+      // Only trigger search if not explicitly skipped
+      if (!skipSearch && store.state.zoConfig?.auto_query_enabled && searchObj.meta.liveMode) {
         emit("searchdata");
       }
     };


### PR DESCRIPTION
#11816 

## What changed

Added an optional `skipSearch` parameter to `SearchBar.vue`'s `applyFilters` method. When `true`, the method applies filters to state without emitting a `searchdata` event. In `Index.vue`, `onMetricsFiltersUpdated` now passes `skipSearch=true` when live mode is ON, letting the datetime trigger (`triggerAbsoluteQueryDebounced`) handle the search call. When live mode is OFF, `skipSearch=false` so the search still fires (since the datetime trigger won't run).

## Why

When auto-search is enabled and a user drags on RED charts to select a time range, both `applyFilters` and `triggerAbsoluteQueryDebounced` were called simultaneously — each triggering a separate `searchdata` API call. Per the user, "searchdata should only be called from triggerAbsoluteQueryDebounced." The fix ensures only one search call happens by having `applyFilters` skip its own search when live mode is on.