### PR TITLE
fix: trace details stream name was missing in short url

### DIFF
--- a/web/src/plugins/traces/Index.spec.ts
+++ b/web/src/plugins/traces/Index.spec.ts
@@ -1050,6 +1050,8 @@ describe("Index.vue (Main Traces Page)", () => {
       mockRemoveFilterByField.mockReset();
       mockSearchObj.meta.showErrorOnly = false;
       mockSearchObj.meta.metricsRangeFilters.clear();
+      // Reset auto_query_enabled to undefined for each test
+      delete store.state.zoConfig.auto_query_enabled;
     });
 
     it("should call applyFilters with all filter terms when metrics filters are updated", async () => {
@@ -1123,6 +1125,7 @@ describe("Index.vue (Main Traces Page)", () => {
 
     it("should skip search when live mode is ON", async () => {
       mockSearchObj.meta.liveMode = true;
+      store.state.zoConfig.auto_query_enabled = true;
       wrapper = mountWithSearchBarStub();
       await flushPromises();
 

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -1742,7 +1742,7 @@ const onMetricsFiltersUpdated = (filters: string[]) => {
   // Apply each filter term independently so replace-or-append works per field
   // Skip search only when live mode is ON (datetime trigger will handle it)
   // Don't skip when live mode is OFF (datetime trigger won't fire)
-  const skipSearch = Boolean(searchObj.meta.liveMode);
+  const skipSearch = !!(searchObj.meta.liveMode && store.state.zoConfig?.auto_query_enabled);
 
   if (searchBarRef.value?.applyFilters) {
     searchBarRef.value.applyFilters(allFilters, skipSearch);

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -2544,6 +2544,10 @@ export default defineComponent({
       if (customFrom) queryParams.from = customFrom;
       if (customTo) queryParams.to = customTo;
 
+      if(effectiveStreamName.value){
+        queryParams.stream = effectiveStreamName.value as string;
+      }
+
       const searchParams = new URLSearchParams();
       for (const [key, value] of Object.entries(queryParams)) {
         searchParams.append(key, String(value));


### PR DESCRIPTION
#11841 

## What changed

Added `queryParams.stream = effectiveStreamName.value` to the share URL generation in `TraceDetails.vue` so the stream name is included when generating a share/short URL.

## Why

When sharing a URL from the Trace Details view, the stream name parameter was missing from the generated URL. This caused the shared link to open without the correct stream context, making it unable to display the trace properly on navigation.

## Approach

The stream name is already resolved by the `effectiveStreamName` computed property — which handles both embedded mode (via `props.streamNameProp`) and standalone mode (via `router.currentRoute.value.query.stream`). The fix simply passes this value into the `queryParams` object before the URL is serialized.