### PR TITLE
perf: reduce compactor memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,6 +2337,7 @@ dependencies = [
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "urlencoding",
  "utoipa",
  "uuid",

--- a/src/service/search/datafusion/table_provider/listing_adapter.rs
+++ b/src/service/search/datafusion/table_provider/listing_adapter.rs
@@ -15,7 +15,7 @@
 
 use std::{any::Any, sync::Arc};
 
-use arrow_schema::SchemaRef;
+use arrow_schema::{SchemaRef, SortOptions};
 use config::{TIMESTAMP_COL_NAME, get_config};
 use datafusion::{
     catalog::{Session, TableProvider, memory::DataSourceExec},
@@ -27,7 +27,8 @@ use datafusion::{
     },
     execution::cache::cache_manager::FileStatisticsCache,
     logical_expr::TableProviderFilterPushDown,
-    physical_plan::ExecutionPlan,
+    physical_expr::{LexOrdering, PhysicalSortExpr},
+    physical_plan::{ExecutionPlan, expressions::Column},
     prelude::Expr,
 };
 use rayon::prelude::*;
@@ -168,14 +169,6 @@ impl TableProvider for ListingTableAdapter {
             filter_projection,
         )?;
 
-        if reverse {
-            log::info!(
-                "[trace_id {}] attempted to split file groups by statistics, but there were more file groups than target_partitions: {}; falling back to unordered",
-                self.trace_id,
-                state.config().target_partitions(),
-            );
-        }
-
         Ok(plan)
     }
 
@@ -204,15 +197,48 @@ fn handler_tantivy_index(
         let mut file_groups = config.file_groups.clone();
 
         if reverse {
-            let new_file_groups = file_groups
-                .into_iter()
-                .map(|file_group| {
-                    let mut files = file_group.into_inner();
-                    files.reverse();
-                    FileGroup::new(files)
-                })
-                .collect();
-            file_groups = new_file_groups;
+            let schema = config.file_source().table_schema().table_schema();
+            match schema.index_of(TIMESTAMP_COL_NAME) {
+                Ok(index) => {
+                    let sort_order = LexOrdering::new(vec![PhysicalSortExpr {
+                        expr: Arc::new(Column::new(TIMESTAMP_COL_NAME, index)),
+                        options: SortOptions {
+                            descending: true,
+                            nulls_first: false,
+                        },
+                    }]);
+                    if let Some(sort_order) = sort_order {
+                        match FileScanConfig::split_groups_by_statistics_with_target_partitions(
+                            schema,
+                            &file_groups,
+                            &sort_order,
+                            target_partitions,
+                        ) {
+                            Ok(new_file_groups) => {
+                                file_groups = new_file_groups;
+                            }
+                            Err(e) => {
+                                log::warn!(
+                                    "[trace_id {trace_id}] failed to split file groups by statistics: {e}, falling back to reversing file groups"
+                                );
+                                file_groups = file_groups
+                                    .into_iter()
+                                    .map(|file_group| {
+                                        let mut files = file_group.into_inner();
+                                        files.reverse();
+                                        FileGroup::new(files)
+                                    })
+                                    .collect();
+                            }
+                        }
+                    }
+                }
+                Err(_) => {
+                    log::warn!(
+                        "[trace_id {trace_id}] _timestamp column not found in schema, skipping split_groups_by_statistics"
+                    );
+                }
+            }
         }
 
         let start = std::time::Instant::now();
@@ -240,7 +266,7 @@ fn handler_tantivy_index(
         let files_nums = new_file_groups.iter().map(|g| g.len()).sum::<usize>();
 
         log::info!(
-            "[trace_id {trace_id}] listing table adapter, file groups: {groups_len}, max group len: {max_group_len}, total files: {files_nums}, took: {} ms",
+            "[trace_id {trace_id}] listing table adapter, target_partitions: {target_partitions}, file groups: {groups_len}, max group len: {max_group_len}, total files: {files_nums}, took: {} ms",
             start.elapsed().as_millis() as usize,
         );
 


### PR DESCRIPTION
On my local machine, merging a 256GB file into 10GB files with 6 merge threads requires too much memory. In the current main branch, each merge thread uses about 8GB of memory, so 6 threads require 48GB in total. Since my machine has only 32GB of memory, it starts using swap, which makes the merge process slow.

this pr reduce the memory usage for merge files, that speed up the merge speed.

Note: if the merge do not trigger the swap the merge speed almost same, because most of time spend for merge parquet is write parquet file, collect all data by datafusion is only 10%-20%.

## main
2026-05-15T10:02:45.357306+00:00 INFO openobserve::service::search::datafusion::peak_memory_pool: [trace_id ] DataFusion peak memory usage: 9093509452 bytes (8672.25 MB)
2026-05-15T10:02:45.369673+00:00 INFO openobserve::service::compact::merge: [COMPACTOR:WORKER:0] merged 20 files into a new file: files/default/logs/default/2026/04/29/08/74609930655246581765c7b.parquet, original_size: 10250729590, compressed_size: 26601268, took: 29443 ms

## this pr
2026-05-15T10:05:27.015179+00:00 INFO openobserve::service::search::datafusion::peak_memory_pool: [trace_id ] DataFusion peak memory usage: 65057480 bytes (62.04 MB)
2026-05-15T10:05:27.015429+00:00 INFO openobserve::service::compact::merge: [COMPACTOR:WORKER:3] merged 20 files into a new file: files/default/logs/default/2026/04/29/08/746099374351712256066ac.parquet, original_size: 10453255400, compressed_size: 25995715, took: 4811 ms
