### PR TITLE
fix: reset file-list-jobs with stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,6 +2337,7 @@ dependencies = [
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "urlencoding",
  "utoipa",
  "uuid",

--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -52,7 +52,8 @@ fn create_cli_app() -> Command {
             Command::new("reset")
                 .about("reset openobserve data")
                 .arg(arg!("component", 'c', "component", "reset data of the component: root, user, alert, dashboard, function, stream-stats, file-list-jobs", true))
-                .arg(arg!("time", 't', "time", "timestamp in microseconds, only used by file-list-jobs (default: 0)")),
+                .arg(arg!("time", 't', "time", "timestamp in microseconds, only used by file-list-jobs (default: 0)"))
+                .arg(arg!("stream", 's', "stream", "stream key org/stream_type/stream_name, only used by file-list-jobs (default: all streams)")),
             Command::new("import")
                 .about("import openobserve data").args(dataArgs()),
             Command::new("export")
@@ -254,6 +255,7 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                         .get_one::<String>("time")
                         .map(|s| s.parse::<i64>().unwrap_or(0))
                         .unwrap_or(0);
+                    let stream = command.get_one::<String>("stream").map(|s| s.as_str());
                     // check if any compactor node is running in the cluster
                     let nodes = infra::cluster::list_nodes().await.unwrap_or_default();
                     let compactor_nodes: Vec<_> = nodes
@@ -283,11 +285,17 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
                         );
                     }
                     // 1. reset file offset in meta table
-                    let n = db::compact::files::reset_offset(time).await?;
-                    println!("reset {n} compact file offsets to {time}");
-                    // 2. set all file list jobs to pending
-                    let rows = infra_file_list::set_job_pending(&[]).await?;
-                    println!("reset {rows} file_list_jobs to pending");
+                    let n = db::compact::files::reset_offset(time, stream).await?;
+                    println!(
+                        "reset {n} compact file offsets to {time} (stream: {})",
+                        stream.unwrap_or("*")
+                    );
+                    // 2. set file list jobs to pending
+                    let rows = infra_file_list::set_job_pending(&[], time, stream).await?;
+                    println!(
+                        "reset {rows} file_list_jobs to pending (offsets >= {time}, stream: {})",
+                        stream.unwrap_or("*")
+                    );
                 }
                 _ => {
                     return Err(anyhow::anyhow!(

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -178,7 +178,8 @@ pub trait FileList: Sync + Send + 'static {
     ) -> Result<i64>;
     async fn get_pending_jobs(&self, node: &str, limit: i64) -> Result<Vec<MergeJobRecord>>;
     async fn get_pending_jobs_count(&self) -> Result<stdHashMap<String, stdHashMap<String, i64>>>;
-    async fn set_job_pending(&self, ids: &[i64]) -> Result<u64>;
+    async fn set_job_pending(&self, ids: &[i64], offsets: i64, stream: Option<&str>)
+    -> Result<u64>;
     async fn set_job_done(&self, ids: &[i64]) -> Result<()>;
     async fn update_running_jobs(&self, ids: &[i64]) -> Result<()>;
     async fn check_running_jobs(&self, before_date: i64) -> Result<()>;
@@ -524,8 +525,8 @@ pub async fn get_pending_jobs_count() -> Result<stdHashMap<String, stdHashMap<St
 }
 
 #[inline]
-pub async fn set_job_pending(ids: &[i64]) -> Result<u64> {
-    CLIENT.set_job_pending(ids).await
+pub async fn set_job_pending(ids: &[i64], offsets: i64, stream: Option<&str>) -> Result<u64> {
+    CLIENT.set_job_pending(ids, offsets, stream).await
 }
 
 #[inline]

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -1398,17 +1398,35 @@ SELECT stream, max(id) as id, COUNT(*)::BIGINT AS num
         Ok(ret)
     }
 
-    async fn set_job_pending(&self, ids: &[i64]) -> Result<u64> {
+    async fn set_job_pending(
+        &self,
+        ids: &[i64],
+        offsets: i64,
+        stream: Option<&str>,
+    ) -> Result<u64> {
         let pool = CLIENT.clone();
-        let sql = if ids.is_empty() {
-            "UPDATE file_list_jobs SET status = $1;".to_string()
-        } else {
-            format!(
-                "UPDATE file_list_jobs SET status = $1 WHERE id IN ({});",
+        let mut conditions: Vec<String> = Vec::new();
+        if !ids.is_empty() {
+            conditions.push(format!(
+                "id IN ({})",
                 ids.iter()
                     .map(|id| id.to_string())
                     .collect::<Vec<_>>()
                     .join(",")
+            ));
+        }
+        if offsets > 0 {
+            conditions.push(format!("offsets >= {offsets}"));
+        }
+        if let Some(stream) = stream {
+            conditions.push(format!("stream = '{stream}'"));
+        }
+        let sql = if conditions.is_empty() {
+            "UPDATE file_list_jobs SET status = $1;".to_string()
+        } else {
+            format!(
+                "UPDATE file_list_jobs SET status = $1 WHERE {};",
+                conditions.join(" AND ")
             )
         };
         DB_QUERY_NUMS

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -1106,18 +1106,36 @@ SELECT stream, max(id) as id, COUNT(*) AS num
         Ok(ret)
     }
 
-    async fn set_job_pending(&self, ids: &[i64]) -> Result<u64> {
+    async fn set_job_pending(
+        &self,
+        ids: &[i64],
+        offsets: i64,
+        stream: Option<&str>,
+    ) -> Result<u64> {
         let client = CLIENT_RW.clone();
         let client = client.lock().await;
-        let sql = if ids.is_empty() {
-            "UPDATE file_list_jobs SET status = $1;".to_string()
-        } else {
-            format!(
-                "UPDATE file_list_jobs SET status = $1 WHERE id IN ({});",
+        let mut conditions: Vec<String> = Vec::new();
+        if !ids.is_empty() {
+            conditions.push(format!(
+                "id IN ({})",
                 ids.iter()
                     .map(|id| id.to_string())
                     .collect::<Vec<_>>()
                     .join(",")
+            ));
+        }
+        if offsets > 0 {
+            conditions.push(format!("offsets >= {offsets}"));
+        }
+        if let Some(stream) = stream {
+            conditions.push(format!("stream = '{stream}'"));
+        }
+        let sql = if conditions.is_empty() {
+            "UPDATE file_list_jobs SET status = $1;".to_string()
+        } else {
+            format!(
+                "UPDATE file_list_jobs SET status = $1 WHERE {};",
+                conditions.join(" AND ")
             )
         };
         let ret = sqlx::query(&sql)

--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -345,7 +345,7 @@ pub async fn run_merge(job_tx: mpsc::Sender<worker::MergeJob>) -> Result<(), any
 
     if !need_release_ids.is_empty() {
         // release those jobs
-        if let Err(e) = infra_file_list::set_job_pending(&need_release_ids).await {
+        if let Err(e) = infra_file_list::set_job_pending(&need_release_ids, 0, None).await {
             log::error!("[COMPACTOR] set_job_pending failed: {e}");
         }
     }

--- a/src/service/db/compact/files.rs
+++ b/src/service/db/compact/files.rs
@@ -105,9 +105,12 @@ pub async fn del_offset(
         .map_err(Into::into)
 }
 
-pub async fn reset_offset(time: i64) -> Result<u64, anyhow::Error> {
-    let prefix = "/compact/files/";
-    let ret = db::list(prefix).await?;
+pub async fn reset_offset(time: i64, stream: Option<&str>) -> Result<u64, anyhow::Error> {
+    let prefix = match stream {
+        Some(s) => format!("/compact/files/{s}"),
+        None => "/compact/files/".to_string(),
+    };
+    let ret = db::list(&prefix).await?;
     let count = ret.len() as u64;
     for key in ret.keys() {
         db::put(key, time.to_string().into(), db::NO_NEED_WATCH, None).await?;


### PR DESCRIPTION
  Usage:
```
  openobserve reset -c file-list-jobs -t 1700000000000000
  openobserve reset -c file-list-jobs -s default/logs/app
  openobserve reset -c file-list-jobs -t 1700000000000000 -s default/logs/app
```