### PR TITLE
fix: remove onupdated becuase it was covered in onmounted

### DIFF
--- a/web/src/components/iam/organizations/ListOrganizations.vue
+++ b/web/src/components/iam/organizations/ListOrganizations.vue
@@ -100,7 +100,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script lang="ts">
 
 // @ts-nocheck
-import { defineComponent, ref, watch, onMounted, onUpdated, computed } from "vue";
+import { defineComponent, ref, watch, onMounted, computed } from "vue";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import { useQuasar, copyToClipboard } from "quasar";
@@ -231,33 +231,6 @@ export default defineComponent({
           name: router.currentRoute.value.query?.to_be_updated_org_name || "",
           identifier: router.currentRoute.value.query?.to_be_updated_org_id || "",
         };
-      }
-    });
-
-    onUpdated(() => {
-      if (
-        router.currentRoute.value.query.action == "add"
-      ) {
-        showAddOrganizationDialog.value = true;
-      }
-      else if (
-        router.currentRoute.value.query.action == "update"
-      ) {
-        showAddOrganizationDialog.value = true;
-        toBeUpdatedOrganization.value = {
-          id: router.currentRoute.value.query?.to_be_updated_org_id || "",
-          name: router.currentRoute.value.query?.to_be_updated_org_name || "",
-          identifier: router.currentRoute.value.query?.to_be_updated_org_id || "",
-        };
-      }
-
-      if (router.currentRoute.value.query.action == "invite") {
-        organizations.value.map((org) => {
-          if (org.identifier == router.currentRoute.value.query.id) {
-            organization.value = org;
-            showJoinOrganizationDialog.value = true;
-          }
-        });
       }
     });
 


### PR DESCRIPTION
Root cause

The onUpdated lifecycle hook was introduced before the dialog→drawer migration and worked fine when the component used q-dialog. The dialog's @before-hide event fired synchronously on close, which cleared action from the URL before Vue re-rendered — so when onUpdated fired, action was already gone and it was a no-op.

Commit 4b4073e140 replaced q-dialog with the add-update-organization drawer component. The drawer uses router.push (async) to clear the URL instead of a synchronous @before-hide. This introduced a race:

User saves → updateOrganizationList runs
showAddOrganizationDialog = false → component re-renders
onUpdated fires → URL still has action: "add" (router.push hasn't resolved yet) → drawer re-opens
router.push resolves → URL finally cleared, but drawer is already open again
Fix

Removed the onUpdated hook. It was always redundant — onMounted handles the initial page load with a query action, and the watch on router.currentRoute.value.query?.action handles all subsequent route-driven opens. Neither has the race condition because they only fire when the route actually changes, not on every component re-render.