### PR TITLE
fix: correct pagination for ORDER BY non-timestamp column in _search_…

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -614,6 +614,13 @@ pub struct SearchPartitionResponse {
     pub streaming_id: Option<String>,
     #[serde(default)]
     pub is_histogram_eligible: bool,
+    /// ORDER BY columns when the primary sort is a non-timestamp column.
+    /// Non-empty means this is a non-ts ORDER BY query; empty means timestamp sort (normal path).
+    /// Each entry is (column_name, is_descending). The heap honors all columns in order so
+    /// that ties on the primary column are broken correctly by secondary columns.
+    /// Skipped from serialization — internal leader use only, not exposed to callers.
+    #[serde(skip)]
+    pub non_ts_order_by_cols: Vec<(String, bool)>,
 }
 
 /// Request parameters for querying search history
@@ -2931,6 +2938,7 @@ mod tests {
             streaming_aggs: false,
             streaming_id: Some("stream123".to_string()),
             is_histogram_eligible: false,
+            non_ts_order_by_cols: vec![],
         };
 
         response

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -1193,11 +1193,25 @@ async fn process_latest_traces_stream(
     // Partitions from search_partition are already in DESC order (newest-first) by default,
     // since the partition SQL has no ORDER BY and the default is OrderBy::Desc.
     let partitions_desc = if sql_order_expr == "zo_sql_timestamp DESC" {
+        log::info!(
+            "[TRACES_STREAM trace_id {trace_id}] using {} time partitions, order=DESC",
+            partitions.len()
+        );
         partitions
     } else if sql_order_expr == "zo_sql_timestamp ASC" {
+        log::info!(
+            "[TRACES_STREAM trace_id {trace_id}] using {} time partitions, order=ASC",
+            partitions.len()
+        );
         partitions.into_iter().rev().collect::<Vec<_>>()
     } else {
         // order by other fields can't be multiple partitions
+        log::info!(
+            "[TRACES_STREAM trace_id {trace_id}] sort_by non-timestamp ({sql_order_expr}), \
+            forcing single partition [{}, {}]",
+            partition_req.start_time,
+            partition_req.end_time,
+        );
         vec![[partition_req.start_time, partition_req.end_time]]
     };
 

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -627,6 +627,28 @@ pub async fn search_multi(
     Ok(multi_res)
 }
 
+/// Returns true when the query's primary ORDER BY column is not a timestamp column,
+/// meaning per-partition `hits_to_skip` is incorrect and the TopKHeap merge path
+/// must be used instead.
+///
+/// Only the first ORDER BY column is evaluated; secondary columns are not compared.
+/// Aggregate and histogram queries always return false — their partitioning is not
+/// affected by non-ts ORDER BY.
+fn detect_non_ts_order_by(
+    order_by: &[(String, config::meta::sql::OrderBy)],
+    ts_column: Option<&str>,
+    is_aggregate: bool,
+    is_histogram: bool,
+) -> bool {
+    if is_aggregate || is_histogram {
+        return false;
+    }
+    order_by
+        .first()
+        .map(|(field, _)| field.as_str() != TIMESTAMP_COL_NAME && ts_column != Some(field.as_str()))
+        .unwrap_or(false)
+}
+
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(name = "service:search_partition", skip(req))]
 pub async fn search_partition(
@@ -893,6 +915,7 @@ pub async fn search_partition(
         #[cfg(feature = "enterprise")]
         streaming_id: None,
         is_histogram_eligible,
+        non_ts_order_by_cols: vec![],
     };
 
     let mut min_step = Duration::try_seconds(1)
@@ -1011,20 +1034,24 @@ pub async fn search_partition(
         })
         .unwrap_or(OrderBy::Desc);
 
-    if cfg.limit.disable_partitions_for_non_ts_order_by
-        && !is_aggregate
-        && !is_histogram
-        && sql
+    let is_non_ts_order_by = detect_non_ts_order_by(
+        &sql.order_by,
+        ts_column.as_deref(),
+        is_aggregate,
+        is_histogram,
+    );
+
+    if is_non_ts_order_by {
+        resp.non_ts_order_by_cols = sql
             .order_by
-            .first()
-            .map(|(field, _)| {
-                field.as_str() != TIMESTAMP_COL_NAME
-                    && (ts_column.as_deref() != Some(field.as_str()))
-            })
-            .unwrap_or(false)
-    {
+            .iter()
+            .map(|(col, dir)| (col.clone(), matches!(dir, OrderBy::Desc)))
+            .collect();
+    }
+
+    if cfg.limit.disable_partitions_for_non_ts_order_by && is_non_ts_order_by {
         log::info!(
-            "[trace_id {trace_id}] search_partition: ORDER BY on non-timestamp column, disabling partitioning"
+            "[trace_id {trace_id}] search_partition: non-ts ORDER BY, disabling partitions (circuit breaker)"
         );
         resp.partitions = vec![[req.start_time, req.end_time]];
         return Ok(resp);
@@ -1736,5 +1763,201 @@ mod tests {
     fn test_check_search_allowed_non_enterprise_always_ok() {
         assert!(check_search_allowed("myorg", None).is_ok());
         assert!(check_search_allowed("myorg", Some("logs")).is_ok());
+    }
+
+    // ── detect_non_ts_order_by unit tests ──────────────────────────────────────
+
+    use config::meta::sql::OrderBy;
+
+    fn ob(col: &str, dir: OrderBy) -> (String, OrderBy) {
+        (col.to_string(), dir)
+    }
+
+    // Helper: parse SQL string → run ColumnVisitor → return order_by vec.
+    // Uses empty schemas so no schema resolution happens, which is fine for
+    // ORDER BY extraction (pre_visit_query doesn't touch schemas).
+    fn parse_order_by(sql_str: &str) -> Vec<(String, OrderBy)> {
+        use ::datafusion::common::TableReference;
+        use hashbrown::HashMap;
+        use sqlparser::{ast::VisitMut, dialect::GenericDialect, parser::Parser};
+
+        use crate::service::search::sql::visitor::column::ColumnVisitor;
+
+        let mut stmt = Parser::parse_sql(&GenericDialect {}, sql_str)
+            .unwrap()
+            .pop()
+            .unwrap();
+        let schemas = HashMap::<TableReference, _>::new();
+        let mut visitor = ColumnVisitor::new(&schemas);
+        let _ = stmt.visit(&mut visitor);
+        visitor.order_by
+    }
+
+    // ── direct helper tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_detect_no_order_by_returns_false() {
+        assert!(!detect_non_ts_order_by(&[], None, false, false));
+    }
+
+    #[test]
+    fn test_detect_timestamp_order_by_returns_false() {
+        let order_by = vec![ob("_timestamp", OrderBy::Desc)];
+        assert!(!detect_non_ts_order_by(&order_by, None, false, false));
+    }
+
+    #[test]
+    fn test_detect_non_ts_desc_returns_true() {
+        let order_by = vec![ob("duration", OrderBy::Desc)];
+        assert!(detect_non_ts_order_by(&order_by, None, false, false));
+    }
+
+    #[test]
+    fn test_detect_non_ts_asc_returns_true() {
+        let order_by = vec![ob("duration", OrderBy::Asc)];
+        assert!(detect_non_ts_order_by(&order_by, None, false, false));
+    }
+
+    #[test]
+    fn test_detect_aggregate_always_false() {
+        let order_by = vec![ob("duration", OrderBy::Desc)];
+        assert!(!detect_non_ts_order_by(&order_by, None, true, false));
+    }
+
+    #[test]
+    fn test_detect_histogram_always_false() {
+        let order_by = vec![ob("duration", OrderBy::Desc)];
+        assert!(!detect_non_ts_order_by(&order_by, None, false, true));
+    }
+
+    #[test]
+    fn test_detect_custom_ts_column_returns_false() {
+        // stream uses "time" as its timestamp column
+        let order_by = vec![ob("time", OrderBy::Desc)];
+        assert!(!detect_non_ts_order_by(
+            &order_by,
+            Some("time"),
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_detect_custom_ts_column_other_col_returns_true() {
+        let order_by = vec![ob("duration", OrderBy::Desc)];
+        assert!(detect_non_ts_order_by(
+            &order_by,
+            Some("time"),
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_detect_multi_col_first_is_ts_returns_false() {
+        // ORDER BY _timestamp DESC, duration ASC — primary is ts → false
+        let order_by = vec![
+            ob("_timestamp", OrderBy::Desc),
+            ob("duration", OrderBy::Asc),
+        ];
+        assert!(!detect_non_ts_order_by(&order_by, None, false, false));
+    }
+
+    #[test]
+    fn test_detect_multi_col_first_is_non_ts_returns_true() {
+        // ORDER BY duration DESC, _timestamp DESC — primary is non-ts → true
+        // secondary _timestamp is ignored (known limitation: ties break arbitrarily)
+        let order_by = vec![
+            ob("duration", OrderBy::Desc),
+            ob("_timestamp", OrderBy::Desc),
+        ];
+        assert!(detect_non_ts_order_by(&order_by, None, false, false));
+    }
+
+    // ── SQL-parsing integration tests (via ColumnVisitor + is_aggregate_query) ──
+
+    #[test]
+    fn test_detect_sql_multi_col_non_ts_primary() {
+        // ORDER BY duration DESC, _timestamp DESC — primary non-ts → true
+        // _timestamp as secondary is honored by the heap but irrelevant for detection
+        let sql = "SELECT * FROM logs ORDER BY duration DESC, _timestamp DESC";
+        let order_by = parse_order_by(sql);
+        assert_eq!(order_by[0].0, "duration");
+        assert_eq!(order_by[1].0, "_timestamp");
+        assert!(detect_non_ts_order_by(&order_by, None, false, false));
+    }
+
+    #[test]
+    fn test_detect_sql_multi_col_ts_primary() {
+        // ORDER BY _timestamp DESC, duration DESC — primary ts → false
+        let sql = "SELECT * FROM logs ORDER BY _timestamp DESC, duration DESC";
+        let order_by = parse_order_by(sql);
+        assert_eq!(order_by[0].0, "_timestamp");
+        assert!(!detect_non_ts_order_by(&order_by, None, false, false));
+    }
+
+    #[test]
+    fn test_detect_sql_three_col_non_ts_primary() {
+        // ORDER BY total_amt DESC, status ASC, _timestamp DESC — primary non-ts → true
+        let sql = "SELECT * FROM logs ORDER BY total_amt DESC, status ASC, _timestamp DESC";
+        let order_by = parse_order_by(sql);
+        assert_eq!(order_by[0].0, "total_amt");
+        assert_eq!(order_by.len(), 3);
+        assert!(detect_non_ts_order_by(&order_by, None, false, false));
+    }
+
+    #[test]
+    fn test_detect_sql_aggregate_with_count_order() {
+        // is_aggregate_query returns true for GROUP BY → detect always false
+        let sql = "SELECT count(*), status FROM logs GROUP BY status ORDER BY count(*) DESC";
+        let is_agg = config::utils::sql::is_aggregate_query(sql).unwrap_or(false);
+        assert!(is_agg, "GROUP BY query must be detected as aggregate");
+        let order_by = parse_order_by(sql);
+        assert!(!detect_non_ts_order_by(&order_by, None, is_agg, false));
+    }
+
+    #[test]
+    fn test_detect_sql_join_is_aggregate_short_circuits() {
+        // is_aggregate_query returns true for JOINs → detect always false regardless of ORDER BY
+        let sql = "SELECT a.duration, b.name FROM logs a \
+                   JOIN users b ON a.user_id = b.id \
+                   ORDER BY duration DESC";
+        let is_agg = config::utils::sql::is_aggregate_query(sql).unwrap_or(false);
+        assert!(is_agg, "JOIN query must be detected as aggregate");
+        let order_by = parse_order_by(sql);
+        assert!(!detect_non_ts_order_by(&order_by, None, is_agg, false));
+    }
+
+    #[test]
+    fn test_detect_sql_subquery_is_aggregate_short_circuits() {
+        // is_aggregate_query returns true for subqueries → detect always false
+        let sql = "SELECT * FROM (SELECT * FROM logs WHERE status = 200) sub \
+                   ORDER BY duration DESC";
+        let is_agg = config::utils::sql::is_aggregate_query(sql).unwrap_or(false);
+        assert!(is_agg, "subquery must be detected as aggregate");
+        let order_by = parse_order_by(sql);
+        assert!(!detect_non_ts_order_by(&order_by, None, is_agg, false));
+    }
+
+    #[test]
+    fn test_detect_sql_cte_outer_ts_order_by() {
+        // CTE: pre_visit_query is top-down → outer ORDER BY _timestamp first → false
+        let sql = "WITH t AS (SELECT * FROM logs ORDER BY duration DESC) \
+                   SELECT * FROM t ORDER BY _timestamp DESC";
+        let order_by = parse_order_by(sql);
+        assert_eq!(order_by[0].0, "_timestamp");
+        assert!(!detect_non_ts_order_by(&order_by, None, false, false));
+    }
+
+    #[test]
+    fn test_detect_sql_cte_outer_non_ts_order_by() {
+        // CTE: outer ORDER BY duration first → true
+        // Note: is_aggregate_query may return true for CTEs with subquery body;
+        // in that case the aggregate guard fires before this helper.
+        let sql = "WITH t AS (SELECT * FROM logs ORDER BY _timestamp DESC) \
+                   SELECT * FROM t ORDER BY duration DESC";
+        let order_by = parse_order_by(sql);
+        assert_eq!(order_by[0].0, "duration");
+        assert!(detect_non_ts_order_by(&order_by, None, false, false));
     }
 }

--- a/src/service/search/streaming/execution.rs
+++ b/src/service/search/streaming/execution.rs
@@ -30,7 +30,7 @@ use tokio::sync::mpsc;
 use tracing::Instrument;
 
 use super::{
-    sorting::order_search_results,
+    sorting::{TopKHeap, order_search_results},
     utils::{calculate_progress_percentage, get_top_k_values},
 };
 #[cfg(feature = "enterprise")]
@@ -107,6 +107,27 @@ pub async fn do_partitioned_search(
         );
     }
 
+    let non_ts_order_by_cols = partition_resp.non_ts_order_by_cols.clone();
+    let is_non_ts_order_by = !non_ts_order_by_cols.is_empty();
+    let original_from = req.query.from as usize;
+    let original_size = if req.query.size > 0 {
+        req.query.size as usize
+    } else {
+        0
+    };
+
+    // Incremental top-k heap for non-ts ORDER BY: fed one partition at a time so the
+    // heap never holds more than k = (from + size) elements regardless of partition count.
+    let mut topk_heap = if is_non_ts_order_by {
+        Some(TopKHeap::new(
+            original_from + original_size,
+            &non_ts_order_by_cols,
+        ))
+    } else {
+        None
+    };
+    let mut non_ts_has_partial = false;
+
     // The order by for the partitions is the same as the order by in the query
     // unless the query is a dashboard or histogram
     let mut partition_order_by = req_order_by;
@@ -135,15 +156,19 @@ pub async fn do_partitioned_search(
         req.query.start_time = start_time;
         req.query.end_time = end_time;
 
-        if req_size != -1 && !is_streaming_aggs {
-            req.query.size -= curr_res_size;
+        if is_non_ts_order_by {
+            // each partition fetches local top-(from+size); leader merges globally after all
+            // partitions
+            req.query.size = (original_from + original_size) as i64;
+            req.query.from = 0;
+        } else {
+            if req_size != -1 && !is_streaming_aggs {
+                req.query.size -= curr_res_size;
+            }
+            // increase size to fetch hits_to_skip + requested hits; start from partition beginning
+            req.query.size += *hits_to_skip;
+            req.query.from = 0;
         }
-
-        // here we increase the size of the query to fetch requested hits in addition to the
-        // hits_to_skip we set the from to 0 to fetch the hits from the the beginning of the
-        // partition
-        req.query.size += *hits_to_skip;
-        req.query.from = 0;
 
         let trace_id = if partition_num == 1 {
             trace_id.to_string()
@@ -164,31 +189,35 @@ pub async fn do_partitioned_search(
 
         let mut total_hits = search_res.total as i64;
 
-        let skip_hits = std::cmp::min(*hits_to_skip, total_hits);
-        if skip_hits > 0 {
-            search_res.hits = search_res.hits[skip_hits as usize..].to_vec();
-            search_res.total = search_res.hits.len();
-            search_res.size = search_res.total as i64;
-            total_hits = search_res.total as i64;
-            *hits_to_skip -= skip_hits;
-            log::info!(
-                "[HTTP2_STREAM trace_id {trace_id}] Skipped {skip_hits} hits, remaining hits to skip: {hits_to_skip}, total hits for partition {idx}: {total_hits}",
-            );
-        }
-
-        if !is_streaming_aggs {
-            curr_res_size += total_hits;
-            if req_size > 0 && curr_res_size >= req_size {
-                log::info!(
-                    "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), truncating results",
-                );
-                let allowed = (req_size - (curr_res_size - total_hits)) as usize;
-                search_res.hits.truncate(allowed);
+        if !is_non_ts_order_by {
+            let skip_hits = std::cmp::min(*hits_to_skip, total_hits);
+            if skip_hits > 0 {
+                search_res.hits = search_res.hits[skip_hits as usize..].to_vec();
                 search_res.total = search_res.hits.len();
+                search_res.size = search_res.total as i64;
+                total_hits = search_res.total as i64;
+                *hits_to_skip -= skip_hits;
+                log::info!(
+                    "[HTTP2_STREAM trace_id {trace_id}] Skipped {skip_hits} hits, remaining hits to skip: {hits_to_skip}, total hits for partition {idx}: {total_hits}",
+                );
+            }
+
+            if !is_streaming_aggs {
+                curr_res_size += total_hits;
+                if req_size > 0 && curr_res_size >= req_size {
+                    log::info!(
+                        "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), truncating results",
+                    );
+                    let allowed = (req_size - (curr_res_size - total_hits)) as usize;
+                    search_res.hits.truncate(allowed);
+                    search_res.total = search_res.hits.len();
+                }
             }
         }
 
-        search_res = order_search_results(search_res, fallback_order_by_col.clone());
+        if !is_non_ts_order_by {
+            search_res = order_search_results(search_res, fallback_order_by_col.clone());
+        }
 
         // set took for this partition only (not cumulative)
         search_res.set_took(start_timer.elapsed().as_millis() as usize);
@@ -207,7 +236,15 @@ pub async fn do_partitioned_search(
         }
 
         // Accumulate the result
-        if is_streaming_aggs {
+        if is_non_ts_order_by {
+            // Feed directly into the heap — never stores more than k hits in memory
+            if search_res.is_partial {
+                non_ts_has_partial = true;
+            }
+            if let Some(ref mut heap) = topk_heap {
+                heap.push_hits(std::mem::take(&mut search_res.hits));
+            }
+        } else if is_streaming_aggs {
             // Only accumulate the results of the last partition
             if idx == partitions.len() - 1 {
                 accumulated_results.push(SearchResultType::Search(search_res.clone()));
@@ -216,7 +253,7 @@ pub async fn do_partitioned_search(
             accumulated_results.push(SearchResultType::Search(search_res.clone()));
         }
 
-        // add top k values for values search
+        // reformat per-partition GROUP BY results into values API response shape
         if req.search_type == Some(SearchEventType::Values)
             && let Some(values_ctx) = values_ctx.as_ref()
         {
@@ -261,20 +298,23 @@ pub async fn do_partitioned_search(
             );
         }
 
-        // Send the cached response
-        let response = StreamResponses::SearchResponse {
-            results: search_res.clone(),
-            streaming_aggs: is_streaming_aggs,
-            streaming_id: partition_resp.streaming_id.clone(),
-            time_offset: TimeOffset {
-                start_time,
-                end_time,
-            },
-        };
+        // Send the cached response (skipped for non-ts ORDER BY — merged after all partitions
+        // complete)
+        if !is_non_ts_order_by {
+            let response = StreamResponses::SearchResponse {
+                results: search_res.clone(),
+                streaming_aggs: is_streaming_aggs,
+                streaming_id: partition_resp.streaming_id.clone(),
+                time_offset: TimeOffset {
+                    start_time,
+                    end_time,
+                },
+            };
 
-        if sender.send(Ok(response)).await.is_err() {
-            log::warn!("[trace_id {trace_id}] Sender is closed, stop sending response");
-            return Ok(());
+            if sender.send(Ok(response)).await.is_err() {
+                log::warn!("[trace_id {trace_id}] Sender is closed, stop sending response");
+                return Ok(());
+            }
         }
 
         // Send progress update
@@ -295,22 +335,95 @@ pub async fn do_partitioned_search(
                 return Ok(());
             }
         }
-        let stop_values_search = req_size != -1
-            && req_size != 0
-            && req.search_type == Some(SearchEventType::Values)
-            && curr_res_size >= req_size;
-        if stop_values_search {
-            log::info!(
-                "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), stopping search",
-            );
-            break;
+        if !is_non_ts_order_by {
+            let stop_values_search = req_size != -1
+                && req_size != 0
+                && req.search_type == Some(SearchEventType::Values)
+                && curr_res_size >= req_size;
+            if stop_values_search {
+                log::info!(
+                    "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), stopping search",
+                );
+                break;
+            }
+            // Stop if reached the requested result size and it is not a streaming aggs query
+            if req_size != -1 && req_size != 0 && curr_res_size >= req_size && !is_streaming_aggs {
+                log::info!(
+                    "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), stopping search",
+                );
+                break;
+            }
         }
-        // Stop if reached the requested result size and it is not a streaming aggs query
-        if req_size != -1 && req_size != 0 && curr_res_size >= req_size && !is_streaming_aggs {
-            log::info!(
-                "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), stopping search",
+    }
+
+    // For non-ts ORDER BY: drain the heap (already bounded to k elements) into the final result
+    if is_non_ts_order_by {
+        let merged = topk_heap
+            .take()
+            .map(|h| h.into_sorted_vec(original_from))
+            .unwrap_or_default();
+
+        let mut final_res = Response::default();
+        final_res.hits = merged;
+        final_res.total = final_res.hits.len();
+        final_res.size = final_res.total as i64;
+
+        if non_ts_has_partial || !range_error.is_empty() {
+            final_res.is_partial = true;
+            if !range_error.is_empty() {
+                final_res.function_error = vec![range_error.clone()];
+                final_res.new_start_time = Some(modified_start_time);
+                final_res.new_end_time = Some(modified_end_time);
+            }
+        }
+
+        #[cfg(feature = "vectorscan")]
+        crate::service::search::cache::apply_regex_to_response(
+            req,
+            org_id,
+            stream_name,
+            stream_type,
+            &mut final_res,
+            trace_id,
+            "non_ts_order_by",
+        )
+        .await?;
+
+        if is_result_array_skip_vrl {
+            final_res.hits = crate::service::search::cache::apply_vrl_to_response(
+                backup_query_fn.clone(),
+                &mut final_res,
+                org_id,
+                stream_name,
+                trace_id,
             );
-            break;
+            final_res.total = final_res.hits.len();
+        }
+
+        accumulated_results.push(SearchResultType::Search(final_res.clone()));
+
+        let response = StreamResponses::SearchResponse {
+            results: final_res,
+            streaming_aggs: false,
+            streaming_id: None,
+            time_offset: TimeOffset {
+                start_time: modified_start_time,
+                end_time: modified_end_time,
+            },
+        };
+        if sender.send(Ok(response)).await.is_err() {
+            log::warn!(
+                "[trace_id {trace_id}] Sender is closed, stop sending non-ts ORDER BY response"
+            );
+            return Ok(());
+        }
+        if sender
+            .send(Ok(StreamResponses::Progress { percent: 100 }))
+            .await
+            .is_err()
+        {
+            log::warn!("[trace_id {trace_id}] Sender is closed, stop sending progress");
+            return Ok(());
         }
     }
 

--- a/src/service/search/streaming/sorting.rs
+++ b/src/service/search/streaming/sorting.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::{cmp::Ordering, collections::BinaryHeap};
+
 use config::{
     meta::{search::Response, sql::OrderBy},
     utils::json::Value,
@@ -207,6 +209,152 @@ fn determine_sort_column(first_hit: &Value) -> Option<(String, bool)> {
     }
     log::warn!("No suitable sort column found in results");
     None
+}
+
+/// Incremental top-k heap for merging hits across partitions.
+///
+/// Feed one partition at a time via `push_hits` — the heap never exceeds k elements
+/// regardless of how many partitions exist. Peak memory = k + one_partition_size,
+/// not total_partitions × partition_size.
+///
+/// Honors all N ORDER BY columns in order: primary sort first, secondary as tiebreaker,
+/// and so on — matching the SQL semantics of multi-column ORDER BY.
+pub struct TopKHeap {
+    heap: BinaryHeap<std::cmp::Reverse<HeapHit>>,
+    k: usize,
+    /// (col_name, is_descending, is_numeric) — is_numeric detected lazily from first non-null
+    /// value.
+    cols: Vec<(String, bool, Option<bool>)>,
+}
+
+impl TopKHeap {
+    /// `order_by_cols`: all ORDER BY columns as (name, is_descending), in query order.
+    pub fn new(k: usize, order_by_cols: &[(String, bool)]) -> Self {
+        Self {
+            heap: BinaryHeap::with_capacity(k + 1),
+            k,
+            cols: order_by_cols
+                .iter()
+                .map(|(col, desc)| (col.clone(), *desc, None))
+                .collect(),
+        }
+    }
+
+    /// Feed one partition's hits into the heap. Hits that don't make the top-k are
+    /// dropped immediately — only k elements are retained in memory at any time.
+    pub fn push_hits(&mut self, hits: Vec<Value>) {
+        for hit in hits {
+            // Detect is_numeric lazily per column from the first non-null value seen.
+            for (col, _, is_numeric) in &mut self.cols {
+                if is_numeric.is_none()
+                    && let Some(v) = hit.get(col.as_str())
+                    && !v.is_null()
+                {
+                    *is_numeric = Some(v.is_number());
+                }
+            }
+
+            let resolved: Vec<(String, bool, bool)> = self
+                .cols
+                .iter()
+                .map(|(col, desc, is_num)| (col.clone(), *desc, is_num.unwrap_or(false)))
+                .collect();
+            let candidate = HeapHit {
+                hit,
+                cols: resolved,
+            };
+
+            if self.heap.len() < self.k {
+                self.heap.push(std::cmp::Reverse(candidate));
+            } else if let Some(std::cmp::Reverse(min)) = self.heap.peek()
+                && candidate > *min
+            {
+                self.heap.pop();
+                self.heap.push(std::cmp::Reverse(candidate));
+            }
+        }
+    }
+
+    /// Drain the heap into a sorted vec and apply the `from` offset.
+    pub fn into_sorted_vec(self, from: usize) -> Vec<Value> {
+        let cols: Vec<(String, bool, bool)> = self
+            .cols
+            .iter()
+            .map(|(col, desc, is_num)| (col.clone(), *desc, is_num.unwrap_or(false)))
+            .collect();
+
+        let mut result: Vec<Value> = self
+            .heap
+            .into_iter()
+            .map(|std::cmp::Reverse(h)| h.hit)
+            .collect();
+
+        result.sort_by(|a, b| {
+            for (col, is_desc, is_numeric) in &cols {
+                let ord = if *is_numeric {
+                    compare_numeric_values(a, b, col)
+                } else {
+                    compare_string_values(a, b, col)
+                };
+                // DESC: sort descending (largest first)
+                let ord = if *is_desc { ord.reverse() } else { ord };
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+            }
+            Ordering::Equal
+        });
+
+        if from >= result.len() {
+            return vec![];
+        }
+        result[from..].to_vec()
+    }
+}
+
+/// Wrapper around a JSON hit that implements `Ord` across all ORDER BY columns.
+///
+/// Direction-aware so that `Reverse<HeapHit>` always evicts the "current worst":
+/// - DESC col: ascending cmp → `Reverse` = min-heap → evicts smallest → keeps k largest
+/// - ASC  col: descending cmp → `Reverse` = max-heap → evicts largest  → keeps k smallest
+///
+/// Tiebreaking proceeds to the next column just as SQL does.
+struct HeapHit {
+    hit: Value,
+    /// (col_name, is_descending, is_numeric) in ORDER BY order.
+    cols: Vec<(String, bool, bool)>,
+}
+
+impl PartialEq for HeapHit {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for HeapHit {}
+
+impl PartialOrd for HeapHit {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for HeapHit {
+    fn cmp(&self, other: &Self) -> Ordering {
+        for (col, is_desc, is_numeric) in &self.cols {
+            let ord = if *is_numeric {
+                compare_numeric_values(&self.hit, &other.hit, col)
+            } else {
+                compare_string_values(&self.hit, &other.hit, col)
+            };
+            // See struct doc: flip direction so Reverse<HeapHit> evicts the right element.
+            let ord = if *is_desc { ord } else { ord.reverse() };
+            if ord != Ordering::Equal {
+                return ord;
+            }
+        }
+        Ordering::Equal
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
…stream (#11654)

## Problem

`ORDER BY <non-timestamp col>` (e.g. `ORDER BY duration DESC`) gave wrong results and risked OOM because per-partition \`hits_to_skip\` assumed rows are time-ordered — but the globally k-th row can be in any partition.

## Solution

Each partition fetches its local top-`k = from+size` rows. A **TopKHeap** on the leader merges them globally, skips `from`, returns `size`. Heap is bounded to `k` elements at all times — O(k) memory regardless of partition count.

**Multi-column ORDER BY** (`ORDER BY duration DESC, _timestamp DESC`) is fully honored: heap comparison and final sort respect all columns in order, using secondary columns as tiebreakers.

## Scenario behavior

| Query | Behavior |
|---|---|
| `ORDER BY _timestamp DESC` | Unchanged — per-partition path | | `ORDER BY duration DESC` | Heap merge path — correct pagination | | `ORDER BY duration DESC, _timestamp DESC` | Heap merge; ties in `duration` broken by `_timestamp` |
| `ORDER BY duration DESC` page 2 | Heap collects global top-k, skips `from`, returns `size` |
| JOIN / subquery / GROUP BY | `is_aggregate=true` → single partition (unchanged) |
| `ZO_DISABLE_PARTITIONS_FOR_NON_TS_ORDER_BY=true` | Forces 1 partition (circuit breaker preserved) |
| Partial cache hit + non-ts ORDER BY | TODO — pre-existing bug, no regression |

## What is NOT changed

- `ORDER BY _timestamp` execution path
- `_search` (non-streaming) — DataFusion handles it correctly
- Aggregate / histogram queries