### PR TITLE
fix: handled multiple root nodes in trace graph

### DIFF
--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -2333,12 +2333,17 @@ export default defineComponent({
           if (maxDepth < depth) maxDepth = depth;
         }
       };
+
+      // Handle multiple root nodes - process each root span to ensure
+      // all root services appear in the service map
       traceTree.value.forEach((span: any) => {
         getService(span, serviceTree, "", 1, 1);
       });
+
       traceServiceMap.value = convertTraceServiceMapData(
         cloneDeep(serviceTree),
         maxDepth,
+        true, // Enable multi-root handling for trace service maps
       );
     };
 

--- a/web/src/utils/traces/convertTraceData.ts
+++ b/web/src/utils/traces/convertTraceData.ts
@@ -166,7 +166,42 @@ export const convertTimelineData = (props: any) => {
 export const convertTraceServiceMapData = (
   data: any,
   treeDepth: number = 3,
+  enableMultiRootHandling: boolean = false,
 ) => {
+  // Handle multiple root nodes properly for ECharts tree when enabled
+  let treeData = data;
+  let layoutConfig: any = {};
+
+  if (enableMultiRootHandling && Array.isArray(data) && data.length > 1) {
+    // Multiple root services - create a virtual root that doesn't affect layout
+    treeData = [{
+      name: "",
+      children: data,
+      symbol: 'none', // Completely hide the symbol
+      symbolSize: 1, // Minimal size to avoid layout calculation issues
+      label: {
+        show: false, // Hide the label
+      },
+      lineStyle: {
+        opacity: 0, // Hide connecting lines from virtual root
+        width: 0, // No line width
+      },
+      itemStyle: {
+        opacity: 0, // Make completely transparent
+      },
+    }];
+
+    // Use orthogonal layout for better multi-root visualization
+    layoutConfig = {
+      layout: 'orthogonal',
+      orient: 'LR', // Left to right layout
+      left: '5%',
+      right: '5%',
+      top: '5%',
+      bottom: '5%',
+    };
+  }
+
   const options = {
     tooltip: {
       show: false,
@@ -174,11 +209,12 @@ export const convertTraceServiceMapData = (
     series: [
       {
         type: "tree",
-        data: data,
+        data: treeData,
         symbolSize: 30,
         initialTreeDepth: treeDepth,
         roam: true,
         expandAndCollapse: false,
+        ...layoutConfig, // Apply layout config for multiple roots
         label: {
           position: "bottom",
           verticalAlign: "bottom",


### PR DESCRIPTION
#11936

## What changed

Fixed `TraceDetails.vue` so that `traceServiceMap` captures services from **all** root span nodes in a trace, not just the first one. Previously, traces with two or more root spans (e.g., from misconfigured instrumentation) would show service data only for the first root.

## Why

When a trace has multiple root spans, the service-map waterfall widget and trace-graph display were incomplete — only the first root's services appeared. Users investigating instrumentation issues or multi-root traces (which the existing UI already supports rendering) were missing service data for the second and subsequent roots.