### PR TITLE
fix: correct size=-1 handling and TopKHeap k=0 guard for non-ts ORDER BY [v0.90]

### DIFF
--- a/src/service/search/streaming/execution.rs
+++ b/src/service/search/streaming/execution.rs
@@ -118,11 +118,14 @@ pub async fn do_partitioned_search(
 
     // Incremental top-k heap for non-ts ORDER BY: fed one partition at a time so the
     // heap never holds more than k = (from + size) elements regardless of partition count.
+    // When size == -1 (unlimited) fall back to the configured default limit.
+    let heap_k = if req.query.size > 0 {
+        original_from + original_size
+    } else {
+        config::get_config().limit.query_default_limit as usize
+    };
     let mut topk_heap = if is_non_ts_order_by {
-        Some(TopKHeap::new(
-            original_from + original_size,
-            &non_ts_order_by_cols,
-        ))
+        Some(TopKHeap::new(heap_k, &non_ts_order_by_cols))
     } else {
         None
     };
@@ -158,8 +161,10 @@ pub async fn do_partitioned_search(
 
         if is_non_ts_order_by {
             // each partition fetches local top-(from+size); leader merges globally after all
-            // partitions
-            req.query.size = (original_from + original_size) as i64;
+            // partitions. When size==-1 (unlimited) keep it as -1 so partition returns all data.
+            if req.query.size > 0 {
+                req.query.size = (original_from + original_size) as i64;
+            }
             req.query.from = 0;
         } else {
             if req_size != -1 && !is_streaming_aggs {

--- a/src/service/search/streaming/sorting.rs
+++ b/src/service/search/streaming/sorting.rs
@@ -229,7 +229,13 @@ pub struct TopKHeap {
 
 impl TopKHeap {
     /// `order_by_cols`: all ORDER BY columns as (name, is_descending), in query order.
+    /// `k=0` is invalid (heap would never accept any row); falls back to `ZO_QUERY_DEFAULT_LIMIT`.
     pub fn new(k: usize, order_by_cols: &[(String, bool)]) -> Self {
+        let k = if k == 0 {
+            config::get_config().limit.query_default_limit as usize
+        } else {
+            k
+        };
         Self {
             heap: BinaryHeap::with_capacity(k + 1),
             k,
@@ -749,5 +755,100 @@ mod tests {
             .collect();
 
         assert_eq!(timestamps, vec![3000, 2000, 1000]);
+    }
+
+    // ── TopKHeap tests ────────────────────────────────────────────────────────
+
+    fn make_hits(pairs: &[(&str, i64)]) -> Vec<Value> {
+        pairs
+            .iter()
+            .map(|(level, cnt)| json!({"level": level, "cnt": cnt}))
+            .collect()
+    }
+
+    #[test]
+    fn test_topk_heap_zero_k_falls_back_to_default_limit() {
+        // k=0 is invalid — heap would never accept rows. Must fall back to query_default_limit.
+        let mut heap = TopKHeap::new(0, &[("cnt".to_string(), true)]);
+        heap.push_hits(make_hits(&[("info", 955), ("error", 382), ("warn", 100)]));
+        let result = heap.into_sorted_vec(0);
+        assert!(
+            !result.is_empty(),
+            "k=0 must fall back to default limit, not drop all rows"
+        );
+        assert_eq!(result[0]["cnt"].as_i64().unwrap(), 955);
+    }
+
+    #[test]
+    fn test_topk_heap_bounded_keeps_top_k() {
+        // k=2 DESC: should keep the 2 largest cnt values
+        let mut heap = TopKHeap::new(2, &[("cnt".to_string(), true)]);
+        heap.push_hits(make_hits(&[("info", 955), ("error", 382), ("warn", 382)]));
+        let result = heap.into_sorted_vec(0);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0]["cnt"].as_i64().unwrap(), 955);
+        assert_eq!(result[1]["cnt"].as_i64().unwrap(), 382);
+    }
+
+    #[test]
+    fn test_topk_heap_unlimited_keeps_all() {
+        // size==-1 path: heap_k == query_default_limit (e.g. 1000), all 3 hits fit
+        let k = 1000; // mirrors ZO_QUERY_DEFAULT_LIMIT default
+        let mut heap = TopKHeap::new(k, &[("cnt".to_string(), true)]);
+        heap.push_hits(make_hits(&[("info", 955), ("error", 382), ("warn", 382)]));
+        let result = heap.into_sorted_vec(0);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0]["cnt"].as_i64().unwrap(), 955);
+    }
+
+    #[test]
+    fn test_topk_heap_from_skips_correctly() {
+        // from=1: skip first sorted row
+        let k = 1000;
+        let mut heap = TopKHeap::new(k, &[("cnt".to_string(), true)]);
+        heap.push_hits(make_hits(&[("info", 955), ("error", 382), ("warn", 100)]));
+        let result = heap.into_sorted_vec(1); // skip rank-0 (955)
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0]["cnt"].as_i64().unwrap(), 382);
+    }
+
+    #[test]
+    fn test_topk_heap_asc_order() {
+        // is_descending=false → ASC sort
+        let mut heap = TopKHeap::new(1000, &[("cnt".to_string(), false)]);
+        heap.push_hits(make_hits(&[("info", 955), ("error", 382), ("warn", 100)]));
+        let result = heap.into_sorted_vec(0);
+        assert_eq!(result[0]["cnt"].as_i64().unwrap(), 100);
+        assert_eq!(result[2]["cnt"].as_i64().unwrap(), 955);
+    }
+
+    #[test]
+    fn test_topk_heap_multiple_partitions_unlimited() {
+        // Simulates multi-partition push with size==-1 (k = default limit)
+        let mut heap = TopKHeap::new(1000, &[("cnt".to_string(), true)]);
+        heap.push_hits(make_hits(&[("info", 955)])); // partition 1
+        heap.push_hits(make_hits(&[("error", 382)])); // partition 2
+        heap.push_hits(make_hits(&[("warn", 100)])); // partition 3
+        let result = heap.into_sorted_vec(0);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0]["cnt"].as_i64().unwrap(), 955);
+    }
+
+    #[test]
+    fn test_topk_heap_unlimited_non_ts_order_by() {
+        // Non-ts ORDER BY with size==-1 (e.g. plain aggregate query, not CTE):
+        // heap_k == query_default_limit, all rows from all partitions must survive.
+        // Note: CTE queries now short-circuit via is_aggregate=true and never reach
+        // the TopKHeap path.
+        let mut heap = TopKHeap::new(1000, &[("level_count".to_string(), true)]);
+        heap.push_hits(vec![
+            json!({"level": "info",  "level_count": 955}),
+            json!({"level": "error", "level_count": 382}),
+        ]);
+        heap.push_hits(vec![json!({"level": "warn", "level_count": 100})]);
+        let result = heap.into_sorted_vec(0);
+        assert_eq!(result.len(), 3, "all rows must survive with unlimited size");
+        assert_eq!(result[0]["level"].as_str().unwrap(), "info");
+        assert_eq!(result[0]["level_count"].as_i64().unwrap(), 955);
     }
 }


### PR DESCRIPTION
Backport of #11947 to `branch-v0.90.0`.

## Bug

Queries with `ORDER BY` on a non-timestamp column and `size: -1` (unlimited) returned empty results when the TopKHeap path was active.

## Root Cause

In `execution.rs`, `size=-1` was cast to `original_size=0`. Per-partition `size=0` → every partition fetches 0 rows → empty result.

## Fixes

- `execution.rs`: use `ZO_QUERY_DEFAULT_LIMIT` as `heap_k` when `size=-1`; keep `size=-1` for per-partition requests
- `sorting.rs` `TopKHeap::new`: guard `k=0` → falls back to `ZO_QUERY_DEFAULT_LIMIT`

## Fixed Behavior

CTE and subquery queries with no `_timestamp` in the outer result take single partition (via `ts_column=None` — fixed in enterprise companion PR) and never reach TopKHeap. For other non-ts ORDER BY queries with `size=-1`, results are now returned correctly.

## Test Queries

```sql
SELECT level, COUNT(*) as cnt FROM "stream" GROUP BY level ORDER BY cnt DESC
-- size: -1  →  must return non-empty hits

SELECT level, COUNT(*) as cnt FROM "stream" GROUP BY level ORDER BY cnt DESC
-- size: 10, from: 0
```

## Related

- Main PR: #11947
- Enterprise companion (v0.90): openobserve/o2-enterprise#1728