### PR TITLE
refactor: update file statistics cache configuration and metrics

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1767,11 +1767,11 @@ pub struct Limit {
     #[env_config(name = "ZO_CONSISTENT_HASH_VNODES", default = 1000)]
     pub consistent_hash_vnodes: usize,
     #[env_config(
-        name = "ZO_DATAFUSION_FILE_STAT_CACHE_MAX_ENTRIES",
-        default = 10000,
-        help = "Maximum number of entries in the file stat cache. Higher values increase memory usage but may improve query performance."
+        name = "ZO_DATAFUSION_FILE_STAT_CACHE_MAX_SIZE",
+        default = 0, // MB, default is 5% of total memory
+        help = "Maximum memory size in MB for the file stat cache. Higher values allow caching more file statistics but increase memory usage."
     )]
-    pub datafusion_file_stat_cache_max_entries: usize,
+    pub datafusion_file_stat_cache_max_size: usize,
     #[env_config(
         name = "ZO_DATAFUSION_STREAMING_AGGS_CACHE_MAX_ENTRIES",
         default = 10000,
@@ -3112,6 +3112,14 @@ fn check_memory_config(cfg: &mut Config) -> Result<(), anyhow::Error> {
                 * (SIZE_IN_MB as usize);
     } else {
         cfg.limit.footer_cache_max_size *= SIZE_IN_MB as usize;
+    }
+
+    if cfg.limit.datafusion_file_stat_cache_max_size == 0 {
+        cfg.limit.datafusion_file_stat_cache_max_size =
+            ((cfg.limit.mem_total as f64 / SIZE_IN_MB * 0.05) as usize).clamp(100, 1024)
+                * (SIZE_IN_MB as usize);
+    } else {
+        cfg.limit.datafusion_file_stat_cache_max_size *= SIZE_IN_MB as usize;
     }
     Ok(())
 }

--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -497,6 +497,58 @@ pub static QUERY_PARQUET_METADATA_CACHE_USED_BYTES: Lazy<IntGaugeVec> = Lazy::ne
     )
     .expect("Metric created")
 });
+pub static QUERY_PARQUET_METADATA_CACHE_HITS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_parquet_metadata_cache_hits_total",
+            "Querier parquet metadata cache hits.".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_PARQUET_METADATA_CACHE_MISS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_parquet_metadata_cache_miss_total",
+            "Querier parquet metadata cache misses.".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_PARQUET_METADATA_CACHE_GC_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "query_parquet_metadata_cache_gc_count",
+            "Querier parquet metadata cache eviction runs.".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
+pub static QUERY_PARQUET_METADATA_CACHE_GC_TIME: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
+            "query_parquet_metadata_cache_gc_time",
+            "Time (ms) spent per eviction run of the querier parquet metadata cache.".to_owned()
+                + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .buckets(vec![
+            0.2, 0.5, 1.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0,
+        ])
+        .const_labels(create_const_labels()),
+        &[],
+    )
+    .expect("Metric created")
+});
 
 // compactor stats
 pub static COMPACT_USED_TIME: Lazy<CounterVec> = Lazy::new(|| {
@@ -1818,6 +1870,18 @@ fn register_metrics(registry: &Registry) {
     registry
         .register(Box::new(QUERY_PARQUET_METADATA_CACHE_USED_BYTES.clone()))
         .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_PARQUET_METADATA_CACHE_HITS_TOTAL.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_PARQUET_METADATA_CACHE_MISS_TOTAL.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_PARQUET_METADATA_CACHE_GC_COUNT.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(QUERY_PARQUET_METADATA_CACHE_GC_TIME.clone()))
+        .expect("Metric registered");
 
     // query manager
     registry
@@ -2317,6 +2381,10 @@ mod tests {
         let _ = QUERY_METRICS_CACHE_RATIO.clone();
         let _ = QUERY_PARQUET_METADATA_CACHE_FILES.clone();
         let _ = QUERY_PARQUET_METADATA_CACHE_USED_BYTES.clone();
+        let _ = QUERY_PARQUET_METADATA_CACHE_HITS_TOTAL.clone();
+        let _ = QUERY_PARQUET_METADATA_CACHE_MISS_TOTAL.clone();
+        let _ = QUERY_PARQUET_METADATA_CACHE_GC_COUNT.clone();
+        let _ = QUERY_PARQUET_METADATA_CACHE_GC_TIME.clone();
         let _ = QUERY_DISK_CACHE_HIT_COUNT.clone();
         let _ = QUERY_DISK_CACHE_MISS_COUNT.clone();
         let _ = QUERY_AGGREGATION_CACHE_ITEMS.clone();

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -132,7 +132,7 @@ pub async fn create_runtime_env(trace_id: &str, memory_limit: usize) -> Result<R
     let cfg = get_config();
     let mut builder =
         RuntimeEnvBuilder::new().with_object_store_registry(Arc::new(object_store_registry));
-    if cfg.limit.datafusion_file_stat_cache_max_entries > 0 {
+    if cfg.limit.datafusion_file_stat_cache_max_size > 0 {
         let cache_config = CacheManagerConfig::default();
         let cache_config = cache_config.with_files_statistics_cache(Some(
             super::storage::file_statistics_cache::GLOBAL_CACHE.clone(),

--- a/src/service/search/datafusion/storage/file_statistics_cache.rs
+++ b/src/service/search/datafusion/storage/file_statistics_cache.rs
@@ -15,9 +15,14 @@
 
 use std::{
     collections::{HashMap, VecDeque},
-    sync::{Arc, LazyLock as Lazy},
+    sync::{
+        Arc, LazyLock as Lazy,
+        atomic::{AtomicI64, Ordering},
+    },
+    time::Instant,
 };
 
+use config::metrics;
 use dashmap::DashMap;
 use datafusion::{
     common::Statistics,
@@ -36,8 +41,9 @@ pub static GLOBAL_CACHE: Lazy<Arc<FileStatisticsCache>> =
 /// Collected statistics for files
 /// Cache is invalided when file size or last modification has changed
 pub struct FileStatisticsCache {
-    statistics: DashMap<String, (ObjectMeta, Arc<Statistics>)>,
+    statistics: DashMap<String, (ObjectMeta, Arc<Statistics>, usize)>,
     cacher: parking_lot::Mutex<VecDeque<String>>,
+    current_memory: AtomicI64,
 }
 
 impl FileStatisticsCache {
@@ -45,6 +51,7 @@ impl FileStatisticsCache {
         Self {
             statistics: DashMap::new(),
             cacher: parking_lot::Mutex::new(VecDeque::new()),
+            current_memory: AtomicI64::new(0),
         }
     }
 
@@ -53,64 +60,67 @@ impl FileStatisticsCache {
     }
 
     pub fn memory_size(&self) -> usize {
-        let mut total_size = 0;
+        self.current_memory.load(Ordering::Relaxed).max(0) as usize
+    }
 
-        // Size of the struct itself
-        total_size += std::mem::size_of::<Self>();
+    fn estimate_entry_size(key: &str, meta: &ObjectMeta, stats: &Statistics) -> usize {
+        // Key is stored both in the DashMap and the eviction queue
+        let mut size = (std::mem::size_of::<String>() + key.len()) * 2;
 
-        // Size of DashMap entries
-        for entry in self.statistics.iter() {
-            let (key, (meta, stats)) = entry.pair();
-
-            // Key string
-            total_size += std::mem::size_of::<String>() + key.len();
-
-            // ObjectMeta
-            total_size += std::mem::size_of::<ObjectMeta>();
-            // Path string in ObjectMeta
-            total_size += meta.location.as_ref().len();
-            // Optional e_tag
-            if let Some(ref etag) = meta.e_tag {
-                total_size += std::mem::size_of::<String>() + etag.len();
-            }
-            // Optional version
-            if let Some(ref version) = meta.version {
-                total_size += std::mem::size_of::<String>() + version.len();
-            }
-
-            // Arc<Statistics> - estimate size
-            // Statistics contains num_rows, total_byte_size, and column_statistics
-            total_size += std::mem::size_of::<Statistics>();
-
-            // Column statistics size estimation
-            for col in &stats.column_statistics {
-                total_size += std::mem::size_of::<datafusion::common::ColumnStatistics>();
-                // add min_value, max_value, sum_value
-                total_size += col.min_value.get_value().map(|v| v.size()).unwrap_or(0);
-                total_size += col.max_value.get_value().map(|v| v.size()).unwrap_or(0);
-                total_size += col.sum_value.get_value().map(|v| v.size()).unwrap_or(0);
-            }
+        size += std::mem::size_of::<ObjectMeta>();
+        size += meta.location.as_ref().len();
+        if let Some(ref etag) = meta.e_tag {
+            size += std::mem::size_of::<String>() + etag.len();
+        }
+        if let Some(ref version) = meta.version {
+            size += std::mem::size_of::<String>() + version.len();
         }
 
-        // Size of VecDeque<String> in cacher
-        let cacher_guard = self.cacher.lock();
-        total_size += std::mem::size_of::<VecDeque<String>>();
-        for key in cacher_guard.iter() {
-            total_size += std::mem::size_of::<String>() + key.len();
+        size += std::mem::size_of::<Statistics>();
+        size += std::mem::size_of::<usize>(); // tracked entry size field
+
+        for col in &stats.column_statistics {
+            size += std::mem::size_of::<datafusion::common::ColumnStatistics>();
+            size += col.min_value.get_value().map(|v| v.size()).unwrap_or(0);
+            size += col.max_value.get_value().map(|v| v.size()).unwrap_or(0);
+            size += col.sum_value.get_value().map(|v| v.size()).unwrap_or(0);
         }
-        drop(cacher_guard);
 
-        // DashMap overhead (approximate)
-        // DashMap uses sharding internally, estimate based on typical overhead
-        // This is an approximation since we can't access internal shards
-        let estimated_shards = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(8)
-            .min(128); // DashMap typically uses CPU count for shards
-        let dashmap_overhead = estimated_shards * std::mem::size_of::<parking_lot::RwLock<()>>();
-        total_size += dashmap_overhead;
+        size
+    }
 
-        total_size
+    fn evict(&self, max_bytes: usize) {
+        let start = Instant::now();
+        let mut warned = false;
+        let mut w = self.cacher.lock();
+        while self.current_memory.load(Ordering::Relaxed) > max_bytes as i64 && !w.is_empty() {
+            if !warned {
+                log::warn!(
+                    "FileStatisticsCache is full ({} bytes > {} bytes), evicting oldest entries",
+                    self.current_memory.load(Ordering::Relaxed),
+                    max_bytes,
+                );
+                warned = true;
+            }
+            let batch = (w.len() / 20).max(1).min(w.len());
+            let mut removed_total = 0i64;
+            for k in w.drain(0..batch) {
+                if let Some((_, (_, _, size))) = self.statistics.remove(&k) {
+                    removed_total += size as i64;
+                }
+            }
+            if removed_total > 0 {
+                self.current_memory
+                    .fetch_sub(removed_total, Ordering::Relaxed);
+            }
+        }
+        drop(w);
+        metrics::QUERY_PARQUET_METADATA_CACHE_GC_COUNT
+            .with_label_values::<&str>(&[])
+            .inc();
+        metrics::QUERY_PARQUET_METADATA_CACHE_GC_TIME
+            .with_label_values::<&str>(&[])
+            .observe(start.elapsed().as_millis() as f64);
     }
 
     fn format_key(&self, k: &Path) -> String {
@@ -135,43 +145,57 @@ impl CacheAccessor<Path, CachedFileMetadata> for FileStatisticsCache {
     /// Get cached metadata for file location.
     fn get(&self, k: &Path) -> Option<CachedFileMetadata> {
         let k = self.format_key(k);
-        self.statistics.get(&k).map(|s| {
-            let (meta, statistics) = s.value();
-            CachedFileMetadata::new(meta.clone(), statistics.clone(), None)
-        })
+        match self.statistics.get(&k) {
+            Some(s) => {
+                metrics::QUERY_PARQUET_METADATA_CACHE_HITS_TOTAL
+                    .with_label_values::<&str>(&[])
+                    .inc();
+                let (meta, statistics, _) = s.value();
+                Some(CachedFileMetadata::new(
+                    meta.clone(),
+                    statistics.clone(),
+                    None,
+                ))
+            }
+            None => {
+                metrics::QUERY_PARQUET_METADATA_CACHE_MISS_TOTAL
+                    .with_label_values::<&str>(&[])
+                    .inc();
+                None
+            }
+        }
     }
 
     /// Save collected file statistics
     fn put(&self, k: &Path, value: CachedFileMetadata) -> Option<CachedFileMetadata> {
         let k = self.format_key(k);
-        let mut w = self.cacher.lock();
+        let entry_size = Self::estimate_entry_size(&k, &value.meta, &value.statistics);
 
-        let max_entries = config::get_config()
-            .limit
-            .datafusion_file_stat_cache_max_entries;
-        if w.len() >= max_entries {
-            // release 10% of the cache
-            log::warn!("FileStatisticsCache is full, releasing 10% of the cache");
-            for _ in 0..(max_entries / 10) {
-                if let Some(k) = w.pop_front() {
-                    self.statistics.remove(&k);
-                } else {
-                    break;
-                }
-            }
+        let old = self.statistics.insert(
+            k.clone(),
+            (value.meta.clone(), value.statistics.clone(), entry_size),
+        );
+        let old_size = old.as_ref().map(|(_, _, s)| *s).unwrap_or(0);
+        let delta = entry_size as i64 - old_size as i64;
+        self.current_memory.fetch_add(delta, Ordering::Relaxed);
+
+        self.cacher.lock().push_back(k);
+
+        let max_bytes = config::get_config().limit.datafusion_file_stat_cache_max_size;
+        if self.current_memory.load(Ordering::Relaxed) > max_bytes as i64 {
+            self.evict(max_bytes);
         }
-        w.push_back(k.clone());
-        drop(w);
-        self.statistics
-            .insert(k, (value.meta.clone(), value.statistics.clone()))
-            .map(|(meta, stats)| CachedFileMetadata::new(meta, stats, None))
+
+        old.map(|(meta, stats, _)| CachedFileMetadata::new(meta, stats, None))
     }
 
     fn remove(&self, k: &Path) -> Option<CachedFileMetadata> {
         let k = self.format_key(k);
-        self.statistics
-            .remove(&k)
-            .map(|(_, (meta, stats))| CachedFileMetadata::new(meta, stats, None))
+        self.statistics.remove(&k).map(|(_, (meta, stats, size))| {
+            self.current_memory
+                .fetch_sub(size as i64, Ordering::Relaxed);
+            CachedFileMetadata::new(meta, stats, None)
+        })
     }
 
     fn contains_key(&self, k: &Path) -> bool {
@@ -184,7 +208,9 @@ impl CacheAccessor<Path, CachedFileMetadata> for FileStatisticsCache {
     }
 
     fn clear(&self) {
-        self.statistics.clear()
+        self.statistics.clear();
+        self.cacher.lock().clear();
+        self.current_memory.store(0, Ordering::Relaxed);
     }
     fn name(&self) -> String {
         "FileStatisticsCache".to_string()
@@ -197,7 +223,7 @@ impl datafusion::execution::cache::cache_manager::FileStatisticsCache for FileSt
 
         for entry in &self.statistics {
             let path = Path::from(entry.key().as_str());
-            let (object_meta, stats) = entry.value();
+            let (object_meta, stats, _) = entry.value();
             entries.insert(
                 path,
                 FileStatisticsCacheEntry {
@@ -276,9 +302,9 @@ mod tests {
     fn test_memory_size_calculation() {
         let cache = FileStatisticsCache::new();
 
-        // Empty cache should have some base size
+        // Empty cache tracks zero memory
         let empty_size = cache.memory_size();
-        assert!(empty_size > 0);
+        assert_eq!(empty_size, 0);
 
         // Add some entries
         for i in 0..10 {
@@ -321,6 +347,10 @@ mod tests {
             cache.len(),
             filled_size,
         );
+
+        // After clearing, tracked memory must return to zero
+        cache.clear();
+        assert_eq!(cache.memory_size(), 0);
     }
 
     #[test]

--- a/src/service/search/datafusion/storage/file_statistics_cache.rs
+++ b/src/service/search/datafusion/storage/file_statistics_cache.rs
@@ -78,6 +78,10 @@ impl FileStatisticsCache {
 
         size += std::mem::size_of::<Statistics>();
         size += std::mem::size_of::<usize>(); // tracked entry size field
+        // Arc<Statistics> header (strong + weak counter) and DashMap bucket
+        // overhead (hash + slot metadata). Conservative fixed overhead per
+        // entry so the memory budget is not systematically underestimated.
+        size += 64;
 
         for col in &stats.column_statistics {
             size += std::mem::size_of::<datafusion::common::ColumnStatistics>();
@@ -179,7 +183,13 @@ impl CacheAccessor<Path, CachedFileMetadata> for FileStatisticsCache {
         let delta = entry_size as i64 - old_size as i64;
         self.current_memory.fetch_add(delta, Ordering::Relaxed);
 
-        self.cacher.lock().push_back(k);
+        // Only queue the key for eviction when it's a fresh insertion.
+        // When `old.is_some()` the key is already present in `cacher`
+        // (it hasn't been drained yet, otherwise stats wouldn't hold it),
+        // so pushing again would create a duplicate tombstone.
+        if old.is_none() {
+            self.cacher.lock().push_back(k);
+        }
 
         let max_bytes = config::get_config()
             .limit

--- a/src/service/search/datafusion/storage/file_statistics_cache.rs
+++ b/src/service/search/datafusion/storage/file_statistics_cache.rs
@@ -181,7 +181,9 @@ impl CacheAccessor<Path, CachedFileMetadata> for FileStatisticsCache {
 
         self.cacher.lock().push_back(k);
 
-        let max_bytes = config::get_config().limit.datafusion_file_stat_cache_max_size;
+        let max_bytes = config::get_config()
+            .limit
+            .datafusion_file_stat_cache_max_size;
         if self.current_memory.load(Ordering::Relaxed) > max_bytes as i64 {
             self.evict(max_bytes);
         }


### PR DESCRIPTION
## ENVs

Replace `ZO_DATAFUSION_FILE_STAT_CACHE_MAX_ENTRIES` to `ZO_DATAFUSION_FILE_STAT_CACHE_MAX_SIZE`

fixed https://github.com/openobserve/openobserve/issues/11835

- Changed `datafusion_file_stat_cache_max_entries` to `datafusion_file_stat_cache_max_size` in configuration, allowing for memory size limits instead of entry counts.
- Implemented logic to set default cache size to 5% of total memory if not specified.
- Added new metrics for cache hits, misses, eviction counts, and eviction time to monitor cache performance.
- Updated cache eviction logic to track current memory usage and log warnings when limits are exceeded.
 