### PR TITLE
fix: do not clear last period end time

### DIFF
--- a/src/service/alerts/scheduler/handlers.rs
+++ b/src/service/alerts/scheduler/handlers.rs
@@ -1845,8 +1845,6 @@ async fn handle_derived_stream_triggers(
             ..Default::default()
         };
         log::info!("[SCHEDULER trace_id {scheduler_trace_id}] {msg}");
-        new_trigger_data.reset();
-        new_trigger.data = new_trigger_data.to_json_string();
         db::scheduler::update_trigger(new_trigger, true, &query_trace_id).await?;
         publish_triggers_usage(trigger_data_stream);
         return Ok(());


### PR DESCRIPTION
In alert manager pipeline handler function, we should not clear the trigger data (containing the period_end_time representing the timestamp used for the last scheduled pipeline query), if the pipeline is disabled. Because, when enabling, this should have the data to know where to start the pipeline from.