### PR TITLE
fix: IAM user role assignment changes

### DIFF
--- a/web/src/components/iam/users/AddUser.vue
+++ b/web/src/components/iam/users/AddUser.vue
@@ -162,7 +162,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             use-input
             @filter="filterFn"
             data-test="user-custom-role-field"
-            :disable="filterdOption.length === 0"
+            :disable="filterdOption.length === 0 || !!formData.is_external"
+            :hint="
+              formData.is_external
+                ? t('user.externalUserCustomRoleHint')
+                : filterdOption.length === 0
+                  ? t('user.noCustomRolesHint')
+                  : ''
+            "
           />
           <div v-if="beingUpdated" class="tw:mt-2">
             <q-toggle
@@ -376,7 +383,14 @@ export default defineComponent({
     const loadingOrganizations = ref(true);
     const logout_confirm = ref(false);
     const loggedInUserEmail = ref(store.state.userInfo.email);
-    const filterdOption = ref(props.customRoles);
+    const filterdOption = ref([...props.customRoles]);
+
+    watch(
+      () => props.customRoles,
+      (next) => {
+        filterdOption.value = [...next];
+      },
+    );
 
     onActivated(() => {
       formData.value.organization = store.state.selectedOrganization.identifier;

--- a/web/src/components/iam/users/User.vue
+++ b/web/src/components/iam/users/User.vue
@@ -521,7 +521,7 @@ export default defineComponent({
           .finally(() => resolve(true));
       });
     };
-    const getCustomRoles = async () => {
+    const getCustomRoles = async (options: { silent?: boolean } = {}) => {
       if (config.isEnterprise !== "true" && config.isCloud !== "true") return;
       try {
         const res = await getCustomRolesApi(
@@ -529,7 +529,7 @@ export default defineComponent({
         );
         customRoles.value = Array.isArray(res.data) ? res.data : [];
       } catch (err: any) {
-        if (err?.response?.status !== 403) {
+        if (!options.silent && err?.response?.status !== 403) {
           $q.notify({
             color: "negative",
             message:
@@ -568,6 +568,12 @@ export default defineComponent({
 
     let hydrateGeneration = 0;
 
+    const clearLoading = (targets: any[]) => {
+      for (const u of targets) {
+        u.custom_roles_loading = false;
+      }
+    };
+
     // Inverts OFGA per-role memberships into per-user role lists.
     // Cost: O(R) HTTP calls where R is the number of custom roles,
     // independent of the user count.
@@ -575,24 +581,30 @@ export default defineComponent({
       const myGen = ++hydrateGeneration;
       const orgId = store.state.selectedOrganization.identifier;
       const targets = usersState.users.filter(
-        (u: any) => u.rawEmail && u.status !== "pending",
+        (u: any) => (u.rawEmail || u.email) && u.status !== "pending",
       );
       if (targets.length === 0) return;
 
       const byEmail = new Map<string, any>();
       for (const u of targets) {
-        byEmail.set(u.rawEmail.toLowerCase(), u);
+        byEmail.set(String(u.rawEmail || u.email).toLowerCase(), u);
       }
-
-      if (!Array.isArray(customRoles.value) || customRoles.value.length === 0) {
-        await getCustomRoles();
-        if (myGen !== hydrateGeneration) return;
-      }
-      const roleNames: string[] = Array.isArray(customRoles.value)
-        ? (customRoles.value as string[])
-        : [];
 
       try {
+        // Always fetch a fresh role list scoped to this hydration run so we
+        // don't race with concurrent picker loads mutating the shared ref.
+        // Silent mode: hydration is a background operation; surface fetch
+        // errors via the per-row loading state, not a toast.
+        let roleNames: string[] = [];
+        try {
+          const res = await getCustomRolesApi(orgId);
+          roleNames = Array.isArray(res.data) ? res.data : [];
+        } catch {
+          roleNames = [];
+        }
+        if (myGen !== hydrateGeneration) return;
+        if (roleNames.length === 0) return;
+
         const results = await Promise.all(
           roleNames.map((role) =>
             getRoleUsers(role, orgId)
@@ -605,15 +617,17 @@ export default defineComponent({
         for (const { role, emails } of results) {
           for (const email of emails) {
             const row = byEmail.get(String(email).toLowerCase());
-            if (row) row.custom_roles.push(role);
+            if (!row) continue;
+            const next = Array.isArray(row.custom_roles)
+              ? row.custom_roles
+              : [];
+            if (next.indexOf(role) === -1) {
+              row.custom_roles = [...next, role];
+            }
           }
         }
       } finally {
-        if (myGen === hydrateGeneration) {
-          for (const u of targets) {
-            u.custom_roles_loading = false;
-          }
-        }
+        clearLoading(targets);
       }
     };
 
@@ -674,7 +688,9 @@ export default defineComponent({
             // Lazy-load custom roles per user in the background so the
             // table renders immediately. Concurrency-capped to avoid
             // saturating the browser/network with many users.
-            void hydrateCustomRoles();
+            hydrateCustomRoles().catch((err) => {
+              console.warn("custom-role hydration failed:", err);
+            });
           })
           .catch(() => {
             dismiss();

--- a/web/src/components/iam/users/User.vue
+++ b/web/src/components/iam/users/User.vue
@@ -114,6 +114,55 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </q-th>
             </q-tr>
           </template>
+          <template #body-cell-auth_type="props">
+            <q-td :props="props">
+              <span
+                class="role-badge"
+                :class="props.row.is_external ? 'role-badge-sso' : 'role-badge-local'"
+                :data-test="`auth-type-${props.row.email}`"
+              >
+                {{ props.row.auth_type }}
+              </span>
+            </q-td>
+          </template>
+          <template #body-cell-roles="props">
+            <q-td :props="props">
+              <div class="tw:flex tw:flex-wrap tw:items-center tw:gap-2">
+                <span
+                  class="role-badge role-badge-system"
+                  :data-test="`role-chip-system-${props.row.email}`"
+                >
+                  {{ props.row.role }}
+                </span>
+                <template v-for="(r, i) in (props.row.custom_roles || []).slice(0, 2)" :key="r">
+                  <span
+                    class="role-badge role-badge-custom"
+                    :data-test="`role-chip-custom-${props.row.email}-${i}`"
+                  >
+                    {{ r }}
+                  </span>
+                </template>
+                <span
+                  v-if="(props.row.custom_roles || []).length > 2"
+                  class="role-badge role-badge-more"
+                  :data-test="`role-chip-more-${props.row.email}`"
+                >
+                  +{{ (props.row.custom_roles || []).length - 2 }} more
+                  <q-tooltip>
+                    <div class="tw:flex tw:flex-col tw:gap-1">
+                      <span v-for="r in (props.row.custom_roles || []).slice(2)" :key="r">{{ r }}</span>
+                    </div>
+                  </q-tooltip>
+                </span>
+                <q-spinner
+                  v-if="props.row.custom_roles_loading"
+                  size="14px"
+                  color="grey-6"
+                  :data-test="`role-loading-${props.row.email}`"
+                />
+              </div>
+            </q-td>
+          </template>
           <template #body-cell-actions="props">
             <q-td :props="props" side>
               <OButton
@@ -310,7 +359,7 @@ import { outlinedDelete } from "@quasar/extras/material-icons-outlined";
 // @ts-ignore
 import usePermissions from "@/composables/iam/usePermissions";
 import { computed, nextTick } from "vue";
-import { getRoles } from "@/services/iam";
+import { getRoles as getCustomRolesApi, getRoleUsers } from "@/services/iam";
 
 export default defineComponent({
   name: "UserPageOpenSource",
@@ -371,6 +420,7 @@ export default defineComponent({
       await getOrgMembers();
       updateUserActions();
       await getRoles();
+      await getCustomRoles();
 
       // if (config.isCloud == "true") {
         // columns.value.push({
@@ -428,12 +478,20 @@ export default defineComponent({
         style: "width: 150px",
       },
       {
-        name: "role",
-        field: "role",
-        label: t("user.role"),
+        name: "auth_type",
+        field: "auth_type",
+        label: t("user.authType"),
         align: "left",
         sortable: true,
-        style: "width: 150px",
+        style: "width: 100px",
+      },
+      {
+        name: "roles",
+        field: "roles",
+        label: t("user.roles"),
+        align: "left",
+        sortable: false,
+        style: "min-width: 240px",
       },
       {
         name: "actions",
@@ -464,13 +522,23 @@ export default defineComponent({
       });
     };
     const getCustomRoles = async () => {
-      await getRoles(store.state.selectedOrganization.identifier)
-        .then((res) => {
-          customRoles.value = res.data;
-        })
-        .catch((err) => {
-          console.log(err);
-        });
+      if (config.isEnterprise !== "true" && config.isCloud !== "true") return;
+      try {
+        const res = await getCustomRolesApi(
+          store.state.selectedOrganization.identifier,
+        );
+        customRoles.value = Array.isArray(res.data) ? res.data : [];
+      } catch (err: any) {
+        if (err?.response?.status !== 403) {
+          $q.notify({
+            color: "negative",
+            message:
+              err?.response?.data?.message ||
+              "Failed to load custom roles.",
+            timeout: 3000,
+          });
+        }
+      }
     };
 
     const getInvitedMembers = () => {
@@ -497,6 +565,57 @@ export default defineComponent({
           });
       });
     }
+
+    let hydrateGeneration = 0;
+
+    // Inverts OFGA per-role memberships into per-user role lists.
+    // Cost: O(R) HTTP calls where R is the number of custom roles,
+    // independent of the user count.
+    const hydrateCustomRoles = async () => {
+      const myGen = ++hydrateGeneration;
+      const orgId = store.state.selectedOrganization.identifier;
+      const targets = usersState.users.filter(
+        (u: any) => u.rawEmail && u.status !== "pending",
+      );
+      if (targets.length === 0) return;
+
+      const byEmail = new Map<string, any>();
+      for (const u of targets) {
+        byEmail.set(u.rawEmail.toLowerCase(), u);
+      }
+
+      if (!Array.isArray(customRoles.value) || customRoles.value.length === 0) {
+        await getCustomRoles();
+        if (myGen !== hydrateGeneration) return;
+      }
+      const roleNames: string[] = Array.isArray(customRoles.value)
+        ? (customRoles.value as string[])
+        : [];
+
+      try {
+        const results = await Promise.all(
+          roleNames.map((role) =>
+            getRoleUsers(role, orgId)
+              .then((r) => ({ role, emails: Array.isArray(r.data) ? r.data : [] }))
+              .catch(() => ({ role, emails: [] as string[] })),
+          ),
+        );
+        if (myGen !== hydrateGeneration) return;
+
+        for (const { role, emails } of results) {
+          for (const email of emails) {
+            const row = byEmail.get(String(email).toLowerCase());
+            if (row) row.custom_roles.push(role);
+          }
+        }
+      } finally {
+        if (myGen === hydrateGeneration) {
+          for (const u of targets) {
+            u.custom_roles_loading = false;
+          }
+        }
+      }
+    };
 
     const getOrgMembers = () => {
       const dismiss = $q.notify({
@@ -529,12 +648,19 @@ export default defineComponent({
                 addUser({ row: data }, true);
               }
 
+              const isPending = data?.status == "pending";
               return {
                 "#": counter <= 9 ? `0${counter++}` : counter++,
                 email: maskText(data.email),
+                rawEmail: data.email,
                 first_name: data.first_name,
                 last_name: data.last_name,
-                role: data?.status == "pending" ? toCamelCase(data.role) + " (Invited)": toCamelCase(data.role),
+                role: isPending ? toCamelCase(data.role) + " (Invited)": toCamelCase(data.role),
+                prebuiltRole: toCamelCase(data.role || ""),
+                auth_type: data?.is_external ? t("user.authTypeSSO") : t("user.authTypeLocal"),
+                is_external: !!data?.is_external,
+                custom_roles: [] as string[],
+                custom_roles_loading: !isPending,
                 enableEdit: store.state.userInfo.email?.toLowerCase() == data.email?.toLowerCase() ? true : false,
                 enableChangeRole: false,
                 enableDelete: config.isCloud == "true" ? true : false,
@@ -544,8 +670,11 @@ export default defineComponent({
             });
 
             dismiss();
-
             resolve(true);
+            // Lazy-load custom roles per user in the background so the
+            // table renders immediately. Concurrency-capped to avoid
+            // saturating the browser/network with many users.
+            void hydrateCustomRoles();
           })
           .catch(() => {
             dismiss();
@@ -1050,7 +1179,11 @@ export default defineComponent({
             rows[i]["first_name"]?.toLowerCase().includes(terms) ||
             rows[i]["last_name"]?.toLowerCase().includes(terms) ||
             rows[i]["email"]?.toLowerCase().includes(terms) ||
-            rows[i]["role"].toLowerCase().includes(terms)
+            rows[i]["role"].toLowerCase().includes(terms) ||
+            (rows[i]["auth_type"] || "").toLowerCase().includes(terms) ||
+            (rows[i]["custom_roles"] || []).some((r: string) =>
+              (r || "").toLowerCase().includes(terms),
+            )
           ) {
             filtered.push(rows[i]);
           }
@@ -1226,5 +1359,44 @@ export default defineComponent({
 .inputHint {
   font-size: 11px;
   color: $light-text;
+}
+
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background-color: transparent;
+  white-space: nowrap;
+}
+
+.role-badge-system {
+  color: #8a6a1f;
+  border: 1px solid #8a6a1f;
+}
+
+.role-badge-custom {
+  color: #a04545;
+  border: 1px solid #a04545;
+  font-weight: 700;
+}
+
+.role-badge-more {
+  color: #a04545;
+  border: 1px solid #a04545;
+  cursor: pointer;
+}
+
+.role-badge-sso {
+  color: #1f6f8b;
+  border: 1px solid #1f6f8b;
+}
+
+.role-badge-local {
+  color: #4a4a4a;
+  border: 1px solid #4a4a4a;
 }
 </style>

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -742,6 +742,12 @@ export default defineComponent({
         });
         if (response.list.length == 0) {
           store.dispatch("setIsDataIngested", false);
+          // IAM is org-setup, not data consumption — don't bounce out
+          // of IAM screens just because no streams exist yet.
+          const currentPath = router.currentRoute.value.path || "";
+          if (currentPath.indexOf("/iam") !== -1) {
+            return;
+          }
           $q.notify({
             type: "warning",
             message:

--- a/web/src/locales/languages/de.json
+++ b/web/src/locales/languages/de.json
@@ -857,7 +857,12 @@
     "groups": "Gruppen",
     "customRole": "Benutzerdefinierte Rollen",
     "description": "Beschreibung",
-    "revoke_invite": "Einladung widerrufen"
+    "revoke_invite": "Einladung widerrufen",
+    "authType": "Auth",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "Einheimisch",
+    "noCustomRolesHint": "Keine benutzerdefinierten Rollen definiert — erstellen Sie eine in IAM → Rollen",
+    "externalUserCustomRoleHint": "Externe Benutzer können nur über das Quellsystem geändert werden"
   },
   "ticket": {
     "header": "Tickets für den Support",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -858,6 +858,11 @@
     "roles": "Roles",
     "groups": "Groups",
     "customRole": "Custom Roles",
+    "authType": "Auth",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "Native",
+    "noCustomRolesHint": "No custom roles defined — create one in IAM → Roles",
+    "externalUserCustomRoleHint": "External users can only be modified via the source system",
     "description": "Description",
     "revoke_invite": "Revoke Invite"
   },

--- a/web/src/locales/languages/es.json
+++ b/web/src/locales/languages/es.json
@@ -857,7 +857,12 @@
     "groups": "Grupos",
     "customRole": "Funciones personalizadas",
     "description": "Descripción",
-    "revoke_invite": "Revocar invitación"
+    "revoke_invite": "Revocar invitación",
+    "authType": "Autenticación",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "Nativo",
+    "noCustomRolesHint": "No hay roles personalizados definidos: cree uno en IAM → Roles",
+    "externalUserCustomRoleHint": "Los usuarios externos solo se pueden modificar a través del sistema fuente"
   },
   "ticket": {
     "header": "Tickets de soporte",

--- a/web/src/locales/languages/fr.json
+++ b/web/src/locales/languages/fr.json
@@ -857,7 +857,12 @@
     "groups": "Groupes",
     "customRole": "Rôles personnalisés",
     "description": "Descriptif",
-    "revoke_invite": "Révoquer l'invitation"
+    "revoke_invite": "Révoquer l'invitation",
+    "authType": "Authentification",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "Autochtone",
+    "noCustomRolesHint": "Aucun rôle personnalisé n'est défini. Créez-en un dans IAM → Rôles",
+    "externalUserCustomRoleHint": "Les utilisateurs externes ne peuvent être modifiés que via le système source"
   },
   "ticket": {
     "header": "Tickets d'assistance",

--- a/web/src/locales/languages/it.json
+++ b/web/src/locales/languages/it.json
@@ -857,7 +857,12 @@
     "groups": "Gruppi",
     "customRole": "Ruoli personalizzati",
     "description": "Descrizione",
-    "revoke_invite": "Revoca l'invito"
+    "revoke_invite": "Revoca l'invito",
+    "authType": "Autenticazione",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "Nativo",
+    "noCustomRolesHint": "Nessun ruolo personalizzato definito: creane uno in IAM → Ruoli",
+    "externalUserCustomRoleHint": "Gli utenti esterni possono essere modificati solo tramite il sistema sorgente"
   },
   "ticket": {
     "header": "Ticket di assistenza",

--- a/web/src/locales/languages/ja.json
+++ b/web/src/locales/languages/ja.json
@@ -857,7 +857,12 @@
     "groups": "グループ",
     "customRole": "カスタムロール",
     "description": "[説明]",
-    "revoke_invite": "招待を取り消す"
+    "revoke_invite": "招待を取り消す",
+    "authType": "認証",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "ネイティブ",
+    "noCustomRolesHint": "カスタムロールは定義されていません — IAM → ロールで作成",
+    "externalUserCustomRoleHint": "外部ユーザーはソースシステム経由でのみ変更できます"
   },
   "serviceAccounts": {
     "header": "サービスアカウント",

--- a/web/src/locales/languages/ko.json
+++ b/web/src/locales/languages/ko.json
@@ -857,7 +857,12 @@
     "groups": "그룹",
     "customRole": "사용자 지정 역할",
     "description": "설명",
-    "revoke_invite": "초대 취소"
+    "revoke_invite": "초대 취소",
+    "authType": "인증",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "원주민",
+    "noCustomRolesHint": "사용자 지정 역할이 정의되지 않음 — IAM → 역할에서 하나 생성",
+    "externalUserCustomRoleHint": "외부 사용자는 소스 시스템을 통해서만 수정할 수 있습니다."
   },
   "ticket": {
     "header": "지원 티켓",

--- a/web/src/locales/languages/nl.json
+++ b/web/src/locales/languages/nl.json
@@ -857,7 +857,12 @@
     "groups": "Groepen",
     "customRole": "Rollen op maat",
     "description": "Omschrijving",
-    "revoke_invite": "Uitnodiging intrekken"
+    "revoke_invite": "Uitnodiging intrekken",
+    "authType": "Auth",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "Inheems",
+    "noCustomRolesHint": "Geen aangepaste rollen gedefinieerd — maak er een in IAM → Rollen",
+    "externalUserCustomRoleHint": "Externe gebruikers kunnen alleen via het bronsysteem worden gewijzigd"
   },
   "ticket": {
     "header": "Tickets voor ondersteuning",

--- a/web/src/locales/languages/pt.json
+++ b/web/src/locales/languages/pt.json
@@ -857,7 +857,12 @@
     "groups": "Grupos",
     "customRole": "Funções personalizadas",
     "description": "Descrição",
-    "revoke_invite": "Revogar convite"
+    "revoke_invite": "Revogar convite",
+    "authType": "Autenticação",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "Nativo",
+    "noCustomRolesHint": "Nenhuma função personalizada definida — crie uma no IAM → Funções",
+    "externalUserCustomRoleHint": "Usuários externos só podem ser modificados por meio do sistema de origem"
   },
   "ticket": {
     "header": "Tickets de suporte",

--- a/web/src/locales/languages/tr.json
+++ b/web/src/locales/languages/tr.json
@@ -857,7 +857,12 @@
     "groups": "Gruplar",
     "customRole": "Özel Roller",
     "description": "Açıklama",
-    "revoke_invite": "Daveti İptal Et"
+    "revoke_invite": "Daveti İptal Et",
+    "authType": "Yetkilendirme",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "Yerli",
+    "noCustomRolesHint": "Özel rol tanımlanmadı - IAM → Roller'de bir tane oluşturun",
+    "externalUserCustomRoleHint": "Harici kullanıcılar yalnızca kaynak sistem üzerinden değiştirilebilir"
   },
   "ticket": {
     "header": "Destek Talepleri",

--- a/web/src/locales/languages/zh.json
+++ b/web/src/locales/languages/zh.json
@@ -857,7 +857,12 @@
     "groups": "群组",
     "customRole": "自定义角色",
     "description": "描述",
-    "revoke_invite": "撤销邀请"
+    "revoke_invite": "撤销邀请",
+    "authType": "身份验证",
+    "authTypeSSO": "SSO",
+    "authTypeLocal": "本地人",
+    "noCustomRolesHint": "未定义自定义角色——在 IAM → 角色中创建一个",
+    "externalUserCustomRoleHint": "只能通过源系统修改外部用户"
   },
   "ticket": {
     "header": "工单",

--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -461,6 +461,8 @@ export const routeGuard = async (to: any, from: any, next: any) => {
 
   if (
     to.path.indexOf("/ingestion") == -1 &&
+    to.path.indexOf("/iam") == -1 &&
+    to.name !== "iam" &&
     trialPeriodAllowedPath.indexOf(to.name) == -1 &&
     store.state.zoConfig.hasOwnProperty("restricted_routes_on_empty_data") &&
     store.state.zoConfig.restricted_routes_on_empty_data == true &&


### PR DESCRIPTION
fixes: 

- [x] In the IAM users view, please show the roles assigned to each user alongside the user (currently not visible). Currently we only show system roles. 
- [x] If a system role has been assigned to an existing user, there's no way to modify it. we should allow edits.
- [x]  Customer expected to be able to set up users/roles ahead of ingestion, when we click in IAM, it goes there but when we try to perform operations then it redirects back to data sources section.