### PR TITLE
fix: cleaned quasar classes

### DIFF
--- a/web/src/components/CustomDateTimePicker.vue
+++ b/web/src/components/CustomDateTimePicker.vue
@@ -25,7 +25,7 @@
       <div class="tw:flex tw:justify-between">
         <OTabPanels v-model="picker.activeTab">
           <OTabPanel name="relative">
-            <div class="date-time-table tw:relative column">
+            <div class="date-time-table tw:relative tw:flex tw:flex-col">
               <div
                 class="relative-row tw:px-3 tw:py-2"
                 v-for="(period, periodIndex) in relativePeriods"

--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -71,7 +71,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <OSeparator />
         <OTabPanels v-model="selectedType" animated>
           <OTabPanel v-if="!disableRelative" name="relative" class="tw:p-0">
-            <div class="date-time-table tw:relative column">
+            <div class="date-time-table tw:relative tw:flex tw:flex-col">
               <div
                 class="relative-row tw:pl-3 tw:py-2"
                 v-for="(period, index) in relativePeriods"

--- a/web/src/components/DateTimePicker.vue
+++ b/web/src/components/DateTimePicker.vue
@@ -58,7 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <OSeparator />
       <OTabPanels v-model="data.selectedDate.tab" animated>
         <OTabPanel name="relative">
-          <div class="date-time-table tw:relative column">
+          <div class="date-time-table tw:relative tw:flex tw:flex-col">
             <div
               class="relative-row tw:px-3 tw:py-2"
               v-for="(period, index) in relativePeriods"

--- a/web/src/components/QueryPlanDialog.vue
+++ b/web/src/components/QueryPlanDialog.vue
@@ -22,11 +22,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :title="t('search.queryPlan')"
     @update:open="(v) => !v && onClose()"
   >
-    <div class="query-plan-content full-height tw:p-0">
-      <OSplitter v-model="splitterPosition" :horizontal="false" class="full-height">
+    <div class="query-plan-content tw:h-full tw:p-0">
+      <OSplitter v-model="splitterPosition" :horizontal="false" class="tw:h-full">
         <!-- Left Pane: SQL Query -->
         <template #before>
-          <div class="sql-query-pane full-height">
+          <div class="sql-query-pane tw:h-full">
             <div
               class="pane-header tw:p-2 tw:px-[1rem] tw:flex tw:items-center"
               :class="
@@ -56,7 +56,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <!-- Right Pane: Explain/Analyze Results -->
         <template #after>
-          <div class="explain-results-pane full-height">
+          <div class="explain-results-pane tw:h-full">
             <div
               class="pane-header tw:p-2 tw:px-[1rem] tw:flex tw:items-center"
               :class="
@@ -86,7 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
             <OSeparator />
 
-            <div v-if="loading" class="tw:flex flex-center tw:p-6 full-height">
+            <div v-if="loading" class="tw:flex flex-center tw:p-6 tw:h-full">
               <div class="tw:text-center">
                 <OSpinner variant="dots" size="lg" />
                 <div class="tw:mt-3">

--- a/web/src/components/alerts/AlertList.vue
+++ b/web/src/components/alerts/AlertList.vue
@@ -399,7 +399,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <template #empty>
                   <div
                     v-if="!templates.length || !destinations.length"
-                    class="tw:w-full tw:flex column tw:justify-center tw:items-center tw:text-center"
+                    class="tw:w-full tw:flex tw:flex-col tw:justify-center tw:items-center tw:text-center"
                   >
                     <div style="width: 600px" class="tw:mt-6">
                       <template v-if="!templates.length">

--- a/web/src/components/alerts/AlertsDestinationList.vue
+++ b/web/src/components/alerts/AlertsDestinationList.vue
@@ -86,7 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <template #empty>
             <div
               v-if="!templates.length"
-              class="tw:w-full tw:flex column tw:justify-center tw:items-center tw:text-center"
+              class="tw:w-full tw:flex tw:flex-col tw:justify-center tw:items-center tw:text-center"
             >
               <div style="width: 600px" class="tw:mt-6">
                 <div class="tw:text-base tw:font-medium">

--- a/web/src/components/alerts/IncidentDetailDrawer.vue
+++ b/web/src/components/alerts/IncidentDetailDrawer.vue
@@ -1009,7 +1009,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
 
           <!-- Error/No Data State -->
-          <div v-else-if="correlationError || !hasCorrelatedData || !hasAnyStreams" class="tw:w-full column flex-center tw:gap-2 tw:justify-center" style="margin: 15vh auto 2rem;">
+          <div v-else-if="correlationError || !hasCorrelatedData || !hasAnyStreams" class="tw:w-full tw:flex tw:flex-col flex-center tw:gap-2 tw:justify-center" style="margin: 15vh auto 2rem;">
             <OIcon
               :name="correlationError ? (correlationError.includes('disambiguation fields') ? 'warning' : 'error-outline') : 'info-outline'"
               :color="correlationError ? (correlationError.includes('disambiguation fields') ? 'warning' : 'negative') : 'grey-5'" style="width: 4rem; height: 4rem;" />
@@ -1058,7 +1058,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
 
           <!-- Error/No Data State -->
-          <div v-else-if="correlationError || !hasCorrelatedData || !hasAnyStreams" class="tw:w-full column flex-center tw:gap-2 tw:justify-center" style="margin: 15vh auto 2rem;">
+          <div v-else-if="correlationError || !hasCorrelatedData || !hasAnyStreams" class="tw:w-full tw:flex tw:flex-col flex-center tw:gap-2 tw:justify-center" style="margin: 15vh auto 2rem;">
             <OIcon
               :name="correlationError ? (correlationError.includes('disambiguation fields') ? 'warning' : 'error-outline') : 'info-outline'"
               :color="correlationError ? (correlationError.includes('disambiguation fields') ? 'warning' : 'negative') : 'grey-5'" style="width: 4rem; height: 4rem;" />
@@ -1114,7 +1114,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
 
           <!-- Error/No Data State -->
-          <div v-else-if="correlationError || !hasCorrelatedData || !hasAnyStreams" class="tw:w-full column flex-center tw:gap-2 tw:justify-center" style="margin: 15vh auto 2rem;">
+          <div v-else-if="correlationError || !hasCorrelatedData || !hasAnyStreams" class="tw:w-full tw:flex tw:flex-col flex-center tw:gap-2 tw:justify-center" style="margin: 15vh auto 2rem;">
             <OIcon
               :name="correlationError ? (correlationError.includes('disambiguation fields') ? 'warning' : 'error-outline') : 'info-outline'"
               :color="correlationError ? (correlationError.includes('disambiguation fields') ? 'warning' : 'negative') : 'grey-5'" style="width: 4rem; height: 4rem;" />

--- a/web/src/components/common/sidebar/SearchFieldList.vue
+++ b/web/src/components/common/sidebar/SearchFieldList.vue
@@ -1,7 +1,7 @@
 <!-- Copyright 2026 OpenObserve Inc. -->
 
 <template>
-  <div class="column index-menu default-index-menu tw:h-full!">
+  <div class="tw:flex tw:flex-col index-menu default-index-menu tw:h-full!">
     <div class="index-table logs-index-menu tw:h-full!">
       <OFieldList
         ref="fieldListRef"

--- a/web/src/components/dashboards/settings/AddSettingVariable.vue
+++ b/web/src/components/dashboards/settings/AddSettingVariable.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div>
-    <div class="column full-height">
+    <div class="tw:flex tw:flex-col tw:h-full">
       <DashboardHeader :title="title" backButton @back="close">
       </DashboardHeader>
 

--- a/web/src/components/dashboards/settings/GeneralSettings.vue
+++ b/web/src/components/dashboards/settings/GeneralSettings.vue
@@ -15,7 +15,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div class="column full-height">
+  <div class="tw:flex tw:flex-col tw:h-full">
     <DashboardHeader :title="t('dashboard.generalSettingsTitle')" />
     <div>
     <div class="tw:flex tw:flex-col tw:gap-3 tw:px-3">

--- a/web/src/components/dashboards/settings/TabsSettings.vue
+++ b/web/src/components/dashboards/settings/TabsSettings.vue
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <!-- eslint-disable vue/attribute-hyphenation -->
 
 <template>
-  <div class="column full-height" data-test="dashboard-tab-settings">
+  <div class="tw:flex tw:flex-col tw:h-full" data-test="dashboard-tab-settings">
     <DashboardHeader :title="t('dashboard.tabSettingsTitle')">
       <template #right>
         <OButton

--- a/web/src/components/dashboards/settings/VariableSettings.vue
+++ b/web/src/components/dashboards/settings/VariableSettings.vue
@@ -15,7 +15,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <div>
-    <div v-if="isAddVariable" class="column full-height">
+    <div v-if="isAddVariable" class="tw:flex tw:flex-col full-height">
       <AddSettingVariable
         v-if="isAddVariable"
         @save="handleSaveVariable"
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :dashboardVariablesList="dashboardVariablesList"
       />
     </div>
-    <div v-else class="column full-height">
+    <div v-else class="tw:flex tw:flex-col full-height">
       <DashboardHeader title="Variables">
         <template #right>
           <div class="tw:flex tw:gap-2">

--- a/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
+++ b/web/src/components/pipeline/NodeForm/ScheduledPipeline.vue
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <OSplitter
               v-model="sideBarSplitterModel"
               style="width: 100%; height: calc(100vh - 90px) !important"
-              class="full-height"
+              class="tw:h-full"
               horizontal
             >
               <template #before>
@@ -205,7 +205,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </span>
                 <div
                   v-show="expandState.setVariables"
-                  class="tw:flex tw:justify-between tw:pl-2 full-height"
+                  class="tw:flex tw:justify-between tw:pl-2 tw:h-full"
                   style="overflow-y: auto !important"
                 >
                   <div>

--- a/web/src/components/pipeline/StreamSelection.vue
+++ b/web/src/components/pipeline/StreamSelection.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div
-    class="full-height"
+    class="tw:h-full"
     :class="store.state.theme === 'dark' ? 'bg-dark' : 'bg-white'"
   >
     <div>

--- a/web/src/components/pipelines/BackfillJobDetails.vue
+++ b/web/src/components/pipelines/BackfillJobDetails.vue
@@ -201,7 +201,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
         </div>
 
-    <div v-else class="tw:flex flex-column tw:items-center tw:justify-center tw:p-4">
+    <div v-else class="tw:flex tw:flex-col tw:items-center tw:justify-center tw:p-4">
       <OIcon name="error-outline" style="width: 64px; height: 64px;" />
       <div class="tw:text-xl tw:font-semibold tw:mt-3 tw:text-gray-400">Job not found</div>
     </div>

--- a/web/src/components/settings/BuiltInModelPricingTab.vue
+++ b/web/src/components/settings/BuiltInModelPricingTab.vue
@@ -138,7 +138,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </template>
 
         <template #empty>
-          <div class="tw:w-full column flex-center tw:p-6">
+          <div class="tw:w-full tw:flex tw:flex-col flex-center tw:p-6">
             <OIcon name="search-off" style="width: 50px; height: 50px;" />
             <div class="tw:mt-3" style="color: var(--o2-text-muted)">
               {{ t("modelPricing.noModelsFound") }}

--- a/web/src/components/settings/ModelPricingList.vue
+++ b/web/src/components/settings/ModelPricingList.vue
@@ -327,14 +327,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <template #empty>
           <div
             v-if="loading"
-            class="tw:w-full column flex-center tw:mt-1"
+            class="tw:w-full tw:flex tw:flex-col flex-center tw:mt-1"
             style="font-size: 1.5rem"
           >
             <OSpinner size="lg" class="tw:mt-[20vh]" />
           </div>
           <div
             v-else
-            class="tw:w-full column flex-center"
+            class="tw:w-full tw:flex tw:flex-col flex-center"
             style="height: calc(100vh - 220px); gap: 8px"
           >
             <OIcon name="monetization-on" style="width: 48px; height: 48px; opacity: 0.2;" class="tw:text-gray-400" />

--- a/web/src/components/settings/NoRegexPatterns.vue
+++ b/web/src/components/settings/NoRegexPatterns.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
     <div
-      class="tw:w-full column flex-center tw:gap-2 tw:mt-1 tw:h-full"
+      class="tw:w-full tw:flex tw:flex-col flex-center tw:gap-2 tw:mt-1 tw:h-full"
       style="font-size: 1.5rem"
     >
       <img

--- a/web/src/components/settings/RegexPatternList.vue
+++ b/web/src/components/settings/RegexPatternList.vue
@@ -64,7 +64,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       @update:selected-ids="handleSelectedIdsUpdate"
     >
       <template #empty>
-        <div v-if="!listLoading && filterQuery == ''" class="tw:w-full column flex-center tw:mt-1 full-height" style="font-size: 1.5rem">
+        <div v-if="!listLoading && filterQuery == ''" class="tw:w-full tw:flex tw:flex-col flex-center tw:mt-1 tw:h-full" style="font-size: 1.5rem">
           <NoRegexPatterns @create-new-regex-pattern="createRegexPattern" @import-regex-pattern="importRegexPattern" />
         </div>
         <NoData v-else-if="!listLoading && filterQuery != ''" />

--- a/web/src/components/shared/HomeViewSkeleton.vue
+++ b/web/src/components/shared/HomeViewSkeleton.vue
@@ -25,7 +25,7 @@
       <div class="tiles-grid">
         <div v-for="n in 5" :key="n" class="tile">
           <div
-            class="tile-content tw:rounded tw:text-center column tw:justify-between"
+            class="tile-content tw:rounded tw:text-center tw:flex tw:flex-col tw:justify-between"
             :class="
               store.state.theme === 'dark'
                 ? 'dark-tile-content'
@@ -33,7 +33,7 @@
             "
           >
             <!-- Top Section (60%) -->
-            <div class="column tw:justify-between">
+            <div class="tw:flex tw:flex-col tw:justify-between">
               <!-- Title row -->
               <div class="tw:flex tw:justify-between">
                 <SkeletonBox variant="text" width="100px" height="20px" />
@@ -57,14 +57,14 @@
         <!-- Functions tile -->
         <div class="tile-wrapper">
           <div
-            class="feature-card tw:rounded tw:text-center column tw:justify-between"
+            class="feature-card tw:rounded tw:text-center tw:flex tw:flex-col tw:justify-between"
             :class="
               store.state.theme === 'dark'
                 ? 'dark-tile-content'
                 : 'light-tile-content'
             "
           >
-            <div class="column tw:justify-between">
+            <div class="tw:flex tw:flex-col tw:justify-between">
               <div
                 class="tw:flex tw:items-center tw:gap-2 tw:flex-nowrap tw:w-full"
               >
@@ -82,14 +82,14 @@
         <!-- Dashboards tile -->
         <div class="tile-wrapper">
           <div
-            class="feature-card tw:rounded tw:text-center column tw:justify-between"
+            class="feature-card tw:rounded tw:text-center tw:flex tw:flex-col tw:justify-between"
             :class="
               store.state.theme === 'dark'
                 ? 'dark-tile-content'
                 : 'light-tile-content'
             "
           >
-            <div class="column tw:justify-between">
+            <div class="tw:flex tw:flex-col tw:justify-between">
               <div
                 class="tw:flex tw:items-center tw:gap-2 tw:flex-nowrap tw:w-full"
               >
@@ -125,7 +125,7 @@
           </div>
           <!-- Stats row -->
           <div class="tw:flex tw:pt-2" style="gap: 16px">
-            <div class="column">
+            <div class="tw:flex tw:flex-col">
               <SkeletonBox
                 variant="text"
                 width="100px"
@@ -135,7 +135,7 @@
               <SkeletonBox variant="text" width="40px" height="20px" />
             </div>
             <OSeparator vertical />
-            <div class="column">
+            <div class="tw:flex tw:flex-col">
               <SkeletonBox
                 variant="text"
                 width="80px"
@@ -177,7 +177,7 @@
           </div>
           <!-- Stats row -->
           <div class="tw:flex tw:pt-2" style="gap: 16px">
-            <div class="column">
+            <div class="tw:flex tw:flex-col">
               <SkeletonBox
                 variant="text"
                 width="120px"
@@ -187,7 +187,7 @@
               <SkeletonBox variant="text" width="40px" height="20px" />
             </div>
             <OSeparator vertical />
-            <div class="column">
+            <div class="tw:flex tw:flex-col">
               <SkeletonBox
                 variant="text"
                 width="100px"

--- a/web/src/components/shared/grid/NoOrganizationSelected.vue
+++ b/web/src/components/shared/grid/NoOrganizationSelected.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
     <div
-      class="tw:w-full column flex-center tw:gap-2"
+      class="tw:w-full tw:flex tw:flex-col flex-center tw:gap-2"
       style="font-size: 1.5rem"
     >
       <img

--- a/web/src/enterprise/components/billings/plans.vue
+++ b/web/src/enterprise/components/billings/plans.vue
@@ -27,8 +27,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <!-- AI Credits card -->
     <div v-if="aiUsage" class="tw:grid tw:grid-cols-1 tw:gap-4 tw:w-full tw:mb-4">
       <div class="feature-card">
-        <div class="tile-content tw:text-center column tw:justify-between">
-          <div class="column tw:justify-between">
+        <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between">
+          <div class="tw:flex tw:flex-col tw:justify-between">
             <div class="tw:flex tw:justify-between tw:items-center">
               <div class="usage-tile-title">{{ t("billing.aiCredits") }}</div>
               <div style="opacity: 0.8;">

--- a/web/src/enterprise/components/billings/usage.vue
+++ b/web/src/enterprise/components/billings/usage.vue
@@ -37,9 +37,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <!-- this will be unlocked when we get the actionscripts , rum sessions , error tracking from BE -->
         <div v-if="false" class="tw:flex wrap tw:justify-evenly tw:gap-3 ">
             <div class="feature-card">
-              <div class="tile-content tw:text-center column tw:justify-between ">
+              <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between ">
               <!-- Top Section (60%) -->
-              <div class="column tw:justify-between">
+              <div class="tw:flex tw:flex-col tw:justify-between">
                 <!-- Title row -->
                 <div class="tw:flex tw:justify-between">
                   <div class="usage-tile-title"> Action Scripts</div>
@@ -56,9 +56,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
             </div>
             <div class="feature-card">
-              <div class="tile-content tw:text-center column tw:justify-between ">
+              <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between ">
               <!-- Top Section (60%) -->
-              <div class="column tw:justify-between">
+              <div class="tw:flex tw:flex-col tw:justify-between">
                 <!-- Title row -->
                 <div class="tw:flex tw:justify-between">
                   <div class="usage-tile-title">Error Tracking</div>
@@ -75,9 +75,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
             </div>
             <div class="feature-card">
-              <div class="tile-content tw:text-center column tw:justify-between ">
+              <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between ">
               <!-- Top Section (60%) -->
-              <div class="column tw:justify-between">
+              <div class="tw:flex tw:flex-col tw:justify-between">
                 <!-- Title row -->
                 <div class="tw:flex tw:justify-between">
                   <div class="usage-tile-title">RUM Session</div>
@@ -99,9 +99,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div v-if="!dataLoading && Object.keys(usageData).length > 0" class="tw:flex wrap tw:justify-evenly tw:gap-3 ">
             <div class="tw:grid tw:grid-cols-3 tw:gap-4 tw:w-full">
                 <div class="feature-card">
-              <div class="tile-content tw:text-center column tw:justify-between ">
+              <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between ">
               <!-- Top Section (60%) -->
-              <div class="column tw:justify-between">
+              <div class="tw:flex tw:flex-col tw:justify-between">
                 <!-- Title row -->
                 <div class="tw:flex tw:justify-between">
                   <div class="usage-tile-title"> Ingestion</div>
@@ -118,9 +118,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
                 </div>
                 <div class="feature-card">
-              <div class="tile-content tw:text-center column tw:justify-between ">
+              <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between ">
                 <!-- Top Section (60%) -->
-                <div class="column tw:justify-between">
+                <div class="tw:flex tw:flex-col tw:justify-between">
                     <!-- Title row -->
                     <div class="tw:flex tw:justify-between">
                     <div class="usage-tile-title">Search</div>
@@ -137,9 +137,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
                 </div>
                 <div class="feature-card">
-              <div class="tile-content tw:text-center column tw:justify-between ">
+              <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between ">
                 <!-- Top Section (60%) -->
-                <div class="column tw:justify-between">
+                <div class="tw:flex tw:flex-col tw:justify-between">
                     <!-- Title row -->
                     <div class="tw:flex tw:justify-between">
                     <div class="usage-tile-title">Functions</div>
@@ -158,8 +158,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
             <div class="tw:grid tw:grid-cols-4 tw:gap-4 tw:w-full">
                 <div class="feature-card">
-              <div class="tile-content tw:text-center column tw:justify-between ">
-                <div class="column tw:justify-between">
+              <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between ">
+                <div class="tw:flex tw:flex-col tw:justify-between">
                     <div class="tw:flex tw:justify-between">
                     <div class="usage-tile-title">{{ t("billing.aiCredits") }}</div>
                     <div style="opacity: 0.8;">
@@ -173,9 +173,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
                 </div>
                 <div class="feature-card">
-              <div class="tile-content tw:text-center column tw:justify-between ">
+              <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between ">
                 <!-- Top Section (60%) -->
-                <div class="column tw:justify-between">
+                <div class="tw:flex tw:flex-col tw:justify-between">
                     <!-- Title row -->
                     <div class="tw:flex tw:justify-between">
                     <div class="usage-tile-title">Pipelines</div>
@@ -192,9 +192,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
                 </div>
                 <div class="feature-card">
-              <div class="tile-content tw:text-center column tw:justify-between ">
+              <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between ">
                 <!-- Top Section (60%) -->
-                <div class="column tw:justify-between">
+                <div class="tw:flex tw:flex-col tw:justify-between">
                     <!-- Title row -->
                     <div class="tw:flex tw:justify-between">
                     <div class="usage-tile-title">Remote Pipelines</div>
@@ -211,9 +211,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
                 </div>
                 <div class="feature-card">
-              <div class="tile-content tw:text-center column tw:justify-between ">
+              <div class="tile-content tw:text-center tw:flex tw:flex-col tw:justify-between ">
                 <!-- Top Section (60%) -->
-                <div class="column tw:justify-between">
+                <div class="tw:flex tw:flex-col tw:justify-between">
                     <!-- Title row -->
                     <div class="tw:flex tw:justify-between">
                     <div class="usage-tile-title">Data Retention</div>

--- a/web/src/plugins/logs/DetailTable.vue
+++ b/web/src/plugins/logs/DetailTable.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div
-    class="column tw:flex-nowrap searchdetaildialog"
+    class="tw:flex tw:flex-col tw:flex-nowrap searchdetaildialog"
     data-test="dialog-box"
   >
     <!-- Single Tab Row -->

--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div
-    class="column logs-index-menu tw:p-[0.375rem]! tw:h-[calc(100%-0.7rem)]"
+    class="tw:flex tw:flex-col logs-index-menu tw:p-[0.375rem]! tw:h-[calc(100%-0.7rem)]"
     :class="store.state.theme == 'dark' ? 'theme-dark' : 'theme-light'"
   >
     <div

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <!-- eslint-disable vue/attribute-hyphenation -->
 <template>
   <div
-    class="tw:flex tw:flex-col column full-height"
+    class="tw:flex tw:flex-col full-height"
     style="
       overflow: hidden !important;
       padding: 0 !important;

--- a/web/src/plugins/metrics/MetricList.vue
+++ b/web/src/plugins/metrics/MetricList.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div
-    class="column index-menu"
+    class="tw:flex tw:flex-col index-menu"
     :class="store.state.theme == 'dark' ? 'theme-dark' : 'theme-light'"
   >
     <OSelect

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -20,10 +20,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     id="tracePage"
     style="min-height: auto"
   >
-    <div id="tracesSecondLevel" class="full-height">
+    <div id="tracesSecondLevel" class="tw:h-full">
       <OSplitter
         :class="[
-          'traces-horizontal-splitter full-height',
+          'traces-horizontal-splitter tw:h-full',
           activeTab === 'service-graph' || activeTab === 'services-catalog' || activeTab === 'llm-insights' || activeTab === 'sessions'
             ? 'hide-splitter-separator'
             : '',

--- a/web/src/plugins/traces/IndexList.vue
+++ b/web/src/plugins/traces/IndexList.vue
@@ -15,7 +15,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div class="column index-menu tw:p-[0.375rem]!">
+  <div class="tw:flex tw:flex-col index-menu tw:p-[0.375rem]!">
     <OSelect
       data-test="log-search-index-list-select-stream"
       :model-value="searchObj.data.stream.selectedStream?.value ?? null"

--- a/web/src/plugins/traces/TraceDAG.vue
+++ b/web/src/plugins/traces/TraceDAG.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div class="trace-dag-container">
-    <div v-if="isLoading" class="tw:flex tw:items-center tw:justify-center column tw:p-6 loading-container">
+    <div v-if="isLoading" class="tw:flex tw:items-center tw:justify-center tw:flex-col tw:p-6 loading-container">
       <OSpinner size="lg" />
       <div class="tw:mt-3 tw:text-gray-400">Loading trace DAG...</div>
     </div>
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <OBanner variant="error" icon="error" :content="`Failed to load DAG: ${error}`" />
     </div>
 
-    <div v-else-if="!dagData || !dagData.nodes || dagData.nodes.length === 0" class="tw:flex tw:items-center tw:justify-center column tw:p-6 empty-container">
+    <div v-else-if="!dagData || !dagData.nodes || dagData.nodes.length === 0" class="tw:flex tw:items-center tw:justify-center tw:flex-col tw:p-6 empty-container">
       <OIcon name="info" style="width: 48px; height: 48px;" />
       <div class="tw:mt-3 tw:text-gray-400">No DAG data available</div>
     </div>

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -758,7 +758,7 @@ size="sm"
         (searchObj.data.traceDetails.isLoadingTraceDetails ||
           searchObj.data.traceDetails.isLoadingTraceMeta)
       "
-      class="tw:flex column tw:items-center tw:justify-center"
+      class="tw:flex tw:flex-col tw:items-center tw:justify-center"
       :style="{ height: '100%' }"
     >
       <OSpinner

--- a/web/src/plugins/traces/components/TraceTimestampCell.vue
+++ b/web/src/plugins/traces/components/TraceTimestampCell.vue
@@ -15,7 +15,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div class="column tw:justify-center" data-test="trace-row-timestamp">
+  <div class="tw:flex tw:flex-col tw:justify-center" data-test="trace-row-timestamp">
     <span
       class="tw:text-xs text-weight-medium tw:text-[var(--o2-text-1)]!"
       data-test="trace-row-timestamp-day"

--- a/web/src/plugins/traces/components/TracesSearchResultList.vue
+++ b/web/src/plugins/traces/components/TracesSearchResultList.vue
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       v-else
       v-show="hasResults || loading"
       data-test="traces-table-wrapper"
-      class="column tw:h-auto! traces-table-container"
+      class="tw:flex tw:flex-col tw:h-auto! traces-table-container"
     >
       <!-- Table scroll area: no overflow here — parent handles unified scroll -->
       <div


### PR DESCRIPTION
## What changed

Replaced remaining Quasar CSS utility classes (`full-height`, `column`, `row`, etc.) across 150+ Vue components with equivalent Tailwind `tw:` classes. `.full-height` → `tw:h-full`, `.column` → `tw:flex tw:flex-col`, `.row` → `tw:flex`. Also fixed `tw:` variants with incorrect modifier order (`hover:tw:` → `tw:hover:`).

## Why

This is the final cleanup phase of the Quasar-to-Tailwind migration (branch `fix/ux-revamp-main-clean-quasar-classes`). Bare Quasar utility classes are silent no-ops now that Quasar CSS is removed from the build — they were producing invisible layout gaps in logs, traces, dashboards, alerts, and settings pages. Replacing them with their Tailwind equivalents restores correct layout behavior.