### PR TITLE
fix: change banner time from 1hr to 6hr

### DIFF
--- a/web/src/enterprise/components/billings/UsageReportBanner.vue
+++ b/web/src/enterprise/components/billings/UsageReportBanner.vue
@@ -33,7 +33,7 @@ export default defineComponent({
     const SEVEN_DAYS = 7 * 24 * ONE_HOUR;
 
     const showBanner = computed(() => {
-      return elapsedMs.value > ONE_HOUR;
+      return elapsedMs.value > 6 * ONE_HOUR;
     });
 
     const isSevere = computed(() => {


### PR DESCRIPTION
changes time to show the usage report banner from 1hr to 6hr.