### PR TITLE
refactor: unify search partition handle (3)

### DIFF
--- a/src/common/utils/http.rs
+++ b/src/common/utils/http.rs
@@ -34,14 +34,6 @@ pub(crate) fn get_stream_type_from_request(query: &HashMap<String, String>) -> O
 }
 
 #[inline(always)]
-pub(crate) fn get_enable_align_histogram_from_request(query: &HashMap<String, String>) -> bool {
-    query
-        .get("enable_align_histogram")
-        .and_then(|s| s.parse::<bool>().ok())
-        .unwrap_or_default()
-}
-
-#[inline(always)]
 pub(crate) fn get_ts_from_request_with_key(
     query: &HashMap<String, String>,
     key: &str,
@@ -479,24 +471,6 @@ mod tests {
 
         let work_groups = vec![None];
         assert_eq!(get_work_group(work_groups), None);
-    }
-
-    #[test]
-    fn test_get_enable_align_histogram_from_request() {
-        let mut query = Query::<HashMap<String, String>>(Default::default());
-        query.insert("enable_align_histogram".to_string(), "true".to_string());
-        assert!(get_enable_align_histogram_from_request(&query));
-
-        let mut query = Query::<HashMap<String, String>>(Default::default());
-        query.insert("enable_align_histogram".to_string(), "false".to_string());
-        assert!(!get_enable_align_histogram_from_request(&query));
-
-        let mut query = Query::<HashMap<String, String>>(Default::default());
-        query.insert("enable_align_histogram".to_string(), "invalid".to_string());
-        assert!(!get_enable_align_histogram_from_request(&query));
-
-        let query = Query::<HashMap<String, String>>(Default::default());
-        assert!(!get_enable_align_histogram_from_request(&query));
     }
 
     #[test]

--- a/src/handler/grpc/request/search/mod.rs
+++ b/src/handler/grpc/request/search/mod.rs
@@ -243,7 +243,6 @@ impl Search for Searcher {
             &request,
             req.skip_max_query_range,
             true,
-            false,
             true, // allow streamings aggs cache for grpc search partition
         )
         .await;

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -55,10 +55,10 @@ use crate::{
             functions,
             http::{
                 get_clear_cache_from_request, get_dashboard_info_from_request,
-                get_enable_align_histogram_from_request, get_is_multi_stream_search_from_request,
-                get_is_ui_histogram_from_request, get_or_create_trace_id,
-                get_search_event_context_from_request, get_search_type_from_request,
-                get_stream_type_from_request, get_use_cache_from_request, get_work_group,
+                get_is_multi_stream_search_from_request, get_is_ui_histogram_from_request,
+                get_or_create_trace_id, get_search_event_context_from_request,
+                get_search_type_from_request, get_stream_type_from_request,
+                get_use_cache_from_request, get_work_group,
             },
             stream::get_settings_max_query_range,
         },
@@ -1457,7 +1457,6 @@ async fn values_v1(
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("type" = Option<String>, Query, description = "Stream type. Must be one of: logs, metrics, traces. Defaults to logs if not specified."),
-        ("enable_align_histogram" = bool, Query, description = "Enable align histogram"),
     ),
     request_body(content = inline(config::meta::search::SearchPartitionRequest), description = "Search query", content_type = "application/json", example = json!({
         "sql": "select * from k8s ",
@@ -1502,8 +1501,6 @@ pub async fn search_partition(
 
     let user_id = &user_email.user_id;
     let stream_type = get_stream_type_from_request(&url_query).unwrap_or_default();
-    let enable_align_histogram = get_enable_align_histogram_from_request(&url_query);
-
     #[cfg(feature = "cloud")]
     {
         match is_org_in_free_trial_period(&org_id).await {
@@ -1569,7 +1566,6 @@ pub async fn search_partition(
         &req,
         false,
         true,
-        enable_align_histogram,
         true, // allow streamings aggs cache for http search partition handler
     )
     .instrument(http_span)

--- a/src/handler/http/request/search/multi_streams.rs
+++ b/src/handler/http/request/search/multi_streams.rs
@@ -56,10 +56,9 @@ use crate::{
             functions,
             http::{
                 get_clear_cache_from_request, get_dashboard_info_from_request,
-                get_enable_align_histogram_from_request, get_fallback_order_by_col_from_request,
-                get_or_create_trace_id, get_search_event_context_from_request,
-                get_search_type_from_request, get_stream_type_from_request,
-                get_use_cache_from_request,
+                get_fallback_order_by_col_from_request, get_or_create_trace_id,
+                get_search_event_context_from_request, get_search_type_from_request,
+                get_stream_type_from_request, get_use_cache_from_request,
             },
             stream::get_settings_max_query_range,
         },
@@ -711,7 +710,6 @@ pub async fn search_multi(
     description = "Executes search queries across partitioned data in multiple log streams",
     params(
         ("org_id" = String, Path, description = "Organization name"),
-        ("enable_align_histogram" = bool, Query, description = "Enable align histogram"),
     ),
     request_body(
         content = inline(search::MultiSearchPartitionRequest),
@@ -776,8 +774,6 @@ pub async fn _search_partition_multi(
 
     let user_id = &user_email.user_id;
     let stream_type = get_stream_type_from_request(&query).unwrap_or_default();
-    let enable_align_histogram = get_enable_align_histogram_from_request(&query);
-
     #[cfg(feature = "cloud")]
     {
         match is_org_in_free_trial_period(&org_id).await {
@@ -805,14 +801,8 @@ pub async fn _search_partition_multi(
         }
     }
 
-    let search_fut = SearchService::search_partition_multi(
-        &trace_id,
-        &org_id,
-        user_id,
-        stream_type,
-        &req,
-        enable_align_histogram,
-    );
+    let search_fut =
+        SearchService::search_partition_multi(&trace_id, &org_id, user_id, stream_type, &req);
     let search_res = if cfg.common.should_create_span() {
         search_fut.instrument(http_span).await
     } else {

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -1335,7 +1335,6 @@ async fn process_latest_traces_stream(
         &partition_req,
         false,
         false,
-        false,
         use_cache,
     )
     .await

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -785,7 +785,6 @@ pub async fn search_partition(
         partition_settings.step,
         sql_order_by,
         is_complex_query,
-        false,
         #[cfg(feature = "enterprise")]
         stremaing_aggs_cache_strategy,
     );

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -66,7 +66,7 @@ use crate::{
     service::search::{
         inspector::{SearchInspectorFieldsBuilder, search_inspector_fields},
         partition::{
-            cpu_cores::get_cpu_cores, settings::calculate_partition_settings,
+            cpu_cores::estimated_secs, settings::calculate_partition_settings,
             stream_files::collect_stream_files,
         },
     },
@@ -708,12 +708,8 @@ pub async fn search_partition(
         non_ts_order_by_cols: vec![],
     };
 
-    // Calculate original step with all factors considered
-    let cpu_cores = get_cpu_cores(trace_id, org_id, &sql, is_http_req).await?;
-    let mut total_secs = resp.original_size / cfg.limit.query_group_base_speed / cpu_cores;
-    if total_secs * cfg.limit.query_group_base_speed * cpu_cores < resp.original_size {
-        total_secs += 1;
-    }
+    // calculate estimated seconds for run query
+    let total_secs = estimated_secs(trace_id, &sql, is_http_req, resp.original_size).await?;
 
     if use_single_partition
         || (is_streaming_aggregate && total_secs <= cfg.limit.aggs_min_num_partition_secs)

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -629,7 +629,6 @@ pub async fn search_partition(
     req: &search::SearchPartitionRequest,
     skip_max_query_range: bool,
     is_http_req: bool,
-    enable_align_histogram: bool,
     use_cache: bool,
 ) -> Result<search::SearchPartitionResponse, Error> {
     let start = std::time::Instant::now();
@@ -726,7 +725,7 @@ pub async fn search_partition(
         &sql.order_by,
         ts_column.as_deref(),
         is_complex_query,
-        sql.histogram_interval.is_some() || enable_align_histogram,
+        sql.histogram_interval.is_some(),
     ) {
         resp.non_ts_order_by_cols = sql
             .order_by
@@ -748,7 +747,6 @@ pub async fn search_partition(
         &sql,
         is_complex_query,
         ts_column.is_some(),
-        enable_align_histogram,
         skip_max_query_range,
         max_query_range,
     );
@@ -775,14 +773,11 @@ pub async fn search_partition(
         })
         .unwrap_or(OrderBy::Desc);
 
-    // Add a mini partition only for histogram-aligned log searches. Actual
-    // histogram queries should keep their original interval-aligned partitions.
     let is_histogram = sql.histogram_interval.is_some();
-    let add_mini_partition = !is_histogram && enable_align_histogram;
     let generator = partition::PartitionGenerator::new(
         partition_settings.min_step,
         cfg.limit.search_mini_partition_duration_secs,
-        is_histogram || enable_align_histogram,
+        is_histogram,
     );
     let partitions = generator.generate_partitions(
         req.start_time,
@@ -790,7 +785,7 @@ pub async fn search_partition(
         partition_settings.step,
         sql_order_by,
         is_complex_query,
-        add_mini_partition,
+        false,
         #[cfg(feature = "enterprise")]
         stremaing_aggs_cache_strategy,
     );
@@ -800,10 +795,6 @@ pub async fn search_partition(
     }
 
     resp.partitions = partitions;
-    if enable_align_histogram {
-        let min_step_secs = partition_settings.min_step / 1_000_000;
-        resp.histogram_interval = Some(min_step_secs);
-    }
     Ok(resp)
 }
 
@@ -1126,7 +1117,6 @@ pub async fn search_partition_multi(
     user_id: &str,
     stream_type: StreamType,
     req: &search::MultiSearchPartitionRequest,
-    enable_align_histogram: bool,
 ) -> Result<search::SearchPartitionResponse, Error> {
     let mut res = search::SearchPartitionResponse::default();
     let mut total_rec = 0;
@@ -1151,7 +1141,6 @@ pub async fn search_partition_multi(
             },
             false,
             true,
-            enable_align_histogram,
             false, // disable aggs cache
         )
         .await

--- a/src/service/search/partition/aggregate.rs
+++ b/src/service/search/partition/aggregate.rs
@@ -70,7 +70,6 @@ pub(crate) fn is_streaming_aggregate(
 ///
 /// Returns `(streaming_aggs, streaming_id, partition_strategy)`.
 #[cfg(feature = "enterprise")]
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn prepare_streaming_aggregate(
     trace_id: &str,
     req: &SearchPartitionRequest,

--- a/src/service/search/partition/cpu_cores.rs
+++ b/src/service/search/partition/cpu_cores.rs
@@ -13,23 +13,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use config::meta::cluster::RoleGroup;
+use config::{get_config, meta::cluster::RoleGroup};
 use infra::{cluster::get_cached_online_querier_nodes, errors::Error};
 
 use super::super::sql::Sql;
 
 /// Resolves the effective CPU core count for the querier nodes that will
-/// actually handle this query.
+/// actually handle this query, then estimates the total seconds required.
 ///
 /// On enterprise, the configured node selection strategy (e.g. "org" or
 /// "stream") determines which subset of online querier nodes are used, so
 /// only the selected nodes' CPU cores are summed. On community edition, all
 /// online querier nodes are summed.
-pub(crate) async fn get_cpu_cores(
+pub(crate) async fn estimated_secs(
     trace_id: &str,
-    _org_id: &str,
     _sql: &Sql,
     is_http_req: bool,
+    original_size: usize,
 ) -> Result<usize, Error> {
     let role_group = if is_http_req {
         Some(RoleGroup::Interactive)
@@ -48,7 +48,7 @@ pub(crate) async fn get_cpu_cores(
     let cpu_cores = {
         let stream_key = _sql.get_first_stream_key();
         let selected = o2_enterprise::enterprise::search::admission::node_selection::select_nodes(
-            _org_id,
+            &_sql.org_id,
             &stream_key,
             nodes,
             role_group,
@@ -56,10 +56,19 @@ pub(crate) async fn get_cpu_cores(
         .await;
         selected.iter().map(|n| n.cpu_num).sum::<u64>() as usize
     };
+
     #[cfg(not(feature = "enterprise"))]
     let cpu_cores = nodes.iter().map(|n| n.cpu_num).sum::<u64>() as usize;
 
-    log::info!("[trace_id {trace_id}] search_partition: selected {cpu_cores} CPU cores");
+    let cfg = get_config();
+    let mut total_secs = original_size / cfg.limit.query_group_base_speed / cpu_cores;
+    if total_secs * cfg.limit.query_group_base_speed * cpu_cores < original_size {
+        total_secs += 1;
+    }
 
-    Ok(cpu_cores)
+    log::info!(
+        "[trace_id {trace_id}] search_partition: selected {cpu_cores} CPU cores, estimated {total_secs}s"
+    );
+
+    Ok(total_secs)
 }

--- a/src/service/search/partition/mod.rs
+++ b/src/service/search/partition/mod.rs
@@ -963,14 +963,8 @@ mod enterprise_tests {
         let generator = PartitionGenerator::new(min_step, mini_partition_duration_secs, false);
         let step = 300000000; // 5 minutes
 
-        let partitions = generator.generate_partitions(
-            start_time,
-            end_time,
-            step,
-            OrderBy::Desc,
-            true,
-            None,
-        );
+        let partitions =
+            generator.generate_partitions(start_time, end_time, step, OrderBy::Desc, true, None);
 
         let mut expected_partitions = vec![
             [1748527200000000, 1748528100000000], // 14:00 - 14:15
@@ -981,14 +975,8 @@ mod enterprise_tests {
         ];
         assert_eq!(partitions, expected_partitions);
 
-        let partitions_asc = generator.generate_partitions(
-            start_time,
-            end_time,
-            step,
-            OrderBy::Asc,
-            true,
-            None,
-        );
+        let partitions_asc =
+            generator.generate_partitions(start_time, end_time, step, OrderBy::Asc, true, None);
         expected_partitions.reverse();
         assert_eq!(partitions_asc, expected_partitions);
     }
@@ -1006,14 +994,8 @@ mod enterprise_tests {
         let generator = PartitionGenerator::new(min_step, mini_partition_duration_secs, false);
         let step = 300000000; // 5 minutes
 
-        let partitions = generator.generate_partitions(
-            start_time,
-            end_time,
-            step,
-            OrderBy::Desc,
-            true,
-            None,
-        );
+        let partitions =
+            generator.generate_partitions(start_time, end_time, step, OrderBy::Desc, true, None);
 
         // Verify no empty partitions exist
         for [start, end] in &partitions {

--- a/src/service/search/partition/mod.rs
+++ b/src/service/search/partition/mod.rs
@@ -52,7 +52,6 @@ impl PartitionGenerator {
     /// * `step` - Regular partition step size in microseconds
     /// * `order_by` - Sort order for partitions
     /// * `is_complex_query` - Whether this query requires complex search handling
-    /// * `add_mini_partition` - Whether to add a mini partition for faster initial results
     /// * `cache_strategy` - Optional cache-aware partition strategy
     ///
     /// # Returns
@@ -65,7 +64,6 @@ impl PartitionGenerator {
         step: i64,
         order_by: OrderBy,
         is_complex_query: bool,
-        add_mini_partition: bool,
         #[cfg(feature = "enterprise")] cache_strategy: Option<StreamingAggsPartitionStrategy>,
     ) -> Vec<[i64; 2]> {
         // If cache-aware strategy is provided, use it
@@ -77,11 +75,7 @@ impl PartitionGenerator {
         // Otherwise, use standard partition generation logic
         if self.is_histogram {
             self.generate_partitions_aligned_with_histogram_interval(
-                start_time,
-                end_time,
-                step,
-                order_by,
-                add_mini_partition,
+                start_time, end_time, step, order_by,
             )
         } else if is_complex_query {
             vec![[start_time, end_time]]
@@ -159,20 +153,9 @@ impl PartitionGenerator {
         end_time: i64,
         step: i64,
         order_by: OrderBy,
-        add_mini_partition: bool,
     ) -> Vec<[i64; 2]> {
-        let mut partitions = if add_mini_partition {
-            let mini_partition_size = self.calculate_mini_partition_size(step);
-            self.generate_histogram_aligned_partitions_with_mini(
-                start_time,
-                end_time,
-                step,
-                order_by,
-                mini_partition_size,
-            )
-        } else {
-            self.generate_histogram_aligned_partitions(start_time, end_time, step, order_by)
-        };
+        let mut partitions =
+            self.generate_histogram_aligned_partitions(start_time, end_time, step, order_by);
 
         self.handle_empty_partitions(&mut partitions, start_time, end_time);
         partitions
@@ -214,55 +197,6 @@ impl PartitionGenerator {
         partitions.sort_by(|a, b| b[0].cmp(&a[0]));
         if order_by == OrderBy::Asc {
             partitions.reverse();
-        }
-
-        partitions
-    }
-
-    /// Generate histogram-aligned partitions with mini partition
-    fn generate_histogram_aligned_partitions_with_mini(
-        &self,
-        start_time: i64,
-        end_time: i64,
-        step: i64,
-        order_by: OrderBy,
-        mini_partition_size: i64,
-    ) -> Vec<[i64; 2]> {
-        let mut partitions = Vec::new();
-
-        // Add mini partition
-        if let Some(mini_partition) =
-            self.create_mini_partition(start_time, end_time, mini_partition_size, order_by)
-        {
-            partitions.push(mini_partition);
-
-            // Generate remaining partitions with histogram alignment
-            match order_by {
-                OrderBy::Desc => {
-                    let remaining_start = mini_partition[0];
-                    let remaining_partitions = self.generate_histogram_aligned_partitions(
-                        start_time,
-                        remaining_start,
-                        step,
-                        OrderBy::Desc,
-                    );
-                    partitions.extend(remaining_partitions);
-                }
-                OrderBy::Asc => {
-                    let remaining_end = mini_partition[1];
-                    let remaining_partitions = self.generate_histogram_aligned_partitions(
-                        remaining_end,
-                        end_time,
-                        step,
-                        OrderBy::Asc,
-                    );
-                    partitions.extend(remaining_partitions);
-                }
-            }
-        } else {
-            // Fall back to regular histogram alignment if mini partition can't be created
-            partitions =
-                self.generate_histogram_aligned_partitions(start_time, end_time, step, order_by);
         }
 
         partitions
@@ -392,7 +326,6 @@ mod tests {
             step,
             OrderBy::Desc,
             false,
-            false, // add_mini_partition = false
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -420,7 +353,6 @@ mod tests {
             step,
             OrderBy::Asc,
             false,
-            false, // add_mini_partition = false
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -464,7 +396,6 @@ mod tests {
             step,
             OrderBy::Desc,
             false,
-            false, // add_mini_partition = false
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -494,7 +425,6 @@ mod tests {
             step,
             OrderBy::Asc,
             false,
-            false, // add_mini_partition = false
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -539,7 +469,6 @@ mod tests {
             step,
             OrderBy::Desc,
             false,
-            false, // add_mini_partition = false
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -569,7 +498,6 @@ mod tests {
             step,
             OrderBy::Asc,
             false,
-            false, // add_mini_partition = false
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -612,7 +540,6 @@ mod tests {
             step,
             OrderBy::Desc,
             false,
-            false, // add_mini_partition = false
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -642,7 +569,6 @@ mod tests {
             step,
             OrderBy::Asc,
             false,
-            false, // add_mini_partition = false
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -685,7 +611,6 @@ mod tests {
             step,
             OrderBy::Desc,
             false,
-            true, // add_mini_partition = true
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -716,7 +641,6 @@ mod tests {
             step,
             OrderBy::Asc,
             false,
-            true, // add_mini_partition = true
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -764,7 +688,6 @@ mod tests {
             step,
             OrderBy::Desc,
             false,
-            true, // add_mini_partition = true
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -792,7 +715,6 @@ mod tests {
             step,
             OrderBy::Asc,
             false,
-            true, // add_mini_partition = true
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -837,7 +759,6 @@ mod tests {
             step,
             OrderBy::Desc,
             false,
-            true, // add_mini_partition = true
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -868,7 +789,6 @@ mod tests {
             step,
             OrderBy::Asc,
             false,
-            true, // add_mini_partition = true
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -916,7 +836,6 @@ mod tests {
             step,
             OrderBy::Desc,
             false,
-            true, // add_mini_partition = true
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -945,7 +864,6 @@ mod tests {
             step,
             OrderBy::Asc,
             false,
-            true, // add_mini_partition = true
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -991,7 +909,6 @@ mod tests {
             step,
             OrderBy::Desc,
             false,
-            true, // add_mini_partition = true
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -1013,7 +930,6 @@ mod tests {
             step,
             OrderBy::Asc,
             false,
-            true, // add_mini_partition = true
             #[cfg(feature = "enterprise")]
             None,
         );
@@ -1053,7 +969,6 @@ mod enterprise_tests {
             step,
             OrderBy::Desc,
             true,
-            false,
             None,
         );
 
@@ -1072,7 +987,6 @@ mod enterprise_tests {
             step,
             OrderBy::Asc,
             true,
-            false,
             None,
         );
         expected_partitions.reverse();
@@ -1098,7 +1012,6 @@ mod enterprise_tests {
             step,
             OrderBy::Desc,
             true,
-            false,
             None,
         );
 

--- a/src/service/search/partition/settings.rs
+++ b/src/service/search/partition/settings.rs
@@ -37,7 +37,6 @@ pub fn calculate_partition_settings(
     sql: &Sql,
     is_complex_query: bool,
     has_ts_column: bool,
-    enable_align_histogram: bool,
     skip_max_query_range: bool,
     max_query_range: i64,
 ) -> PartitionSettings {
@@ -63,7 +62,7 @@ pub fn calculate_partition_settings(
         .unwrap()
         .num_microseconds()
         .unwrap();
-    if (is_complex_query && has_ts_column) || enable_align_histogram {
+    if is_complex_query && has_ts_column {
         let hist_int = if let Some(hist_int) = histogram_interval {
             hist_int
         } else {

--- a/src/service/search/sql/mod.rs
+++ b/src/service/search/sql/mod.rs
@@ -105,23 +105,6 @@ impl Sql {
         Self::new_with_options(query, org_id, stream_type, search_event_type, false).await
     }
 
-    pub fn get_first_stream_key(&self) -> String {
-        self.stream_names
-            .first()
-            .map(|s| {
-                format!(
-                    "{}/{}",
-                    s.get_stream_type(self.stream_type),
-                    s.stream_name()
-                )
-            })
-            // For multi-stream / cross-index queries there is no single stream
-            // name.  Fall back to the stream-type prefix so select_nodes always
-            // receives a non-empty, deterministic key (rather than "" which
-            // would silently select all nodes and defeat org/stream affinity).
-            .unwrap_or_else(|| format!("{}/", self.stream_type))
-    }
-
     pub async fn new_with_options(
         query: &SearchQuery,
         org_id: &str,
@@ -257,17 +240,19 @@ impl Sql {
         if let Some(error) = histogram_interval_visitor.error {
             return Err(Error::ErrorCode(ErrorCodes::SearchSQLNotValid(error)));
         }
-        let mut histogram_interval = if query.histogram_interval > 0 {
-            Some(validate_and_adjust_histogram_interval(
-                query.histogram_interval,
-                (query.start_time, query.end_time),
-            ))
-        } else {
-            histogram_interval_visitor.interval
-        };
-        if !histogram_interval_visitor.is_histogram {
-            histogram_interval = None;
-        }
+        let histogram_interval = histogram_interval_visitor
+            .is_histogram
+            .then(|| {
+                if query.histogram_interval > 0 {
+                    Some(validate_and_adjust_histogram_interval(
+                        query.histogram_interval,
+                        (query.start_time, query.end_time),
+                    ))
+                } else {
+                    histogram_interval_visitor.interval
+                }
+            })
+            .flatten();
 
         //********************Change the sql start*********************************//
         // 11. add _timestamp and _o2_id if need
@@ -311,6 +296,23 @@ impl Sql {
                 extract_patterns,
             ),
         })
+    }
+
+    pub fn get_first_stream_key(&self) -> String {
+        self.stream_names
+            .first()
+            .map(|s| {
+                format!(
+                    "{}/{}",
+                    s.get_stream_type(self.stream_type),
+                    s.stream_name()
+                )
+            })
+            // For multi-stream / cross-index queries there is no single stream
+            // name.  Fall back to the stream-type prefix so select_nodes always
+            // receives a non-empty, deterministic key (rather than "" which
+            // would silently select all nodes and defeat org/stream affinity).
+            .unwrap_or_else(|| format!("{}/", self.stream_type))
     }
 }
 

--- a/src/service/search/streaming/execution.rs
+++ b/src/service/search/streaming/execution.rs
@@ -474,7 +474,6 @@ pub async fn get_partitions(
         &search_partition_req,
         false,
         false,
-        false,
         req.use_cache,
     )
     .instrument(tracing::info_span!(


### PR DESCRIPTION
related to 
- https://github.com/openobserve/openobserve/pull/8003
- https://github.com/openobserve/openobserve/issues/7986


# Why We Can Delete `enable_align_histogram`

## What It Was

`enable_align_histogram` was a query parameter introduced in [PR #8003](https://github.com/openobserve/openobserve/pull/8003) to fix [Issue #7986](https://github.com/openobserve/openobserve/issues/7986). The bug was that in the old two-step search flow (`_search_partition` → `_search`), the two APIs independently generated histogram intervals, leading to mismatched time buckets and inaccurate chart rendering in dashboards.

The flag told `_search_partition` to:
1. Align partition boundaries to histogram interval boundaries (e.g., round to the start of a minute/hour/day).
2. Return the computed `histogram_interval` in the response so the frontend could pass it to `_search`.

## Why It Is Now Dead Code

### 1. The frontend no longer calls `_search_partition`

All frontend search now uses `_search_stream` (HTTP/2 streaming), which internally calls `search_partition()` with `enable_align_histogram = false`. The old `_search_partition` endpoint is no longer consumed by the UI. The only frontend caller (`getValuesPartition` in `IndexList.vue`) is defined but never invoked.

### 2. `search_stream` handles alignment inherently

In the streaming search flow, partitions themselves define the search time ranges. Each partition search runs on the exact aligned time boundaries returned by the partition step. There is no separate histogram query that needs an externally provided interval — alignment is "baked into" the partition boundaries.

### 3. Histogram queries are already covered by `is_complex_query`

For histogram queries (which have `GROUP BY`), `is_complex_query` returns `true`. Combined with `has_ts_column = true`, this triggers `calculate_partition_settings()` to align `min_step` to the histogram interval — the same alignment behavior that `enable_align_histogram` previously provided, but without the extra flag.

### 4. All backend callers pass `false`

Of the 5 callers of `search_partition()`:
| Caller | Value |
|--------|-------|
| gRPC handler | hardcoded `false` |
| streaming execution | hardcoded `false` |
| traces handler | hardcoded `false` |
| HTTP `_search_partition` | from query param (frontend always passed `true`, but frontend no longer calls this) |
| HTTP `_search_partition_multi` | from query param (frontend always passed `true`, but frontend no longer calls this) |

No active code path ever sets `enable_align_histogram = true`.

## What Was Removed

- `get_enable_align_histogram_from_request()` — the HTTP query param parser
- The `enable_align_histogram` parameter from:
  - `search_partition()` function signature
  - `search_partition_multi()` function signature
  - `calculate_partition_settings()` function signature
- The alignment logic in `search_partition()`:
  - `add_mini_partition` (always `false` without the flag)
  - `PartitionGenerator` align parameter (now driven by `is_histogram` alone)
  - `resp.histogram_interval` override block
- The `|| enable_align_histogram` branch in `calculate_partition_settings`
- The query parameter from both HTTP handler `utoipa` specs
- The `false` argument from all 5 call sites

