### PR TITLE
feat: add gc-file-list cli to clean stale stream files from storage

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -100,11 +100,18 @@ fn create_cli_app() -> Command {
                     arg!("account", 'a', "account", "the account name", false).value_name("account"),
                     arg!("file", 'f', "file", "the parquet file name", true).value_name("file"),
                 ]),
-            Command::new("recover-file-list").about("recover file list from s3")
+            Command::new("recover-file-list").about("recover file list from remote object store")
                 .args([
                     arg!("account", 'a', "account", "the account name", true).value_name("account"),
                     arg!("prefix", 'p', "prefix", "only migrate specified prefix", true).value_name("prefix"),
                     arg!("insert", 'i', "insert", "insert file list into db", false).value_name("insert").action(ArgAction::SetTrue),
+                ]),
+            Command::new("gc-file-list")
+                .about("delete stale stream files from remote storage that are past data retention")
+                .args([
+                    arg!("account", 'a', "account", "override storage account to list/delete, required for file_hash multi-account setups (default: resolve per stream)", false).value_name("account"),
+                    arg!("stream", 's', "stream", "only clean a specific stream, format: org/stream_type/stream_name (default: all streams)", false).value_name("stream"),
+                    arg!("dry-run", 'd', "dry-run", "only print what would be deleted, don't touch storage", false).action(ArgAction::SetTrue),
                 ]),
                 Command::new("node").about("node command").subcommands([
                 Command::new("offline").about("offline node"),
@@ -416,6 +423,12 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
             let prefix = command.get_one::<String>("prefix").unwrap();
             let insert = command.get_flag("insert");
             super::load::load_file_list_from_s3(&account, prefix, insert).await?;
+        }
+        "gc-file-list" => {
+            let account = command.get_one::<String>("account").map(|s| s.as_str());
+            let stream = command.get_one::<String>("stream").map(|s| s.as_str());
+            let dry_run = command.get_flag("dry-run");
+            super::gc::run(account, stream, dry_run).await?;
         }
         "node" => {
             let command = command.subcommand();

--- a/src/cli/basic/gc.rs
+++ b/src/cli/basic/gc.rs
@@ -1,0 +1,404 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Garbage collect stale stream files from remote object storage.
+//!
+//! Sometimes the compactor retention job marks files as deleted in the
+//! `file_list` table but fails to remove the physical objects from remote
+//! storage (s3/gcs/azure), leaving orphaned files behind. This command walks
+//! every stream, computes its data retention cutoff and deletes any date
+//! directory on remote storage whose data is entirely older than the cutoff.
+//!
+//! The deletion decision mirrors the compactor retention logic
+//! ([`crate::service::compact::retention`]): a stream's effective retention is
+//! `stream_settings.data_retention` (falling back to
+//! `ZO_COMPACT_DATA_RETENTION_DAYS`), and any day overlapping an
+//! `extended_retention_days` range is preserved.
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use config::{
+    get_config, is_local_disk_storage,
+    meta::stream::{ALL_STREAM_TYPES, StreamType, TimeRange},
+    utils::time::now,
+};
+
+use crate::service::db;
+
+/// Entry point for the `gc-file-list` command.
+///
+/// * `account_override` - force this storage account for listing/deleting instead of resolving it
+///   per stream. Required for `file_hash` multi-account setups where a single stream's files are
+///   spread across accounts.
+/// * `stream_filter` - only process this stream, given as a full stream key
+///   `org/stream_type/stream_name`. Processes all streams when `None`/empty.
+/// * `dry_run` - only print what would be deleted, don't touch storage.
+pub async fn run(
+    account_override: Option<&str>,
+    stream_filter: Option<&str>,
+    dry_run: bool,
+) -> Result<(), anyhow::Error> {
+    if is_local_disk_storage() {
+        return Err(anyhow::anyhow!(
+            "gc-file-list only works with remote object storage (s3/gcs/azure)"
+        ));
+    }
+
+    infra::init().await?;
+
+    let cfg = get_config();
+    let now = now();
+    let default_retention_days = cfg.compact.data_retention_days;
+    let stream_filter = stream_filter.filter(|s| !s.is_empty());
+
+    let mut total_dirs = 0usize;
+    let mut total_files = 0usize;
+
+    if let Some(stream_key) = stream_filter {
+        // a specific stream was requested: process it directly, no need to scan
+        // the whole schema cache
+        let parts: Vec<&str> = stream_key.split('/').collect();
+        if parts.len() != 3 || parts.iter().any(|p| p.is_empty()) {
+            return Err(anyhow::anyhow!(
+                "invalid stream key {stream_key:?}, expected org/stream_type/stream_name"
+            ));
+        }
+        let (org_id, stream_type, stream_name) = (parts[0], StreamType::from(parts[1]), parts[2]);
+        let (dirs, files) = gc_stream(
+            org_id,
+            stream_type,
+            stream_name,
+            default_retention_days,
+            now,
+            account_override,
+            dry_run,
+        )
+        .await?;
+        total_dirs += dirs;
+        total_files += files;
+    } else {
+        // process every stream: load schema cache to enumerate orgs/streams
+        db::schema::cache().await?;
+        let orgs = db::schema::list_organizations_from_cache().await;
+        for org_id in orgs {
+            for stream_type in ALL_STREAM_TYPES {
+                // enrichment tables and file_list streams are not subject to data
+                // retention, skip them (same as compactor retention::generate_jobs)
+                if stream_type == StreamType::EnrichmentTables
+                    || stream_type == StreamType::Filelist
+                {
+                    continue;
+                }
+                let streams = db::schema::list_streams_from_cache(&org_id, stream_type).await;
+                for stream_name in streams {
+                    let (dirs, files) = gc_stream(
+                        &org_id,
+                        stream_type,
+                        &stream_name,
+                        default_retention_days,
+                        now,
+                        account_override,
+                        dry_run,
+                    )
+                    .await?;
+                    total_dirs += dirs;
+                    total_files += files;
+                }
+            }
+        }
+    }
+
+    println!(
+        "[GC] done, {} {total_dirs} stale date dir(s) / {total_files} file(s)",
+        if dry_run { "would delete" } else { "deleted" },
+    );
+
+    Ok(())
+}
+
+/// Garbage collect a single stream: resolve its effective retention and clean
+/// both its data and index directories on remote storage.
+///
+/// Returns the number of (date dirs, files) deleted (or that would be deleted in
+/// dry-run mode).
+async fn gc_stream(
+    org_id: &str,
+    stream_type: StreamType,
+    stream_name: &str,
+    default_retention_days: i64,
+    now: DateTime<Utc>,
+    account_override: Option<&str>,
+    dry_run: bool,
+) -> Result<(usize, usize), anyhow::Error> {
+    let stream_settings = infra::schema::get_settings(org_id, stream_name, stream_type)
+        .await
+        .unwrap_or_default();
+
+    // effective retention: stream override wins over global config
+    let mut retention_days = default_retention_days;
+    if stream_settings.data_retention > 0 {
+        retention_days = stream_settings.data_retention;
+    }
+    if retention_days <= 1 {
+        // retention disabled (0) or 1 day: skip as a safety guard so this tool
+        // never deletes near-current data
+        return Ok((0, 0));
+    }
+
+    let lifecycle_end = now - Duration::try_days(retention_days).unwrap();
+
+    // data dir + derived index dir (see retention::generate_local_dirs)
+    let prefixes = [
+        format!("files/{org_id}/{stream_type}/{stream_name}/"),
+        format!("files/{org_id}/index/{stream_name}_{stream_type}/"),
+    ];
+    let mut total_dirs = 0usize;
+    let mut total_files = 0usize;
+    for prefix in prefixes {
+        match gc_prefix(
+            org_id,
+            &prefix,
+            account_override,
+            lifecycle_end,
+            &stream_settings.extended_retention_days,
+            dry_run,
+        )
+        .await
+        {
+            Ok((dirs, files)) => {
+                total_dirs += dirs;
+                total_files += files;
+            }
+            Err(e) => {
+                log::error!("[GC] failed to process prefix {prefix}: {e}");
+            }
+        }
+    }
+
+    Ok((total_dirs, total_files))
+}
+
+/// Process a single `files/{org}/.../` prefix.
+///
+/// Rather than listing every object under the prefix (which can be billions of
+/// files / TBs for a large stream and would blow up memory), this walks the
+/// `year/month/day` directory tree using delimiter listings (which only return
+/// directory names) and only does a full object listing for the day directories
+/// that are actually past retention and about to be deleted.
+///
+/// Returns the number of (date dirs, files) deleted (or that would be deleted
+/// in dry-run mode).
+async fn gc_prefix(
+    org_id: &str,
+    prefix: &str,
+    account_override: Option<&str>,
+    lifecycle_end: DateTime<Utc>,
+    extended_retentions: &[TimeRange],
+    dry_run: bool,
+) -> Result<(usize, usize), anyhow::Error> {
+    let account = match account_override {
+        Some(a) if !a.is_empty() => a.to_string(),
+        _ => infra::storage::get_account(org_id, prefix).unwrap_or_default(),
+    };
+
+    let mut deleted_dirs = 0usize;
+    let mut deleted_files = 0usize;
+
+    // level 1: year directories, e.g. `files/{org}/{type}/{stream}/2025`
+    for year_dir in infra::storage::list_dirs(&account, prefix).await? {
+        let Some(year) = last_segment(&year_dir).and_then(|s| s.parse::<i32>().ok()) else {
+            continue;
+        };
+        // prune: the whole year is newer than the cutoff, nothing to delete
+        if let Some(year_start) = month_start(year, 1)
+            && year_start > lifecycle_end
+        {
+            continue;
+        }
+
+        // level 2: month directories
+        for month_dir in infra::storage::list_dirs(&account, &format!("{year_dir}/")).await? {
+            let Some(month) = last_segment(&month_dir).and_then(|s| s.parse::<u32>().ok()) else {
+                continue;
+            };
+            if let Some(month_start) = month_start(year, month)
+                && month_start > lifecycle_end
+            {
+                continue;
+            }
+
+            // level 3: day directories
+            for day_dir in infra::storage::list_dirs(&account, &format!("{month_dir}/")).await? {
+                let Some(day) = last_segment(&day_dir).and_then(|s| s.parse::<u32>().ok()) else {
+                    continue;
+                };
+                let Some((day_start, day_end)) = day_bounds(year, month, day) else {
+                    log::warn!("[GC] skip non-date dir: {day_dir}");
+                    continue;
+                };
+
+                // only delete a day directory when the whole day is past retention
+                if day_end > lifecycle_end {
+                    continue;
+                }
+
+                // preserve days that overlap an extended retention ("red day") range
+                let day_range =
+                    TimeRange::new(day_start.timestamp_micros(), day_end.timestamp_micros());
+                if extended_retentions.iter().any(|r| r.intersects(&day_range)) {
+                    log::info!("[GC] keep {day_dir}: within extended retention");
+                    continue;
+                }
+
+                // this day is past retention: list just this day and delete it
+                let files = infra::storage::list(&account, &format!("{day_dir}/")).await?;
+                if files.is_empty() {
+                    continue;
+                }
+                log::info!(
+                    "[GC] {} {day_dir} ({} file(s))",
+                    if dry_run { "would delete" } else { "delete" },
+                    files.len(),
+                );
+                deleted_dirs += 1;
+                deleted_files += files.len();
+
+                if !dry_run {
+                    let del_list = files
+                        .iter()
+                        .map(|f| (account.as_str(), f.as_str()))
+                        .collect::<Vec<_>>();
+                    infra::storage::del(del_list).await?;
+                }
+            }
+        }
+    }
+
+    Ok((deleted_dirs, deleted_files))
+}
+
+/// Return the last `/`-separated segment of a directory key, e.g.
+/// `files/default/logs/default/2025` -> `2025`. Returns `None` if empty.
+fn last_segment(path: &str) -> Option<&str> {
+    path.trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+}
+
+/// Midnight UTC at the first day of the given `year/month`.
+fn month_start(year: i32, month: u32) -> Option<DateTime<Utc>> {
+    Utc.with_ymd_and_hms(year, month, 1, 0, 0, 0).single()
+}
+
+/// The `[day_start, day_end)` UTC range for a `year/month/day`.
+fn day_bounds(year: i32, month: u32, day: u32) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+    let day_start = Utc.with_ymd_and_hms(year, month, day, 0, 0, 0).single()?;
+    Some((day_start, day_start + Duration::days(1)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_last_segment() {
+        assert_eq!(
+            last_segment("files/default/logs/default/2025"),
+            Some("2025")
+        );
+        assert_eq!(
+            last_segment("my-bucket-prefix/files/default/logs/default/2025/01"),
+            Some("01")
+        );
+        // trailing slash is tolerated
+        assert_eq!(
+            last_segment("files/default/index/default_logs/15/"),
+            Some("15")
+        );
+        assert_eq!(last_segment(""), None);
+    }
+
+    #[test]
+    fn test_day_bounds() {
+        let (start, end) = day_bounds(2025, 1, 2).unwrap();
+        assert_eq!(
+            start,
+            Utc.with_ymd_and_hms(2025, 1, 2, 0, 0, 0).single().unwrap()
+        );
+        assert_eq!(
+            end,
+            Utc.with_ymd_and_hms(2025, 1, 3, 0, 0, 0).single().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_day_bounds_invalid() {
+        assert!(day_bounds(2025, 13, 2).is_none()); // bad month
+        assert!(day_bounds(2025, 2, 30).is_none()); // bad day
+    }
+
+    #[test]
+    fn test_month_start() {
+        assert_eq!(
+            month_start(2025, 6),
+            Utc.with_ymd_and_hms(2025, 6, 1, 0, 0, 0).single()
+        );
+    }
+
+    /// A full day older than the cutoff and outside any extended range should be
+    /// eligible for deletion.
+    #[test]
+    fn test_retention_decision_deletes_old_day() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 5, 25, 12, 0, 0)
+            .single()
+            .unwrap();
+        let lifecycle_end = now - Duration::days(3); // keep last 3 days
+        let (_, day_end) = day_bounds(2026, 5, 15).unwrap();
+        assert!(day_end <= lifecycle_end, "10-day-old dir is past retention");
+    }
+
+    /// The boundary day must be preserved: its data is partly within retention,
+    /// so the whole-directory rule (`day_end <= lifecycle_end`) keeps it.
+    #[test]
+    fn test_retention_decision_keeps_boundary_day() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 5, 25, 12, 0, 0)
+            .single()
+            .unwrap();
+        let lifecycle_end = now - Duration::days(3); // 2026-05-22 12:00
+        let (_, day_end) = day_bounds(2026, 5, 22).unwrap(); // ends 05-23 00:00
+        assert!(day_end > lifecycle_end, "boundary day must be kept");
+    }
+
+    /// A day overlapping an extended retention range must be preserved even when
+    /// it is past the data retention cutoff.
+    #[test]
+    fn test_retention_decision_keeps_extended_retention_day() {
+        let (day_start, day_end) = day_bounds(2026, 5, 15).unwrap();
+        let day_range = TimeRange::new(day_start.timestamp_micros(), day_end.timestamp_micros());
+        let extended = vec![TimeRange::new(
+            Utc.with_ymd_and_hms(2026, 5, 14, 0, 0, 0)
+                .single()
+                .unwrap()
+                .timestamp_micros(),
+            Utc.with_ymd_and_hms(2026, 5, 16, 0, 0, 0)
+                .single()
+                .unwrap()
+                .timestamp_micros(),
+        )];
+        assert!(extended.iter().any(|r| r.intersects(&day_range)));
+    }
+}

--- a/src/cli/basic/mod.rs
+++ b/src/cli/basic/mod.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub mod cli;
+mod gc;
 mod http;
 mod load;
 mod query_optimiser;

--- a/src/infra/src/storage/mod.rs
+++ b/src/infra/src/storage/mod.rs
@@ -121,6 +121,24 @@ pub async fn list(account: &str, prefix: &str) -> Result<Vec<String>> {
     Ok(files)
 }
 
+/// List the immediate child "directories" (common prefixes) under `prefix`
+/// using a `/` delimiter, without recursing into them. This is cheap compared
+/// to [`list`] for large prefixes because it only returns directory names, not
+/// every object underneath.
+///
+/// Returned prefixes are full storage keys (they may carry the
+/// `ZO_S3_BUCKET_PREFIX`) and do not include a trailing slash.
+pub async fn list_dirs(account: &str, prefix: &str) -> Result<Vec<String>> {
+    let res = MULTI_ACCOUNTS
+        .list_with_delimiter(account, Some(&prefix.into()))
+        .await?;
+    Ok(res
+        .common_prefixes
+        .into_iter()
+        .map(|p| p.to_string())
+        .collect())
+}
+
 pub fn get_account(org_id: &str, file: &str) -> Option<String> {
     MULTI_ACCOUNTS.get_account(org_id, file)
 }

--- a/src/infra/src/storage/remote.rs
+++ b/src/infra/src/storage/remote.rs
@@ -206,11 +206,10 @@ impl ObjectStore for Remote {
         self.client.list(Some(&prefix.into()))
     }
 
-    async fn list_with_delimiter(&self, _prefix: Option<&Path>) -> Result<ListResult> {
-        Err(Error::NotImplemented {
-            operation: "list_with_delimiter".to_string(),
-            implementer: Self::name().to_string(),
-        })
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        let key = prefix.map(|p| p.as_ref());
+        let prefix = self.format_key(key.unwrap_or(""));
+        self.client.list_with_delimiter(Some(&prefix.into())).await
     }
 
     async fn copy_opts(&self, _from: &Path, _to: &Path, _options: CopyOptions) -> Result<()> {


### PR DESCRIPTION
## What

Design at: #12199
Relate to: 
https://github.com/openobserve/openobserve/issues/12105 https://github.com/openobserve/openobserve/issues/12202

Adds a new CLI command `gc-file-list` that deletes orphaned stream files left on remote object storage (s3/gcs/azure).

Sometimes the compactor retention job marks files as deleted in the `file_list` table but fails to remove the physical objects from storage, leaving garbage behind. This command cleans up that leftover data.

## How it works

For every stream (or a single one via `-s org/stream_type/stream_name`):
- Resolves the effective data retention: `stream_settings.data_retention` if set, otherwise `ZO_COMPACT_DATA_RETENTION_DAYS` (mirrors the compactor `retention` logic).
- Deletes date directories whose data is **entirely** past the retention cutoff (`day_end <= now - retention`), so the boundary day is always preserved.
- Preserves any day overlapping an `extended_retention_days` ("red day") range.
- Cleans both the data dir `files/{org}/{type}/{stream}/` and the derived index dir `files/{org}/index/{stream}_{type}/`.

## Performance

To avoid loading every object of a TB-scale stream into memory, it walks the `year/month/day` directory tree using delimiter listings (which only return directory names) and only does a full object listing for the day directories it actually deletes.

Supporting changes in `infra::storage`:
- New `storage::list_dirs(account, prefix)` returning immediate child directories (common prefixes).
- Implemented `list_with_delimiter` for the remote store (previously `NotImplemented`).

## Usage

```
openobserve gc-file-list                                  # all streams
openobserve gc-file-list -s default/logs/mystream         # one stream
openobserve gc-file-list -s default/logs/mystream -d      # dry-run preview
openobserve gc-file-list -a account2                       # override storage account (file_hash setups)
```

## Safety notes

- Only works against remote object storage (errors out on local disk).
- Streams with effective retention `<= 1` day are skipped as a safety guard.
- Recommend running with `-d` (dry-run) first to review what would be deleted.

## Tests

Added unit tests for the date/segment parsing and retention decision helpers (`last_segment`, `day_bounds`, `month_start`, and the deletes-old-day / keeps-boundary-day / keeps-extended-retention-day cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)