### PR TITLE
fix: badge text 200GB → 50GB for open_source variant in en.json

### DIFF
--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -649,7 +649,7 @@
       "open_source": {
         "hero_title": "Get Enterprise Edition",
         "offer_text": "Download and unlock all enterprise features completely free",
-        "badge_text": "Free up to 200GB / day",
+        "badge_text": "Free up to 50GB / day",
         "features_title": "Unlock All Enterprise Features",
         "features_subtitle": "Everything you need for production-ready observability",
         "primary_button_text": "Download Now"


### PR DESCRIPTION
## Summary
- Backport of #12230 to branch-v0.90.0
- The previous PR (#12229) fixed most instances of `200GB` in `en.json` but missed the `open_source.badge_text` key which powers the "Get Enterprise Edition" dialog shown to OSS users
- Fixed: `about.enterprise_offer.open_source.badge_text` → `Free up to 50GB / day`

## Test plan
- [ ] Open the app as an OSS user (no enterprise license)
- [ ] Trigger the Enterprise upgrade dialog
- [ ] Confirm badge reads "Free up to 50GB / day"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)