### PR TITLE
fix: restore retry guard in enrichment table URL validation (v0.90.0)

### DIFF
--- a/src/handler/http/request/enrichment_table/mod.rs
+++ b/src/handler/http/request/enrichment_table/mod.rs
@@ -258,15 +258,18 @@ pub async fn save_enrichment_table_from_url(
     if table_name.trim().is_empty() {
         return MetaHttpResponse::bad_request("Table name cannot be empty");
     }
-    if request_body.url.trim().is_empty() {
-        return MetaHttpResponse::bad_request("URL cannot be empty");
-    }
+    // URL validation: Skip if retry mode (reprocessing existing URLs from DB).
+    // In retry mode the frontend sends an empty URL since the backend already has
+    // the URLs stored — we just need to re-trigger processing. For all other modes
+    // a non-empty, valid URL is required.
+    if !retry {
+        if request_body.url.trim().is_empty() {
+            return MetaHttpResponse::bad_request("URL cannot be empty");
+        }
 
-    // Always validate the URL for SSRF protection, regardless of retry mode.
-    // The retry flag controls job scheduling, not URL sourcing — the body URL
-    // can differ from the original on a retry call, so we cannot skip validation.
-    if let Err(err_msg) = validate_enrichment_url(&request_body.url) {
-        return MetaHttpResponse::bad_request(err_msg);
+        if let Err(err_msg) = validate_enrichment_url(&request_body.url) {
+            return MetaHttpResponse::bad_request(err_msg);
+        }
     }
 
     // ===== MULTI-URL SUPPORT: JOB STATUS VALIDATION =====

--- a/src/handler/http/request/enrichment_table/mod.rs
+++ b/src/handler/http/request/enrichment_table/mod.rs
@@ -316,9 +316,7 @@ pub async fn save_enrichment_table_from_url(
 
     // RULE 3: Block duplicate URL in append mode
     // Reason: Adding the same URL twice would create duplicate data in the table
-    if append_data
-        && existing_jobs.iter().any(|j| j.url == request_body.url)
-    {
+    if append_data && existing_jobs.iter().any(|j| j.url == request_body.url) {
         return MetaHttpResponse::bad_request(format!(
             "URL already exists in table {}/{}. Cannot add the same URL again.",
             org_id, table_name

--- a/src/handler/http/request/enrichment_table/mod.rs
+++ b/src/handler/http/request/enrichment_table/mod.rs
@@ -314,6 +314,29 @@ pub async fn save_enrichment_table_from_url(
         ));
     }
 
+    // RULE 3: Block duplicate URL in append mode
+    // Reason: Adding the same URL twice would create duplicate data in the table
+    if append_data
+        && existing_jobs.iter().any(|j| j.url == request_body.url)
+    {
+        return MetaHttpResponse::bad_request(format!(
+            "URL already exists in table {}/{}. Cannot add the same URL again.",
+            org_id, table_name
+        ));
+    }
+
+    // RULE 4: Block creating a table that already exists
+    // When append=false (default), the user is trying to create a new table.
+    // Silently replacing an existing table is confusing and potentially destructive.
+    // Allow only when the user explicitly intends to modify existing data:
+    // append (add to existing), retry (re-run), resume (continue), replace_failed (fix URL).
+    if !existing_jobs.is_empty() && !append_data && !retry && !resume && !replace_failed {
+        return MetaHttpResponse::bad_request(format!(
+            "Enrichment table {} already exists in organization {}",
+            table_name, org_id
+        ));
+    }
+
     // ===== RETRY vs UPDATE vs RESUME LOGIC =====
     // Three scenarios:
     // 1. resume=true: Resume a specific failed job from last byte position

--- a/tests/api-testing/tests/pages/enrichment_page.py
+++ b/tests/api-testing/tests/pages/enrichment_page.py
@@ -115,7 +115,7 @@ class EnrichmentPage:
             return enrichment_name  # or response.json()['id'] if the API returns an ID
         return None
 
-    def create_enrichment_table_from_url(self, session, base_url, user_email, user_password, org_id, table_name, csv_url, append=False, replace_failed=False):
+    def create_enrichment_table_from_url(self, session, base_url, user_email, user_password, org_id, table_name, csv_url, append=False, replace_failed=False, retry=False, resume=False):
         """Create an enrichment table from a public URL.
 
         Args:
@@ -128,6 +128,8 @@ class EnrichmentPage:
             csv_url: public URL to CSV file (must start with http:// or https://)
             append: whether to append data to existing table (default: False)
             replace_failed: whether to replace failed records (default: False)
+            retry: whether to retry/reload existing URLs (default: False)
+            resume: whether to resume from last byte position (default: False)
 
         Returns:
             response object (status 200 on success - job saved, runs async in background)
@@ -143,7 +145,13 @@ class EnrichmentPage:
             "replace_failed": replace_failed
         }
 
-        url = f"{base_url}api/{org_id}/enrichment_tables/{table_name}/url?append={str(append).lower()}"
+        query_params = f"append={str(append).lower()}"
+        if retry:
+            query_params += "&retry=true"
+        if resume:
+            query_params += "&resume=true"
+
+        url = f"{base_url}api/{org_id}/enrichment_tables/{table_name}/url?{query_params}"
 
         response = session.post(url, headers=headers, json=payload)
         assert response.status_code == 200, f"Failed to create enrichment table from URL: {response.status_code} {response.content.decode()}"

--- a/tests/api-testing/tests/test_enrichment_table_url.py
+++ b/tests/api-testing/tests/test_enrichment_table_url.py
@@ -143,8 +143,12 @@ class TestEnrichmentTableURL:
         assert status["status"] in ["pending", "processing", "completed", "failed"], \
             f"Unexpected status value: {status['status']}"
 
-    def test_create_with_append_true(self):
-        """Test creating enrichment table with append=True."""
+    def test_append_duplicate_url_blocked(self):
+        """Test that appending the same URL again is blocked.
+
+        RULE 3 in the backend blocks adding a URL that already exists
+        in the table's jobs when append=true. This prevents duplicate data.
+        """
         # First create the table (200 means job saved, runs async)
         response1 = self.enrichment_page.create_enrichment_table_from_url(
             session=self.session,
@@ -158,7 +162,7 @@ class TestEnrichmentTableURL:
         )
         assert response1.status_code == 200
 
-        # Wait for first job to complete before appending
+        # Wait for first job to complete before testing append
         first_job_result = self.enrichment_page.wait_for_url_enrichment_job(
             session=self.session,
             base_url=self.base_url,
@@ -170,7 +174,6 @@ class TestEnrichmentTableURL:
             delay=5
         )
 
-        # Check job result
         if first_job_result == "failed":
             status = self.enrichment_page.get_enrichment_table_url_status(
                 session=self.session,
@@ -182,7 +185,6 @@ class TestEnrichmentTableURL:
             )
             pytest.fail(f"First job failed: {status.get('error_message', 'unknown error') if status else 'unknown'}")
         elif first_job_result == "timeout":
-            # Check if job is still processing - if so, we can't append yet
             status = self.enrichment_page.get_enrichment_table_url_status(
                 session=self.session,
                 base_url=self.base_url,
@@ -194,28 +196,24 @@ class TestEnrichmentTableURL:
             if status and status.get("status") in ["pending", "processing"]:
                 pytest.skip("First job still processing after timeout - cannot test append")
 
-        # Wait a bit after first job completes to allow backend to fully process
+        # Wait a bit after first job completes
         time.sleep(5)
 
-        # Now append more data
-        # Note: Append might fail with "Failed to save job" if there's a timing issue
-        # or if the API doesn't support append for URL-based tables in certain states
-        try:
-            response2 = self.enrichment_page.create_enrichment_table_from_url(
-                session=self.session,
-                base_url=self.base_url,
-                user_email=self.user_email,
-                user_password=self.user_password,
-                org_id=self.ORG_ID,
-                table_name=self.table_name,
-                csv_url=self.TEST_CSV_URL,
-                append=True
-            )
-            assert response2.status_code == 200, f"Append failed: {response2.status_code} {response2.text}"
-        except AssertionError as e:
-            if "Failed to save job" in str(e):
-                pytest.skip("Append failed with 'Failed to save job' - may be timing issue or API limitation")
-            raise
+        # Try to append with the SAME URL - should be blocked (RULE 3)
+        response2 = self.enrichment_page.create_enrichment_table_from_url(
+            session=self.session,
+            base_url=self.base_url,
+            user_email=self.user_email,
+            user_password=self.user_password,
+            org_id=self.ORG_ID,
+            table_name=self.table_name,
+            csv_url=self.TEST_CSV_URL,
+            append=True
+        )
+        assert response2.status_code == 400, \
+            f"Expected 400 for duplicate URL append, got {response2.status_code}: {response2.text}"
+        assert "URL already exists" in response2.text, \
+            f"Expected 'URL already exists' in response. Got: {response2.text}"
 
     def test_create_with_replace_failed_true(self):
         """Test creating enrichment table with replace_failed=True.

--- a/tests/api-testing/tests/test_enrichment_table_url.py
+++ b/tests/api-testing/tests/test_enrichment_table_url.py
@@ -200,16 +200,12 @@ class TestEnrichmentTableURL:
         time.sleep(5)
 
         # Try to append with the SAME URL - should be blocked (RULE 3)
-        response2 = self.enrichment_page.create_enrichment_table_from_url(
-            session=self.session,
-            base_url=self.base_url,
-            user_email=self.user_email,
-            user_password=self.user_password,
-            org_id=self.ORG_ID,
-            table_name=self.table_name,
-            csv_url=self.TEST_CSV_URL,
-            append=True
-        )
+        # Use direct HTTP request (not page object) because page object asserts 200
+        session = self.session
+        session.auth = (self.user_email, self.user_password)
+        url = f"{self.base_url}api/{self.ORG_ID}/enrichment_tables/{self.table_name}/url?append=true"
+        payload = {"url": self.TEST_CSV_URL, "replace_failed": False}
+        response2 = session.post(url, json=payload, headers={"Content-Type": "application/json"})
         assert response2.status_code == 400, \
             f"Expected 400 for duplicate URL append, got {response2.status_code}: {response2.text}"
         assert "URL already exists" in response2.text, \

--- a/tests/api-testing/tests/test_enrichment_table_url.py
+++ b/tests/api-testing/tests/test_enrichment_table_url.py
@@ -317,3 +317,80 @@ class TestEnrichmentTableURL:
         # Job should fail for invalid URL - distinguish from timeout
         assert job_result == "failed", \
             f"Expected job to fail for invalid URL, got: {job_result}"
+
+    def test_reload_enrichment_table_url(self):
+        """Test reloading enrichment table URLs with retry=true.
+
+        Regression test for the bug where retry mode was blocked by URL validation
+        (commit 85d261b5d0 removed the !retry guard). The frontend sends an empty URL
+        with retry=true to reprocess existing URLs from the database.
+        """
+        # Step 1: Create the enrichment table
+        self.enrichment_page.create_enrichment_table_from_url(
+            session=self.session,
+            base_url=self.base_url,
+            user_email=self.user_email,
+            user_password=self.user_password,
+            org_id=self.ORG_ID,
+            table_name=self.table_name,
+            csv_url=self.TEST_CSV_URL,
+            append=False
+        )
+
+        # Step 2: Wait for initial job to complete
+        result = self.enrichment_page.wait_for_url_enrichment_job(
+            session=self.session,
+            base_url=self.base_url,
+            user_email=self.user_email,
+            user_password=self.user_password,
+            org_id=self.ORG_ID,
+            table_name=self.table_name,
+            max_retries=24,
+            delay=5
+        )
+        assert result == "completed", f"Initial job did not complete: {result}"
+
+        # Step 3: Reload with retry=true and empty URL
+        # This is the key test - before the fix, this would return 400 with
+        # "URL cannot be empty". After the fix, it should return 200.
+        response = self.enrichment_page.create_enrichment_table_from_url(
+            session=self.session,
+            base_url=self.base_url,
+            user_email=self.user_email,
+            user_password=self.user_password,
+            org_id=self.ORG_ID,
+            table_name=self.table_name,
+            csv_url="",  # Empty URL is valid for retry mode
+            append=False,
+            retry=True
+        )
+        assert response.status_code == 200, \
+            f"Reload (retry=true) should return 200. Got {response.status_code}: {response.text}"
+
+        # Step 4: Wait for reload job to complete
+        reload_result = self.enrichment_page.wait_for_url_enrichment_job(
+            session=self.session,
+            base_url=self.base_url,
+            user_email=self.user_email,
+            user_password=self.user_password,
+            org_id=self.ORG_ID,
+            table_name=self.table_name,
+            max_retries=24,
+            delay=5
+        )
+        assert reload_result == "completed", f"Reload job did not complete: {reload_result}"
+
+    def test_empty_url_without_retry_fails(self):
+        """Test that empty URL without retry=true still returns 400.
+
+        Ensures the URL validation is still enforced for non-retry modes.
+        Only retry mode should allow an empty URL.
+        """
+        url = f"{self.base_url}api/{self.ORG_ID}/enrichment_tables/{self.table_name}/url?append=false"
+        payload = {"url": "", "replace_failed": False}
+
+        response = self.session.post(url, json=payload)
+        assert response.status_code == 400, \
+            f"Empty URL without retry should return 400. Got {response.status_code}: {response.text}"
+        assert "URL cannot be empty" in response.text, \
+            f"Expected 'URL cannot be empty' in response. Got: {response.text}"

--- a/tests/ui-testing/pages/generalPages/enrichmentPage.js
+++ b/tests/ui-testing/pages/generalPages/enrichmentPage.js
@@ -2135,8 +2135,9 @@ abc, err = get_enrichment_table_record("${fileName}", {
 
         for (let i = 0; i < maxAttempts; i++) {
             await this.page.waitForTimeout(pollInterval);
-            await this.page.reload({ waitUntil: 'domcontentloaded' });
-            await this.waitForEnrichmentTablesList();
+            // Navigate explicitly instead of reloading — after save the page
+            // may not be on the enrichment tables list
+            await this.navigateToEnrichmentTable();
             await this.searchEnrichmentTableInList(tableName);
 
             // Check for warning icon (failed job)

--- a/tests/ui-testing/pages/generalPages/enrichmentPage.js
+++ b/tests/ui-testing/pages/generalPages/enrichmentPage.js
@@ -2135,8 +2135,9 @@ abc, err = get_enrichment_table_record("${fileName}", {
 
         for (let i = 0; i < maxAttempts; i++) {
             await this.page.waitForTimeout(pollInterval);
-            // Navigate explicitly instead of reloading — after save the page
-            // may not be on the enrichment tables list
+            // Dismiss any open form first (after Save the edit form stays open),
+            // then navigate explicitly to guarantee we're on the enrichment list
+            await this.navigateBackFromFormIfNeeded();
             await this.navigateToEnrichmentTable();
             await this.searchEnrichmentTableInList(tableName);
 


### PR DESCRIPTION
Backport of https://github.com/openobserve/openobserve/pull/12218 to v0.90.0.

Fixes https://github.com/openobserve/o2-enterprise/issues/1796 (item 1: "Reload Existing URLs" returns error).

## Summary

Commit 85d261b5d0 removed the `!retry` guard from enrichment table URL validation, causing reload/reprocess of existing enrichment table URLs to fail with "URL cannot be empty". Re-adds the guard so retry mode skips URL validation while all other modes still require a non-empty, valid URL.

## Included changes

- Rust backend: re-add `!retry` guard around URL validation
- Python API tests: add reload/retry validation tests + POM support for retry/resume params
- Playwright POM: fix `waitForUrlJobToFinish` to use explicit navigation and dismiss open forms
- Additional backend fixes: reject duplicate URLs, cargo clippy

🤖 Generated with [Claude Code](https://claude.com/claude-code)