### PR TITLE
fix: port non-ts ORDER BY TopKHeap fixes to v0.80

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -611,6 +611,13 @@ pub struct SearchPartitionResponse {
     pub streaming_id: Option<String>,
     #[serde(default)]
     pub is_histogram_eligible: bool,
+    /// ORDER BY columns when the primary sort is a non-timestamp column.
+    /// Non-empty means this is a non-ts ORDER BY query; empty means timestamp sort (normal path).
+    /// Each entry is (column_name, is_descending). The heap honors all columns in order so
+    /// that ties on the primary column are broken correctly by secondary columns.
+    /// Skipped from serialization — internal leader use only, not exposed to callers.
+    #[serde(skip)]
+    pub non_ts_order_by_cols: Vec<(String, bool)>,
 }
 
 /// Request parameters for querying search history
@@ -2928,6 +2935,7 @@ mod tests {
             streaming_aggs: false,
             streaming_id: Some("stream123".to_string()),
             is_histogram_eligible: false,
+            non_ts_order_by_cols: vec![],
         };
 
         response

--- a/src/handler/http/request/traces/mod.rs
+++ b/src/handler/http/request/traces/mod.rs
@@ -49,7 +49,10 @@ use crate::{
             CONTENT_TYPE_JSON, CONTENT_TYPE_PROTO, search::error_utils::map_error_to_http_response,
         },
     },
-    service::{search as SearchService, traces},
+    service::{
+        search::{self as SearchService, streaming::sorting::TopKHeap},
+        traces,
+    },
 };
 
 pub mod dag;
@@ -1000,7 +1003,6 @@ pub async fn get_latest_traces_stream(
             from,
             size,
             timeout,
-            sort_by,
             sort_order.to_string(),
             sql_order_expr,
             is_llm_stream,
@@ -1063,7 +1065,6 @@ async fn process_latest_traces_stream(
     from: i64,
     size: i64,
     timeout: i64,
-    sort_by: String,
     sort_order: String,
     sql_order_expr: String,
     is_llm_stream: bool,
@@ -1190,15 +1191,38 @@ async fn process_latest_traces_stream(
     }
 
     let total_partitions = partitions.len();
-    // Partitions from search_partition are already in DESC order (newest-first) by default,
-    // since the partition SQL has no ORDER BY and the default is OrderBy::Desc.
-    let partitions_desc = if sql_order_expr == "zo_sql_timestamp DESC" {
-        partitions
-    } else if sql_order_expr == "zo_sql_timestamp ASC" {
-        partitions.into_iter().rev().collect::<Vec<_>>()
+    // Non-ts ORDER BY uses TopKHeap across all partitions — no single-partition collapse.
+    // ts ASC reverses partition order; everything else (ts DESC and all non-ts) is newest-first.
+    let is_non_ts_order_by = !sql_order_expr.starts_with("zo_sql_timestamp");
+    let partitions_desc: Vec<[i64; 2]> = if sql_order_expr == "zo_sql_timestamp ASC" {
+        log::info!(
+            "[TRACES_STREAM trace_id {trace_id}] using {} time partitions, order=ASC",
+            partitions.len()
+        );
+        partitions.into_iter().rev().collect()
     } else {
-        // order by other fields can't be multiple partitions
-        vec![[partition_req.start_time, partition_req.end_time]]
+        log::info!(
+            "[TRACES_STREAM trace_id {trace_id}] using {} time partitions, order={}",
+            partitions.len(),
+            if is_non_ts_order_by {
+                format!("non-ts ({sql_order_expr}), TopKHeap")
+            } else {
+                "DESC".to_string()
+            }
+        );
+        partitions
+    };
+
+    let heap_k = if from + size > 0 {
+        (from + size) as usize
+    } else {
+        config::get_config().limit.query_default_limit as usize
+    };
+    let (non_ts_col, non_ts_is_desc) = parse_order_expr(&sql_order_expr);
+    let mut topk_heap: Option<TopKHeap> = if is_non_ts_order_by {
+        Some(TopKHeap::new(heap_k, &[(non_ts_col, non_ts_is_desc)]))
+    } else {
+        None
     };
 
     // `from` is a global offset: skip the first `from` hits across all partitions,
@@ -1229,12 +1253,16 @@ async fn process_latest_traces_stream(
         let p_start = partition[0];
         let p_end = partition[1];
 
-        // Ask for enough rows to cover remaining offset + remaining needed,
-        // capped at query_default_limit (default 1000) to prevent oversized Q1 scans.
         let remaining_to_skip = (hits_to_skip - hits_seen).max(0);
         let remaining_needed = hits_to_deliver - hits_delivered;
-        let fetch_size =
-            (remaining_to_skip + remaining_needed).min(get_config().limit.query_default_limit);
+        // Non-ts ORDER BY: each partition fetches its local top-k = heap_k rows so the heap can
+        // select the global top-k after all partitions complete. No query_default_limit cap here.
+        // ts ORDER BY: cap per partition to avoid oversized Q1 scans.
+        let fetch_size = if is_non_ts_order_by {
+            heap_k as i64
+        } else {
+            (remaining_to_skip + remaining_needed).min(get_config().limit.query_default_limit)
+        };
 
         // ---------- Query 1: aggregate over this partition ----------
         let mut req1 = base_req.clone();
@@ -1294,8 +1322,29 @@ async fn process_latest_traces_stream(
             continue;
         }
 
-        // Sort Q1 hits by trace_start_time descending (same order as the final result).
-        // Q1 returns traces ordered by zo_sql_timestamp DESC, but we need start_time order.
+        // Non-ts ORDER BY: push this partition's Q1 hits into the global heap and move on.
+        // Seen trace IDs are registered here so later partitions skip duplicates.
+        // Q2 and final streaming happen after all partitions complete.
+        if is_non_ts_order_by {
+            for item in &deduped_hits {
+                if let Some(tid) = item.get("trace_id").and_then(|v| v.as_str())
+                    && !tid.is_empty()
+                {
+                    seen_trace_ids.insert(tid.to_string());
+                }
+            }
+            if let Some(ref mut heap) = topk_heap {
+                heap.push_hits(deduped_hits);
+            }
+            let progress = ((idx + 1) * 100) / total_partitions;
+            let _ = sender
+                .send(Ok(StreamResponses::Progress { percent: progress }))
+                .await;
+            continue;
+        }
+
+        // ts ORDER BY: sort Q1 hits by trace_start_time (Q1 orders by zo_sql_timestamp; UI expects
+        // trace_start_time order). Register seen IDs before slicing so dedup covers skipped traces.
         let mut sorted_hits = deduped_hits;
         sorted_hits.sort_by(|a, b| {
             let a_t = json::get_int_value(a.get("trace_start_time").unwrap_or_default());
@@ -1337,312 +1386,30 @@ async fn process_latest_traces_stream(
         }
 
         // ---------- Query 2: fetch span details only for the traces we will deliver ----------
-        let mut traces_data: HashMap<String, TraceResponseItem> =
-            HashMap::with_capacity(deliverable_q1.len());
-        let mut p_start_actual = p_start;
-        let mut p_end_actual = p_end;
-
-        for item in &deliverable_q1 {
-            let tid = item
-                .get("trace_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let trace_start_time = json::get_int_value(
-                item.get("trace_start_time")
-                    .unwrap_or(&serde_json::Value::Null),
-            );
-            let trace_end_time = json::get_int_value(
-                item.get("trace_end_time")
-                    .unwrap_or(&serde_json::Value::Null),
-            );
-            // Expand window to cover actual span times (nanoseconds → microseconds)
-            if trace_start_time > 0 && trace_start_time / 1000 < p_start_actual {
-                p_start_actual = trace_start_time / 1000;
-            }
-            if trace_end_time > 0 && trace_end_time / 1000 > p_end_actual {
-                // becuase we search with < end_time, so we need to add 1 to the end_time
-                p_end_actual = trace_end_time / 1000 + 1;
-            }
-            traces_data.insert(
-                tid.clone(),
-                TraceResponseItem {
-                    trace_id: tid,
-                    start_time: trace_start_time,
-                    end_time: trace_end_time,
-                    duration: 0,
-                    spans: [0, 0],
-                    service_name: Vec::new(),
-                    first_event: serde_json::Value::Null,
-                    llm_usage_tokens_input: json::get_int_value(
-                        item.get("llm_usage_details_input").unwrap_or_default(),
-                    ),
-                    llm_usage_tokens_output: json::get_int_value(
-                        item.get("llm_usage_details_output").unwrap_or_default(),
-                    ),
-                    llm_usage_tokens_total: json::get_int_value(
-                        item.get("llm_usage_details_total").unwrap_or_default(),
-                    ),
-                    llm_usage_cost_total: json::get_float_value(
-                        item.get("llm_cost_details_total").unwrap_or_default(),
-                    ),
-                    llm_input: item.get("llm_input").cloned(),
-                },
-            );
-        }
-
-        // Sanitize trace IDs before interpolating into SQL: allow only hex chars and hyphens.
-        // Trace IDs originate from ingested data and could contain injected SQL if not validated.
-        let sanitized_ids: Vec<String> = traces_data
-            .keys()
-            .map(|tid| {
-                tid.chars()
-                    .filter(|c| c.is_ascii_hexdigit() || *c == '-')
-                    .collect::<String>()
-            })
-            .filter(|tid| !tid.is_empty())
-            .collect();
-        let trace_ids_str = sanitized_ids.join("','");
-
-        // Q2a: per-trace aggregates. One row per trace_id (bounded by N traces) so this
-        // never trips the search-service row cap, which the previous SELECT * approach
-        // could hit when traces had tens of thousands of spans.
-        let detail_sql = format!(
-            "SELECT trace_id, \
-                count(*) AS span_count, \
-                sum(CASE WHEN span_status = 'ERROR' THEN 1 ELSE 0 END) AS error_count, \
-                min(start_time) AS min_start_time, \
-                max(end_time) AS max_end_time, \
-                max(duration) AS max_duration, \
-                count(DISTINCT service_name) AS service_count, \
-                max(CASE WHEN reference_parent_span_id IS NULL OR reference_parent_span_id = '' THEN service_name END) AS root_service_name, \
-                max(CASE WHEN reference_parent_span_id IS NULL OR reference_parent_span_id = '' THEN operation_name END) AS root_operation_name, \
-                first_value(service_name ORDER BY {TIMESTAMP_COL_NAME} ASC) AS first_service_name, \
-                first_value(operation_name ORDER BY {TIMESTAMP_COL_NAME} ASC) AS first_operation_name \
-             FROM \"{stream_name}\" WHERE trace_id IN ('{trace_ids_str}') GROUP BY trace_id"
-        );
-
-        let mut req2 = base_req.clone();
-        req2.query.sql = detail_sql;
-        req2.query.from = 0;
-        // Q2a returns one row per trace_id, so size = number of traces.
-        req2.query.size = traces_data.len() as i64;
-        req2.query.start_time = p_start_actual;
-        req2.query.end_time = p_end_actual;
-
-        // Trace IDs that have more than one service — these need a follow-up Q2b.
-        // Single-service traces are fully populated from Q2a alone.
-        // Track the total expected (trace_id, service_name) row count so Q2b can
-        // size its request exactly and skip pagination.
-        let mut multi_service_tids: Vec<String> = Vec::new();
-        let mut multi_service_total: i64 = 0;
-
-        if sender.is_closed() {
-            return;
-        }
-        let detail_res = match SearchService::cache::search(
+        let Some(traces_data) = run_q2_for_traces(
+            &deliverable_q1,
+            p_start,
+            p_end,
+            &base_req,
             &trace_id,
             &org_id,
             stream_type,
-            Some(user_id.clone()),
-            &req2,
-            "".to_string(),
-            false,
-            None,
-            false,
+            &user_id,
+            &stream_name,
+            &sender,
+            &format!("partition [{p_start},{p_end}]"),
         )
         .await
-        {
-            Ok(res) => res,
-            Err(e) => {
-                log::error!(
-                    "[TRACES_STREAM trace_id {trace_id}] Query2 error on partition [{p_start},{p_end}]: {e}"
-                );
-                let _ = sender.send(Err(e)).await;
-                return;
-            }
+        else {
+            return;
         };
 
-        for item in detail_res.hits {
-            let tid = item
-                .get("trace_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            if tid.is_empty() {
-                continue;
-            }
-            let span_count = json::get_int_value(item.get("span_count").unwrap_or_default());
-            let error_count = json::get_int_value(item.get("error_count").unwrap_or_default());
-            let min_start = json::get_int_value(item.get("min_start_time").unwrap_or_default());
-            let max_end = json::get_int_value(item.get("max_end_time").unwrap_or_default());
-            let max_duration = json::get_int_value(item.get("max_duration").unwrap_or_default());
-            let service_count = json::get_int_value(item.get("service_count").unwrap_or_default());
-            let root_service_name = item
-                .get("root_service_name")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let root_operation_name = item
-                .get("root_operation_name")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let first_service_name = item
-                .get("first_service_name")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let first_operation_name = item
-                .get("first_operation_name")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-
-            // Prefer the true root span's labels; fall back to earliest span.
-            let event_service_name = if !root_service_name.is_empty() {
-                root_service_name
-            } else {
-                first_service_name
-            };
-            let event_operation_name = if !root_operation_name.is_empty() {
-                root_operation_name
-            } else {
-                first_operation_name
-            };
-
-            if let Some(trace) = traces_data.get_mut(&tid) {
-                trace.spans[0] = span_count.try_into().unwrap_or_default();
-                trace.spans[1] = error_count.try_into().unwrap_or_default();
-                if trace.start_time == 0 || trace.start_time > min_start {
-                    trace.start_time = min_start;
-                }
-                if trace.end_time < max_end {
-                    trace.end_time = max_end;
-                }
-                trace.duration = max_duration;
-                // update the duration if the duration is not correct
-                if trace.end_time - trace.start_time > trace.duration * 1000 {
-                    trace.duration = (trace.end_time - trace.start_time) / 1000;
-                }
-                trace.first_event = serde_json::json!({
-                    "service_name": event_service_name,
-                    "operation_name": event_operation_name,
-                });
-
-                if service_count <= 1 {
-                    // Single service: populate the services list directly from Q2a;
-                    // skip Q2b for this trace.
-                    if !event_service_name.is_empty() {
-                        trace.service_name.push(TraceServiceNameItem {
-                            service_name: event_service_name,
-                            count: span_count.try_into().unwrap_or_default(),
-                            duration: max_duration,
-                        });
-                    }
-                } else {
-                    multi_service_tids.push(tid);
-                    multi_service_total += service_count;
-                }
-            }
-        }
-
-        // Q2b: per-(trace_id, service_name) breakdown, only for multi-service traces.
-        if !multi_service_tids.is_empty() {
-            // Same sanitization as Q2a above — trace IDs come from DB rows and must be
-            // validated before interpolating into SQL.
-            let multi_ids_str = multi_service_tids
-                .iter()
-                .map(|tid| {
-                    tid.chars()
-                        .filter(|c| c.is_ascii_hexdigit() || *c == '-')
-                        .collect::<String>()
-                })
-                .filter(|tid| !tid.is_empty())
-                .collect::<Vec<String>>()
-                .join("','");
-            let svc_sql = format!(
-                "SELECT trace_id, service_name, count(*) AS svc_count, max(duration) AS svc_duration \
-                 FROM \"{stream_name}\" WHERE trace_id IN ('{multi_ids_str}') \
-                 GROUP BY trace_id, service_name"
-            );
-
-            let mut req3 = base_req.clone();
-            req3.query.sql = svc_sql;
-            req3.query.from = 0;
-            // Output is bounded to the total service count summed from Q2a, so a
-            // single request fetches everything.
-            req3.query.size = multi_service_total;
-            req3.query.start_time = p_start_actual;
-            req3.query.end_time = p_end_actual;
-
-            if sender.is_closed() {
-                return;
-            }
-            let svc_res = match SearchService::cache::search(
-                &trace_id,
-                &org_id,
-                stream_type,
-                Some(user_id.clone()),
-                &req3,
-                "".to_string(),
-                false,
-                None,
-                false,
-            )
-            .await
-            {
-                Ok(res) => res,
-                Err(e) => {
-                    log::error!(
-                        "[TRACES_STREAM trace_id {trace_id}] Query2b error on partition [{p_start},{p_end}]: {e}"
-                    );
-                    let _ = sender.send(Err(e)).await;
-                    return;
-                }
-            };
-
-            for item in svc_res.hits {
-                let tid = item
-                    .get("trace_id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default()
-                    .to_string();
-                let svc_name = item
-                    .get("service_name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default()
-                    .to_string();
-                let svc_count = json::get_int_value(item.get("svc_count").unwrap_or_default());
-                let svc_duration =
-                    json::get_int_value(item.get("svc_duration").unwrap_or_default());
-                if let Some(trace) = traces_data.get_mut(&tid) {
-                    trace.service_name.push(TraceServiceNameItem {
-                        service_name: svc_name,
-                        count: svc_count.try_into().unwrap_or_default(),
-                        duration: svc_duration,
-                    });
-                }
-            }
-        }
-
-        // Sort by start_time descending (Q2 may have refined start_time from actual span data).
+        // Sort by start_time (Q2 may have refined start_time from actual span data).
         let mut partition_hits: Vec<&TraceResponseItem> = traces_data.values().collect();
-        match sort_by.as_str() {
-            "duration" => {
-                if sort_order == "ASC" {
-                    partition_hits.sort_by(|a, b| a.duration.cmp(&b.duration));
-                } else {
-                    partition_hits.sort_by(|a, b| b.duration.cmp(&a.duration));
-                }
-            }
-            _ => {
-                if sort_order == "ASC" {
-                    partition_hits.sort_by(|a, b| a.start_time.cmp(&b.start_time));
-                } else {
-                    partition_hits.sort_by(|a, b| b.start_time.cmp(&a.start_time));
-                }
-            }
+        if sort_order == "ASC" {
+            partition_hits.sort_by(|a, b| a.start_time.cmp(&b.start_time));
+        } else {
+            partition_hits.sort_by(|a, b| b.start_time.cmp(&a.start_time));
         }
 
         let deliverable: Vec<serde_json::Value> = partition_hits
@@ -1690,7 +1457,370 @@ async fn process_latest_traces_stream(
         }
     }
 
+    // ── Non-ts ORDER BY: drain heap → Q2 once → stream final result ─────────────────────────
+    if is_non_ts_order_by {
+        let deliverable_q1 = topk_heap
+            .take()
+            .map(|h| h.into_sorted_vec(from as usize))
+            .unwrap_or_default();
+
+        if deliverable_q1.is_empty() {
+            let _ = sender.send(Ok(StreamResponses::Done)).await;
+            return;
+        }
+
+        let Some(traces_data) = run_q2_for_traces(
+            &deliverable_q1,
+            start_time,
+            end_time,
+            &base_req,
+            &trace_id,
+            &org_id,
+            stream_type,
+            &user_id,
+            &stream_name,
+            &sender,
+            "non-ts",
+        )
+        .await
+        else {
+            return;
+        };
+
+        // Preserve heap ordering: walk deliverable_q1 in heap-drain order (already globally
+        // sorted by the non-ts column). Q2 may have refined start_time/duration but the
+        // relative ORDER BY column rank from Q1 is authoritative.
+        let partition_hits: Vec<&TraceResponseItem> = deliverable_q1
+            .iter()
+            .filter_map(|item| {
+                let tid = item.get("trace_id").and_then(|v| v.as_str())?;
+                traces_data.get(tid)
+            })
+            .collect();
+
+        let deliverable: Vec<serde_json::Value> = partition_hits
+            .iter()
+            .map(|t| serde_json::to_value(t).unwrap_or(serde_json::Value::Null))
+            .collect();
+
+        let mut results = config::meta::search::Response::default();
+        for h in deliverable {
+            results.add_hit(&h);
+        }
+        results.set_total(total_across_partitions);
+        if !range_error.is_empty() {
+            results.function_error.push(range_error.clone());
+        }
+
+        let _ = sender
+            .send(Ok(StreamResponses::SearchResponse {
+                results,
+                streaming_aggs: false,
+                streaming_id: None,
+                time_offset: TimeOffset {
+                    start_time,
+                    end_time,
+                },
+            }))
+            .await;
+        let _ = sender.send(Ok(StreamResponses::Done)).await;
+        return;
+    }
+
     let _ = sender.send(Ok(StreamResponses::Done)).await;
+}
+
+/// Extract ORDER BY column name and direction from a `"<col> DESC|ASC"` expression.
+fn parse_order_expr(sql_order_expr: &str) -> (String, bool) {
+    let mut parts = sql_order_expr.split_whitespace();
+    let col = parts.next().unwrap_or("zo_sql_duration").to_string();
+    let is_desc = parts
+        .next()
+        .map(|d| d.to_uppercase() != "ASC")
+        .unwrap_or(true);
+    (col, is_desc)
+}
+
+/// Runs Q2a (per-trace aggregates) and Q2b (per-service breakdown) for a slice of Q1 hits,
+/// building the `TraceResponseItem` map.
+///
+/// `window_start` / `window_end` (microseconds) are the initial search window; they expand
+/// to cover actual span times reported by Q1.
+///
+/// Returns `Some(traces_data)` on success. On error the error is sent on `sender` and
+/// `None` is returned — callers should `return` immediately.
+#[allow(clippy::too_many_arguments)]
+async fn run_q2_for_traces(
+    q1_hits: &[serde_json::Value],
+    window_start: i64,
+    window_end: i64,
+    base_req: &config::meta::search::Request,
+    req_trace_id: &str,
+    org_id: &str,
+    stream_type: StreamType,
+    user_id: &str,
+    stream_name: &str,
+    sender: &mpsc::Sender<Result<StreamResponses, infra::errors::Error>>,
+    log_ctx: &str,
+) -> Option<HashMap<String, TraceResponseItem>> {
+    let mut q2_start = window_start;
+    let mut q2_end = window_end;
+    let mut traces_data: HashMap<String, TraceResponseItem> = HashMap::with_capacity(q1_hits.len());
+
+    for item in q1_hits {
+        let tid = item
+            .get("trace_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let trace_start_time =
+            json::get_int_value(item.get("trace_start_time").unwrap_or_default());
+        let trace_end_time = json::get_int_value(item.get("trace_end_time").unwrap_or_default());
+        if trace_start_time > 0 && trace_start_time / 1000 < q2_start {
+            q2_start = trace_start_time / 1000;
+        }
+        if trace_end_time > 0 && trace_end_time / 1000 + 1 > q2_end {
+            q2_end = trace_end_time / 1000 + 1;
+        }
+        if tid.is_empty() {
+            continue;
+        }
+        traces_data.insert(
+            tid.clone(),
+            TraceResponseItem {
+                trace_id: tid,
+                start_time: trace_start_time,
+                end_time: trace_end_time,
+                duration: 0,
+                spans: [0, 0],
+                service_name: Vec::new(),
+                first_event: serde_json::Value::Null,
+                llm_usage_tokens_input: json::get_int_value(
+                    item.get("llm_usage_details_input").unwrap_or_default(),
+                ),
+                llm_usage_tokens_output: json::get_int_value(
+                    item.get("llm_usage_details_output").unwrap_or_default(),
+                ),
+                llm_usage_tokens_total: json::get_int_value(
+                    item.get("llm_usage_details_total").unwrap_or_default(),
+                ),
+                llm_usage_cost_total: json::get_float_value(
+                    item.get("llm_cost_details_total").unwrap_or_default(),
+                ),
+                llm_input: item.get("llm_input").cloned(),
+            },
+        );
+    }
+
+    let sanitized_ids: Vec<String> = traces_data
+        .keys()
+        .map(|tid| {
+            tid.chars()
+                .filter(|c| c.is_ascii_hexdigit() || *c == '-')
+                .collect::<String>()
+        })
+        .filter(|tid| !tid.is_empty())
+        .collect();
+
+    let trace_ids_str = sanitized_ids.join("','");
+    let detail_sql = format!(
+        "SELECT trace_id, \
+            count(*) AS span_count, \
+            sum(CASE WHEN span_status = 'ERROR' THEN 1 ELSE 0 END) AS error_count, \
+            min(start_time) AS min_start_time, \
+            max(end_time) AS max_end_time, \
+            max(duration) AS max_duration, \
+            count(DISTINCT service_name) AS service_count, \
+            max(CASE WHEN reference_parent_span_id IS NULL OR reference_parent_span_id = '' THEN service_name END) AS root_service_name, \
+            max(CASE WHEN reference_parent_span_id IS NULL OR reference_parent_span_id = '' THEN operation_name END) AS root_operation_name, \
+            first_value(service_name ORDER BY {TIMESTAMP_COL_NAME} ASC) AS first_service_name, \
+            first_value(operation_name ORDER BY {TIMESTAMP_COL_NAME} ASC) AS first_operation_name \
+         FROM \"{stream_name}\" WHERE trace_id IN ('{trace_ids_str}') GROUP BY trace_id"
+    );
+
+    let mut req2 = base_req.clone();
+    req2.query.sql = detail_sql;
+    req2.query.from = 0;
+    req2.query.size = traces_data.len() as i64;
+    req2.query.start_time = q2_start;
+    req2.query.end_time = q2_end;
+
+    let mut multi_service_tids: Vec<String> = Vec::new();
+    let mut multi_service_total: i64 = 0;
+
+    if sender.is_closed() {
+        return None;
+    }
+    let detail_res = match SearchService::cache::search(
+        req_trace_id,
+        org_id,
+        stream_type,
+        Some(user_id.to_string()),
+        &req2,
+        "".to_string(),
+        false,
+        None,
+        false,
+    )
+    .await
+    {
+        Ok(res) => res,
+        Err(e) => {
+            log::error!("[TRACES_STREAM trace_id {req_trace_id}] Q2a error ({log_ctx}): {e}");
+            let _ = sender.send(Err(e)).await;
+            return None;
+        }
+    };
+
+    for item in detail_res.hits {
+        let tid = item
+            .get("trace_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        if tid.is_empty() {
+            continue;
+        }
+        let span_count = json::get_int_value(item.get("span_count").unwrap_or_default());
+        let error_count = json::get_int_value(item.get("error_count").unwrap_or_default());
+        let min_start = json::get_int_value(item.get("min_start_time").unwrap_or_default());
+        let max_end = json::get_int_value(item.get("max_end_time").unwrap_or_default());
+        let max_duration = json::get_int_value(item.get("max_duration").unwrap_or_default());
+        let service_count = json::get_int_value(item.get("service_count").unwrap_or_default());
+        let root_service_name = item
+            .get("root_service_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let root_operation_name = item
+            .get("root_operation_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let first_service_name = item
+            .get("first_service_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let first_operation_name = item
+            .get("first_operation_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+
+        let event_service_name = if !root_service_name.is_empty() {
+            root_service_name
+        } else {
+            first_service_name
+        };
+        let event_operation_name = if !root_operation_name.is_empty() {
+            root_operation_name
+        } else {
+            first_operation_name
+        };
+
+        if let Some(trace) = traces_data.get_mut(&tid) {
+            trace.spans[0] = span_count.try_into().unwrap_or_default();
+            trace.spans[1] = error_count.try_into().unwrap_or_default();
+            if trace.start_time == 0 || trace.start_time > min_start {
+                trace.start_time = min_start;
+            }
+            if trace.end_time < max_end {
+                trace.end_time = max_end;
+            }
+            trace.duration = max_duration;
+            if trace.end_time - trace.start_time > trace.duration * 1000 {
+                trace.duration = (trace.end_time - trace.start_time) / 1000;
+            }
+            trace.first_event = serde_json::json!({
+                "service_name": event_service_name,
+                "operation_name": event_operation_name,
+            });
+            if service_count <= 1 {
+                if !event_service_name.is_empty() {
+                    trace.service_name.push(TraceServiceNameItem {
+                        service_name: event_service_name,
+                        count: span_count.try_into().unwrap_or_default(),
+                        duration: max_duration,
+                    });
+                }
+            } else {
+                multi_service_tids.push(tid);
+                multi_service_total += service_count;
+            }
+        }
+    }
+
+    if !multi_service_tids.is_empty() {
+        let multi_ids_str = multi_service_tids
+            .iter()
+            .map(|tid| {
+                tid.chars()
+                    .filter(|c| c.is_ascii_hexdigit() || *c == '-')
+                    .collect::<String>()
+            })
+            .filter(|tid| !tid.is_empty())
+            .collect::<Vec<String>>()
+            .join("','");
+        let svc_sql = format!(
+            "SELECT trace_id, service_name, count(*) AS svc_count, max(duration) AS svc_duration \
+             FROM \"{stream_name}\" WHERE trace_id IN ('{multi_ids_str}') \
+             GROUP BY trace_id, service_name"
+        );
+        let mut req3 = base_req.clone();
+        req3.query.sql = svc_sql;
+        req3.query.from = 0;
+        req3.query.size = multi_service_total;
+        req3.query.start_time = q2_start;
+        req3.query.end_time = q2_end;
+
+        if sender.is_closed() {
+            return None;
+        }
+        let svc_res = match SearchService::cache::search(
+            req_trace_id,
+            org_id,
+            stream_type,
+            Some(user_id.to_string()),
+            &req3,
+            "".to_string(),
+            false,
+            None,
+            false,
+        )
+        .await
+        {
+            Ok(res) => res,
+            Err(e) => {
+                log::error!("[TRACES_STREAM trace_id {req_trace_id}] Q2b error ({log_ctx}): {e}");
+                let _ = sender.send(Err(e)).await;
+                return None;
+            }
+        };
+        for item in svc_res.hits {
+            let tid = item
+                .get("trace_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let svc_name = item
+                .get("service_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let svc_count = json::get_int_value(item.get("svc_count").unwrap_or_default());
+            let svc_duration = json::get_int_value(item.get("svc_duration").unwrap_or_default());
+            if let Some(trace) = traces_data.get_mut(&tid) {
+                trace.service_name.push(TraceServiceNameItem {
+                    service_name: svc_name,
+                    count: svc_count.try_into().unwrap_or_default(),
+                    duration: svc_duration,
+                });
+            }
+        }
+    }
+
+    Some(traces_data)
 }
 
 #[derive(Debug, Serialize)]

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -627,6 +627,27 @@ pub async fn search_multi(
     Ok(multi_res)
 }
 
+/// Returns true when the query's primary ORDER BY column is not a timestamp column,
+/// meaning per-partition `hits_to_skip` is incorrect and the TopKHeap merge path
+/// must be used instead.
+///
+/// Only the first ORDER BY column is evaluated; secondary columns are not compared.
+/// Aggregate and histogram queries always return false.
+fn detect_non_ts_order_by(
+    order_by: &[(String, config::meta::sql::OrderBy)],
+    ts_column: Option<&str>,
+    is_aggregate: bool,
+    is_histogram: bool,
+) -> bool {
+    if is_aggregate || is_histogram {
+        return false;
+    }
+    order_by
+        .first()
+        .map(|(field, _)| field.as_str() != TIMESTAMP_COL_NAME && ts_column != Some(field.as_str()))
+        .unwrap_or(false)
+}
+
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(name = "service:search_partition", skip(req))]
 pub async fn search_partition(
@@ -893,6 +914,7 @@ pub async fn search_partition(
         #[cfg(feature = "enterprise")]
         streaming_id: None,
         is_histogram_eligible,
+        non_ts_order_by_cols: vec![],
     };
 
     let mut min_step = Duration::try_seconds(1)
@@ -1011,20 +1033,24 @@ pub async fn search_partition(
         })
         .unwrap_or(OrderBy::Desc);
 
-    if cfg.limit.disable_partitions_for_non_ts_order_by
-        && !is_aggregate
-        && !is_histogram
-        && sql
+    let is_non_ts_order_by = detect_non_ts_order_by(
+        &sql.order_by,
+        ts_column.as_deref(),
+        is_aggregate,
+        is_histogram,
+    );
+
+    if is_non_ts_order_by {
+        resp.non_ts_order_by_cols = sql
             .order_by
-            .first()
-            .map(|(field, _)| {
-                field.as_str() != TIMESTAMP_COL_NAME
-                    && (ts_column.as_deref() != Some(field.as_str()))
-            })
-            .unwrap_or(false)
-    {
+            .iter()
+            .map(|(col, dir)| (col.clone(), matches!(dir, config::meta::sql::OrderBy::Desc)))
+            .collect();
+    }
+
+    if cfg.limit.disable_partitions_for_non_ts_order_by && is_non_ts_order_by {
         log::info!(
-            "[trace_id {trace_id}] search_partition: ORDER BY on non-timestamp column, disabling partitioning"
+            "[trace_id {trace_id}] search_partition: non-ts ORDER BY, disabling partitions (circuit breaker)"
         );
         resp.partitions = vec![[req.start_time, req.end_time]];
         return Ok(resp);

--- a/src/service/search/streaming/execution.rs
+++ b/src/service/search/streaming/execution.rs
@@ -30,7 +30,7 @@ use tokio::sync::mpsc;
 use tracing::Instrument;
 
 use super::{
-    sorting::order_search_results,
+    sorting::{TopKHeap, order_search_results},
     utils::{calculate_progress_percentage, get_top_k_values},
 };
 #[cfg(feature = "enterprise")]
@@ -107,6 +107,27 @@ pub async fn do_partitioned_search(
         );
     }
 
+    let non_ts_order_by_cols = partition_resp.non_ts_order_by_cols.clone();
+    let is_non_ts_order_by = !non_ts_order_by_cols.is_empty();
+    let original_from = req.query.from as usize;
+    let original_size = if req.query.size > 0 {
+        req.query.size as usize
+    } else {
+        0
+    };
+
+    // Incremental top-k heap for non-ts ORDER BY: fed one partition at a time so the
+    // heap never holds more than k = (from + size) elements regardless of partition count.
+    let mut topk_heap = if is_non_ts_order_by {
+        Some(TopKHeap::new(
+            original_from + original_size,
+            &non_ts_order_by_cols,
+        ))
+    } else {
+        None
+    };
+    let mut non_ts_has_partial = false;
+
     // The order by for the partitions is the same as the order by in the query
     // unless the query is a dashboard or histogram
     let mut partition_order_by = req_order_by;
@@ -135,15 +156,19 @@ pub async fn do_partitioned_search(
         req.query.start_time = start_time;
         req.query.end_time = end_time;
 
-        if req_size != -1 && !is_streaming_aggs {
-            req.query.size -= curr_res_size;
+        if is_non_ts_order_by {
+            // each partition fetches local top-(from+size); leader merges globally after all
+            // partitions
+            req.query.size = (original_from + original_size) as i64;
+            req.query.from = 0;
+        } else {
+            if req_size != -1 && !is_streaming_aggs {
+                req.query.size -= curr_res_size;
+            }
+            // increase size to fetch hits_to_skip + requested hits; start from partition beginning
+            req.query.size += *hits_to_skip;
+            req.query.from = 0;
         }
-
-        // here we increase the size of the query to fetch requested hits in addition to the
-        // hits_to_skip we set the from to 0 to fetch the hits from the the beginning of the
-        // partition
-        req.query.size += *hits_to_skip;
-        req.query.from = 0;
 
         let trace_id = if partition_num == 1 {
             trace_id.to_string()
@@ -164,31 +189,33 @@ pub async fn do_partitioned_search(
 
         let mut total_hits = search_res.total as i64;
 
-        let skip_hits = std::cmp::min(*hits_to_skip, total_hits);
-        if skip_hits > 0 {
-            search_res.hits = search_res.hits[skip_hits as usize..].to_vec();
-            search_res.total = search_res.hits.len();
-            search_res.size = search_res.total as i64;
-            total_hits = search_res.total as i64;
-            *hits_to_skip -= skip_hits;
-            log::info!(
-                "[HTTP2_STREAM trace_id {trace_id}] Skipped {skip_hits} hits, remaining hits to skip: {hits_to_skip}, total hits for partition {idx}: {total_hits}",
-            );
-        }
-
-        if !is_streaming_aggs {
-            curr_res_size += total_hits;
-            if req_size > 0 && curr_res_size >= req_size {
-                log::info!(
-                    "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), truncating results",
-                );
-                let allowed = (req_size - (curr_res_size - total_hits)) as usize;
-                search_res.hits.truncate(allowed);
+        if !is_non_ts_order_by {
+            let skip_hits = std::cmp::min(*hits_to_skip, total_hits);
+            if skip_hits > 0 {
+                search_res.hits = search_res.hits[skip_hits as usize..].to_vec();
                 search_res.total = search_res.hits.len();
+                search_res.size = search_res.total as i64;
+                total_hits = search_res.total as i64;
+                *hits_to_skip -= skip_hits;
+                log::info!(
+                    "[HTTP2_STREAM trace_id {trace_id}] Skipped {skip_hits} hits, remaining hits to skip: {hits_to_skip}, total hits for partition {idx}: {total_hits}",
+                );
             }
-        }
 
-        search_res = order_search_results(search_res, fallback_order_by_col.clone());
+            if !is_streaming_aggs {
+                curr_res_size += total_hits;
+                if req_size > 0 && curr_res_size >= req_size {
+                    log::info!(
+                        "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), truncating results",
+                    );
+                    let allowed = (req_size - (curr_res_size - total_hits)) as usize;
+                    search_res.hits.truncate(allowed);
+                    search_res.total = search_res.hits.len();
+                }
+            }
+
+            search_res = order_search_results(search_res, fallback_order_by_col.clone());
+        }
 
         // set took for this partition only (not cumulative)
         search_res.set_took(start_timer.elapsed().as_millis() as usize);
@@ -207,7 +234,15 @@ pub async fn do_partitioned_search(
         }
 
         // Accumulate the result
-        if is_streaming_aggs {
+        if is_non_ts_order_by {
+            // Feed directly into the heap — never stores more than k hits in memory
+            if search_res.is_partial {
+                non_ts_has_partial = true;
+            }
+            if let Some(ref mut heap) = topk_heap {
+                heap.push_hits(std::mem::take(&mut search_res.hits));
+            }
+        } else if is_streaming_aggs {
             // Only accumulate the results of the last partition
             if idx == partitions.len() - 1 {
                 accumulated_results.push(SearchResultType::Search(search_res.clone()));
@@ -216,7 +251,7 @@ pub async fn do_partitioned_search(
             accumulated_results.push(SearchResultType::Search(search_res.clone()));
         }
 
-        // add top k values for values search
+        // reformat per-partition GROUP BY results into values API response shape
         if req.search_type == Some(SearchEventType::Values)
             && let Some(values_ctx) = values_ctx.as_ref()
         {
@@ -261,20 +296,23 @@ pub async fn do_partitioned_search(
             );
         }
 
-        // Send the cached response
-        let response = StreamResponses::SearchResponse {
-            results: search_res.clone(),
-            streaming_aggs: is_streaming_aggs,
-            streaming_id: partition_resp.streaming_id.clone(),
-            time_offset: TimeOffset {
-                start_time,
-                end_time,
-            },
-        };
+        // Send the cached response (skipped for non-ts ORDER BY — merged after all partitions
+        // complete)
+        if !is_non_ts_order_by {
+            let response = StreamResponses::SearchResponse {
+                results: search_res.clone(),
+                streaming_aggs: is_streaming_aggs,
+                streaming_id: partition_resp.streaming_id.clone(),
+                time_offset: TimeOffset {
+                    start_time,
+                    end_time,
+                },
+            };
 
-        if sender.send(Ok(response)).await.is_err() {
-            log::warn!("[trace_id {trace_id}] Sender is closed, stop sending response");
-            return Ok(());
+            if sender.send(Ok(response)).await.is_err() {
+                log::warn!("[trace_id {trace_id}] Sender is closed, stop sending response");
+                return Ok(());
+            }
         }
 
         // Send progress update
@@ -295,22 +333,95 @@ pub async fn do_partitioned_search(
                 return Ok(());
             }
         }
-        let stop_values_search = req_size != -1
-            && req_size != 0
-            && req.search_type == Some(SearchEventType::Values)
-            && curr_res_size >= req_size;
-        if stop_values_search {
-            log::info!(
-                "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), stopping search",
-            );
-            break;
+        if !is_non_ts_order_by {
+            let stop_values_search = req_size != -1
+                && req_size != 0
+                && req.search_type == Some(SearchEventType::Values)
+                && curr_res_size >= req_size;
+            if stop_values_search {
+                log::info!(
+                    "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), stopping search",
+                );
+                break;
+            }
+            // Stop if reached the requested result size and it is not a streaming aggs query
+            if req_size != -1 && req_size != 0 && curr_res_size >= req_size && !is_streaming_aggs {
+                log::info!(
+                    "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), stopping search",
+                );
+                break;
+            }
         }
-        // Stop if reached the requested result size and it is not a streaming aggs query
-        if req_size != -1 && req_size != 0 && curr_res_size >= req_size && !is_streaming_aggs {
-            log::info!(
-                "[HTTP2_STREAM trace_id {trace_id}] Reached requested result size ({req_size}), stopping search",
+    }
+
+    // For non-ts ORDER BY: drain the heap (already bounded to k elements) into the final result
+    if is_non_ts_order_by {
+        let merged = topk_heap
+            .take()
+            .map(|h| h.into_sorted_vec(original_from))
+            .unwrap_or_default();
+
+        let mut final_res = config::meta::search::Response::default();
+        final_res.hits = merged;
+        final_res.total = final_res.hits.len();
+        final_res.size = final_res.total as i64;
+
+        if non_ts_has_partial || !range_error.is_empty() {
+            final_res.is_partial = true;
+            if !range_error.is_empty() {
+                final_res.function_error = vec![range_error.clone()];
+                final_res.new_start_time = Some(modified_start_time);
+                final_res.new_end_time = Some(modified_end_time);
+            }
+        }
+
+        #[cfg(feature = "vectorscan")]
+        crate::service::search::cache::apply_regex_to_response(
+            req,
+            org_id,
+            stream_name,
+            stream_type,
+            &mut final_res,
+            trace_id,
+            "non_ts_order_by",
+        )
+        .await?;
+
+        if is_result_array_skip_vrl {
+            final_res.hits = crate::service::search::cache::apply_vrl_to_response(
+                backup_query_fn.clone(),
+                &mut final_res,
+                org_id,
+                stream_name,
+                trace_id,
             );
-            break;
+            final_res.total = final_res.hits.len();
+        }
+
+        accumulated_results.push(SearchResultType::Search(final_res.clone()));
+
+        let response = StreamResponses::SearchResponse {
+            results: final_res,
+            streaming_aggs: false,
+            streaming_id: None,
+            time_offset: TimeOffset {
+                start_time: modified_start_time,
+                end_time: modified_end_time,
+            },
+        };
+        if sender.send(Ok(response)).await.is_err() {
+            log::warn!(
+                "[trace_id {trace_id}] Sender is closed, stop sending non-ts ORDER BY response"
+            );
+            return Ok(());
+        }
+        if sender
+            .send(Ok(StreamResponses::Progress { percent: 100 }))
+            .await
+            .is_err()
+        {
+            log::warn!("[trace_id {trace_id}] Sender is closed, stop sending progress");
+            return Ok(());
         }
     }
 

--- a/src/service/search/streaming/sorting.rs
+++ b/src/service/search/streaming/sorting.rs
@@ -317,6 +317,10 @@ impl TopKHeap {
 }
 
 /// Wrapper around a JSON hit that implements `Ord` across all ORDER BY columns.
+///
+/// Direction-aware so that `Reverse<HeapHit>` always evicts the "current worst":
+/// - DESC col: ascending cmp → `Reverse` = min-heap → evicts smallest → keeps k largest
+/// - ASC  col: descending cmp → `Reverse` = min-heap → evicts largest → keeps k smallest
 struct HeapHit {
     hit: Value,
     cols: Vec<(String, bool, bool)>,
@@ -344,6 +348,7 @@ impl Ord for HeapHit {
             } else {
                 compare_string_values(&self.hit, &other.hit, col)
             };
+            // Flip direction for ASC so Reverse<HeapHit> evicts the largest (keeps k smallest).
             let ord = if *is_desc { ord } else { ord.reverse() };
             if ord != Ordering::Equal {
                 return ord;

--- a/src/service/search/streaming/sorting.rs
+++ b/src/service/search/streaming/sorting.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::{cmp::Ordering, collections::BinaryHeap};
+
 use config::{
     meta::{search::Response, sql::OrderBy},
     utils::json::Value,
@@ -207,6 +209,148 @@ fn determine_sort_column(first_hit: &Value) -> Option<(String, bool)> {
     }
     log::warn!("No suitable sort column found in results");
     None
+}
+
+/// Incremental top-k heap for merging hits across partitions.
+///
+/// Feed one partition at a time via `push_hits` — the heap never exceeds k elements
+/// regardless of how many partitions exist. Peak memory = k + one_partition_size,
+/// not total_partitions × partition_size.
+///
+/// Honors all N ORDER BY columns in order: primary sort first, secondary as tiebreaker,
+/// and so on — matching the SQL semantics of multi-column ORDER BY.
+pub struct TopKHeap {
+    heap: BinaryHeap<std::cmp::Reverse<HeapHit>>,
+    k: usize,
+    /// (col_name, is_descending, is_numeric) — is_numeric detected lazily from first non-null
+    /// value.
+    cols: Vec<(String, bool, Option<bool>)>,
+}
+
+impl TopKHeap {
+    /// `order_by_cols`: all ORDER BY columns as (name, is_descending), in query order.
+    /// `k=0` falls back to `ZO_QUERY_DEFAULT_LIMIT`.
+    pub fn new(k: usize, order_by_cols: &[(String, bool)]) -> Self {
+        let k = if k == 0 {
+            config::get_config().limit.query_default_limit as usize
+        } else {
+            k
+        };
+        Self {
+            heap: BinaryHeap::with_capacity(k + 1),
+            k,
+            cols: order_by_cols
+                .iter()
+                .map(|(col, desc)| (col.clone(), *desc, None))
+                .collect(),
+        }
+    }
+
+    /// Feed one partition's hits into the heap. Hits that don't make the top-k are
+    /// dropped immediately — only k elements are retained in memory at any time.
+    pub fn push_hits(&mut self, hits: Vec<Value>) {
+        for hit in hits {
+            for (col, _, is_numeric) in &mut self.cols {
+                if is_numeric.is_none()
+                    && let Some(v) = hit.get(col.as_str())
+                    && !v.is_null()
+                {
+                    *is_numeric = Some(v.is_number());
+                }
+            }
+
+            let resolved: Vec<(String, bool, bool)> = self
+                .cols
+                .iter()
+                .map(|(col, desc, is_num)| (col.clone(), *desc, is_num.unwrap_or(false)))
+                .collect();
+            let candidate = HeapHit {
+                hit,
+                cols: resolved,
+            };
+
+            if self.heap.len() < self.k {
+                self.heap.push(std::cmp::Reverse(candidate));
+            } else if let Some(std::cmp::Reverse(min)) = self.heap.peek()
+                && candidate > *min
+            {
+                self.heap.pop();
+                self.heap.push(std::cmp::Reverse(candidate));
+            }
+        }
+    }
+
+    /// Drain the heap into a sorted vec and apply the `from` offset.
+    pub fn into_sorted_vec(self, from: usize) -> Vec<Value> {
+        let cols: Vec<(String, bool, bool)> = self
+            .cols
+            .iter()
+            .map(|(col, desc, is_num)| (col.clone(), *desc, is_num.unwrap_or(false)))
+            .collect();
+
+        let mut result: Vec<Value> = self
+            .heap
+            .into_iter()
+            .map(|std::cmp::Reverse(h)| h.hit)
+            .collect();
+
+        result.sort_by(|a, b| {
+            for (col, is_desc, is_numeric) in &cols {
+                let ord = if *is_numeric {
+                    compare_numeric_values(a, b, col)
+                } else {
+                    compare_string_values(a, b, col)
+                };
+                let ord = if *is_desc { ord.reverse() } else { ord };
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+            }
+            Ordering::Equal
+        });
+
+        if from >= result.len() {
+            return vec![];
+        }
+        result[from..].to_vec()
+    }
+}
+
+/// Wrapper around a JSON hit that implements `Ord` across all ORDER BY columns.
+struct HeapHit {
+    hit: Value,
+    cols: Vec<(String, bool, bool)>,
+}
+
+impl PartialEq for HeapHit {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for HeapHit {}
+
+impl PartialOrd for HeapHit {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for HeapHit {
+    fn cmp(&self, other: &Self) -> Ordering {
+        for (col, is_desc, is_numeric) in &self.cols {
+            let ord = if *is_numeric {
+                compare_numeric_values(&self.hit, &other.hit, col)
+            } else {
+                compare_string_values(&self.hit, &other.hit, col)
+            };
+            let ord = if *is_desc { ord } else { ord.reverse() };
+            if ord != Ordering::Equal {
+                return ord;
+            }
+        }
+        Ordering::Equal
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Ports two fixes from main to `branch-v0.80.0`:

- **#11654** — correct pagination for `ORDER BY <non-timestamp col>` in `_search_stream`
- **#12134** — TopKHeap for non-ts `ORDER BY` in `latest_stream`

## Problem

Both `_search_stream` and `latest_stream` had three bugs when sorting by a non-timestamp column (e.g. `sort_by=duration`):

1. All partitions collapsed into one full-range scan (wrong results, memory risk)
2. Per-partition `hits_to_skip` logic assumed rows are time-ordered — globally k-th row can be in any partition
3. `fetch_size` capped at `query_default_limit` (1000), so top-k ranked on a truncated sample

## Fix

Mirrors the approach from the main branch PRs:

- `search_partition` detects non-ts ORDER BY and populates `non_ts_order_by_cols` on the response
- `do_partitioned_search` creates a `TopKHeap` bounded to `k = from + size`; each partition feeds its local top-k into the heap; after all partitions complete the heap is drained and sorted
- `latest_stream`: same heap approach — run Q1 across all partitions, push into heap, then run Q2 once on the merged top-k

## Changes

| File | What changed |
|---|---|
| `src/service/search/streaming/sorting.rs` | Added `TopKHeap` struct + `HeapHit` ord wrapper |
| `src/config/src/meta/search.rs` | Added `non_ts_order_by_cols` field to `SearchPartitionResponse` |
| `src/service/search/mod.rs` | Added `detect_non_ts_order_by()` helper; `search_partition` sets `non_ts_order_by_cols` |
| `src/service/search/streaming/execution.rs` | `do_partitioned_search` TopKHeap integration |
| `src/handler/http/request/traces/mod.rs` | `latest_stream` TopKHeap fix; extracted `run_q2_for_traces` helper |

## References

- openobserve/openobserve#11654 — `_search_stream` fix (main)
- openobserve/openobserve#12134 — `latest_stream` fix (main)