### PR TITLE
fix: prevent cross-type enrichment table name collision

### DIFF
--- a/src/handler/http/request/enrichment_table/mod.rs
+++ b/src/handler/http/request/enrichment_table/mod.rs
@@ -73,6 +73,28 @@ pub async fn save_enrichment_table(
         return MetaHttpResponse::bad_request(msg);
     }
 
+    // Reject if a URL enrichment already exists with this name
+    // to prevent cross-type silent overwrite
+    {
+        use config::{meta::stream::StreamType, utils::schema::format_stream_name};
+
+        use crate::{
+            common::infra::config::ENRICHMENT_TABLES,
+            service::db::enrichment_table::get_url_jobs_for_table,
+        };
+
+        let stream_name = format_stream_name(table_name.trim().to_string());
+        let key = format!("{org_id}/{}/{}", StreamType::EnrichmentTables, stream_name);
+        if ENRICHMENT_TABLES.contains_key(&key)
+            && let Ok(jobs) = get_url_jobs_for_table(&org_id, &stream_name).await
+            && !jobs.is_empty()
+        {
+            return MetaHttpResponse::bad_request(format!(
+                "Enrichment table [{table_name}] already exists as a URL enrichment. Use the URL enrichment API to update it."
+            ));
+        }
+    }
+
     let content_type = headers.get("content-type");
     let content_length = match headers.get("content-length") {
         None => 0.0,
@@ -286,6 +308,24 @@ pub async fn save_enrichment_table_from_url(
             return MetaHttpResponse::internal_error("Failed to check job status");
         }
     };
+
+    // Reject if a file upload enrichment already exists with this name
+    // to prevent cross-type silent overwrite. A file upload enrichment has
+    // data in ENRICHMENT_TABLES but no URL jobs. If the table exists in the
+    // cache but there are no URL jobs, it must be a file upload enrichment.
+    {
+        use config::{meta::stream::StreamType, utils::schema::format_stream_name};
+
+        use crate::common::infra::config::ENRICHMENT_TABLES;
+
+        let stream_name = format_stream_name(table_name.trim().to_string());
+        let key = format!("{org_id}/{}/{}", StreamType::EnrichmentTables, stream_name);
+        if ENRICHMENT_TABLES.contains_key(&key) && existing_jobs.is_empty() {
+            return MetaHttpResponse::bad_request(format!(
+                "Enrichment table [{table_name}] already exists as a file upload enrichment. Use the file upload API to update it."
+            ));
+        }
+    }
 
     // Check job statuses
     let has_processing = existing_jobs


### PR DESCRIPTION
## Summary
Bug fix for - https://github.com/openobserve/openobserve/issues/12247

- **Bug:** Creating a URL enrichment table with name `X`, then creating a file upload enrichment also named `X` (or vice versa), silently overwrites the first one at every storage layer.
- **Fix:** Added cross-type name collision checks at the API boundary. The file upload handler now rejects if a URL enrichment already exists with the same name, and the URL handler rejects if a file upload enrichment already exists. Same-type updates (append/retry/replace) are unaffected.


## Root Cause

Enrichment tables are uniquely identified by `(org_id, table_name)` across all storage layers — database, caches, object store, and coordinator keys. Both URL-based and file-upload enrichments share the same `StreamType::EnrichmentTables` and the same key space, so creating one with the same name as another silently clobbers the previous one.

## Changes

**1 file changed** — [src/handler/http/request/enrichment_table/mod.rs](src/handler/http/request/enrichment_table/mod.rs)

### `save_enrichment_table` (file upload handler)
Added check after input validation: if the table name already exists in `ENRICHMENT_TABLES` and has URL jobs, return `400` — "already exists as a URL enrichment."

### `save_enrichment_table_from_url` (URL handler)
Added check after fetching existing jobs: if the table name exists in `ENRICHMENT_TABLES` but has no URL jobs, return `400` — "already exists as a file upload enrichment."

### Behavior matrix

| | Existing: URL | Existing: File Upload | Existing: None |
|---|---|---|---|
| **Create File Upload** | ❌ Reject (400) | ✅ Allow (update) | ✅ Allow |
| **Create URL** | ✅ Allow (update) | ❌ Reject (400) | ✅ Allow |

## Test Plan

- [ ] Manually verify: create a URL enrichment named `test_cross_type` → attempt file upload with same name → should get 400 error
- [ ] Manually verify: create a file upload enrichment named `test_cross_type2` → attempt URL creation with same name → should get 400 error
- [ ] Manually verify: same-type updates still work (file→file append, URL→URL retry/replace)
- [ ] Playwright automation will be added in a follow-up PR in the `RegressionSet` folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)