### PR TITLE
fix: Logs fixed interesting field selection and field row selection

### DIFF
--- a/web/src/components/common/FieldExpansion.vue
+++ b/web/src/components/common/FieldExpansion.vue
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <template #trigger>
       <OFieldRow
         :data-test="`log-search-expand-${field.name}-field-btn`"
+        :highlight="isFieldSelected"
       >
         <span class="field-type-container">
           <OIcon
@@ -51,7 +52,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           size="icon"
           @click.stop="$emit('toggle-interesting', field, field.isInterestingField)"
         >
-          <OIcon :name="field.isInterestingField ? 'info' : 'info-outline'" size="sm" />
+          <OIcon :name="field.isInterestingField ? 'info-filled' : 'info-outline'" size="sm" />
         </OButton>
 
         <template #actions>
@@ -97,7 +98,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             size="icon"
             @click.stop="$emit('toggle-interesting', field, field.isInterestingField)"
           >
-            <OIcon :name="field.isInterestingField ? 'info' : 'info-outline'" size="sm" />
+            <OIcon :name="field.isInterestingField ? 'info-filled' : 'info-outline'" size="sm" />
           </OButton>
         </template>
       </OFieldRow>

--- a/web/src/components/common/FieldRow.vue
+++ b/web/src/components/common/FieldRow.vue
@@ -20,50 +20,73 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     v-if="(field.ftsKey && !showFtsFieldValues) || !field.isSchemaField || !field.showValues"
     :data-test="`logs-field-list-item-${field.name}`"
     class="tw:pl-[1.5rem]"
+    :highlight="isFieldSelected && field.name !== timestampColumn"
   >
     <OFieldLabel :field="field" :show-type-icon="false" />
-    <OIcon
+    <OButton
       :data-test="`log-search-index-list-interesting-${field.name}-field-btn`"
       v-if="showQuickMode && field.name !== timestampColumn"
-      :name="field.isInterestingField ? 'info' : 'info-outline'"
-      size="sm"
+      :name="field.isInterestingField ? 'info-filled' : 'info-outline'"
+      variant="ghost-neutral"
+      class="tw:gap-0! tw:mr-1"
+      size="icon"
       :title="
         field.isInterestingField
           ? 'Remove from interesting fields'
           : 'Add to interesting fields'
       "
-      class="tw:cursor-pointer tw:flex-shrink-0"
       @click.stop="$emit('toggle-interesting', field, field.isInterestingField)"
-    />
+    >
+      <OIcon :name="field.isInterestingField ? 'info-filled' : 'info-outline'" size="sm" />
+    </OButton>
 
     <template v-if="field.name !== timestampColumn" #actions>
       <OButton
         v-if="field.isSchemaField && field.name != timestampColumn"
-        variant="ghost-primary"
-        size="icon-xs-circle"
+        variant="ghost-neutral"
+        size="icon"
         :data-test="`log-search-index-list-filter-${field.name}-field-btn`"
         @click.stop="$emit('add-to-filter', `${field.name}=''`)"
       >
-        <OIcon name="add" size="xs" />
+        <OIcon name="add" size="sm" />
       </OButton>
-      <OIcon
+      <OButton
         :data-test="`log-search-index-list-add-${field.name}-field-btn`"
         v-if="showVisibilityToggle && !isFieldSelected && field.name !== timestampColumn"
-        name="visibility"
-        size="sm"
+        variant="ghost-neutral"
+        size="icon"
+        class="tw:gap-0!"
         title="Add field to table"
-        class="tw:cursor-pointer!"
         @click.stop="$emit('toggle-field', field)"
-      />
-      <OIcon
+      >
+        <OIcon name="visibility" size="sm" />
+      </OButton>
+      <OButton
         :data-test="`log-search-index-list-remove-${field.name}-field-btn`"
         v-if="showVisibilityToggle && isFieldSelected"
-        name="visibility-off"
-        size="sm"
+        variant="ghost-neutral"
+        class="tw:gap-0!"
+        size="icon"
         title="Remove field from table"
-        class="tw:cursor-pointer!"
         @click.stop="$emit('toggle-field', field)"
-      />
+      >
+        <OIcon name="visibility-off" size="sm" />
+      </OButton>
+      <OButton
+        :data-test="`log-search-index-list-interesting-${field.name}-field-btn`"
+        v-if="showQuickMode && field.name !== timestampColumn"
+        variant="ghost-neutral"
+        class="tw:gap-0!"
+        size="icon"
+        :title="
+          field.isInterestingField
+            ? 'Remove from interesting fields'
+            : 'Add to interesting fields'
+        "
+        @click.stop="$emit('toggle-interesting', field, field.isInterestingField)"
+      >
+        <OIcon :name="field.isInterestingField ? 'info-filled' : 'info-outline'" size="sm" />
+      </OButton>
     </template>
   </OFieldRow>
 

--- a/web/src/lib/core/Icon/OIcon.icons.ts
+++ b/web/src/lib/core/Icon/OIcon.icons.ts
@@ -61,6 +61,7 @@ import GroupWork from "~icons/material-symbols/group-work-outline";
 import Groups from "~icons/material-symbols/groups-outline";
 import HelpOutline from "~icons/material-symbols/help-outline";
 import History from "~icons/material-symbols/history";
+import InfoFilled from "~icons/material-symbols/info";
 import Info from "~icons/material-symbols/info-outline";
 import InfoOutline from "~icons/material-symbols/info-outline";
 import AccountTree from "~icons/material-symbols/account-tree-outline";
@@ -367,6 +368,7 @@ export const iconRegistry = {
   "help-outline": HelpOutline,
   "history": History,
   "info": Info,
+  "info-filled": InfoFilled,
   "info-outline": InfoOutline,
   "account-tree": AccountTree,
   "dark-mode": DarkMode,

--- a/web/src/lib/lists/FieldList/OFieldRow.vue
+++ b/web/src/lib/lists/FieldList/OFieldRow.vue
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <template>
   <div
     class="o-field-row tw:h-6 tw:flex tw:items-center tw:gap-1 tw:w-full tw:relative tw:rounded-[0.25rem] tw:hover:bg-field-list-row-hover-bg"
+    :class="[highlight && 'tw:bg-field-list-row-hover-bg!']"
   >
     <slot />
     <div v-if="$slots.actions" class="o-field-row__actions">
@@ -26,9 +27,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script setup lang="ts">
-// Shell component — provides consistent row height, hover background,
-// and an optional positioned action overlay for field list rows.
-// Slot consumers own their label content and hover actions independently.
+defineProps<{
+  highlight?: boolean
+}>()
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## What changed

Added a `highlight` prop to `OFieldRow.vue` that applies the `field-list-row-hover-bg` background color when set to `true`.

## Why

The field list UI in the logs/traces views needed to visually distinguish selected or active field rows from unselected ones. Previously there was no mechanism to highlight a row other than hover state.
