### PR TITLE
test: switch playwright CI runners from ubicloud to repo-openobserve

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -145,7 +145,7 @@ jobs:
     name: e2e / ${{ matrix.testfolder }}
     needs: [build_binary]
     runs-on:
-      labels: ubicloud-standard-8
+      labels: repo-openobserve-standard-8
     permissions:
       contents: read
       actions: read
@@ -816,7 +816,7 @@ jobs:
     needs: [ui_integration_tests]
     if: ${{ !cancelled() && needs.ui_integration_tests.result != 'skipped' }}
     runs-on:
-      labels: ubicloud-standard-8
+      labels: repo-openobserve-standard-8
     permissions:
       contents: read
       actions: read
@@ -1003,7 +1003,7 @@ jobs:
   playwright_summary:
     timeout-minutes: 5
     runs-on:
-      labels: ubicloud-standard-8
+      labels: repo-openobserve-standard-8
     permissions: {}
     needs: [check_changes, build_binary, ui_integration_tests, merge_and_upload_reports]
     if: always()


### PR DESCRIPTION
## Summary
- Switch `ui_integration_tests`, `merge_and_upload_reports`, and `playwright_summary` jobs from `ubicloud-standard-8` to `repo-openobserve-standard-8`
- `build_binary` remains on `ubicloud-standard-16` (unchanged)

## Test plan
- [ ] Verify CI triggers and jobs pick up the correct `repo-openobserve` runners
- [ ] Confirm `build_binary` still runs on ubicloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)