### PR TITLE
fix: snap histogram scan start down to bucket boundary to fix left-edge drop

### DIFF
--- a/src/service/search/datafusion/distributed_plan/node.rs
+++ b/src/service/search/datafusion/distributed_plan/node.rs
@@ -26,6 +26,7 @@ use proto::cluster_rpc::{IndexInfo, KvItem, QueryIdentifier, SearchInfo, SuperCl
 use crate::service::search::{
     index::IndexCondition,
     request::{FlightSearchRequest, Request},
+    sql::histogram::histogram_bucket_start,
 };
 
 pub struct RemoteScanNodes {
@@ -83,7 +84,16 @@ impl RemoteScanNodes {
                 .get(table_name)
                 .unwrap_or(&vec![])
                 .clone(),
-            start_time: self.req.time_range.as_ref().map(|x| x.0).unwrap_or(0),
+            start_time: {
+                let t = self.req.time_range.as_ref().map(|x| x.0).unwrap_or(0);
+                if self.req.histogram_interval > 0 {
+                    // Snap down to bucket boundary so date_bin()'s first bucket is fully populated.
+                    // histogram_interval is in seconds; convert to microseconds to match _timestamp.
+                    histogram_bucket_start(t, self.req.histogram_interval * 1_000_000)
+                } else {
+                    t
+                }
+            },
             end_time: self.req.time_range.as_ref().map(|x| x.1).unwrap_or(0),
             timeout: self.req.timeout as u64,
             use_cache: self.req.use_cache,

--- a/src/service/search/sql/histogram.rs
+++ b/src/service/search/sql/histogram.rs
@@ -21,6 +21,13 @@ use sqlparser::{
     parser::Parser,
 };
 
+/// Snaps `timestamp_us` down to the nearest histogram bucket boundary.
+/// Both arguments are in microseconds. Ensures the scan start aligns with
+/// `date_bin()` bucket boundaries so the first bucket is fully populated.
+pub fn histogram_bucket_start(timestamp_us: i64, interval_us: i64) -> i64 {
+    timestamp_us - timestamp_us % interval_us
+}
+
 /// Converts an original query to a histogram query
 /// Extracts WHERE clause and builds histogram query with provided stream name
 pub fn convert_to_histogram_query(


### PR DESCRIPTION
## Problem

Histogram panels showed a false drop in the **leftmost bucket**.

`histogram()` rewrites to `date_bin(interval, _timestamp, epoch)`, which assigns each record to the **left boundary** of its bucket. So a record at `08:10:17` gets key `08:10:00`.

But the scan filter was `_timestamp >= start_time` where `start_time` was the raw query time (e.g. `08:10:17`). Records in `[08:10:00, 08:10:17)` passed the bucket label check but were excluded from the scan — making the first bucket appear partially filled.

Fixes https://github.com/openobserve/o2-enterprise/issues/1753

## Fix

Snap `start_time` **down to the nearest bucket boundary** at the **leader node**, before it is broadcast to all follower nodes via `FlightSearchRequest`.

Location: `RemoteScanNodes::get_remote_node()` in `distributed_plan/node.rs`

```rust
start_time: {
    let t = self.req.time_range.as_ref().map(|x| x.0).unwrap_or(0);
    if self.req.histogram_interval > 0 {
        histogram_bucket_start(t, self.req.histogram_interval * 1_000_000)
    } else {
        t
    }
},
```

The arithmetic is extracted into `histogram_bucket_start(timestamp_us, interval_us)` in `sql/histogram.rs` so the formula lives in one place.

Doing the snap at the leader means all followers receive an already-aligned `start_time`, and covers both cluster leader and super cluster leader (both go through `get_remote_node()`).

## Test plan

- [ ] Deploy and run a histogram query spanning a non-aligned `start_time`
- [ ] Verify first bucket count matches adjacent full buckets
- [ ] Verify queries without `histogram_interval` are unaffected