### PR TITLE
fix(metrics): poll for invalid PromQL error indicator (enterprise CI fix)

### DIFF
--- a/tests/ui-testing/playwright-tests/Metrics/metrics.spec.js
+++ b/tests/ui-testing/playwright-tests/Metrics/metrics.spec.js
@@ -459,30 +459,32 @@ test.describe("Metrics testcases", () => {
     await pm.metricsPage.clickApplyButton();
     await pm.metricsPage.waitForMetricsResults();
 
-    // Check for inline error list rendered by DashboardErrors component
-    const inlineError = pm.metricsPage.getDashboardError();
-    const hasInlineError = await inlineError.isVisible({ timeout: 5000 }).catch(() => false);
+    // Poll for any graceful-handling indicator — CI (especially enterprise) can be slower to render
+    let hasInlineError = false;
+    let hasChartError = false;
+    let hasNoData = false;
 
-    // Check for chart-area error rendered by PanelSchemaRenderer
-    // This element is shown when errorDetail.message is set; at that point [data-test="no-data"]
-    // is intentionally hidden (v-if="!errorDetail?.message"), so we must check both paths.
-    const chartError = pm.metricsPage.getChartErrorMessage();
-    const hasChartError = await chartError.isVisible({ timeout: 3000 }).catch(() => false);
+    await expect.poll(async () => {
+      const inlineError = pm.metricsPage.getDashboardError();
+      hasInlineError = await inlineError.isVisible().catch(() => false);
 
-    // Check for no-data message (only present when there is no error detail)
-    const noDataMessage = await pm.metricsPage.getNoDataMessage();
-    const hasNoData = await noDataMessage.isVisible({ timeout: 3000 }).catch(() => false);
+      const chartError = pm.metricsPage.getChartErrorMessage();
+      hasChartError = await chartError.isVisible().catch(() => false);
+
+      const noDataMessage = await pm.metricsPage.getNoDataMessage();
+      hasNoData = await noDataMessage.isVisible().catch(() => false);
+
+      return hasInlineError || hasChartError || hasNoData;
+    }, { timeout: 10000, intervals: [500, 1000, 2000] }).toBe(true);
 
     testLogger.info(`Invalid query state: hasInlineError=${hasInlineError}, hasChartError=${hasChartError}, hasNoData=${hasNoData}`);
 
-    // System must handle invalid syntax gracefully - show error or no data
-    const handledGracefully = hasInlineError || hasChartError || hasNoData;
-    expect(handledGracefully).toBe(true);
-
     if (hasInlineError) {
+      const inlineError = pm.metricsPage.getDashboardError();
       const errorText = await inlineError.textContent().catch(() => '');
       testLogger.info(`Dashboard error displayed: ${errorText.substring(0, 100)}`);
     } else if (hasChartError) {
+      const chartError = pm.metricsPage.getChartErrorMessage();
       const errorText = await chartError.textContent().catch(() => '');
       testLogger.info(`Chart error displayed: ${errorText.substring(0, 100)}`);
     } else {


### PR DESCRIPTION
## Summary

- Fixes the `Invalid PromQL syntax error handling` test failing in enterprise CI
- Enterprise CI renders the no-data/error state slower than the 3s fixed timeout used previously
- Replaced `isVisible({ timeout: 3000})` with `expect.poll` (10s window, 500ms–2s intervals) so the assertion is real but tolerates CI rendering lag

## Root cause

When `sum(rate(` is entered and applied, the UI renders a no-data indicator asynchronously. Locally (enterprise) this appears in ~2s. In enterprise CI (slower hardware, more features enabled) it takes longer than 3s, causing all three indicator checks to return `false` before they appear.

## Test plan

- [x] Passes locally: `hasNoData=true` confirmed
- [ ] Enterprise CI Metrics shard goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)