### PR TITLE
test: fix clickScheduledSearchRow selector for logs-regression-ent tests

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -9481,14 +9481,15 @@ export class LogsPage {
     }
 
     /**
-     * Click a scheduled search row by its trace_id.
-     * @param {string} traceId - The trace_id of the scheduled search job
-     * @returns {Promise<boolean>} true if the row was clicked, false if not found
+     * Click a scheduled search row to expand it.
+     * OTable renders rows as data-test="o2-table-row-{index}" (not by trace_id),
+     * so we click the first visible row which triggers expand-on-row-click.
+     * @param {string} traceId - kept for API compatibility but not used for locating
      */
     async clickScheduledSearchRow(traceId) {
-        const row = this.page.locator(`[data-test="search-scheduler-table-${traceId}-row"]`);
-        await row.waitFor({ state: 'visible', timeout: 10000 });
-        await row.locator('[data-test="search-scheduler-expand-btn"]').click();
+        const firstRow = this.page.locator('[data-test="o2-table-row-0"]');
+        await firstRow.waitFor({ state: 'visible', timeout: 30000 });
+        await firstRow.click();
         await this.page.waitForTimeout(3000);
     }
 


### PR DESCRIPTION
## Summary
- `clickScheduledSearchRow` in `logsPage.js` was waiting for `[data-test="search-scheduler-table-{traceId}-row"]` which never exists in the DOM
- `OTableBodyRow` renders rows as `data-test="o2-table-row-{index}"` (zero-based integer), not by trace_id
- Fixed to wait for `o2-table-row-0` (first row) and click it — the table has `expand-on-row-click="true"` so no separate expand button click is needed
- Timeout bumped from 10 s → 30 s to allow the API data fetch to complete

## Failing tests fixed
- `logs-regression-ent.spec.js` › No Undefined Length error after navigating Logs -> Scheduled Search -> Streams -> Logs (`@P0`)
- `logs-regression-ent.spec.js` › No console errors after navigating the reproduction path (`@P1`)

## Test plan
- [x] Both tests run and pass locally against the enterprise binary (`2 passed (1.0m)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)