### PR TITLE
fix:_search_multi_stream (streaming) multiple different histogram_int…

### DIFF
--- a/src/config/src/utils/query_select_utils.rs
+++ b/src/config/src/utils/query_select_utils.rs
@@ -325,6 +325,37 @@ pub fn replace_o2_custom_patterns(sql: &str) -> Result<String, String> {
     Ok(StringMatchReplacer::clean_sql_output(modified_sql))
 }
 
+/// Like `replace_o2_custom_patterns` but also returns the parsed AST so callers
+/// can run additional visitors without a second `Parser::parse_sql` call.
+pub fn parse_and_replace_o2_custom_patterns(
+    sql: &str,
+) -> Result<(String, Vec<sqlparser::ast::Statement>), String> {
+    use sqlparser::{dialect::GenericDialect, parser::Parser};
+
+    let mut statements =
+        Parser::parse_sql(&GenericDialect {}, sql).map_err(|e| format!("Parse error: {e}"))?;
+
+    if statements.is_empty() {
+        return Err("No statements found".to_string());
+    }
+
+    if sql.contains(O2_CUSTOM_SUFFIX) {
+        let mut replacer = StringMatchReplacer::new();
+        for statement in &mut statements {
+            let _ = replacer.pre_visit_statement(statement);
+        }
+        let modified_sql = statements
+            .iter()
+            .map(|stmt| stmt.to_string())
+            .collect::<Vec<_>>()
+            .join(";\n");
+        let modified_sql = StringMatchReplacer::clean_sql_output(modified_sql);
+        Ok((modified_sql, statements))
+    } else {
+        Ok((sql.to_string(), statements))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/service/search/sql/visitor/histogram_interval.rs
+++ b/src/service/search/sql/visitor/histogram_interval.rs
@@ -546,4 +546,64 @@ mod tests {
         assert_eq!(convert_histogram_interval_to_seconds("3hr").unwrap(), 10800);
         assert_eq!(convert_histogram_interval_to_seconds("1d").unwrap(), 86400);
     }
+
+    #[test]
+    fn test_different_time_ranges_produce_different_intervals() {
+        let hour = 3600 * 1_000_000_i64;
+        let sql = "SELECT histogram(_timestamp) FROM logs";
+
+        let parse = |sql: &str| {
+            sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+                .unwrap()
+                .pop()
+                .unwrap()
+        };
+
+        let mut statement = parse(sql);
+
+        // Full query range (1 hour) produces interval 30s
+        let mut v1 = HistogramIntervalVisitor::new((0, 1 * hour));
+        let _ = statement.visit(&mut v1);
+        assert_eq!(v1.interval, Some(30));
+
+        // Small partition range (2 minutes) produces interval 10s
+        let mut statement = parse(sql);
+        let mut v2 = HistogramIntervalVisitor::new((0, 2 * 60 * 1_000_000));
+        let _ = statement.visit(&mut v2);
+        assert_eq!(v2.interval, Some(10));
+
+        // Medium partition range (1 hour) produces interval 30s again
+        let mut statement = parse(sql);
+        let mut v3 = HistogramIntervalVisitor::new((0, 1 * hour));
+        let _ = statement.visit(&mut v3);
+        assert_eq!(v3.interval, Some(30));
+    }
+
+    #[test]
+    fn test_validate_adjust_preserves_valid_interval_regardless_of_time_range() {
+        let hour = 3600 * 1_000_000_i64;
+        let minute = 60 * 1_000_000_i64;
+
+        // When query.histogram_interval is preset (non-zero), validate_and_adjust
+        // should preserve it regardless of the time range
+        let preset = 30; // 30 seconds
+        assert_eq!(
+            validate_and_adjust_histogram_interval(preset, (0, 1 * hour)),
+            30
+        );
+        assert_eq!(
+            validate_and_adjust_histogram_interval(preset, (0, 2 * minute)),
+            30
+        );
+
+        let preset = 3600; // 1 hour
+        assert_eq!(
+            validate_and_adjust_histogram_interval(preset, (0, 1 * hour)),
+            3600
+        );
+        assert_eq!(
+            validate_and_adjust_histogram_interval(preset, (0, 2 * minute)),
+            3600
+        );
+    }
 }

--- a/src/service/search/sql/visitor/histogram_interval.rs
+++ b/src/service/search/sql/visitor/histogram_interval.rs
@@ -606,4 +606,48 @@ mod tests {
             3600
         );
     }
+
+    /// Simulates the streaming fix: pre-compute interval from the full query time range,
+    /// then verify that running the visitor over each partition's (smaller) time range
+    /// with that preset value produces the same interval every time.
+    #[test]
+    fn test_preset_interval_is_consistent_across_partitions() {
+        let hour = 3600 * 1_000_000_i64;
+        let sql = "SELECT histogram(_timestamp) FROM logs";
+
+        let parse = |sql: &str| {
+            sqlparser::parser::Parser::parse_sql(&GenericDialect {}, sql)
+                .unwrap()
+                .pop()
+                .unwrap()
+        };
+
+        // Step 1: pre-compute from full query range (mirrors mod.rs fix)
+        let full_range = (0_i64, 1 * hour);
+        let preset_interval = {
+            let mut stmt = parse(sql);
+            let mut v = HistogramIntervalVisitor::new(full_range);
+            let _ = stmt.visit(&mut v);
+            v.interval
+                .map(|i| validate_and_adjust_histogram_interval(i, full_range))
+                .unwrap_or(0)
+        };
+        assert_eq!(preset_interval, 30, "full-range interval should be 30s");
+
+        // Step 2: simulate three partitions with different time ranges;
+        // each uses the preset value — all must agree
+        let partitions: &[(i64, i64)] = &[
+            (0, 2 * 60 * 1_000_000),  // 2 min partition
+            (0, 15 * 60 * 1_000_000), // 15 min partition
+            (0, 1 * hour),            // full-range partition
+        ];
+
+        for &(start, end) in partitions {
+            let adjusted = validate_and_adjust_histogram_interval(preset_interval, (start, end));
+            assert_eq!(
+                adjusted, preset_interval,
+                "partition ({start},{end}) should preserve preset interval {preset_interval}, got {adjusted}"
+            );
+        }
+    }
 }

--- a/src/service/search/streaming/mod.rs
+++ b/src/service/search/streaming/mod.rs
@@ -42,6 +42,7 @@ use o2_enterprise::enterprise::{
     },
     log_patterns::{PatternAccumulator, PatternExtractionConfig},
 };
+use sqlparser::ast::VisitMut;
 use tokio::sync::mpsc;
 use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -55,7 +56,9 @@ use crate::{
     service::search::{
         cache as search_cache,
         inspector::{SearchInspectorFieldsBuilder, search_inspector_fields},
-        sql::Sql,
+        sql::visitor::histogram_interval::{
+            HistogramIntervalVisitor, validate_and_adjust_histogram_interval,
+        },
     },
 };
 #[cfg(feature = "enterprise")]
@@ -182,16 +185,27 @@ pub async fn process_search_stream_request(
     };
 
     if req.query.histogram_interval == 0 {
-        if let Ok(sql) = Sql::new(
-            &req.query.clone().into(),
-            &org_id,
-            stream_type,
-            req.search_type,
-        )
-        .await
-        {
-            if let Some(interval) = sql.histogram_interval {
-                req.query.histogram_interval = interval;
+        match sqlparser::parser::Parser::parse_sql(
+            &sqlparser::dialect::GenericDialect {},
+            &req.query.sql,
+        ) {
+            Ok(mut stmts) => {
+                if let Some(mut stmt) = stmts.pop() {
+                    let mut visitor =
+                        HistogramIntervalVisitor::new((req.query.start_time, req.query.end_time));
+                    let _ = stmt.visit(&mut visitor);
+                    if let Some(interval) = visitor.interval {
+                        req.query.histogram_interval = validate_and_adjust_histogram_interval(
+                            interval,
+                            (req.query.start_time, req.query.end_time),
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "[HTTP2_STREAM trace_id {trace_id}] failed to pre-compute histogram_interval, will recompute per-partition: {e}"
+                );
             }
         }
     }

--- a/src/service/search/streaming/mod.rs
+++ b/src/service/search/streaming/mod.rs
@@ -55,6 +55,7 @@ use crate::{
     service::search::{
         cache as search_cache,
         inspector::{SearchInspectorFieldsBuilder, search_inspector_fields},
+        sql::Sql,
     },
 };
 #[cfg(feature = "enterprise")]
@@ -179,6 +180,21 @@ pub async fn process_search_stream_request(
     if let Ok(sql) = config::utils::query_select_utils::replace_o2_custom_patterns(&req.query.sql) {
         req.query.sql = sql;
     };
+
+    if req.query.histogram_interval == 0 {
+        if let Ok(sql) = Sql::new(
+            &req.query.clone().into(),
+            &org_id,
+            stream_type,
+            req.search_type,
+        )
+        .await
+        {
+            if let Some(interval) = sql.histogram_interval {
+                req.query.histogram_interval = interval;
+            }
+        }
+    }
 
     let started_at = chrono::Utc::now().timestamp_micros();
     let start = Instant::now();

--- a/src/service/search/streaming/mod.rs
+++ b/src/service/search/streaming/mod.rs
@@ -18,7 +18,7 @@
 //! This module contains all the components for handling streaming search requests,
 //! including caching, execution, sorting, and utility functions.
 
-use std::{collections::HashMap, time::Instant};
+use std::{collections::HashMap, ops::ControlFlow, time::Instant};
 
 use config::{
     cluster::LOCAL_NODE,
@@ -180,20 +180,30 @@ pub async fn process_search_stream_request(
         );
     }
 
-    if let Ok(sql) = config::utils::query_select_utils::replace_o2_custom_patterns(&req.query.sql) {
-        req.query.sql = sql;
-    };
+    // Parse once: apply custom pattern replacement and pre-compute histogram_interval
+    // from the full query time range so all partition clones inherit a consistent value.
+    // Guard both checks to skip the parse entirely for non-histogram / non-custom queries.
+    let has_custom_patterns = req
+        .query
+        .sql
+        .contains(config::utils::query_select_utils::O2_CUSTOM_SUFFIX);
+    let needs_histogram = req.query.histogram_interval == 0 && req.query.sql.contains("histogram(");
 
-    if req.query.histogram_interval == 0 {
-        match sqlparser::parser::Parser::parse_sql(
-            &sqlparser::dialect::GenericDialect {},
+    if has_custom_patterns || needs_histogram {
+        match config::utils::query_select_utils::parse_and_replace_o2_custom_patterns(
             &req.query.sql,
         ) {
-            Ok(mut stmts) => {
-                if let Some(mut stmt) = stmts.pop() {
+            Ok((modified_sql, stmts)) => {
+                req.query.sql = modified_sql;
+                if needs_histogram {
                     let mut visitor =
                         HistogramIntervalVisitor::new((req.query.start_time, req.query.end_time));
-                    let _ = stmt.visit(&mut visitor);
+                    for mut stmt in stmts {
+                        match stmt.visit(&mut visitor) {
+                            ControlFlow::Continue(()) => {}
+                            ControlFlow::Break(()) => break, // histogram found, stop early
+                        }
+                    }
                     if let Some(interval) = visitor.interval {
                         req.query.histogram_interval = validate_and_adjust_histogram_interval(
                             interval,
@@ -204,7 +214,7 @@ pub async fn process_search_stream_request(
             }
             Err(e) => {
                 log::warn!(
-                    "[HTTP2_STREAM trace_id {trace_id}] failed to pre-compute histogram_interval, will recompute per-partition: {e}"
+                    "[HTTP2_STREAM trace_id {trace_id}] failed to parse SQL, histogram_interval will recompute per-partition: {e}"
                 );
             }
         }


### PR DESCRIPTION
## Issue

When `_search_multi_stream` processes a histogram query, streaming execution splits the time range into partitions. Each partition calls `do_search()` with its own (smaller) time range, causing `Sql::new_with_options()` to recompute `histogram_interval` via `generate_histogram_interval()` based on the **partition's** time range duration instead of the **original query's** time range.

Since different partitions have different time range durations, each gets a different auto-generated histogram interval (e.g. 10s for a small partition, 30s for the full range). This produces inconsistent bucket boundaries across partitions in the streaming response.

The non-streaming `_search_multi` endpoint does not have this issue because it searches the entire time range as a single unit.

### Root cause

In `src/service/search/streaming/mod.rs`, `process_search_stream_request()` enters either:
- the **cache path**: `handle_cache_responses_and_deltas()` → `process_delta()` → per-partition `do_search()`
- the **no-cache path**: `do_partitioned_search()` → per-partition `do_search()`

In both paths, each partition clones `req` with a narrowed `start_time`/`end_time`, so when `do_search()` creates a fresh `Sql` struct, `histogram_interval` is 0 and `Sql::new_with_options()` recomputes it from the partition's (shorter) time range.

### Fix

Before either path is entered, parse the SQL once with `HistogramIntervalVisitor` using the **full query time range** and set the resulting interval on `req.query.histogram_interval`. All subsequent partition clones inherit this value, and `Sql::new_with_options()` takes the `query.histogram_interval > 0` branch — using the preset value instead of recomputing from the partition range.