### PR TITLE
fix: create default ingestion token for existing orgs

### DIFF
--- a/src/handler/http/request/organization/ingestion_tokens.rs
+++ b/src/handler/http/request/organization/ingestion_tokens.rs
@@ -31,7 +31,7 @@ use crate::{
     service::ingestion_tokens,
 };
 
-/// List all org-level ingestion tokens (masked).
+/// List all org-level ingestion tokens.
 ///
 /// GET /{org_id}/ingestion-tokens
 #[utoipa::path(
@@ -41,7 +41,7 @@ use crate::{
     tag = "Organizations",
     operation_id = "ListOrgIngestionTokens",
     summary = "List org-level ingestion tokens",
-    description = "Returns all org-level ingestion tokens for the organization. Token values are masked. Any authenticated user in the organization can access this.",
+    description = "Returns all org-level ingestion tokens for the organization. Any authenticated user in the organization can access this.",
     security(
         ("Authorization"= [])
     ),

--- a/src/service/ingestion_tokens.rs
+++ b/src/service/ingestion_tokens.rs
@@ -43,24 +43,11 @@ pub async fn create_default_token(org_id: &str, created_by: &str) -> Result<(), 
 /// is auto-generated and returned so the org always has at least one
 /// ingestion token.
 pub async fn list_tokens(org_id: &str) -> Result<Vec<OrgIngestionToken>, anyhow::Error> {
-    let records = db::org_ingestion_tokens::list_by_org(org_id).await?;
+    let mut records = db::org_ingestion_tokens::list_by_org(org_id).await?;
     if records.is_empty() {
         // No tokens exist (including disabled) — create a system default
         create_default_token(org_id, "system").await?;
-        let records = db::org_ingestion_tokens::list_by_org(org_id).await?;
-        let tokens = records
-            .into_iter()
-            .map(|r| OrgIngestionToken {
-                name: r.name,
-                token: r.token,
-                description: r.description,
-                is_default: r.is_default,
-                enabled: r.enabled,
-                created_by: r.created_by,
-                created_at: r.created_at,
-            })
-            .collect();
-        return Ok(tokens);
+        records = db::org_ingestion_tokens::list_by_org(org_id).await?;
     }
     let tokens = records
         .into_iter()

--- a/src/service/ingestion_tokens.rs
+++ b/src/service/ingestion_tokens.rs
@@ -38,8 +38,30 @@ pub async fn create_default_token(org_id: &str, created_by: &str) -> Result<(), 
 }
 
 /// List all tokens for an org.
+///
+/// If no tokens exist (including disabled), a system-created default token
+/// is auto-generated and returned so the org always has at least one
+/// ingestion token.
 pub async fn list_tokens(org_id: &str) -> Result<Vec<OrgIngestionToken>, anyhow::Error> {
     let records = db::org_ingestion_tokens::list_by_org(org_id).await?;
+    if records.is_empty() {
+        // No tokens exist (including disabled) — create a system default
+        create_default_token(org_id, "system").await?;
+        let records = db::org_ingestion_tokens::list_by_org(org_id).await?;
+        let tokens = records
+            .into_iter()
+            .map(|r| OrgIngestionToken {
+                name: r.name,
+                token: r.token,
+                description: r.description,
+                is_default: r.is_default,
+                enabled: r.enabled,
+                created_by: r.created_by,
+                created_at: r.created_at,
+            })
+            .collect();
+        return Ok(tokens);
+    }
     let tokens = records
         .into_iter()
         .map(|r| OrgIngestionToken {


### PR DESCRIPTION
Fixes https://github.com/openobserve/openobserve/issues/12407. Instead of running a migration, it creates the default ingestion token whenever the GET ingestion token api is called.