### PR TITLE
fix: correlation settings visibility, AI i18n prompts, and traces LLM/Sessions tab fixes

### DIFF
--- a/web/src/components/ai-assistant/welcome/CapabilityCards.vue
+++ b/web/src/components/ai-assistant/welcome/CapabilityCards.vue
@@ -18,9 +18,9 @@ const emit = defineEmits<{ (e: "select", prompt: string): void }>();
       tabindex="0"
       class="capability-card"
       :data-accent="card.id"
-      @click="emit('select', card.prompt)"
-      @keydown.enter.prevent="emit('select', card.prompt)"
-      @keydown.space.prevent="emit('select', card.prompt)"
+      @click="emit('select', t(`aiAssistant.capabilities.${card.id}.prompt`))"
+      @keydown.enter.prevent="emit('select', t(`aiAssistant.capabilities.${card.id}.prompt`))"
+      @keydown.space.prevent="emit('select', t(`aiAssistant.capabilities.${card.id}.prompt`))"
     >
       <span class="capability-card__glow" aria-hidden="true"></span>
       <div class="capability-card__icon" :class="card.iconBgClass">

--- a/web/src/components/ai-assistant/welcome/welcomeContent.ts
+++ b/web/src/components/ai-assistant/welcome/welcomeContent.ts
@@ -4,7 +4,7 @@
  */
 
 export interface CapabilityCard {
-  /** i18n key — under aiAssistant.capabilities.<id>.title */
+  /** i18n key — under aiAssistant.capabilities.<id>.{title,description,prompt} */
   id: "query" | "incident" | "dashboard" | "alert";
   /** OIcon registry name */
   icon: string;
@@ -12,8 +12,6 @@ export interface CapabilityCard {
   iconColorClass: string;
   /** Tailwind tinted background class for the icon chip */
   iconBgClass: string;
-  /** Pre-filled prompt to send when the card is clicked */
-  prompt: string;
 }
 
 export const CAPABILITY_CARDS: CapabilityCard[] = [
@@ -22,28 +20,24 @@ export const CAPABILITY_CARDS: CapabilityCard[] = [
     icon: "edit",
     iconColorClass: "tw:text-[#7B61FF]",
     iconBgClass: "tw:bg-[#7B61FF]/10",
-    prompt: "Help me write a query",
   },
   {
     id: "incident",
     icon: "warning",
     iconColorClass: "tw:text-[#F59E0B]",
     iconBgClass: "tw:bg-[#F59E0B]/10",
-    prompt: "Help me investigate an incident",
   },
   {
     id: "dashboard",
     icon: "dashboard",
     iconColorClass: "tw:text-[#10B981]",
     iconBgClass: "tw:bg-[#10B981]/10",
-    prompt: "Help me build a dashboard or panel",
   },
   {
     id: "alert",
     icon: "notifications",
     iconColorClass: "tw:text-[#EF4444]",
     iconBgClass: "tw:bg-[#EF4444]/10",
-    prompt: "Help me create an alert or pipeline",
   },
 ];
 

--- a/web/src/components/alerts/OrganizationDeduplicationSettings.vue
+++ b/web/src/components/alerts/OrganizationDeduplicationSettings.vue
@@ -239,17 +239,9 @@ const saveSettings = async () => {
 
   saving.value = true;
   try {
-    // Sanitize: convert empty string/NaN time_window_minutes to null
-    // Also normalise cross-alert fields: if org-level dedup is off, force
-    // sub-fields to their disabled state so the backend stays consistent.
     const rawWindow = localConfig.value.time_window_minutes;
-    const crossAlertEnabled = localConfig.value.enabled && localConfig.value.alert_dedup_enabled;
     const configToSave = {
       ...localConfig.value,
-      alert_dedup_enabled: crossAlertEnabled,
-      alert_fingerprint_groups: crossAlertEnabled
-        ? localConfig.value.alert_fingerprint_groups
-        : [],
       time_window_minutes:
         rawWindow == null || rawWindow === "" || isNaN(Number(rawWindow))
           ? null

--- a/web/src/components/alerts/OrganizationDeduplicationSettings.vue
+++ b/web/src/components/alerts/OrganizationDeduplicationSettings.vue
@@ -61,7 +61,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
 
       <!-- Cross-Alert Fingerprint Groups -->
-      <div class="tw:mb-6" v-if="localConfig.alert_dedup_enabled">
+      <div class="tw:mb-6" v-if="localConfig.enabled && localConfig.alert_dedup_enabled">
         <div class="tw:font-semibold tw:pb-2 tw:flex tw:items-center">
           {{ t('alerts.correlation.fingerprintGroups') }} <span class="tw:text-red-500 tw:ml-1">*</span>
           <OIcon
@@ -226,7 +226,7 @@ const emitUpdate = () => {
 
 const saveSettings = async () => {
   // Validate cross-alert dedup requires fingerprint groups
-  if (localConfig.value.alert_dedup_enabled) {
+  if (localConfig.value.enabled && localConfig.value.alert_dedup_enabled) {
     if (!localConfig.value.alert_fingerprint_groups ||
         localConfig.value.alert_fingerprint_groups.length === 0) {
       toast({
@@ -240,9 +240,16 @@ const saveSettings = async () => {
   saving.value = true;
   try {
     // Sanitize: convert empty string/NaN time_window_minutes to null
+    // Also normalise cross-alert fields: if org-level dedup is off, force
+    // sub-fields to their disabled state so the backend stays consistent.
     const rawWindow = localConfig.value.time_window_minutes;
+    const crossAlertEnabled = localConfig.value.enabled && localConfig.value.alert_dedup_enabled;
     const configToSave = {
       ...localConfig.value,
+      alert_dedup_enabled: crossAlertEnabled,
+      alert_fingerprint_groups: crossAlertEnabled
+        ? localConfig.value.alert_fingerprint_groups
+        : [],
       time_window_minutes:
         rawWindow == null || rawWindow === "" || isNaN(Number(rawWindow))
           ? null

--- a/web/src/components/settings/index.vue
+++ b/web/src/components/settings/index.vue
@@ -224,7 +224,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   :label="t('regex_patterns.title')"
                 />
                 <ORouteTab
-                  v-if="config.isEnterprise == 'true' && store.state.zoConfig.service_streams_enabled !== false"
+                  v-if="config.isEnterprise == 'true'"
                   data-test="correlation-settings-tab"
                   name="correlation_settings"
                   :to="{

--- a/web/src/locales/languages/de.json
+++ b/web/src/locales/languages/de.json
@@ -3890,19 +3890,23 @@
     "capabilities": {
       "query": {
         "title": "Schreiben Sie eine Anfrage",
-        "description": "SQL für Logs, Traces, RUM oder PromQL für Metriken."
+        "description": "SQL für Logs, Traces, RUM oder PromQL für Metriken.",
+        "prompt": "Hilf mir, eine Anfrage zu schreiben"
       },
       "incident": {
         "title": "Vorfälle untersuchen",
-        "description": "Ursache für Logs, Traces und Alerts — z. B. „Warum hat Gateway-5xx gezündet?“"
+        "description": "Ursache für Logs, Traces und Alerts — z. B. „Warum hat Gateway-5xx gezündet?“",
+        "prompt": "Hilf mir, einen Vorfall zu untersuchen"
       },
       "dashboard": {
         "title": "Erstellen Sie ein Dashboard",
-        "description": "Aus einem Thema — z. B. „Zustand des K8s-Knotens: CPU, Speicher, Neustarts“. Erstellt auch Panels."
+        "description": "Aus einem Thema — z. B. „Zustand des K8s-Knotens: CPU, Speicher, Neustarts“. Erstellt auch Panels.",
+        "prompt": "Hilf mir, ein Dashboard zu erstellen"
       },
       "alert": {
         "title": "Eine Warnung erstellen",
-        "description": "Schwellenwerte oder geplante Warnungen und VRL-Pipelines zum Zeitpunkt der Aufnahme."
+        "description": "Schwellenwerte oder geplante Warnungen und VRL-Pipelines zum Zeitpunkt der Aufnahme.",
+        "prompt": "Hilf mir, eine Warnung zu erstellen"
       }
     },
     "suggestions": {

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -2070,19 +2070,23 @@
     "capabilities": {
       "query": {
         "title": "Write a Query",
-        "description": "SQL for logs, traces, RUM, or PromQL for metrics."
+        "description": "SQL for logs, traces, RUM, or PromQL for metrics.",
+        "prompt": "Help me write a query"
       },
       "incident": {
         "title": "Investigate Incidents",
-        "description": "Root-cause across logs, traces, alerts — e.g. \"Why did gateway-5xx fire?\""
+        "description": "Root-cause across logs, traces, alerts — e.g. \"Why did gateway-5xx fire?\"",
+        "prompt": "Help me investigate an incident"
       },
       "dashboard": {
         "title": "Build a Dashboard",
-        "description": "From a topic — e.g. \"K8s node health: CPU, memory, restarts\". Also creates panels."
+        "description": "From a topic — e.g. \"K8s node health: CPU, memory, restarts\". Also creates panels.",
+        "prompt": "Help me build a dashboard or panel"
       },
       "alert": {
         "title": "Create an Alert",
-        "description": "Threshold or scheduled alerts, and ingest-time VRL pipelines."
+        "description": "Threshold or scheduled alerts, and ingest-time VRL pipelines.",
+        "prompt": "Help me create an alert or pipeline"
       }
     },
     "suggestions": {

--- a/web/src/locales/languages/es.json
+++ b/web/src/locales/languages/es.json
@@ -3888,19 +3888,23 @@
     "capabilities": {
       "query": {
         "title": "Escribe una consulta",
-        "description": "SQL para registros, seguimientos, RUM o PromQL para métricas."
+        "description": "SQL para registros, seguimientos, RUM o PromQL para métricas.",
+        "prompt": "Ayúdame a escribir una consulta"
       },
       "incident": {
         "title": "Investigue los incidentes",
-        "description": "Causa raíz en registros, rastreos y alertas, por ejemplo, «¿Por qué se activó Gateway-5xx?»"
+        "description": "Causa raíz en registros, rastreos y alertas, por ejemplo, «¿Por qué se activó Gateway-5xx?»",
+        "prompt": "Ayúdame a investigar los incidentes"
       },
       "dashboard": {
         "title": "Cree un tablero",
-        "description": "De un tema, por ejemplo, «Estado del nodo K8: CPU, memoria, reinicios». También crea paneles."
+        "description": "De un tema, por ejemplo, «Estado del nodo K8: CPU, memoria, reinicios». También crea paneles.",
+        "prompt": "Ayúdame a crear un tablero"
       },
       "alert": {
         "title": "Crear una alerta",
-        "description": "Alertas de umbral o programadas y canalizaciones de VRL de tiempo de ingesta."
+        "description": "Alertas de umbral o programadas y canalizaciones de VRL de tiempo de ingesta.",
+        "prompt": "Ayúdame a crear una alerta"
       }
     },
     "suggestions": {

--- a/web/src/locales/languages/fr.json
+++ b/web/src/locales/languages/fr.json
@@ -3890,19 +3890,23 @@
     "capabilities": {
       "query": {
         "title": "Rédiger une requête",
-        "description": "SQL pour les logs, les traces, RUM ou ProMQL pour les métriques."
+        "description": "SQL pour les logs, les traces, RUM ou ProMQL pour les métriques.",
+        "prompt": "Aide-moi à rédiger une requête"
       },
       "incident": {
         "title": "Étudier les incidents",
-        "description": "Cause première parmi les journaux, les traces et les alertes, par exemple « Pourquoi la passerelle -5xx s'est-elle déclenchée ? »"
+        "description": "Cause première parmi les journaux, les traces et les alertes, par exemple « Pourquoi la passerelle -5xx s'est-elle déclenchée ? »",
+        "prompt": "Aide-moi à étudier les incidents"
       },
       "dashboard": {
         "title": "Créez un tableau de bord",
-        "description": "À partir d'un sujet, par exemple « État du nœud K8s : processeur, mémoire, redémarrages ». Crée également des panneaux."
+        "description": "À partir d'un sujet, par exemple « État du nœud K8s : processeur, mémoire, redémarrages ». Crée également des panneaux.",
+        "prompt": "Aide-moi à créer un tableau de bord"
       },
       "alert": {
         "title": "Créer une alerte",
-        "description": "Alertes à seuil ou planifiées et pipelines VRL à durée d'ingestion."
+        "description": "Alertes à seuil ou planifiées et pipelines VRL à durée d'ingestion.",
+        "prompt": "Aide-moi à créer une alerte"
       }
     },
     "suggestions": {

--- a/web/src/locales/languages/it.json
+++ b/web/src/locales/languages/it.json
@@ -3899,19 +3899,23 @@
     "capabilities": {
       "query": {
         "title": "Scrivere una richiesta",
-        "description": "SQL per log, trace, RUM o ProMQL per le metriche."
+        "description": "SQL per log, trace, RUM o ProMQL per le metriche.",
+        "prompt": "Aiutami a scrivere una richiesta"
       },
       "incident": {
         "title": "Indagare sugli incidenti",
-        "description": "Causa principale nei log, nelle tracce e negli avvisi, ad esempio «Perché il gateway-5xx si è attivato?»"
+        "description": "Causa principale nei log, nelle tracce e negli avvisi, ad esempio «Perché il gateway-5xx si è attivato?»",
+        "prompt": "Aiutami a indagare sugli incidenti"
       },
       "dashboard": {
         "title": "Crea una dashboard",
-        "description": "Da un argomento, ad esempio «Stato del nodo K8s: CPU, memoria, riavvii». Crea anche pannelli."
+        "description": "Da un argomento, ad esempio «Stato del nodo K8s: CPU, memoria, riavvii». Crea anche pannelli.",
+        "prompt": "Aiutami a creare una dashboard o un pannello"
       },
       "alert": {
         "title": "Crea un avviso",
-        "description": "Avvisi di soglia o pianificati e pipeline VRL in fase di inserimento."
+        "description": "Avvisi di soglia o pianificati e pipeline VRL in fase di inserimento.",
+        "prompt": "Aiutami a creare un avviso o una pipeline"
       }
     },
     "suggestions": {

--- a/web/src/locales/languages/ja.json
+++ b/web/src/locales/languages/ja.json
@@ -3890,19 +3890,23 @@
     "capabilities": {
       "query": {
         "title": "クエリーを書く",
-        "description": "ログ用の SQL、トレース、RUM、またはメトリクス用の PromQL。"
+        "description": "ログ用の SQL、トレース、RUM、またはメトリクス用の PromQL。",
+        "prompt": "クエリーの作成を手伝ってください"
       },
       "incident": {
         "title": "インシデントを調査",
-        "description": "ログ、トレース、アラートにわたる根本原因 — 例:「なぜgateway-5xxが起動したのか?」"
+        "description": "ログ、トレース、アラートにわたる根本原因 — 例:「なぜgateway-5xxが起動したのか?」",
+        "prompt": "インシデントの調査を手伝ってください"
       },
       "dashboard": {
         "title": "ダッシュボードの作成",
-        "description": "トピックから — 例:「K8s ノードの状態:CPU、メモリ、再起動」パネルも作成します。"
+        "description": "トピックから — 例:「K8s ノードの状態:CPU、メモリ、再起動」パネルも作成します。",
+        "prompt": "ダッシュボードまたはパネルの作成を手伝ってください"
       },
       "alert": {
         "title": "アラートを作成",
-        "description": "しきい値またはスケジュールされたアラート、および取り込み時間の VRL パイプライン。"
+        "description": "しきい値またはスケジュールされたアラート、および取り込み時間の VRL パイプライン。",
+        "prompt": "アラートまたはパイプラインの作成を手伝ってください"
       }
     },
     "suggestions": {

--- a/web/src/locales/languages/ko.json
+++ b/web/src/locales/languages/ko.json
@@ -3901,19 +3901,23 @@
     "capabilities": {
       "query": {
         "title": "쿼리 작성",
-        "description": "로그, 트레이스, RUM용 SQL 또는 메트릭용 PromQL"
+        "description": "로그, 트레이스, RUM용 SQL 또는 메트릭용 PromQL",
+        "prompt": "쿼리 작성을 도와주세요"
       },
       "incident": {
         "title": "인시던트 조사",
-        "description": "로그, 트레이스, 경보의 근본 원인 (예: “게이트웨이 5xx가 왜 작동했나요?”)"
+        "description": "로그, 트레이스, 경보의 근본 원인 (예: “게이트웨이 5xx가 왜 작동했나요?”)",
+        "prompt": "인시던트 조사를 도와주세요"
       },
       "dashboard": {
         "title": "대시보드 구축",
-        "description": "주제 (예: “K8s 노드 상태: CPU, 메모리, 재시작”)또한 패널을 생성합니다."
+        "description": "주제 (예: “K8s 노드 상태: CPU, 메모리, 재시작”)또한 패널을 생성합니다.",
+        "prompt": "대시보드 또는 패널 구축을 도와주세요"
       },
       "alert": {
         "title": "알림 생성",
-        "description": "임계값 또는 예약된 알림, 인제스트 타임 VRL 파이프라인."
+        "description": "임계값 또는 예약된 알림, 인제스트 타임 VRL 파이프라인.",
+        "prompt": "알림 또는 파이프라인 생성을 도와주세요"
       }
     },
     "suggestions": {

--- a/web/src/locales/languages/nl.json
+++ b/web/src/locales/languages/nl.json
@@ -3901,19 +3901,23 @@
     "capabilities": {
       "query": {
         "title": "Een vraag schrijven",
-        "description": "SQL voor logboeken, traces, RUM of ProMQL voor statistieken."
+        "description": "SQL voor logboeken, traces, RUM of ProMQL voor statistieken.",
+        "prompt": "Help me een vraag te schrijven"
       },
       "incident": {
         "title": "Incidenten onderzoeken",
-        "description": "Oorzaak in logboeken, sporen, waarschuwingen — bijvoorbeeld „Waarom is gateway-5xx geactiveerd?”"
+        "description": "Oorzaak in logboeken, sporen, waarschuwingen — bijvoorbeeld „Waarom is gateway-5xx geactiveerd?”",
+        "prompt": "Help me incidenten te onderzoeken"
       },
       "dashboard": {
         "title": "Een dashboard bouwen",
-        "description": "Uit een onderwerp — bijvoorbeeld „K8s node health: CPU, memory, herstarts”. Creëert ook panelen."
+        "description": "Uit een onderwerp — bijvoorbeeld „K8s node health: CPU, memory, herstarts”. Creëert ook panelen.",
+        "prompt": "Help me een dashboard of paneel te bouwen"
       },
       "alert": {
         "title": "Een waarschuwing aanmaken",
-        "description": "Drempelwaarden of geplande waarschuwingen en VRL-pijplijnen die tijdens de looptijd worden gebruikt."
+        "description": "Drempelwaarden of geplande waarschuwingen en VRL-pijplijnen die tijdens de looptijd worden gebruikt.",
+        "prompt": "Help me een waarschuwing of pipeline aan te maken"
       }
     },
     "suggestions": {

--- a/web/src/locales/languages/pt.json
+++ b/web/src/locales/languages/pt.json
@@ -3890,19 +3890,23 @@
     "capabilities": {
       "query": {
         "title": "Escrever uma consulta",
-        "description": "SQL para registros, rastreamentos, RUM ou ProMQL para métricas."
+        "description": "SQL para registros, rastreamentos, RUM ou ProMQL para métricas.",
+        "prompt": "Ajude-me a escrever uma consulta"
       },
       "incident": {
         "title": "Investigue incidentes",
-        "description": "Causa raiz em registros, rastreamentos e alertas — por exemplo, “Por que o gateway-5xx foi acionado?”"
+        "description": "Causa raiz em registros, rastreamentos e alertas — por exemplo, “Por que o gateway-5xx foi acionado?”",
+        "prompt": "Ajude-me a investigar incidentes"
       },
       "dashboard": {
         "title": "Crie um painel",
-        "description": "De um tópico — por exemplo, “Integridade do nó K8s: CPU, memória, reinicializações”. Também cria painéis."
+        "description": "De um tópico — por exemplo, “Integridade do nó K8s: CPU, memória, reinicializações”. Também cria painéis.",
+        "prompt": "Ajude-me a criar um painel ou dashboard"
       },
       "alert": {
         "title": "Crie um alerta",
-        "description": "Alertas limitados ou programados e pipelines de VRL com tempo de ingestão."
+        "description": "Alertas limitados ou programados e pipelines de VRL com tempo de ingestão.",
+        "prompt": "Ajude-me a criar um alerta ou pipeline"
       }
     },
     "suggestions": {

--- a/web/src/locales/languages/tr.json
+++ b/web/src/locales/languages/tr.json
@@ -3901,19 +3901,23 @@
     "capabilities": {
       "query": {
         "title": "Bir Sorgu Yazın",
-        "description": "Günlükler için SQL, izler, ölçümler için RUM veya PromQL."
+        "description": "Günlükler için SQL, izler, ölçümler için RUM veya PromQL.",
+        "prompt": "Bir sorgu yazmama yardım et"
       },
       "incident": {
         "title": "Olayları Araştırın",
-        "description": "Günlükler, izler, uyarılar arasında kök neden — örn. “Gateway-5xx neden ateşlendi?”"
+        "description": "Günlükler, izler, uyarılar arasında kök neden — örn. “Gateway-5xx neden ateşlendi?”",
+        "prompt": "Olayları araştırmama yardım et"
       },
       "dashboard": {
         "title": "Bir Gösterge Tablosu Oluşturun",
-        "description": "Bir konudan — örn. “K8s düğüm durumu: CPU, bellek, yeniden başlatmalar”. Ayrıca paneller oluşturur."
+        "description": "Bir konudan — örn. “K8s düğüm durumu: CPU, bellek, yeniden başlatmalar”. Ayrıca paneller oluşturur.",
+        "prompt": "Bir gösterge tablosu veya panel oluşturmama yardım et"
       },
       "alert": {
         "title": "Uyarı Oluştur",
-        "description": "Eşik veya zamanlanmış uyarılar ve alım zamanı VRL boru hatları."
+        "description": "Eşik veya zamanlanmış uyarılar ve alım zamanı VRL boru hatları.",
+        "prompt": "Uyarı veya pipeline oluşturmama yardım et"
       }
     },
     "suggestions": {

--- a/web/src/locales/languages/zh.json
+++ b/web/src/locales/languages/zh.json
@@ -3894,19 +3894,23 @@
     "capabilities": {
       "query": {
         "title": "写一个查询",
-        "description": "SQL 用于日志、跟踪，RUM，或用于衡量指标的 PromQL。"
+        "description": "SQL 用于日志、跟踪，RUM，或用于衡量指标的 PromQL。",
+        "prompt": "帮我写一个查询"
       },
       "incident": {
         "title": "调查事件",
-        "description": "日志、跟踪、警报的根本原因，例如 “Gateway-5xx 为什么会触发？”"
+        "description": "日志、跟踪、警报的根本原因，例如 “Gateway-5xx 为什么会触发？”",
+        "prompt": "帮我调查一个事件"
       },
       "dashboard": {
         "title": "构建仪表板",
-        "description": "来自一个主题，例如 “K8s 节点运行状况：CPU、内存、重启”。还会创建面板。"
+        "description": "来自一个主题，例如 “K8s 节点运行状况：CPU、内存、重启”。还会创建面板。",
+        "prompt": "帮我构建一个仪表板或面板"
       },
       "alert": {
         "title": "创建警报",
-        "description": "阈值或预设警报，以及采集时间 VRL 管道。"
+        "description": "阈值或预设警报，以及采集时间 VRL 管道。",
+        "prompt": "帮我创建一个警报或管道"
       }
     },
     "suggestions": {

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -101,6 +101,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             class="tw:px-[0.625rem] tw:pb-[0.625rem] tw:h-full tw:overflow-hidden"
           >
             <LLMInsightsDashboard
+              :key="'llm-' + store.state.selectedOrganization.identifier"
               ref="llmInsightsRef"
               :streamName="selectedStreamName"
               :startTime="insightsTimeRange.startTime"
@@ -115,6 +116,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             class="tw:px-[0.625rem] tw:pb-[0.625rem] tw:h-full tw:overflow-hidden"
           >
             <SessionsList
+              :key="'sessions-' + store.state.selectedOrganization.identifier"
               ref="sessionsListRef"
               :streamName="selectedStreamName"
               :startTime="insightsTimeRange.startTime"
@@ -1605,14 +1607,6 @@ onBeforeMount(async () => {
   await importSqlParser();
   if (!searchObj.loading) {
     await loadPageData();
-    // If the restored tab requires LLM streams but this org has none, fall back to traces.
-    if (
-      (searchObj.meta.searchMode === "llm-insights" ||
-        searchObj.meta.searchMode === "sessions") &&
-      !hasLLMStreams.value
-    ) {
-      searchObj.meta.searchMode = "traces";
-    }
   }
 });
 
@@ -1646,14 +1640,6 @@ onActivated(async () => {
     resetSearchObj();
     restoreUrlQueryParams();
     await loadPageData();
-    // If the restored tab requires LLM streams but this org has none, fall back to traces.
-    if (
-      (searchObj.meta.searchMode === "llm-insights" ||
-        searchObj.meta.searchMode === "sessions") &&
-      !hasLLMStreams.value
-    ) {
-      searchObj.meta.searchMode = "traces";
-    }
   }
 });
 

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -1605,6 +1605,14 @@ onBeforeMount(async () => {
   await importSqlParser();
   if (!searchObj.loading) {
     await loadPageData();
+    // If the restored tab requires LLM streams but this org has none, fall back to traces.
+    if (
+      (searchObj.meta.searchMode === "llm-insights" ||
+        searchObj.meta.searchMode === "sessions") &&
+      !hasLLMStreams.value
+    ) {
+      searchObj.meta.searchMode = "traces";
+    }
   }
 });
 
@@ -1638,6 +1646,14 @@ onActivated(async () => {
     resetSearchObj();
     restoreUrlQueryParams();
     await loadPageData();
+    // If the restored tab requires LLM streams but this org has none, fall back to traces.
+    if (
+      (searchObj.meta.searchMode === "llm-insights" ||
+        searchObj.meta.searchMode === "sessions") &&
+      !hasLLMStreams.value
+    ) {
+      searchObj.meta.searchMode = "traces";
+    }
   }
 });
 

--- a/web/src/plugins/traces/LLMInsightsDashboard.vue
+++ b/web/src/plugins/traces/LLMInsightsDashboard.vue
@@ -16,14 +16,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div
-    class="llm-insights-dashboard tw:h-full tw:overflow-y-auto tw:px-[0.625rem] tw:pb-[0.625rem]"
+    class="llm-insights-dashboard tw:h-full tw:flex tw:flex-col tw:bg-[var(--o2-card-bg-solid)] card-container tw:px-[0.625rem]"
   >
-    <!-- Toolbar: stream selector. The page-level "Run query" button in the
-         top toolbar is the single source of refresh — picking a different
-         stream here auto-applies the change (same convention as the rest of
-         the Traces tabs), and changing the time range / clicking Run query
-         re-runs the panels via prop watchers below. -->
-    <div class="tw:flex tw:items-center tw:gap-[0.5rem] tw:py-[0.5rem]">
+    <!-- Toolbar: stream selector — hidden when no streams are available -->
+    <div
+      v-if="availableStreams.length > 0"
+      class="tw:flex tw:items-center tw:gap-[0.5rem] tw:py-[0.5rem]"
+    >
       <div
         data-test="llm-insights-stream-selector"
         class="tw:w-[14rem] tw:flex-shrink-0"
@@ -34,17 +33,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           labelKey="label"
           valueKey="value"
           class="tw:w-[auto] tw:flex-shrink-0 tw:rounded"
-          :disabled="availableStreams.length === 0"
           @update:model-value="onStreamChange"
         />
-        <OTooltip v-if="availableStreams.length === 0" content="No LLM streams available." />
       </div>
     </div>
 
     <!-- Streams list loaded but no LLM streams exist for this org. -->
     <div
       v-if="streamsLoaded && availableStreams.length === 0"
-      class="tw:flex tw:flex-col tw:items-center tw:justify-center tw:h-[320px] tw:text-center"
+      class="tw:flex-1 tw:flex tw:flex-col tw:items-center tw:justify-center tw:text-center"
     >
       <OIcon name="auto-awesome" class="tw:mb-3" style="width: 3rem; height: 3rem;" />
       <div class="tw:text-base tw:text-[var(--o2-text-primary)] tw:mb-2">
@@ -61,23 +58,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
     </div>
 
-    <!-- Skeleton shown only while a real request is in flight (initial
-         streams fetch or KPI/sparkline load). Prevents the post-tab-switch
-         "Failed to load" flash by not painting the error state until data
-         actually fails for the *current* mount. -->
-    <LLMInsightsSkeleton v-else-if="!streamsLoaded || loading" />
+    <!-- Skeleton shown only while a real request is in flight -->
+    <LLMInsightsSkeleton v-else-if="!streamsLoaded || loading" class="tw:flex-1" />
 
     <!-- Stream has no LLM (gen_ai_*) fields → friendly empty state -->
     <div
       v-else-if="streamHasNoLLMFields"
-      class="tw:flex tw:flex-col tw:items-center tw:justify-center tw:h-[300px]"
+      class="tw:flex-1 tw:flex tw:flex-col tw:items-center tw:justify-center tw:text-center"
     >
       <OIcon name="auto-awesome" class="tw:mb-3" style="width: 3rem; height: 3rem;" />
       <div class="tw:text-base tw:text-[var(--o2-text-primary)] tw:mb-2">
         No LLM data in <b>{{ activeStream }}</b>
       </div>
       <div
-        class="tw:text-sm tw:text-[var(--o2-text-muted)] tw:mb-3 tw:max-w-[28rem] tw:text-center"
+        class="tw:text-sm tw:text-[var(--o2-text-muted)] tw:mb-3 tw:max-w-[28rem]"
       >
         This stream doesn't have any LLM (<code>gen_ai_*</code>) fields. Pick a
         different stream above, or instrument your service with the OpenTelemetry
@@ -85,11 +79,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
     </div>
 
-    <!-- Generic error state — only after at least one successful mount-load
-         attempt has resolved. -->
+    <!-- Generic error state -->
     <div
       v-else-if="error && hasLoadedOnce"
-      class="tw:flex tw:flex-col tw:items-center tw:justify-center tw:h-[200px]"
+      class="tw:flex-1 tw:flex tw:flex-col tw:items-center tw:justify-center tw:text-center"
     >
       <OIcon name="error-outline" class="tw:mb-3" style="width: 3rem; height: 3rem;" />
       <div class="tw:text-base tw:mb-2">Failed to load LLM Insights</div>
@@ -104,10 +97,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </OButton>
     </div>
 
-    <!-- Empty state -->
+    <!-- Empty state — streams exist but no data in this time window -->
     <div
       v-else-if="hasLoadedOnce && !hasData"
-      class="tw:flex tw:flex-col tw:items-center tw:justify-center tw:h-[200px]"
+      class="tw:flex-1 tw:flex tw:flex-col tw:items-center tw:justify-center tw:text-center"
     >
       <OIcon name="info" class="tw:mb-3" style="width: 3rem; height: 3rem;" />
       <div class="tw:text-base tw:text-[var(--o2-text-muted)]">
@@ -115,8 +108,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
     </div>
 
-    <!-- Dashboard content -->
-    <template v-else>
+    <!-- Dashboard content — scrollable panel area -->
+    <div v-else class="tw:flex-1 tw:overflow-y-auto tw:pb-[0.625rem]">
       <!-- KPI Cards Row -->
       <div class="tw:grid tw:grid-cols-5 tw:gap-[0.625rem] tw:mt-[0.625rem] tw:mb-[0.625rem]">
         <div
@@ -177,7 +170,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           />
         </div>
       </div>
-    </template>
+    </div>
   </div>
 </template>
 

--- a/web/src/plugins/traces/SearchBar.vue
+++ b/web/src/plugins/traces/SearchBar.vue
@@ -79,10 +79,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             active selection isn't orphaned mid-session.
           -->
           <OToggleGroupItem
-            v-if="
-              config.showLLMUI !== 'false' &&
-              (hasLLMStreams || searchObj.meta.searchMode === 'sessions')
-            "
+            v-if="config.showLLMUI !== 'false'"
             data-test="traces-search-mode-sessions-btn"
             value="sessions"
             size="sm"
@@ -93,10 +90,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             Sessions
           </OToggleGroupItem>
           <OToggleGroupItem
-            v-if="
-              config.showLLMUI !== 'false' &&
-              (hasLLMStreams || searchObj.meta.searchMode === 'llm-insights')
-            "
+            v-if="config.showLLMUI !== 'false'"
             data-test="traces-search-mode-llm-insights-btn"
             value="llm-insights"
             size="sm"

--- a/web/src/plugins/traces/SessionsList.vue
+++ b/web/src/plugins/traces/SessionsList.vue
@@ -20,24 +20,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   >
     <!-- Toolbar: stream selector + count pill + pagination -->
     <div class="tw:flex tw:items-center tw:gap-2 tw:py-[0.625rem]">
-      <!-- Stream selector -->
+      <!-- Stream selector — hidden when there are no LLM streams (empty state is shown below) -->
       <div
+        v-if="availableStreams.length > 0"
         data-test="sessions-list-stream-selector"
         class="tw:w-[14rem] tw:flex-shrink-0"
       >
         <OSelect
           v-model="activeStream"
-          :options="
-            availableStreams.length > 0
-              ? availableStreams.map((s) => ({ label: s, value: s }))
-              : []
-          "
+          :options="availableStreams.map((s) => ({ label: s, value: s }))"
           size="sm"
           class="tw:w-[auto] tw:flex-shrink-0 tw:rounded"
           @update:model-value="onStreamChange"
-          :disabled="availableStreams.length === 0"
         />
-        <OTooltip v-if="availableStreams.length === 0" :content="t('traces.sessionsList.noStreamsTooltip')" />
       </div>
 
       <!-- Count pill -->


### PR DESCRIPTION
## Summary

Fixes openobserve/o2-enterprise#1850, openobserve/o2-enterprise#1851, openobserve/o2-enterprise#1852

- **Correlation Settings tab always visible for enterprise** (ent#1850): Removed unnecessary `service_streams_enabled` backend-flag guard from the sidebar nav item — the route was already registered for all enterprise builds, only the tab was incorrectly gated
- **Cross-alert fingerprint groups hidden when org-level dedup is off** (ent#1850): Fingerprint groups section now uses `v-if` tied to both `enabled` and `alert_dedup_enabled`; save payload also sanitizes `alert_fingerprint_groups` to `[]` when cross-alert dedup is disabled
- **AI suggestion cards use i18n prompts** (ent#1851): Capability card click/keydown handlers now call `t('aiAssistant.capabilities.{id}.prompt')` instead of the hardcoded English `card.prompt` field; `prompt` keys added to all 12 locale files that include the `aiAssistant` section
- **LLM Insights and Sessions tabs always visible** (ent#1852): Removed `hasLLMStreams` guard from both tab toggle buttons so they appear whenever `showLLMUI` is enabled — empty/no-stream states are handled inside each component
- **LLM Insights org-switch fix** (ent#1852): Added `:key` tied to org identifier on both `LLMInsightsDashboard` and `SessionsList` so Vue re-mounts them (and re-runs `onMounted` / `loadTraceStreams`) when the org changes
- **LLM Insights layout and background** (ent#1852): Root div now uses `card-container` + `--o2-card-bg-solid` to match Sessions; ghost stream-selector dropdown hidden when no streams exist; all empty states use `flex-1` flex layout instead of fixed heights

## Test plan
- [ ] Enable enterprise build (`VITE_OPENOBSERVE_ENTERPRISE=true`) and verify **Correlation Settings** appears under Management
- [ ] In Correlation Settings, disable org-level dedup → fingerprint groups section disappears; re-enable → reappears; save while disabled → payload has empty `alert_fingerprint_groups`
- [ ] Switch UI language (e.g. Japanese) and click an AI home suggestion card → prompt text sent to chat is in the selected language, not English
- [ ] In Traces page, switch to an org with no LLM streams → **LLM Insights** and **Sessions** tabs still visible; each shows its own empty state
- [ ] Switch orgs while on LLM Insights tab → page reloads data for the new org correctly
- [ ] LLM Insights background matches Sessions background (themed, not white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)