### PR TITLE
ci: publish aarch64-unknown-linux-musl release artifact (#12369)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
             features: "--features mimalloc"
             file_name: openobserve-${{ github.ref_name }}-linux-amd64-musl
             file_ext: .tar.gz
-          # - arch: aarch64-unknown-linux-musl
-          #   os: ubicloud-standard-8
-          #   features: "--features mimalloc"
-          #   file_name: openobserve-${{ github.ref_name }}-linux-arm64-musl
-          #   file_ext: .tar.gz
+          - arch: aarch64-unknown-linux-musl
+            os: ubicloud-standard-16-arm
+            features: "--features mimalloc"
+            file_name: openobserve-${{ github.ref_name }}-linux-arm64-musl
+            file_ext: .tar.gz
           - arch: aarch64-unknown-linux-gnu
             os: ubicloud-standard-16-arm
             features: "--features mimalloc"


### PR DESCRIPTION
## What

Re-enables the `aarch64-unknown-linux-musl` release target so we publish an `openobserve-<tag>-linux-arm64-musl.tar.gz` artifact. Closes #12369 (OSS portion).

## Why

A user requested an arm64 + musl build. The target was commented out in `release.yml` (since #1909, late 2023). This brings it back.

## The fix

The old commented entry ran on an **x86 runner** (`ubicloud-standard-8`) and cross-compiled. On that host the `Install Protoc for linux ARM` step (`contains(arch, 'aarch64-unknown-linux')`) installs an **aarch64 protoc** binary, which can't execute on x86 — `prost-build` invokes protoc at build time, so the build dies. That mismatch is the likely original "build trouble."

This PR instead builds arm64-musl on the **native ARM runner** (`ubicloud-standard-16-arm`), the same setup the working `aarch64-unknown-linux-gnu` artifact already uses, which sidesteps the host/target protoc problem.

Everything else is already in place:
- `.cargo/config.toml` already configures `[target.aarch64-unknown-linux-musl]` (linker + `+aes,+neon`)
- the `linux-musl` deps step already installs `musl-dev`/`musl-tools` + toolchain
- the ARM protoc step matches and runs natively
- OpenSSL-on-musl is already proven by the working `amd64-musl` build

## Verification

This only takes effect on the next `v*.*.*` tag, so it can't be exercised until a release runs the workflow. The matrix and YAML parse correctly and the new entry mirrors the arm64-gnu config.

## Note

This covers **OSS** only. The Enterprise arm64-musl build needs a separate change in the o2-enterprise pipeline.

