### PR TITLE
fix(tests): increase query_agent ingest timeout 120s → 300s

### DIFF
--- a/tests/api-testing/tests/query_agent/conftest.py
+++ b/tests/api-testing/tests/query_agent/conftest.py
@@ -274,6 +274,6 @@ def ingest_query_agent_data():
         thits = tr.json().get("hits", [])
         return bool(thits and thits[0].get("c", 0) >= 1)
 
-    wait_until(_data_is_searchable, timeout=120, interval=1.0,
+    wait_until(_data_is_searchable, timeout=300, interval=1.0,
                msg=f"{stream} data not searchable ({expected} records)")
     logging.info("%s data is searchable (%d records)", stream, expected)


### PR DESCRIPTION
## Summary
- ENT CI runner is slower than local — `ingest_query_agent_data` fixture was hitting the 120s timeout before 1550 records became searchable
- This caused all 310 query_agent tests to fail at setup (not during the actual test logic)
- Bumped `wait_until` timeout to 300s to match the slower environment

## Test plan
- [ ] OSS CI passes as before (already passing locally)
- [ ] ENT `oss_in_ent` shard no longer shows 310 WaitTimeout errors on query_agent tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)