### PR TITLE
fix: billing group icons follow applied theme color

### DIFF
--- a/web/src/enterprise/components/billings/BillingGroup.vue
+++ b/web/src/enterprise/components/billings/BillingGroup.vue
@@ -782,7 +782,7 @@ export default defineComponent({
     width: 100px;
     height: 100px;
     border-radius: 50%;
-    border: 1px dashed color-mix(in srgb, var(--o2-primary-color) 30%, transparent);
+    border: 1px dashed color-mix(in srgb, var(--color-primary-600) 30%, transparent);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -792,14 +792,14 @@ export default defineComponent({
     width: 68px;
     height: 68px;
     border-radius: 50%;
-    background: color-mix(in srgb, var(--o2-primary-color) 10%, transparent);
-    border: 1.5px solid color-mix(in srgb, var(--o2-primary-color) 24%, transparent);
+    background: color-mix(in srgb, var(--color-primary-600) 10%, transparent);
+    border: 1.5px solid color-mix(in srgb, var(--color-primary-600) 24%, transparent);
     display: flex;
     align-items: center;
     justify-content: center;
   }
   &__icon {
-    color: var(--o2-primary-color);
+    color: var(--color-primary-600);
     opacity: 0.85;
   }
   &__title {
@@ -874,9 +874,9 @@ export default defineComponent({
     font-size: 0.72rem;
     font-weight: 600;
     letter-spacing: 0.4px;
-    color: var(--o2-primary-color);
-    background: color-mix(in srgb, var(--o2-primary-color) 10%, transparent);
-    border: 1px solid color-mix(in srgb, var(--o2-primary-color) 25%, transparent);
+    color: var(--color-primary-600);
+    background: color-mix(in srgb, var(--color-primary-600) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--color-primary-600) 25%, transparent);
     padding: 4px 10px;
     border-radius: 20px;
     margin-bottom: 20px;
@@ -935,8 +935,8 @@ export default defineComponent({
     display: flex;
     align-items: center;
     justify-content: center;
-    background: color-mix(in srgb, var(--o2-primary-color) 10%, transparent);
-    color: var(--o2-primary-color);
+    background: color-mix(in srgb, var(--color-primary-600) 10%, transparent);
+    color: var(--color-primary-600);
   }
   &__content {
     flex: 1;

--- a/web/src/enterprise/components/billings/BillingGroup.vue
+++ b/web/src/enterprise/components/billings/BillingGroup.vue
@@ -124,10 +124,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 {{ payerName }}
                 <OTooltip side="bottom">
                   <template #content>
-                    <div v-if="membership?.payer_org_name">
+                    <div v-if="membership?.payer_org_name" class="tw:break-all">
                       {{ membership.payer_org_name }}
                     </div>
-                    <div class="tw:text-xs tw:opacity-70">
+                    <div class="tw:text-xs tw:opacity-70 tw:break-all">
                       {{ membership?.payer_org_id }}
                     </div>
                   </template>
@@ -890,8 +890,13 @@ export default defineComponent({
   }
   &__brand {
     color: var(--color-tabs-active-text);
-    word-break: break-word;
     cursor: pointer;
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
   }
   &__sub {
     font-size: 0.95rem;

--- a/web/src/enterprise/components/billings/plans.vue
+++ b/web/src/enterprise/components/billings/plans.vue
@@ -553,7 +553,7 @@ export default defineComponent({
     width: 100px;
     height: 100px;
     border-radius: 50%;
-    border: 1px dashed color-mix(in srgb, var(--o2-primary-color) 30%, transparent);
+    border: 1px dashed color-mix(in srgb, var(--color-primary-600) 30%, transparent);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -563,14 +563,14 @@ export default defineComponent({
     width: 68px;
     height: 68px;
     border-radius: 50%;
-    background: color-mix(in srgb, var(--o2-primary-color) 10%, transparent);
-    border: 1.5px solid color-mix(in srgb, var(--o2-primary-color) 24%, transparent);
+    background: color-mix(in srgb, var(--color-primary-600) 10%, transparent);
+    border: 1.5px solid color-mix(in srgb, var(--color-primary-600) 24%, transparent);
     display: flex;
     align-items: center;
     justify-content: center;
   }
   &__icon {
-    color: var(--o2-primary-color);
+    color: var(--color-primary-600);
     opacity: 0.85;
   }
   &__title {


### PR DESCRIPTION
## Summary

Follow-up to #12380 (feat: super org).

- `plans.vue` and `BillingGroup.vue` were using `--o2-primary-color` (hardcoded iris/blue `#575FC5`) for the new managed-billing and org-group hero UI introduced in the super org feature
- `--o2-primary-color` is a static constant — it is never updated by the theme system
- Replace all 13 occurrences with `--color-primary-600`, which is dynamically regenerated by `syncO2LibraryTokens()` in `utils/theme.ts` whenever the user selects a theme color

**Affected elements:**
- `plans.vue` — managed-billing empty state (bank icon circle + icon color), 4 spots
- `BillingGroup.vue` — standalone invite empty state icon, "Active" eyebrow badge, and the three membership fact cards (Invited By / Accepted By / Member Since) icon backgrounds + colors, 9 spots

## Test plan

- [ ] Apply a non-default theme color (e.g. green) and navigate to Billing → Plans as a child org — bank building icon and circle ring should match the theme color
- [ ] Navigate to Billing → Organization Group as a child org — "Active" eyebrow badge and the three sidebar fact-card icons should match the theme color
- [ ] Verify same views look correct with the default theme and in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)