### PR TITLE
fix: pass org_id explicitly in all AI agent requests

### DIFF
--- a/src/handler/http/request/ai/chat.rs
+++ b/src/handler/http/request/ai/chat.rs
@@ -297,6 +297,7 @@ pub async fn chat(Path(org_id): Path<String>, in_req: axum::extract::Request) ->
         let query_req = QueryRequest {
             query: last_user_message,
             context,
+            org_id: Some(org_id.clone()),
             model: if prompt_body.model.is_empty() {
                 None
             } else {
@@ -731,6 +732,7 @@ pub async fn chat_stream(Path(org_id): Path<String>, in_req: axum::extract::Requ
         let query_req = QueryRequest {
             query: last_user_message,
             context,
+            org_id: Some(org_id_str.clone()),
             model: if prompt_body.model.is_empty() {
                 None
             } else {


### PR DESCRIPTION
Self-hosted users on non-default orgs were getting a 401 from the AI assistant:

  Agent query failed: Query stream failed with status 401 Unauthorized:
  {"detail":"Authentication required. Please provide user_token for this agent."}

  Root cause: QueryRequest had no top-level org_id field. The org identifier was buried in the context JSON blob as a best-effort insertion — but only when context was already a non-null object. o2-ai's fallback
  chain (request.org_id → context.org_id → "default") would land on "default" whenever the context path was unavailable, causing every MCP tool call to hit /api/default/mcp regardless of the user's actual org. For
  users on a non-default org, the SA token is not valid for default, so OpenObserve returns 401.

  This was identified in issue [openobserve/o2-enterprise#1581 ](https://github.com/openobserve/o2-enterprise/issues/1581)as a required fix alongside the static MCP URL fix (merged in o2-ai PR #97)