### PR TITLE
fix(traces): preserve resource attributes during span flattening

### DIFF
--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -2035,10 +2035,7 @@ mod tests {
         let mut service_att_map: HashMap<String, json::Value> = HashMap::new();
         service_att_map.insert(super::SERVICE_NAME.to_string(), json!("serviceA"));
 
-        let key = super::span_attribute_key(
-            "service_name".to_string(),
-            &service_att_map,
-        );
+        let key = super::span_attribute_key("service_name".to_string(), &service_att_map);
 
         assert_eq!(key, "attr_service_name");
     }
@@ -2052,10 +2049,7 @@ mod tests {
         let mut service_att_map: HashMap<String, json::Value> = HashMap::new();
         service_att_map.insert("service.version".to_string(), json!("1.0.0"));
 
-        let key = super::span_attribute_key(
-            "service_version".to_string(),
-            &service_att_map,
-        );
+        let key = super::span_attribute_key("service_version".to_string(), &service_att_map);
 
         assert_eq!(key, "attr_service_version");
     }
@@ -2064,10 +2058,7 @@ mod tests {
     fn test_span_attribute_key_allows_non_colliding_attributes() {
         let service_att_map = std::collections::HashMap::new();
 
-        let key = super::span_attribute_key(
-            "http.method".to_string(),
-            &service_att_map,
-        );
+        let key = super::span_attribute_key("http.method".to_string(), &service_att_map);
 
         assert_eq!(key, "http.method");
     }

--- a/src/service/traces/mod.rs
+++ b/src/service/traces/mod.rs
@@ -87,15 +87,23 @@ const SERVICE: &str = "service";
 const PARENT_SPAN_ID: &str = "reference.parent_span_id";
 const PARENT_TRACE_ID: &str = "reference.parent_trace_id";
 const REF_TYPE: &str = "reference.ref_type";
-const BLOCK_FIELDS: [&str; 8] = [
-    TIMESTAMP_COL_NAME,
-    "duration",
+const RESERVED_SPAN_FIELDS: [&str; 16] = [
+    "trace_id",
+    "span_id",
+    "flags",
+    "span_status",
+    "span_kind",
+    "operation_name",
     "start_time",
     "end_time",
+    "duration",
     "service_name",
     inferred::INFER_SERVICE_NAME,
     inferred::INFER_SERVICE_TYPE,
     inferred::INFER_SERVICE_SYSTEM,
+    "events",
+    "links",
+    TIMESTAMP_COL_NAME,
 ];
 // ref https://opentelemetry.io/docs/specs/otel/trace/api/#retrieving-the-traceid-and-spanid
 const SPAN_ID_BYTES_COUNT: usize = 8;
@@ -137,6 +145,37 @@ fn normalize_llm_field_types(record_val: &mut Map<String, json::Value>) {
                     .unwrap_or_else(|| json::Number::from_f64(0.0).unwrap()),
             );
         }
+    }
+}
+
+fn normalized_trace_key(key: &str) -> String {
+    let mut key = key.to_string();
+    flatten::format_key(&mut key);
+    key
+}
+
+fn span_attribute_key(raw_key: String, service_att_map: &HashMap<String, json::Value>) -> String {
+    let normalized_key = normalized_trace_key(&raw_key);
+    let collides_with_reserved = RESERVED_SPAN_FIELDS.contains(&normalized_key.as_str());
+    let collides_with_resource = service_att_map
+        .keys()
+        .any(|service_key| normalized_trace_key(service_key) == normalized_key);
+
+    if collides_with_reserved || collides_with_resource {
+        format!("attr_{raw_key}")
+    } else {
+        raw_key
+    }
+}
+
+fn resource_attribute_key(raw_key: String) -> String {
+    let service_key = format!("{SERVICE}_{raw_key}");
+    let normalized_key = normalized_trace_key(&service_key);
+
+    if RESERVED_SPAN_FIELDS.contains(&normalized_key.as_str()) {
+        format!("{SERVICE}_attr_{raw_key}")
+    } else {
+        service_key
     }
 }
 
@@ -330,10 +369,8 @@ pub async fn handle_otlp_request(
                         }
                     }
                 } else {
-                    service_att_map.insert(
-                        format!("{}_{}", SERVICE, res_attr.key),
-                        get_val(&res_attr.value.as_ref()),
-                    );
+                    let key = resource_attribute_key(res_attr.key);
+                    service_att_map.insert(key, get_val(&res_attr.value.as_ref()));
                 }
             }
         }
@@ -372,10 +409,7 @@ pub async fn handle_otlp_request(
                 let end_time: u64 = span.end_time_unix_nano;
                 let mut span_att_map: HashMap<String, json::Value> = HashMap::new();
                 for span_att in span.attributes {
-                    let mut key = span_att.key;
-                    if BLOCK_FIELDS.contains(&key.as_str()) {
-                        key = format!("attr_{key}");
-                    }
+                    let key = span_attribute_key(span_att.key, &service_att_map);
                     span_att_map.insert(key, get_val(&span_att.value.as_ref()));
                 }
 
@@ -1599,17 +1633,21 @@ mod tests {
     // Test constants and validation logic
 
     #[test]
-    fn test_block_fields() {
-        let block_fields = &super::BLOCK_FIELDS;
-        assert_eq!(block_fields.len(), 8);
-        assert!(block_fields.contains(&"_timestamp"));
-        assert!(block_fields.contains(&"duration"));
-        assert!(block_fields.contains(&"start_time"));
-        assert!(block_fields.contains(&"end_time"));
-        assert!(block_fields.contains(&"service_name"));
-        assert!(block_fields.contains(&"infer_service_name"));
-        assert!(block_fields.contains(&"infer_service_type"));
-        assert!(block_fields.contains(&"infer_service_system"));
+    fn test_reserved_span_fields() {
+        let reserved_span_fields = &super::RESERVED_SPAN_FIELDS;
+        assert_eq!(reserved_span_fields.len(), 16);
+        assert!(reserved_span_fields.contains(&"_timestamp"));
+        assert!(reserved_span_fields.contains(&"duration"));
+        assert!(reserved_span_fields.contains(&"start_time"));
+        assert!(reserved_span_fields.contains(&"end_time"));
+        assert!(reserved_span_fields.contains(&"service_name"));
+        assert!(reserved_span_fields.contains(&"infer_service_name"));
+        assert!(reserved_span_fields.contains(&"infer_service_type"));
+        assert!(reserved_span_fields.contains(&"infer_service_system"));
+        assert!(reserved_span_fields.contains(&"trace_id"));
+        assert!(reserved_span_fields.contains(&"span_id"));
+        assert!(reserved_span_fields.contains(&"events"));
+        assert!(reserved_span_fields.contains(&"links"));
     }
 
     // Test validation helper functions
@@ -1646,7 +1684,7 @@ mod tests {
     #[test]
     fn test_blocked_field_transformation() {
         let blocked_field = "_timestamp";
-        let transformed = if super::BLOCK_FIELDS.contains(&blocked_field) {
+        let transformed = if super::RESERVED_SPAN_FIELDS.contains(&blocked_field) {
             format!("attr_{blocked_field}")
         } else {
             blocked_field.to_string()
@@ -1657,7 +1695,7 @@ mod tests {
     #[test]
     fn test_non_blocked_field_no_transformation() {
         let normal_field = "http.method";
-        let transformed = if super::BLOCK_FIELDS.contains(&normal_field) {
+        let transformed = if super::RESERVED_SPAN_FIELDS.contains(&normal_field) {
             format!("attr_{normal_field}")
         } else {
             normal_field.to_string()
@@ -1915,7 +1953,7 @@ mod tests {
         ];
 
         for key in test_keys {
-            let processed_key = if super::BLOCK_FIELDS.contains(&key) {
+            let processed_key = if super::RESERVED_SPAN_FIELDS.contains(&key) {
                 format!("attr_{key}")
             } else {
                 key.to_string()
@@ -1972,13 +2010,114 @@ mod tests {
         // Test non-service.name attribute (should get service_ prefix)
         if attr_key != super::SERVICE_NAME {
             service_att_map.insert(
-                format!("{}_{}", super::SERVICE, attr_key),
+                super::resource_attribute_key(attr_key.to_string()),
                 attr_value.clone(),
             );
         }
 
         assert!(service_att_map.contains_key("service_version"));
         assert_eq!(service_att_map.get("service_version").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn test_resource_attribute_key_preserves_canonical_service_name() {
+        let key = super::resource_attribute_key("name".to_string());
+
+        assert_eq!(key, "service_attr_name");
+    }
+
+    #[test]
+    fn test_span_attribute_key_preserves_resource_service_name() {
+        use std::collections::HashMap;
+
+        use config::utils::json;
+
+        let mut service_att_map: HashMap<String, json::Value> = HashMap::new();
+        service_att_map.insert(super::SERVICE_NAME.to_string(), json!("serviceA"));
+
+        let key = super::span_attribute_key(
+            "service_name".to_string(),
+            &service_att_map,
+        );
+
+        assert_eq!(key, "attr_service_name");
+    }
+
+    #[test]
+    fn test_span_attribute_key_preserves_resource_fields_after_normalization() {
+        use std::collections::HashMap;
+
+        use config::utils::json;
+
+        let mut service_att_map: HashMap<String, json::Value> = HashMap::new();
+        service_att_map.insert("service.version".to_string(), json!("1.0.0"));
+
+        let key = super::span_attribute_key(
+            "service_version".to_string(),
+            &service_att_map,
+        );
+
+        assert_eq!(key, "attr_service_version");
+    }
+
+    #[test]
+    fn test_span_attribute_key_allows_non_colliding_attributes() {
+        let service_att_map = std::collections::HashMap::new();
+
+        let key = super::span_attribute_key(
+            "http.method".to_string(),
+            &service_att_map,
+        );
+
+        assert_eq!(key, "http.method");
+    }
+
+    #[test]
+    fn test_service_name_collisions_preserve_canonical_service_name() {
+        use std::collections::HashMap;
+
+        use config::utils::{flatten, json};
+
+        use crate::common::meta::traces::Span;
+
+        let mut service_att_map: HashMap<String, json::Value> = HashMap::new();
+        service_att_map.insert(super::SERVICE_NAME.to_string(), json!("my.service1"));
+        service_att_map.insert(
+            super::resource_attribute_key("name".to_string()),
+            json!("my.service2"),
+        );
+
+        let mut span_att_map: HashMap<String, json::Value> = HashMap::new();
+        span_att_map.insert(
+            super::span_attribute_key("service_name".to_string(), &service_att_map),
+            json!("my.service3"),
+        );
+
+        let local_val = Span {
+            trace_id: "5b8efff798038103d269b633813fc60c".to_string(),
+            span_id: "eee19b7ec3c1b174".to_string(),
+            flags: 1,
+            span_status: "Ok".to_string(),
+            span_kind: "2".to_string(),
+            operation_name: "I'm a server span".to_string(),
+            start_time: 1780645897000000001,
+            end_time: 1780645909000000001,
+            duration: 12_000_000,
+            reference: HashMap::new(),
+            service_name: "my.service1".to_string(),
+            attributes: span_att_map,
+            service: service_att_map,
+            events: "[]".to_string(),
+            links: "[]".to_string(),
+        };
+
+        let value = json::to_value(local_val).unwrap();
+        let flattened = flatten::flatten(value).unwrap();
+        let record = flattened.as_object().unwrap();
+
+        assert_eq!(record.get("service_name").unwrap(), "my.service1");
+        assert_eq!(record.get("service_attr_name").unwrap(), "my.service2");
+        assert_eq!(record.get("attr_service_name").unwrap(), "my.service3");
     }
 
     // Test time validation boundary conditions


### PR DESCRIPTION
## Summary
- Preserve canonical/resource-derived trace fields when resource or span attributes collide with flattened span fields like `service_name`.
- Keep resource `service.name` as the canonical `service_name` while moving colliding resource fields such as resource `name` to `service_attr_name`.
- Prefix colliding span attributes with `attr_` before serde flattening.
- Add regression coverage for span/resource `service_name` collisions and normalized resource-field collisions.

Fixes #12448

## Testing
- `git diff --check`

Not run: cargo test, because this local environment does not have rustc/cargo installed.