### PR TITLE
perf: prune partitions in file_list query_by_ids via time range filter

### DIFF
--- a/src/cli/basic/bloom.rs
+++ b/src/cli/basic/bloom.rs
@@ -52,7 +52,7 @@ pub async fn inspect(file: &str) -> Result<(), anyhow::Error> {
     let name_by_id: HashMap<i64, String> = if all_ids.is_empty() {
         HashMap::new()
     } else {
-        match infra::file_list::query_by_ids(&all_ids).await {
+        match infra::file_list::query_by_ids(&all_ids, None).await {
             Ok(files) => files.into_iter().map(|f| (f.id, f.key)).collect(),
             Err(e) => {
                 eprintln!("warning: could not resolve file names from file_list: {e}");

--- a/src/infra/src/file_list/mod.rs
+++ b/src/infra/src/file_list/mod.rs
@@ -118,7 +118,11 @@ pub trait FileList: Sync + Send + 'static {
         stream_name: &str,
         date: &str,
     ) -> Result<Vec<FileKey>>;
-    async fn query_by_ids(&self, ids: &[i64]) -> Result<Vec<FileKey>>;
+    async fn query_by_ids(
+        &self,
+        ids: &[i64],
+        time_range: Option<(i64, i64)>,
+    ) -> Result<Vec<FileKey>>;
     async fn query_ids(
         &self,
         org_id: &str,
@@ -411,11 +415,11 @@ pub async fn query_for_bloom(
 
 #[inline]
 #[tracing::instrument(name = "infra:file_list:query_db_by_ids", skip_all)]
-pub async fn query_by_ids(ids: &[i64]) -> Result<Vec<FileKey>> {
+pub async fn query_by_ids(ids: &[i64], time_range: Option<(i64, i64)>) -> Result<Vec<FileKey>> {
     if ids.is_empty() {
         return Ok(Vec::default());
     }
-    CLIENT.query_by_ids(ids).await
+    CLIENT.query_by_ids(ids, time_range).await
 }
 
 #[inline]

--- a/src/infra/src/file_list/postgres.rs
+++ b/src/infra/src/file_list/postgres.rs
@@ -655,12 +655,28 @@ SELECT id, account, stream, date, file, records, index_size FROM file_list WHERE
         Ok(ret?.iter().map(|r| r.into()).collect())
     }
 
-    async fn query_by_ids(&self, ids: &[i64]) -> Result<Vec<FileKey>> {
+    async fn query_by_ids(
+        &self,
+        ids: &[i64],
+        time_range: Option<(i64, i64)>,
+    ) -> Result<Vec<FileKey>> {
         if ids.is_empty() {
             return Ok(Vec::default());
         }
         let mut ret = Vec::new();
         let pool = CLIENT_RO.clone();
+
+        // Derive a date filter from the time range to enable partition pruning.
+        // Without it, planning must open and lock every partition and execution
+        // probes every partition's id index. Measured on 2.7B rows / 384 daily
+        // partitions: ~110ms per call without the filter vs 1.2~2.9ms with it.
+        let date_filter = match time_range {
+            Some((time_start, time_end)) if time_start > 0 && time_end >= time_start => {
+                let (date_from, date_to) = derive_date_range(time_start, time_end);
+                format!(" AND date >= '{date_from}' AND date < '{date_to}'")
+            }
+            _ => String::new(),
+        };
 
         for chunk in ids.chunks(get_config().compact.file_list_deleted_batch_size) {
             if chunk.is_empty() {
@@ -672,7 +688,7 @@ SELECT id, account, stream, date, file, records, index_size FROM file_list WHERE
                 .collect::<Vec<String>>()
                 .join(",");
             let query_str = format!(
-                "SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, compressed_size, index_size, bloom_ver FROM file_list WHERE id IN ({ids})"
+                "SELECT id, account, stream, date, file, min_ts, max_ts, records, original_size, compressed_size, index_size, bloom_ver FROM file_list WHERE id IN ({ids}){date_filter}"
             );
             DB_QUERY_NUMS
                 .with_label_values(&["query_by_ids", "file_list"])

--- a/src/infra/src/file_list/sqlite.rs
+++ b/src/infra/src/file_list/sqlite.rs
@@ -531,7 +531,13 @@ SELECT id, account, stream, date, file, records, index_size FROM file_list WHERE
         Ok(ret?.iter().map(|r| r.into()).collect())
     }
 
-    async fn query_by_ids(&self, ids: &[i64]) -> Result<Vec<FileKey>> {
+    async fn query_by_ids(
+        &self,
+        ids: &[i64],
+        _time_range: Option<(i64, i64)>,
+    ) -> Result<Vec<FileKey>> {
+        // SQLite backend is not partitioned, the id lookup is already a single
+        // index probe; the time range filter is only useful for partition pruning.
         if ids.is_empty() {
             return Ok(Vec::default());
         }

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -119,7 +119,10 @@ pub async fn query_by_ids(
         (Vec::with_capacity(ids.len()), ids_set)
     } else {
         let start = std::time::Instant::now();
-        let cached_files = match infra_file_list::LOCAL_CACHE.query_by_ids(ids).await {
+        let cached_files = match infra_file_list::LOCAL_CACHE
+            .query_by_ids(ids, time_range)
+            .await
+        {
             Ok(files) => files,
             Err(e) => {
                 log::error!("[trace_id {trace_id}] file_list query cache failed: {e:?}");
@@ -163,7 +166,7 @@ pub async fn query_by_ids(
     // 2. query from remote db
     let start = std::time::Instant::now();
     let ids: Vec<_> = ids_set.iter().cloned().collect();
-    let mut db_files = infra_file_list::query_by_ids(&ids).await?;
+    let mut db_files = infra_file_list::query_by_ids(&ids, time_range).await?;
     log::info!(
         "{}",
         search_inspector_fields(


### PR DESCRIPTION
## Problem

`query_by_ids` runs `SELECT ... WHERE id IN (...)` with **no partition key filter**. On the partitioned `file_list` table this means:

- **planning** must open and lock **every** partition (~101ms on 384 partitions)
- **execution** probes **every** partition's id index (~10ms)

Measured on production-scale data (2.7B rows / 1.2TB / 384 daily partitions, PostgreSQL 17): **~110ms per call**, vs ~1.5ms on a non-partitioned table. `query_by_ids` is on the search hot path (id → FileKey reverse lookup), so every search pays this cost.

## Fix

The ids passed to `query_by_ids` are produced by `query_ids` **using a known time range** — the search path already holds it (`service::file_list::query_by_ids` already takes `time_range` but did not pass it down). This PR passes the range down to the infra layer and derives a `date` filter via the existing `derive_date_range`, enabling plan-time partition pruning:

```sql
SELECT ... FROM file_list WHERE id IN (...)
  AND date >= '2026/05/06/00' AND date < '2026/05/14/00'   -- new
```

## Benchmark

From the file_list partitioning performance test (2.7B rows, 384 daily partitions, c6i.8xlarge, PG 17.10, jit=off/work_mem=128MB/rpc=1.1/ANALYZEd). Same in-window batch of 1000 ids, median of 3 runs, total = execution + planning:

| Query window | Before (total) | After (total) | Improvement | Partitions scanned |
|---|---:|---:|---|---|
| 1h | 112.7ms (11.7 + 101.0) | **1.18ms** (0.82 + 0.36) | **95x** | 384 → 1 |
| 1d | 110.3ms (9.4 + 100.9) | **1.60ms** (0.97 + 0.62) | **69x** | 384 → 2 |
| 7d | 109.4ms (8.4 + 100.9) | **2.93ms** (0.79 + 2.14) | **37x** | 384 → 8 |

With the filter, the partitioned table matches or **beats** the non-partitioned baseline (execution 0.8~1.0ms vs 1.2~1.3ms — per-day partition id indexes are shallower than one monolithic 2.7B-row index).

## Safety

- **Semantically safe**: the ids were selected by `query_ids` with exactly the same derived date range, so the added filter cannot drop rows.
- **No side effect on non-partitioned tables**: measured 1.5ms → 1.7ms (within noise) on the single-table baseline.
- **Guarded**: the filter is only applied when `time_range` is `Some((start, end))` with `start > 0 && end >= start`; all other callers pass `None` and keep the previous behavior.
- SQLite backend ignores the parameter (not partitioned; already a single index probe).

## Changes

- `infra::file_list::FileList::query_by_ids` trait: add `time_range: Option<(i64, i64)>`
- postgres impl: derive and append the date filter when a valid range is given
- sqlite impl: accept and ignore the parameter
- `service::file_list::query_by_ids`: pass its existing `time_range` down (db + local cache)
- `cli::basic::bloom`: pass `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)