### PR TITLE
fix: promql federated search (#12468)

### DIFF
--- a/src/handler/grpc/request/metrics/querier.rs
+++ b/src/handler/grpc/request/metrics/querier.rs
@@ -121,10 +121,27 @@ impl Metrics for MetricsQuerier {
             req.query.as_ref().unwrap().label_selector,
         );
 
+        #[cfg(feature = "enterprise")]
+        let trace_id = req.job.as_ref().unwrap().trace_id.clone();
+
+        // Register trace_id in SEARCH_SERVER so selector_load_data_inner can
+        // insert_sender — without this the engine returns SearchCancelQuery
+        // immediately (same registration the `query` handler performs).
+        #[cfg(feature = "enterprise")]
+        if !SEARCH_SERVER.contain_key(&trace_id).await {
+            SEARCH_SERVER
+                .insert(trace_id.clone(), TaskStatus::new_follower(vec![], false))
+                .await;
+        }
+
         // spawn a task to push streaming responses
         tokio::task::spawn(async move {
             if let Err(e) = crate::service::promql::search::grpc::data(&req, tx).await {
                 log::error!("[gRPC:metrics:data] get data error: req:{req:?}, error:{e:?}")
+            }
+            #[cfg(feature = "enterprise")]
+            if !SEARCH_SERVER.is_leader(&trace_id).await {
+                SEARCH_SERVER.remove(&trace_id, false).await;
             }
         });
 


### PR DESCRIPTION
Fixes #12461
ref: https://github.com/openobserve/openobserve/pull/12468

## Problem

PromQL queries in a super-cluster returned data **only from the hub cluster** — remote (spoke) clusters were silently skipped. SQL queries across the same super-cluster worked correctly.

**Root cause:** The `data` gRPC handler on the spoke never registered the incoming `trace_id` in `SEARCH_SERVER`. When the PromQL engine called `insert_sender(trace_id)` to attach its abort channel, it found no entry and immediately returned `SearchCancelQuery` (error code 20009). The spoke returned empty data with no visible error — the hub received nothing from the spoke and returned only its local results.

The `query` gRPC handler already had the correct registration. The `data` handler was missing it.

## Fix

Before spawning the data fetch task on the spoke, the `data` gRPC handler now registers the incoming `trace_id` in `SEARCH_SERVER` as a follower task — exactly the same registration the `query` handler already performed. This allows the PromQL engine to successfully attach its abort sender and proceed with execution. After the task completes, the trace_id is removed from `SEARCH_SERVER` to avoid memory leaks.

## Test Queries

Ingest a metric with a distinguishing label to both hub and spoke, wait ~30s for WAL flush, then run:

**PromQL — before fix:** only hub cluster returned, spoke missing   **PromQL — after fix:** both hub and spoke returned

```bash
curl -s "http://<hub-host>/api/<org>/prometheus/api/v1/query_range" \
  -u '<user>:<pass>' \
  --data-urlencode "query=sum by (cluster) (total_payment_req)" \
  --data-urlencode "start=$(($(date +%s) - 3600))" \
  --data-urlencode "end=$(date +%s)" \
  --data-urlencode "step=60"
```

**SQL — works both before and after (baseline check):**

```bash
curl -s -X POST "http://<hub-host>/api/<org>/_search?type=metrics" \
  -H "Authorization: Basic <token>" \
  -H "Content-Type: application/json" \
  -d '{
    "query": {
      "sql": "SELECT cluster, SUM(value) as total FROM \"total_payment_req\" GROUP BY cluster",
      "start_time": '"$(($(date +%s) - 3600))"'000000,
      "end_time": '"$(date +%s)"'000000,
      "size": 10
    }
  }'
```