### PR TITLE
test: fix isQueryEditorExpanded selector and enableHistogram state detection

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -4290,8 +4290,10 @@ export class LogsPage {
     }
 
     async isQueryEditorExpanded() {
-        const container = this.page.locator(this.queryEditorContainer);
-        return await container.locator(this.expandOnFocusClass).count() > 0;
+        // editor-fullscreen is added to the container itself, not a child element.
+        // Use a combined selector (.query-editor-container.editor-fullscreen) instead of
+        // container.locator('.editor-fullscreen') which would search descendants only.
+        return await this.page.locator(`${this.queryEditorContainer}${this.expandOnFocusClass}`).count() > 0;
     }
 
     async toggleQueryEditorFullScreen() {
@@ -7592,10 +7594,11 @@ export class LogsPage {
      * Histogram toggle is now directly visible in the toolbar (moved out of utilities menu)
      */
     async enableHistogram() {
-        // If histogram canvas is already visible, nothing to do.
-        const canvas = this.page.locator(this.barChartCanvas);
-        const alreadyVisible = await canvas.isVisible({ timeout: 2000 }).catch(() => false);
-        if (alreadyVisible) {
+        // Use button checked-state detection, not canvas visibility.
+        // Canvas is absent before the first query runs, so visibility check
+        // would incorrectly toggle histogram OFF when it is already ON.
+        const isOn = await this.logsQueryPage.isHistogramOn();
+        if (isOn) {
             testLogger.info('Histogram already enabled');
             return;
         }


### PR DESCRIPTION
## Summary

- **Streams-Regression** — `isQueryEditorExpanded()` used `container.locator('.editor-fullscreen')` which searches *descendants*, but Vue adds `editor-fullscreen` directly to the container element itself. Fixed by using combined CSS selector `.query-editor-container.editor-fullscreen`.
- **Logs-Regression** — `enableHistogram()` checked canvas visibility to detect histogram state. Canvas is absent before the first query runs, so it always assumed histogram was OFF and toggled it OFF when it was already ON. This removed `[data-test="logs-search-result-bar-chart"]` from the DOM (it is `v-if`-gated), breaking `expectBarChartHasContent()`. Fixed by using `logsQueryPage.isHistogramOn()` (reads button `data-state` attribute), consistent with how `ensureHistogramState()` already works.

## Failing tests fixed
- `should allow query expand icon to work after navigating from stream explorer (#9337)` — Streams-Regression
- `should not show blank histogram after cancelling query @bug-4315` — Logs-Regression
- `collapsing/expanding index list should redraw histogram chart` — Logs-Regression

## Test plan
- [ ] Ran `streams-regression.spec.js --grep "9337"` locally — passes
- [ ] Ran `logs-regression-bugs.spec.js --grep "blank histogram after cancelling"` locally — passes
- [ ] Ran `logs-regression-bugs-2.spec.js --grep "collapsing/expanding index list"` locally — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)