### PR TITLE
chore: improve openobserve maintenance path

### DIFF
--- a/web/src/App.spec.ts
+++ b/web/src/App.spec.ts
@@ -26,8 +26,8 @@ describe('App.vue', () => {
   let wrapper: VueWrapper;
   let store: any;
   let router: any;
-  let mockDispatch: any;
-  let mockPush: any;
+  let mockDispatch: ReturnType<typeof vi.fn>;
+  let mockPush: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     // Reset mocks

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -50,16 +50,37 @@ reoInit();
 
 // app.use(SearchPlugin);
 
+interface ConfigResponse {
+  data?: {
+    telemetry_enabled?: boolean;
+    commit_hash?: string;
+    rum?: {
+      enabled: boolean;
+      client_token: string;
+      application_id: string;
+      site: string;
+      service: string;
+      env: string;
+      version?: string;
+      organization_identifier: string;
+      insecure_http?: boolean;
+      api_version?: string;
+    };
+  };
+}
+
 const getConfig = async () => {
-  await configService.get_config().then((res: any) => {
+  await configService.get_config().then((res: ConfigResponse) => {
+    if (!res.data) return;
+
     store.dispatch("setConfig", res.data);
-    config.enableAnalytics = res.data.telemetry_enabled.toString();
+    config.enableAnalytics = res.data.telemetry_enabled?.toString() ?? "false";
 
     // Store initial commit hash for version checking
     if (res.data.commit_hash) {
       buildVersionChecker.setInitialVersion(res.data.commit_hash);
     }
-    if (res.data.rum.enabled) {
+    if (res.data.rum?.enabled) {
       const options = {
         clientToken: res.data.rum.client_token,
         applicationId: res.data.rum.application_id,


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in web/src/main.ts, web/src/App.spec.ts related to TypeScript, frontend tooling, test stability, build fixes; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.