### PR TITLE
fix: prevent NATS lock keep-alive from resurrecting a purged lock (#12491)

### DIFF
--- a/src/infra/src/db/nats.rs
+++ b/src/infra/src/db/nats.rs
@@ -661,6 +661,7 @@ pub(crate) struct Locker {
     lock_id: String,
     state: Arc<AtomicU8>, // 0: init, 1: locking, 2: release
     tx: Option<mpsc::Sender<()>>,
+    keep_alive: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl Locker {
@@ -670,6 +671,7 @@ impl Locker {
             lock_id: ider::uuid(),
             state: Arc::new(AtomicU8::new(0)),
             tx: None,
+            keep_alive: Mutex::new(None),
         }
     }
 
@@ -746,13 +748,15 @@ impl Locker {
         let lock_id = self.lock_id.clone();
         let lock_key = self.key.clone();
         let bucket_key = key.clone();
-        tokio::task::spawn(async move {
+        let state = self.state.clone();
+        let handle = tokio::task::spawn(async move {
             if let Err(e) =
-                keep_alive_lock(&mut rx, &bucket, &bucket_key, &lock_key, &lock_id).await
+                keep_alive_lock(&mut rx, &bucket, &bucket_key, &lock_key, &lock_id, state).await
             {
                 log::error!("nats keep alive for key: {lock_key}, error: {e}");
             }
         });
+        *self.keep_alive.lock().await = Some(handle);
 
         Ok(())
     }
@@ -776,6 +780,18 @@ impl Locker {
         self.state.store(2, Ordering::SeqCst);
         if let Err(e) = self.tx.as_ref().unwrap().send(()).await {
             log::error!("nats unlock sender for key: {}, error: {e}", self.key);
+        }
+
+        // Wait for the keep-alive task to fully exit before purging. Otherwise an
+        // in-flight `put` could resurrect the key right after we purge it.
+        let keep_alive = self.keep_alive.lock().await.take();
+        if let Some(handle) = keep_alive
+            && let Err(e) = handle.await
+        {
+            log::error!(
+                "nats unlock keep alive join for key: {}, error: {e}",
+                self.key
+            );
         }
         if let Err(e) = bucket.purge(&key).await {
             log::error!("nats unlock for key: {}, error: {e}", self.key);
@@ -865,16 +881,23 @@ async fn keep_alive_lock(
     key: &str,
     orig_key: &str,
     lock_id: &str,
+    state: Arc<AtomicU8>,
 ) -> Result<()> {
     let interval = std::cmp::max(1, LOCKER_WATCHER_UPDATE_TTL as u64 / 3);
     let mut ticker = tokio::time::interval(tokio::time::Duration::from_secs(interval));
     ticker.tick().await; // first tick will be immediate
     loop {
         tokio::select! {
-            _ = ticker.tick() => {}
+            // prefer the stop signal so we never issue a `put` once unlock began
+            biased;
             _ = rx.recv() => {
                 break;
             }
+            _ = ticker.tick() => {}
+        }
+        // the lock has been released, stop keeping it alive
+        if state.load(Ordering::SeqCst) != 1 {
+            break;
         }
         // update the locker time to keep alive
         let value = Bytes::from(format!(


### PR DESCRIPTION
## Problem

Closes #12491 — a quick refresh (several queries in a row) occasionally results in `wait in queue` for ~**10s**, then a retry works. Intermittent, not frequent.

## Root cause

The search-queue dist-lock (`/search/cluster_queue/<work_group>`, `work_group.rs`) is a NATS KV key whose value embeds an expiration of `now + LOCKER_WATCHER_UPDATE_TTL` (**10s**). A detached **keep-alive task** re-`put`s a fresh `now + 10s` value every 3s (`keep_alive_lock`).

`unlock()` did:
```
state = 2  ->  tx.send(())  (signal keep-alive to stop)  ->  bucket.purge(key)
```
but the stop signal and the purge were **not synchronized** with the keep-alive task. A keep-alive `put` that was already in flight (or fired from the same `select!` tick as the stop signal) could land **after** `purge`, recreating the key with a 10s-future expiration.

Because the locker bucket TTL is `lock_max_age` (2h), nothing deletes that orphan. The next waiter spins in `wait_for_delete` — no delete event ever comes, and the 1s fallback `check_exist_lock` keeps seeing "not expired" — until the embedded **10s** expiration passes and `check_exist_lock` finally purges it. Hence the exact 10s wait.

### Why it's intermittent and tied to "quick refresh"
The keep-alive only `put`s if the lock is held **≥3s**. That happens under contention: in enterprise the dist-lock is held across the whole `work_group_need_wait` polling loop, and in OSS for the query duration. Quick refresh → many concurrent queries → work-group saturated → lock held >3s → keep-alive fires → narrow race window (≈ put-latency / 3s) → orphan that clears itself after 10s ("retry works").

## Fix

- `unlock()` now awaits the keep-alive task's `JoinHandle` **before** `purge`, so any in-flight `put` completes first and the purge is guaranteed to be the last write.
- The keep-alive `select!` is `biased` toward the stop signal and re-checks the lock `state` before each `put`, so it never issues a `put` once unlock has begun.

## Testing

- `cargo check` / `cargo clippy` / `cargo fmt` on `infra` pass.
- The race is timing-dependent and needs a live NATS server, so it isn't covered by a deterministic unit test; the reasoning above and the existing locker unit tests stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)