### PR TITLE
adding new data source secrion for ec2 instances to read the metadata…

### DIFF
--- a/web/src/components/ingestion/recommended/LinuxConfig.spec.ts
+++ b/web/src/components/ingestion/recommended/LinuxConfig.spec.ts
@@ -79,7 +79,7 @@ describe('LinuxConfig.vue', () => {
 
     it('should render installation description', () => {
       wrapper = createWrapper();
-      expect(wrapper.text()).toContain('Once you have installed');
+      expect(wrapper.text()).toContain('Once installed');
     });
 
     it('should render system logs collection info', () => {
@@ -105,41 +105,41 @@ describe('LinuxConfig.vue', () => {
     });
   });
 
-  describe('getCommand Computed', () => {
+  describe('activeCommand Computed', () => {
     it('should generate a command string', () => {
       wrapper = createWrapper();
       const vm = wrapper.vm as any;
-      expect(typeof vm.getCommand).toBe('string');
+      expect(typeof vm.activeCommand).toBe('string');
     });
 
     it('should include install.sh in the command', () => {
       wrapper = createWrapper();
       const vm = wrapper.vm as any;
-      expect(vm.getCommand).toContain('install.sh');
+      expect(vm.activeCommand).toContain('install.sh');
     });
 
     it('should include the endpoint URL in the command', () => {
       wrapper = createWrapper();
       const vm = wrapper.vm as any;
-      expect(vm.getCommand).toContain('http://localhost:5080');
+      expect(vm.activeCommand).toContain('http://localhost:5080');
     });
 
     it('should include the org identifier in the command', () => {
       wrapper = createWrapper({ currOrgIdentifier: 'my-org' });
       const vm = wrapper.vm as any;
-      expect(vm.getCommand).toContain('my-org');
+      expect(vm.activeCommand).toContain('my-org');
     });
 
     it('should include BASIC_PASSCODE placeholder', () => {
       wrapper = createWrapper();
       const vm = wrapper.vm as any;
-      expect(vm.getCommand).toContain('[BASIC_PASSCODE]');
+      expect(vm.activeCommand).toContain('[BASIC_PASSCODE]');
     });
 
     it('should include curl command', () => {
       wrapper = createWrapper();
       const vm = wrapper.vm as any;
-      expect(vm.getCommand).toContain('curl');
+      expect(vm.activeCommand).toContain('curl');
     });
   });
 

--- a/web/src/components/ingestion/recommended/LinuxConfig.vue
+++ b/web/src/components/ingestion/recommended/LinuxConfig.vue
@@ -1,58 +1,114 @@
 <template>
-  <div class="tw:p-3 tw:pt-1">
-    <ContentCopy :content="getCommand"></ContentCopy>
-    <br />
-    <hr />
-    <div>
-      <div class="tw:text-base tw:font-medium tw:pl-1 tw:mt-3">
-        Once you have installed the OpenObserve collector, it will:
-        <ol class="tw:list-decimal tw:ml-5">
-          <li>Collect system logs</li>
-          <li>Collect host metrics</li>
-        </ol>
+  <div class="tw:p-3">
+    <!-- Environment selection cards -->
+    <div class="tw:grid tw:grid-cols-2 tw:gap-3 tw:mb-5">
+      <div
+        v-for="opt in options"
+        :key="opt.value"
+        class="tw:rounded-lg tw:border tw:p-4 tw:cursor-pointer tw:transition-all tw:flex tw:gap-3 tw:items-start"
+        :class="selected === opt.value ? selectedCardClass : unselectedCardClass"
+        @click="selected = opt.value"
+      >
+        <OIcon :name="opt.icon" size="lg" :class="selected === opt.value ? 'tw:text-[var(--q-primary)]' : 'tw:text-gray-400'" />
+        <div>
+          <div class="tw:font-semibold tw:text-sm">{{ opt.label }}</div>
+          <div class="tw:text-xs tw:mt-0.5" :class="store.state.theme === 'dark' ? 'tw:text-gray-400' : 'tw:text-gray-500'">{{ opt.description }}</div>
+        </div>
       </div>
+    </div>
+
+    <!-- EC2 IAM prerequisite note -->
+    <div
+      v-if="selected === 'ec2'"
+      class="tw:flex tw:gap-2 tw:items-start tw:rounded-lg tw:p-3 tw:mb-4 tw:text-sm"
+      :class="store.state.theme === 'dark' ? 'tw:bg-amber-950/40 tw:border tw:border-amber-800/50' : 'tw:bg-amber-50 tw:border tw:border-amber-200'"
+    >
+      <OIcon name="info" size="sm" class="tw:text-amber-500 tw:shrink-0 tw:mt-0.5" />
+      <div :class="store.state.theme === 'dark' ? 'tw:text-amber-200' : 'tw:text-amber-900'">
+        <span class="tw:font-semibold">IAM role required.</span>
+        Attach an IAM role to your EC2 instance with
+        <code class="tw:font-mono tw:text-xs">ec2:DescribeTags</code> and
+        <code class="tw:font-mono tw:text-xs">ec2:DescribeInstances</code>
+        permissions. This allows the collector to read the instance Name tag and use it as the host identifier.
+      </div>
+    </div>
+
+    <!-- Install command -->
+    <ContentCopy :content="activeCommand" :key="selected" />
+
+    <OSeparator class="tw:my-4" />
+
+    <!-- What it collects -->
+    <div class="tw:text-sm tw:font-medium tw:pl-1">
+      Once installed, the collector will:
+      <ul class="tw:list-disc tw:ml-5 tw:mt-1 tw:font-normal tw:space-y-0.5">
+        <li>Collect system logs and journald logs</li>
+        <li>Collect host metrics (CPU, memory, disk, network)</li>
+        <li v-if="selected === 'ec2'">Detect EC2 instance metadata automatically</li>
+        <li v-if="selected === 'ec2'">Use the EC2 Name tag as the host identifier in dashboards</li>
+      </ul>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, type Ref } from "vue";
-import type { Endpoint } from "@/ts/interfaces";
+import { computed, ref } from "vue";
 import ContentCopy from "@/components/CopyContent.vue";
+import OIcon from "@/lib/core/Icon/OIcon.vue";
+import OSeparator from "@/lib/core/Separator/OSeparator.vue";
 import { useStore } from "vuex";
 import { b64EncodeStandard, getEndPoint, getIngestionURL } from "../../../utils/zincutils";
 
 const store = useStore();
 
 const props = defineProps({
-  currOrgIdentifier: {
-    type: String,
-  },
-  currUserEmail: {
-    type: String,
-  },
+  currOrgIdentifier: { type: String },
+  currUserEmail: { type: String },
 });
 
-const endpoint: any = ref({
-  url: "",
-  host: "",
-  port: "",
-  protocol: "",
-  tls: "",
-});
+const selected = ref("generic");
 
+const options = [
+  {
+    value: "generic",
+    label: "Generic Linux",
+    description: "Any Linux server or VM",
+    icon: "terminal",
+  },
+  {
+    value: "ec2",
+    label: "AWS EC2",
+    description: "EC2 instances with Name tag detection",
+    icon: "cloud",
+  },
+];
+
+const endpoint: any = ref({ url: "", host: "", port: "", protocol: "", tls: "" });
 const ingestionURL = getIngestionURL();
 endpoint.value = getEndPoint(ingestionURL);
 
-const accessKey = computed(() => {
-  return b64EncodeStandard(
-    `${props.currUserEmail}:${store.state.organizationData.organizationPasscode}`,
-  );
+const accessKey = computed(() =>
+  b64EncodeStandard(`${props.currUserEmail}:${store.state.organizationData.organizationPasscode}`)
+);
+
+const activeCommand = computed(() => {
+  const base = selected.value === "ec2"
+    ? "https://raw.githubusercontent.com/openobserve/agents/main/linux/ec2/install.sh"
+    : "https://raw.githubusercontent.com/openobserve/agents/main/linux/install.sh";
+  return `curl -O ${base} && chmod +x install.sh && sudo ./install.sh ${endpoint.value.url}/api/${props.currOrgIdentifier}/ [BASIC_PASSCODE]`;
 });
 
-const getCommand = computed(() => {
-  return `curl -O https://raw.githubusercontent.com/openobserve/agents/main/linux/install.sh && chmod +x install.sh && sudo ./install.sh ${endpoint.value.url}/api/${props.currOrgIdentifier}/ [BASIC_PASSCODE]`;
-});
+const selectedCardClass = computed(() =>
+  store.state.theme === "dark"
+    ? "tw:border-[var(--q-primary)] tw:bg-blue-950/30"
+    : "tw:border-[var(--q-primary)] tw:bg-blue-50"
+);
+
+const unselectedCardClass = computed(() =>
+  store.state.theme === "dark"
+    ? "tw:border-gray-700 tw:bg-gray-800/40 hover:tw:border-gray-500"
+    : "tw:border-gray-200 tw:bg-white hover:tw:border-gray-300"
+);
 </script>
 
 <style scoped></style>

--- a/web/src/components/ingestion/recommended/WindowsConfig.spec.ts
+++ b/web/src/components/ingestion/recommended/WindowsConfig.spec.ts
@@ -79,22 +79,22 @@ describe('WindowsConfig.vue', () => {
 
     it('should render PowerShell instructions', () => {
       wrapper = createWrapper();
-      expect(wrapper.text()).toContain('powershell');
+      expect(wrapper.text()).toContain('PowerShell');
     });
 
     it('should render installation description', () => {
       wrapper = createWrapper();
-      expect(wrapper.text()).toContain('Once you have installed');
+      expect(wrapper.text()).toContain('Once installed');
     });
 
     it('should render Windows event log info', () => {
       wrapper = createWrapper();
-      expect(wrapper.text()).toContain('Windows event log');
+      expect(wrapper.text()).toContain('Windows Event Log');
     });
 
     it('should render metrics collection info', () => {
       wrapper = createWrapper();
-      expect(wrapper.text()).toContain('performance counters');
+      expect(wrapper.text()).toContain('performance counter');
     });
   });
 
@@ -110,41 +110,41 @@ describe('WindowsConfig.vue', () => {
     });
   });
 
-  describe('getCommand Computed', () => {
+  describe('activeCommand Computed', () => {
     it('should generate a command string', () => {
       wrapper = createWrapper();
       const vm = wrapper.vm as any;
-      expect(typeof vm.getCommand).toBe('string');
+      expect(typeof vm.activeCommand).toBe('string');
     });
 
     it('should include PowerShell command (Invoke-WebRequest)', () => {
       wrapper = createWrapper();
       const vm = wrapper.vm as any;
-      expect(vm.getCommand).toContain('Invoke-WebRequest');
+      expect(vm.activeCommand).toContain('Invoke-WebRequest');
     });
 
     it('should include install.ps1 in the command', () => {
       wrapper = createWrapper();
       const vm = wrapper.vm as any;
-      expect(vm.getCommand).toContain('install.ps1');
+      expect(vm.activeCommand).toContain('install.ps1');
     });
 
     it('should include the endpoint URL in the command', () => {
       wrapper = createWrapper();
       const vm = wrapper.vm as any;
-      expect(vm.getCommand).toContain('http://localhost:5080');
+      expect(vm.activeCommand).toContain('http://localhost:5080');
     });
 
     it('should include the org identifier in the command', () => {
       wrapper = createWrapper({ currOrgIdentifier: 'my-org' });
       const vm = wrapper.vm as any;
-      expect(vm.getCommand).toContain('my-org');
+      expect(vm.activeCommand).toContain('my-org');
     });
 
     it('should include BASIC_PASSCODE placeholder', () => {
       wrapper = createWrapper();
       const vm = wrapper.vm as any;
-      expect(vm.getCommand).toContain('[BASIC_PASSCODE]');
+      expect(vm.activeCommand).toContain('[BASIC_PASSCODE]');
     });
   });
 

--- a/web/src/components/ingestion/recommended/WindowsConfig.vue
+++ b/web/src/components/ingestion/recommended/WindowsConfig.vue
@@ -1,62 +1,120 @@
 <template>
-  <div class="tw:p-3 tw:pt-1">
-    <div class="tw:text-base tw:font-medium tw:pl-1">
-      Run the powershell terminal as administrator and execute the following
-      command:
-    </div>
-    <ContentCopy class="tw:mt-2" :content="getCommand" />
-    <br />
-    <hr />
-    <div>
-      <div class="tw:text-base tw:font-medium tw:pl-1 tw:mt-3">
-        Once you have installed the OpenObserve collector, it will:
-        <ul class="tw:list-disc tw:ml-5">
-          <li>Collect logs from Windows event log</li>
-          <li>Collect metrics from Windows performance counters</li>
-        </ul>
+  <div class="tw:p-3">
+    <!-- Environment selection cards -->
+    <div class="tw:grid tw:grid-cols-2 tw:gap-3 tw:mb-5">
+      <div
+        v-for="opt in options"
+        :key="opt.value"
+        class="tw:rounded-lg tw:border tw:p-4 tw:cursor-pointer tw:transition-all tw:flex tw:gap-3 tw:items-start"
+        :class="selected === opt.value ? selectedCardClass : unselectedCardClass"
+        @click="selected = opt.value"
+      >
+        <OIcon :name="opt.icon" size="lg" :class="selected === opt.value ? 'tw:text-[var(--q-primary)]' : 'tw:text-gray-400'" />
+        <div>
+          <div class="tw:font-semibold tw:text-sm">{{ opt.label }}</div>
+          <div class="tw:text-xs tw:mt-0.5" :class="store.state.theme === 'dark' ? 'tw:text-gray-400' : 'tw:text-gray-500'">{{ opt.description }}</div>
+        </div>
       </div>
+    </div>
+
+    <!-- EC2 IAM prerequisite note -->
+    <div
+      v-if="selected === 'ec2'"
+      class="tw:flex tw:gap-2 tw:items-start tw:rounded-lg tw:p-3 tw:mb-4 tw:text-sm"
+      :class="store.state.theme === 'dark' ? 'tw:bg-amber-950/40 tw:border tw:border-amber-800/50' : 'tw:bg-amber-50 tw:border tw:border-amber-200'"
+    >
+      <OIcon name="info" size="sm" class="tw:text-amber-500 tw:shrink-0 tw:mt-0.5" />
+      <div :class="store.state.theme === 'dark' ? 'tw:text-amber-200' : 'tw:text-amber-900'">
+        <span class="tw:font-semibold">IAM role required.</span>
+        Attach an IAM role to your EC2 instance with
+        <code class="tw:font-mono tw:text-xs">ec2:DescribeTags</code> and
+        <code class="tw:font-mono tw:text-xs">ec2:DescribeInstances</code>
+        permissions. This allows the collector to read the instance Name tag and use it as the host identifier.
+      </div>
+    </div>
+
+    <!-- Admin note -->
+    <div class="tw:text-sm tw:font-medium tw:mb-2">
+      Run the following command in PowerShell as Administrator:
+    </div>
+
+    <!-- Install command -->
+    <ContentCopy :content="activeCommand" :key="selected" />
+
+    <OSeparator class="tw:my-4" />
+
+    <!-- What it collects -->
+    <div class="tw:text-sm tw:font-medium tw:pl-1">
+      Once installed, the collector will:
+      <ul class="tw:list-disc tw:ml-5 tw:mt-1 tw:font-normal tw:space-y-0.5">
+        <li>Collect Windows Event Log (Application, Security, Setup, System)</li>
+        <li>Collect host metrics (CPU, memory, disk, network)</li>
+        <li>Collect Windows performance counter metrics</li>
+        <li v-if="selected === 'ec2'">Detect EC2 instance metadata automatically</li>
+        <li v-if="selected === 'ec2'">Use the EC2 Name tag as the host identifier in dashboards</li>
+      </ul>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, type Ref } from "vue";
-import type { Endpoint } from "@/ts/interfaces";
+import { computed, ref } from "vue";
 import ContentCopy from "@/components/CopyContent.vue";
+import OIcon from "@/lib/core/Icon/OIcon.vue";
+import OSeparator from "@/lib/core/Separator/OSeparator.vue";
 import { useStore } from "vuex";
 import { b64EncodeStandard, getEndPoint, getIngestionURL } from "../../../utils/zincutils";
 
 const store = useStore();
 
 const props = defineProps({
-  currOrgIdentifier: {
-    type: String,
-  },
-  currUserEmail: {
-    type: String,
-  },
+  currOrgIdentifier: { type: String },
+  currUserEmail: { type: String },
 });
 
-const endpoint: any = ref({
-  url: "",
-  host: "",
-  port: "",
-  protocol: "",
-  tls: "",
-});
+const selected = ref("generic");
 
+const options = [
+  {
+    value: "generic",
+    label: "Generic Windows",
+    description: "Any Windows server or VM",
+    icon: "desktop_windows",
+  },
+  {
+    value: "ec2",
+    label: "AWS EC2",
+    description: "EC2 instances with Name tag detection",
+    icon: "cloud",
+  },
+];
+
+const endpoint: any = ref({ url: "", host: "", port: "", protocol: "", tls: "" });
 const ingestionURL = getIngestionURL();
 endpoint.value = getEndPoint(ingestionURL);
 
-const accessKey = computed(() => {
-  return b64EncodeStandard(
-    `${props.currUserEmail}:${store.state.organizationData.organizationPasscode}`,
-  );
+const accessKey = computed(() =>
+  b64EncodeStandard(`${props.currUserEmail}:${store.state.organizationData.organizationPasscode}`)
+);
+
+const activeCommand = computed(() => {
+  const script = selected.value === "ec2"
+    ? "https://raw.githubusercontent.com/openobserve/agents/main/windows/ec2/install.ps1"
+    : "https://raw.githubusercontent.com/openobserve/agents/main/windows/install.ps1";
+  return `Invoke-WebRequest -Uri ${script} -OutFile install.ps1 ; .\\install.ps1 -URL ${endpoint.value.url}/api/${props.currOrgIdentifier}/ -AUTH_KEY [BASIC_PASSCODE]`;
 });
 
-const getCommand = computed(() => {
-  return `Invoke-WebRequest -Uri https://raw.githubusercontent.com/openobserve/agents/main/windows/install.ps1 -OutFile install.ps1 ; .\\install.ps1 -URL ${endpoint.value.url}/api/${props.currOrgIdentifier}/ -AUTH_KEY [BASIC_PASSCODE]`;
-});
+const selectedCardClass = computed(() =>
+  store.state.theme === "dark"
+    ? "tw:border-[var(--q-primary)] tw:bg-blue-950/30"
+    : "tw:border-[var(--q-primary)] tw:bg-blue-50"
+);
+
+const unselectedCardClass = computed(() =>
+  store.state.theme === "dark"
+    ? "tw:border-gray-700 tw:bg-gray-800/40 hover:tw:border-gray-500"
+    : "tw:border-gray-200 tw:bg-white hover:tw:border-gray-300"
+);
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
## Data Sources - Linux & Windows Agent Installer Improvements

### What changed

**LinuxConfig.vue** and **WindowsConfig.vue** have been updated to support environment-specific installation options. Both now show a two-card selector so users can pick their deployment target before copying the install command.

---

### Linux

Added an **AWS EC2** option alongside Generic Linux.

- Two clickable selection cards: Generic Linux and AWS EC2
- Switching cards updates the install command automatically
- EC2 card uses the new `linux/ec2/install.sh` script which includes:
  - `resourcedetection/ec2` processor to read EC2 instance metadata
  - `resource/hostname` processor to set `host.name` from the EC2 Name tag
- Amber prerequisite callout shown when EC2 is selected, explaining that an IAM role with `ec2:DescribeTags` and `ec2:DescribeInstances` is required

---

### Windows

Added an **AWS EC2** option alongside Generic Windows.

- Same two-card selection pattern as Linux
- EC2 card uses the new `windows/ec2/install.ps1` script
- Amber IAM prerequisite callout shown when EC2 is selected
- Updated Generic Windows to use the improved `install.ps1` which:
  - Bumps OTel version from 0.90.1 to 0.111.0
  - Switches download source back to official GitHub releases
  - Removes deprecated `memory_ballast` extension
  - Fixes processor perf counter instances from hardcoded `[1, 2]` to `"*"` for all cores

---

### Agent scripts (openobserve/agents repo)

- `linux/ec2/install.sh` - new EC2-specific Linux installer
- `windows/install.ps1` - updated with OTel 0.111.0 and config fixes
- `windows/ec2/install.ps1` - new EC2-specific Windows installer

---

### Test plan

- [ ] Open Data Sources > Recommended > Linux, verify two cards render correctly in light and dark mode
- [ ] Select EC2 card, verify IAM callout appears and command URL changes to `linux/ec2/install.sh`
- [ ] Open Data Sources > Recommended > Windows, verify same behaviour
- [ ] Select EC2 Windows card, verify command URL changes to `windows/ec2/install.ps1`
- [ ] Verify Generic selection on both shows the original install script URLs
