### PR TITLE
fix: fixed filtering for infered services from service-details operation table

### DIFF
--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -2258,18 +2258,10 @@ const handleServiceGraphViewTraces = (data: any) => {
 };
 
 // Handler for services catalog row click — switches to traces mode filtered by service
-const handleServicesCatalogViewTraces = (data: string | { serviceName: string; serviceType?: string }) => {
-  const serviceName = typeof data === "string" ? data : data.serviceName;
-  const serviceType = typeof data === "string" ? undefined : data.serviceType;
-  const escapedName = escapeSingleQuotes(serviceName);
-  const serviceField = serviceType ? "infer_service_name" : "service_name";
-  searchObj.data.editorValue = `${serviceField} = '${escapedName}'`;
-  searchObj.data.query = searchObj.data.editorValue;
-  searchObj.meta.sqlMode = false;
-  searchObj.meta.searchMode = "traces";
-  nextTick(() => {
-    runQueryFn();
-  });
+const handleServicesCatalogViewTraces = (data: string | Record<string, any>) => {
+  // Normalize plain string to object then delegate to the full handler
+  const payload = typeof data === "string" ? { serviceName: data, mode: "traces" } : data;
+  handleServiceGraphViewTraces(payload);
 };
 
 // watch(updateSelectedColumns, () => {

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -2209,7 +2209,8 @@ const handleServiceGraphViewTraces = (data: any) => {
   // Set the filter query (just the WHERE condition, no SELECT or ORDER BY)
   if (data.serviceName) {
     const escapedServiceName = escapeSingleQuotes(data.serviceName);
-    let filterQuery = `service_name = '${escapedServiceName}'`;
+    const serviceField = data.serviceType ? "infer_service_name" : "service_name";
+    let filterQuery = `${serviceField} = '${escapedServiceName}'`;
     if (data.operationName) {
       const escapedOpName = escapeSingleQuotes(data.operationName);
       filterQuery += ` AND operation_name = '${escapedOpName}'`;
@@ -2257,9 +2258,12 @@ const handleServiceGraphViewTraces = (data: any) => {
 };
 
 // Handler for services catalog row click — switches to traces mode filtered by service
-const handleServicesCatalogViewTraces = (serviceName: string) => {
+const handleServicesCatalogViewTraces = (data: string | { serviceName: string; serviceType?: string }) => {
+  const serviceName = typeof data === "string" ? data : data.serviceName;
+  const serviceType = typeof data === "string" ? undefined : data.serviceType;
   const escapedName = escapeSingleQuotes(serviceName);
-  searchObj.data.editorValue = `service_name = '${escapedName}'`;
+  const serviceField = serviceType ? "infer_service_name" : "service_name";
+  searchObj.data.editorValue = `${serviceField} = '${escapedName}'`;
   searchObj.data.query = searchObj.data.editorValue;
   searchObj.meta.sqlMode = false;
   searchObj.meta.searchMode = "traces";

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -2269,7 +2269,20 @@ const handleServiceGraphViewTraces = (data: any) => {
   });
 };
 
-// Handler for services catalog row click — switches to traces mode filtered by service
+/**
+ * Handler for the services catalog `view-traces` event.
+ *
+ * Normalizes the payload (which may be a plain service name string for backward
+ * compatibility, or a full object with `serviceName`, `serviceType`,
+ * `resourceFilter`, etc.) and delegates to {@link handleServiceGraphViewTraces}
+ * to populate the search bar and run the filtered traces query.
+ *
+ * @param data - Service name string (legacy) or structured filter object.
+ *               Structured objects may include `serviceName`, `serviceType`,
+ *               `operationName`, `nodeName`, `podName`, `callerService`,
+ *               `resourceFilter`, `errorsOnly`, `minDurationMicros`,
+ *               `maxDurationMicros`, `mode`, and `stream`.
+ */
 const handleServicesCatalogViewTraces = (data: string | Record<string, any>) => {
   // Normalize plain string to object then delegate to the full handler
   const payload = typeof data === "string" ? { serviceName: data, mode: "traces" } : data;

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -2223,9 +2223,21 @@ const handleServiceGraphViewTraces = (data: any) => {
       const escapedPodName = escapeSingleQuotes(data.podName);
       filterQuery += ` AND service_k8s_pod_name = '${escapedPodName}'`;
     }
-    if (data.resourceFilter?.field && data.resourceFilter?.value) {
+    if (data.callerService) {
+      const escapedCaller = escapeSingleQuotes(data.callerService);
+      filterQuery += ` AND service_name = '${escapedCaller}'`;
+    }
+    if (data.resourceFilter?.value) {
       const escapedValue = escapeSingleQuotes(data.resourceFilter.value);
-      filterQuery += ` AND ${data.resourceFilter.field} = '${escapedValue}'`;
+      if (data.resourceFilter.fields?.length) {
+        // Fallback chain: (field1 = 'val' OR field2 = 'val')
+        const clauses = data.resourceFilter.fields
+          .map((f: string) => `${f} = '${escapedValue}'`)
+          .join(" OR ");
+        filterQuery += ` AND (${clauses})`;
+      } else if (data.resourceFilter.field) {
+        filterQuery += ` AND ${data.resourceFilter.field} = '${escapedValue}'`;
+      }
     }
     if (data.errorsOnly) {
       filterQuery += ` AND span_status = 'ERROR'`;

--- a/web/src/plugins/traces/ServiceGraph.vue
+++ b/web/src/plugins/traces/ServiceGraph.vue
@@ -1143,6 +1143,7 @@ export default defineComponent({
           errors: node.errors || 0,
           error_rate: node.error_rate || 0,
           is_virtual: node.is_virtual || false,
+          service_type: node.service_type || undefined,
         }));
 
         // Ensure edges have all required fields and valid node references

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.spec.ts
@@ -48,13 +48,18 @@ vi.mock("@/services/service_streams", () => ({
     .mockResolvedValue({ data: { available_groups: [] } }),
 }));
 
-// fetchDatabaseOperations (called for nodes identified as database nodes) and
-// resolveWorkloadFields both call streamService.schema. Mock it so those calls
-// complete instantly instead of making real HTTP requests that hang in tests.
-vi.mock("@/services/stream", () => ({
-  default: {
-    schema: vi.fn().mockResolvedValue({ data: { schema: [], fields: [] } }),
-  },
+// resolveStreamSchema calls useStreams().getStream() to fetch and cache the
+// stream schema. Mock it so those calls complete instantly instead of making
+// real HTTP requests that hang in tests.
+const { getStreamMock } = vi.hoisted(() => ({
+  getStreamMock: vi.fn().mockResolvedValue({ schema: [] }),
+}));
+
+vi.mock("@/composables/useStreams", () => ({
+  default: vi.fn(() => ({
+    getStream: getStreamMock,
+    getStreams: vi.fn().mockResolvedValue([]),
+  })),
 }));
 
 vi.mock("@/utils/dashboard/convertDashboardSchemaVersion", () => ({
@@ -97,6 +102,7 @@ vi.mock("@/lib/feedback/Toast/useToast", () => ({
 
 import ServiceGraphNodeSidePanel from "./ServiceGraphNodeSidePanel.vue";
 import searchService from "@/services/search";
+import useStreams from "@/composables/useStreams";
 import { correlate as correlateStreams } from "@/services/service_streams";
 
 
@@ -987,6 +993,268 @@ describe("ServiceGraphNodeSidePanel", () => {
         const rows = wrapper.vm.sortedOperationsTableRows;
         expect(rows).toHaveLength(0);
       });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isInferred computed
+  // ---------------------------------------------------------------------------
+
+  describe("isInferred", () => {
+    it("should return false when service_type is undefined", () => {
+      wrapper = mountPanel({ selectedNode: baseNode });
+      expect(wrapper.vm.isInferred).toBe(false);
+    });
+
+    it("should return false when service_type is null", () => {
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: null },
+      });
+      expect(wrapper.vm.isInferred).toBe(false);
+    });
+
+    it("should return true when service_type is 'database'", () => {
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+      });
+      expect(wrapper.vm.isInferred).toBe(true);
+    });
+
+    it("should return true for all supported inferred service types", () => {
+      for (const st of ["database", "queue", "rpc", "external"]) {
+        wrapper = mountPanel({
+          selectedNode: { ...baseNode, service_type: st },
+        });
+        expect(wrapper.vm.isInferred).toBe(true);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // operationsTableColumns — Caller column for inferred services
+  // ---------------------------------------------------------------------------
+
+  describe("operationsTableColumns", () => {
+    it("should NOT include a caller column when service_type is unset", () => {
+      wrapper = mountPanel({ selectedNode: baseNode });
+      const cols = wrapper.vm.operationsTableColumns;
+      const callerCol = cols.find((c: any) => c.id === "caller");
+      expect(callerCol).toBeUndefined();
+    });
+
+    it("should include a caller column as the first column when service_type is 'database'", () => {
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+      });
+      const cols = wrapper.vm.operationsTableColumns;
+      expect(cols[0].id).toBe("caller");
+      expect(cols[0].header).toBe("Caller");
+      expect(cols[0].accessorKey).toBe("caller");
+    });
+
+    it("should include a caller column for all inferred service types", () => {
+      for (const st of ["database", "queue", "rpc", "external"]) {
+        wrapper = mountPanel({
+          selectedNode: { ...baseNode, service_type: st },
+        });
+        const cols = wrapper.vm.operationsTableColumns;
+        expect(cols[0].id).toBe("caller");
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // activeResourceTabConfigs for inferred services
+  // ---------------------------------------------------------------------------
+
+  describe("activeResourceTabConfigs for inferred services", () => {
+    it("should return empty array when schema is not yet resolved", () => {
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+      });
+      // Schema hasn't resolved yet, so inferredTabConfigs should be empty
+      // and activeResourceTabConfigs falls back through inferredTabConfigs
+      const configs = wrapper.vm.activeResourceTabConfigs;
+      expect(configs).toEqual([]);
+    });
+
+    it("should return inferred tabs when schema is resolved with matching fields", async () => {
+      // Override schema mock to return database-related fields
+      getStreamMock.mockResolvedValueOnce({
+        schema: [
+          { name: "server_address", type: "keyword" },
+          { name: "net_peer_name", type: "keyword" },
+          { name: "db_name", type: "keyword" },
+          { name: "db_operation", type: "keyword" },
+        ],
+      });
+
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+        streamFilter: "default",
+      });
+      await flushPromises();
+      await flushPromises();
+
+      const configs = wrapper.vm.activeResourceTabConfigs;
+      expect(configs.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should return empty when schema has none of the fallback fields", async () => {
+      getStreamMock.mockResolvedValueOnce({
+        schema: [{ name: "unrelated_field", type: "keyword" }],
+      });
+
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+        streamFilter: "default",
+      });
+      await flushPromises();
+      await flushPromises();
+
+      const configs = wrapper.vm.activeResourceTabConfigs;
+      expect(configs).toEqual([]);
+    });
+
+    it("should return empty array when service_type is not set", () => {
+      wrapper = mountPanel({ selectedNode: baseNode });
+      // Without service_type, inferredTabConfigs returns []
+      // and availableResourceTabConfigs (user-selected) defaults to []
+      // because no workload fields are selected
+      expect(wrapper.vm.isInferred).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // INFERRED_SERVICE_TABS registry (test through component)
+  // ---------------------------------------------------------------------------
+
+  describe("INFERRED_SERVICE_TABS registry", () => {
+    it("should generate hosts tab for database when server_address exists in schema", async () => {
+      getStreamMock.mockResolvedValueOnce({
+        schema: [{ name: "server_address", type: "keyword" }],
+      });
+
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+        streamFilter: "default",
+      });
+      await flushPromises();
+      await flushPromises();
+
+      const configs = wrapper.vm.activeResourceTabConfigs;
+      const hostsTab = configs.find((c: any) => c.id === "hosts");
+      expect(hostsTab).toBeDefined();
+      expect(hostsTab.label).toBe("Hosts");
+      expect(hostsTab.colLabel).toBe("Host");
+      expect(hostsTab.groupField).toContain("COALESCE");
+      expect(hostsTab.groupField).toContain("server_address");
+    });
+
+    it("should generate hosts tab with COALESCE when multiple host fields exist", async () => {
+      getStreamMock.mockResolvedValueOnce({
+        schema: [
+          { name: "server_address", type: "keyword" },
+          { name: "net_peer_name", type: "keyword" },
+          { name: "net_peer_ip", type: "keyword" },
+        ],
+      });
+
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+        streamFilter: "default",
+      });
+      await flushPromises();
+      await flushPromises();
+
+      const configs = wrapper.vm.activeResourceTabConfigs;
+      const hostsTab = configs.find((c: any) => c.id === "hosts");
+      expect(hostsTab).toBeDefined();
+      // COALESCE should include all three fields
+      expect(hostsTab.groupField).toContain("server_address");
+      expect(hostsTab.groupField).toContain("net_peer_name");
+      expect(hostsTab.groupField).toContain("net_peer_ip");
+      // network_peer_address is not in schema, so it should NOT be in COALESCE
+      expect(hostsTab.groupField).not.toContain("network_peer_address");
+    });
+
+    it("should NOT generate databases tab when db fields are absent from schema", async () => {
+      getStreamMock.mockResolvedValueOnce({
+        schema: [{ name: "server_address", type: "keyword" }],
+      });
+
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+        streamFilter: "default",
+      });
+      await flushPromises();
+      await flushPromises();
+
+      const configs = wrapper.vm.activeResourceTabConfigs;
+      const databasesTab = configs.find((c: any) => c.id === "databases");
+      expect(databasesTab).toBeUndefined();
+    });
+
+    it("should generate queries tab when db_operations exists in schema", async () => {
+      getStreamMock.mockResolvedValueOnce({
+        schema: [
+          { name: "server_address", type: "keyword" },
+          { name: "db_operations", type: "keyword" },
+        ],
+      });
+
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+        streamFilter: "default",
+      });
+      await flushPromises();
+      await flushPromises();
+
+      const configs = wrapper.vm.activeResourceTabConfigs;
+      const queriesTab = configs.find((c: any) => c.id === "queries");
+      expect(queriesTab).toBeDefined();
+      expect(queriesTab.colLabel).toBe("DB Operation");
+      expect(queriesTab.groupField).toContain("db_operations");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Template: Metrics tab hidden for inferred services
+  // ---------------------------------------------------------------------------
+
+  describe("metrics tab visibility for inferred services", () => {
+    it("should render metrics tab for regular (non-inferred) services", () => {
+      wrapper = mountPanel({ selectedNode: baseNode });
+      const metricsTab = wrapper.find(
+        '[data-test="service-graph-node-panel-tab-metrics"]',
+      );
+      expect(metricsTab.exists()).toBe(true);
+    });
+
+    it("should NOT render metrics tab for inferred services", () => {
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+      });
+      const metricsTab = wrapper.find(
+        '[data-test="service-graph-node-panel-tab-metrics"]',
+      );
+      expect(metricsTab.exists()).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Template: Resource dropdown hidden for inferred services
+  // ---------------------------------------------------------------------------
+
+  describe("resource dropdown visibility for inferred services", () => {
+    it("should NOT render resource dropdown for inferred services", () => {
+      wrapper = mountPanel({
+        selectedNode: { ...baseNode, service_type: "database" },
+      });
+      const dropdownBtn = wrapper.find(
+        '[data-test="service-graph-node-panel-workload-fields-btn"]',
+      );
+      expect(dropdownBtn.exists()).toBe(false);
     });
   });
 });

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -808,6 +808,11 @@ export default defineComponent({
       return escapeSingleQuotes(name);
     };
 
+    // Returns the correct SQL field name based on whether the node is an inferred service
+    const serviceNameField = computed(() =>
+      props.selectedNode?.service_type ? "infer_service_name" : "service_name",
+    );
+
     const loadDashboard = () => {
       if (!props.selectedNode || props.streamFilter === "all") {
         dashboardData.value = {};
@@ -832,7 +837,7 @@ export default defineComponent({
       const convertedDashboard = convertDashboardSchemaVersion(
         deepCopy(metrics),
       );
-      const serviceFilter = `service_name = '${serviceName}'`;
+      const serviceFilter = `${serviceNameField.value} = '${serviceName}'`;
 
       convertedDashboard.tabs[0].panels.forEach((panel: any, index) => {
         let whereClause: string;
@@ -1125,7 +1130,7 @@ export default defineComponent({
           org_identifier: org,
           query: {
             query: {
-              sql: `SELECT * FROM "${streamName}" WHERE service_name = '${escapeSingleQuotes(serviceName)}' ORDER BY _timestamp DESC`,
+              sql: `SELECT * FROM "${streamName}" WHERE ${serviceNameField.value} = '${escapeSingleQuotes(serviceName)}' ORDER BY _timestamp DESC`,
               start_time: props.timeRange.startTime,
               end_time: props.timeRange.endTime,
               from: 0,
@@ -1608,7 +1613,7 @@ export default defineComponent({
       try {
         const serviceName = buildServiceName();
         const streamName = props.streamFilter || "default";
-        const sql = `SELECT operation_name, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE service_name = '${serviceName}' GROUP BY operation_name`;
+        const sql = `SELECT operation_name, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' GROUP BY operation_name`;
 
         const response = await searchService.search({
           org_identifier: store.state.selectedOrganization.identifier,
@@ -1666,7 +1671,7 @@ export default defineComponent({
             org_identifier: org,
             query: {
               query: {
-                sql: `SELECT operation_name, duration, start_time FROM "${streamName}" WHERE service_name = '${serviceName}' AND span_status = 'ERROR' ORDER BY start_time DESC`,
+                sql: `SELECT operation_name, duration, start_time FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' AND span_status = 'ERROR' ORDER BY start_time DESC`,
                 ...timeParams,
                 size: 5,
               },
@@ -1677,7 +1682,7 @@ export default defineComponent({
             org_identifier: org,
             query: {
               query: {
-                sql: `SELECT operation_name, duration FROM "${streamName}" WHERE service_name = '${serviceName}' ORDER BY duration DESC`,
+                sql: `SELECT operation_name, duration FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' ORDER BY duration DESC`,
                 ...timeParams,
                 size: 20,
               },
@@ -1753,7 +1758,7 @@ export default defineComponent({
         const groupField = config.groupField;
         const alias = config.colId + "_name";
 
-        const sql = `SELECT ${groupField} as ${alias}, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE service_name = '${serviceName}' AND ${groupField} IS NOT NULL GROUP BY ${groupField} ORDER BY request_count DESC`;
+        const sql = `SELECT ${groupField} as ${alias}, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' AND ${groupField} IS NOT NULL GROUP BY ${groupField} ORDER BY request_count DESC`;
 
         const response = await searchService.search({
           org_identifier: store.state.selectedOrganization.identifier,
@@ -1972,6 +1977,7 @@ export default defineComponent({
           props.selectedNode?.name ||
           props.selectedNode?.label ||
           props.selectedNode?.id,
+        serviceType: props.selectedNode?.service_type,
         operationName: params.operationName,
         nodeName: params.nodeName,
         podName: params.podName,
@@ -2000,7 +2006,7 @@ export default defineComponent({
       const org = store.state.selectedOrganization.identifier;
 
       let streamName: string | undefined;
-      let filterQuery = `service_name='${escapeSingleQuotes(serviceName)}'`;
+      let filterQuery = `${serviceNameField.value}='${escapeSingleQuotes(serviceName)}'`;
 
       try {
         const correlateResponse = await correlateStreams(org, {

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -677,13 +677,58 @@ export interface ResourceTabConfig {
 // chains that generate COALESCE expressions for both SELECT/GROUP BY and
 // the downstream filter clause.
 // ---------------------------------------------------------------------------
+/**
+ * Describes a resource tab rendered for an inferred service in the node detail panel.
+ *
+ * Each tab exposes a group of related span attributes (e.g. host info, database names)
+ * organised as a table. Because OTel semantic conventions have evolved across
+ * generations, a single conceptual attribute may map to several field names
+ * (e.g. host → `server_address`, `net_peer_name`, `net_peer_ip`, `network_peer_address`).
+ *
+ * The `fields` array defines a **fallback chain** — the first field found in the
+ * stream schema is used as both the GROUP BY column and the link target for View
+ * Traces drill-down. If multiple fields exist, they are assembled into a
+ * `COALESCE(NULLIF(f1, ''), NULLIF(f2, ''), ...)` expression so that rows with
+ * different generations of the same attribute still aggregate together.
+ */
 export interface InferredServiceTab {
-  id: string;        // unique tab name, e.g. "hosts", "databases"
-  label: string;     // display label, e.g. "Hosts", "Databases"
-  colLabel: string;  // table column header, e.g. "Host", "Database"
-  fields: string[];  // fallback order for COALESCE, e.g. ["server_address", "net_peer_name"]
+  /** Unique tab identifier, e.g. "hosts", "databases", "queries" */
+  id: string;
+  /** User-facing tab label, e.g. "Hosts", "Databases", "Queries" */
+  label: string;
+  /** Column header shown in the resource table, e.g. "Host", "Database", "DB Operation" */
+  colLabel: string;
+  /**
+   * Fallback-ordered field names for the attribute column, evaluated against the
+   * stream schema at runtime. The first field present in the schema wins as the
+   * primary GROUP BY column; additional matching fields contribute to a COALESCE
+   * expression for unified aggregation.
+   */
+  fields: string[];
 }
 
+/**
+ * Registry of inferred-service resource tabs, keyed by `service_type`.
+ *
+ * Each entry defines the resource breakdowns available for that service type.
+ * At runtime, tabs are filtered against the target stream's schema so that
+ * only tabs whose `fields` intersect the schema are shown to the user.
+ *
+ * OTel semantic convention coverage:
+ * | Service Type | Tabs          | Attribute Generations                                     |
+ * |-------------|---------------|-----------------------------------------------------------|
+ * | database    | Hosts         | server_address, net_peer_*, network_peer_address          |
+ * |             | Databases     | db_namespace, db_name (stabilised OTel DB)                |
+ * |             | Queries       | db_operations (OTel DB operations)                        |
+ * | queue       | Hosts         | server_address, net_peer_*, network_peer_address          |
+ * |             | Destinations  | messaging_destination_name, messaging_destination         |
+ * | rpc         | Hosts         | server_address, net_peer_*, network_peer_address          |
+ * |             | RPC Services  | rpc_service, rpc_method                                   |
+ * | http        | Hosts         | server_address, net_peer_*, network_peer_address          |
+ *
+ * When adding a new dependency type, add its entry here — the panel will
+ * automatically render the appropriate resource tabs.
+ */
 const INFERRED_SERVICE_TABS: Record<string, InferredServiceTab[]> = {
   database: [
     {
@@ -907,7 +952,16 @@ export default defineComponent({
       return escapeSingleQuotes(name);
     };
 
-    // Returns the correct SQL field name based on whether the node is an inferred service
+    /**
+     * Returns the correct SQL field name for the service name column in WHERE clauses.
+     *
+     * Inferred services (those discovered from span attributes rather than instrumented
+     * SDKs) use `infer_service_name`, while regular instrumented services use `service_name`.
+     * The distinction is driven by `props.selectedNode.service_type`:
+     * - When `service_type` is set (e.g. "database", "queue", "rpc", "http"), the node
+     *   represents an inferred service → `infer_service_name`.
+     * - When `service_type` is absent, the node represents an instrumented service → `service_name`.
+     */
     const serviceNameField = computed(() =>
       props.selectedNode?.service_type ? "infer_service_name" : "service_name",
     );

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -1229,7 +1229,7 @@ export default defineComponent({
           org_identifier: org,
           query: {
             query: {
-              sql: `SELECT * FROM "${streamName}" WHERE ${serviceNameField.value} = '${escapeSingleQuotes(serviceName)}' ORDER BY _timestamp DESC`,
+              sql: `SELECT * FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' ORDER BY _timestamp DESC`,
               start_time: props.timeRange.startTime,
               end_time: props.timeRange.endTime,
               from: 0,
@@ -2212,7 +2212,7 @@ export default defineComponent({
       const org = store.state.selectedOrganization.identifier;
 
       let streamName: string | undefined;
-      let filterQuery = `${serviceNameField.value}='${escapeSingleQuotes(serviceName)}'`;
+      let filterQuery = `${serviceNameField.value}='${serviceName}'`;
 
       try {
         const correlateResponse = await correlateStreams(org, {

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -602,7 +602,7 @@ import {
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import searchService from "@/services/search";
-import streamService from "@/services/stream";
+import useStreams from "@/composables/useStreams";
 import {
   correlate as correlateStreams,
   getSemanticGroups,
@@ -865,6 +865,7 @@ export default defineComponent({
     const store = useStore();
     const { t } = useI18n();
     const router = useRouter();
+    const { getStream } = useStreams();
 
     // RED Charts State
     const dashboardData = ref<any>({});
@@ -1381,7 +1382,9 @@ export default defineComponent({
     const schemaResolved = ref(false);
 
     /** Fetch the trace stream schema and populate streamFieldSet.
-     *  Idempotent — skips if already resolved for the current stream. */
+     *  Idempotent — skips if already resolved for the current stream.
+     *  Uses useStreams().getStream() which caches the schema in the Vuex store
+     *  so other components benefit from the cached data. */
     const resolveStreamSchema = async () => {
       if (
         !props.visible ||
@@ -1392,14 +1395,9 @@ export default defineComponent({
         return;
 
       try {
-        const org = store.state.selectedOrganization.identifier;
-        const schemaResponse = await streamService.schema(
-          org,
-          props.streamFilter,
-          "traces",
-        );
+        const stream = await getStream(props.streamFilter, "traces", true);
         const schemaFields: { name: string; type: string }[] =
-          schemaResponse.data?.schema || schemaResponse.data?.fields || [];
+          stream?.schema || [];
         streamFieldSet.value = new Set(schemaFields.map((f) => f.name));
         schemaResolved.value = true;
       } catch (err) {
@@ -1427,7 +1425,6 @@ export default defineComponent({
       if (!schemaResolved.value) return [];
       const resolved: ResourceTabConfig[] = [];
       for (const t of tabs) {
-        debugger;
         const present = t.fields.filter((f) => fieldSet.has(f));
         if (present.length === 0) continue;
         resolved.push({

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -173,6 +173,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 :data-test="`service-graph-node-panel-tab-${cfg.id}`"
               />
               <OTab
+                v-if="!isInferred"
                 name="metrics"
                 label="Metrics"
                 style="text-transform: capitalize"
@@ -181,8 +182,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </OTabs>
 
             <!-- Resource tabs dropdown — shows/hides individual OTEL resource tabs -->
+            <!-- Hidden for inferred services (they have fixed tabs from the registry) -->
             <ODropdown
-              v-if="availableResourceTabConfigs.length > 0"
+              v-if="!isInferred && availableResourceTabConfigs.length > 0"
               side="bottom"
               align="end"
             >
@@ -279,7 +281,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     @sort-change="handleSortChange"
                     @click:data-row="
                       (row: any) =>
-                        navigateToTraces({ operationName: row.operation })
+                        navigateToTraces({
+                          operationName: row.operation,
+                          callerService: isInferred ? row.caller : undefined,
+                        })
                     "
                   >
                     <template #cell-errors="{ item }">
@@ -332,6 +337,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         @click.stop="
                           navigateToTraces({
                             operationName: row.operation,
+                            callerService: isInferred ? row.caller : undefined,
                             errorsOnly: column.id === 'errors',
                             minDurationMicros: isDurationColumn(column.id) ? row[column.id] : undefined
                           })
@@ -401,10 +407,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     @click:data-row="
                       (row: any) =>
                         navigateToTraces({
-                          resourceFilter: {
-                            field: cfg.groupField,
-                            value: row[cfg.colId],
-                          },
+                          resourceFilter: cfg.fields
+                            ? { fields: cfg.fields, value: row[cfg.colId] }
+                            : { field: cfg.groupField, value: row[cfg.colId] },
                         })
                     "
                   >
@@ -417,10 +422,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         :data-test="`service-graph-side-panel-${cfg.id}-view-traces-btn`"
                         @click.stop="
                           navigateToTraces({
-                            resourceFilter: {
-                              field: cfg.groupField,
-                              value: row[cfg.colId],
-                            },
+                            resourceFilter: cfg.fields
+                              ? { fields: cfg.fields, value: row[cfg.colId] }
+                              : { field: cfg.groupField, value: row[cfg.colId] },
                             errorsOnly: column.id === 'errors',
                             minDurationMicros: isDurationColumn(column.id) ? row[column.id] : undefined
                           })
@@ -485,6 +489,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
             <!-- Metrics Tab -->
             <OTabPanel
+              v-if="!isInferred"
               name="metrics"
               class="tw:p-0! panel-section tw:mb-0! tw:h-full!"
               data-test="service-graph-side-panel-metrics"
@@ -661,7 +666,100 @@ export interface ResourceTabConfig {
   colId: string; // row property key for the entity name column
   environment: string; // env key derived from group_id first segment
   isDefault: boolean; // pre-selected when the environment is first detected
+  /** Fallback field chain for inferred service tabs. When set, the GROUP BY
+   *  expression is COALESCE(NULLIF(fields[0], ''), NULLIF(fields[1], ''), …).
+   *  When absent, groupField is used directly (existing OTEL resource tabs). */
+  fields?: string[];
 }
+
+// ---------------------------------------------------------------------------
+// Inferred Service Tabs — one entry per dependency type, with field fallback
+// chains that generate COALESCE expressions for both SELECT/GROUP BY and
+// the downstream filter clause.
+// ---------------------------------------------------------------------------
+export interface InferredServiceTab {
+  id: string;        // unique tab name, e.g. "hosts", "databases"
+  label: string;     // display label, e.g. "Hosts", "Databases"
+  colLabel: string;  // table column header, e.g. "Host", "Database"
+  fields: string[];  // fallback order for COALESCE, e.g. ["server_address", "net_peer_name"]
+}
+
+const INFERRED_SERVICE_TABS: Record<string, InferredServiceTab[]> = {
+  database: [
+    {
+      id: "hosts",
+      label: "Hosts",
+      colLabel: "Host",
+      fields: ["server_address", "net_peer_name", "net_peer_ip", "network_peer_address"],
+    },
+    {
+      id: "databases",
+      label: "Databases",
+      colLabel: "Database",
+      fields: ["db_namespace", "db_name"],
+    },
+    {
+      id: "queries",
+      label: "Queries",
+      colLabel: "DB Operation",
+      fields: ["db_operations"],
+    },
+  ],
+  queue: [
+    {
+      id: "hosts",
+      label: "Hosts",
+      colLabel: "Host",
+      fields: ["server_address", "net_peer_name", "net_peer_ip", "network_peer_address"],
+    },
+    {
+      id: "destinations",
+      label: "Destinations",
+      colLabel: "Destination",
+      fields: ["messaging_destination_name", "messaging_destination"],
+    },
+  ],
+  rpc: [
+    {
+      id: "hosts",
+      label: "Hosts",
+      colLabel: "Host",
+      fields: ["server_address", "net_peer_name", "net_peer_ip", "network_peer_address"],
+    },
+    {
+      id: "rpc_services",
+      label: "RPC Services",
+      colLabel: "RPC Service",
+      fields: ["rpc_service"],
+    },
+  ],
+  external: [
+    {
+      id: "hosts",
+      label: "Hosts",
+      colLabel: "Host",
+      fields: ["server_address", "net_peer_name", "net_peer_ip", "network_peer_address"],
+    },
+    {
+      id: "urls",
+      label: "URLs",
+      colLabel: "URL",
+      fields: ["http_url", "url_full"],
+    },
+  ],
+};
+
+/** Build a COALESCE expression from a fallback field chain.
+ *  e.g. ["server_address", "net_peer_name"]
+ *    → "COALESCE(NULLIF(server_address, ''), NULLIF(net_peer_name, ''))" */
+const buildCoalesceExpr = (fields: string[]): string =>
+  fields.map((f) => `NULLIF(${f}, '')`).join(", ");
+
+/** Build a WHERE clause fragment to exclude rows where all fallback fields are null.
+ *  e.g. ["server_address", "net_peer_name"]
+ *    → "(server_address IS NOT NULL OR net_peer_name IS NOT NULL)" */
+const buildNullCheck = (fields: string[]): string =>
+  fields.map((f) => `${f} IS NOT NULL`).join(" OR ");
 
 export interface ResourceRow {
   name: string;
@@ -1274,11 +1372,89 @@ export default defineComponent({
     // Resource groups from getDimensionAnalytics that match the current stream schema
     // (after platform-priority filtering — see resolveWorkloadFields)
     const availableResourceTabConfigs = ref<ResourceTabConfig[]>([]);
-    // Tabs actually shown = those selected by the user in the dropdown
+    // IDs of alias entries the user has checked in the dropdown
+    const selectedWorkloadFields = ref<string[]>([]);
+
+    // Shared cache of stream schema field names — populated by resolveStreamSchema,
+    // consumed by both resolveWorkloadFields and inferredTabConfigs.
+    const streamFieldSet = ref<Set<string>>(new Set());
+    const schemaResolved = ref(false);
+
+    /** Fetch the trace stream schema and populate streamFieldSet.
+     *  Idempotent — skips if already resolved for the current stream. */
+    const resolveStreamSchema = async () => {
+      if (
+        !props.visible ||
+        props.streamFilter === "all" ||
+        !props.streamFilter ||
+        schemaResolved.value
+      )
+        return;
+
+      try {
+        const org = store.state.selectedOrganization.identifier;
+        const schemaResponse = await streamService.schema(
+          org,
+          props.streamFilter,
+          "traces",
+        );
+        const schemaFields: { name: string; type: string }[] =
+          schemaResponse.data?.schema || schemaResponse.data?.fields || [];
+        streamFieldSet.value = new Set(schemaFields.map((f) => f.name));
+        schemaResolved.value = true;
+      } catch (err) {
+        console.error(
+          "[ServiceGraphNodeSidePanel] Failed to resolve stream schema:",
+          err,
+        );
+        streamFieldSet.value = new Set();
+      }
+    };
+
+    // Inferred service tabs — built from INFERRED_SERVICE_TABS registry when
+    // the selected node has a service_type (database/queue/rpc/external).
+    // Each tab's fallback field chain is filtered to only include fields that
+    // actually exist in the stream schema. Tabs with zero surviving fields are
+    // dropped entirely.
+    const inferredTabConfigs = computed<ResourceTabConfig[]>(() => {
+      const st = props.selectedNode?.service_type as string | undefined;
+      if (!st) return [];
+      const tabs = INFERRED_SERVICE_TABS[st];
+      if (!tabs?.length) return [];
+      const fieldSet = streamFieldSet.value;
+      // If schema hasn't resolved yet, return empty — tabs appear once the
+      // schema fetch completes (reactive via streamFieldSet).
+      if (!schemaResolved.value) return [];
+      const resolved: ResourceTabConfig[] = [];
+      for (const t of tabs) {
+        debugger;
+        const present = t.fields.filter((f) => fieldSet.has(f));
+        if (present.length === 0) continue;
+        resolved.push({
+          id: t.id,
+          label: t.label,
+          groupField: `COALESCE(${buildCoalesceExpr(present)})`,
+          colLabel: t.colLabel,
+          colId: t.id,
+          environment: "",
+          isDefault: true,
+          fields: present,
+        });
+      }
+      return resolved;
+    });
+
+    /** Whether the selected node is an inferred service (uninstrumented dependency). */
+    const isInferred = computed(() => !!props.selectedNode?.service_type);
+
+    // Tabs actually shown. For inferred services use the registry tabs;
+    // for instrumented services use the user-selected OTEL resource tabs.
     const activeResourceTabConfigs = computed(() =>
-      availableResourceTabConfigs.value.filter((c) =>
-        selectedWorkloadFields.value.includes(c.id),
-      ),
+      isInferred.value
+        ? inferredTabConfigs.value
+        : availableResourceTabConfigs.value.filter((c) =>
+            selectedWorkloadFields.value.includes(c.id),
+          ),
     );
     // Deduped list of environments detected from visible resource groups
     const detectedEnvironments = computed<{ key: string; label: string }[]>(
@@ -1302,8 +1478,6 @@ export default defineComponent({
     const resolvedWorkloadFields = ref<{ field: string; alias: FieldAlias }[]>(
       [],
     );
-    // IDs of alias entries the user has checked in the dropdown
-    const selectedWorkloadFields = ref<string[]>([]);
 
     // Toggle a workload field id in the selected set — invoked when the user
     // selects the surrounding ODropdownItem (in addition to clicking the
@@ -1585,14 +1759,26 @@ export default defineComponent({
     ];
 
     // Computed: Operations table columns
-    const operationsTableColumns = computed(() =>
-      buildEntityTableColumns("operation", "Operation"),
-    );
+    const operationsTableColumns = computed(() => {
+      const cols = buildEntityTableColumns("operation", "Operation");
+      if (isInferred.value) {
+        cols.unshift({
+          id: "caller",
+          accessorKey: "caller",
+          header: "Caller",
+          size: 180,
+          enableSorting: true,
+          meta: { slot: false, sortable: true },
+        });
+      }
+      return cols;
+    });
 
     // Computed: Operations table rows
     const operationsTableRows = computed(() =>
       recentOperations.value.map((op) => ({
         operation: op.name,
+        caller: op.callerService || "",
         requests: op.requestCount,
         errors: op.errorCount,
         p99: op.p99Latency,
@@ -1602,7 +1788,8 @@ export default defineComponent({
       })),
     );
 
-    // Fetch aggregated operations (grouped by operation_name with percentiles)
+    // Fetch aggregated operations (grouped by operation_name with percentiles).
+    // For inferred services we also GROUP BY service_name so the caller is visible.
     const fetchAggregatedOperations = async () => {
       if (!props.selectedNode || !props.visible || props.streamFilter === "all")
         return;
@@ -1613,7 +1800,14 @@ export default defineComponent({
       try {
         const serviceName = buildServiceName();
         const streamName = props.streamFilter || "default";
-        const sql = `SELECT operation_name, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' GROUP BY operation_name`;
+        const isInf = isInferred.value;
+        const selectCols = isInf
+          ? "service_name as caller_service, operation_name"
+          : "operation_name";
+        const groupCols = isInf
+          ? "service_name, operation_name"
+          : "operation_name";
+        const sql = `SELECT ${selectCols}, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' GROUP BY ${groupCols}`;
 
         const response = await searchService.search({
           org_identifier: store.state.selectedOrganization.identifier,
@@ -1632,6 +1826,7 @@ export default defineComponent({
         if (response.data && response.data.hits) {
           recentOperations.value = response.data.hits.map((op: any) => ({
             name: op.operation_name || "unknown",
+            callerService: op.caller_service || undefined,
             requestCount: op.request_count || 0,
             errorCount: op.error_count || 0,
             p50Latency: op.p50_latency || 0,
@@ -1741,7 +1936,8 @@ export default defineComponent({
       { immediate: true },
     );
 
-    // Generic fetch for any OTEL resource tab config
+    // Generic fetch for any OTEL resource tab config (supports both instrumented
+    // and inferred service tabs; inferred tabs use a COALESCE field chain).
     const fetchResourceData = async (config: ResourceTabConfig) => {
       if (!props.selectedNode || !props.visible || props.streamFilter === "all")
         return;
@@ -1758,7 +1954,13 @@ export default defineComponent({
         const groupField = config.groupField;
         const alias = config.colId + "_name";
 
-        const sql = `SELECT ${groupField} as ${alias}, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' AND ${groupField} IS NOT NULL GROUP BY ${groupField} ORDER BY request_count DESC`;
+        // For inferred tabs with fallback fields, the null-check must span all
+        // fields in the chain; for instrumented tabs a simple IS NOT NULL works.
+        const nullClause = config.fields
+          ? `(${buildNullCheck(config.fields)})`
+          : `${groupField} IS NOT NULL`;
+
+        const sql = `SELECT ${groupField} as ${alias}, count(*) as request_count, count(*) FILTER (WHERE span_status = 'ERROR') as error_count, approx_percentile_cont(duration, 0.50) as p50_latency, approx_percentile_cont(duration, 0.75) as p75_latency, approx_percentile_cont(duration, 0.95) as p95_latency, approx_percentile_cont(duration, 0.99) as p99_latency FROM "${streamName}" WHERE ${serviceNameField.value} = '${serviceName}' AND ${nullClause} GROUP BY ${alias} ORDER BY request_count DESC`;
 
         const response = await searchService.search({
           org_identifier: store.state.selectedOrganization.identifier,
@@ -1807,6 +2009,10 @@ export default defineComponent({
       if (!props.visible || props.streamFilter === "all" || !props.streamFilter)
         return;
 
+      // Ensure the stream schema is resolved (shared with inferred tab resolution)
+      await resolveStreamSchema();
+      if (streamFieldSet.value.size === 0) return;
+
       try {
         const org = store.state.selectedOrganization.identifier;
 
@@ -1819,25 +2025,16 @@ export default defineComponent({
           }
         }
 
-        // Fetch trace stream schema
-        const schemaResponse = await streamService.schema(
-          org,
-          props.streamFilter,
-          "traces",
-        );
-        const schemaFields: { name: string; type: string }[] =
-          schemaResponse.data?.schema || schemaResponse.data?.fields || [];
-        const schemaFieldSet = new Set(schemaFields.map((f) => f.name));
-
         // Filter for service_ fields, intersect with semantic groups, deduplicate by alias.id
         const seen = new Set<string>();
         const matched: { field: string; alias: FieldAlias }[] = [];
-        for (const schemaField of schemaFields) {
-          if (!schemaField.name.startsWith("service_")) continue;
-          const alias = fieldToAliasMap.get(schemaField.name);
+        const schemaFields = [...streamFieldSet.value]; // already resolved above
+        for (const fieldName of schemaFields) {
+          if (!fieldName.startsWith("service_")) continue;
+          const alias = fieldToAliasMap.get(fieldName);
           if (!alias || seen.has(alias.id)) continue;
           seen.add(alias.id);
-          matched.push({ field: schemaField.name, alias });
+          matched.push({ field: fieldName, alias });
         }
         resolvedWorkloadFields.value = matched;
 
@@ -1849,7 +2046,7 @@ export default defineComponent({
         // Filter to groups whose traces (or spans) alias exists in this stream's schema
         const schemaMatchedGroups = allGroups.filter((g) => {
           const field = g.aliases["traces"] ?? g.aliases["spans"];
-          return field && schemaFieldSet.has(field);
+          return field && streamFieldSet.value.has(field);
         });
 
         // Apply ENV_SEGMENTS priority
@@ -1928,12 +2125,18 @@ export default defineComponent({
       },
     );
 
-    // Trigger workload field discovery when the panel becomes visible with a valid stream
+    // Trigger workload field discovery when the panel becomes visible with a valid stream.
+    // For inferred services, resolve the stream schema so inferredTabConfigs can filter
+    // fallback field chains to only those present in the schema.
     watch(
       () => [props.visible, props.selectedNode?.id, props.streamFilter],
       ([visible]) => {
         if (visible && props.selectedNode && props.streamFilter !== "all") {
-          resolveWorkloadFields();
+          if (isInferred.value) {
+            resolveStreamSchema();
+          } else {
+            resolveWorkloadFields();
+          }
         }
       },
       { immediate: true },
@@ -1948,6 +2151,8 @@ export default defineComponent({
         availableResourceTabConfigs.value = [];
         resolvedWorkloadFields.value = [];
         selectedWorkloadFields.value = [];
+        schemaResolved.value = false;
+        streamFieldSet.value = new Set();
         metricsCorrelationData.value = null;
         metricsCorrelationError.value = null;
         metricsCorrelationLoaded.value = false;
@@ -1960,12 +2165,15 @@ export default defineComponent({
     // Navigate to traces explore page with contextual filters
     const navigateToTraces = (params: {
       operationName?: string;
+      /** When the service is inferred, this is the caller's service_name. */
+      callerService?: string;
       /** @deprecated use resourceFilter instead */
       nodeName?: string;
       /** @deprecated use resourceFilter instead */
       podName?: string;
-      /** Generic OTEL resource filter: { field: stream field name, value: field value } */
-      resourceFilter?: { field: string; value: string };
+      /** Generic OTEL resource filter. Use `field` for a single field,
+       *  or `fields` for a fallback chain (OR clause in the filter). */
+      resourceFilter?: { field?: string; fields?: string[]; value: string };
       errorsOnly?: boolean;
       minDurationMicros?: number;
       maxDurationMicros?: number;
@@ -1979,6 +2187,7 @@ export default defineComponent({
           props.selectedNode?.id,
         serviceType: props.selectedNode?.service_type,
         operationName: params.operationName,
+        callerService: params.callerService,
         nodeName: params.nodeName,
         podName: params.podName,
         resourceFilter: params.resourceFilter,
@@ -2111,6 +2320,7 @@ export default defineComponent({
       serviceMetrics,
       serviceHealth,
       isAllStreamsSelected,
+      isInferred,
       formatNumber,
       getErrorRateClass,
       getLatencyClass,

--- a/web/src/plugins/traces/ServicesCatalog.spec.ts
+++ b/web/src/plugins/traces/ServicesCatalog.spec.ts
@@ -31,6 +31,16 @@ vi.mock("@/services/search", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock stream service
+// ---------------------------------------------------------------------------
+const mockStreamSchema = vi.fn().mockResolvedValue({ data: { schema: [] } });
+vi.mock("@/services/stream", () => ({
+  default: {
+    schema: (...args: any[]) => mockStreamSchema(...args),
+  },
+}));
+
+// ---------------------------------------------------------------------------
 // Shared reactive searchObj
 // ---------------------------------------------------------------------------
 const now = Date.now();

--- a/web/src/plugins/traces/ServicesCatalog.vue
+++ b/web/src/plugins/traces/ServicesCatalog.vue
@@ -402,6 +402,7 @@ import ServiceGraphNodeSidePanel from "./ServiceGraphNodeSidePanel.vue";
 import useTraces from "@/composables/useTraces";
 import useStreams from "@/composables/useStreams";
 import useHttpStreaming from "@/composables/useStreamingSearch";
+import streamService from "@/services/stream";
 import { formatLatency } from "@/utils/traces/treeTooltipHelpers";
 import {
   b64EncodeUnicode,
@@ -427,7 +428,7 @@ const { fetchQueryDataWithHttpStream, cancelStreamQueryBasedOnRequestId } =
   useHttpStreaming();
 
 const emit = defineEmits<{
-  "view-traces": [data: string | { serviceName: string; serviceType?: string }];
+  "view-traces": [data: string | Record<string, any>];
 }>();
 
 // p99 > 1 second triggers the orange highlight
@@ -463,8 +464,8 @@ const rowsPerPage = ref(25);
 const rowsPerPageOptions = [10, 25, 50, 100];
 const sortBy = ref<string>("status");
 const sortOrder = ref<"asc" | "desc">("desc");
-const useInferServiceFields = ref(true);
-const isLoadingFallback = ref(false);
+// null = not yet checked; boolean = whether infer_service_name column exists in the stream schema
+const hasInferColumns = ref<boolean | null>(null);
 
 const totalPages = computed(() =>
   filteredServices.value.length && rowsPerPage.value
@@ -714,14 +715,7 @@ function handleCloseSidePanel() {
 }
 
 function viewTraces(data: string | Record<string, any>) {
-  if (typeof data === "string") {
-    emit("view-traces", data);
-  } else {
-    emit("view-traces", {
-      serviceName: data?.serviceName ?? "",
-      serviceType: data?.serviceType,
-    });
-  }
+  emit("view-traces", data);
 }
 
 function getTimeRange(): { start_time: number; end_time: number } {
@@ -756,6 +750,7 @@ const loadAvailableStreams = async () => {
 const onStreamFilterChange = (stream: string) => {
   streamFilter.value = stream;
   localStorage.setItem("servicesCatalog_streamFilter", stream);
+  hasInferColumns.value = null; // re-check schema for new stream
   loadServicesCatalog();
 };
 
@@ -782,9 +777,28 @@ async function loadServicesCatalog() {
 
   const { start_time, end_time } = getTimeRange();
 
-  // Build SQL: try to group by infer_service_name first (with COALESCE fallback to service_name).
-  // If the infer columns don't exist in the schema, the error callback retries without them.
-  const useInfer = useInferServiceFields.value;
+  // Check stream schema for infer_service_name column (cache result per stream)
+  if (hasInferColumns.value === null) {
+    try {
+      const org = searchObj.organizationIdentifier;
+      const schemaResponse = await streamService.schema(
+        org,
+        streamName,
+        "traces",
+      );
+      const schemaFields =
+        schemaResponse.data?.schema || schemaResponse.data?.fields || [];
+      hasInferColumns.value = schemaFields.some(
+        (f: any) => f.name === "infer_service_name",
+      );
+    } catch {
+      // If schema check fails, default to false (use service_name only)
+      hasInferColumns.value = false;
+    }
+  }
+
+  // Build SQL: use infer_service_name when the column exists in the schema
+  const useInfer = hasInferColumns.value;
   const sql = useInfer
     ? `SELECT
   COALESCE(NULLIF(infer_service_name, ''), service_name) AS service_name,
@@ -868,21 +882,10 @@ ORDER BY total_requests DESC`;
         }
       },
       error: (_payload: any, _response: any) => {
-        // If the query failed because infer columns don't exist in the schema,
-        // retry once with the fallback query that only uses service_name.
-        // Guard against re-entry: only retry if we haven't already fallen back.
-        if (useInferServiceFields.value && !isLoadingFallback.value) {
-          useInferServiceFields.value = false;
-          isLoadingFallback.value = true;
-          isLoading.value = false;
-          loadServicesCatalog();
-          return;
-        }
         isLoading.value = false;
       },
       complete: (_payload: any, _response: any) => {
         isLoading.value = false;
-        isLoadingFallback.value = false;
       },
       reset: (_payload: any, _response: any) => {
         services.value = [];

--- a/web/src/plugins/traces/ServicesCatalog.vue
+++ b/web/src/plugins/traces/ServicesCatalog.vue
@@ -427,7 +427,7 @@ const { fetchQueryDataWithHttpStream, cancelStreamQueryBasedOnRequestId } =
   useHttpStreaming();
 
 const emit = defineEmits<{
-  "view-traces": [serviceName: string];
+  "view-traces": [data: string | { serviceName: string; serviceType?: string }];
 }>();
 
 // p99 > 1 second triggers the orange highlight
@@ -452,6 +452,7 @@ interface ServiceRow {
   p99_latency_ns: number;
   infer_service_name?: string;
   infer_service_system?: string;
+  infer_service_type?: string;
 }
 
 const isLoading = ref(false);
@@ -501,6 +502,7 @@ const selectedServiceNode = computed(() =>
     ? {
         id: selectedServiceRow.value.service_name,
         name: selectedServiceRow.value.service_name,
+        service_type: selectedServiceRow.value.infer_service_type,
       }
     : null,
 );
@@ -712,9 +714,14 @@ function handleCloseSidePanel() {
 }
 
 function viewTraces(data: string | Record<string, any>) {
-  const serviceName =
-    typeof data === "string" ? data : (data?.serviceName ?? "");
-  emit("view-traces", serviceName);
+  if (typeof data === "string") {
+    emit("view-traces", data);
+  } else {
+    emit("view-traces", {
+      serviceName: data?.serviceName ?? "",
+      serviceType: data?.serviceType,
+    });
+  }
 }
 
 function getTimeRange(): { start_time: number; end_time: number } {
@@ -781,8 +788,9 @@ async function loadServicesCatalog() {
   const sql = useInfer
     ? `SELECT
   COALESCE(NULLIF(infer_service_name, ''), service_name) AS service_name,
-  MAX(infer_service_name) AS infer_service_name,
-  MAX(infer_service_system) AS infer_service_system,
+  MAX(infer_service_name) AS _infer_service_name,
+  MAX(infer_service_system) AS _infer_service_system,
+  MAX(infer_service_type) AS _infer_service_type,
   COUNT(*) AS total_requests,
   SUM(CASE WHEN span_status = 'ERROR' THEN 1 ELSE 0 END) AS error_count,
   CAST(SUM(CASE WHEN span_status = 'ERROR' THEN 1 ELSE 0 END) AS DOUBLE) / CAST(COUNT(*) AS DOUBLE) * 100 AS error_rate,
@@ -851,8 +859,9 @@ ORDER BY total_requests DESC`;
               p95_latency_ns: hit.p95_latency_ns ?? 0,
               p99_latency_ns: hit.p99_latency_ns ?? 0,
               status: deriveStatus(hit.error_rate ?? 0),
-              infer_service_name: hit.infer_service_name ?? undefined,
-              infer_service_system: hit.infer_service_system ?? undefined,
+              infer_service_name: hit._infer_service_name ?? undefined,
+              infer_service_system: hit._infer_service_system ?? undefined,
+              infer_service_type: hit._infer_service_type ?? undefined,
             });
           }
           services.value = Array.from(serviceMap.values());

--- a/web/src/plugins/traces/ServicesCatalog.vue
+++ b/web/src/plugins/traces/ServicesCatalog.vue
@@ -464,7 +464,16 @@ const rowsPerPage = ref(25);
 const rowsPerPageOptions = [10, 25, 50, 100];
 const sortBy = ref<string>("status");
 const sortOrder = ref<"asc" | "desc">("desc");
-// null = not yet checked; boolean = whether infer_service_name column exists in the stream schema
+/**
+ * Tri-state cache for whether the current stream's schema contains the `infer_service_name` column.
+ *
+ * - `null`  — not yet checked for the current stream; triggers a schema API call on next load.
+ * - `true`  — column exists; queries will use `infer_service_name` for service grouping.
+ * - `false` — column absent; queries will fall back to `service_name` only.
+ *
+ * The value is reset to `null` whenever the stream filter changes so that the next
+ * `loadServicesCatalog()` call re-validates against the new stream's schema.
+ */
 const hasInferColumns = ref<boolean | null>(null);
 
 const totalPages = computed(() =>


### PR DESCRIPTION
## What changed

Enriches the ServiceGraph Node Detail Panel for **inferred services** (uninstrumented dependencies discovered from span attributes — databases, message queues, RPC backends, external APIs). Instead of showing only a single operation for these services, the panel now displays type-specific dynamic tabs (Hosts, Databases, Queries, Destinations, URLs, RPC Services) using field fallback chains with COALESCE expressions, filtered against the actual stream schema.

## Why

Inferred services (detected via `infer_service_name`) previously showed only one operation in the panel because they're derived from CLIENT/PRODUCER spans. There was no way to see the different servers, databases, or URLs they connect to. This PR adds structured context by inspecting peer attributes (`server_address`, `net_peer_name`, `db_namespace`, `messaging_destination_name`, etc.) and grouping data into meaningful tabs per service type.

## Approach

- **INFERRED_SERVICE_TABS registry** — maps each `service_type` (database/queue/rpc/external) to its relevant tabs with fallback field chains (e.g., `["server_address", "net_peer_name", "net_peer_ip", "network_peer_address"]`)
- **SQL helper functions** — `buildCoalesceExpr` and `buildNullCheck` generate COALESCE expressions for GROUP BY/SELECT and OR clauses for WHERE filters
- **Schema-aware field filtering** — `resolveStreamSchema` fetches the trace stream schema; each tab's fallback fields are filtered against it, dropping tabs with zero surviving fields
- **Caller-aware operations** — Operations table gains a "Caller" column for inferred services, showing which upstream service invokes each operation
- **Filter construction** — Row clicks on inferred service tabs generate `(field1 = 'val' OR field2 = 'val')` filters instead of single-field equality
- **Metrics tab hidden** for inferred services — no meaningful metric correlation for uninstrumented backends
- Non-breaking — existing single-field `resourceFilter` paths left unchanged; `handleServicesCatalogViewTraces` normalizes legacy string payloads