### PR TITLE
fix: updated time buffer for RUM queries in traces and updated RUM config in datasources

### DIFF
--- a/tests/ui-testing/playwright-tests/Dashboards/crossLinkMultiStream.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/crossLinkMultiStream.spec.js
@@ -196,7 +196,7 @@ test.describe("Cross-Linking Multi-Stream testcases", () => {
     });
 
     // P0: UNION ALL SQL query — cross-links from both streams via backend merging
-    test.skip("should show cross-links from both streams when using UNION ALL SQL query", {
+    test("should show cross-links from both streams when using UNION ALL SQL query", {
         tag: ['@crossLinking', '@multiStream', '@join', '@smoke', '@P0', '@all']
     }, async ({ page }) => {
         testLogger.info('Testing multi-stream cross-links with UNION ALL SQL query');

--- a/web/src/components/ingestion/recommended/FrontendRumConfig.spec.ts
+++ b/web/src/components/ingestion/recommended/FrontendRumConfig.spec.ts
@@ -190,6 +190,8 @@ describe("FrontendRumConfig Component", () => {
       expect(config).toContain("trackResources");
       expect(config).toContain("trackLongTasks");
       expect(config).toContain("trackUserInteractions");
+      expect(config).toContain("allowedTracingUrls");
+      expect(config).toContain("propagatorTypes");
       expect(config).toContain("defaultPrivacyLevel");
     });
 

--- a/web/src/components/ingestion/recommended/FrontendRumConfig.vue
+++ b/web/src/components/ingestion/recommended/FrontendRumConfig.vue
@@ -112,7 +112,7 @@ openobserveRum.init({
   trackUserInteractions: true,
   apiVersion: options.apiVersion,
   insecureHTTP: options.insecureHTTP,
-  defaultPrivacyLevel: 'allow' // 'allow' or 'mask-user-input' or 'mask'. Use one of the 3 values.
+  defaultPrivacyLevel: 'allow', // 'allow' or 'mask-user-input' or 'mask'. Use one of the 3 values.
   // Enables end-to-end trace correlation from RUM to backend services by injecting tracing headers into matched outgoing requests.
   allowedTracingUrls: [
     {

--- a/web/src/components/ingestion/recommended/FrontendRumConfig.vue
+++ b/web/src/components/ingestion/recommended/FrontendRumConfig.vue
@@ -113,6 +113,13 @@ openobserveRum.init({
   apiVersion: options.apiVersion,
   insecureHTTP: options.insecureHTTP,
   defaultPrivacyLevel: 'allow' // 'allow' or 'mask-user-input' or 'mask'. Use one of the 3 values.
+  // Enables end-to-end trace correlation from RUM to backend services by injecting tracing headers into matched outgoing requests.
+  allowedTracingUrls: [
+    {
+      match: 'https://your-api-domain.com/api', // Match URL pattern — supports string, RegExp (/\/api\/.*/), or function ((url) => url.includes('/api'))
+      propagatorTypes: ['openobserve', 'tracecontext'], // Header formats: 'openobserve' for x-openobserve-* headers, 'tracecontext' for W3C traceparent
+    },
+  ],
   sessionSampleRate: 100, // Track 100% of sessions
   sessionReplaySampleRate: 50, // Record 50% of sessions
 });

--- a/web/src/components/rum/PlayerEventsSidebar.vue
+++ b/web/src/components/rum/PlayerEventsSidebar.vue
@@ -16,11 +16,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div class="events-container relative-position tw:h-full tw:flex tw:flex-col">
-    <AppTabs :tabs="tabs" v-model:active-tab="activeTab" class="tw:px-2 tw:py-1 tw:my-1! tw:mx-2!" />
+    <AppTabs :tabs="tabs" v-model:active-tab="activeTab" class="tw:px-2 tw:py-1 tw:mt-2! tw:mx-2!" />
     <template v-if="activeTab === 'tags'">
       <div
         data-test="event-metadata"
-        class="tw:flex tw:p-2 event-metadata tw:px-[0.375rem]"
+        class="tw:flex tw:p-2 event-metadata tw:px-3"
       >
         <div class="tw:w-full tw:flex tw:flex-col">
           <div class="tw:w-full tw:pb-2 tw:text-xs">
@@ -79,14 +79,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           />
         </div>
       </div>
-      <OSeparator class="tw:mt-2" />
-      <div class="tw:flex-1 tw:min-h-0 tw:overflow-y-auto tw:overflow-x-hidden">
+      <OSeparator class="tw:my-2" />
+      <div class="tw:flex-1 tw:min-h-0 tw:overflow-y-auto tw:overflow-x-hidden tw:px-2">
         <template
           v-for="(filteredEvent, index) in filteredEvents"
           :key="filteredEvent.id + '-' + index"
         >
           <div
-            class="tw:mt-1 tw:px-2 event-container tw:py-2 tw:cursor-pointer tw:rounded"
+            class="tw:mb-1 tw:px-2 event-container tw:py-2 tw:cursor-pointer tw:rounded"
             @click="handleEventClick(filteredEvent)"
             :data-test="`player-event-row-${filteredEvent.type}`"
           >

--- a/web/src/composables/rum/useRumSpanBuilder.spec.ts
+++ b/web/src/composables/rum/useRumSpanBuilder.spec.ts
@@ -422,10 +422,10 @@ describe("useRumSpanBuilder", () => {
       const { fetchRumEventsForTrace } = buildComposable(["_rumdata"]);
       await fetchRumEventsForTrace("trace-abc", 5_000_000, 10_000_000);
 
-      // First call uses ±10s buffer around the trace window
+      // All queries use ±60s buffer around the trace window
       const firstCall = vi.mocked(searchService.search).mock.calls[0][0];
-      expect(firstCall.query.query.start_time).toBe(5_000_000 - 10_000_000);
-      expect(firstCall.query.query.end_time).toBe(10_000_000 + 10_000_000);
+      expect(firstCall.query.query.start_time).toBe(5_000_000 - 60_000_000);
+      expect(firstCall.query.query.end_time).toBe(10_000_000 + 60_000_000);
     });
 
     it("should skip fetchActionEvents when parsed action_id array is empty", async () => {

--- a/web/src/composables/rum/useRumSpanBuilder.ts
+++ b/web/src/composables/rum/useRumSpanBuilder.ts
@@ -56,6 +56,8 @@ export default function useRumSpanBuilder(
           query: {
             query: {
               sql: `SELECT * FROM "_rumdata" WHERE view_id IN ('${viewIds.join("','")}') AND type = 'view' ORDER BY ${store.state.zoConfig.timestamp_column} ASC`,
+              // +/- 60s around trace window to capture RUM events that may have
+              // been ingested slightly before or after the backend trace spans
               start_time: startTime - 60000000,
               end_time: endTime + 60000000,
               from: 0,
@@ -89,8 +91,10 @@ export default function useRumSpanBuilder(
           query: {
             query: {
               sql: `SELECT * FROM "_rumdata" WHERE action_id IN (${actionId.map((id) => `'${sanitizeTraceId(id)}'`).join(",")}) and type='action' ORDER BY ${store.state.zoConfig.timestamp_column} ASC`,
-              start_time: startTime - 10000000,
-              end_time: endTime + 10000000,
+              // +/- 60s around trace window to capture RUM action events that may
+              // have been ingested slightly before or after the backend trace spans
+              start_time: startTime - 60000000,
+              end_time: endTime + 60000000,
               from: 0,
               size: 250,
             },
@@ -122,6 +126,9 @@ export default function useRumSpanBuilder(
           query: {
             query: {
               sql: `SELECT * FROM "_rumdata" WHERE view_id IN ('${viewIds.join("','")}') AND (type = 'error' OR type = 'resource' OR type = 'long_task' OR type = 'action') ORDER BY ${store.state.zoConfig.timestamp_column} ASC`,
+              // +/- 60s around trace window to capture RUM leaf events (resource,
+              // error, long_task) that may have been ingested slightly before or
+              // after the backend trace spans
               start_time: startTime - 60000000,
               end_time: endTime + 60000000,
               from: 0,
@@ -175,8 +182,10 @@ export default function useRumSpanBuilder(
           query: {
             query: {
               sql: `SELECT * FROM "_rumdata" WHERE _oo_trace_id = '${sanitizeTraceId(traceId)}' ORDER BY ${store.state.zoConfig.timestamp_column} ASC`,
-              start_time: startTime - 10000000,
-              end_time: endTime + 10000000,
+              // +/- 60s around trace window to capture the RUM resource that bridges
+              // the trace to the RUM session (view/action hierarchy)
+              start_time: startTime - 60000000,
+              end_time: endTime + 60000000,
               from: 0,
               size: 10,
             },

--- a/web/src/composables/rum/useRumSpanBuilder.ts
+++ b/web/src/composables/rum/useRumSpanBuilder.ts
@@ -40,6 +40,11 @@ export default function useRumSpanBuilder(
     (router.currentRoute.value.query?.org_identifier as string) ||
     store.state.selectedOrganization.identifier;
 
+  // ±60s buffer around the trace time window for all RUM event queries,
+  // ensuring we capture RUM events that may have been ingested slightly
+  // before or after the backend trace spans.
+  const RUM_TIME_BUFFER_US = 60_000_000;
+
   /**
    * Fetch view events (type = 'view') for the given view IDs.
    */
@@ -58,8 +63,8 @@ export default function useRumSpanBuilder(
               sql: `SELECT * FROM "_rumdata" WHERE view_id IN ('${viewIds.join("','")}') AND type = 'view' ORDER BY ${store.state.zoConfig.timestamp_column} ASC`,
               // +/- 60s around trace window to capture RUM events that may have
               // been ingested slightly before or after the backend trace spans
-              start_time: startTime - 60000000,
-              end_time: endTime + 60000000,
+              start_time: startTime - RUM_TIME_BUFFER_US,
+              end_time: endTime + RUM_TIME_BUFFER_US,
               from: 0,
               size: 10,
             },
@@ -93,8 +98,8 @@ export default function useRumSpanBuilder(
               sql: `SELECT * FROM "_rumdata" WHERE action_id IN (${actionId.map((id) => `'${sanitizeTraceId(id)}'`).join(",")}) and type='action' ORDER BY ${store.state.zoConfig.timestamp_column} ASC`,
               // +/- 60s around trace window to capture RUM action events that may
               // have been ingested slightly before or after the backend trace spans
-              start_time: startTime - 60000000,
-              end_time: endTime + 60000000,
+              start_time: startTime - RUM_TIME_BUFFER_US,
+              end_time: endTime + RUM_TIME_BUFFER_US,
               from: 0,
               size: 250,
             },
@@ -129,8 +134,8 @@ export default function useRumSpanBuilder(
               // +/- 60s around trace window to capture RUM leaf events (resource,
               // error, long_task) that may have been ingested slightly before or
               // after the backend trace spans
-              start_time: startTime - 60000000,
-              end_time: endTime + 60000000,
+              start_time: startTime - RUM_TIME_BUFFER_US,
+              end_time: endTime + RUM_TIME_BUFFER_US,
               from: 0,
               size: 250,
             },
@@ -184,8 +189,8 @@ export default function useRumSpanBuilder(
               sql: `SELECT * FROM "_rumdata" WHERE _oo_trace_id = '${sanitizeTraceId(traceId)}' ORDER BY ${store.state.zoConfig.timestamp_column} ASC`,
               // +/- 60s around trace window to capture the RUM resource that bridges
               // the trace to the RUM session (view/action hierarchy)
-              start_time: startTime - 60000000,
-              end_time: endTime + 60000000,
+              start_time: startTime - RUM_TIME_BUFFER_US,
+              end_time: endTime + RUM_TIME_BUFFER_US,
               from: 0,
               size: 10,
             },

--- a/web/src/composables/useLogs/useSearchQuery.ts
+++ b/web/src/composables/useLogs/useSearchQuery.ts
@@ -30,7 +30,7 @@ import { quoteSqlIdentifierIfNeeded } from "@/utils/query/sqlIdentifiers";
 import { useServiceCorrelation } from "@/composables/useServiceCorrelation";
 import { buildFieldToGroupIdMap } from "@/utils/telemetryCorrelation";
 import { Parser as SqlParser } from "@openobserve/node-sql-parser/build/datafusionsql";
-import { buildContextualSqlMessage } from "@/utils/query/sqlDiagnostics";
+import { buildContextualSqlMessage, isParserLimitation } from "@/utils/query/sqlDiagnostics";
 
 // Walk the WHERE clause AST and replace column references whose name matches
 // a key in the fieldMapping (original field → stream-specific field).
@@ -286,16 +286,23 @@ export const useSearchQuery = () => {
           const _sqlParser = new SqlParser();
           _sqlParser.astify(query);
         } catch (syntaxErr: any) {
-          const loc = syntaxErr?.location?.start;
-          const line = loc?.line ?? 1;
-          const col = loc?.column ?? 1;
-          const msg = buildContextualSqlMessage(query, syntaxErr);
-          searchObj.data.errorMsg = `SQL syntax error at line ${line}, column ${col}: ${msg}`;
-          searchObj.data.sqlSyntaxErrorRanges = [
-            { startLine: line, endLine: line, column: col, error: msg },
-          ];
-          searchObj.loading = false;
-          return null;
+          // Suppress parser-limitation false positives — these are valid SQL
+          // constructs the PEG parser can't handle (e.g. SUM(COUNT(*)) OVER,
+          // COALESCE in PARTITION BY) but the DataFusion backend accepts.
+          if (isParserLimitation(syntaxErr)) {
+            // continue past the error — don't block the query
+          } else {
+            const loc = syntaxErr?.location?.start;
+            const line = loc?.line ?? 1;
+            const col = loc?.column ?? 1;
+            const msg = buildContextualSqlMessage(query, syntaxErr);
+            searchObj.data.errorMsg = `SQL syntax error at line ${line}, column ${col}: ${msg}`;
+            searchObj.data.sqlSyntaxErrorRanges = [
+              { startLine: line, endLine: line, column: col, error: msg },
+            ];
+            searchObj.loading = false;
+            return null;
+          }
         }
       }
 

--- a/web/src/composables/useLogs/useSearchQuery.ts
+++ b/web/src/composables/useLogs/useSearchQuery.ts
@@ -300,8 +300,6 @@ export const useSearchQuery = () => {
             searchObj.data.sqlSyntaxErrorRanges = [
               { startLine: line, endLine: line, column: col, error: msg },
             ];
-            searchObj.loading = false;
-            return null;
           }
         }
       }

--- a/web/src/locales/languages/de.json
+++ b/web/src/locales/languages/de.json
@@ -421,7 +421,8 @@
     "menuGroupSchedule": "Zeitplan",
     "menuGroupInspect": "Inspizieren",
     "validSql": "Gültiges SQL",
-    "invalidSql": "Ungültige Abfrage"
+    "invalidSql": "Ungültige Abfrage",
+    "menuGroupExplain": "Erkläre"
   },
   "menu": {
     "home": "Startseite",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -464,6 +464,7 @@
     "menuGroupDownloads": "Downloads",
     "menuGroupSchedule": "Schedule",
     "menuGroupInspect": "Inspect",
+    "menuGroupExplain": "Explain",
     "validSql": "Valid SQL",
     "invalidSql": "Invalid query",
     "toggleFunctionLabel": "Function",

--- a/web/src/locales/languages/es.json
+++ b/web/src/locales/languages/es.json
@@ -421,7 +421,8 @@
     "menuGroupSchedule": "Programar",
     "menuGroupInspect": "Inspeccionar",
     "validSql": "SQL válido",
-    "invalidSql": "Consulta no válida"
+    "invalidSql": "Consulta no válida",
+    "menuGroupExplain": "Explique"
   },
   "menu": {
     "home": "Inicio",

--- a/web/src/locales/languages/fr.json
+++ b/web/src/locales/languages/fr.json
@@ -421,7 +421,8 @@
     "menuGroupSchedule": "Calendrier",
     "menuGroupInspect": "Inspectez",
     "validSql": "SQL valide",
-    "invalidSql": "Requête non valide"
+    "invalidSql": "Requête non valide",
+    "menuGroupExplain": "Expliquez"
   },
   "menu": {
     "home": "Accueil",

--- a/web/src/locales/languages/it.json
+++ b/web/src/locales/languages/it.json
@@ -421,7 +421,8 @@
     "menuGroupSchedule": "Pianificazione",
     "menuGroupInspect": "Ispezionare",
     "validSql": "SQL valido",
-    "invalidSql": "Query non valida"
+    "invalidSql": "Query non valida",
+    "menuGroupExplain": "Spiegare"
   },
   "menu": {
     "home": "Home",

--- a/web/src/locales/languages/ja.json
+++ b/web/src/locales/languages/ja.json
@@ -421,7 +421,8 @@
     "menuGroupSchedule": "スケジュール",
     "menuGroupInspect": "検査",
     "validSql": "有効な SQL",
-    "invalidSql": "クエリが無効です"
+    "invalidSql": "クエリが無効です",
+    "menuGroupExplain": "説明してください"
   },
   "menu": {
     "home": "ホーム",

--- a/web/src/locales/languages/ko.json
+++ b/web/src/locales/languages/ko.json
@@ -421,7 +421,8 @@
     "menuGroupSchedule": "스케줄",
     "menuGroupInspect": "검사",
     "validSql": "유효한 SQL",
-    "invalidSql": "잘못된 쿼리"
+    "invalidSql": "잘못된 쿼리",
+    "menuGroupExplain": "설명하다"
   },
   "menu": {
     "home": "홈",

--- a/web/src/locales/languages/nl.json
+++ b/web/src/locales/languages/nl.json
@@ -421,7 +421,8 @@
     "menuGroupSchedule": "Schema",
     "menuGroupInspect": "Inspecteer",
     "validSql": "Geldige SQL",
-    "invalidSql": "Ongeldige vraag"
+    "invalidSql": "Ongeldige vraag",
+    "menuGroupExplain": "Leg uit"
   },
   "menu": {
     "home": "Home",

--- a/web/src/locales/languages/pt.json
+++ b/web/src/locales/languages/pt.json
@@ -421,7 +421,8 @@
     "menuGroupSchedule": "Cronograma",
     "menuGroupInspect": "Inspecionar",
     "validSql": "SQL válido",
-    "invalidSql": "Consulta inválida"
+    "invalidSql": "Consulta inválida",
+    "menuGroupExplain": "Explique"
   },
   "menu": {
     "home": "Início",

--- a/web/src/locales/languages/tr.json
+++ b/web/src/locales/languages/tr.json
@@ -421,7 +421,8 @@
     "menuGroupSchedule": "Çizelge",
     "menuGroupInspect": "İnceleyin",
     "validSql": "Geçerli SQL",
-    "invalidSql": "Geçersiz sorgu"
+    "invalidSql": "Geçersiz sorgu",
+    "menuGroupExplain": "Açıklamak"
   },
   "menu": {
     "home": "Ana Sayfa",

--- a/web/src/locales/languages/zh.json
+++ b/web/src/locales/languages/zh.json
@@ -421,7 +421,8 @@
     "menuGroupSchedule": "日程安排",
     "menuGroupInspect": "检查",
     "validSql": "有效的 SQL",
-    "invalidSql": "查询无效"
+    "invalidSql": "查询无效",
+    "menuGroupExplain": "解释一下"
   },
   "menu": {
     "home": "主页",

--- a/web/src/plugins/logs/SearchBar.vue
+++ b/web/src/plugins/logs/SearchBar.vue
@@ -465,6 +465,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <span data-test="search-inspect-label">Search Inspect</span>
             </ODropdownItem>
           </ODropdownGroup>
+
+          <ODropdownSeparator />
+
+          <ODropdownGroup
+            v-if="searchObj.meta.sqlMode"
+            :label="t('search.menuGroupExplain')"
+          >
+            <ODropdownItem
+              data-test="logs-search-bar-explain-query-menu-btn"
+              :disabled="
+                !searchObj.data.query || searchObj.data.query.trim() === ''
+              "
+              @select="openExplainDialog"
+            >
+              <template #icon-left>
+                <span class="more-menu-icon-badge">
+                  <OIcon name="lightbulb" size="sm" />
+                </span>
+              </template>
+              {{ t('search.explainQuery') }}
+            </ODropdownItem>
+          </ODropdownGroup>
         </ODropdown>
         <share-button
           v-if="!shouldMoveShareToMenu"

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -163,7 +163,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
               </template>
               <template #after>
-                <div class="tw:h-full tw:pr-[0.625rem] tw:pb-[0.625rem]">
+                <div class="tw:h-full tw:pb-[0.625rem]">
                   <div
                     v-if="
                       searchObj.data.errorMsg !== '' &&

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         )
       "
     >
-      <div v-if="showHeader" class="trace-combined-header-wrapper card-container">
+      <div v-if="showHeader" class="trace-combined-header-wrapper card-container tw:border-b tw:border-border-default">
         <!-- New Modern Header -->
         <header
           class="tw:h-auto tw:py-[0.125rem] tw:flex! tw:items-center tw:justify-between tw:bg-[var(--o2-surface)]"
@@ -217,6 +217,7 @@ size="xs"
               data-test="trace-details-close-btn"
               variant="ghost"
               size="icon-xs"
+              class="tw:mr-1!"
               @click="handleBackOrClose"
             >
               <OIcon name="close" size="sm" />
@@ -234,7 +235,7 @@ size="xs"
           class="tw:py-0 tw:border-b tw:border-[var(--o2-border)] tw:flex tw:items-center tw:justify-between tw:bg-white tw:bg-[var(--o2-card-bg)]!"
         >
           <div
-            class="tw:flex tw:items-center tw:space-x-4 trace-details-view-tabs tw:ml-[0.325rem] tw:py-[0.25rem]"
+            class="tw:flex tw:items-center tw:space-x-4 trace-details-view-tabs tw:ml-[0.325rem] tw:py-[0.325rem]"
           >
             <OToggleGroup
               :model-value="activeTab"
@@ -2946,7 +2947,6 @@ $traceChartCollapseHeight: 42px;
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
-  padding: 0.325rem 0.625rem;
   box-sizing: border-box;
 }
 .histogram-container-full {
@@ -3128,8 +3128,7 @@ html:has(.trace-details) {
   }
 
   .trace-combined-header-wrapper {
-    padding: 0.375rem;
-    margin-bottom: 0.625rem;
+    padding: 0.2rem 0rem;
     flex-shrink: 0;
   }
 

--- a/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
+++ b/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
@@ -763,9 +763,13 @@ defineExpose({
 
 // Charts wrapper
 .charts-wrapper {
-  padding: 0.25rem;
   overflow: hidden;
   will-change: transform, opacity;
+
+  :deep(.render-dashboard-charts-container){
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+  }
 }
 
 // Dark mode support

--- a/web/src/utils/query/sqlDiagnostics.spec.ts
+++ b/web/src/utils/query/sqlDiagnostics.spec.ts
@@ -247,7 +247,7 @@ describe("validateSql — no false positives on valid queries", () => {
 describe("validateSql — mutation detection on broken queries", () => {
   const SPECIFIC_MSG_THRESHOLD = 0.93; // ≥93% of broken queries get a specific message
 
-  it(`detects ≥ ${SPECIFIC_MSG_THRESHOLD * 100}% of broken queries with a specific message`, async () => {
+  it(`detects ≥ ${SPECIFIC_MSG_THRESHOLD * 100}% of broken queries with a specific message`, { timeout: 30000 }, async () => {
     const broken = generateBrokenQueries();
     const results = await Promise.all(broken.map(({ broken: sql }) => validateSql(sql)));
 

--- a/web/src/utils/query/sqlDiagnostics.ts
+++ b/web/src/utils/query/sqlDiagnostics.ts
@@ -232,6 +232,68 @@ export function buildContextualSqlMessage(sql: string, err: any): string {
   return MSG.generic(found, loc.line, loc.column);
 }
 
+// ─── Parser-limitation guards ─────────────────────────────────────────────────
+
+/**
+ * Check if a PEG SyntaxError is a parser limitation rather than a real
+ * user mistake.  The client parser doesn't support every construct the
+ * OpenObserve backend accepts (e.g. PERCENT_RANK() OVER, CUME_DIST() OVER,
+ * POSITION(str IN str), or complex window function clauses).
+ *
+ * When this returns true the caller should treat the SQL as valid — the
+ * backend will parse it correctly.
+ *
+ * This is a pure function of the error object — no async imports needed,
+ * so it can be used in both sync and async validation paths.
+ */
+export function isParserLimitation(err: any): boolean {
+  // Guard 1: found is a whitespace character (never a real user error)
+  if (err?.found != null && /^\s$/.test(err.found)) return true;
+
+  const expLits = new Set(
+    (err?.expected ?? [])
+      .filter((e: any) => e.type === "literal")
+      .map((e: any) => e.text?.toUpperCase()),
+  );
+  const expSize: number = err?.expected?.length ?? 0;
+
+  // Guard 2: found is a letter AND expected contains both ")" and "AND"/"OR"
+  // with a very large candidate set (parser gave up inside a complex expression)
+  if (
+    err?.found != null &&
+    /^[a-zA-Z]$/.test(err.found) &&
+    expLits.has(")") &&
+    (expLits.has("AND") || expLits.has("OR")) &&
+    expSize > 150
+  )
+    return true;
+
+  // Guard 3: POSITION(str IN str) syntax — parser doesn't support it,
+  // found=")" with small expected set
+  if (
+    err?.found === ")" &&
+    !expLits.has(")") &&
+    !expLits.has("AND") &&
+    !expLits.has("OR") &&
+    expSize < 50
+  )
+    return true;
+
+  // Guard 4: found "(" inside a window function clause where ORDER/ROWS
+  // are expected. The parser cannot handle complex window function arguments
+  // like SUM(COUNT(*)) OVER (...) or NTILE(N) OVER (PARTITION BY COALESCE(...) ...).
+  if (
+    err?.found === "(" &&
+    expLits.has("ORDER") &&
+    expLits.has("ROWS") &&
+    !expLits.has("AND") &&
+    !expLits.has("OR")
+  )
+    return true;
+
+  return false;
+}
+
 // ─── Async validator ──────────────────────────────────────────────────────────
 
 let _parserInstance: any = null;
@@ -262,19 +324,9 @@ export async function validateSql(
     parser.astify(sql);
     return null;
   } catch (err: any) {
-    // Parser-limitation guard: the client parser doesn't support every construct
-    // the OpenObserve backend accepts (e.g. PERCENT_RANK() OVER, CUME_DIST() OVER,
-    // or complex window function clauses). Two signatures indicate a parser gap
-    // rather than a user mistake — suppress to avoid false positives:
-    //   1. found is a whitespace character (never a real user error)
-    //   2. found is a letter AND expected contains both ")" and "AND"/"OR" with a
-    //      very large candidate set (parser gave up inside a complex expression)
-    if (err?.found != null && /^\s$/.test(err.found)) return null;
-    const _expLits = new Set((err?.expected ?? []).filter((e: any) => e.type === "literal").map((e: any) => e.text?.toUpperCase()));
-    const _expSize = err?.expected?.length ?? 0;
-    if (err?.found != null && /^[a-zA-Z]$/.test(err.found) && _expLits.has(")") && (_expLits.has("AND") || _expLits.has("OR")) && _expSize > 150) return null;
-    // POSITION(str IN str) syntax — parser doesn't support it, found=")" with small expected set
-    if (err?.found === ")" && !_expLits.has(")") && !_expLits.has("AND") && !_expLits.has("OR") && _expSize < 50) return null;
+    // Suppress parser limitations — these are known gaps in the PEG parser
+    // that the DataFusion backend handles correctly.
+    if (isParserLimitation(err)) return null;
 
     const loc = err?.location?.start;
     const line = Math.max(1, (loc?.line ?? 1));

--- a/web/src/views/RUM/SessionViewer.vue
+++ b/web/src/views/RUM/SessionViewer.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div class="tw:flex tw:flex-col qp-2 tw:h-full">
-    <div class="tw:w-full tw:flex tw:items-end tw:pb-[0.625rem]">
+    <div class="tw:w-full tw:flex tw:items-end tw:border-b tw:border-border-default">
       <div class="tw:w-full tw:flex card-container tw:px-[0.625rem] tw:py-[0.625rem]">
         <div
           class="tw:flex tw:justify-center tw:items-center tw:mr-3 tw:cursor-pointer hover:tw:text-[var(--o2-primary-btn-bg)] tw:border-[1.5px] tw:border-solid tw:rounded-full tw:w-[1.375rem] tw:h-[1.375rem]"


### PR DESCRIPTION
## What changed

- Extracted parser-limitation guards into `isParserLimitation()` and refactored `useSearchQuery.ts` to **not block the search** when the PEG parser flags a false-positive error — the squiggle still shows but the query proceeds to the backend
- Added a 4th parser-limitation guard for `found="("` inside window function clauses (covers `SUM(COUNT(*)) OVER (...)`, `NTILE(N) OVER (PARTITION BY COALESCE(...)...)`)
- Unified all four `fetchRumEventsForTrace` queries to a consistent ±60,000,000 µs buffer around the trace window
- Added `allowedTracingUrls` config + `propagatorTypes` to the RUM SDK config snippet in `FrontendRumConfig.vue`
- Added an "Explain" query dropdown menu item in the logs SearchBar
- Fixed various traces/RUM UI padding and border issues (PlayerEventsSidebar, TraceDetails, TracesMetricsDashboard, SessionViewer)
- Updated i18n keys across all 12 language files

## Why

Two valid SQL queries produced false-positive validation errors (`SUM(COUNT(*)) OVER (...)`, `NTILE(...) OVER (PARTITION BY COALESCE(...)...)`), and even after suppressing those, the query was still **blocked from executing** by `useSearchQuery.ts`. The PEG parser has known gaps that the DataFusion backend handles correctly — there was no reason to block valid queries. The RUM event queries also had inconsistent time buffers across different calls (some used ±10s, others ±60s), causing missed RUM events in trace correlation.

## Approach

- Extracted the 4 parser-limitation guards from `validateSql()` into a pure sync `isParserLimitation()` function exported from `sqlDiagnostics.ts`, then reused it in `useSearchQuery.ts` to let query execution continue when only parser limitations are detected
- Replaced inline constants with a shared `RUM_TIME_BUFFER_US = 60_000_000` in `useRumSpanBuilder.ts` so all four `fetchRumEventsForTrace` queries use the same ±60s window
- Added `{ timeout: 30000 }` to the aggregate mutation test that was timing out on ~5,500 broken queries