### PR TITLE
fix: return 403 Unauthorized from AI chat endpoints when user lacks access

### DIFF
--- a/web/src/components/CodeQueryEditor.vue
+++ b/web/src/components/CodeQueryEditor.vue
@@ -76,6 +76,7 @@ import { useNLQuery } from "@/composables/useNLQuery";
 import { useI18n } from "vue-i18n";
 import useNotifications from "@/composables/useNotifications";
 import { getImageURL } from "@/utils/zincutils";
+import { isAuthError } from "@/utils/authErrors";
 import OButton from "@/lib/core/Button/OButton.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
@@ -483,11 +484,14 @@ export default defineComponent({
         });
 
         if (!generatedSQL || generatedSQL.trim() === "") {
-          // Show error notification
+          // Show error notification - use streaming error message if available (e.g. Unauthorized Access)
           console.log(
             "[NL2Q-UI] Showing error notification - query generation failed or empty",
           );
-          showErrorNotification(t("search.nlQueryGenerationFailed"));
+          const errorMsg = isAuthError(streamingResponse.value)
+            ? streamingResponse.value
+            : t("search.nlQueryGenerationFailed");
+          showErrorNotification(errorMsg);
           throw new Error("Query generation failed");
         }
 

--- a/web/src/components/O2AIChat.vue
+++ b/web/src/components/O2AIChat.vue
@@ -1400,6 +1400,7 @@ import OSearchInput from "@/lib/forms/SearchInput/OSearchInput.vue";
 import { toast } from "@/lib/feedback/Toast/useToast";
 import { copyToClipboard } from "@/utils/clipboard";
 import OSeparator from '@/lib/core/Separator/OSeparator.vue';
+import { UNAUTHORIZED_MESSAGE, isAuthError } from "@/utils/authErrors";
 
 const { fetchAiChat, submitFeedback } = useAiChat();
 const { emit: emitDashboardEvent } = useAiDashboardEvents();
@@ -2462,8 +2463,12 @@ export default defineComponent({
                         ? rawError
                         : JSON.stringify(rawError, null, 2);
 
-                    let errorMessage = `Error: ${errorText}`;
-                    if (data.suggestion) {
+                    // Check if this is an authorization/access error
+                    const authErr = isAuthError(errorText, data.error_type);
+                    let errorMessage = authErr
+                      ? UNAUTHORIZED_MESSAGE
+                      : `Error: ${errorText}`;
+                    if (data.suggestion && !authErr) {
                       errorMessage += `\n\n${data.suggestion}`;
                     }
 
@@ -2757,12 +2762,24 @@ export default defineComponent({
                     }
 
                     // Add inline error block
+                    const rawErrorMessage =
+                      data.message || data.error || "An error occurred";
+                    const authErr = isAuthError(
+                      rawErrorMessage,
+                      data.error_type,
+                    );
                     const errorBlock: ContentBlock = {
                       type: "error",
-                      message: data.message || "An error occurred",
+                      message: authErr
+                        ? UNAUTHORIZED_MESSAGE
+                        : rawErrorMessage,
                       errorType: data.error_type || undefined,
-                      suggestion: data.suggestion || undefined,
-                      recoverable: data.recoverable ?? undefined,
+                      suggestion: authErr
+                        ? undefined
+                        : data.suggestion || undefined,
+                      recoverable: authErr
+                        ? false
+                        : data.recoverable ?? undefined,
                     };
                     let lastMessage = msgs[msgs.length - 1];
                     if (lastMessage && lastMessage.role === "assistant") {
@@ -2982,8 +2999,12 @@ export default defineComponent({
                       ? rawError
                       : JSON.stringify(rawError, null, 2);
 
-                  let errorMessage = `Error: ${errorText}`;
-                  if (data.suggestion) {
+                  // Check if this is an authorization/access error
+                  const authErr = isAuthError(errorText, data.error_type);
+                  let errorMessage = authErr
+                    ? UNAUTHORIZED_MESSAGE
+                    : `Error: ${errorText}`;
+                  if (data.suggestion && !authErr) {
                     errorMessage += `\n\n${data.suggestion}`;
                   }
 
@@ -3150,12 +3171,24 @@ export default defineComponent({
                     if (isActive()) activeToolCall.value = null;
                   }
 
+                  const rawErrorMessage =
+                    data.message || data.error || "An error occurred";
+                  const authErr = isAuthError(
+                    rawErrorMessage,
+                    data.error_type,
+                  );
                   const errorBlock: ContentBlock = {
                     type: "error",
-                    message: data.message || "An error occurred",
+                    message: authErr
+                      ? UNAUTHORIZED_MESSAGE
+                      : rawErrorMessage,
                     errorType: data.error_type || undefined,
-                    suggestion: data.suggestion || undefined,
-                    recoverable: data.recoverable ?? undefined,
+                    suggestion: authErr
+                      ? undefined
+                      : data.suggestion || undefined,
+                    recoverable: authErr
+                      ? false
+                      : data.recoverable ?? undefined,
                   };
                   let lastMessage = msgs[msgs.length - 1];
                   if (lastMessage && lastMessage.role === "assistant") {
@@ -4218,7 +4251,7 @@ export default defineComponent({
         let errorMessage: string;
         if (error.status === 403) {
           errorMessage =
-            "Unauthorized Access: You are not authorized to perform this operation, please contact your administrator.";
+            UNAUTHORIZED_MESSAGE;
         } else if (error.message && error.message !== "No response body") {
           errorMessage = error.message;
         } else {

--- a/web/src/composables/useNLQuery.ts
+++ b/web/src/composables/useNLQuery.ts
@@ -17,6 +17,7 @@ import { ref } from "vue";
 import useAiChat from "@/composables/useAiChat";
 import useSuggestions from "@/composables/useSuggestions";
 import { parsePromQlQuery } from "@/utils/query/promQLUtils";
+import { UNAUTHORIZED_MESSAGE, isAuthError } from "@/utils/authErrors";
 
 /**
  * Composable for Natural Language to SQL Query transformation
@@ -507,7 +508,10 @@ export function useNLQuery() {
                 // Error event
                 console.error('[NL2Q] Error event:', data.error || data.message);
                 hasError = true;
-                errorMessage = data.error || data.message || 'Unknown error';
+                const rawErr = data.error || data.message || 'Unknown error';
+                errorMessage = isAuthError(rawErr, data.error_type)
+                  ? UNAUTHORIZED_MESSAGE
+                  : rawErr;
                 streamingResponse.value = errorMessage;
               } else if (data.type === 'complete') {
                 // Completion event - may contain full response in history

--- a/web/src/utils/authErrors.ts
+++ b/web/src/utils/authErrors.ts
@@ -18,8 +18,7 @@ export const UNAUTHORIZED_MESSAGE =
 
 /**
  * Check whether an error message or error_type indicates an authorization failure.
- * Prefers the structured `errorType` field (e.g. from SSE events) over fuzzy
- * text matching on the message body.
+ * Checks both fields independently — auth if either indicates it.
  */
 export const isAuthError = (message?: string, errorType?: string): boolean => {
   if (errorType && /unauthorized|forbidden|permission_denied/i.test(errorType)) {

--- a/web/src/utils/authErrors.ts
+++ b/web/src/utils/authErrors.ts
@@ -1,0 +1,34 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+export const UNAUTHORIZED_MESSAGE =
+  "Unauthorized Access: You are not authorized to perform this operation, please contact your administrator.";
+
+/**
+ * Check whether an error message or error_type indicates an authorization failure.
+ * Prefers the structured `errorType` field (e.g. from SSE events) over fuzzy
+ * text matching on the message body.
+ */
+export const isAuthError = (message?: string, errorType?: string): boolean => {
+  if (errorType) {
+    return /unauthorized|forbidden|permission_denied/i.test(errorType);
+  }
+  if (message) {
+    return /unauthorized|forbidden|not\s+authorized|permission\s*denied/i.test(
+      message,
+    );
+  }
+  return false;
+};

--- a/web/src/utils/authErrors.ts
+++ b/web/src/utils/authErrors.ts
@@ -22,13 +22,11 @@ export const UNAUTHORIZED_MESSAGE =
  * text matching on the message body.
  */
 export const isAuthError = (message?: string, errorType?: string): boolean => {
-  if (errorType) {
-    return /unauthorized|forbidden|permission_denied/i.test(errorType);
+  if (errorType && /unauthorized|forbidden|permission_denied/i.test(errorType)) {
+    return true;
   }
-  if (message) {
-    return /unauthorized|forbidden|not\s+authorized|permission\s*denied/i.test(
-      message,
-    );
+  if (message && /unauthorized|forbidden|not\s+authorized|permission\s*denied/i.test(message)) {
+    return true;
   }
   return false;
 };


### PR DESCRIPTION
## Summary

Fixes - https://github.com/openobserve/o2-enterprise/issues/1892
- Added explicit permission check in `chat` and `chat_stream` handlers that returns `MetaHttpResponse::forbidden("Unauthorized Access")` (HTTP 403) when the user lacks AI access, ensuring consistent 403 behavior regardless of OpenFGA state
- Updated all 4 SSE error event handlers in `O2AIChat.vue` to recognize authorization-related error messages and display the standard "Unauthorized Access" message

## Why
When a user without AI permissions used the query editor, the auth middleware could pass the request through (e.g., when OpenFGA was disabled), and the agent service error would arrive as an SSE event within a 200 response — bypassing the standard 403 flow. This fix ensures the backend returns proper HTTP 403 and the frontend displays the standard unauthorized message consistently.

## Test plan
- [ ] Verify non-root user without AI permission gets HTTP 403 from `/api/{org}/ai/chat_stream`
- [ ] Verify non-root user without AI permission gets HTTP 403 from `/api/{org}/ai/chat`
- [ ] Verify root users are unaffected (bypass permission check)
- [ ] Verify the frontend displays "Unauthorized Access: You are not authorized to perform this operation..." for auth-related SSE errors
- [ ] Verify non-auth SSE errors continue to display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)