### PR TITLE
fix: add bf for parquet back

### DIFF
--- a/src/config/src/config.rs
+++ b/src/config/src/config.rs
@@ -1112,6 +1112,12 @@ pub struct Common {
     pub metrics_dedup_enabled: bool,
     #[env_config(name = "ZO_BLOOM_FILTER_ENABLED", default = true)]
     pub bloom_filter_enabled: bool,
+    #[env_config(
+        name = "ZO_BLOOM_FILTER_PARQUET_ENABLED",
+        default = false,
+        help = "Enable bloom filter for parquet files"
+    )]
+    pub bloom_filter_parquet_enabled: bool,
     #[env_config(name = "ZO_BLOOM_FILTER_DEFAULT_FIELDS", default = "")]
     pub bloom_filter_default_fields: String,
     #[env_config(

--- a/src/config/src/utils/parquet.rs
+++ b/src/config/src/utils/parquet.rs
@@ -13,7 +13,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{io::Cursor, path::PathBuf, pin::Pin, sync::Arc};
+use std::{
+    cmp::{max, min},
+    io::Cursor,
+    path::PathBuf,
+    pin::Pin,
+    sync::Arc,
+};
 
 #[cfg(feature = "vortex")]
 use arrow::{array::StructArray, datatypes::DataType};
@@ -42,6 +48,7 @@ use crate::{FileFormat, config::*, ider, meta::stream::FileMeta};
 pub fn new_parquet_writer<'a>(
     buf: &'a mut Vec<u8>,
     schema: &'a Arc<Schema>,
+    bloom_filter_fields: &'a [String],
     metadata: &'a FileMeta,
     write_metadata: bool,
     compression: Option<&str>,
@@ -75,6 +82,25 @@ pub fn new_parquet_writer<'a>(
             ),
         ]));
     }
+
+    // Bloom filter stored by row_group, set NDV to reduce the memory usage.
+    // In this link, it says that the optimal number of NDV is 1000, here we use rg_size / NDV_RATIO
+    // refer: https://www.influxdata.com/blog/using-parquets-bloom-filters/
+    let mut bf_ndv = min(metadata.records as u64, PARQUET_MAX_ROW_GROUP_SIZE as u64);
+    if bf_ndv > 1000 {
+        bf_ndv = max(1000, bf_ndv / 100);
+    }
+    if cfg.common.bloom_filter_parquet_enabled {
+        let mut fields = bloom_filter_fields.to_vec();
+        fields.sort();
+        fields.dedup();
+        for field in fields {
+            writer_props = writer_props
+                .set_column_bloom_filter_enabled(field.as_str().into(), true)
+                .set_column_bloom_filter_fpp(field.as_str().into(), DEFAULT_BLOOM_FILTER_FPP)
+                .set_column_bloom_filter_ndv(field.into(), bf_ndv); // take the field ownership
+        }
+    }
     let writer_props = writer_props.build();
     AsyncArrowWriter::try_new(buf, schema.clone(), Some(writer_props)).unwrap()
 }
@@ -82,10 +108,12 @@ pub fn new_parquet_writer<'a>(
 pub async fn write_recordbatch_to_parquet(
     schema: Arc<Schema>,
     record_batches: &[RecordBatch],
+    bloom_filter_fields: &[String],
     metadata: &FileMeta,
 ) -> Result<Vec<u8>, anyhow::Error> {
     let mut buf = Vec::new();
-    let mut writer = new_parquet_writer(&mut buf, &schema, metadata, true, None);
+    let mut writer =
+        new_parquet_writer(&mut buf, &schema, bloom_filter_fields, metadata, true, None);
     for batch in record_batches {
         writer.write(batch).await?;
     }
@@ -421,10 +449,14 @@ mod tests {
         };
 
         // Write to parquet
-        let data =
-            write_recordbatch_to_parquet(schema.clone(), std::slice::from_ref(&batch), &metadata)
-                .await
-                .unwrap();
+        let data = write_recordbatch_to_parquet(
+            schema.clone(),
+            std::slice::from_ref(&batch),
+            &["name".to_string()],
+            &metadata,
+        )
+        .await
+        .unwrap();
 
         // Read back
         let (read_schema, read_batches) =
@@ -453,7 +485,7 @@ mod tests {
         };
 
         // Write to parquet
-        let data = write_recordbatch_to_parquet(schema, &[batch], &metadata)
+        let data = write_recordbatch_to_parquet(schema, &[batch], &["name".to_string()], &metadata)
             .await
             .unwrap();
 

--- a/src/ingester/src/partition.rs
+++ b/src/ingester/src/partition.rs
@@ -190,6 +190,13 @@ impl Partition {
                     records: file_meta.records as usize,
                 };
                 // write into parquet buf
+                let bloom_filter_fields =
+                    if self.schema.fields().len() >= cfg.limit.file_move_fields_limit {
+                        let settings = infra::schema::unwrap_stream_settings(self.schema.as_ref());
+                        infra::schema::get_stream_setting_bloom_filter_fields(&settings)
+                    } else {
+                        vec![]
+                    };
                 let batches = data
                     .iter()
                     .map(|r| {
@@ -208,8 +215,14 @@ impl Partition {
                 } else {
                     None
                 };
-                let mut writer =
-                    new_parquet_writer(&mut buf_parquet, &schema, &file_meta, true, compression);
+                let mut writer = new_parquet_writer(
+                    &mut buf_parquet,
+                    &schema,
+                    &bloom_filter_fields,
+                    &file_meta,
+                    true,
+                    compression,
+                );
 
                 writer
                     .write(&batches)

--- a/src/job/files/parquet.rs
+++ b/src/job/files/parquet.rs
@@ -40,7 +40,10 @@ use config::{
 };
 use hashbrown::HashSet;
 use infra::{
-    schema::{SchemaCache, get_stream_setting_fts_fields, get_stream_setting_index_fields},
+    schema::{
+        SchemaCache, get_stream_setting_bloom_filter_fields, get_stream_setting_fts_fields,
+        get_stream_setting_index_fields,
+    },
     storage,
 };
 use ingester::WAL_PARQUET_METADATA;
@@ -714,6 +717,7 @@ async fn merge_files(
 
     // get latest version of schema
     let stream_settings = infra::schema::unwrap_stream_settings(&latest_schema);
+    let bloom_filter_fields = get_stream_setting_bloom_filter_fields(&stream_settings);
     let full_text_search_fields = get_stream_setting_fts_fields(&stream_settings);
     let index_fields = get_stream_setting_index_fields(&stream_settings);
     let (defined_schema_fields, need_original, index_original_data, index_all_values) =
@@ -774,6 +778,7 @@ async fn merge_files(
         &stream_name,
         schema,
         tables,
+        &bloom_filter_fields,
         new_file_meta,
         true,
     )

--- a/src/service/compact/flatten.rs
+++ b/src/service/compact/flatten.rs
@@ -35,7 +35,10 @@ use config::{
     },
 };
 use hashbrown::HashSet;
-use infra::{cluster::get_node_from_consistent_hash, file_list as infra_file_list, storage};
+use infra::{
+    cluster::get_node_from_consistent_hash, file_list as infra_file_list,
+    schema::get_stream_setting_bloom_filter_fields, storage,
+};
 use parking_lot::RwLock;
 use tokio::sync::{Semaphore, mpsc};
 
@@ -174,10 +177,16 @@ pub async fn generate_file(file: &FileKey) -> Result<(), anyhow::Error> {
         get_config().common.column_all,
         file.key.strip_prefix("files/").unwrap()
     );
+    let org_id = columns[1];
+    let stream_type = StreamType::from(columns[2]);
+    let stream_name = columns[3];
+    let stream_setting = infra::schema::get_settings(org_id, stream_name, stream_type).await;
+    let bloom_filter_fields = get_stream_setting_bloom_filter_fields(&stream_setting);
     let new_schema = new_batches.first().unwrap().schema();
-    let new_data = write_recordbatch_to_parquet(new_schema, &new_batches, &file.meta)
-        .await
-        .map_err(|e| anyhow::anyhow!("write_recordbatch_to_parquet error: {}", e))?;
+    let new_data =
+        write_recordbatch_to_parquet(new_schema, &new_batches, &bloom_filter_fields, &file.meta)
+            .await
+            .map_err(|e| anyhow::anyhow!("write_recordbatch_to_parquet error: {}", e))?;
     // upload filee
     storage::put(&file.account, &new_file, new_data.into()).await?;
     // delete from queue

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -40,8 +40,8 @@ use infra::{
     dist_lock, file_list as infra_file_list,
     runtime::DATAFUSION_RUNTIME,
     schema::{
-        SchemaCache, get_partition_time_level, get_stream_setting_fts_fields,
-        get_stream_setting_index_fields, unwrap_stream_created_at,
+        SchemaCache, get_partition_time_level, get_stream_setting_bloom_filter_fields,
+        get_stream_setting_fts_fields, get_stream_setting_index_fields, unwrap_stream_created_at,
     },
     storage,
 };
@@ -777,6 +777,7 @@ pub async fn merge_files(
     // get latest version of schema
     let latest_schema = infra::schema::get(org_id, stream_name, stream_type).await?;
     let stream_settings = infra::schema::unwrap_stream_settings(&latest_schema);
+    let bloom_filter_fields = get_stream_setting_bloom_filter_fields(&stream_settings);
     let full_text_search_fields = get_stream_setting_fts_fields(&stream_settings);
     let index_fields = get_stream_setting_index_fields(&stream_settings);
     let (defined_schema_fields, need_original, index_original_data, index_all_values, storage_type) =
@@ -872,6 +873,7 @@ pub async fn merge_files(
                     &stream_name,
                     schema,
                     tables,
+                    &bloom_filter_fields,
                     new_file_meta,
                     false,
                 )

--- a/src/service/enrichment/storage.rs
+++ b/src/service/enrichment/storage.rs
@@ -179,6 +179,7 @@ pub mod remote {
             record_batch_ext::convert_json_to_record_batch,
         },
     };
+    use infra::schema::get_stream_setting_bloom_filter_fields;
 
     use super::*;
 
@@ -260,10 +261,18 @@ pub mod remote {
             ..Default::default()
         };
 
+        let stream_settings =
+            infra::schema::get_settings(org_id, table_name, StreamType::EnrichmentTables).await;
+        let bloom_filter_fields = get_stream_setting_bloom_filter_fields(&stream_settings);
         let data: Vec<_> = data.iter().map(|row| Arc::new(row.clone())).collect();
         let data = convert_json_to_record_batch(schema.schema(), &data)?;
-        let data =
-            write_recordbatch_to_parquet(schema.schema().clone(), &[data], &file_meta).await?;
+        let data = write_recordbatch_to_parquet(
+            schema.schema().clone(),
+            &[data],
+            &bloom_filter_fields,
+            &file_meta,
+        )
+        .await?;
 
         file_meta.compressed_size = data.len() as i64;
 
@@ -300,10 +309,18 @@ pub mod remote {
             ..Default::default()
         };
 
+        let stream_settings =
+            infra::schema::get_settings(org_id, table_name, StreamType::EnrichmentTables).await;
+        let bloom_filter_fields = get_stream_setting_bloom_filter_fields(&stream_settings);
         let data: Vec<_> = data.iter().map(|row| Arc::new(row.clone())).collect();
         let data = convert_json_to_record_batch(schema.schema(), &data)?;
-        let data =
-            write_recordbatch_to_parquet(schema.schema().clone(), &[data], &file_meta).await?;
+        let data = write_recordbatch_to_parquet(
+            schema.schema().clone(),
+            &[data],
+            &bloom_filter_fields,
+            &file_meta,
+        )
+        .await?;
         file_meta.compressed_size = data.len() as i64;
         upload_to_remote(org_id, table_name, file_meta, &data, created_at).await?;
         Ok(())
@@ -393,7 +410,8 @@ pub mod local {
             ..Default::default()
         };
 
-        let parquet_data = write_recordbatch_to_parquet(schema.clone(), &data, &file_meta).await?;
+        let parquet_data =
+            write_recordbatch_to_parquet(schema.clone(), &data, &[], &file_meta).await?;
 
         // Write parquet data to file
         tokio::fs::write(&file_path, parquet_data)

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -93,6 +93,10 @@ pub fn create_session_config(
         cfg.common.feature_pushdown_filter_enabled;
     // config = config.set_bool("datafusion.execution.parquet.reorder_filters", true);
 
+    if cfg.common.bloom_filter_parquet_enabled {
+        config.options_mut().execution.parquet.bloom_filter_on_read = true;
+    }
+
     if sorted_by_time {
         config
             .options_mut()

--- a/src/service/search/datafusion/exec.rs
+++ b/src/service/search/datafusion/exec.rs
@@ -93,10 +93,6 @@ pub fn create_session_config(
         cfg.common.feature_pushdown_filter_enabled;
     // config = config.set_bool("datafusion.execution.parquet.reorder_filters", true);
 
-    if cfg.common.bloom_filter_parquet_enabled {
-        config.options_mut().execution.parquet.bloom_filter_on_read = true;
-    }
-
     if sorted_by_time {
         config
             .options_mut()

--- a/src/service/search/datafusion/merge/downsampling.rs
+++ b/src/service/search/datafusion/merge/downsampling.rs
@@ -54,6 +54,7 @@ const TIMESTAMP_ALIAS: &str = "_timestamp_alias";
 pub async fn merge_parquet_files_with_downsampling(
     schema: Arc<Schema>,
     tables: Vec<Arc<dyn TableProvider>>,
+    bloom_filter_fields: &[String],
     rule: &DownsamplingRule,
     metadata: &FileMeta,
 ) -> Result<MergeParquetResult> {
@@ -107,7 +108,9 @@ pub async fn merge_parquet_files_with_downsampling(
 
     // Write batches to the appropriate format
     let (bufs, file_metas) = match cfg.common.file_format {
-        FileFormat::Parquet => write_downsampled_parquet(rx, &schema, metadata, &cfg).await?,
+        FileFormat::Parquet => {
+            write_downsampled_parquet(rx, &schema, bloom_filter_fields, metadata, &cfg).await?
+        }
         #[cfg(all(feature = "enterprise", feature = "vortex"))]
         FileFormat::Vortex => {
             write_downsampled_vortex(rx, schema.clone(), cfg.compact.max_file_size as i64).await?
@@ -136,6 +139,7 @@ pub async fn merge_parquet_files_with_downsampling(
 async fn write_downsampled_parquet(
     mut rx: tokio::sync::mpsc::Receiver<RecordBatch>,
     schema: &Arc<datafusion::arrow::datatypes::Schema>,
+    bloom_filter_fields: &[String],
     metadata: &FileMeta,
     cfg: &config::Config,
 ) -> Result<(Vec<Vec<u8>>, Vec<FileMeta>)> {
@@ -144,7 +148,8 @@ async fn write_downsampled_parquet(
 
     let mut buf = Vec::with_capacity(cfg.compact.max_file_size);
     let mut file_meta = FileMeta::default();
-    let mut writer = new_parquet_writer(&mut buf, schema, metadata, false, None);
+    let mut writer =
+        new_parquet_writer(&mut buf, schema, bloom_filter_fields, metadata, false, None);
     let mut last_min_ts = 0;
 
     while let Some(batch_result) = rx.recv().await {
@@ -166,7 +171,8 @@ async fn write_downsampled_parquet(
             // reset for next file
             buf.clear();
             file_meta = FileMeta::default();
-            writer = new_parquet_writer(&mut buf, schema, metadata, false, None);
+            writer =
+                new_parquet_writer(&mut buf, schema, bloom_filter_fields, metadata, false, None);
         }
 
         // Update metadata for current batch

--- a/src/service/search/datafusion/merge/mod.rs
+++ b/src/service/search/datafusion/merge/mod.rs
@@ -55,6 +55,7 @@ pub async fn merge_parquet_files(
     stream_name: &str,
     schema: Arc<Schema>,
     tables: Vec<Arc<dyn TableProvider>>,
+    bloom_filter_fields: &[String],
     mut metadata: FileMeta,
     is_ingester: bool,
 ) -> Result<MergeParquetResult> {
@@ -68,7 +69,14 @@ pub async fn merge_parquet_files(
             log::info!(
                 "merge_parquet_files: stream_type={stream_type}, stream_name={stream_name}, downsampling rule={rule:?}"
             );
-            return merge_parquet_files_with_downsampling(schema, tables, rule, &metadata).await;
+            return merge_parquet_files_with_downsampling(
+                schema,
+                tables,
+                bloom_filter_fields,
+                rule,
+                &metadata,
+            )
+            .await;
         }
     }
 
@@ -145,7 +153,15 @@ pub async fn merge_parquet_files(
     // write batches to the appropriate format
     let buf = match cfg.common.file_format {
         FileFormat::Parquet => {
-            write_parquet(&schema, &metadata, is_ingester, &mut rx, read_task).await?
+            write_parquet(
+                &schema,
+                bloom_filter_fields,
+                &metadata,
+                is_ingester,
+                &mut rx,
+                read_task,
+            )
+            .await?
         }
         FileFormat::Vortex => write_vortex(schema, rx, read_task).await?,
     };
@@ -161,6 +177,7 @@ pub async fn merge_parquet_files(
 
 async fn write_parquet(
     schema: &Arc<Schema>,
+    bloom_filter_fields: &[String],
     metadata: &FileMeta,
     is_ingester: bool,
     rx: &mut tokio::sync::mpsc::Receiver<RecordBatch>,
@@ -173,7 +190,14 @@ async fn write_parquet(
     } else {
         None
     };
-    let mut writer = new_parquet_writer(&mut buf, schema, metadata, false, compression);
+    let mut writer = new_parquet_writer(
+        &mut buf,
+        schema,
+        bloom_filter_fields,
+        metadata,
+        false,
+        compression,
+    );
 
     let mut new_file_meta = metadata.clone();
     new_file_meta.records = 0;
@@ -262,6 +286,7 @@ mod tests {
             "test_stream",
             schema,
             empty_tables,
+            &[],
             metadata,
             false,
         )

--- a/src/service/tantivy/mod.rs
+++ b/src/service/tantivy/mod.rs
@@ -340,6 +340,7 @@ pub(super) mod tests {
         let mut writer = config::utils::parquet::new_parquet_writer(
             &mut buffer,
             &schema,
+            &[],
             &file_meta,
             false,
             None,


### PR DESCRIPTION
This PR add bloom filter for parquet again under a env `ZO_BLOOM_FILTER_PARQUET_ENABLED=false`, if you want to generate bloom filter for parquet set it to `true`.

> We no longer use it even you generate it.