### PR TITLE
fix: duplicated search calls in traces

### DIFF
--- a/web/src/components/DateTime.spec.ts
+++ b/web/src/components/DateTime.spec.ts
@@ -205,9 +205,41 @@ describe("DateTime Component", () => {
       
       wrapper.vm.saveDate("relative");
       await wrapper.vm.$nextTick();
-      
+
       // Should emit date change
       expect(wrapper.emitted("on:date-change")).toBeTruthy();
+    });
+
+    it("should stamp userChangedValue=true on a direct (user-initiated) saveDate", async () => {
+      wrapper = createWrapper();
+      // Let the mount-time programmatic flag reset back to user-initiated.
+      await wrapper.vm.$nextTick();
+      store.state.savedViewFlag = false;
+
+      wrapper.vm.saveDate("relative");
+      await wrapper.vm.$nextTick();
+
+      const events = wrapper.emitted("on:date-change");
+      expect(events).toBeTruthy();
+      const lastPayload = events[events.length - 1][0];
+      expect(lastPayload.userChangedValue).toBe(true);
+    });
+
+    it("should stamp userChangedValue=false when a programmatic setter precedes the emit", async () => {
+      wrapper = createWrapper();
+      await wrapper.vm.$nextTick();
+      store.state.savedViewFlag = false;
+
+      // setAbsoluteTime marks the change programmatic; the immediately-following
+      // saveDate runs before the nextTick reset, so it must be tagged false.
+      wrapper.vm.setAbsoluteTime(Date.now() * 1000 - 3_600_000_000, Date.now() * 1000);
+      wrapper.vm.saveDate("absolute");
+      await wrapper.vm.$nextTick();
+
+      const events = wrapper.emitted("on:date-change");
+      expect(events).toBeTruthy();
+      const lastPayload = events[events.length - 1][0];
+      expect(lastPayload.userChangedValue).toBe(false);
     });
 
     it("should test setCustomDate function", () => {

--- a/web/src/components/DateTime.vue
+++ b/web/src/components/DateTime.vue
@@ -635,6 +635,8 @@ export default defineComponent({
     };
 
     const setAbsoluteTime = (startTime, endTime) => {
+      // Parent-invoked setter — the resulting auto-apply emit is programmatic.
+      markProgrammaticDateChange();
       if (!startTime || !endTime) {
         var dateString = new Date().toLocaleDateString("en-ZA");
         selectedDate.value.from = dateString;
@@ -670,7 +672,24 @@ export default defineComponent({
     }
 
     const refresh = () => {
+      // Parent-invoked (e.g. on tab re-activation / auto-refresh) — programmatic.
+      markProgrammaticDateChange();
       saveDate();
+    };
+
+    // Distinguishes genuine user-driven date changes from programmatic ones
+    // (parent-invoked setters, mount replay). Stamped onto each `on:date-change`
+    // payload as `userChangedValue` so consumers (e.g. traces live-mode auto-run)
+    // can ignore programmatic changes instead of relying on value-diff heuristics.
+    let isUserInitiated = true;
+    const markProgrammaticDateChange = () => {
+      isUserInitiated = false;
+      // Reset after the current flush. Default ('pre') watchers — including the
+      // deep selectedDate/selectedTime watcher that drives auto-apply — run before
+      // nextTick callbacks, so the watch-triggered saveDate still reads `false`.
+      nextTick(() => {
+        isUserInitiated = true;
+      });
     };
 
     const saveDate = (dateType) => {
@@ -681,6 +700,7 @@ export default defineComponent({
       // }
       datePayload.value = date;
       date["valueType"] = dateType || selectedType.value;
+      date["userChangedValue"] = isUserInitiated;
       // date["relativeTimePeriod"] = "";
       if (store.state.savedViewFlag == false) {
         emit("on:date-change", date);
@@ -702,6 +722,8 @@ export default defineComponent({
     }
 
     const setCustomDate = (dateType, dateobj) => {
+      // Parent-invoked setter (e.g. metrics-brush time range) — programmatic.
+      markProgrammaticDateChange();
       var start_date = new Date(Math.floor(dateobj.start));
       const startObj = formatDate(start_date);
 

--- a/web/src/plugins/traces/Index.spec.ts
+++ b/web/src/plugins/traces/Index.spec.ts
@@ -1065,7 +1065,7 @@ describe("Index.vue (Main Traces Page)", () => {
       expect(mockApplyFilters).toHaveBeenCalledWith([
         "duration >= 100",
         "service_name = 'test'",
-      ], false); // liveMode is undefined, so skipSearch = false
+      ]); // applyFilters owns the single trigger; no skipSearch arg
     });
 
     it("should append error filter to applyFilters call when showErrorOnly is enabled", async () => {
@@ -1079,7 +1079,7 @@ describe("Index.vue (Main Traces Page)", () => {
       expect(mockApplyFilters).toHaveBeenCalledWith([
         "duration >= 100",
         "span_status = 'ERROR'",
-      ], false); // liveMode is undefined, so skipSearch = false
+      ]); // applyFilters owns the single trigger; no skipSearch arg
     });
 
     it("should not duplicate error filter when it is already present in incoming filters", async () => {
@@ -1121,7 +1121,10 @@ describe("Index.vue (Main Traces Page)", () => {
       expect(mockRemoveFilterByField).toHaveBeenCalledWith("span_status");
     });
 
-    it("should skip search when live mode is ON", async () => {
+    // Index no longer branches on liveMode / passes a skipSearch flag — it always
+    // calls applyFilters with just the filters; the live-mode search-gating now
+    // lives inside SearchBar.applyFilters (covered in SearchBar.spec).
+    it("should call applyFilters with only the filters when live mode is ON", async () => {
       mockSearchObj.meta.liveMode = true;
       store.state.zoConfig.auto_query_enabled = true;
       wrapper = mountWithSearchBarStub();
@@ -1131,10 +1134,10 @@ describe("Index.vue (Main Traces Page)", () => {
       wrapper.vm.onMetricsFiltersUpdated(testFilters);
       await flushPromises();
 
-      expect(mockApplyFilters).toHaveBeenCalledWith(testFilters, true);
+      expect(mockApplyFilters).toHaveBeenCalledWith(testFilters);
     });
 
-    it("should not skip search when live mode is OFF", async () => {
+    it("should call applyFilters with only the filters when live mode is OFF", async () => {
       mockSearchObj.meta.liveMode = false;
       wrapper = mountWithSearchBarStub();
       await flushPromises();
@@ -1143,10 +1146,10 @@ describe("Index.vue (Main Traces Page)", () => {
       wrapper.vm.onMetricsFiltersUpdated(testFilters);
       await flushPromises();
 
-      expect(mockApplyFilters).toHaveBeenCalledWith(testFilters, false);
+      expect(mockApplyFilters).toHaveBeenCalledWith(testFilters);
     });
 
-    it("should handle undefined liveMode as false", async () => {
+    it("should call applyFilters with only the filters when liveMode is undefined", async () => {
       mockSearchObj.meta.liveMode = undefined;
       wrapper = mountWithSearchBarStub();
       await flushPromises();
@@ -1155,7 +1158,7 @@ describe("Index.vue (Main Traces Page)", () => {
       wrapper.vm.onMetricsFiltersUpdated(testFilters);
       await flushPromises();
 
-      expect(mockApplyFilters).toHaveBeenCalledWith(testFilters, false);
+      expect(mockApplyFilters).toHaveBeenCalledWith(testFilters);
     });
 
     it("should handle searchBarRef not available", async () => {
@@ -1258,6 +1261,40 @@ describe("Index.vue (Main Traces Page)", () => {
 
       // SQL-style escaping uses double quotes: test'service becomes test''service
       expect(mockSearchObj.data.editorValue).toContain("test''service");
+    });
+
+    it("should not write searchObj.data.query on view-traces (no duplicate trigger)", async () => {
+      // The redirect used to set searchObj.data.query, which tripped a query
+      // watcher in addition to its own runQueryFn() → duplicate search. The
+      // watcher and that write are removed; only editorValue is set now.
+      mockSearchObj.data.query = "";
+
+      wrapper = mount(Index, {
+        attachTo: node,
+        global: {
+          plugins: [i18n, router],
+          provide: { store: store },
+          stubs: {
+            "search-bar": true,
+            "index-list": true,
+            "search-result": true,
+            "service-graph": true,
+            SanitizedHtmlRenderer: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      wrapper.vm.handleServiceGraphViewTraces({
+        stream: "default",
+        serviceName: "checkout",
+        timeRange: { startTime: 1755853746625720, endTime: 1755853746725720 },
+      });
+      await flushPromises();
+
+      expect(mockSearchObj.data.editorValue).toContain("checkout");
+      expect(mockSearchObj.data.query).toBe("");
     });
 
     function mountIndexComponent() {

--- a/web/src/plugins/traces/Index.spec.ts
+++ b/web/src/plugins/traces/Index.spec.ts
@@ -911,8 +911,8 @@ describe("Index.vue (Main Traces Page)", () => {
 
   describe("DateTime Handling", () => {
     it("should restore datetime from URL params", async () => {
-      const startTime = "1755853746625720";
-      const endTime = "1755853746725720";
+      const startTime = 1755853746625720;
+      const endTime = 1755853746725720;
 
       routerCurrentRouteSpy.mockReturnValue({
         value: {

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -1579,8 +1579,8 @@ function restoreUrlQueryParams() {
   const queryParams = router.currentRoute.value.query;
 
   const date = {
-    startTime: queryParams.from,
-    endTime: queryParams.to,
+    startTime: typeof queryParams.from === "string" ? Number(queryParams.from) : queryParams.from,
+    endTime: typeof queryParams.from === "string" ? Number(queryParams.to) : queryParams.to,
     relativeTimePeriod: queryParams.period || null,
     type: queryParams.period ? "relative" : "absolute",
   };

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -317,7 +317,7 @@ import config from "@/aws-exports";
 import { logsErrorMessage } from "@/utils/common";
 import useNotifications from "@/composables/useNotifications";
 import { getConsumableRelativeTime } from "@/utils/date";
-import { cloneDeep, debounce } from "lodash-es";
+import { cloneDeep } from "lodash-es";
 import { computed } from "vue";
 import useStreams from "@/composables/useStreams";
 import { parseDurationWhereClause } from "@/composables/useDurationPercentiles";
@@ -518,18 +518,17 @@ async function getStreamList() {
         }
 
         await extractFields();
-        const queryBeforeRestore = searchObj.data.editorValue;
         correlationFilters.restore();
-        const filterWasRestored =
-          !queryBeforeRestore && !!searchObj.data.editorValue;
 
+        // Restore filter chips from the editor value. The single mount search is
+        // owned by loadPageData() (after getStreamList resolves), so we do NOT
+        // trigger a search here — that previously produced a duplicate on load.
         if (
           searchObj.data.editorValue &&
           searchObj.data.stream.selectedStreamFields.length
         )
           nextTick(() => {
             restoreFilters(searchObj.data.editorValue);
-            if (filterWasRestored) searchData();
           });
       })
       .catch((e) => {
@@ -1680,13 +1679,13 @@ const onMetricsFiltersUpdated = (filters: string[]) => {
   ) {
     allFilters.push("span_status = 'ERROR'");
   }
-  // Apply each filter term independently so replace-or-append works per field
-  // Skip search only when live mode is ON (datetime trigger will handle it)
-  // Don't skip when live mode is OFF (datetime trigger won't fire)
-  const skipSearch = !!(searchObj.meta.liveMode && store.state.zoConfig?.auto_query_enabled);
-
+  // Apply each filter term independently so replace-or-append works per field.
+  // applyFilters owns the single trigger: it emits `searchdata` (one search) only
+  // in live mode. The brush also sets a time range programmatically, which the
+  // DateTime picker stamps userChangedValue=false, so it never adds a competing
+  // search — this filter apply is the sole trigger.
   if (searchBarRef.value?.applyFilters) {
-    searchBarRef.value.applyFilters(allFilters, skipSearch);
+    searchBarRef.value.applyFilters(allFilters);
   } else {
     console.warn("SearchBar not ready for filter application");
   }
@@ -2058,23 +2057,10 @@ watch(
   { immediate: true },
 );
 
-// Debounced auto-run on query text changes in live mode.
-const debouncedAutoRunOnQuery = debounce(() => {
-  if (
-    searchObj.meta.liveMode &&
-    store.state.zoConfig?.auto_query_enabled &&
-    !searchObj.loading
-  ) {
-    searchData();
-  }
-}, 500);
-
-watch(
-  () => searchObj.data.query,
-  () => {
-    debouncedAutoRunOnQuery();
-  },
-);
+// NOTE: auto-run in live mode is driven by explicit triggers at each user-intent
+// handler (filter add/remove, manual date change, redirect, metrics brush) — not
+// by watching `searchObj.data.query`. A query watcher duplicated those explicit
+// triggers (every writer of `data.query` also runs a search), so it was removed.
 
 // Handler for service graph view traces event
 const handleServiceGraphViewTraces = (data: any) => {
@@ -2132,7 +2118,6 @@ const handleServiceGraphViewTraces = (data: any) => {
       filterQuery += ` AND duration <= ${data.maxDurationMicros}`;
     }
     searchObj.data.editorValue = filterQuery;
-    searchObj.data.query = filterQuery;
     searchObj.meta.sqlMode = false; // Traces doesn't use SQL mode
   }
 

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -1580,7 +1580,7 @@ function restoreUrlQueryParams() {
 
   const date = {
     startTime: typeof queryParams.from === "string" ? Number(queryParams.from) : queryParams.from,
-    endTime: typeof queryParams.from === "string" ? Number(queryParams.to) : queryParams.to,
+    endTime: typeof queryParams.to === "string" ? Number(queryParams.to) : queryParams.to,
     relativeTimePeriod: queryParams.period || null,
     type: queryParams.period ? "relative" : "absolute",
   };
@@ -2069,60 +2069,12 @@ const debouncedAutoRunOnQuery = debounce(() => {
   }
 }, 500);
 
-// Debounced auto-run on datetime changes in live mode.
-// Traces has no existing auto-run on datetime, so no guard needed.
-const debouncedAutoRunOnDatetime = debounce(() => {
-  // Absolute time is handled by SearchBar's triggerAbsoluteQueryDebounced (2500ms).
-  // Only auto-run here for relative time to avoid double-triggering.
-  if (
-    searchObj.data.datetime.type === "relative" &&
-    searchObj.meta.liveMode &&
-    store.state.zoConfig?.auto_query_enabled &&
-    !searchObj.loading
-  ) {
-    searchData();
-  }
-}, 500);
-
 watch(
   () => searchObj.data.query,
   () => {
     debouncedAutoRunOnQuery();
   },
 );
-
-watch(
-  () => [
-    searchObj.data.datetime.type,
-    searchObj.data.datetime.startTime,
-    searchObj.data.datetime.endTime,
-    searchObj.data.datetime.relativeTimePeriod,
-  ],
-  () => {
-    debouncedAutoRunOnDatetime();
-  },
-  { deep: true },
-);
-
-// watch(
-//   changeStream,
-//   (stream, oldStream) => {
-//     if (stream.value === oldStream.value) return;
-//     if (searchObj.data.stream.selectedStream.hasOwnProperty("value")) {
-//       if (oldStream.value) {
-//         searchObj.data.query = "";
-//         searchObj.data.advanceFiltersQuery = "";
-//       }
-//       setTimeout(() => {
-//         runQueryFn();
-//         extractFields();
-//       }, 500);
-//     }
-//   },
-//   {
-//     immediate: false,
-//   },
-// );
 
 // Handler for service graph view traces event
 const handleServiceGraphViewTraces = (data: any) => {

--- a/web/src/plugins/traces/SearchBar.spec.ts
+++ b/web/src/plugins/traces/SearchBar.spec.ts
@@ -980,6 +980,48 @@ describe("SearchBar", () => {
 
       expect(searchObjInstance.data.datetime.startTime).toBe(originalStart);
     });
+
+    it("should emit searchdata on a user-driven relative date change in live mode", async () => {
+      store.state.zoConfig = { auto_query_enabled: true };
+      searchObjInstance.meta.liveMode = true;
+
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      // Control `prev` so isDatetimeChanged() is true for the "1h" change.
+      searchObjInstance.data.datetime.relativeTimePeriod = "15m";
+
+      await (wrapper.vm as any).updateDateTime({
+        startTime: 0,
+        endTime: 0,
+        relativeTimePeriod: "1h",
+        valueType: "relative",
+        userChangedValue: true,
+      });
+
+      expect(wrapper.emitted("searchdata")).toBeTruthy();
+      expect(wrapper.emitted("searchdata")).toHaveLength(1);
+    });
+
+    it("should NOT emit searchdata for a programmatic date change (userChangedValue false) in live mode", async () => {
+      store.state.zoConfig = { auto_query_enabled: true };
+      searchObjInstance.meta.liveMode = true;
+
+      wrapper = mountSearchBar();
+      await flushPromises();
+
+      searchObjInstance.data.datetime.relativeTimePeriod = "15m";
+
+      await (wrapper.vm as any).updateDateTime({
+        startTime: 0,
+        endTime: 0,
+        relativeTimePeriod: "1h",
+        valueType: "relative",
+        userChangedValue: false,
+      });
+
+      expect(wrapper.emitted("searchdata")).toBeFalsy();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -1233,33 +1275,6 @@ describe("SearchBar", () => {
       (wrapper.vm as any).refreshTimeChange({ value: 60, label: "1 min" });
 
       expect((wrapper.vm as any).btnRefreshInterval).toBe(false);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // [auto-generated] updateQuery
-  // -------------------------------------------------------------------------
-  describe("updateQuery", () => {
-    it("should call queryEditorRef.setValue with searchObj.data.query", async () => {
-      wrapper = mountSearchBar();
-      await flushPromises();
-
-      const mockSetValue = vi.fn();
-      (wrapper.vm as any).queryEditorRef = { setValue: mockSetValue };
-      searchObjInstance.data.query = "SELECT trace_id FROM default";
-
-      (wrapper.vm as any).updateQuery();
-
-      expect(mockSetValue).toHaveBeenCalledWith("SELECT trace_id FROM default");
-    });
-
-    it("should not throw when queryEditorRef is null", async () => {
-      wrapper = mountSearchBar();
-      await flushPromises();
-
-      (wrapper.vm as any).queryEditorRef = null;
-
-      expect(() => (wrapper.vm as any).updateQuery()).not.toThrow();
     });
   });
 

--- a/web/src/plugins/traces/SearchBar.vue
+++ b/web/src/plugins/traces/SearchBar.vue
@@ -760,24 +760,13 @@ export default defineComponent({
 
       if (
         value.valueType === "absolute" &&
+        searchObj.meta.liveMode &&
         store.state.zoConfig?.auto_query_enabled && 
         datetimeChanged
       ) {
         // Debounce query trigger so user can finish typing the full time value
         triggerAbsoluteQueryDebounced(value);
         return;
-      }
-
-      if (config.isCloud == "true" && value.userChangedValue) {
-        segment.track("Button Click", {
-          button: "Date Change",
-          tab: value.tab,
-          value: value,
-          //user_org: this.store.state.selectedOrganization.identifier,
-          //user_id: this.store.state.userInfo.email,
-          stream_name: searchObj.data.stream.selectedStream.value,
-          page: "Search Logs",
-        });
       }
 
       // Live mode: auto-trigger search on a real time-range change.
@@ -791,6 +780,18 @@ export default defineComponent({
         datetimeChanged
       ) {
         emit("searchdata");
+      }
+
+      if (config.isCloud == "true" && value.userChangedValue) {
+        segment.track("Button Click", {
+          button: "Date Change",
+          tab: value.tab,
+          value: value,
+          //user_org: this.store.state.selectedOrganization.identifier,
+          //user_id: this.store.state.userInfo.email,
+          stream_name: searchObj.data.stream.selectedStream.value,
+          page: "Search Logs",
+        });
       }
     };
 

--- a/web/src/plugins/traces/SearchBar.vue
+++ b/web/src/plugins/traces/SearchBar.vue
@@ -761,7 +761,8 @@ export default defineComponent({
       if (
         value.valueType === "absolute" &&
         searchObj.meta.liveMode &&
-        store.state.zoConfig?.auto_query_enabled && 
+        store.state.zoConfig?.auto_query_enabled &&
+        value.userChangedValue === true &&
         datetimeChanged
       ) {
         // Debounce query trigger so user can finish typing the full time value
@@ -769,14 +770,16 @@ export default defineComponent({
         return;
       }
 
-      // Live mode: auto-trigger search on a real time-range change.
-      // The DateTime component also fires `on:date-change` once on its own
-      // mount with the current value (no actual change). The `prev`
-      // comparison above filters out that mount-time replay so a tab
-      // switch that remounts the picker doesn't fire a redundant search.
+      // Live mode: auto-trigger search ONLY on a genuine user-driven time-range
+      // change. `userChangedValue` (stamped by DateTime.vue) is the authoritative
+      // signal — programmatic sets (redirect, metrics brush, mount replay) emit
+      // `false` and must never auto-run, since they are owned by an explicit
+      // trigger elsewhere. `datetimeChanged` additionally filters a user toggling
+      // the type tab without actually changing the range.
       if (
         store.state.zoConfig?.auto_query_enabled &&
         searchObj.meta.liveMode &&
+        value.userChangedValue === true &&
         datetimeChanged
       ) {
         emit("searchdata");
@@ -801,12 +804,6 @@ export default defineComponent({
         "oo_toggle_auto_run",
         String(searchObj.meta.liveMode),
       );
-    };
-
-    const updateQuery = () => {
-      // alert(searchObj.data.query);
-      if (queryEditorRef.value?.setValue)
-        queryEditorRef.value.setValue(searchObj.data.query);
     };
 
     // This method is used in parent component using ref
@@ -996,7 +993,6 @@ export default defineComponent({
       onQueryEditorBlur,
       updateQueryValue,
       updateDateTime,
-      updateQuery,
       downloadLogs,
       setEditorValue,
       autoCompleteKeywords,
@@ -1038,7 +1034,6 @@ export default defineComponent({
           this.searchObj.data.editorValue,
         );
         this.searchObj.data.editorValue = newValue;
-        this.searchObj.data.query = newValue;
         this.searchObj.data.stream.addToFilter = "";
         if (this.queryEditorRef?.setValue)
           this.queryEditorRef.setValue(newValue);
@@ -1057,7 +1052,6 @@ export default defineComponent({
         fieldName,
       );
       this.searchObj.data.editorValue = newValue;
-      this.searchObj.data.query = newValue;
       this.searchObj.data.stream.removeFilterField = "";
       if (this.queryEditorRef?.setValue) this.queryEditorRef.setValue(newValue);
       if (

--- a/web/src/plugins/traces/SearchBar.vue
+++ b/web/src/plugins/traces/SearchBar.vue
@@ -760,7 +760,8 @@ export default defineComponent({
 
       if (
         value.valueType === "absolute" &&
-        store.state.zoConfig?.auto_query_enabled
+        store.state.zoConfig?.auto_query_enabled && 
+        datetimeChanged
       ) {
         // Debounce query trigger so user can finish typing the full time value
         triggerAbsoluteQueryDebounced(value);

--- a/web/src/plugins/traces/tracesSearchBar.utils.ts
+++ b/web/src/plugins/traces/tracesSearchBar.utils.ts
@@ -71,5 +71,5 @@ export function isDatetimeChanged(
   if (isRelative) {
     return prev.relativeTimePeriod !== value.relativeTimePeriod;
   }
-  return prev.startTime !== value.startTime || prev.endTime !== value.endTime;
+  return prev.startTime.toString() !== value.startTime.toString() || prev.endTime.toString() !== value.endTime.toString();
 }

--- a/web/src/plugins/traces/tracesSearchBar.utils.ts
+++ b/web/src/plugins/traces/tracesSearchBar.utils.ts
@@ -69,7 +69,7 @@ export function isDatetimeChanged(
   if (!prev) return true;
   const isRelative = !!value.relativeTimePeriod;
   if (isRelative) {
-    return prev.relativeTimePeriod !== value.relativeTimePeriod;
+    return (prev.relativeTimePeriod !== value.relativeTimePeriod) || prev.type === 'absolute';
   }
   return prev.startTime !== value.startTime || prev.endTime !== value.endTime;
 }

--- a/web/src/plugins/traces/tracesSearchBar.utils.ts
+++ b/web/src/plugins/traces/tracesSearchBar.utils.ts
@@ -71,5 +71,5 @@ export function isDatetimeChanged(
   if (isRelative) {
     return prev.relativeTimePeriod !== value.relativeTimePeriod;
   }
-  return prev.startTime.toString() !== value.startTime.toString() || prev.endTime.toString() !== value.endTime.toString();
+  return prev.startTime !== value.startTime || prev.endTime !== value.endTime;
 }


### PR DESCRIPTION
#12608 

## What changed

Fixed three interrelated issues in the Traces: 
(1) duplicated search calls caused by redundant watchers and programmatic triggers, and (3) `isDatetimeChanged` returning `false` when switching from absolute to relative mode.

## Why

Separately, loading Traces in any mode triggered 2 redundant search API calls — watchers on `searchObj.data.query` duplicated explicit trigger calls at every query writer, mount-time filter restoration also called `searchData()` despite `loadPageData()` already owning the initial search, and the DateTime picker's mount replay fired a false positive "change" that triggered an auto-run.

## Approach

- Added a `markProgrammaticDateChange()` / `userChangedValue` flag to `DateTime.vue` so the SearchBar can distinguish user-driven date changes from programmatic ones (redirect, metrics brush, mount replay), using `nextTick` to reset the flag after the flush.
- Removed the `watch` on `searchObj.data.query` and the debounced auto-run watchers on query/datetime — every writer of `data.query` in the codebase already calls a search explicitly, so a watcher doubled every trigger.
- Removed the `searchData()` call inside the `restoreFilters` block on mount; the single mount search is owned by `loadPageData()`.
- In `SearchBar.vue`, gated the live-mode auto-run on `userChangedValue === true` and `datetimeChanged`, and removed the `searchObj.data.query = newValue` writes in `applyFilters`/`removeFilter` (filter operations already trigger search via emit).
- Fixed `isDatetimeChanged` to return `true` when the previous type was `absolute` and the value is now `relative`, so switching mode always registers as a change.