### PR TITLE
fix: show Unauthorized message when NL query generation gets HTTP 403

### DIFF
--- a/web/src/composables/useNLQuery.ts
+++ b/web/src/composables/useNLQuery.ts
@@ -426,6 +426,9 @@ export function useNLQuery() {
 
       if (!(response as Response).ok) {
         console.error('[NL2Q] AI assistant returned error:', (response as Response).status);
+        if ((response as Response).status === 403) {
+          streamingResponse.value = UNAUTHORIZED_MESSAGE;
+        }
         return null;
       }
 


### PR DESCRIPTION
## Summary
When the AI chat endpoint returns HTTP 403, `generateSQL` returned `null` without setting `streamingResponse`, so `CodeQueryEditor` fell through to the generic "Failed to generate SQL query" message. Now sets `UNAUTHORIZED_MESSAGE` so the UI displays the proper error.

## Why
The initial auth fix only handled SSE error events. But when the middleware blocks the request with an HTTP 403, the response never reaches the SSE reader — `generateSQL` sees `!response.ok` and returns `null` early. `streamingResponse.value` stays empty, so `isAuthError('')` returns false and the code falls to the generic `t("search.nlQueryGenerationFailed")`.

## Test plan
- [ ] User without AI access sees "Unauthorized Access" when using NL-to-SQL generation
- [ ] Non-auth HTTP errors continue to show generic "Failed to generate SQL query"

🤖 Generated with [Claude Code](https://claude.com/claude-code)