### PR TITLE
fix: show Unauthorized message when NL query generation gets HTTP 403

### DIFF
--- a/web/src/composables/useNLQuery.ts
+++ b/web/src/composables/useNLQuery.ts
@@ -426,6 +426,9 @@ export function useNLQuery() {
 
       if (!(response as Response).ok) {
         console.error('[NL2Q] AI assistant returned error:', (response as Response).status);
+        if ((response as Response).status === 403) {
+          streamingResponse.value = UNAUTHORIZED_MESSAGE;
+        }
         return null;
       }
 


### PR DESCRIPTION
## Summary
When the AI chat endpoint returns HTTP 403, `generateSQL` returned `null` without setting `streamingResponse`, so `CodeQueryEditor` fell through to the generic "Failed to generate SQL query" message. Now sets `UNAUTHORIZED_MESSAGE` so the UI displays the proper error.

## Why
The earlier auth fix (#12558) only handled SSE error events inside the stream. But when the middleware blocks the request with HTTP 403, `!response.ok` triggers before the SSE reader starts — leaving `streamingResponse.value` empty. `isAuthError('')` returns false, so the code falls to the generic message.

## Test plan
- [ ] User without AI access sees "Unauthorized Access" when using NL-to-SQL generation
- [ ] Non-auth HTTP errors continue to show generic "Failed to generate SQL query"

🤖 Generated with [Claude Code](https://claude.com/claude-code)