### PR TITLE
fix: trace graph fails rendering multi root traces

### DIFF
--- a/web/src/composables/useTracePatternTree.spec.ts
+++ b/web/src/composables/useTracePatternTree.spec.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, expect, it } from "vitest";
+import { ref } from "vue";
+import { useTracePatternTree } from "@/composables/useTracePatternTree";
+import { buildPatternConsolidatedTree } from "@/utils/traces/patternDetection";
+import { patternTraceTrees } from "@/test/unit/mockData/traces";
+
+// Runs the same pipeline TraceDetails uses for the Trace Graph tab:
+// traceTree → buildPatternConsolidatedTree → useTracePatternTree.treeData
+const getTreeData = (traceTree: any[]) => {
+  const patterns = ref(buildPatternConsolidatedTree(traceTree));
+  const { treeData } = useTracePatternTree(patterns, ref(false));
+  return treeData.value;
+};
+
+describe("useTracePatternTree", () => {
+  describe("treeData transformation", () => {
+    it("should build a single root tree when the trace has one root span calling another service", () => {
+      const treeData = getTreeData(patternTraceTrees.singleRoot);
+
+      expect(treeData.length).toBe(1);
+      expect(treeData[0].name).toBe("alertmanager");
+      expect(treeData[0].children?.map((c) => c.name)).toEqual(["querier"]);
+    });
+
+    it("should build one tree per root service when root spans have distinct services", () => {
+      const treeData = getTreeData(patternTraceTrees.multiRootDistinctServices);
+
+      expect(treeData.map((n) => n.name).sort()).toEqual([
+        "alertmanager",
+        "ingester",
+      ]);
+      expect(treeData.find((n) => n.name === "alertmanager")?.children?.map((c) => c.name)).toEqual(["querier"]);
+      expect(treeData.find((n) => n.name === "ingester")?.children?.map((c) => c.name)).toEqual(["compactor"]);
+    });
+
+    it("should render a service node when all root spans belong to the same service", () => {
+      const treeData = getTreeData(patternTraceTrees.multiRootSameService);
+
+      expect(treeData.length).toBe(1);
+      expect(treeData[0].name).toBe("alertmanager");
+      // Metrics come from the service's self-pattern (2 spans, avg 75ms)
+      expect(treeData[0].metadata?.count).toBe(2);
+      expect(treeData[0].metadata?.avg).toBe(75);
+    });
+
+    it("should render a service node when the trace has a single span and single service", () => {
+      const treeData = getTreeData(patternTraceTrees.singleServiceOnly);
+
+      expect(treeData.length).toBe(1);
+      expect(treeData[0].name).toBe("alertmanager");
+      expect(treeData[0].metadata?.count).toBe(1);
+    });
+
+    it("should build a tree when root services call each other cyclically", () => {
+      const treeData = getTreeData(patternTraceTrees.multiRootCyclicServices);
+
+      // Cycle alertmanager→querier / querier→alertmanager: no parentless
+      // service exists, but both services must still be represented.
+      expect(treeData.length).toBe(1);
+      expect(treeData[0].name).toBe("alertmanager");
+      expect(treeData[0].children?.map((c) => c.name)).toEqual(["querier"]);
+    });
+
+    it("should not promote a service to root when it already appears as a child of another root", () => {
+      const treeData = getTreeData(
+        patternTraceTrees.multiRootOrphanChildService,
+      );
+
+      expect(treeData.length).toBe(1);
+      expect(treeData[0].name).toBe("alertmanager");
+      expect(treeData[0].children?.map((c) => c.name)).toEqual(["querier"]);
+    });
+
+    it("should return an empty tree when the pattern map is empty", () => {
+      const { treeData } = useTracePatternTree(ref(new Map()), ref(false));
+
+      expect(treeData.value).toEqual([]);
+    });
+  });
+});

--- a/web/src/composables/useTracePatternTree.ts
+++ b/web/src/composables/useTracePatternTree.ts
@@ -57,6 +57,13 @@ export function useTracePatternTree(
         // Add relationship
         serviceMap.get(fromService)!.children.push(pattern)
         serviceMap.get(toService)!.parents.push(fromService)
+      } else if (services.length === 1 && services[0]) {
+        // Self-pattern — register standalone services so they still get a
+        // node when they have no cross-service relationships (e.g. traces
+        // whose root spans all belong to the same service)
+        if (!serviceMap.has(services[0])) {
+          serviceMap.set(services[0], { children: [], parents: [] })
+        }
       }
     })
 
@@ -65,6 +72,11 @@ export function useTracePatternTree(
       service => serviceMap.get(service)!.parents.length === 0
     )
 
+    // Track every service reached from a root so services that are
+    // unreachable (cyclic relationships between root services) can be
+    // promoted to roots afterwards instead of disappearing from the graph
+    const globalVisited = new Set<string>()
+
     // Build tree recursively from root services
     const buildServiceTree = (serviceName: string, visited = new Set<string>()): TreeNode | null => {
       if (visited.has(serviceName)) return null // Prevent cycles
@@ -72,6 +84,8 @@ export function useTracePatternTree(
 
       const serviceInfo = serviceMap.get(serviceName)
       if (!serviceInfo) return null
+
+      globalVisited.add(serviceName)
 
       // Create children from outgoing relationships
       const children: TreeNode[] = []
@@ -126,6 +140,17 @@ export function useTracePatternTree(
     const treeNodes: TreeNode[] = rootServices
       .map(serviceName => buildServiceTree(serviceName))
       .filter((node): node is TreeNode => node !== null)
+
+    // Services unreachable from any parentless root — e.g. two root spans
+    // whose services call each other (A→B and B→A) leave no parentless
+    // service at all. Promote one uncovered service at a time to a root;
+    // each promotion marks everything it reaches as visited
+    serviceMap.forEach((_info, serviceName) => {
+      if (!globalVisited.has(serviceName)) {
+        const node = buildServiceTree(serviceName)
+        if (node) treeNodes.push(node)
+      }
+    })
 
     return treeNodes
   }

--- a/web/src/composables/useTreeVisualization.spec.ts
+++ b/web/src/composables/useTreeVisualization.spec.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, expect, it } from "vitest";
+import { ref } from "vue";
+import {
+  useTreeVisualization,
+  type TreeNode,
+} from "@/composables/useTreeVisualization";
+
+const makeNode = (name: string, metadata: Record<string, any> = {}): TreeNode => ({
+  id: name,
+  name,
+  value: 29.3,
+  errorRate: 0,
+  metadata,
+});
+
+const getLabelFn = (nodeType: "service" | "pattern") =>
+  useTreeVisualization(ref(null), () => [], { nodeType }).getNodeLabel;
+
+describe("useTreeVisualization", () => {
+  describe("getNodeLabel", () => {
+    it("should truncate the name with an ellipsis when it exceeds the label limit", () => {
+      const label = getLabelFn("pattern")(
+        makeNode("oteldemo.RecommendationService"),
+      );
+
+      expect(label).toContain("{name|oteldemo.Recommendation…}");
+      expect(label).not.toContain("RecommendationService");
+    });
+
+    it("should keep short names unchanged when within the label limit", () => {
+      const label = getLabelFn("pattern")(makeNode("frontend"));
+
+      expect(label).toContain("{name|frontend}");
+      expect(label).not.toContain("…");
+    });
+
+    it("should truncate long names when node type is service", () => {
+      const label = getLabelFn("service")(
+        makeNode("oteldemo.ProductCatalogService"),
+      );
+
+      expect(label).toContain("{name|oteldemo.ProductCatalog…}");
+    });
+
+    it("should keep the duration line when the name is truncated", () => {
+      const label = getLabelFn("pattern")(
+        makeNode("oteldemo.RecommendationService", { count: 3, avg: 39.49 }),
+      );
+
+      expect(label).toContain("{duration|39.49ms (avg) }");
+    });
+  });
+});

--- a/web/src/composables/useTreeVisualization.ts
+++ b/web/src/composables/useTreeVisualization.ts
@@ -19,6 +19,12 @@ import {
   generateServiceNodeTooltipContent,
   generatePatternNodeTooltipContent
 } from '@/utils/traces/treeTooltipHelpers'
+import { truncateText } from '@/utils/zincutils'
+
+// Node labels render beside chart nodes with no width cap — long service
+// names would overlap the next tree level, so cap the visible name. The
+// full name stays available in the hover tooltip.
+const MAX_LABEL_NAME_LENGTH = 24
 
 /**
  * Tree node interface for shared tree visualization
@@ -61,9 +67,10 @@ export function useTreeVisualization<T>(
    * - Pattern context: Shows duration with aggregation info
    */
   const getNodeLabel = (node: TreeNode): string => {
+    const displayName = truncateText(node.name, MAX_LABEL_NAME_LENGTH)
     if (config.nodeType === 'service') {
       // ServiceGraph format: service name + request count
-      return `{name|${node.name}}\n{requests|${formatNumber(node.value)} req}`
+      return `{name|${displayName}}\n{requests|${formatNumber(node.value)} req}`
     } else {
       // Pattern format: pattern name + duration (with avg for grouped patterns)
       const count = node.metadata?.count || 1
@@ -71,10 +78,10 @@ export function useTreeVisualization<T>(
 
       if (count > 1) {
         // Grouped pattern: show average with call count
-        return `{name|${node.name}}\n{duration|${duration}ms (avg) }`
+        return `{name|${displayName}}\n{duration|${duration}ms (avg) }`
       } else {
         // Single pattern: show duration without avg label
-        return `{name|${node.name}}\n{duration|${duration}ms}`
+        return `{name|${displayName}}\n{duration|${duration}ms}`
       }
     }
   }

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -31,7 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div v-if="showHeader" class="trace-combined-header-wrapper card-container tw:border-b tw:border-border-default">
         <!-- New Modern Header -->
         <header
-          class="tw:h-auto tw:py-[0.125rem] tw:flex! tw:items-center tw:justify-between tw:bg-[var(--o2-surface)]"
+          class="tw:h-auto tw:py-[0.125rem] tw:flex! tw:items-center tw:justify-between tw:bg-[var(--o2-surface)] tw:pl-1"
         >
           <div class="tw:flex tw:items-center tw:space-x-4 tw:w-fit!">
             <!-- Back button -->

--- a/web/src/test/unit/mockData/traces.ts
+++ b/web/src/test/unit/mockData/traces.ts
@@ -1,3 +1,71 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Formatted span node in the shape produced by TraceDetails getFormattedSpan,
+// as it appears inside traceTree (children nested under `spans`).
+const treeSpan = (
+  spanId: string,
+  serviceName: string,
+  parentId: string,
+  spans: any[],
+  durationMs: number,
+) => ({
+  spanId,
+  span_id: spanId,
+  serviceName,
+  resolvedIdentity: serviceName,
+  parentId,
+  durationMs,
+  spans,
+  operationName: `${serviceName}:op`,
+  operation_name: `${serviceName}:op`,
+  start_time: 1755853746625720300,
+  spanStatus: "UNSET",
+});
+
+// Trace-tree fixtures for pattern-tree (Trace Graph) tests. Each fixture is
+// the `traceTree` array TraceDetails builds — one entry per root span.
+export const patternTraceTrees = {
+  // Baseline: single root, root service calls one downstream service
+  singleRoot: [
+    treeSpan("a1", "alertmanager", "", [treeSpan("q1", "querier", "a1", [], 80)], 100),
+  ],
+  // Two root spans with distinct services, each with its own downstream call
+  multiRootDistinctServices: [
+    treeSpan("a1", "alertmanager", "", [treeSpan("q1", "querier", "a1", [], 80)], 100),
+    treeSpan("i1", "ingester", "", [treeSpan("c1", "compactor", "i1", [], 40)], 60),
+  ],
+  // Two root spans that belong to the same service, no cross-service calls
+  multiRootSameService: [
+    treeSpan("a1", "alertmanager", "", [], 100),
+    treeSpan("a2", "alertmanager", "", [], 50),
+  ],
+  // Two root spans whose services call each other (cyclic service relationship)
+  multiRootCyclicServices: [
+    treeSpan("a1", "alertmanager", "", [treeSpan("q1", "querier", "a1", [], 80)], 100),
+    treeSpan("q2", "querier", "", [treeSpan("a2", "alertmanager", "q2", [], 30)], 50),
+  ],
+  // Root span calling another service, plus an orphan root of that same child service
+  multiRootOrphanChildService: [
+    treeSpan("a1", "alertmanager", "", [treeSpan("q1", "querier", "a1", [], 80)], 100),
+    treeSpan("q2", "querier", "missing-parent", [], 30),
+  ],
+  // Single root span, single service, no relationships at all
+  singleServiceOnly: [treeSpan("a1", "alertmanager", "", [], 100)],
+};
+
 export default {
   tracesDetails: {
     traceMeta: {

--- a/web/src/utils/traces/treeTooltipHelpers.spec.ts
+++ b/web/src/utils/traces/treeTooltipHelpers.spec.ts
@@ -23,6 +23,7 @@ import {
   findIncomingEdgeForNode,
   calculateRootNodeMetrics,
   generateTracePatternTooltipContent,
+  generatePatternNodeTooltipContent,
 } from './treeTooltipHelpers';
 
 describe('treeTooltipHelpers', () => {
@@ -267,6 +268,50 @@ describe('treeTooltipHelpers', () => {
       const metrics = calculateRootNodeMetrics('node', edges);
 
       expect(metrics.errorRate).toBe(0);
+    });
+  });
+
+  describe('generatePatternNodeTooltipContent', () => {
+    it('should show the full service name as the tooltip header', () => {
+      const result = generatePatternNodeTooltipContent({
+        serviceName: 'oteldemo.RecommendationService',
+        count: 3,
+        avg: 39.49,
+        traceTimePercent: 27.9,
+        errorCount: 0,
+      });
+
+      expect(result).toContain('oteldemo.RecommendationService');
+      expect(result).toContain('Spans:');
+      expect(result).toContain('Average:');
+    });
+
+    it('should fall back to the path signature when service name is missing', () => {
+      const result = generatePatternNodeTooltipContent({
+        pathSignature: 'frontend→recommendation',
+        count: 1,
+        avg: 1.5,
+        traceTimePercent: 10,
+      });
+
+      expect(result).toContain('frontend→recommendation');
+    });
+
+    it('should escape HTML in the service name', () => {
+      const result = generatePatternNodeTooltipContent({
+        serviceName: '<img src=x onerror=alert(1)>',
+        count: 1,
+        avg: 0,
+        traceTimePercent: 0,
+      });
+
+      expect(result).not.toContain('<img');
+      expect(result).toContain('&lt;img');
+    });
+
+    it('should return empty string when metadata is missing', () => {
+      expect(generatePatternNodeTooltipContent(null)).toBe('');
+      expect(generatePatternNodeTooltipContent(undefined)).toBe('');
     });
   });
 

--- a/web/src/utils/traces/treeTooltipHelpers.ts
+++ b/web/src/utils/traces/treeTooltipHelpers.ts
@@ -179,8 +179,8 @@ export const generateServiceNodeTooltipContent = (metadata: any): string => {
  */
 export const generatePatternNodeTooltipContent = (metadata: any): string => {
   if (!metadata) return '';
-  // console.log('[TOOLTIP CONTENT DEBUG] metadata:', metadata);
   const {
+    serviceName,
     pathSignature = 'Unknown Pattern',
     count = 1,
     avg = 0,
@@ -189,6 +189,7 @@ export const generatePatternNodeTooltipContent = (metadata: any): string => {
 
   return `
     <div class="tw:flex tw:flex-col tw:gap-0.5">
+      <div class="tw:font-semibold tw:pb-1 tw:text-left">${escapeHtml(serviceName || pathSignature)}</div>
       <div class="tw:flex tw:justify-between tw:gap-3">
         <span class="tw:w-12 tw:text-left">Spans:</span>
         <span class="tw:font-mono tw:text-left tw:flex-1">${count}</span>

--- a/web/src/utils/zincutils.spec.ts
+++ b/web/src/utils/zincutils.spec.ts
@@ -24,6 +24,7 @@ import {
   getLocalTime,
   getBasicAuth,
   convertToTitleCase,
+  truncateText,
   convertTimeFromMicroToMilli,
   formatLargeNumber,
   formatSizeFromMB,
@@ -535,6 +536,28 @@ if .severity == "error" {
       it("should convert hyphenated string to title case", () => {
         expect(convertToTitleCase("hello-world")).toBe("Hello World");
         expect(convertToTitleCase("test-case-string")).toBe("Test Case String");
+      });
+    });
+
+    describe("truncateText", () => {
+      it("should truncate text exceeding maxLength and append ellipsis", () => {
+        expect(truncateText("oteldemo.RecommendationService", 24)).toBe(
+          "oteldemo.Recommendation…",
+        );
+        expect(truncateText("oteldemo.RecommendationService", 24).length).toBe(
+          24,
+        );
+      });
+
+      it("should return text unchanged when within maxLength", () => {
+        expect(truncateText("frontend", 24)).toBe("frontend");
+        expect(truncateText("exactly-24-characters-ok", 24)).toBe(
+          "exactly-24-characters-ok",
+        );
+      });
+
+      it("should handle empty string", () => {
+        expect(truncateText("", 24)).toBe("");
       });
     });
 

--- a/web/src/utils/zincutils.ts
+++ b/web/src/utils/zincutils.ts
@@ -520,6 +520,15 @@ export const convertToTitleCase = (str: string) => {
     .join(" ");
 };
 
+/**
+ * Truncate text to a maximum length, appending an ellipsis when cut.
+ * The returned string never exceeds maxLength characters (ellipsis included).
+ */
+export const truncateText = (text: string, maxLength: number): string => {
+  if (!text || text.length <= maxLength) return text;
+  return `${text.slice(0, Math.max(maxLength - 1, 0))}…`;
+};
+
 export const verifyOrganizationStatus = (Organizations: any, Router: any) => {
   // for (const org of Organizations) {
   //   if (org.status == "pending-subscription") {


### PR DESCRIPTION
## What changed

Fixed three issues in the Trace Graph:
- **Multi-root traces no longer crash** — traces where root spans belonged to distinct services, the same service, or had cyclic service relationships now render correctly instead of showing an empty graph.
- **Overlapping node labels are truncated** — long service names in chart nodes are capped at 24 characters with an ellipsis, preventing overlap with the next tree level.
- **Tooltip now shows the service name** — the pattern node tooltip header was missing the service name, making it impossible to seethe full name of a truncated node on hover.

Also added `truncateText` utility to `zincutils.ts` and comprehensive test fixtures covering all multi-root scenarios.