### PR TITLE
fix: report took_wait_in_queue correctly in super cluster

### DIFF
--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -2341,6 +2341,7 @@ mod tests {
             file_list_took: 30,
             aggs_cache_ratio: 80,
             peak_memory_usage: 1024000,
+            wait_in_queue: 0,
         };
 
         let stats2 = ScanStats {
@@ -2356,6 +2357,7 @@ mod tests {
             file_list_took: 40,
             aggs_cache_ratio: 90,
             peak_memory_usage: 2048000,
+            wait_in_queue: 0,
         };
 
         stats1.add(&stats2);
@@ -2534,6 +2536,7 @@ mod tests {
             file_list_took: 30,
             aggs_cache_ratio: 80,
             peak_memory_usage: 1024000,
+            wait_in_queue: 0,
         };
 
         // Test conversion to cluster_rpc::ScanStats

--- a/src/config/src/meta/search.rs
+++ b/src/config/src/meta/search.rs
@@ -874,6 +874,7 @@ pub struct ScanStats {
     pub file_list_took: i64,
     pub aggs_cache_ratio: i64,
     pub peak_memory_usage: i64,
+    pub wait_in_queue: i64,
 }
 
 impl ScanStats {
@@ -900,6 +901,7 @@ impl ScanStats {
             std::cmp::min(self.aggs_cache_ratio, other.aggs_cache_ratio)
         };
         self.peak_memory_usage = std::cmp::max(self.peak_memory_usage, other.peak_memory_usage);
+        self.wait_in_queue = std::cmp::max(self.wait_in_queue, other.wait_in_queue);
     }
 
     pub fn format_to_mb(&mut self) {
@@ -947,6 +949,7 @@ impl From<&ScanStats> for cluster_rpc::ScanStats {
             file_list_took: req.file_list_took,
             aggs_cache_ratio: req.aggs_cache_ratio,
             peak_memory_usage: req.peak_memory_usage,
+            wait_in_queue: req.wait_in_queue,
         }
     }
 }
@@ -966,6 +969,7 @@ impl From<&cluster_rpc::ScanStats> for ScanStats {
             file_list_took: req.file_list_took,
             aggs_cache_ratio: req.aggs_cache_ratio,
             peak_memory_usage: req.peak_memory_usage,
+            wait_in_queue: req.wait_in_queue,
         }
     }
 }

--- a/src/flight/src/common.rs
+++ b/src/flight/src/common.rs
@@ -228,6 +228,7 @@ mod tests {
             file_list_took: 50,
             aggs_cache_ratio: 80,
             peak_memory_usage: 1024000,
+            wait_in_queue: 0,
         }
     }
 

--- a/src/flight/src/decoder.rs
+++ b/src/flight/src/decoder.rs
@@ -230,6 +230,7 @@ mod tests {
             file_list_took: 25,
             aggs_cache_ratio: 90,
             peak_memory_usage: 1024000,
+            wait_in_queue: 0,
         };
         let custom_message = CustomMessage::ScanStats(scan_stats);
         let metadata = serde_json::to_string(&custom_message).unwrap();
@@ -264,6 +265,7 @@ mod tests {
             file_list_took: 25,
             aggs_cache_ratio: 90,
             peak_memory_usage: 1024000,
+            wait_in_queue: 0,
         };
         let custom_message = CustomMessage::ScanStats(scan_stats);
 

--- a/src/flight/src/encoder.rs
+++ b/src/flight/src/encoder.rs
@@ -225,6 +225,7 @@ mod tests {
             file_list_took: 50,
             aggs_cache_ratio: 80,
             peak_memory_usage: 1024000,
+            wait_in_queue: 0,
         };
         CustomMessage::ScanStats(scan_stats)
     }

--- a/src/proto/proto/cluster/common.proto
+++ b/src/proto/proto/cluster/common.proto
@@ -39,6 +39,7 @@ message ScanStats {
     int64 file_list_took             = 10; // unit: ms
     int64 aggs_cache_ratio           = 11; // unit: %
     int64 peak_memory_usage          = 12; // unit: bytes
+    int64 wait_in_queue              = 13; // unit: ms
 }
 
 message FileList {

--- a/src/proto/src/generated/cluster.rs
+++ b/src/proto/src/generated/cluster.rs
@@ -68,6 +68,9 @@ pub struct ScanStats {
     /// unit: bytes
     #[prost(int64, tag = "12")]
     pub peak_memory_usage: i64,
+    /// unit: ms
+    #[prost(int64, tag = "13")]
+    pub wait_in_queue: i64,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -779,6 +779,7 @@ pub async fn query_status() -> Result<search::QueryStatusResponse, Error> {
                 file_list_took: scan_stats.file_list_took,
                 aggs_cache_ratio: scan_stats.aggs_cache_ratio,
                 peak_memory_usage: scan_stats.peak_memory_usage / 1024 / 1024, // change to MB
+                wait_in_queue: scan_stats.wait_in_queue,
             });
         let query_status = if result.is_queue {
             "waiting"

--- a/src/service/search/super_cluster/follower.rs
+++ b/src/service/search/super_cluster/follower.rs
@@ -295,6 +295,7 @@ pub async fn search(
     // we only want to get the scan stats from the remote scan exec
     let scan_stats = ScanStats {
         file_list_took: file_id_list_took as i64,
+        wait_in_queue: took_wait as i64,
         ..Default::default()
     };
 

--- a/src/service/search/super_cluster/leader.rs
+++ b/src/service/search/super_cluster/leader.rs
@@ -202,8 +202,15 @@ pub async fn search(
 
     log::info!("[trace_id {trace_id}] super cluster leader: search finished");
 
+    let wait_in_queue = scan_stats.wait_in_queue as usize;
     scan_stats.format_to_mb();
-    Ok((data, scan_stats, 0, !partial_err.is_empty(), partial_err))
+    Ok((
+        data,
+        scan_stats,
+        wait_in_queue,
+        !partial_err.is_empty(),
+        partial_err,
+    ))
 }
 
 async fn run_datafusion(


### PR DESCRIPTION
## Summary
- Super cluster leader was hardcoding `0` for `took_wait_in_queue` in all search responses
- Added `wait_in_queue` field to `ScanStats` proto and struct
- Follower now propagates its queue wait time via `ScanStats`
- Leader reads aggregated value (`max` across followers) instead of `0`

Single-cluster deployments were unaffected.