### PR TITLE
fix: prevent duplicate error notification on auth failure in NL query

### DIFF
--- a/web/src/components/CodeQueryEditor.vue
+++ b/web/src/components/CodeQueryEditor.vue
@@ -485,6 +485,9 @@ export default defineComponent({
             ? streamingResponse.value
             : t("search.nlQueryGenerationFailed");
           showErrorNotification(errorMsg);
+          if (isAuthError(streamingResponse.value)) {
+            return; // Auth error already handled, don't trigger catch block
+          }
           throw new Error("Query generation failed");
         }
 


### PR DESCRIPTION
## Summary
Fixes duplicate error notifications when NL-to-SQL generation fails due to 403. The `throw` in `generateAndUpdateQuery` was caught by the catch block which showed a second generic "Failed to generate SQL query" notification on top of the correct Unauthorized message. Now returns early for auth errors, matching the pattern used in alerts.

## Before
User sees two notifications:
1. "Unauthorized Access: You are not authorized..."
2. "Failed to generate SQL query. Please try again."

## After
User sees only:
1. "Unauthorized Access: You are not authorized..."

## Test plan
- [ ] User without AI access sees only one error notification (the unauthorized message)
- [ ] Non-auth errors still show the generic "Failed to generate SQL query" message
- [ ] Auth errors don't trigger SearchBar error handling via re-throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)