### PR TITLE
fix: added stream-change confirmation dialogs across Traces tabs

### DIFF
--- a/web/src/plugins/traces/Index.spec.ts
+++ b/web/src/plugins/traces/Index.spec.ts
@@ -2998,4 +2998,211 @@ describe("Index.vue (Main Traces Page)", () => {
       };
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Stream Change Confirmation Dialog
+  // ---------------------------------------------------------------------------
+  describe("Stream Change Confirmation Dialog", () => {
+    function mountIndexStubbed() {
+      return mount(Index, {
+        attachTo: node,
+        global: {
+          plugins: [i18n, router],
+          provide: { store: store },
+          stubs: {
+            "search-bar": true,
+            "index-list": true,
+            "search-result": true,
+            "service-graph": {
+              name: "service-graph",
+              template: "<div />",
+              emits: ["request:stream-change"],
+            },
+            "services-catalog": {
+              name: "services-catalog",
+              template: "<div />",
+              emits: ["request:stream-change"],
+            },
+            ODialog: true,
+            SanitizedHtmlRenderer: true,
+          },
+        },
+      });
+    }
+
+    beforeEach(() => {
+      mockSearchObj.data.editorValue = "";
+      mockSearchObj.meta.searchMode = "service-graph";
+    });
+
+    it("should apply stream change immediately when editorValue is empty", async () => {
+      mockSearchObj.data.editorValue = "";
+      mockSearchObj.data.stream.selectedStream = {
+        label: "old-stream",
+        value: "old-stream",
+      };
+
+      wrapper = mountIndexStubbed();
+      await flushPromises();
+
+      wrapper.vm.onChildStreamChangeRequest("new-stream");
+      await flushPromises();
+
+      expect(wrapper.vm.streamChangeDialog.show).toBe(false);
+      expect(mockSearchObj.data.stream.selectedStream.value).toBe("new-stream");
+      expect(mockSearchObj.data.stream.selectedStream.label).toBe("new-stream");
+    });
+
+    it("should apply stream change immediately when editorValue is only whitespace", async () => {
+      mockSearchObj.data.editorValue = "   ";
+      mockSearchObj.data.stream.selectedStream = {
+        label: "old-stream",
+        value: "old-stream",
+      };
+
+      wrapper = mountIndexStubbed();
+      await flushPromises();
+
+      wrapper.vm.onChildStreamChangeRequest("new-stream");
+      await flushPromises();
+
+      expect(wrapper.vm.streamChangeDialog.show).toBe(false);
+      expect(mockSearchObj.data.stream.selectedStream.value).toBe("new-stream");
+    });
+
+    it("should show confirmation dialog when editorValue has content", async () => {
+      mockSearchObj.data.editorValue = "service_name = 'test'";
+
+      wrapper = mountIndexStubbed();
+      await flushPromises();
+
+      wrapper.vm.onChildStreamChangeRequest("other-stream");
+      await flushPromises();
+
+      expect(wrapper.vm.streamChangeDialog.show).toBe(true);
+      expect(wrapper.vm.streamChangeDialog.pendingStream).toBe("other-stream");
+    });
+
+    it("should not change selectedStream when dialog is shown instead of applying immediately", async () => {
+      // Use a stream name present in mockStreamList so loadStreamLists does not
+      // clear it during mount — the assertion checks the stream stays unchanged.
+      mockSearchObj.data.editorValue = "duration >= 1000";
+      mockSearchObj.data.stream.selectedStream = {
+        label: "default",
+        value: "default",
+      };
+
+      wrapper = mountIndexStubbed();
+      await flushPromises();
+
+      // Ensure stream is still "default" after mount before triggering request
+      // (it can be re-set by loadStreamLists when it finds a match)
+      await vi.waitFor(
+        () => {
+          expect(mockSearchObj.data.stream.selectedStream.value).toBe("default");
+        },
+        { timeout: 2000 },
+      );
+
+      wrapper.vm.onChildStreamChangeRequest("requested-stream");
+      await flushPromises();
+
+      // Dialog was shown — selectedStream must NOT have been changed
+      expect(wrapper.vm.streamChangeDialog.show).toBe(true);
+      expect(mockSearchObj.data.stream.selectedStream.value).toBe("default");
+    });
+
+    it("should update selectedStream, clear editorValue, and hide dialog when applyStreamChange is called", async () => {
+      mockSearchObj.data.editorValue = "service_name = 'svc'";
+      wrapper = mountIndexStubbed();
+      await flushPromises();
+
+      // Simulate dialog being shown with a pending stream
+      wrapper.vm.streamChangeDialog.show = true;
+      wrapper.vm.streamChangeDialog.pendingStream = "target-stream";
+
+      await wrapper.vm.applyStreamChange("target-stream");
+      await flushPromises();
+
+      expect(mockSearchObj.data.stream.selectedStream.value).toBe(
+        "target-stream",
+      );
+      expect(mockSearchObj.data.stream.selectedStream.label).toBe(
+        "target-stream",
+      );
+      expect(mockSearchObj.data.editorValue).toBe("");
+      expect(wrapper.vm.streamChangeDialog.show).toBe(false);
+    });
+
+    it("should close dialog and leave stream unchanged when secondary button sets show to false", async () => {
+      // Use a stream name present in mockStreamList so loadStreamLists keeps it.
+      mockSearchObj.data.editorValue = "service_name = 'svc'";
+      mockSearchObj.data.stream.selectedStream = {
+        label: "default",
+        value: "default",
+      };
+
+      wrapper = mountIndexStubbed();
+      await flushPromises();
+
+      // Wait until mount resolves and selectedStream remains "default".
+      await vi.waitFor(
+        () => {
+          expect(mockSearchObj.data.stream.selectedStream.value).toBe("default");
+        },
+        { timeout: 2000 },
+      );
+
+      // Open dialog as if primary button was not clicked
+      wrapper.vm.streamChangeDialog.show = true;
+      wrapper.vm.streamChangeDialog.pendingStream = "other-stream";
+
+      // Secondary button handler — just closes the dialog
+      wrapper.vm.streamChangeDialog.show = false;
+      await flushPromises();
+
+      expect(wrapper.vm.streamChangeDialog.show).toBe(false);
+      // Stream must remain unchanged — the cancel did not apply the pending change
+      expect(mockSearchObj.data.stream.selectedStream.value).toBe("default");
+    });
+
+    it("should trigger onChildStreamChangeRequest when service-graph emits request:stream-change", async () => {
+      mockSearchObj.data.editorValue = "duration >= 500";
+
+      wrapper = mountIndexStubbed();
+      await flushPromises();
+
+      const serviceGraphEl = wrapper.findComponent({ name: "service-graph" });
+      expect(serviceGraphEl.exists()).toBe(true);
+
+      await serviceGraphEl.vm.$emit("request:stream-change", "graph-stream");
+      await flushPromises();
+
+      // Non-empty editorValue → dialog must be shown
+      expect(wrapper.vm.streamChangeDialog.show).toBe(true);
+      expect(wrapper.vm.streamChangeDialog.pendingStream).toBe("graph-stream");
+    });
+
+    it("should trigger onChildStreamChangeRequest when services-catalog emits request:stream-change", async () => {
+      mockSearchObj.data.editorValue = "span_status = 'ERROR'";
+      mockSearchObj.meta.searchMode = "services-catalog";
+
+      wrapper = mountIndexStubbed();
+      await flushPromises();
+
+      const servicesCatalogEl = wrapper.findComponent({
+        name: "services-catalog",
+      });
+      expect(servicesCatalogEl.exists()).toBe(true);
+
+      await servicesCatalogEl.vm.$emit(
+        "request:stream-change",
+        "catalog-stream",
+      );
+      await flushPromises();
+
+      expect(wrapper.vm.streamChangeDialog.show).toBe(true);
+      expect(wrapper.vm.streamChangeDialog.pendingStream).toBe("catalog-stream");
+    });
+  });
 });

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -85,6 +85,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               ref="serviceGraphRef"
               class="tw:h-full"
               @view-traces="handleServiceGraphViewTraces"
+              @request:stream-change="onChildStreamChangeRequest"
             />
           </div>
 
@@ -97,6 +98,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               ref="servicesCatalogRef"
               class="tw:h-full"
               @view-traces="handleServicesCatalogViewTraces"
+              @request:stream-change="onChildStreamChangeRequest"
             />
           </div>
 
@@ -273,6 +275,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </template>
       </OSplitter>
     </div>
+
+    <ODialog
+      v-model:open="streamChangeDialog.show"
+      title="Change stream?"
+      size="sm"
+      primary-button-label="Switch stream"
+      secondary-button-label="Cancel"
+      @click:primary="applyStreamChange(streamChangeDialog.pendingStream)"
+      @click:secondary="streamChangeDialog.show = false"
+    >
+      <p>This will also update the stream in the Traces/Spans tab and reset existing query.</p>
+    </ODialog>
   </div>
 </template>
 
@@ -339,6 +353,7 @@ import { useTracesTableColumns } from "./composables/useTracesTableColumns";
 import type { TraceSearchMode } from "@/ts/interfaces/traces/trace.types";
 import { isLLMTrace } from "@/utils/llmUtils";
 import OButton from "@/lib/core/Button/OButton.vue";
+import ODialog from "@/lib/overlay/Dialog/ODialog.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OSplitter from "@/lib/core/Splitter/OSplitter.vue";
 import OEmptyState from "@/lib/core/EmptyState/OEmptyState.vue";
@@ -1962,6 +1977,26 @@ const getMoreData = () => {
 const onChangeStream = async () => {
   await extractFields();
   runQueryFn();
+};
+
+const streamChangeDialog = ref({ show: false, pendingStream: "" });
+
+const applyStreamChange = async (newStream: string) => {
+  searchObj.data.stream.selectedStream = {
+    label: newStream,
+    value: newStream,
+  };
+  searchObj.data.editorValue = "";
+  streamChangeDialog.value.show = false;
+  await onChangeStream();
+};
+
+const onChildStreamChangeRequest = (newStream: string) => {
+  if (searchObj.data.editorValue?.trim()) {
+    streamChangeDialog.value = { show: true, pendingStream: newStream };
+  } else {
+    applyStreamChange(newStream);
+  }
 };
 
 const collapseFieldList = () => {

--- a/web/src/plugins/traces/ServiceGraph.spec.ts
+++ b/web/src/plugins/traces/ServiceGraph.spec.ts
@@ -215,6 +215,11 @@ describe("ServiceGraph.vue - Cache Invalidation & Data Refresh", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Clear persisted stream filter so localStorage does not bleed between tests.
+    // Without this, a previous test that wrote "stream2" to localStorage causes
+    // the next component instance to initialise streamFilter = "stream2", which
+    // makes the watch guard (newStream !== streamFilter.value) skip the update.
+    localStorage.removeItem("serviceGraph_streamFilter");
     // Reset shared reactive searchObj to baseline before every test so watcher
     // state does not bleed between tests.
     mockSearchObj.meta.serviceGraphVisualizationType = "tree";
@@ -223,6 +228,7 @@ describe("ServiceGraph.vue - Cache Invalidation & Data Refresh", () => {
     mockSearchObj.data.datetime.endTime = Date.now();
     mockSearchObj.data.datetime.relativeTimePeriod = "15m";
     mockSearchObj.data.datetime.type = "relative";
+    mockSearchObj.data.stream.selectedStream.value = "";
     vi.mocked(serviceGraphService.getCurrentTopology).mockResolvedValue(
       mockApiResponse,
     );
@@ -318,98 +324,56 @@ describe("ServiceGraph.vue - Cache Invalidation & Data Refresh", () => {
   });
 
   describe("Cache Invalidation on Stream Filter Change", () => {
-    it("should invalidate cache when stream filter changes", async () => {
+    // onStreamFilterChange now only emits "request:stream-change" to the parent.
+    // The parent is responsible for updating the global stream, which then flows
+    // back via the watch on searchObj.data.stream.selectedStream.value.
+
+    it("should emit request:stream-change with the selected stream value", async () => {
       wrapper = createWrapper();
       await flushPromises();
 
-      const initialChartKey = wrapper.vm.chartKey;
+      wrapper.vm.onStreamFilterChange("stream1");
 
-      // Change stream filter
-      await wrapper.vm.onStreamFilterChange("stream1");
-      await flushPromises();
-
-      // Verify chartKey was incremented (which invalidates any cached data)
-      // This forces chart to regenerate with fresh data
-      expect(wrapper.vm.chartKey).toBeGreaterThan(initialChartKey);
+      expect(wrapper.emitted("request:stream-change")).toBeTruthy();
+      expect(wrapper.emitted("request:stream-change")![0]).toEqual(["stream1"]);
     });
 
-    it("should increment chartKey when stream filter changes", async () => {
+    it("should NOT update streamFilter immediately when a new stream is selected", async () => {
       wrapper = createWrapper();
       await flushPromises();
 
-      const initialChartKey = wrapper.vm.chartKey;
+      const initialStreamFilter = wrapper.vm.streamFilter;
 
-      // Change stream filter
-      await wrapper.vm.onStreamFilterChange("stream1");
+      wrapper.vm.onStreamFilterChange("stream1");
       await flushPromises();
 
-      // Verify chartKey was incremented
-      expect(wrapper.vm.chartKey).toBe(initialChartKey + 1);
+      // streamFilter stays unchanged — the parent must confirm the change first
+      expect(wrapper.vm.streamFilter).toBe(initialStreamFilter);
     });
 
-    it("should call API with new stream parameter", async () => {
+    it("should NOT call loadServiceGraph when onStreamFilterChange is invoked", async () => {
       wrapper = createWrapper();
       await flushPromises();
 
       vi.mocked(serviceGraphService.getCurrentTopology).mockClear();
 
-      // Change stream filter
-      await wrapper.vm.onStreamFilterChange("stream1");
+      wrapper.vm.onStreamFilterChange("stream1");
       await flushPromises();
 
-      // Verify API was called with new stream
-      expect(serviceGraphService.getCurrentTopology).toHaveBeenCalledWith(
-        "test-org",
-        expect.objectContaining({
-          streamName: "stream1",
-          startTime: expect.any(Number),
-          endTime: expect.any(Number),
-        }),
-      );
+      expect(serviceGraphService.getCurrentTopology).not.toHaveBeenCalled();
     });
 
-    it("should update graphData with new data from API", async () => {
-      wrapper = createWrapper();
-      await flushPromises();
-
-      const newApiResponse = {
-        data: {
-          nodes: [
-            {
-              id: "service-c",
-              label: "Service C",
-              requests: 3000,
-              errors: 30,
-              error_rate: 1.0,
-              is_virtual: false,
-            },
-          ],
-          edges: [],
-          availableStreams: ["stream1"],
-        },
-      };
-
-      vi.mocked(serviceGraphService.getCurrentTopology).mockResolvedValue(
-        newApiResponse,
-      );
-
-      // Change stream filter
-      await wrapper.vm.onStreamFilterChange("stream1");
-      await flushPromises();
-
-      // Verify graphData was updated
-      expect(wrapper.vm.graphData.nodes).toHaveLength(1);
-      expect(wrapper.vm.graphData.nodes[0].id).toBe("service-c");
-    });
-
-    it("should persist stream filter to localStorage", async () => {
+    it("should NOT write to localStorage when onStreamFilterChange is invoked", async () => {
       const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
       wrapper = createWrapper();
       await flushPromises();
 
-      await wrapper.vm.onStreamFilterChange("stream1");
+      setItemSpy.mockClear();
 
-      expect(setItemSpy).toHaveBeenCalledWith(
+      wrapper.vm.onStreamFilterChange("stream1");
+      await flushPromises();
+
+      expect(setItemSpy).not.toHaveBeenCalledWith(
         "serviceGraph_streamFilter",
         "stream1",
       );
@@ -417,22 +381,115 @@ describe("ServiceGraph.vue - Cache Invalidation & Data Refresh", () => {
       setItemSpy.mockRestore();
     });
 
-    it("should handle 'all' streams filter", async () => {
+    it("should emit request:stream-change even when 'all' is selected", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      wrapper.vm.onStreamFilterChange("all");
+
+      expect(wrapper.emitted("request:stream-change")).toBeTruthy();
+      expect(wrapper.emitted("request:stream-change")![0]).toEqual(["all"]);
+    });
+  });
+
+  describe("Global Stream Watch — bidirectional stream sync", () => {
+    beforeEach(() => {
+      // Ensure selectedStream starts empty so watcher fires when we set a value
+      mockSearchObj.data.stream.selectedStream.value = "";
+    });
+
+    afterEach(() => {
+      mockSearchObj.data.stream.selectedStream.value = "";
+    });
+
+    it("should update streamFilter when global selectedStream changes", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      // Confirm initial state
+      const initialStreamFilter = wrapper.vm.streamFilter;
+
+      // Simulate Traces/Spans tab changing the global stream
+      mockSearchObj.data.stream.selectedStream.value = "stream2";
+      await flushPromises();
+
+      expect(wrapper.vm.streamFilter).toBe("stream2");
+      expect(wrapper.vm.streamFilter).not.toBe(initialStreamFilter);
+    });
+
+    it("should call loadServiceGraph when global selectedStream changes", async () => {
       wrapper = createWrapper();
       await flushPromises();
 
       vi.mocked(serviceGraphService.getCurrentTopology).mockClear();
 
-      await wrapper.vm.onStreamFilterChange("all");
+      mockSearchObj.data.stream.selectedStream.value = "stream2";
       await flushPromises();
 
-      // Verify API was called without streamName parameter
+      expect(serviceGraphService.getCurrentTopology).toHaveBeenCalledTimes(1);
+    });
+
+    it("should persist the new stream to localStorage when global selectedStream changes", async () => {
+      const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+      wrapper = createWrapper();
+      await flushPromises();
+
+      setItemSpy.mockClear();
+
+      mockSearchObj.data.stream.selectedStream.value = "stream2";
+      await flushPromises();
+
+      expect(setItemSpy).toHaveBeenCalledWith(
+        "serviceGraph_streamFilter",
+        "stream2",
+      );
+
+      setItemSpy.mockRestore();
+    });
+
+    it("should NOT reload when global selectedStream changes to the same value as current streamFilter", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      // Set streamFilter to "stream1" first via the global watch
+      mockSearchObj.data.stream.selectedStream.value = "stream1";
+      await flushPromises();
+
+      vi.mocked(serviceGraphService.getCurrentTopology).mockClear();
+
+      // Setting the same value again — the watch guard (newStream !== streamFilter.value) prevents a reload
+      mockSearchObj.data.stream.selectedStream.value = "stream1";
+      await flushPromises();
+
+      expect(serviceGraphService.getCurrentTopology).not.toHaveBeenCalled();
+    });
+
+    it("should NOT react when global selectedStream changes to an empty string", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      vi.mocked(serviceGraphService.getCurrentTopology).mockClear();
+
+      // Empty string is falsy — the watch guard skips the update
+      mockSearchObj.data.stream.selectedStream.value = "";
+      await flushPromises();
+
+      expect(serviceGraphService.getCurrentTopology).not.toHaveBeenCalled();
+    });
+
+    it("should call loadServiceGraph with the new stream name after global stream sync", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      vi.mocked(serviceGraphService.getCurrentTopology).mockClear();
+
+      mockSearchObj.data.stream.selectedStream.value = "stream2";
+      await flushPromises();
+
       expect(serviceGraphService.getCurrentTopology).toHaveBeenCalledWith(
         "test-org",
         expect.objectContaining({
-          streamName: undefined,
-          startTime: expect.any(Number),
-          endTime: expect.any(Number),
+          streamName: "stream2",
         }),
       );
     });
@@ -675,18 +732,21 @@ describe("ServiceGraph.vue - Cache Invalidation & Data Refresh", () => {
   });
 
   describe("Chart Re-rendering", () => {
-    it("should trigger chart re-render when chartKey changes", async () => {
+    it("should trigger chart re-render when chartKey changes via global stream sync", async () => {
+      mockSearchObj.data.stream.selectedStream.value = "";
       wrapper = createWrapper();
       await flushPromises();
 
       const initialChartKey = wrapper.vm.chartKey;
 
-      // Change stream filter to trigger chartKey increment
-      await wrapper.vm.onStreamFilterChange("stream1");
+      // Stream change flows through the global watch — chartKey increments via loadServiceGraph
+      mockSearchObj.data.stream.selectedStream.value = "stream1";
       await flushPromises();
 
       // Verify chartKey changed
       expect(wrapper.vm.chartKey).not.toBe(initialChartKey);
+
+      mockSearchObj.data.stream.selectedStream.value = "";
     });
 
     it("should regenerate chartData computed property after chartKey is incremented", async () => {
@@ -717,45 +777,52 @@ describe("ServiceGraph.vue - Cache Invalidation & Data Refresh", () => {
   });
 
   describe("Multiple Sequential Changes", () => {
-    it("should handle multiple stream changes in sequence", async () => {
+    beforeEach(() => {
+      mockSearchObj.data.stream.selectedStream.value = "";
+    });
+
+    afterEach(() => {
+      mockSearchObj.data.stream.selectedStream.value = "";
+    });
+
+    it("should handle multiple global stream changes in sequence via watch", async () => {
       wrapper = createWrapper();
       await flushPromises();
 
       const initialChartKey = wrapper.vm.chartKey;
 
-      // Make multiple stream changes
-      await wrapper.vm.onStreamFilterChange("stream1");
+      // Three distinct stream values — each triggers the global watch
+      mockSearchObj.data.stream.selectedStream.value = "stream1";
       await flushPromises();
 
-      await wrapper.vm.onStreamFilterChange("stream2");
+      mockSearchObj.data.stream.selectedStream.value = "stream2";
       await flushPromises();
 
-      await wrapper.vm.onStreamFilterChange("all");
+      mockSearchObj.data.stream.selectedStream.value = "default";
       await flushPromises();
 
-      // Verify chartKey was incremented for each change
+      // chartKey increments once per loadServiceGraph call (once per stream change)
       expect(wrapper.vm.chartKey).toBe(initialChartKey + 3);
     });
 
-    it("should handle stream change followed by refresh", async () => {
+    it("should handle global stream change followed by explicit refresh", async () => {
       wrapper = createWrapper();
       await flushPromises();
 
       const initialChartKey = wrapper.vm.chartKey;
 
-      // Change stream
-      await wrapper.vm.onStreamFilterChange("stream1");
+      // Global stream change — increments chartKey once
+      mockSearchObj.data.stream.selectedStream.value = "stream1";
       await flushPromises();
 
-      // Then refresh
+      // Explicit refresh — increments chartKey again
       await wrapper.vm.loadServiceGraph();
       await flushPromises();
 
-      // Verify chartKey was incremented twice (once for stream change, once for refresh)
       expect(wrapper.vm.chartKey).toBe(initialChartKey + 2);
     });
 
-    it("should handle time range change followed by stream change", async () => {
+    it("should handle time range change followed by global stream change", async () => {
       wrapper = createWrapper();
       await flushPromises();
 
@@ -767,11 +834,11 @@ describe("ServiceGraph.vue - Cache Invalidation & Data Refresh", () => {
       wrapper.vm.searchObj.data.datetime.relativeTimePeriod = "30m";
       await flushPromises();
 
-      // Then change stream
-      await wrapper.vm.onStreamFilterChange("stream1");
+      // Then a global stream change via the selectedStream watch
+      mockSearchObj.data.stream.selectedStream.value = "stream1";
       await flushPromises();
 
-      // Verify API was called twice with correct parameters
+      // API called once for time range change, once for stream change
       expect(serviceGraphService.getCurrentTopology).toHaveBeenCalledTimes(2);
     });
   });

--- a/web/src/plugins/traces/ServiceGraph.vue
+++ b/web/src/plugins/traces/ServiceGraph.vue
@@ -8,7 +8,7 @@
         class="tw:w-[11rem] tw:flex-shrink-0"
       >
         <OSelect
-          v-model="streamFilter"
+          :model-value="streamFilter"
           :options="availableStreams.map((s) => ({ label: s, value: s }))"
           labelKey="label"
           valueKey="value"
@@ -311,7 +311,7 @@ export default defineComponent({
     OCard,
     OCardSection,
 },
-  emits: ["view-traces"],
+  emits: ["view-traces", "request:stream-change"],
   setup(props, { emit }) {
     const store = useStore();
     const router = useRouter();
@@ -1321,11 +1321,7 @@ export default defineComponent({
     };
 
     const onStreamFilterChange = (stream: string) => {
-      streamFilter.value = stream;
-      localStorage.setItem("serviceGraph_streamFilter", stream);
-
-      // Reload service graph with new stream filter
-      loadServiceGraph();
+      emit("request:stream-change", stream);
     };
 
     const applyFilters = () => {
@@ -1378,6 +1374,18 @@ export default defineComponent({
         loadServiceGraph();
       },
       { deep: true },
+    );
+
+    // Keep streamFilter in sync when Traces/Spans tab changes the global stream
+    watch(
+      () => searchObj.data.stream.selectedStream.value,
+      (newStream) => {
+        if (newStream && newStream !== streamFilter.value) {
+          streamFilter.value = newStream;
+          localStorage.setItem("serviceGraph_streamFilter", newStream);
+          loadServiceGraph();
+        }
+      },
     );
 
     const formatNumber = (num: number) => {

--- a/web/src/plugins/traces/ServicesCatalog.spec.ts
+++ b/web/src/plugins/traces/ServicesCatalog.spec.ts
@@ -1792,8 +1792,8 @@ describe("ServicesCatalog", () => {
       });
     });
 
-    describe("changing stream triggers data reload", () => {
-      it("should update streamFilter, persist to localStorage, and trigger reload", async () => {
+    describe("onStreamFilterChange — emits request:stream-change", () => {
+      it("should emit request:stream-change with the new stream value when stream selection changes", async () => {
         mockGetStreams.mockResolvedValueOnce({
           list: [{ name: "default" }, { name: "production" }],
         });
@@ -1801,18 +1801,140 @@ describe("ServicesCatalog", () => {
         wrapper = mountServicesCatalog();
         await flushPromises();
 
-        // Clear the call from onMounted so we can assert the reload call
         mockFetchQueryDataWithHttpStream.mockClear();
 
-        wrapper.vm.streamFilter = "production";
         wrapper.vm.onStreamFilterChange("production");
+        await flushPromises();
+
+        const emitted = wrapper.emitted("request:stream-change");
+        expect(emitted).toBeTruthy();
+        expect(emitted![0]).toEqual(["production"]);
+      });
+
+      it("should NOT update streamFilter immediately when onStreamFilterChange is called", async () => {
+        mockGetStreams.mockResolvedValueOnce({
+          list: [{ name: "default" }, { name: "production" }],
+        });
+
+        // Ensure selectedStream starts as "default" so streamFilter initialises to "default"
+        mockSearchObj.data.stream.selectedStream = {
+          label: "default",
+          value: "default",
+        };
+
+        wrapper = mountServicesCatalog();
+        await flushPromises();
+
+        expect(wrapper.vm.streamFilter).toBe("default");
+
+        wrapper.vm.onStreamFilterChange("production");
+        await flushPromises();
+
+        // streamFilter must remain unchanged — only the watcher syncs it
+        expect(wrapper.vm.streamFilter).toBe("default");
+      });
+
+      it("should NOT call loadServicesCatalog when onStreamFilterChange is called", async () => {
+        mockGetStreams.mockResolvedValueOnce({
+          list: [{ name: "default" }, { name: "production" }],
+        });
+
+        wrapper = mountServicesCatalog();
+        await flushPromises();
+
+        // Clear the onMounted call so only subsequent calls are counted
+        mockFetchQueryDataWithHttpStream.mockClear();
+
+        wrapper.vm.onStreamFilterChange("production");
+        await flushPromises();
+
+        expect(mockFetchQueryDataWithHttpStream).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("global stream watch — syncs streamFilter from searchObj", () => {
+      it("should update streamFilter when searchObj.data.stream.selectedStream.value changes externally", async () => {
+        mockSearchObj.data.stream.selectedStream = {
+          label: "default",
+          value: "default",
+        };
+
+        wrapper = mountServicesCatalog();
+        await flushPromises();
+
+        expect(wrapper.vm.streamFilter).toBe("default");
+
+        // Simulate external global stream change
+        mockSearchObj.data.stream.selectedStream = {
+          label: "production",
+          value: "production",
+        };
+        await flushPromises();
+
+        expect(wrapper.vm.streamFilter).toBe("production");
+      });
+
+      it("should call loadServicesCatalog when the global stream changes", async () => {
+        mockSearchObj.data.stream.selectedStream = {
+          label: "default",
+          value: "default",
+        };
+
+        wrapper = mountServicesCatalog();
+        await flushPromises();
+
+        mockFetchQueryDataWithHttpStream.mockClear();
+
+        mockSearchObj.data.stream.selectedStream = {
+          label: "production",
+          value: "production",
+        };
+        await flushPromises();
+
+        expect(mockFetchQueryDataWithHttpStream).toHaveBeenCalled();
+      });
+
+      it("should persist the new stream to localStorage when the global stream changes", async () => {
+        mockSearchObj.data.stream.selectedStream = {
+          label: "default",
+          value: "default",
+        };
+
+        wrapper = mountServicesCatalog();
+        await flushPromises();
+
+        localStorage.removeItem("servicesCatalog_streamFilter");
+
+        mockSearchObj.data.stream.selectedStream = {
+          label: "production",
+          value: "production",
+        };
         await flushPromises();
 
         expect(localStorage.getItem("servicesCatalog_streamFilter")).toBe(
           "production",
         );
-        expect(wrapper.vm.streamFilter).toBe("production");
-        expect(mockFetchQueryDataWithHttpStream).toHaveBeenCalled();
+      });
+
+      it("should NOT call loadServicesCatalog when the global stream value is unchanged", async () => {
+        mockSearchObj.data.stream.selectedStream = {
+          label: "default",
+          value: "default",
+        };
+
+        wrapper = mountServicesCatalog();
+        await flushPromises();
+
+        mockFetchQueryDataWithHttpStream.mockClear();
+
+        // Set to same value — watcher guard `newStream !== streamFilter.value` prevents reload
+        mockSearchObj.data.stream.selectedStream = {
+          label: "default",
+          value: "default",
+        };
+        await flushPromises();
+
+        expect(mockFetchQueryDataWithHttpStream).not.toHaveBeenCalled();
       });
     });
 

--- a/web/src/plugins/traces/ServicesCatalog.vue
+++ b/web/src/plugins/traces/ServicesCatalog.vue
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         class="tw:w-[11rem] tw:flex-shrink-0"
       >
         <OSelect
-          v-model="streamFilter"
+          :model-value="streamFilter"
           :options="availableStreams.map((s) => ({ label: s, value: s }))"
           labelKey="label"
           valueKey="value"
@@ -400,6 +400,7 @@ const { fetchQueryDataWithHttpStream, cancelStreamQueryBasedOnRequestId } =
 
 const emit = defineEmits<{
   "view-traces": [data: string | Record<string, any>];
+  "request:stream-change": [stream: string];
 }>();
 
 // p99 > 1 second triggers the orange highlight
@@ -728,10 +729,7 @@ const loadAvailableStreams = async () => {
 };
 
 const onStreamFilterChange = (stream: string) => {
-  streamFilter.value = stream;
-  localStorage.setItem("servicesCatalog_streamFilter", stream);
-  hasInferColumns.value = null; // re-check schema for new stream
-  loadServicesCatalog();
+  emit("request:stream-change", stream);
 };
 
 async function loadServicesCatalog() {
@@ -877,6 +875,19 @@ ORDER BY total_requests DESC`;
 
 // Expose for parent ref access
 defineExpose({ loadServicesCatalog, streamFilter });
+
+// Keep streamFilter in sync when Traces/Spans tab changes the global stream
+watch(
+  () => searchObj.data.stream.selectedStream.value,
+  (newStream) => {
+    if (newStream && newStream !== streamFilter.value) {
+      streamFilter.value = newStream;
+      localStorage.setItem("servicesCatalog_streamFilter", newStream);
+      hasInferColumns.value = null;
+      loadServicesCatalog();
+    }
+  },
+);
 
 watch(
   () => [


### PR DESCRIPTION
## What changed

Adds stream-change confirmation dialogs across Traces tabs. When a user changes the stream in **Service Graph** or **Services Catalog**, the change is no longer applied silently — instead an `ODialog` prompts the user to confirm, since changing the stream clears the existing query in the Traces/Spans tabs.

## Why

Previously, stream selection was only synced one-way: changing the stream in Traces/Spans propagated to all other tabs. Changing the stream in Service Graph or Services Catalog did not sync back because those tabs don't show a query — so doing so could erase an active query in Traces/Spans without user awareness. This change ensures the user is explicitly asked before clearing their query.