### PR TITLE
feat: rewrite tantivy histogram collectors, support histogram() timezone in optimize rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,6 +2271,7 @@ dependencies = [
  "dotenv_config",
  "dotenvy",
  "expect-test",
+ "fastdivide",
  "faststr",
  "float-cmp",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,6 +336,7 @@ sqlparser = { version = "0.61", features = ["serde", "visitor"] }
 dotenv_config = "0.2"
 dotenvy = "0.15"
 env_logger = "0.11"
+fastdivide = "0.4"
 faststr = { version = "0.2", features = ["serde"] }
 flate2 = { version = "1.0", features = ["zlib"] }
 futures = "0.3"

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -38,6 +38,7 @@ datafusion.workspace = true
 dashmap.workspace = true
 dotenv_config.workspace = true
 dotenvy.workspace = true
+fastdivide.workspace = true
 faststr.workspace = true
 futures.workspace = true
 local-ip-address.workspace = true

--- a/src/config/src/meta/inverted_index.rs
+++ b/src/config/src/meta/inverted_index.rs
@@ -25,8 +25,10 @@ pub const MAX_SIMPLE_TOPN_FIELDS: usize = 4;
 pub enum IndexOptimizeMode {
     SimpleSelect(usize, bool),
     SimpleCount,
-    SimpleHistogram(i64, u64, usize),
-    SimpleMultiHistogram(i64, i64, u64, String),
+    /// (min_value, bucket_width, num_buckets, ts_offset)
+    SimpleHistogram(i64, u64, usize, i64),
+    /// (min_value, max_value, bucket_width, ts_offset, breakdown_field)
+    SimpleMultiHistogram(i64, i64, u64, i64, String),
     SimpleTopN(Vec<String>, usize, bool),
     SimpleDistinct(String, usize, bool),
 }
@@ -48,11 +50,17 @@ impl IndexOptimizeMode {
         match self {
             IndexOptimizeMode::SimpleSelect(limit, ascend) => format!("s(l:{limit},a:{ascend})"),
             IndexOptimizeMode::SimpleCount => "c".to_string(),
-            IndexOptimizeMode::SimpleHistogram(min_value, bucket_width, num_buckets) => {
-                format!("h(m:{min_value},b:{bucket_width},n:{num_buckets})")
+            IndexOptimizeMode::SimpleHistogram(min_value, bucket_width, num_buckets, ts_offset) => {
+                format!("h(m:{min_value},b:{bucket_width},n:{num_buckets},o:{ts_offset})")
             }
-            IndexOptimizeMode::SimpleMultiHistogram(min_value, max_value, bucket_width, field) => {
-                format!("mh(m:{min_value},x:{max_value},b:{bucket_width},f:{field})")
+            IndexOptimizeMode::SimpleMultiHistogram(
+                min_value,
+                max_value,
+                bucket_width,
+                ts_offset,
+                field,
+            ) => {
+                format!("mh(m:{min_value},x:{max_value},b:{bucket_width},o:{ts_offset},f:{field})")
             }
             IndexOptimizeMode::SimpleTopN(fields, limit, ascend) => {
                 let fields_str = fields.join(",");
@@ -72,16 +80,22 @@ impl std::fmt::Display for IndexOptimizeMode {
                 write!(f, "select(limit: {limit}, ascend: {ascend})")
             }
             IndexOptimizeMode::SimpleCount => write!(f, "count"),
-            IndexOptimizeMode::SimpleHistogram(min_value, bucket_width, num_buckets) => {
+            IndexOptimizeMode::SimpleHistogram(min_value, bucket_width, num_buckets, ts_offset) => {
                 write!(
                     f,
-                    "histogram(min_value: {min_value}, bucket_width: {bucket_width}, num_buckets: {num_buckets})"
+                    "histogram(min_value: {min_value}, bucket_width: {bucket_width}, num_buckets: {num_buckets}, ts_offset: {ts_offset})"
                 )
             }
-            IndexOptimizeMode::SimpleMultiHistogram(min_value, max_value, bucket_width, field) => {
+            IndexOptimizeMode::SimpleMultiHistogram(
+                min_value,
+                max_value,
+                bucket_width,
+                ts_offset,
+                field,
+            ) => {
                 write!(
                     f,
-                    "multi_histogram(min_value: {min_value}, max_value: {max_value}, bucket_width: {bucket_width}, field: {field})"
+                    "multi_histogram(min_value: {min_value}, max_value: {max_value}, bucket_width: {bucket_width}, ts_offset: {ts_offset}, field: {field})"
                 )
             }
             IndexOptimizeMode::SimpleTopN(fields, limit, ascend) => {
@@ -153,7 +167,7 @@ mod tests {
                 .is_empty()
         );
         assert!(
-            IndexOptimizeMode::SimpleHistogram(0, 10, 5)
+            IndexOptimizeMode::SimpleHistogram(0, 10, 5, 0)
                 .referenced_fields()
                 .is_empty()
         );
@@ -172,7 +186,7 @@ mod tests {
             vec!["a".to_string(), "b".to_string()]
         );
         assert_eq!(
-            IndexOptimizeMode::SimpleMultiHistogram(0, 1000, 10, "level".to_string())
+            IndexOptimizeMode::SimpleMultiHistogram(0, 1000, 10, 0, "level".to_string())
                 .referenced_fields(),
             vec!["level".to_string()]
         );
@@ -194,17 +208,17 @@ mod tests {
         );
         assert_eq!(IndexOptimizeMode::SimpleCount.to_rule_string(), "c");
         assert_eq!(
-            IndexOptimizeMode::SimpleHistogram(0, 10, 5).to_rule_string(),
-            "h(m:0,b:10,n:5)"
+            IndexOptimizeMode::SimpleHistogram(0, 10, 5, 0).to_rule_string(),
+            "h(m:0,b:10,n:5,o:0)"
         );
         assert_eq!(
-            IndexOptimizeMode::SimpleHistogram(-100, 25, 20).to_rule_string(),
-            "h(m:-100,b:25,n:20)"
+            IndexOptimizeMode::SimpleHistogram(-100, 25, 20, 0).to_rule_string(),
+            "h(m:-100,b:25,n:20,o:0)"
         );
         assert_eq!(
-            IndexOptimizeMode::SimpleMultiHistogram(0, 1000, 10, "level".to_string())
+            IndexOptimizeMode::SimpleMultiHistogram(0, 1000, 10, 0, "level".to_string())
                 .to_rule_string(),
-            "mh(m:0,x:1000,b:10,f:level)"
+            "mh(m:0,x:1000,b:10,o:0,f:level)"
         );
         assert_eq!(
             IndexOptimizeMode::SimpleTopN(vec!["cpu".to_string()], 10, true).to_rule_string(),
@@ -239,7 +253,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "Invalid IndexOptimizeMode")]
     fn test_to_rpc_simple_histogram_panics() {
-        let _: cluster_rpc::IdxOptimizeMode = IndexOptimizeMode::SimpleHistogram(0, 10, 5).into();
+        let _: cluster_rpc::IdxOptimizeMode =
+            IndexOptimizeMode::SimpleHistogram(0, 10, 5, 0).into();
     }
 
     #[test]
@@ -256,16 +271,16 @@ mod tests {
             ),
             (IndexOptimizeMode::SimpleCount, "count"),
             (
-                IndexOptimizeMode::SimpleHistogram(0, 10, 5),
-                "histogram(min_value: 0, bucket_width: 10, num_buckets: 5)",
+                IndexOptimizeMode::SimpleHistogram(0, 10, 5, 0),
+                "histogram(min_value: 0, bucket_width: 10, num_buckets: 5, ts_offset: 0)",
             ),
             (
-                IndexOptimizeMode::SimpleHistogram(-100, 25, 20),
-                "histogram(min_value: -100, bucket_width: 25, num_buckets: 20)",
+                IndexOptimizeMode::SimpleHistogram(-100, 25, 20, 0),
+                "histogram(min_value: -100, bucket_width: 25, num_buckets: 20, ts_offset: 0)",
             ),
             (
-                IndexOptimizeMode::SimpleMultiHistogram(0, 1000, 10, "level".to_string()),
-                "multi_histogram(min_value: 0, max_value: 1000, bucket_width: 10, field: level)",
+                IndexOptimizeMode::SimpleMultiHistogram(0, 1000, 10, 0, "level".to_string()),
+                "multi_histogram(min_value: 0, max_value: 1000, bucket_width: 10, ts_offset: 0, field: level)",
             ),
             (
                 IndexOptimizeMode::SimpleTopN(vec!["cpu_usage".to_string()], 10, true),

--- a/src/config/src/tantivy/query/histogram_collector.rs
+++ b/src/config/src/tantivy/query/histogram_collector.rs
@@ -1,0 +1,680 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use fastdivide::DividerU64;
+use hashbrown::HashMap;
+use tantivy::{
+    DocId, Score, SegmentOrdinal, SegmentReader,
+    collector::{Collector, SegmentCollector},
+    columnar::{Cardinality, Column, StrColumn},
+};
+
+use super::topn_collector::{DENSE_GROUP_SPACE_LIMIT, resolve_ords, truncate_top_k};
+
+/// Fixed-width bucket math shared by the histogram collectors: shifts a raw
+/// timestamp into local wall-clock space (`ts + ts_offset`), bounds-checks it,
+/// and maps it to a bucket index with a precomputed divider instead of a
+/// per-doc hardware division.
+///
+/// `ts_offset` (microseconds east of UTC) mirrors `histogram()` with a
+/// timezone, which is rewritten to `date_bin` over `_timestamp + offset`;
+/// `min_value` is the first bucket's key in that shifted space.
+#[derive(Clone)]
+struct BucketComputer {
+    min_value: i64,
+    ts_offset: i64,
+    divider: DividerU64,
+    num_buckets: usize,
+}
+
+impl BucketComputer {
+    fn new(min_value: i64, bucket_width: u64, num_buckets: usize, ts_offset: i64) -> Self {
+        Self {
+            min_value,
+            ts_offset,
+            divider: DividerU64::divide_by(bucket_width.max(1)),
+            num_buckets,
+        }
+    }
+
+    #[inline]
+    fn bucket(&self, ts: i64) -> Option<usize> {
+        let v = ts + self.ts_offset;
+        if v < self.min_value {
+            return None;
+        }
+        let bucket = self.divider.divide((v - self.min_value) as u64) as usize;
+        (bucket < self.num_buckets).then_some(bucket)
+    }
+}
+
+/// Block-fetch the first value per doc into a reusable buffer. `first_vals`
+/// only writes present slots, so stale values are reset to None first —
+/// unless the column is Full cardinality and writes every slot anyway.
+#[inline]
+fn fetch_first_vals<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static>(
+    col: &Column<T>,
+    docs: &[DocId],
+    buf: &mut Vec<Option<T>>,
+) {
+    if col.get_cardinality() != Cardinality::Full {
+        buf.clear();
+    }
+    buf.resize(docs.len(), None);
+    col.first_vals(docs, buf);
+}
+
+/// Counts matching docs into fixed-width timestamp buckets, for
+/// `SELECT histogram(_timestamp) AS ts, count(*) GROUP BY ts`.
+///
+/// Replaces `tantivy::collector::HistogramCollector`, which fetches the fast
+/// field per doc through an `Arc<dyn ColumnValues>` and implements no
+/// `collect_block`; this version fetches timestamps block-wise.
+pub struct SimpleHistogramCollector {
+    field: String,
+    min_value: i64,
+    bucket_width: u64,
+    num_buckets: usize,
+    ts_offset: i64,
+}
+
+impl SimpleHistogramCollector {
+    pub fn new(
+        field: String,
+        min_value: i64,
+        bucket_width: u64,
+        num_buckets: usize,
+        ts_offset: i64,
+    ) -> Self {
+        Self {
+            field,
+            min_value,
+            bucket_width,
+            num_buckets,
+            ts_offset,
+        }
+    }
+}
+
+pub struct SimpleHistogramSegmentCollector {
+    /// None when the column is missing from this segment (legacy index file)
+    col: Option<Column<i64>>,
+    computer: BucketComputer,
+    counts: Vec<u32>,
+    ts_buf: Vec<Option<i64>>,
+}
+
+impl Collector for SimpleHistogramCollector {
+    /// Bucket counts, always `num_buckets` long (zeros included).
+    type Fruit = Vec<u64>;
+    type Child = SimpleHistogramSegmentCollector;
+
+    fn for_segment(
+        &self,
+        _segment_local_id: SegmentOrdinal,
+        segment: &SegmentReader,
+    ) -> tantivy::Result<Self::Child> {
+        let col = segment.fast_fields().column_opt::<i64>(&self.field)?;
+        Ok(SimpleHistogramSegmentCollector {
+            col,
+            computer: BucketComputer::new(
+                self.min_value,
+                self.bucket_width,
+                self.num_buckets,
+                self.ts_offset,
+            ),
+            counts: vec![0; self.num_buckets],
+            ts_buf: Vec::new(),
+        })
+    }
+
+    fn requires_scoring(&self) -> bool {
+        false
+    }
+
+    fn merge_fruits(&self, mut segment_fruits: Vec<Vec<u64>>) -> tantivy::Result<Self::Fruit> {
+        debug_assert!(
+            segment_fruits.len() <= 1,
+            "SimpleHistogramCollector used on multi-segment index"
+        );
+        Ok(segment_fruits
+            .pop()
+            .unwrap_or_else(|| vec![0; self.num_buckets]))
+    }
+}
+
+impl SegmentCollector for SimpleHistogramSegmentCollector {
+    type Fruit = Vec<u64>;
+
+    fn collect(&mut self, doc: DocId, _score: Score) {
+        let Some(col) = &self.col else {
+            return;
+        };
+        if let Some(ts) = col.first(doc)
+            && let Some(bucket) = self.computer.bucket(ts)
+        {
+            self.counts[bucket] += 1;
+        }
+    }
+
+    /// Block variant of [`Self::collect`]: fetch the whole block's timestamps
+    /// at once instead of paying a per-document column lookup.
+    fn collect_block(&mut self, docs: &[DocId]) {
+        let Some(col) = &self.col else {
+            return;
+        };
+        fetch_first_vals(col, docs, &mut self.ts_buf);
+        for ts in self.ts_buf.iter().flatten() {
+            if let Some(bucket) = self.computer.bucket(*ts) {
+                self.counts[bucket] += 1;
+            }
+        }
+    }
+
+    fn harvest(self) -> Self::Fruit {
+        // counts are u32 (bounded by the segment's doc count) to halve the
+        // cache footprint of the hot loop; widen for the public result
+        self.counts.into_iter().map(u64::from).collect()
+    }
+}
+
+/// Counts matching docs into (fixed-width timestamp bucket × breakdown term)
+/// groups, for `SELECT histogram(_timestamp) AS ts, level, count(*) GROUP BY
+/// ts, level`.
+///
+/// Replaces tantivy's `HistogramAggregation` + nested `TermsAggregation`,
+/// which re-dispatches every doc through a buffered sub-aggregation cache and
+/// materializes a String per (bucket, term) pair at harvest. This version
+/// counts (bucket, term-ordinal) groups in one pass — a flat array when the
+/// group space is small, a hash map otherwise — and resolves ordinals to
+/// strings once per distinct surviving term.
+pub struct MultiHistogramCollector {
+    ts_field: String,
+    breakdown_field: String,
+    /// first bucket's key in local wall-clock space, aligned to bucket_width
+    min_value: i64,
+    bucket_width: u64,
+    num_buckets: usize,
+    ts_offset: i64,
+    /// top terms kept per bucket (the old TermsAggregation `size`,
+    /// ZO_QUERY_DEFAULT_LIMIT); a bucket with at most this many distinct
+    /// terms contributes exactly
+    per_bucket_limit: usize,
+    /// group space size up to which the dense counting array is used
+    dense_limit: usize,
+}
+
+impl MultiHistogramCollector {
+    pub fn new(
+        ts_field: String,
+        breakdown_field: String,
+        min_value: i64,
+        max_value: i64,
+        bucket_width: u64,
+        ts_offset: i64,
+    ) -> Self {
+        let num_buckets = if max_value > min_value {
+            ((max_value - min_value) as u64).div_ceil(bucket_width.max(1)) as usize
+        } else {
+            0
+        };
+        let per_bucket_limit = crate::get_config().limit.query_default_limit.max(1) as usize;
+        Self {
+            ts_field,
+            breakdown_field,
+            min_value,
+            bucket_width,
+            // sparse keys pack the bucket index into 32 bits; a query needs a
+            // sub-second interval over more than an hour to even get near this
+            num_buckets: num_buckets.min(u32::MAX as usize),
+            ts_offset,
+            per_bucket_limit,
+            dense_limit: DENSE_GROUP_SPACE_LIMIT,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_per_bucket_limit(mut self, limit: usize) -> Self {
+        self.per_bucket_limit = limit;
+        self
+    }
+
+    #[cfg(test)]
+    fn with_dense_limit(mut self, dense_limit: usize) -> Self {
+        self.dense_limit = dense_limit;
+        self
+    }
+}
+
+/// Per-segment (bucket, term) counters: a flat array when `num_buckets *
+/// num_terms` is small, otherwise a hash map.
+enum GroupCounts {
+    /// counts indexed by `bucket * num_terms + ord` — bucket-major because
+    /// docs within a file are roughly time-ordered, so consecutive docs stay
+    /// within one bucket's row
+    Dense { counts: Vec<u32>, num_terms: usize },
+    /// keyed by `(bucket << 32) | ord`, so sorting the keys yields
+    /// bucket-major order with ordinals ascending within each bucket
+    Sparse(HashMap<u64, u32>),
+}
+
+impl GroupCounts {
+    #[inline]
+    fn add(&mut self, bucket: usize, ord: u64) {
+        match self {
+            Self::Dense { counts, num_terms } => counts[bucket * *num_terms + ord as usize] += 1,
+            Self::Sparse(counts) => *counts.entry(((bucket as u64) << 32) | ord).or_insert(0) += 1,
+        }
+    }
+}
+
+pub struct MultiHistogramSegmentCollector {
+    /// None when either column is missing from this segment (legacy index file)
+    cols: Option<(Column<i64>, StrColumn)>,
+    computer: BucketComputer,
+    counts: GroupCounts,
+    per_bucket_limit: usize,
+    bucket_width: u64,
+    ts_buf: Vec<Option<i64>>,
+    ord_buf: Vec<Option<u64>>,
+}
+
+impl Collector for MultiHistogramCollector {
+    /// `(bucket key in local wall-clock µs, breakdown value, count)` rows
+    type Fruit = Vec<(i64, String, u64)>;
+    type Child = MultiHistogramSegmentCollector;
+
+    fn for_segment(
+        &self,
+        _segment_local_id: SegmentOrdinal,
+        segment: &SegmentReader,
+    ) -> tantivy::Result<Self::Child> {
+        let fast_fields = segment.fast_fields();
+        let ts_col = fast_fields.column_opt::<i64>(&self.ts_field)?;
+        let str_col = fast_fields.str(&self.breakdown_field)?;
+        let cols = ts_col.zip(str_col);
+        let counts = match &cols {
+            Some((_, str_col)) => {
+                let num_terms = str_col.num_terms();
+                match num_terms.checked_mul(self.num_buckets) {
+                    Some(space) if num_terms > 0 && space <= self.dense_limit => {
+                        GroupCounts::Dense {
+                            counts: vec![0; space],
+                            num_terms,
+                        }
+                    }
+                    _ => GroupCounts::Sparse(HashMap::new()),
+                }
+            }
+            None => GroupCounts::Sparse(HashMap::new()),
+        };
+        Ok(MultiHistogramSegmentCollector {
+            cols,
+            computer: BucketComputer::new(
+                self.min_value,
+                self.bucket_width,
+                self.num_buckets,
+                self.ts_offset,
+            ),
+            counts,
+            per_bucket_limit: self.per_bucket_limit,
+            bucket_width: self.bucket_width,
+            ts_buf: Vec::new(),
+            ord_buf: Vec::new(),
+        })
+    }
+
+    fn requires_scoring(&self) -> bool {
+        false
+    }
+
+    fn merge_fruits(
+        &self,
+        mut segment_fruits: Vec<Vec<(i64, String, u64)>>,
+    ) -> tantivy::Result<Self::Fruit> {
+        debug_assert!(
+            segment_fruits.len() <= 1,
+            "MultiHistogramCollector used on multi-segment index"
+        );
+        Ok(segment_fruits.pop().unwrap_or_default())
+    }
+}
+
+impl SegmentCollector for MultiHistogramSegmentCollector {
+    type Fruit = Vec<(i64, String, u64)>;
+
+    fn collect(&mut self, doc: DocId, _score: Score) {
+        let Some((ts_col, str_col)) = &self.cols else {
+            return;
+        };
+        // a doc missing the breakdown value forms no group (terms agg `missing: None`)
+        if let Some(ts) = ts_col.first(doc)
+            && let Some(ord) = str_col.ords().first(doc)
+            && let Some(bucket) = self.computer.bucket(ts)
+        {
+            self.counts.add(bucket, ord);
+        }
+    }
+
+    /// Block variant of [`Self::collect`]: fetch both columns' values for the
+    /// whole block at once instead of paying per-document column lookups.
+    fn collect_block(&mut self, docs: &[DocId]) {
+        let Self {
+            cols,
+            computer,
+            counts,
+            ts_buf,
+            ord_buf,
+            ..
+        } = self;
+        let Some((ts_col, str_col)) = cols else {
+            return;
+        };
+        fetch_first_vals(ts_col, docs, ts_buf);
+        fetch_first_vals(str_col.ords(), docs, ord_buf);
+        for (ts, ord) in ts_buf.iter().zip(ord_buf.iter()) {
+            let (Some(ts), Some(ord)) = (ts, ord) else {
+                continue;
+            };
+            if let Some(bucket) = computer.bucket(*ts) {
+                counts.add(bucket, *ord);
+            }
+        }
+    }
+
+    fn harvest(self) -> Self::Fruit {
+        let Self {
+            cols,
+            computer,
+            counts,
+            per_bucket_limit,
+            bucket_width,
+            ..
+        } = self;
+        let Some((_, str_col)) = cols else {
+            return Vec::new();
+        };
+
+        // Per bucket, keep all terms when within per_bucket_limit (the bucket's
+        // contribution is exact) or only the top-k by count otherwise, on cheap
+        // integer ordinals BEFORE touching the term dictionary. Count ties break
+        // toward smaller ordinals, clustering survivors for cheaper resolution.
+        let mut groups: Vec<(u32, u64, u32)> = Vec::new();
+        let mut entries: Vec<(u64, u32)> = Vec::new();
+        let mut truncated_buckets = 0usize;
+        let mut keep_bucket =
+            |bucket: u32, entries: &mut Vec<(u64, u32)>, groups: &mut Vec<(u32, u64, u32)>| {
+                if entries.len() > per_bucket_limit {
+                    truncated_buckets += 1;
+                    truncate_top_k(entries, per_bucket_limit, false);
+                }
+                groups.extend(entries.iter().map(|(ord, count)| (bucket, *ord, *count)));
+            };
+        match counts {
+            GroupCounts::Dense { counts, num_terms } => {
+                for (bucket, row) in counts.chunks_exact(num_terms).enumerate() {
+                    entries.clear();
+                    entries.extend(
+                        row.iter()
+                            .enumerate()
+                            .filter(|(_, count)| **count > 0)
+                            .map(|(ord, count)| (ord as u64, *count)),
+                    );
+                    keep_bucket(bucket as u32, &mut entries, &mut groups);
+                }
+            }
+            GroupCounts::Sparse(counts) => {
+                let mut all = counts.into_iter().collect::<Vec<_>>();
+                all.sort_unstable_by_key(|(key, _)| *key);
+                for run in all.chunk_by(|a, b| a.0 >> 32 == b.0 >> 32) {
+                    let bucket = (run[0].0 >> 32) as u32;
+                    entries.clear();
+                    entries.extend(run.iter().map(|(key, count)| (key & 0xFFFF_FFFF, *count)));
+                    keep_bucket(bucket, &mut entries, &mut groups);
+                }
+            }
+        }
+        if truncated_buckets > 0 {
+            log::debug!(
+                "tantivy multi_histogram collector: {truncated_buckets} buckets exceeded \
+                 {per_bucket_limit} distinct terms, keeping the per-bucket top-k, the merged \
+                 counts are approximate",
+            );
+        }
+
+        // resolve the distinct surviving ordinals in one sorted dictionary pass
+        let ord_map = resolve_ords(&str_col, groups.iter().map(|(_, ord, _)| *ord).collect());
+        let mut out = Vec::with_capacity(groups.len());
+        for (bucket, ord, count) in groups {
+            if let Some(s) = ord_map.get(&ord) {
+                let key = computer.min_value + bucket as i64 * bucket_width as i64;
+                out.push((key, s.clone(), count as u64));
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tantivy::{
+        Index, doc,
+        query::AllQuery,
+        schema::{FAST, SchemaBuilder, TextOptions},
+    };
+
+    use super::*;
+
+    /// One segment: timestamps 0..50 with breakdown levels, one doc missing
+    /// the level, one doc below and one above the [0, 50) bucket range.
+    fn build_index() -> tantivy::Searcher {
+        let mut schema_builder = SchemaBuilder::new();
+        let ts = schema_builder.add_i64_field("_timestamp", FAST);
+        let level = schema_builder.add_text_field("level", TextOptions::default().set_fast(None));
+        let index = Index::create_in_ram(schema_builder.build());
+
+        let mut writer = index.writer_with_num_threads(1, 15_000_000).unwrap();
+        writer.add_document(doc!(ts => 0i64, level => "a")).unwrap();
+        writer.add_document(doc!(ts => 5i64, level => "b")).unwrap();
+        writer.add_document(doc!(ts => 6i64, level => "b")).unwrap();
+        // missing level: counted by the simple histogram, no group in the multi
+        writer.add_document(doc!(ts => 7i64)).unwrap();
+        writer
+            .add_document(doc!(ts => 15i64, level => "a"))
+            .unwrap();
+        writer
+            .add_document(doc!(ts => 25i64, level => "a"))
+            .unwrap();
+        writer
+            .add_document(doc!(ts => 25i64, level => "b"))
+            .unwrap();
+        writer
+            .add_document(doc!(ts => 49i64, level => "c"))
+            .unwrap();
+        // outside [min, max): dropped by both collectors
+        writer
+            .add_document(doc!(ts => 50i64, level => "a"))
+            .unwrap();
+        writer
+            .add_document(doc!(ts => -10i64, level => "a"))
+            .unwrap();
+        writer.commit().unwrap();
+
+        index.reader().unwrap().searcher()
+    }
+
+    #[test]
+    fn test_simple_histogram_collector() {
+        let searcher = build_index();
+        let collector = SimpleHistogramCollector::new("_timestamp".to_string(), 0, 10, 5, 0);
+        let res = searcher.search(&AllQuery, &collector).unwrap();
+        assert_eq!(res, vec![4, 1, 2, 0, 1]);
+    }
+
+    #[test]
+    fn test_simple_histogram_collector_with_ts_offset() {
+        let searcher = build_index();
+        // shift +10: -10 lands in bucket 0, 49/50 shift out of range
+        let collector = SimpleHistogramCollector::new("_timestamp".to_string(), 0, 10, 5, 10);
+        let res = searcher.search(&AllQuery, &collector).unwrap();
+        assert_eq!(res, vec![1, 4, 1, 2, 0]);
+    }
+
+    #[test]
+    fn test_simple_histogram_collector_missing_column() {
+        let searcher = build_index();
+        let collector = SimpleHistogramCollector::new("no_such".to_string(), 0, 10, 5, 0);
+        let res = searcher.search(&AllQuery, &collector).unwrap();
+        assert_eq!(res, vec![0; 5]);
+    }
+
+    #[test]
+    fn test_multi_histogram_collector() {
+        let searcher = build_index();
+        let row = |ts: i64, s: &str, count: u64| (ts, s.to_string(), count);
+
+        // dense_limit usize::MAX forces the dense counting array, 0 forces the
+        // hash map; both must produce identical results
+        for dense_limit in [usize::MAX, 0] {
+            let collector = MultiHistogramCollector::new(
+                "_timestamp".to_string(),
+                "level".to_string(),
+                0,
+                50,
+                10,
+                0,
+            )
+            .with_dense_limit(dense_limit);
+            let mut res = searcher.search(&AllQuery, &collector).unwrap();
+            res.sort_unstable();
+            assert_eq!(
+                res,
+                vec![
+                    row(0, "a", 1),
+                    row(0, "b", 2),
+                    row(10, "a", 1),
+                    row(20, "a", 1),
+                    row(20, "b", 1),
+                    row(40, "c", 1),
+                ],
+                "dense_limit={dense_limit}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_multi_histogram_collector_per_bucket_limit() {
+        let searcher = build_index();
+        for dense_limit in [usize::MAX, 0] {
+            let collector = MultiHistogramCollector::new(
+                "_timestamp".to_string(),
+                "level".to_string(),
+                0,
+                50,
+                10,
+                0,
+            )
+            .with_per_bucket_limit(1)
+            .with_dense_limit(dense_limit);
+            let mut res = searcher.search(&AllQuery, &collector).unwrap();
+            res.sort_unstable();
+            // bucket 0 keeps "b" (count 2 beats 1); ties keep the smaller ordinal
+            assert_eq!(
+                res,
+                vec![
+                    (0, "b".to_string(), 2),
+                    (10, "a".to_string(), 1),
+                    (20, "a".to_string(), 1),
+                    (40, "c".to_string(), 1),
+                ],
+                "dense_limit={dense_limit}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_multi_histogram_collector_with_ts_offset() {
+        let searcher = build_index();
+        // shift +10 with range [0, 50): -10 → bucket 0, 49 → out of range
+        let collector = MultiHistogramCollector::new(
+            "_timestamp".to_string(),
+            "level".to_string(),
+            0,
+            50,
+            10,
+            10,
+        );
+        let mut res = searcher.search(&AllQuery, &collector).unwrap();
+        res.sort_unstable();
+        assert_eq!(
+            res,
+            vec![
+                (0, "a".to_string(), 1),
+                (10, "a".to_string(), 1),
+                (10, "b".to_string(), 2),
+                (20, "a".to_string(), 1),
+                (30, "a".to_string(), 1),
+                (30, "b".to_string(), 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multi_histogram_collector_missing_column() {
+        let searcher = build_index();
+        let collector = MultiHistogramCollector::new(
+            "_timestamp".to_string(),
+            "no_such".to_string(),
+            0,
+            50,
+            10,
+            0,
+        );
+        let res = searcher.search(&AllQuery, &collector).unwrap();
+        assert!(res.is_empty());
+    }
+
+    #[test]
+    fn test_multi_histogram_collector_empty_range() {
+        let searcher = build_index();
+        let collector = MultiHistogramCollector::new(
+            "_timestamp".to_string(),
+            "level".to_string(),
+            50,
+            50,
+            10,
+            0,
+        );
+        let res = searcher.search(&AllQuery, &collector).unwrap();
+        assert!(res.is_empty());
+    }
+
+    #[test]
+    fn test_bucket_computer_bounds() {
+        let computer = BucketComputer::new(100, 10, 3, 0);
+        assert_eq!(computer.bucket(99), None);
+        assert_eq!(computer.bucket(100), Some(0));
+        assert_eq!(computer.bucket(115), Some(1));
+        assert_eq!(computer.bucket(129), Some(2));
+        assert_eq!(computer.bucket(130), None);
+
+        // offset shifts the value before bucketing
+        let computer = BucketComputer::new(100, 10, 3, 50);
+        assert_eq!(computer.bucket(49), None);
+        assert_eq!(computer.bucket(50), Some(0));
+        assert_eq!(computer.bucket(79), Some(2));
+        assert_eq!(computer.bucket(80), None);
+    }
+}

--- a/src/config/src/tantivy/query/mod.rs
+++ b/src/config/src/tantivy/query/mod.rs
@@ -14,5 +14,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub mod contains_query;
+pub mod histogram_collector;
 pub mod ids_collector;
 pub mod topn_collector;

--- a/src/config/src/tantivy/query/topn_collector.rs
+++ b/src/config/src/tantivy/query/topn_collector.rs
@@ -140,7 +140,7 @@ impl<K: OrdKey> TopNCollector<K> {
 }
 
 /// Above this many cells (4 bytes each = 32MB) the dense counting array gives way to a hash map.
-const DENSE_GROUP_SPACE_LIMIT: usize = 8_000_000;
+pub(crate) const DENSE_GROUP_SPACE_LIMIT: usize = 8_000_000;
 
 /// Per-segment group counters: a flat array indexed by the mixed-radix ordinal when the
 /// product of the fields' dictionary sizes is small (one add per doc, no hashing), otherwise
@@ -416,7 +416,7 @@ impl<K: OrdKey> SegmentCollector for TopNSegmentCollector<K> {
 /// Resolve term ordinals to strings in one sorted forward pass over the term dictionary:
 /// `sorted_ords_to_term_cb` opens each dictionary block once, while `ord_to_term` would
 /// re-scan a block per call.
-fn resolve_ords(col: &StrColumn, mut ords: Vec<u64>) -> HashMap<u64, String> {
+pub(crate) fn resolve_ords(col: &StrColumn, mut ords: Vec<u64>) -> HashMap<u64, String> {
     ords.sort_unstable();
     ords.dedup();
     let mut strings: Vec<String> = Vec::with_capacity(ords.len());
@@ -472,7 +472,7 @@ fn select_top_k_dense(counts: &[u32], k: usize, ascend: bool) -> Vec<(usize, u32
 /// Keep the top-K entries by count, in place: the K smallest when `ascend`, the K largest
 /// otherwise. Count ties break toward the smaller key, which keeps survivors clustered by
 /// ordinal for cheaper resolution (SQL leaves tie order unspecified).
-fn truncate_top_k<K: Ord>(items: &mut Vec<(K, u32)>, k: usize, ascend: bool) {
+pub(crate) fn truncate_top_k<K: Ord>(items: &mut Vec<(K, u32)>, k: usize, ascend: bool) {
     if k == 0 {
         items.clear();
         return;

--- a/src/service/search/datafusion/optimizer/physical_optimizer/index_optimizer/histogram.rs
+++ b/src/service/search/datafusion/optimizer/physical_optimizer/index_optimizer/histogram.rs
@@ -21,9 +21,12 @@ use datafusion::{
         Result,
         tree_node::{TreeNode, TreeNodeRecursion, TreeNodeVisitor},
     },
+    logical_expr::Operator,
     physical_expr::ScalarFunctionExpr,
     physical_plan::{
-        ExecutionPlan, PhysicalExpr, aggregates::AggregateExec, expressions::Literal,
+        ExecutionPlan, PhysicalExpr,
+        aggregates::AggregateExec,
+        expressions::{BinaryExpr, Literal},
         projection::ProjectionExec,
     },
     scalar::ScalarValue,
@@ -36,7 +39,9 @@ use crate::service::search::datafusion::optimizer::physical_optimizer::{
 };
 
 #[rustfmt::skip]
-/// SimpleHistogram(i64, u64, usize): select histogram(_timestamp, '1m') as ts, count(*) as cnt from table where match_all() group by ts;
+/// SimpleHistogram(i64, u64, usize, i64): select histogram(_timestamp, '1m') as ts, count(*) as cnt from table where match_all() group by ts;
+/// histogram() with a timezone rewrites to date_bin over `_timestamp@0 + offset`; the
+/// extracted mode then carries the offset and its bucket edges live in local wall-clock space.
 /// condition: group by histogram(_timestamp), only count(*)
 /// example plan:
 /// ProjectionExec: expr=[histogram(default._timestamp)@0 as histogram(default._timestamp), count(Int64(1))@1 as cnt]
@@ -51,11 +56,12 @@ use crate::service::search::datafusion::optimizer::physical_optimizer::{
 pub(crate) fn is_simple_histogram(plan: Arc<dyn ExecutionPlan>, time_range: (i64, i64)) -> Option<IndexOptimizeMode> {
     let mut visitor = SimpleHistogramVisitor::new(time_range);
     let _ = plan.visit(&mut visitor);
-    if let Some((min_value, bucket_width, num_buckets)) = visitor.simple_histogram {
+    if let Some((min_value, bucket_width, num_buckets, ts_offset)) = visitor.simple_histogram {
         Some(IndexOptimizeMode::SimpleHistogram(
             min_value,
             bucket_width,
             num_buckets,
+            ts_offset,
         ))
     } else {
         None
@@ -64,7 +70,7 @@ pub(crate) fn is_simple_histogram(plan: Arc<dyn ExecutionPlan>, time_range: (i64
 
 struct SimpleHistogramVisitor {
     time_range: (i64, i64),
-    pub simple_histogram: Option<(i64, u64, usize)>,
+    pub simple_histogram: Option<(i64, u64, usize, i64)>,
 }
 
 impl SimpleHistogramVisitor {
@@ -90,8 +96,8 @@ impl<'n> TreeNodeVisitor<'n> for SimpleHistogramVisitor {
                 if let Some((group_expr, _)) = aggregate.group_expr().expr().first()
                     && let Some(func) = get_data_bin(group_expr)
                     && func.args().len() == 3
-                    && is_timestamp_column(&func.args()[1])
-                // check second argument is _timestamp
+                    // check second argument is _timestamp (with an optional timezone shift)
+                    && let Some(ts_offset) = get_timestamp_offset(&func.args()[1])
                 {
                     let args = func.args();
                     if let Some(histogram_interval) = get_histogram_interval(&args[0]) {
@@ -103,7 +109,8 @@ impl<'n> TreeNodeVisitor<'n> for SimpleHistogramVisitor {
                         let num_buckets = ((max_value - min_value) as f64
                             / histogram_interval as f64)
                             .ceil() as usize;
-                        self.simple_histogram = Some((min_value, histogram_interval, num_buckets));
+                        self.simple_histogram =
+                            Some((min_value, histogram_interval, num_buckets, ts_offset));
                         return Ok(TreeNodeRecursion::Continue);
                     }
                 }
@@ -156,17 +163,30 @@ fn get_histogram_interval(expr: &Arc<dyn PhysicalExpr>) -> Option<u64> {
     }
 }
 
-fn is_timestamp_column(expr: &Arc<dyn PhysicalExpr>) -> bool {
-    if let Some(func) = expr.as_any().downcast_ref::<ScalarFunctionExpr>() {
-        let column_name = get_column_name(&func.args()[0]);
-        column_name == TIMESTAMP_COL_NAME
-    } else {
-        false
+/// Returns the fixed timezone offset (µs east of UTC) carried by the date_bin source
+/// expression: `to_timestamp_micros(_timestamp)` yields 0 and
+/// `to_timestamp_micros(_timestamp + offset)` — the shape histogram() with a timezone
+/// rewrites to — yields the offset. None when the source is not the timestamp column.
+fn get_timestamp_offset(expr: &Arc<dyn PhysicalExpr>) -> Option<i64> {
+    let func = expr.as_any().downcast_ref::<ScalarFunctionExpr>()?;
+    let arg = func.args().first()?;
+    if get_column_name(arg) == TIMESTAMP_COL_NAME {
+        return Some(0);
+    }
+    let bin = arg.as_any().downcast_ref::<BinaryExpr>()?;
+    if *bin.op() != Operator::Plus || get_column_name(bin.left()) != TIMESTAMP_COL_NAME {
+        return None;
+    }
+    match bin.right().as_any().downcast_ref::<Literal>()?.value() {
+        ScalarValue::Int64(Some(ts_offset)) => Some(*ts_offset),
+        _ => None,
     }
 }
 
 #[rustfmt::skip]
-/// SimpleMultiHistogram(i64, i64, u64, String):
+/// SimpleMultiHistogram(i64, i64, u64, i64, String):
+/// histogram() with a timezone rewrites to date_bin over `_timestamp@0 + offset`; the
+/// extracted mode then carries the offset and its bucket edges live in local wall-clock space.
 /// select histogram(_timestamp) as ts, level as zo_sql_breakdown, count(*) as cnt
 ///   from table where match_all() group by ts, zo_sql_breakdown;
 /// condition: group by histogram(_timestamp) AND a secondary index field, only count(*)
@@ -184,13 +204,14 @@ pub(crate) fn is_simple_multi_histogram(
 ) -> Option<IndexOptimizeMode> {
     let mut visitor = SimpleMultiHistogramVisitor::new(time_range, index_fields);
     let _ = plan.visit(&mut visitor);
-    if let Some((min_value, max_value, bucket_width, breakdown_field)) =
+    if let Some((min_value, max_value, bucket_width, ts_offset, breakdown_field)) =
         visitor.simple_multi_histogram
     {
         Some(IndexOptimizeMode::SimpleMultiHistogram(
             min_value,
             max_value,
             bucket_width,
+            ts_offset,
             breakdown_field,
         ))
     } else {
@@ -201,7 +222,7 @@ pub(crate) fn is_simple_multi_histogram(
 struct SimpleMultiHistogramVisitor {
     time_range: (i64, i64),
     index_fields: HashSet<String>,
-    pub simple_multi_histogram: Option<(i64, i64, u64, String)>,
+    pub simple_multi_histogram: Option<(i64, i64, u64, i64, String)>,
 }
 
 impl SimpleMultiHistogramVisitor {
@@ -239,7 +260,9 @@ impl<'n> TreeNodeVisitor<'n> for SimpleMultiHistogramVisitor {
                     if self.index_fields.contains(column_name) {
                         // Extract histogram parameters from the date_bin expression
                         let func = get_data_bin(&groups[db_idx].0).unwrap();
-                        if func.args().len() == 3 && is_timestamp_column(&func.args()[1]) {
+                        if func.args().len() == 3
+                            && let Some(ts_offset) = get_timestamp_offset(&func.args()[1])
+                        {
                             let args = func.args();
                             if let Some(histogram_interval) = get_histogram_interval(&args[0]) {
                                 let (start_time, end_time) = self.time_range;
@@ -250,6 +273,7 @@ impl<'n> TreeNodeVisitor<'n> for SimpleMultiHistogramVisitor {
                                     min_value,
                                     max_value,
                                     histogram_interval,
+                                    ts_offset,
                                     column_name.to_string(),
                                 ));
                                 return Ok(TreeNodeRecursion::Continue);
@@ -331,6 +355,18 @@ mod tests {
                     1757401680000000,
                     60000000,
                     16,
+                    0,
+                )),
+            ),
+            // an explicit timezone shifts the bucket edges into local wall-clock
+            // space and the extracted mode carries the offset (issue #12564)
+            (
+                "SELECT histogram(_timestamp, '1 minute', '+08:00') as ts, count(*) as cnt from t group by ts",
+                Some(IndexOptimizeMode::SimpleHistogram(
+                    1757430480000000,
+                    60000000,
+                    16,
+                    28800000000,
                 )),
             ),
             (
@@ -390,6 +426,19 @@ mod tests {
                     1757401680000000,
                     1757402594060000,
                     60000000,
+                    0,
+                    "level".to_string(),
+                )),
+            ),
+            // an explicit timezone shifts the bucket edges into local wall-clock
+            // space and the extracted mode carries the offset (issue #12564)
+            (
+                "SELECT histogram(_timestamp, '1 minute', '-05:30') as ts, level, count(*) as cnt from t group by ts, level",
+                Some(IndexOptimizeMode::SimpleMultiHistogram(
+                    1757381880000000,
+                    1757382794060000,
+                    60000000,
+                    -19800000000,
                     "level".to_string(),
                 )),
             ),

--- a/src/service/search/datafusion/optimizer/physical_optimizer/index_optimizer/histogram.rs
+++ b/src/service/search/datafusion/optimizer/physical_optimizer/index_optimizer/histogram.rs
@@ -363,7 +363,7 @@ mod tests {
             (
                 "SELECT histogram(_timestamp, '1 minute', '+08:00') as ts, count(*) as cnt from t group by ts",
                 Some(IndexOptimizeMode::SimpleHistogram(
-                    1757430480000000,
+                    1757401680000000,
                     60000000,
                     16,
                     28800000000,
@@ -435,8 +435,8 @@ mod tests {
             (
                 "SELECT histogram(_timestamp, '1 minute', '-05:30') as ts, level, count(*) as cnt from t group by ts, level",
                 Some(IndexOptimizeMode::SimpleMultiHistogram(
-                    1757381880000000,
-                    1757382794060000,
+                    1757401680000000,
+                    1757402594060000,
                     60000000,
                     -19800000000,
                     "level".to_string(),

--- a/src/service/search/datafusion/plan/tantivy_optimize_exec.rs
+++ b/src/service/search/datafusion/plan/tantivy_optimize_exec.rs
@@ -204,7 +204,7 @@ async fn adapt_tantivy_result(
                 result.num_rows() as i64
             ]))]]
         }
-        IndexOptimizeMode::SimpleHistogram(min_value, bucket_width, num_buckets) => {
+        IndexOptimizeMode::SimpleHistogram(min_value, bucket_width, num_buckets, _ts_offset) => {
             vec![create_histogram_arrow_array(
                 &schema,
                 result.histogram(),

--- a/src/service/search/tantivy/mod.rs
+++ b/src/service/search/tantivy/mod.rs
@@ -511,7 +511,7 @@ async fn search_tantivy_index(
         Some(IndexOptimizeMode::SimpleCount) => {
             TantivyResult::handle_simple_count(&searcher, query)
         }
-        Some(IndexOptimizeMode::SimpleHistogram(min_value, bucket_width, num_buckets)) => {
+        Some(IndexOptimizeMode::SimpleHistogram(min_value, bucket_width, num_buckets, ts_offset)) => {
             // fail the function if field not in tantivy schema
             if tantivy_schema.get_field(TIMESTAMP_COL_NAME).is_err() {
                 log::warn!("[trace_id {trace_id_clone}] search->tantivy: _timestamp not index in tantivy file: {ttv_file_name}");
@@ -523,12 +523,14 @@ async fn search_tantivy_index(
                 min_value,
                 bucket_width,
                 num_buckets,
+                ts_offset,
             )
         }
         Some(IndexOptimizeMode::SimpleMultiHistogram(
             min_value,
             max_value,
             bucket_width,
+            ts_offset,
             breakdown_field,
         )) => {
             if tantivy_schema.get_field(TIMESTAMP_COL_NAME).is_err() {
@@ -545,6 +547,7 @@ async fn search_tantivy_index(
                 min_value,
                 max_value,
                 bucket_width,
+                ts_offset,
                 &breakdown_field,
             )
         }

--- a/src/service/search/tantivy/search.rs
+++ b/src/service/search/tantivy/search.rs
@@ -22,18 +22,14 @@ use config::{
         inverted_index::{IndexOptimizeMode, MAX_SIMPLE_TOPN_FIELDS},
     },
     tantivy::query::{
-        contains_query::ContainsAutomaton, ids_collector::SingleSegmentDocIdCollector,
+        contains_query::ContainsAutomaton,
+        histogram_collector::{MultiHistogramCollector, SimpleHistogramCollector},
+        ids_collector::SingleSegmentDocIdCollector,
         topn_collector::TopNCollector,
     },
 };
 use tantivy::{
     DocId, Score, Searcher,
-    aggregation::{
-        AggregationCollector, Key,
-        agg_req::{Aggregation, AggregationVariants, Aggregations},
-        agg_result::{AggregationResult, BucketEntries, BucketResult},
-        bucket::{HistogramAggregation, HistogramBounds, TermsAggregation},
-    },
     collector::{Count, TopDocs},
     query::Query,
 };
@@ -146,14 +142,16 @@ impl TantivyResult {
         min_value: i64,
         bucket_width: u64,
         num_buckets: usize,
+        ts_offset: i64,
     ) -> anyhow::Result<Self> {
         let res = searcher.search(
             &query,
-            &tantivy::collector::HistogramCollector::new::<i64>(
+            &SimpleHistogramCollector::new(
                 TIMESTAMP_COL_NAME.to_string(),
                 min_value,
                 bucket_width,
                 num_buckets,
+                ts_offset,
             ),
         )?;
 
@@ -166,80 +164,22 @@ impl TantivyResult {
         min_value: i64,
         max_value: i64,
         bucket_width: u64,
+        ts_offset: i64,
         breakdown_field: &str,
     ) -> anyhow::Result<Self> {
-        let limit = config::get_config().limit.query_default_limit;
-        // this value should be zero
-        let offset = (min_value % bucket_width as i64) as f64;
-        let histogram_agg = Aggregation {
-            agg: AggregationVariants::Histogram(HistogramAggregation {
-                field: TIMESTAMP_COL_NAME.to_string(),
-                interval: bucket_width as f64,
-                offset: Some(offset),
-                min_doc_count: Some(1),
-                hard_bounds: Some(HistogramBounds {
-                    min: min_value as f64,
-                    max: max_value as f64,
-                }),
-                extended_bounds: None,
-                keyed: false,
-                is_normalized_to_ns: false,
-            }),
-            sub_aggregation: Aggregations::from_iter(vec![(
-                "breakdown".to_string(),
-                Aggregation {
-                    agg: AggregationVariants::Terms(TermsAggregation {
-                        field: breakdown_field.to_string(),
-                        size: Some(limit as u32),
-                        order: None,
-                        missing: None,
-                        min_doc_count: Some(1),
-                        show_term_doc_count_error: Some(false),
-                        segment_size: None,
-                        include: None,
-                        exclude: None,
-                    }),
-                    sub_aggregation: Default::default(),
-                },
-            )]),
-        };
-        let aggregations = Aggregations::from_iter(vec![("histogram".to_string(), histogram_agg)]);
-        let collector = AggregationCollector::from_aggs(aggregations, Default::default());
+        let res = searcher.search(
+            &query,
+            &MultiHistogramCollector::new(
+                TIMESTAMP_COL_NAME.to_string(),
+                breakdown_field.to_string(),
+                min_value,
+                max_value,
+                bucket_width,
+                ts_offset,
+            ),
+        )?;
 
-        let mut res = searcher.search(&query, &collector)?;
-
-        let mut results = Vec::new();
-        if let AggregationResult::BucketResult(BucketResult::Histogram { buckets }) =
-            res.0.remove("histogram").unwrap()
-        {
-            let hist_buckets = match buckets {
-                BucketEntries::Vec(vec) => vec,
-                BucketEntries::HashMap(map) => map.into_values().collect(),
-            };
-            for mut bucket_entry in hist_buckets {
-                let timestamp = match bucket_entry.key {
-                    Key::F64(k) => k as i64,
-                    _ => continue,
-                };
-                if let AggregationResult::BucketResult(BucketResult::Terms {
-                    buckets: term_entries,
-                    ..
-                }) = bucket_entry.sub_aggregation.0.remove("breakdown").unwrap()
-                {
-                    for term_bucket in term_entries {
-                        let breakdown_value = match term_bucket.key {
-                            Key::Str(s) => s,
-                            Key::F64(f) => f.to_string(),
-                            Key::I64(i) => i.to_string(),
-                            Key::U64(u) => u.to_string(),
-                        };
-                        results.push((timestamp, breakdown_value, term_bucket.doc_count));
-                    }
-                }
-            }
-        }
-
-        Ok(Self::MultiHistogram(results))
+        Ok(Self::MultiHistogram(res))
     }
 
     pub fn handle_simple_top_n(
@@ -549,7 +489,7 @@ mod tests {
     #[test]
     fn test_tantivy_multi_result_builder_new() {
         // Test with SimpleHistogram
-        let optimize_rule = Some(IndexOptimizeMode::SimpleHistogram(0, 1000, 10));
+        let optimize_rule = Some(IndexOptimizeMode::SimpleHistogram(0, 1000, 10, 0));
         let builder = TantivyMultiResultBuilder::new(&optimize_rule);
         assert!(matches!(builder, TantivyMultiResultBuilder::Histogram(_)));
 


### PR DESCRIPTION
Design at: #12620

Closes #12620
Fixes #12564

## What

Rewrites both tantivy histogram optimize-rule collectors following the same approach as the recent `TopNCollector` / `SingleSegmentDocIdCollector` rewrites, and adds timezone support to both rules.

- `MultiHistogramCollector` (replaces the aggregation framework for `SimpleMultiHistogram`)
- `SimpleHistogramCollector` (replaces `tantivy::collector::HistogramCollector` for `SimpleHistogram`)

### Timezone support (#12564)

`histogram(ts, interval, tz)` rewrites to `date_bin(interval, to_timestamp_micros(_timestamp + offset), origin)`; the optimizer's `get_column_name` hit the `BinaryExpr` and silently skipped both rules. Now:
- the visitors extract the fixed offset from that shape (`get_timestamp_offset`), so the rules fire with a timezone
- `IndexOptimizeMode::SimpleHistogram` / `SimpleMultiHistogram` carry a `ts_offset` field (no proto change — histogram modes never cross gRPC, they're re-derived per node)
- bucket edges are computed in shifted wall-clock space and the collectors bucket on `_timestamp + ts_offset`, so emitted keys match `date_bin` exactly when merging with non-tantivy partials

## Testing

- New collector unit tests: dense vs sparse equality, ts_offset shifting, bounds filtering, missing column / missing breakdown docs, per-bucket truncation with tie-breaks
- Visitor tests now include real-DataFusion-plan timezone cases (`'+08:00'` simple, `'-05:30'` multi) asserting the extracted shifted bounds and offset
- `cargo test -p config` (1936 passed), plus `index_optimizer` / `search::tantivy` / `tantivy_optimize_exec` suites in the main crate; clippy clean

- Low cardinality: fast `20%` than main
```
histogram(_timestamp, '1h') AS ts, count(*) FROM default GROUP BY ts ORDER BY ts ASC
```
- Low cardinality: fast `30%` than main
```
histgoram(_timestamp, '1h') AS ts, breakdown, count(*) FROM default GROUP BY ts, breakdown ORDER BY ts ASC
```
- High cardinality: faster `5x` than main
```
histgoram(_timestamp, '1h') AS ts, breakdown, count(*) FROM default GROUP BY ts, breakdown ORDER BY ts ASC
```