### PR TITLE
test: fix logs error-message field-identification assertion after query-error UI redesign

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -197,6 +197,9 @@ export class LogsPage {
         // Block layout (panels):   query-error-toggle-detail-btn + query-error-detail-expanded
         this.resultErrorDetailsBtn = '[data-test="error-detail-toggle-btn"], [data-test="query-error-toggle-detail-btn"]';
         this.searchDetailErrorMessage = '[data-test="error-detail-body"], [data-test="query-error-detail-expanded"]';
+        // Always-visible first sentence of the error (carries the field/function name).
+        // Hero layout: error-detail-summary · Block layout: query-error-summary
+        this.searchErrorSummary = '[data-test="error-detail-summary"], [data-test="query-error-summary"]';
 
         // Download locators (SearchBar.vue more-options dropdown + custom-download ODialog)
         this.moreOptionsBtn = '[data-test="logs-search-bar-more-options-btn"]';
@@ -3590,9 +3593,15 @@ export class LogsPage {
     }
 
     /**
-     * Get the detailed error dialog text
-     * Clicks on error details button if available and returns the error message text
-     * @returns {Promise<string>} The error dialog text
+     * Get the detailed error dialog text.
+     *
+     * Expands the collapsible error detail panel (best effort) and returns the
+     * FULL error message — both the always-visible summary line (which carries
+     * the offending field/function name) and the expanded detail body (e.g.
+     * "Valid fields are …"). Earlier this returned only the detail body, which
+     * after the QueryErrorState redesign omits the field name.
+     *
+     * @returns {Promise<string>} The full error dialog text (summary line + detail body)
      */
     async getDetailedErrorDialogText() {
         // The QueryErrorState redesign splits the backend message across two
@@ -3614,15 +3623,26 @@ export class LogsPage {
 
         // Prefer the full error-state container so both the summary line (which
         // holds the field name) and the expanded detail body are captured in a
-        // single string. Fall back to the detail body only if the container is
-        // unavailable.
-        for (const selector of [this.errorMessage, this.searchDetailErrorMessage]) {
+        // single string.
+        const container = this.page.locator(this.errorMessage).first();
+        if (await container.isVisible({ timeout: 2000 }).catch(() => false)) {
+            const text = (await container.textContent()) || '';
+            if (text.trim()) return text;
+        }
+
+        // Fallback (container unavailable, e.g. a rendering race): stitch the
+        // summary line and detail body together explicitly so the field name is
+        // never dropped — never fall back to the detail body alone, which is the
+        // exact gap that hid the field name in the first place.
+        const parts = [];
+        for (const selector of [this.searchErrorSummary, this.searchDetailErrorMessage]) {
             const locator = this.page.locator(selector).first();
             if (await locator.isVisible({ timeout: 2000 }).catch(() => false)) {
                 const text = (await locator.textContent()) || '';
-                if (text.trim()) return text;
+                if (text.trim()) parts.push(text.trim());
             }
         }
+        if (parts.length) return parts.join(' ');
 
         // Return empty string if no error message found
         testLogger.warn('No error message found');

--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -3595,23 +3595,33 @@ export class LogsPage {
      * @returns {Promise<string>} The error dialog text
      */
     async getDetailedErrorDialogText() {
-        // Try to click the error details button if visible
-        const detailsBtn = this.page.locator(this.resultErrorDetailsBtn);
+        // The QueryErrorState redesign splits the backend message across two
+        // elements: the summary line (data-test="error-detail-summary",
+        // always visible) carries the first sentence — which is where the
+        // offending field/function name lives (e.g. "No field named X.") —
+        // while the remainder ("Valid fields are …") is tucked behind the
+        // expand toggle in the detail body (data-test="error-detail-body").
+        // Reading only the detail body misses the field name, so we expand the
+        // panel (best effort) and return the WHOLE error container text — the
+        // summary line plus the detail body — to assert against the full message.
+
+        // Expand the collapsible detail panel if a toggle is present.
+        const detailsBtn = this.page.locator(this.resultErrorDetailsBtn).first();
         if (await detailsBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
             await detailsBtn.click();
             await this.page.waitForTimeout(500);
         }
 
-        // Try to get text from detailed error message first
-        const detailedError = this.page.locator(this.searchDetailErrorMessage);
-        if (await detailedError.isVisible({ timeout: 2000 }).catch(() => false)) {
-            return await detailedError.textContent();
-        }
-
-        // Fall back to the main error message
-        const errorMsg = this.page.locator(this.errorMessage);
-        if (await errorMsg.isVisible({ timeout: 2000 }).catch(() => false)) {
-            return await errorMsg.textContent();
+        // Prefer the full error-state container so both the summary line (which
+        // holds the field name) and the expanded detail body are captured in a
+        // single string. Fall back to the detail body only if the container is
+        // unavailable.
+        for (const selector of [this.errorMessage, this.searchDetailErrorMessage]) {
+            const locator = this.page.locator(selector).first();
+            if (await locator.isVisible({ timeout: 2000 }).catch(() => false)) {
+                const text = (await locator.textContent()) || '';
+                if (text.trim()) return text;
+            }
         }
 
         // Return empty string if no error message found


### PR DESCRIPTION
## What

Fixes the failing **Logs-Regression** test `should show correct error message identifying the problematic field @errorMessage @P0 @regression` ([logs-regression-bugs.spec.js:330](tests/ui-testing/playwright-tests/RegressionSet/logs-regression-bugs.spec.js#L330)).

Failed identically in the latest scheduled runs:
- OSS: https://github.com/openobserve/openobserve/actions/runs/27405296335
- ENT: https://github.com/openobserve/o2-enterprise/actions/runs/27405221785

(The spec is shared from OSS and merged into the enterprise test tree, so this single OSS fix covers both.)

## Root cause

Not a product bug — the test wasn't updated after the query-error UI redesign (`QueryErrorState.vue` + `ErrorDetailPanel.vue` / `useQueryError`). The backend message `No field named nonexistent_field_xyz_12345. Valid fields are e2e_automate._timestamp.` is now split at the first `". "`:

- **summary line** (`data-test="error-detail-summary"`, always visible) → `No field named nonexistent_field_xyz_12345.` — carries the field name
- **detail body** (`data-test="error-detail-body"`, behind the expand toggle) → `Valid fields are e2e_automate._timestamp.`

The page-object helper `getDetailedErrorDialogText()` read **only** the expanded detail body, so it never captured the field name the assertion checks for (`Received string: "valid fields are e2e_automate._timestamp."`).

## Fix

Rewrote `getDetailedErrorDialogText()` in [logsPage.js](tests/ui-testing/pages/logsPages/logsPage.js) to expand the detail panel and return the **whole** `logs-search-error-state` container text (summary line + detail body), falling back to the detail body if the container is unavailable. Test-only change — no assertion or product code touched; the assertion was always correct.

## Verification

Run locally against a hosted instance (`http://localhost:5080`):

- `should show correct error message identifying the problematic field` → **PASS** (21.7s)
- Stability `--repeat-each=2` → **PASS x2**, no flakiness

Only one caller of `getDetailedErrorDialogText()` exists (this test), so the change is fully contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review feedback addressed

- **Robust fallback:** when the full error container isn't visible (e.g. a rendering race), the helper now stitches the summary line (`error-detail-summary`) + detail body (`error-detail-body`) together explicitly, instead of falling back to the detail body alone — so the field name can never be dropped.
- **JSDoc:** `@returns` now documents that the value is the full error text (summary line + detail body).

No change to the test flow or assertion — only the page-object helper that reads the error text was touched.