### PR TITLE
ci: assign stranger issues to simran only

### DIFF
--- a/.github/workflows/auto-assign-metadata.yml
+++ b/.github/workflows/auto-assign-metadata.yml
@@ -229,8 +229,8 @@ jobs:
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh issue edit "$NUMBER" --add-assignee "Shrinath-O2" --add-assignee "Manazsharma" --add-assignee "neha00290" \
-            && echo "Assigned Shrinath-O2, Manazsharma and neha00290 to stranger issue #$NUMBER" \
+          gh issue edit "$NUMBER" --add-assignee "simranquirky" \
+            && echo "Assigned simranquirky to stranger issue #$NUMBER" \
             || echo "::warning::Could not assign to stranger issue #$NUMBER"
 
       # ── Stranger: assign PR to oasisk + hengfeiyang ──


### PR DESCRIPTION
## Summary
- Changes the stranger-issue triage in `auto-assign-metadata` to assign **only `simranquirky`**, replacing the previous `Shrinath-O2` + `Manazsharma` + `neha00290` set
- Stranger **PR** assignment (`oasisk` + `hengfeiyang`) is unchanged

## Test plan
- [ ] Open an issue as an external contributor → verify only `simranquirky` is assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)