### PR TITLE
ci: e2e-council pre-use hardening (PR-bound trigger, agent-discovery fix, live feedback, exact /e2e)

### DIFF
--- a/.github/workflows/e2e-council.yml
+++ b/.github/workflows/e2e-council.yml
@@ -117,6 +117,31 @@ jobs:
             echo "dry_run=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Acknowledge — react + post in-progress comment
+        # Give the user immediate feedback (within seconds) that the agent is working. We post a
+        # placeholder comment now and EDIT it in place with the decision later (no extra noise).
+        id: ack
+        if: steps.resolve.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = Number('${{ steps.resolve.outputs.pr_number }}');
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            // 👀 reaction on the triggering /e2e comment (comment trigger only).
+            if (context.eventName === 'issue_comment') {
+              try {
+                await github.rest.reactions.createForIssueComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: context.payload.comment.id, content: 'eyes',
+                });
+              } catch (e) { core.info(`reaction failed: ${e.message}`); }
+            }
+            const { data } = await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: pr,
+              body: `### 🤖 E2E Council — triage in progress…\n\nAnalyzing the change with DeepSeek; I'll update this comment with the decision shortly.\n\n[View run](${runUrl})`,
+            });
+            core.setOutput('comment_id', data.id);
+
       - uses: actions/checkout@v4
         # SECURITY (untrusted-checkout TOCTOU / "pwn request"): this job is privileged — the
         # issue_comment trigger runs with repo secrets. So we check out ONLY the trusted default
@@ -196,8 +221,10 @@ jobs:
           name: triage-context
           path: docs/test_generator/ci/
 
-      - name: Post triage comment
-        if: steps.resolve.outputs.pr_number != ''
+      - name: Post or update triage comment
+        # always() so a failed/empty run still updates the in-progress comment (never leaves it
+        # stuck on "in progress…"). Edits the ack comment in place; creates one if ack didn't run.
+        if: always() && steps.resolve.outputs.pr_number != ''
         uses: actions/github-script@v7
         with:
           script: |
@@ -205,6 +232,7 @@ jobs:
             // Keep LLM-authored text out of any markdown that could render as active content.
             const clean = (s, max = 600) =>
               String(s ?? '').replace(/[<>]/g, '').slice(0, max);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             let body = '### 🤖 E2E Council — triage\n\n';
             try {
               const t = JSON.parse(fs.readFileSync('docs/test_generator/ci/triage.json', 'utf8'));
@@ -214,14 +242,22 @@ jobs:
               if (t.feature_title) body += `- **Feature:** ${clean(t.feature_title, 120)} (area: ${clean(t.area, 40) || '?'})\n`;
               if (t.spec_path) body += `- **Would write:** \`${clean(t.spec_path, 200)}\`\n`;
               body += `\n**Rationale:** ${clean(t.rationale)}\n`;
+              body += `\n_Dry-run (v1 manual-first): no tests generated._`;
             } catch (e) {
-              body += `⚠️ Triage did not produce a decision file — check the run logs.\n`;
+              body += `❌ Triage did not produce a decision (the run may have failed or the diff was empty).\n\n[View run](${runUrl})`;
             }
-            body += `\n_Dry-run (v1 manual-first): no tests generated._`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: Number('${{ steps.resolve.outputs.pr_number }}'), body,
-            });
+            const commentId = '${{ steps.ack.outputs.comment_id }}';
+            if (commentId) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: Number(commentId), body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: Number('${{ steps.resolve.outputs.pr_number }}'), body,
+              });
+            }
 
   # ---------------------------------------------------------------------------
   # JOB 2 — Generate (Analyst → Architect → Engineer → Sentinel). No live env.

--- a/.github/workflows/e2e-council.yml
+++ b/.github/workflows/e2e-council.yml
@@ -11,6 +11,7 @@ name: E2E Council (Test Generation)
 #   - Manual run with `oss_branch` (a feature branch ahead of main) → that branch's diff vs main.
 #   - Manual run with neither / oss_branch=main → EMPTY diff → the run fails fast with a clear
 #     message. (Running from main triages main-against-itself = nothing.)
+#   Example: to triage PR #1234, dispatch with pr_number=1234 (leave oss_branch empty).
 #
 # IMPORTANT: both triggers read this workflow's definition from the DEFAULT BRANCH (main).
 # So this file must be merged to main before `workflow_dispatch` appears in the Actions UI or
@@ -27,11 +28,11 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to triage (recommended). Overrides oss_branch when set."
+        description: "PR number to triage (recommended, e.g. '1234'). Overrides oss_branch when set."
         required: false
         default: ""
       oss_branch:
-        description: "OR a feature branch AHEAD of main to triage (ignored if pr_number is set). Do NOT use 'main' — it diffs against itself and triages nothing."
+        description: "OR a feature branch AHEAD of main to triage (ignored if pr_number is set). If set to 'main' (or left empty with no pr_number), the diff is empty and the run fails with a clear message."
         required: false
         default: ""
       feature_hint:

--- a/.github/workflows/e2e-council.yml
+++ b/.github/workflows/e2e-council.yml
@@ -5,13 +5,12 @@ name: E2E Council (Test Generation)
 #
 # REQUIRED SECRET: DEEPSEEK_API_KEY_E2E (repo Settings → Secrets and variables → Actions).
 #
-# WHAT IT TRIAGES (it needs a diff — there is nothing to do without one):
-#   - `/e2e` comment on a PR  → that PR's diff.
-#   - Manual run with `pr_number` → that PR's diff (recommended for on-demand triage).
-#   - Manual run with `oss_branch` (a feature branch ahead of main) → that branch's diff vs main.
-#   - Manual run with neither / oss_branch=main → EMPTY diff → the run fails fast with a clear
-#     message. (Running from main triages main-against-itself = nothing.)
-#   Example: to triage PR #1234, dispatch with pr_number=1234 (leave oss_branch empty).
+# EVERY RUN IS TIED TO A PR — by design. A PR is the unit of change + review; generating tests
+# detached from a PR is not allowed. There are exactly two entry points, both PR-bound:
+#   - `/e2e` comment on a PR        → triages that PR's diff.
+#   - Manual run with `pr_number`   → triages that PR's diff (pr_number is REQUIRED).
+# No PR ⇒ no run. (There is intentionally no free-form branch option.)
+#   Example: to triage PR #1234, dispatch with pr_number=1234.
 #
 # IMPORTANT: both triggers read this workflow's definition from the DEFAULT BRANCH (main).
 # So this file must be merged to main before `workflow_dispatch` appears in the Actions UI or
@@ -28,13 +27,8 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to triage (recommended, e.g. '1234'). Overrides oss_branch when set."
-        required: false
-        default: ""
-      oss_branch:
-        description: "OR a feature branch AHEAD of main to triage (ignored if pr_number is set). If set to 'main' (or left empty with no pr_number), the diff is empty and the run fails with a clear message."
-        required: false
-        default: ""
+        description: "PR number to triage / generate E2E tests for (REQUIRED, e.g. '1234'). Tests are only ever generated for a PR."
+        required: true
       feature_hint:
         description: "Optional feature name/area hint for triage"
         required: false
@@ -55,7 +49,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: e2e-council-${{ github.event.issue.number || github.event.inputs.oss_branch || github.ref }}
+  group: e2e-council-${{ github.event.issue.number || github.event.inputs.pr_number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -100,7 +94,7 @@ jobs:
           script: |
             // Only the PR number is needed — we read the change as a diff (data), never check
             // out the PR head. (See the checkout step below for the security rationale.)
-            // issue_comment → the commented PR; workflow_dispatch → the optional pr_number input.
+            // issue_comment → the commented PR; workflow_dispatch → the required pr_number input.
             const pr = context.eventName === 'issue_comment'
               ? context.payload.issue.number
               : (context.payload.inputs.pr_number || '');
@@ -136,33 +130,25 @@ jobs:
 
       - name: Fetch diff + untrusted inputs as files
         # The PR change is read as a DIFF via the API (data) — the PR head is never checked out.
-        # Untrusted text (comment, hint, branch name) goes through env vars + files, never
-        # interpolated into a shell command. The agent treats all of it as data, not instructions.
+        # Untrusted text (comment, hint) goes through env vars + files, never interpolated into a
+        # shell command. The agent treats all of it as data, not instructions.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OSS_BRANCH: ${{ github.event.inputs.oss_branch }}
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
           FEATURE_HINT: ${{ github.event.inputs.feature_hint }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           mkdir -p docs/test_generator/ci
-          if [ -n "$PR_NUMBER" ]; then
-            # A PR was given (comment trigger, or pr_number on manual dispatch).
-            # Read the PR's diff via API — do NOT check out its code.
-            echo "Triaging PR #$PR_NUMBER"
-            gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > docs/test_generator/ci/diff.patch || true
-          elif [ -n "$OSS_BRANCH" ] && [ "$OSS_BRANCH" != "main" ]; then
-            # Manual dispatch against a feature branch: diff it vs main (fetch only; no checkout/run).
-            echo "Triaging branch '$OSS_BRANCH' vs main"
-            git fetch origin "$OSS_BRANCH" --depth=50 || true
-            git diff "origin/main...origin/$OSS_BRANCH" > docs/test_generator/ci/diff.patch 2>/dev/null || true
-          else
-            : > docs/test_generator/ci/diff.patch
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::No PR number. This workflow only runs against a PR — comment /e2e on a PR, or dispatch with pr_number."
+            exit 1
           fi
-          # Guard: nothing to triage. Fail fast with a clear, actionable message rather than
-          # running the model on an empty diff (e.g. someone dispatched with oss_branch=main).
+          # Read the PR's diff via API — do NOT check out its code.
+          echo "Triaging PR #$PR_NUMBER"
+          gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > docs/test_generator/ci/diff.patch || true
+          # Guard: empty diff (e.g. invalid/closed PR, or a PR with no file changes).
           if [ ! -s docs/test_generator/ci/diff.patch ]; then
-            echo "::error::Nothing to triage — empty diff. Provide a 'pr_number', or an 'oss_branch' that has commits ahead of main (not 'main' itself), or comment /e2e on a PR."
+            echo "::error::Empty diff for PR #$PR_NUMBER — nothing to triage (invalid PR number, or no changes)."
             exit 1
           fi
           # Cap the diff so it can't exceed the model context window.

--- a/.github/workflows/e2e-council.yml
+++ b/.github/workflows/e2e-council.yml
@@ -28,14 +28,14 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number OR PR URL to triage / generate E2E tests for (REQUIRED, e.g. '1234' or 'https://github.com/openobserve/openobserve/pull/1234'). Tests are only ever generated for a PR."
+        description: "PR number or URL (required)"
         required: true
       feature_hint:
-        description: "Optional feature name/area hint for triage"
+        description: "Feature/area hint (optional)"
         required: false
         default: ""
       dry_run:
-        description: "Dry-run: only post the triage decision, do not generate"
+        description: "Dry-run: triage only, don't generate"
         type: boolean
         required: true
         default: true

--- a/.github/workflows/e2e-council.yml
+++ b/.github/workflows/e2e-council.yml
@@ -8,9 +8,10 @@ name: E2E Council (Test Generation)
 # EVERY RUN IS TIED TO A PR — by design. A PR is the unit of change + review; generating tests
 # detached from a PR is not allowed. There are exactly two entry points, both PR-bound:
 #   - `/e2e` comment on a PR        → triages that PR's diff.
-#   - Manual run with `pr_number`   → triages that PR's diff (pr_number is REQUIRED).
+#   - Manual run with `pr_number`   → triages that PR's diff (pr_number is REQUIRED; accepts a
+#                                     bare number, "#123", or a full PR URL).
 # No PR ⇒ no run. (There is intentionally no free-form branch option.)
-#   Example: to triage PR #1234, dispatch with pr_number=1234.
+#   Example: dispatch with pr_number=1234 (or .../pull/1234).
 #
 # IMPORTANT: both triggers read this workflow's definition from the DEFAULT BRANCH (main).
 # So this file must be merged to main before `workflow_dispatch` appears in the Actions UI or
@@ -27,7 +28,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to triage / generate E2E tests for (REQUIRED, e.g. '1234'). Tests are only ever generated for a PR."
+        description: "PR number OR PR URL to triage / generate E2E tests for (REQUIRED, e.g. '1234' or 'https://github.com/openobserve/openobserve/pull/1234'). Tests are only ever generated for a PR."
         required: true
       feature_hint:
         description: "Optional feature name/area hint for triage"
@@ -94,10 +95,16 @@ jobs:
           script: |
             // Only the PR number is needed — we read the change as a diff (data), never check
             // out the PR head. (See the checkout step below for the security rationale.)
-            // issue_comment → the commented PR; workflow_dispatch → the required pr_number input.
-            const pr = context.eventName === 'issue_comment'
-              ? context.payload.issue.number
-              : (context.payload.inputs.pr_number || '');
+            // issue_comment → the commented PR; workflow_dispatch → the required pr_number input,
+            // which accepts a bare number, "#123", or a full PR URL. Normalize to a bare integer
+            // so downstream (gh pr diff, comment posting, concurrency) always gets a number.
+            const raw = context.eventName === 'issue_comment'
+              ? String(context.payload.issue.number)
+              : String(context.payload.inputs.pr_number || '');
+            const urlMatch = raw.match(/\/pull\/(\d+)/);   // PR URL → the /pull/<n> segment
+            const numMatch = raw.match(/\d+/);             // else first run of digits ("#123", "123")
+            const pr = urlMatch ? urlMatch[1] : (numMatch ? numMatch[0] : '');
+            if (!pr) core.setFailed(`Could not parse a PR number from input: "${raw}"`);
             core.setOutput('pr_number', pr);
 
       - name: Determine dry-run mode

--- a/.github/workflows/e2e-council.yml
+++ b/.github/workflows/e2e-council.yml
@@ -5,6 +5,13 @@ name: E2E Council (Test Generation)
 #
 # REQUIRED SECRET: DEEPSEEK_API_KEY_E2E (repo Settings → Secrets and variables → Actions).
 #
+# WHAT IT TRIAGES (it needs a diff — there is nothing to do without one):
+#   - `/e2e` comment on a PR  → that PR's diff.
+#   - Manual run with `pr_number` → that PR's diff (recommended for on-demand triage).
+#   - Manual run with `oss_branch` (a feature branch ahead of main) → that branch's diff vs main.
+#   - Manual run with neither / oss_branch=main → EMPTY diff → the run fails fast with a clear
+#     message. (Running from main triages main-against-itself = nothing.)
+#
 # IMPORTANT: both triggers read this workflow's definition from the DEFAULT BRANCH (main).
 # So this file must be merged to main before `workflow_dispatch` appears in the Actions UI or
 # `/e2e` comments take effect. The first run is dry-run, which only posts a comment.
@@ -19,10 +26,14 @@ name: E2E Council (Test Generation)
 on:
   workflow_dispatch:
     inputs:
+      pr_number:
+        description: "PR number to triage (recommended). Overrides oss_branch when set."
+        required: false
+        default: ""
       oss_branch:
-        description: "OSS branch to analyze for new E2E tests"
-        required: true
-        default: "main"
+        description: "OR a feature branch AHEAD of main to triage (ignored if pr_number is set). Do NOT use 'main' — it diffs against itself and triages nothing."
+        required: false
+        default: ""
       feature_hint:
         description: "Optional feature name/area hint for triage"
         required: false
@@ -88,7 +99,10 @@ jobs:
           script: |
             // Only the PR number is needed — we read the change as a diff (data), never check
             // out the PR head. (See the checkout step below for the security rationale.)
-            const pr = context.eventName === 'issue_comment' ? context.payload.issue.number : '';
+            // issue_comment → the commented PR; workflow_dispatch → the optional pr_number input.
+            const pr = context.eventName === 'issue_comment'
+              ? context.payload.issue.number
+              : (context.payload.inputs.pr_number || '');
             core.setOutput('pr_number', pr);
 
       - name: Determine dry-run mode
@@ -131,13 +145,24 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           mkdir -p docs/test_generator/ci
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+          if [ -n "$PR_NUMBER" ]; then
+            # A PR was given (comment trigger, or pr_number on manual dispatch).
             # Read the PR's diff via API — do NOT check out its code.
+            echo "Triaging PR #$PR_NUMBER"
             gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > docs/test_generator/ci/diff.patch || true
-          else
-            # workflow_dispatch: diff the chosen branch against main (fetch only; no checkout/run).
+          elif [ -n "$OSS_BRANCH" ] && [ "$OSS_BRANCH" != "main" ]; then
+            # Manual dispatch against a feature branch: diff it vs main (fetch only; no checkout/run).
+            echo "Triaging branch '$OSS_BRANCH' vs main"
             git fetch origin "$OSS_BRANCH" --depth=50 || true
             git diff "origin/main...origin/$OSS_BRANCH" > docs/test_generator/ci/diff.patch 2>/dev/null || true
+          else
+            : > docs/test_generator/ci/diff.patch
+          fi
+          # Guard: nothing to triage. Fail fast with a clear, actionable message rather than
+          # running the model on an empty diff (e.g. someone dispatched with oss_branch=main).
+          if [ ! -s docs/test_generator/ci/diff.patch ]; then
+            echo "::error::Nothing to triage — empty diff. Provide a 'pr_number', or an 'oss_branch' that has commits ahead of main (not 'main' itself), or comment /e2e on a PR."
+            exit 1
           fi
           # Cap the diff so it can't exceed the model context window.
           if [ "$(wc -c < docs/test_generator/ci/diff.patch)" -gt "$MAX_DIFF_BYTES" ]; then

--- a/.github/workflows/e2e-council.yml
+++ b/.github/workflows/e2e-council.yml
@@ -7,7 +7,7 @@ name: E2E Council (Test Generation)
 #
 # EVERY RUN IS TIED TO A PR — by design. A PR is the unit of change + review; generating tests
 # detached from a PR is not allowed. There are exactly two entry points, both PR-bound:
-#   - `/e2e` comment on a PR        → triages that PR's diff.
+#   - a comment that is EXACTLY `/e2e` on a PR → triages that PR's diff (extra text won't match).
 #   - Manual run with `pr_number`   → triages that PR's diff (pr_number is REQUIRED; accepts a
 #                                     bare number, "#123", or a full PR URL).
 # No PR ⇒ no run. (There is intentionally no free-form branch option.)
@@ -63,12 +63,14 @@ jobs:
   # write run-context.json, and post the decision as a PR comment.
   # ---------------------------------------------------------------------------
   triage:
-    # Run for manual dispatch, or for a `/e2e` comment on a PR by a trusted author.
+    # Run for manual dispatch, or for a comment that is EXACTLY `/e2e` on a PR by a trusted
+    # author. Exact match (not `contains`) so "Generate /e2e", "/e2e please", etc. do NOT trigger
+    # — the job never starts, so there is no reaction, no comment, and no run for those.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       contains(github.event.comment.body, '/e2e') &&
+       github.event.comment.body == '/e2e' &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -23,5 +23,35 @@
 
   // Default model for runs that don't pass --model explicitly.
   // The workflow passes --model deepseek/deepseek-v4-pro per agent invocation.
-  "model": "deepseek/deepseek-v4-pro"
+  "model": "deepseek/deepseek-v4-pro",
+
+  // Register the CI agents explicitly so `--agent e2e-ci-*` resolves deterministically.
+  // OpenCode does NOT auto-discover agents nested in .opencode/agents/<subdir>/ (the first CI
+  // run fell back to the default agent), so we point each name at its prompt file here.
+  "agent": {
+    "e2e-ci-triage": {
+      "mode": "primary",
+      "prompt": "{file:./.opencode/agents/e2e_ci_council_of_agents/e2e-ci-triage.md}"
+    },
+    "e2e-ci-analyst": {
+      "mode": "primary",
+      "prompt": "{file:./.opencode/agents/e2e_ci_council_of_agents/e2e-ci-analyst.md}"
+    },
+    "e2e-ci-architect": {
+      "mode": "primary",
+      "prompt": "{file:./.opencode/agents/e2e_ci_council_of_agents/e2e-ci-architect.md}"
+    },
+    "e2e-ci-engineer": {
+      "mode": "primary",
+      "prompt": "{file:./.opencode/agents/e2e_ci_council_of_agents/e2e-ci-engineer.md}"
+    },
+    "e2e-ci-sentinel": {
+      "mode": "primary",
+      "prompt": "{file:./.opencode/agents/e2e_ci_council_of_agents/e2e-ci-sentinel.md}"
+    },
+    "e2e-ci-healer": {
+      "mode": "primary",
+      "prompt": "{file:./.opencode/agents/e2e_ci_council_of_agents/e2e-ci-healer.md}"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #12652 that makes the **E2E Council** workflow correct and pleasant for real use, after the first live dry-run triages exposed gaps. v1 scope is unchanged: **OSS-only, manual-first, dry-run** (only Job 1 triage runs; Jobs 2–4 are gated scaffolds).

## Changes

**Trigger is strictly PR-bound**
- Removed the free-form `oss_branch` input (it let you generate tests detached from a PR, and dispatching from `main` diffed main-against-itself = nothing).
- `pr_number` is now **required** for manual dispatch and accepts a **number, `#123`, or a full PR URL** (normalized to an integer).
- A test is only ever generated for a PR. No PR ⇒ no run (empty/missing diff fails fast with a clear message).

**`/e2e` is an exact match**
- Triggers only when the comment body is exactly `/e2e`. `Generate /e2e`, `/e2e please`, etc. do **not** fire anything (the job's `if` is false → no reaction, no comment, no run).

**Agent discovery fixed (the important one)**
- The first live run logged `agent "e2e-ci-triage" not found. Falling back to default agent` — OpenCode does not auto-discover agents nested under `.opencode/agents/<subdir>/`. It only worked by luck (the default agent read the spec file).
- Fixed by registering all six agents in `opencode.jsonc` under the `agent` key with `prompt: "{file:...}"`. **Confirmed working** on the next run (`> e2e-ci-triage · deepseek-v4-pro`, no fallback).

**Immediate user feedback on a run**
- Posts a 👀 reaction on the `/e2e` comment and an "⏳ triage in progress…" comment within seconds, then **edits that same comment in place** with the decision (no second comment). Runs with `always()` so a failed/empty run still updates it (never stuck on "in progress").

**Form/docs polish**
- Decluttered the Run-workflow form (short input labels; full guidance lives in the workflow header).

## Verified live (dry-run triages on this PR)
- OpenCode installs (v1.17.7); DeepSeek model `deepseek/deepseek-v4-pro` works.
- Secure path confirmed: PR read as a **diff via API**, no untrusted PR-head checkout.
- Triage decisions correct + conservative (CI-only change → skip).
- Agent discovery fix confirmed (named agent loads as the system prompt).

## Not in scope (still scaffolds)
Jobs 2–4 (generate → heal → PR-back). Build those once the triage gate is trusted over a dry-run period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)