### PR TITLE
fix: merge split discovered services when service_optional is enabled

### DIFF
--- a/src/handler/http/request/service_streams/mod.rs
+++ b/src/handler/http/request/service_streams/mod.rs
@@ -119,6 +119,24 @@ pub async fn list_services(
     Path(org_id): Path<String>,
     Headers(_user_email): Headers<UserEmail>,
 ) -> Response {
+    #[cfg(feature = "enterprise")]
+    {
+        let records = match infra::table::service_streams::list(&org_id).await {
+            Ok(r) => r,
+            Err(e) => {
+                return MetaHttpResponse::internal_error(format!("Failed to list services: {e}"));
+            }
+        };
+        let identity_config =
+            crate::service::db::system_settings::get_service_identity_config(&org_id).await;
+        let records = if identity_config.service_optional {
+            o2_enterprise::enterprise::service_streams::storage::merge_by_disambiguation(records)
+        } else {
+            records
+        };
+        return MetaHttpResponse::json(records);
+    }
+    #[cfg(not(feature = "enterprise"))]
     match infra::table::service_streams::list(&org_id).await {
         Ok(records) => MetaHttpResponse::json(records),
         Err(e) => MetaHttpResponse::internal_error(format!("Failed to list services: {e}")),

--- a/src/handler/http/request/service_streams/mod.rs
+++ b/src/handler/http/request/service_streams/mod.rs
@@ -134,7 +134,7 @@ pub async fn list_services(
         } else {
             records
         };
-        return MetaHttpResponse::json(records);
+        MetaHttpResponse::json(records)
     }
     #[cfg(not(feature = "enterprise"))]
     match infra::table::service_streams::list(&org_id).await {


### PR DESCRIPTION
## Problem

When **"Correlate without service attribute"** (`service_optional = true`) is enabled, the same physical service can appear as two (or more) separate entries in **Discovered Services**.

**Root cause:** `ServiceKey` is always `(service_name, set_id, disambiguation)`. When a log has no `service.name` attribute, the processor falls back to the stream name (e.g. `repro_logs`) as `service_name`. A trace for the same workload carries the real `service.name` (e.g. `ecs-api-service`). Both entries share identical `(set_id, disambiguation)` but are stored as separate rows — they never merge.

**What the DB looks like (bug):**

| service_name | set_id | disambiguation | logs_streams | traces_streams |
|---|---|---|---|---|
| `ecs-api-service` | `kubernetes` | `{"k8s-namespace":"ecs-prod"}` | `[]` | `["repro_traces"]` |
| `repro_logs` | `kubernetes` | `{"k8s-namespace":"ecs-prod"}` | `["repro_logs"]` | `[]` |

Two rows. `disambiguation` is byte-for-byte identical. Only `service_name` differs.

In production this gets worse — ECS metric streams (which also have no `service.name`) each become their own phantom row under the same disambiguation. We observed 85 rows for a single ECS service, with only 2 rows carrying actual streams.

## Fix

`GET /api/:org_id/service_streams` now performs a read-time merge when `service_optional = true`:

1. Fetches raw rows from the DB (unchanged)
2. Loads the org's service identity config (already cached)
3. If `service_optional = true` — groups rows by `(set_id, disambiguation)`, unions their `logs_streams` / `metrics_streams` / `traces_streams` arrays, and picks the real service name (the one that does NOT appear in its own stream arrays) as the display name
4. Returns the merged list

**After fix — what the API returns:**

```json
[{
  "service_name": "ecs-api-service",
  "set_id": "kubernetes",
  "disambiguation": {"k8s-namespace": "ecs-prod"},
  "logs_streams": ["repro_logs"],
  "traces_streams": ["repro_traces"]
}]
```

One entry. Real service name. All streams unified.

The DB rows are not changed — merge is purely at read time in the handler. When `service_optional = false` the handler returns raw rows as before (no change in behaviour).


Fixes #1848