### PR TITLE
fix: add missing POM locators and fix Monaco keyboard input in regression tests

### DIFF
--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -154,9 +154,12 @@ export class PipelinesPage {
         this.confirmButton = page.locator('[data-test="confirm-dialog"] [data-test="o-dialog-primary-btn"]');
         this.settingsMenu = page.locator('[data-test="menu-link-\\/settings-item"]');
         this.pipelineDestinationsTab = page.locator('button[data-test="pipeline-destinations-tab"]');
+        // "Add Destination" button in the pipeline destinations list
         this.destinationListAddBtn = page.locator('[data-test="pipeline-destination-list-add-btn"]');
+        // Destination type selection cards (prefix match — use .first() to avoid strict-mode violations)
         this.destinationTypeCard = page.locator('[data-test^="destination-type-card-"]');
         this.searchInput = page.locator('[data-test="destination-list-search-input"]');
+        // OToast notifications — data-test-variant is emitted by OToastProvider
         this.toastError = page.locator('[data-test-variant="error"]');
         this.toastSuccess = page.locator('[data-test-variant="success"]');
         this.functionNameInput = page.locator('[data-test="add-function-name-input"]');
@@ -329,7 +332,10 @@ export class PipelinesPage {
     }
 
     async addPipeline() {
-        // Wait for the add pipeline button to be visible
+        // Wait for the add pipeline button to be visible.
+        // Reduced from 30s to 15s — slowMo:500 in serial mode amplifies
+        // cascading delays when the page doesn't load, and 15s is still
+        // generous enough for CI variance.
         await this.addPipelineButton.waitFor({ state: 'visible', timeout: 15000 });
         await this.addPipelineButton.click();
     }

--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -154,7 +154,11 @@ export class PipelinesPage {
         this.confirmButton = page.locator('[data-test="confirm-dialog"] [data-test="o-dialog-primary-btn"]');
         this.settingsMenu = page.locator('[data-test="menu-link-\\/settings-item"]');
         this.pipelineDestinationsTab = page.locator('button[data-test="pipeline-destinations-tab"]');
+        this.destinationListAddBtn = page.locator('[data-test="pipeline-destination-list-add-btn"]');
+        this.destinationTypeCard = page.locator('[data-test^="destination-type-card-"]');
         this.searchInput = page.locator('[data-test="destination-list-search-input"]');
+        this.toastError = page.locator('[data-test-variant="error"]');
+        this.toastSuccess = page.locator('[data-test-variant="success"]');
         this.functionNameInput = page.locator('[data-test="add-function-name-input"]');
         this.functionNameInputField = page.locator('[data-test="add-function-name-input-field"]');
         this.addConditionSaveButton = page.locator('[data-test="add-condition-drawer"] [data-test="o-drawer-primary-btn"]');
@@ -326,7 +330,7 @@ export class PipelinesPage {
 
     async addPipeline() {
         // Wait for the add pipeline button to be visible
-        await this.addPipelineButton.waitFor({ state: 'visible', timeout: 30000 });
+        await this.addPipelineButton.waitFor({ state: 'visible', timeout: 15000 });
         await this.addPipelineButton.click();
     }
 

--- a/tests/ui-testing/playwright-tests/RegressionSet/traces-regression-bugs.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/traces-regression-bugs.spec.js
@@ -170,23 +170,26 @@ test.describe("Traces Regression Bugs — Batch 1", () => {
     await page.locator('body').click({ position: { x: 10, y: 10 } });
     await page.waitForTimeout(300);
 
-    // Focus Monaco via its hidden textarea (.inputarea) — clicking .view-lines
-    // (the display div) does not route keyboard input to the editor model.
-    // Use Monaco's own trigger API to simulate typing, which fires the
-    // autocomplete provider and updates the editor model.
+    // page.keyboard.type() cannot route input to Monaco because Monaco
+    // listens on a hidden <textarea> (.inputarea) positioned off-screen,
+    // not on the visible .view-lines div. Use Monaco's own trigger API to
+    // simulate typed characters — this correctly updates the editor model
+    // and fires the autocomplete provider.
     const editorId = 'traces-query-editor';
-    await page.evaluate(({ editorId }) => {
+    const editorFound = await page.evaluate(({ editorId }) => {
       const w = /** @type {any} */ (window);
       const editors = w.monaco?.editor?.getEditors?.();
-      if (!editors?.length) return;
+      if (!editors?.length) throw new Error('No Monaco editors found on page');
       const target = editors.find(e => {
         const node = e.getDomNode?.();
         return node && node.closest(`#${editorId}`);
       }) || editors[0];
-      if (!target) return;
+      if (!target) throw new Error(`Monaco editor with id "${editorId}" not found`);
       target.focus();
       target.trigger('keyboard', 'type', { text: 'select ' });
+      return true;
     }, { editorId });
+    expect(editorFound, 'Monaco editor must be found and receive input').toBe(true);
     await page.waitForTimeout(800);
 
     // Explicitly trigger autocomplete suggestions (Ctrl+Space in Monaco)

--- a/tests/ui-testing/playwright-tests/RegressionSet/traces-regression-bugs.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/traces-regression-bugs.spec.js
@@ -170,11 +170,24 @@ test.describe("Traces Regression Bugs — Batch 1", () => {
     await page.locator('body').click({ position: { x: 10, y: 10 } });
     await page.waitForTimeout(300);
 
-    // Click the visible text surface to focus Monaco, then type
-    await queryEditor.locator(pm.tracesPage.viewLines).first().click({ force: true });
-    await page.waitForTimeout(300);
-    await page.keyboard.type('select ', { delay: 50 });
-    await page.waitForTimeout(500);
+    // Focus Monaco via its hidden textarea (.inputarea) — clicking .view-lines
+    // (the display div) does not route keyboard input to the editor model.
+    // Use Monaco's own trigger API to simulate typing, which fires the
+    // autocomplete provider and updates the editor model.
+    const editorId = 'traces-query-editor';
+    await page.evaluate(({ editorId }) => {
+      const w = /** @type {any} */ (window);
+      const editors = w.monaco?.editor?.getEditors?.();
+      if (!editors?.length) return;
+      const target = editors.find(e => {
+        const node = e.getDomNode?.();
+        return node && node.closest(`#${editorId}`);
+      }) || editors[0];
+      if (!target) return;
+      target.focus();
+      target.trigger('keyboard', 'type', { text: 'select ' });
+    }, { editorId });
+    await page.waitForTimeout(800);
 
     // Explicitly trigger autocomplete suggestions (Ctrl+Space in Monaco)
     await page.keyboard.press('Control+Space');


### PR DESCRIPTION
## Summary
- Fixes 2 hard-failing regression tests (traces autocomplete + pipeline destination save)
- Improves 6 flaky pipeline timeout tests

## Root causes

### Pipeline destination save test (line 513)
`destinationListAddBtn`, `destinationTypeCard`, `toastError`, and `toastSuccess` were referenced in the test but never defined in `PipelinesPage`. Added the four missing locators with their verified `data-test` attributes.

### Traces autocomplete test (line 139)
The test clicked `.view-lines` (a display-only div) and used `page.keyboard.type()`, but Monaco only routes keyboard input through its hidden `.inputarea` textarea. Switched to Monaco's `editor.trigger('keyboard', 'type', {text})` API which properly updates the editor model and fires the autocomplete provider.

### Pipeline timeout tests (lines 73, 181, 289, 368, 451, 478)
Reduced `addPipeline` timeout from 30s to 15s so tests fail faster instead of hanging when the pipeline page doesn't load. Combined with `slowMo: 500`, the old 30s timeout amplified cascading delays in serial test mode.

## Verification
Both hard-failure tests pass against the pentest environment:
- `traces-regression-bugs.spec.js:139` — PASSED (editor content: "select", suggestions: true)
- `pipeline-regression.spec.js:513` — PASSED (no duplicate notifications)

## Test plan
- [x] Traces autocomplete test passes
- [x] Pipeline destination save test passes
- [ ] Pipeline timeout tests run within CI timeout (improved, not fully resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)