### PR TITLE
perf(traces): order spans by timestamp column instead of start_time

### DIFF
--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -1015,10 +1015,20 @@ async function getQueryData(
         : "start_time";
     })();
 
+    // Spans are physically stored sorted by the timestamp column, and the
+    // backend has a dedicated optimizer for timestamp-sorted segments. A span's
+    // `start_time` is monotonically equivalent to the timestamp column, so
+    // ordering by the timestamp column yields the same visible order while
+    // avoiding the costly full re-sort that `ORDER BY start_time` forces.
+    const orderByCol =
+      validSortCol === "start_time"
+        ? store.state.zoConfig.timestamp_column
+        : validSortCol;
+
     const spansQueryReq = (() => {
       if (!isSpansMode) return null;
       const whereClause = combinedFilter ? ` WHERE ${combinedFilter}` : "";
-      const spansSql = `SELECT * FROM "${selectedStreamName.value}"${whereClause} ORDER BY ${validSortCol} ${sortOrd}`;
+      const spansSql = `SELECT * FROM "${selectedStreamName.value}"${whereClause} ORDER BY ${orderByCol} ${sortOrd}`;
       return {
         query: {
           sql: b64EncodeUnicode(spansSql),


### PR DESCRIPTION
## What

In the traces **spans-mode** list view, the query was built as:

```sql
SELECT * FROM "<stream>" [WHERE ...] ORDER BY start_time <dir>
```

`start_time` is a regular column, so the engine has to perform a full
re-sort of the result set. This change makes the query order by the
configured timestamp column (`_timestamp`) whenever the active sort
column is the default `start_time`:

```sql
SELECT * FROM "<stream>" [WHERE ...] ORDER BY _timestamp <dir>
```

## Why

- Span data is physically stored sorted by the timestamp column, and the
  backend has a dedicated optimizer for timestamp-sorted segments.
- A span's `_timestamp` is monotonically equivalent to its `start_time`,
  so the **visible row order is unchanged**.
- This avoids the costly full re-sort that `ORDER BY start_time` forces,
  improving query latency for the trace/spans view.

## Scope / Notes

- Change is contained to `web/src/plugins/traces/Index.vue`
  (spans-mode query builder in `getQueryData`).
- Only the default `start_time` sort is remapped. Any explicit
  non-`start_time` sort column the user picks is passed through
  unchanged.
- The `sortBy` UI state still reports `start_time`, so the sort
  indicator and reset logic are unaffected.
- Not in scope: the single-trace span fetch in `TraceDetails.vue` still
  uses `ORDER BY start_time` (can be addressed separately).

## Testing

- Verified the generated spans SQL now uses the timestamp column for the
  default sort and produces the same visible ordering.
