### PR TITLE
fix: layout revamp ui and bug fixes (#12666)

### DIFF
--- a/web/src/components/alerts/AlertHistoryDrawer.vue
+++ b/web/src/components/alerts/AlertHistoryDrawer.vue
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <template>
   <ODrawer data-test="alert-history-drawer"
     :open="open"
-    :width="60"
+    :width="65"
     :title="t('alert_list.alert_history')"
     @update:open="emit('update:open', $event)"
   >
@@ -25,14 +25,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
          tab toggle, and datetime picker — too complex for title + sub-slots -->
     <template #header-left>
           <div
-            class="tw:flex tw:items-center tw:gap-2"
+            class="tw:flex tw:items-center tw:gap-2 tw:flex-1 tw:min-w-0"
             data-test="alert-details-title"
           >
-            <!-- Alert Name Badge -->
+            <!-- Alert Name Badge — truncates so a long name can never push the
+                 tab toggle into the datetime picker; full name stays in tooltip -->
             <span
               v-if="alertDetails"
               :class="[
-                'tw:font-semibold tw:text-[18px] tw:mr-2 tw:px-2 tw:py-1 tw:rounded-md tw:ml-2 tw:inline-block',
+                'tw:font-semibold tw:text-[18px] tw:mr-2 tw:px-2 tw:py-1 tw:rounded-md tw:ml-2 tw:min-w-0 tw:truncate',
                 store.state.theme === 'dark'
                   ? 'tw:text-blue-400 tw:bg-blue-900/50'
                   : 'tw:text-blue-600 tw:bg-blue-50',
@@ -41,7 +42,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             >
               {{ alertDetails.name }}
               <OTooltip
-                v-if="alertDetails.name && alertDetails.name.length > 35"
+                v-if="alertDetails.name"
                 :content="alertDetails.name"
               />
             </span>
@@ -49,7 +50,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div
               v-if="alertDetails"
               :class="[
-                'tw:flex tw:items-center tw:gap-1 tw:px-2 tw:py-1 tw:rounded-md tw:border',
+                'tw:flex tw:items-center tw:gap-1 tw:px-2 tw:py-1 tw:rounded-md tw:border tw:shrink-0',
                 store.state.theme === 'dark'
                   ? 'tw:bg-gray-800/50 tw:border-gray-600'
                   : 'tw:bg-gray-50 tw:border-gray-200',
@@ -85,6 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
             <!-- Tab toggle -->
             <OToggleGroup
+              class="tw:shrink-0"
               :model-value="activeTab"
               @update:model-value="activeTab = $event as string"
             >

--- a/web/src/components/common/ConstrainedPage.vue
+++ b/web/src/components/common/ConstrainedPage.vue
@@ -35,8 +35,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     data-test="constrained-page"
   >
     <div
-      class="tw:mx-auto tw:w-full"
-      :class="[maxWidthClass, padded ? 'tw:px-6 tw:py-6' : '']"
+      class="tw:w-full"
+      :class="[alignClass, maxWidthClass, padded ? 'tw:px-6 tw:py-6' : '']"
     >
       <slot />
     </div>
@@ -52,10 +52,13 @@ const props = withDefaults(
     size?: "sm" | "md" | "lg" | "xl";
     /** Apply the default page gutter (px-6 py-6). Off → child owns padding. */
     padded?: boolean;
+    /** Column placement. `center` (default) for hubs; `left` for form pages. */
+    align?: "center" | "left";
   }>(),
   {
     size: "lg",
     padded: true,
+    align: "center",
   },
 );
 
@@ -68,4 +71,10 @@ const SIZE_CLASS = {
 } as const;
 
 const maxWidthClass = computed(() => SIZE_CLASS[props.size]);
+
+// `center` keeps the column centered (mx-auto); `left` pins it to the start so
+// form pages read left-aligned instead of floating in the middle of wide screens.
+const alignClass = computed(() =>
+  props.align === "left" ? "tw:mr-auto" : "tw:mx-auto",
+);
 </script>

--- a/web/src/components/common/SectionRail.vue
+++ b/web/src/components/common/SectionRail.vue
@@ -34,38 +34,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </div>
 
     <div class="tw:flex-1 tw:overflow-y-auto tw:px-2 tw:pt-1 tw:pb-3">
-      <div
-        v-for="group in visibleGroups"
-        :key="group.label"
-        class="tw:mt-1.5 tw:first:mt-0"
+      <OTabs
+        :model-value="activeKey ?? ''"
+        orientation="vertical"
+        class="tw:w-full"
+        @change="onTabChange"
       >
-        <div
-          class="tw:px-2 tw:pt-2 tw:pb-1 tw:text-[0.72rem] tw:font-semibold tw:text-text-secondary"
-        >
-          {{ group.label }}
-        </div>
-        <button
-          v-for="item in group.items"
-          :key="item.key"
-          type="button"
-          :data-test="item.dataTest"
-          :title="item.label"
-          :aria-current="item.key === activeKey ? 'page' : undefined"
-          class="tw:flex tw:w-full tw:items-center tw:gap-2.5 tw:px-2.5 tw:py-1.5 tw:my-0.5 tw:rounded-lg tw:text-sm tw:font-medium tw:text-left tw:transition-colors"
-          :class="item.key === activeKey
-            ? 'tw:bg-tabs-active-bg tw:text-tabs-active-text'
-            : 'tw:text-text-secondary tw:hover:bg-surface-subtle tw:hover:text-text-primary'"
-          @click="navigate(item.to)"
-        >
-          <OIcon
-            v-if="item.icon"
-            :name="(item.icon as any)"
-            size="sm"
-            class="tw:shrink-0"
+        <template v-for="group in visibleGroups" :key="group.label">
+          <div
+            class="tw:px-2 tw:py-1 tw:text-[0.72rem] tw:font-semibold tw:text-text-secondary"
+          >
+            {{ group.label }}
+          </div>
+          <OTab
+            v-for="item in group.items"
+            :key="item.key"
+            :name="item.key"
+            :label="item.label"
+            :icon="item.icon"
+            :data-test="item.dataTest"
+            class="tw:w-full"
+            @click="navigate(item.to)"
           />
-          <span class="tw:leading-snug tw:whitespace-nowrap tw:truncate tw:min-w-0">{{ item.label }}</span>
-        </button>
-      </div>
+        </template>
+      </OTabs>
     </div>
   </nav>
 </template>
@@ -73,7 +65,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script setup lang="ts">
 import { computed } from "vue";
 import { useRouter, type RouteLocationRaw } from "vue-router";
-import OIcon from "@/lib/core/Icon/OIcon.vue";
+import OTabs from "@/lib/navigation/Tabs/OTabs.vue";
+import OTab from "@/lib/navigation/Tabs/OTab.vue";
 import type { SectionHubGroup } from "@/components/common/SectionHub.vue";
 
 const router = useRouter();
@@ -83,6 +76,10 @@ const router = useRouter();
 function navigate(to: RouteLocationRaw) {
   Promise.resolve(router.push(to)).catch(() => {});
 }
+
+// OTabs emits change when a tab is clicked; navigation is handled by navigate()
+// above, so this is a no-op that satisfies the required @change binding.
+function onTabChange(_key: string | number) {}
 
 const props = defineProps<{
   /** The same grouped sections the hub uses. */
@@ -103,5 +100,4 @@ const visibleGroups = computed(() =>
     .filter((g) => g.items.length > 0),
 );
 
-// Group labels in the data are sometimes ALL-CAPS ("ACCESS"); the design system
 </script>

--- a/web/src/components/dashboards/VariablesValueSelector.vue
+++ b/web/src/components/dashboards/VariablesValueSelector.vue
@@ -1101,7 +1101,7 @@ export default defineComponent({
         // This ensures child variables update based on parent changes, not initial custom/all values
         if (
           isCurrentlyReset &&
-          (v.isVariableLoadingPending || v.options.length === 0)
+          (v.isVariableLoadingPending || (v?.options?.length === 0))
         ) {
           // For child variables, always clear oldVariablesData on reset regardless of custom/all config
           // For parent variables, only clear if not custom/all default

--- a/web/src/components/dashboards/settings/VariableQueryValueSelector.vue
+++ b/web/src/components/dashboards/settings/VariableQueryValueSelector.vue
@@ -304,7 +304,7 @@ export default defineComponent({
             const remainingCount = selectedValue.value.length - 2;
             return `${firstTwoValues} ...+${remainingCount} more`;
           } else if (
-            props.variableItem.options.length === 0 &&
+            props?.variableItem?.options?.length === 0 &&
             selectedValue.value.length === 0
           ) {
             return "(No Data Found)";

--- a/web/src/components/settings/General.vue
+++ b/web/src/components/settings/General.vue
@@ -19,8 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <div>
     <!-- Section header (title + description) is provided full-width by the
          Settings shell; this component renders only the form content. -->
-    <!-- platform settings section -->
-    <div class="tw:mx-4">
+    <!-- platform settings section. The page gutter is owned by the Settings
+         shell's ConstrainedPage; this block adds none of its own. -->
+    <div>
       <GroupHeader :title="t('settings.platformSettings')" :showIcon="false" />
       <div class="tw:w-full tw:flex tw:flex-col">
         <OForm @submit.stop="onSubmit.execute">
@@ -162,13 +163,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           store.state.selectedOrganization.identifier
       "
     >
-      <div class="tw:px-3 tw:py-2">
+      <div class="tw:py-2">
         <GroupHeader
           :title="t('settings.enterpriseFeatures')"
           :showIcon="false"
         />
       </div>
-      <div class="tw:mx-3">
+      <div>
         <div class="settings-grid-item no-border-bottom">
           <span class="individual-setting-title">
             {{ t("settings.customLogoText") }}

--- a/web/src/components/settings/License.vue
+++ b/web/src/components/settings/License.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="tw:p-3">
+  <!-- Page gutter is owned by the Settings shell's ConstrainedPage. -->
+  <div>
     <LicensePeriod @updateLicense="showUpdateFormAndFocus"></LicensePeriod>
 
     <div v-if="loading" class="tw:p-3 tw:flex tw:flex-col tw:items-center tw:justify-center">

--- a/web/src/components/settings/OrganizationSettings.vue
+++ b/web/src/components/settings/OrganizationSettings.vue
@@ -1,13 +1,14 @@
 <template>
   <div>
-    <!-- Section header is provided full-width by the Settings shell. -->
-    <div class="tw:px-3 tw:pt-3 tw:pb-3">
+    <!-- Section header is provided full-width by the Settings shell. The page
+         gutter is owned by ConstrainedPage; this page adds none of its own. -->
+    <div class="tw:pb-3">
       <div class="tw:text-base tw:font-bold">
         {{ t("settings.logDetails") }}
       </div>
     </div>
 
-    <div class="tw:mx-3 tw:mb-3">
+    <div class="tw:mb-3">
     <div
       data-test="add-role-rolename-input-btn"
       class="trace-id-field-name o2-input tw:mb-2"

--- a/web/src/components/settings/index.vue
+++ b/web/src/components/settings/index.vue
@@ -41,7 +41,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <span :data-test="`settings-${activeSectionItem?.key}-page-title`">{{ activeSectionItem?.label || '' }}</span>
         </template>
       </AppPageHeader>
-      <ConstrainedPage size="lg" class="tw:flex-1 tw:min-h-0">
+      <ConstrainedPage
+        size="lg"
+        align="left"
+        :padded="false"
+        class="tw:flex-1 tw:min-h-0 tw:px-4 tw:py-3"
+      >
         <router-view title="" />
       </ConstrainedPage>
     </div>

--- a/web/src/lib/core/Table/OTable.flexwidth.spec.ts
+++ b/web/src/lib/core/Table/OTable.flexwidth.spec.ts
@@ -121,4 +121,36 @@ describe("OTable flex column width", () => {
     // The invisible spacer must be 0 in the fill state — no trailing gap.
     expect(headerVar(wrapper, "--spacer--")).toBe(0);
   });
+
+  // Regression: in the FILL state (before any resize), when the columns can't
+  // fit even at their min widths the table must scroll horizontally instead of
+  // clipping the trailing columns (table-fixed otherwise grows past 100% and
+  // the overflow is hidden).
+  it("fill state: enables horizontal scroll when columns overflow the container", async () => {
+    const wrapper = mount(OTable, {
+      props: {
+        data, columns,
+        selection: "multiple",
+        showIndex: true,
+        enableColumnResize: true,
+        defaultColumns: false,
+        tableId: "flexdiag3",
+      } as any,
+    });
+    await flushPromises();
+    const st: any = (wrapper.vm.$ as any).setupState;
+
+    // Wide container: fixed (272) + flex min (160) = 432 < 1000 → fills, no scroll.
+    st.containerWidth = 1000;
+    await flushPromises();
+    expect(st.frozen).toBe(false);
+    expect(st.allowHorizontalScroll).toBe(false);
+
+    // Narrow container: 432 > 400 → even at min widths the columns overflow, so
+    // the scroll container must expose a horizontal scrollbar.
+    st.containerWidth = 400;
+    await flushPromises();
+    expect(st.frozen).toBe(false);
+    expect(st.allowHorizontalScroll).toBe(true);
+  });
 });

--- a/web/src/lib/core/Table/OTable.vue
+++ b/web/src/lib/core/Table/OTable.vue
@@ -502,8 +502,13 @@ const hasFillColumn = computed(() =>
 const allowHorizontalScroll = computed(() => {
   if (props.horizontalScroll) return true;
   if (!hasFillColumn.value) return true;
-  if (useComputedWidth.value && frozen.value) {
-    return realSum() > containerWidth.value + 1;
+  if (useComputedWidth.value) {
+    if (containerWidth.value <= 0) return false;
+    // Frozen → scroll once the resized columns exceed the container.
+    if (frozen.value) return realSum() > containerWidth.value + 1;
+    // Fill → scroll once the columns can't fit even at their min widths
+    // (table-fixed otherwise grows past 100% and the overflow is clipped).
+    return fillMinSum() > containerWidth.value + 1;
   }
   return false;
 });
@@ -581,6 +586,17 @@ function realSum(): number {
   return (
     nonFlexFixedSum() +
     flexColIds.value.reduce((a, id) => a + frozenFlexWidth(id), 0)
+  );
+}
+
+// Minimum width the table needs in the FILL state: fixed columns + every flex
+// column shrunk to its minSize. When this exceeds the container the flex fill
+// can no longer absorb the overflow (table-fixed grows the table past 100%), so
+// the table must scroll horizontally instead of clipping the trailing columns.
+function fillMinSum(): number {
+  return (
+    nonFlexFixedSum() +
+    flexColIds.value.reduce((a, id) => a + colMinSize(id), 0)
   );
 }
 

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -361,7 +361,12 @@ export const convertPromQLData = async (
   // Skip rotation and truncation for time-based x-axis
   // PromQL always uses time-series data, so no rotation/truncation calculations needed
   const additionalBottomSpace = 0;
-  const dynamicXAxisNameGap = 25;
+  // nameGap is the distance from the axis line to the middle-anchored axis name.
+  // The time tick labels occupy ~22px below the axis line (margin + fontSize), so a
+  // gap of 25 placed the bold axis name on top of the labels (and, with a bottom
+  // legend, on top of the legend). 35 lets the name sit clearly below the labels.
+  const dynamicXAxisNameGap = 35;
+  const hasXAxisName = !!panelSchema.queries?.[0]?.fields?.x?.[0]?.label;
 
   const options: any = {
     backgroundColor: "transparent",
@@ -373,6 +378,11 @@ export const convertPromQLData = async (
       right: 20,
       top: "15",
       bottom: (() => {
+        // Reserve space below the plot for: tick labels, the axis name (when present)
+        // and — for a horizontal bottom legend — the legend row. Without the axis name
+        // the original tight values are kept; with it we add ~25px so "Time" clears
+        // both the labels above and the legend below it.
+        const nameReserve = hasXAxisName ? 25 : 0;
         const baseBottom =
           legendConfig.orient === "horizontal" && panelSchema.config?.show_legends
             ? panelSchema.config?.axis_width == null
@@ -381,7 +391,7 @@ export const convertPromQLData = async (
             : panelSchema.config?.axis_width == null
               ? 5
               : 25;
-        return baseBottom + additionalBottomSpace;
+        return baseBottom + additionalBottomSpace + nameReserve;
       })(),
     },
     tooltip: {

--- a/web/src/utils/dashboard/sql/shared/contextBuilder.ts
+++ b/web/src/utils/dashboard/sql/shared/contextBuilder.ts
@@ -341,10 +341,15 @@ export function buildSQLContext(
   const labelMargin = 10;
 
   // Calculate the section height (nameGap) upfront so we can use it for bottom spacing
-  // Skip rotation-based calculations for horizontal charts and time-based axes
+  // Skip rotation-based calculations for horizontal charts and time-based axes.
+  // nameGap is the distance from the axis line to the (middle-anchored) axis name.
+  // The tick labels occupy ~22px below the axis line (labelMargin 10 + fontSize 12),
+  // so a gap of 25 placed the bold axis name on top of the labels (and, with a bottom
+  // legend, on top of the legend). Use 35 so the name sits clearly below the labels —
+  // matching `calculateDynamicNameGap`'s own formula (labelHeight + margin + buffer).
   const dynamicXAxisNameGap =
     hasTimestampField || isHorizontalChart
-      ? 25
+      ? 35
       : calculateDynamicNameGap(
           labelRotation,
           labelWidth,
@@ -375,15 +380,21 @@ export function buildSQLContext(
       top: "15",
       bottom: hasXAxisName
         ? (() => {
+            // Reserve enough vertical space below the plot for the tick labels, the
+            // axis name (`nameGap` 35) and — when a horizontal legend is shown — the
+            // legend row beneath it. Measured ideal is roughly `nameGap + 20` for the
+            // containLabel case (labels are reserved inside the grid box, so only the
+            // name needs to clear the bottom-anchored legend); the earlier values left
+            // the name overlapping the legend, and over-padding leaves a visible gap.
             const baseBottom =
               legendConfig.orient === "horizontal" &&
               panelSchema.config?.show_legends
                 ? panelSchema.config?.axis_width == null
-                  ? 50
-                  : 60
+                  ? 55
+                  : 75
                 : panelSchema.config?.axis_width == null
-                  ? 35
-                  : 40;
+                  ? 30
+                  : 50;
             // When an x-axis name is present, `nameGap` already reserves space
             // between rotated labels and the axis name. Adding `additionalBottomSpace`
             // here causes double-counting and extra blank space beneath the axis

--- a/web/src/views/Dashboards/ViewDashboard.vue
+++ b/web/src/views/Dashboards/ViewDashboard.vue
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           fullscreen: isFullscreen,
           'print-mode-container': store.state.printMode,
         },
-        store.state.printMode === true ? 'tw:px-6 tw:pb-6' : '',
+        store.state.printMode === true ? 'tw:pb-6' : '',
       ]"
       class="tw:h-full"
     >
@@ -213,7 +213,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <RenderDashboardCharts
         :frame="false"
-        :class="store.state.printMode ? '' : 'tw:flex-1 tw:min-h-0'"
+        :class="store.state.printMode ? 'tw:px-6' : 'tw:flex-1 tw:min-h-0'"
         :key="
           currentDashboardData.data?.dashboardId + '-' + dashboardRemountKey
         "
@@ -1758,6 +1758,15 @@ export default defineComponent({
     onUnmounted(() => {
       document.removeEventListener("fullscreenchange", onFullscreenChange);
 
+      // Reset print mode on leave. Print mode hides the global chrome
+      // (left nav sidebar). The close button resets it, but navigating away
+      // via the browser back button skips that, leaving the sidebar hidden on
+      // other pages until a manual refresh. Resetting here guarantees the
+      // chrome is restored whenever the dashboard view is destroyed.
+      if (store.state.printMode === true) {
+        setPrint(false);
+      }
+
       // Clean up AI dashboard event listener
       offDashboardEvent(handleAiDashboardEvent);
 
@@ -1926,12 +1935,16 @@ export default defineComponent({
   background-color: $white;
 }
 
-.stickyHeader {
+// The header wrapper is rendered inside PageLayout (a child component), so these
+// rules must use :deep() to cross the scope boundary. Without it the scoped class
+// names passed via `header-class` never match, position:sticky is never applied,
+// and the header scrolls away in print/fullscreen mode.
+:deep(.stickyHeader) {
   position: sticky;
   top: 0;
   z-index: 1001;
 }
-.stickyHeader.fullscreenHeader {
+:deep(.stickyHeader.fullscreenHeader) {
   top: 0px;
   z-index: 5100 !important;
 }
@@ -1949,8 +1962,15 @@ export default defineComponent({
 }
 
 .print-mode-container {
-  height: 100vh !important;
-  overflow-y: auto !important;
+  // Grow to the dashboard's natural content height and let the app's outer
+  // scroll wrapper (MainLayout's .o2-content-scroll) do the scrolling — the same
+  // model the @media print block below relies on. Pinning a viewport height here
+  // (100vh or 100%) capped the subtree, and PageLayout's body (overflow-hidden)
+  // then clipped the trailing panels, so tall dashboards could never be scrolled
+  // to the bottom. `overflow: visible` keeps the sticky header pinned to the
+  // outer scroll wrapper rather than to a dead inner scroll box.
+  height: auto !important;
+  overflow: visible !important;
 }
 
 @media print {


### PR DESCRIPTION
- alert history title truncate and drawer width increase
- management page content left align and padding
- horizontal scroll in table without resizing columns
- print dashboard header and back button reset print mode
- x-axis name overlapping tick labels and legend
- print dashboard header sticky and scroll fix

---------