### PR TITLE
fix: merge split discovered services when service_optional is enabled

### DIFF
--- a/src/handler/http/request/service_streams/mod.rs
+++ b/src/handler/http/request/service_streams/mod.rs
@@ -119,6 +119,24 @@ pub async fn list_services(
     Path(org_id): Path<String>,
     Headers(_user_email): Headers<UserEmail>,
 ) -> Response {
+    #[cfg(feature = "enterprise")]
+    {
+        let records = match infra::table::service_streams::list(&org_id).await {
+            Ok(r) => r,
+            Err(e) => {
+                return MetaHttpResponse::internal_error(format!("Failed to list services: {e}"));
+            }
+        };
+        let identity_config =
+            crate::service::db::system_settings::get_service_identity_config(&org_id).await;
+        let records = if identity_config.service_optional {
+            o2_enterprise::enterprise::service_streams::storage::merge_by_disambiguation(records)
+        } else {
+            records
+        };
+        return MetaHttpResponse::json(records);
+    }
+    #[cfg(not(feature = "enterprise"))]
     match infra::table::service_streams::list(&org_id).await {
         Ok(records) => MetaHttpResponse::json(records),
         Err(e) => MetaHttpResponse::internal_error(format!("Failed to list services: {e}")),

--- a/src/handler/http/request/service_streams/mod.rs
+++ b/src/handler/http/request/service_streams/mod.rs
@@ -134,7 +134,7 @@ pub async fn list_services(
         } else {
             records
         };
-        return MetaHttpResponse::json(records);
+        MetaHttpResponse::json(records)
     }
     #[cfg(not(feature = "enterprise"))]
     match infra::table::service_streams::list(&org_id).await {


### PR DESCRIPTION
Cherry-pick of #12661 onto branch-v0.91.0.

## Problem

When **"Correlate without service attribute"** (`service_optional = true`) is ON, the same physical service appears as multiple rows in Discovered Services. Logs without `service.name` fall back to the stream name; traces carry the real name. Both stored as separate DB rows with identical `(set_id, disambiguation)`, never merged.

## Fix

`GET /api/:org_id/service_streams` now performs a read-time merge when `service_optional=true`: groups rows by `(set_id, disambiguation)`, unions stream arrays, picks the real service name over stream-name fallbacks.

No DB writes. No behavior change when `service_optional=false`.

Enterprise PR: openobserve/o2-enterprise#1919