### PR TITLE
fix: traces error filter not getting reset on resetting query

### DIFF
--- a/web/src/composables/useTraces.ts
+++ b/web/src/composables/useTraces.ts
@@ -91,7 +91,6 @@ const defaultObject = {
       string,
       { panelTitle: string; start: number; end: number }
     >(),
-    showErrorOnly: false,
     queryEditorPlaceholderFlag: true,
     liveMode: localStorage.getItem("oo_toggle_auto_run") === "true",
     searchMode: "spans" as TraceSearchMode,

--- a/web/src/plugins/traces/Index.spec.ts
+++ b/web/src/plugins/traces/Index.spec.ts
@@ -162,7 +162,6 @@ const mockSearchObj = {
     liveMode: false,
     serviceColors: {},
     metricsRangeFilters: new Map(),
-    showErrorOnly: false,
   }),
   data: {
     query: "",
@@ -1046,7 +1045,7 @@ describe("Index.vue (Main Traces Page)", () => {
     beforeEach(() => {
       mockApplyFilters.mockReset();
       mockRemoveFilterByField.mockReset();
-      mockSearchObj.meta.showErrorOnly = false;
+      mockSearchObj.data.editorValue = "";
       mockSearchObj.meta.metricsRangeFilters.clear();
       // Reset auto_query_enabled to undefined for each test
       delete store.state.zoConfig.auto_query_enabled;
@@ -1068,8 +1067,8 @@ describe("Index.vue (Main Traces Page)", () => {
       ]); // applyFilters owns the single trigger; no skipSearch arg
     });
 
-    it("should append error filter to applyFilters call when showErrorOnly is enabled", async () => {
-      mockSearchObj.meta.showErrorOnly = true;
+    it("should append error filter to applyFilters call when span_status = 'ERROR' is in the query", async () => {
+      mockSearchObj.data.editorValue = "span_status = 'ERROR'";
       wrapper = mountWithSearchBarStub();
       await flushPromises();
 
@@ -1083,7 +1082,7 @@ describe("Index.vue (Main Traces Page)", () => {
     });
 
     it("should not duplicate error filter when it is already present in incoming filters", async () => {
-      mockSearchObj.meta.showErrorOnly = true;
+      mockSearchObj.data.editorValue = "span_status = 'ERROR'";
       wrapper = mountWithSearchBarStub();
       await flushPromises();
 

--- a/web/src/plugins/traces/Index.vue
+++ b/web/src/plugins/traces/Index.vue
@@ -256,6 +256,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   >
                     <search-result
                       ref="searchResultRef"
+                      :show-error-only="showErrorOnly"
                       @update:datetime="setHistogramDate"
                       @update:scroll="getMoreData"
                       @update:sort="runQueryOnSort"
@@ -1698,9 +1699,9 @@ const setHistogramDate = async (date: any) => {
 // User can manually add their own filters before clicking "Run Query"
 const onMetricsFiltersUpdated = (filters: string[]) => {
   const allFilters = [...filters];
-  // Add error filter only if toggle is on and not already present from Error panel brush
+  // Add error filter only if span_status='ERROR' is currently active and not already present
   if (
-    searchObj.meta.showErrorOnly &&
+    showErrorOnly.value &&
     !allFilters.includes("span_status = 'ERROR'")
   ) {
     allFilters.push("span_status = 'ERROR'");
@@ -1930,6 +1931,10 @@ const activeExcludeFilterValues = computed((): Record<string, string[]> => {
   }
   return result;
 });
+
+const showErrorOnly = computed(
+  () => activeIncludeFilterValues.value["span_status"]?.includes("ERROR") ?? false,
+);
 
 const searchData = () => {
   if (

--- a/web/src/plugins/traces/SearchBar.spec.ts
+++ b/web/src/plugins/traces/SearchBar.spec.ts
@@ -116,7 +116,6 @@ const makeSearchObj = () =>
         | "spans"
         | "service-graph"
         | "services-catalog",
-      showErrorOnly: false,
       queryEditorPlaceholderFlag: true,
       metricsRangeFilters: new Map<
         string,

--- a/web/src/plugins/traces/SearchResult.vue
+++ b/web/src/plugins/traces/SearchResult.vue
@@ -65,12 +65,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           variant="error"
           :clickable="true"
           class="tw:text-xs tw:rounded! tw:py-[0.4rem]! tw:px-[0.625rem]! tw:text-[0.75rem]!"
-          :class="!searchObj.meta.showErrorOnly ? 'tw:bg-[var(--o2-error-tag-bg)]! tw:text-[var(--o2-error-tag-text)]!' : ''"
+          :class="!showErrorOnly ? 'tw:bg-[var(--o2-error-tag-bg)]! tw:text-[var(--o2-error-tag-text)]!' : ''"
           @click="toggleErrorOnly"
         >
           {{ `${formatLargeNumber(searchObj.data.queryResults.errorCount)} ${searchObj.meta.searchMode === 'traces' ? t('traces.errorTraces') : t('traces.errorSpans')}` }}
           <OTooltip
-            :content="searchObj.meta.showErrorOnly ? t('traces.clearErrorFilter') : t('traces.filterByErrors')"
+            :content="showErrorOnly ? t('traces.clearErrorFilter') : t('traces.filterByErrors')"
             side="bottom"
           />
           <template #trailing>
@@ -224,6 +224,12 @@ export default defineComponent({
     ),
     OIcon,
 },
+  props: {
+    showErrorOnly: {
+      type: Boolean,
+      default: false,
+    },
+  },
   emits: [
     "update:scroll",
     "update:datetime",
@@ -239,9 +245,7 @@ export default defineComponent({
   ],
   methods: {
     toggleErrorOnly() {
-      const newVal = !this.searchObj.meta.showErrorOnly;
-      this.searchObj.meta.showErrorOnly = newVal;
-      this.$emit("error-only-toggled", newVal);
+      this.$emit("error-only-toggled", !this.showErrorOnly);
     },
     closeColumn(col: any) {
       const RGIndex = this.searchObj.data.resultGrid.columns.indexOf(col.name);
@@ -268,6 +272,7 @@ export default defineComponent({
     const router = useRouter();
 
     const { searchObj, updatedLocalLogFilterField } = useTraces();
+
     const metricsDashboardRef: any = ref(null);
 
     const sectionHeaderRef = ref<HTMLElement | null>(null);

--- a/web/src/plugins/traces/ServicesCatalog.spec.ts
+++ b/web/src/plugins/traces/ServicesCatalog.spec.ts
@@ -66,7 +66,6 @@ const mockSearchObj = reactive({
       string,
       { panelTitle: string; start: number; end: number }
     >(),
-    showErrorOnly: false,
     queryEditorPlaceholderFlag: true,
     liveMode: false,
     serviceGraphVisualizationType: "tree" as "tree" | "graph",

--- a/web/src/plugins/traces/metrics/TracesMetricsDashboard.spec.ts
+++ b/web/src/plugins/traces/metrics/TracesMetricsDashboard.spec.ts
@@ -53,7 +53,6 @@ const mockSearchObj = reactive({
   },
   meta: {
     showHistogram: true,
-    showErrorOnly: false,
     metricsRangeFilters: mockMetricsRangeFilters,
     searchMode: "traces" as "traces" | "spans",
   },
@@ -173,7 +172,6 @@ describe("TracesMetricsDashboard", () => {
     // Reset all shared state before every test
     mockMetricsRangeFilters.clear();
     mockSearchObj.meta.showHistogram = true;
-    mockSearchObj.meta.showErrorOnly = false;
     mockSearchObj.meta.searchMode = "traces";
     mockSearchObj.data.stream.selectedStream.value = "default";
     mockSearchObj.data.stream.selectedStreamFields = [];
@@ -640,16 +638,14 @@ describe("TracesMetricsDashboard", () => {
       expect(filters[0]).toBe("duration >= 100 and duration <= 500");
     });
 
-    it("should include span_status = 'ERROR' when showErrorOnly is true and filter prop contains it", () => {
+    it("should include span_status = 'ERROR' when filter prop contains it", () => {
       wrapper.unmount();
-      mockSearchObj.meta.showErrorOnly = true;
       wrapper = mountComponent({ filter: "span_status = 'ERROR'" });
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).toContain("span_status = 'ERROR'");
     });
 
-    it("should NOT include span_status = 'ERROR' from toggle alone when filter prop does not contain it", () => {
-      mockSearchObj.meta.showErrorOnly = true;
+    it("should NOT include span_status = 'ERROR' when filter prop does not contain it", () => {
       const filters = wrapper.vm.getBaseFilters();
       expect(filters).not.toContain("span_status = 'ERROR'");
     });

--- a/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
+++ b/web/src/plugins/traces/metrics/TracesMetricsDashboard.vue
@@ -163,13 +163,6 @@ const streamFields = computed(() => {
   return searchObj.data.stream.selectedStreamFields || [];
 });
 
-// Use filters from searchObj
-const showErrorOnly = computed({
-  get: () => searchObj.meta.showErrorOnly,
-  set: (val) => {
-    searchObj.meta.showErrorOnly = val;
-  },
-});
 const rangeFilters = computed(() => searchObj.meta.metricsRangeFilters);
 
 // Check if ANY RED panel has a time-based brush selection


### PR DESCRIPTION
#12703 

## What changed

Removed the `showErrorOnly` key from `searchObj.meta` state and replaced it with a `computed` property that derives from `activeIncludeFilterValues` — specifically checking whether `span_status` includes `"ERROR"`. The `SearchResult.vue` component now receives `showErrorOnly` as a prop from `Index.vue` instead of reading it from the shared composable state. `TracesMetricsDashboard.vue` had its own writable `showErrorOnly` computed removed since it no longer needs to sync a top-level state key.

## Why

The user identified that `showErrorOnly` was redundant state — the information is already encoded in `activeIncludeFilterValues["span_status"]`. Keeping both in sync was unnecessary maintenance burden. Deriving it from the existing filter state is the single source of truth and eliminates the risk of the flag and the actual query filters diverging.