### PR TITLE
fix: port cloud hotfixes (edit user + usage stream) [v0.91.0]

### DIFF
--- a/web/src/components/iam/users/User.vue
+++ b/web/src/components/iam/users/User.vue
@@ -143,7 +143,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <OIcon name="cancel" size="sm" />
             </OButton>
             <OButton
-              v-if="row.enableEdit && row.status != 'pending' && config.isCloud == 'false'"
+              v-if="row.enableEdit && row.status != 'pending'"
               :title="t('user.update')"
               variant="ghost"
               size="icon-sm"
@@ -179,12 +179,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <add-user
       v-model:open="showAddUserDialog"
-      v-if="config.isCloud == 'false'"
       v-model="selectedUser"
       :isUpdated="isUpdated"
       :userRole="currentUserRole"
       :roles="options"
       :customRoles="customRoles"
+      :isCloud="config.isCloud == 'true'"
       @updated="addMember"
     />
 
@@ -773,6 +773,12 @@ export default defineComponent({
       // Allow editing for root users only if the current user is root
       if (user.role?.toLowerCase() === "root") {
         return store.state.userInfo.email === user.email;
+      }
+      // Cloud: cannot edit self (same as delete behavior)
+      if (config.isCloud == "true") {
+        return (
+          store.state.userInfo.email.toLowerCase() !== user.email.toLowerCase()
+        );
       }
       // Allow editing for all other users
       return true;

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -883,6 +883,7 @@ export default defineComponent({
         span_id_field_name: "spanId",
         trace_id_field_name: "traceId",
         toggle_ingestion_logs: false,
+        usage_stream_enabled: false,
         enable_websocket_search: false,
         enable_streaming_search: false,
         streaming_aggregation_enabled: false,
@@ -914,6 +915,9 @@ export default defineComponent({
           toggle_ingestion_logs:
             orgSettings?.data?.data?.toggle_ingestion_logs ??
             defaultSettings.toggle_ingestion_logs,
+          usage_stream_enabled:
+            orgSettings?.data?.data?.usage_stream_enabled ??
+            defaultSettings.usage_stream_enabled,
           enable_websocket_search:
             orgSettings?.data?.data?.enable_websocket_search ??
             defaultSettings.enable_websocket_search,


### PR DESCRIPTION
## What
Ports yesterday's two Cloud hotfixes from the `ch-bug-fix-cloud` deploy branch so they are durable and don't regress on the next build:

1. **`608b355dbd` — edit user fix** — restores the **Edit user** (pencil) button on IAM → Users for Cloud builds. It was hidden for all rows due to an edition gate (`config.isCloud == 'false'`) on the edit action. Also passes `:isCloud` to the add-user dialog and adds the Cloud rule that a user can't edit themselves (mirrors delete).
2. **`e029eca212` — enable usage stream fix** — adds `usage_stream_enabled` to the org-settings defaults in `MainLayout.vue`.

## Why this is needed
Both fixes currently live **only** on the `ch-bug-fix-cloud` deploy branch — neither is in `main` or `branch-v0.91.0`. The edit-button bug already has a fix-then-revert history (12432 fixed it, 12521 reverted it on stale code). Without these PRs, the next Cloud build from this branch silently drops both fixes again.

## Files
- `web/src/components/iam/users/User.vue` (edit user)
- `web/src/layouts/MainLayout.vue` (usage stream)

Companion PR applies the identical two cherry-picks to the other branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)