### PR TITLE
test: prevent flaky DOM detachment in searchAndAddField and validate API response status

### DIFF
--- a/tests/ui-testing/pages/dashboardPages/dashboard-chart.js
+++ b/tests/ui-testing/pages/dashboardPages/dashboard-chart.js
@@ -157,11 +157,23 @@ export default class ChartTypeSelector {
 
     // New data-test format: o-field-list-row-{fieldName}
     const fieldItem = this.page.locator(`[data-test="o-field-list-row-${fieldName}"]`);
-    await fieldItem.first().waitFor({ state: "visible", timeout: 5000 });
+    await fieldItem.first().waitFor({ state: "visible", timeout: 10000 });
 
-    // Add button is hidden until hover — reveal it first
-    await fieldItem.first().scrollIntoViewIfNeeded();
-    await fieldItem.first().hover();
+    // hover() auto-scrolls into view — scrollIntoViewIfNeeded() is not needed.
+    // Retry for DOM stability: Vue re-renders the field list multiple times after
+    // search input changes (debounce / virtual scroll), which detaches the element
+    // between waitFor and the action. Re-waiting after each detachment lets the
+    // list settle before the next attempt.
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await fieldItem.first().hover({ timeout: 5000 });
+        break;
+      } catch (e) {
+        if (attempt === maxAttempts) throw e;
+        await fieldItem.first().waitFor({ state: "visible", timeout: 5000 });
+      }
+    }
 
     // Now locate and click the button within the field item.
     // Use .first() — in join panels the same field name can appear multiple times

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
@@ -379,9 +379,8 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       // Matches both _search_stream (raw logs) and _histogram_stream (aggregated).
       const apiResponsePromise = page.waitForResponse(
         (r) =>
-          (r.url().includes("_search_stream") ||
-            r.url().includes("_histogram_stream")) &&
-          r.status() === 200,
+          r.url().includes("_search_stream") ||
+          r.url().includes("_histogram_stream"),
         { timeout: 15000 }
       );
 

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
@@ -373,9 +373,23 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       await pm.chartTypeSelector.searchAndAddField("code", "y");
       await pm.chartTypeSelector.configureYAxisFunction("y_axis_1", "count");
 
-      const streamPromise = waitForStreamComplete(page);
+      // Register the response waiter BEFORE clicking Apply so the request isn't missed.
+      // Matches both _search_stream (raw logs) and _histogram_stream (aggregated).
+      const apiResponsePromise = page.waitForResponse(
+        (r) =>
+          (r.url().includes("_search_stream") ||
+            r.url().includes("_histogram_stream")) &&
+          r.status() === 200,
+        { timeout: 15000 }
+      );
+
       await pm.dashboardPanelActions.applyDashboardBtn();
-      await streamPromise;
+
+      // Assert the backend returned 200 — catches auth/query errors early.
+      const apiResponse = await apiResponsePromise;
+      expect(apiResponse.status()).toBe(200);
+
+      // Wait for table DOM to reflect the streamed data.
       await pm.chartTypeSelector.waitForTableDataLoad();
 
       // Verify headers — should have at least 2 columns (Timestamp + Code)

--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js
@@ -374,6 +374,8 @@ test.describe("Dashboard Table Chart - Core Features", () => {
       await pm.chartTypeSelector.configureYAxisFunction("y_axis_1", "count");
 
       // Register the response waiter BEFORE clicking Apply so the request isn't missed.
+      // Uses waitForResponse instead of waitForStreamComplete so the HTTP status
+      // is asserted directly — waitForStreamComplete silently times out on non-200s.
       // Matches both _search_stream (raw logs) and _histogram_stream (aggregated).
       const apiResponsePromise = page.waitForResponse(
         (r) =>


### PR DESCRIPTION
## PR #12726 — Change Summary

### Problem
Test `should render table with histogram(_timestamp) as X and count aggregation as Y` was flaky with:

  Error: locator.scrollIntoViewIfNeeded: Element is not attached to the DOM
  at dashboard-chart.js:163

Root cause: After searchInput.fill(fieldName), Vue reactively re-renders the field list
multiple times (debounce / virtual scroll). waitFor({ state: "visible" }) passed during
an intermediate render, then Vue triggered another re-render, detaching the element before
scrollIntoViewIfNeeded() could act on it.

---

### Changes Made

1. tests/ui-testing/pages/dashboardPages/dashboard-chart.js — Flakiness Fix
   - Removed redundant scrollIntoViewIfNeeded() — hover() already auto-scrolls
   - Wrapped hover() in a 3-attempt retry loop that re-waits for the element after
     each DOM detachment
   - Raised initial waitFor timeout from 5000ms → 10000ms for heavier field lists

2. tests/ui-testing/playwright-tests/Dashboards/dashboard-table-chart.spec.js — Two changes

   a) Replaced waitForStreamComplete with page.waitForResponse + explicit status assertion
      - waitForStreamComplete silently timed out on non-200 responses — no assertion
      - page.waitForResponse resolves on any matching URL response, then
        expect(apiResponse.status()).toBe(200) fails clearly on 401/500

   b) Fixed vacuous assertion (Test Inspector finding)
      - Original predicate had && r.status() === 200 — waitForResponse would only resolve
        on 200, making expect(apiResponse.status()).toBe(200) always true (no-op)
      - Removed status condition from predicate so the expect() is now a real assertion

---

### Test Inspector Findings Addressed

| Finding                                                              | Status              |
|----------------------------------------------------------------------|---------------------|
| Vacuous assertion — expect(apiResponse.status()).toBe(200) was no-op | Fixed               |
| Selector cross-validation — o-field-list-row-* matches OFieldList.vue:67 | Verified        |

