### PR TITLE
fix(pipelines): prevent preview popup from overflowing viewport

### DIFF
--- a/web/src/components/pipeline/PipelinesList.vue
+++ b/web/src/components/pipeline/PipelinesList.vue
@@ -1,4 +1,4 @@
-﻿<!-- Copyright 2026 OpenObserve Inc.
+<!-- Copyright 2026 OpenObserve Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
@@ -99,7 +99,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :title="t('pipeline.view')"
               icon-left="visibility"
             >
-              <OTooltip max-width="none">
+              <OTooltip max-width="none" side="left">
                 <template #content
                   ><PipelineView :pipeline="row"
                 /></template>


### PR DESCRIPTION
This PR fixes a UI layout bug where the pipeline graph preview popup would overflow past the right edge of the viewport when hovering over the View action button. By setting the side prop of OTooltip to left, the preview card renders to the left of the button, keeping it fully visible.