### PR TITLE
fix: Field list field-expansion fixes

### DIFF
--- a/web/src/components/common/FieldValuesPanel.spec.ts
+++ b/web/src/components/common/FieldValuesPanel.spec.ts
@@ -126,6 +126,22 @@ describe("FieldValuesPanel.vue", () => {
       expect(loading.exists()).toBe(true);
     });
 
+    it("confines the loading overlay to its own box via a positioned wrapper", () => {
+      // Regression: OInnerLoading is `absolute inset-0`, so its wrapper must be a
+      // positioning context. Without `tw:relative` the overlay escaped to the
+      // nearest positioned ancestor (`.o-field-list__row`) and covered the field
+      // row, blocking the click that collapses/cancels the request.
+      wrapper = createWrapper({
+        fieldValues: { isLoading: true, values: [], errMsg: "" },
+      });
+      const loading = wrapper.find(
+        '[data-test="field-values-panel-loading-indicator"]',
+      );
+      expect(loading.exists()).toBe(true);
+      const wrapperEl = loading.element.parentElement as HTMLElement;
+      expect(wrapperEl.classList.contains("tw:relative")).toBe(true);
+    });
+
     it("hides values list while loading with no interim cache", () => {
       wrapper = createWrapper({
         fieldValues: { isLoading: true, values: [], errMsg: "" },

--- a/web/src/components/common/FieldValuesPanel.vue
+++ b/web/src/components/common/FieldValuesPanel.vue
@@ -91,7 +91,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- Scrollable values area -->
     <div class="values-scroll-container">
-      <!-- Loading state (only shown when there are no interim cached results) -->
+      <!-- Loading state (only shown when there are no interim cached results).
+           tw:relative is required: OInnerLoading is `absolute inset-0`, so this
+           wrapper must be its positioning context — otherwise the overlay escapes
+           to the nearest positioned ancestor (.o-field-list__row) and covers the
+           field row, blocking the click that collapses/cancels the request. -->
       <div
         v-show="fieldValues?.isLoading && !displayValues.length"
         class="tw:relative tw:pl-3 tw:py-1"

--- a/web/src/components/common/FieldValuesPanel.vue
+++ b/web/src/components/common/FieldValuesPanel.vue
@@ -94,7 +94,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <!-- Loading state (only shown when there are no interim cached results) -->
       <div
         v-show="fieldValues?.isLoading && !displayValues.length"
-        class="tw:pl-3 tw:py-1"
+        class="tw:relative tw:pl-3 tw:py-1"
         style="height: 3.75rem"
       >
         <OInnerLoading

--- a/web/src/plugins/logs/IndexList.spec.ts
+++ b/web/src/plugins/logs/IndexList.spec.ts
@@ -28,6 +28,7 @@ const mockExtractFields = vi.fn();
 const mockGetValuesPartition = vi.fn();
 const mockGetFilterExpressionByFieldType = vi.fn(() => "field = 'value'");
 const mockFetchQueryDataWithHttpStream = vi.fn();
+const mockCancelStreamQueryBasedOnRequestId = vi.fn();
 
 vi.mock("@/services/search", () => ({
   default: {
@@ -248,6 +249,7 @@ vi.mock("@/composables/useLocalInterestingFields", () => ({
 vi.mock("@/composables/useStreamingSearch", () => ({
   default: () => ({
     fetchQueryDataWithHttpStream: mockFetchQueryDataWithHttpStream,
+    cancelStreamQueryBasedOnRequestId: mockCancelStreamQueryBasedOnRequestId,
   }),
 }));
 
@@ -1181,25 +1183,49 @@ describe("Index List", async () => {
       expect(wrapper.vm.openedFilterFields.value).toEqual(["field1", "field3"]);
     });
 
-    it.skip("should cancel trace ID by calling cancelSearchQueryBasedOnRequestId", async () => {
+    it("should abort in-flight streams and clear the mapper in cancelTraceId", async () => {
+      mockCancelStreamQueryBasedOnRequestId.mockClear();
       const field = "testField";
-      const traceIds = ["trace1", "trace2"];
-      wrapper.vm.traceIdMapper[field] = traceIds;
-
-      const mockCancelSearchQuery = vi.fn();
-      wrapper.vm.cancelSearchQueryBasedOnRequestId = mockCancelSearchQuery;
+      wrapper.vm.traceIdMapper[field] = ["trace1", "trace2"];
 
       wrapper.vm.cancelTraceId(field);
 
-      expect(mockCancelSearchQuery).toHaveBeenCalledTimes(2);
-      expect(mockCancelSearchQuery).toHaveBeenCalledWith({
+      expect(mockCancelStreamQueryBasedOnRequestId).toHaveBeenCalledTimes(2);
+      expect(mockCancelStreamQueryBasedOnRequestId).toHaveBeenCalledWith({
         trace_id: "trace1",
         org_id: wrapper.vm.store.state.selectedOrganization.identifier,
       });
-      expect(mockCancelSearchQuery).toHaveBeenCalledWith({
+      expect(mockCancelStreamQueryBasedOnRequestId).toHaveBeenCalledWith({
         trace_id: "trace2",
         org_id: wrapper.vm.store.state.selectedOrganization.identifier,
       });
+      // Trace IDs are cleared so a re-expand starts a clean stream.
+      expect(wrapper.vm.traceIdMapper[field]).toEqual([]);
+    });
+
+    it("should cancel the in-flight request when collapsing a loading field", async () => {
+      mockCancelStreamQueryBasedOnRequestId.mockClear();
+      const field = "level";
+      // Simulate an expanded field with a request in-flight.
+      wrapper.vm.traceIdMapper[field] = ["trace-abc"];
+      wrapper.vm.fieldValues[field] = {
+        isLoading: true,
+        values: [],
+        errMsg: "",
+      };
+
+      wrapper.vm.cancelFilterCreator({ name: field });
+
+      // The HTTP stream is aborted via the trace ID...
+      expect(mockCancelStreamQueryBasedOnRequestId).toHaveBeenCalledWith({
+        trace_id: "trace-abc",
+        org_id: wrapper.vm.store.state.selectedOrganization.identifier,
+      });
+      // ...the mapper is emptied, the loading flag is cleared, and the field
+      // is marked collapsed so the row is interactive again.
+      expect(wrapper.vm.traceIdMapper[field]).toEqual([]);
+      expect(wrapper.vm.fieldValues[field].isLoading).toBe(false);
+      expect(wrapper.vm.expandedFields[field]).toBe(false);
     });
   });
 
@@ -2271,25 +2297,49 @@ describe("Index List", async () => {
       expect(wrapper.vm.openedFilterFields.value).toEqual(["field1", "field3"]);
     });
 
-    it.skip("should cancel trace ID by calling cancelSearchQueryBasedOnRequestId", async () => {
+    it("should abort in-flight streams and clear the mapper in cancelTraceId", async () => {
+      mockCancelStreamQueryBasedOnRequestId.mockClear();
       const field = "testField";
-      const traceIds = ["trace1", "trace2"];
-      wrapper.vm.traceIdMapper[field] = traceIds;
-
-      const mockCancelSearchQuery = vi.fn();
-      wrapper.vm.cancelSearchQueryBasedOnRequestId = mockCancelSearchQuery;
+      wrapper.vm.traceIdMapper[field] = ["trace1", "trace2"];
 
       wrapper.vm.cancelTraceId(field);
 
-      expect(mockCancelSearchQuery).toHaveBeenCalledTimes(2);
-      expect(mockCancelSearchQuery).toHaveBeenCalledWith({
+      expect(mockCancelStreamQueryBasedOnRequestId).toHaveBeenCalledTimes(2);
+      expect(mockCancelStreamQueryBasedOnRequestId).toHaveBeenCalledWith({
         trace_id: "trace1",
         org_id: wrapper.vm.store.state.selectedOrganization.identifier,
       });
-      expect(mockCancelSearchQuery).toHaveBeenCalledWith({
+      expect(mockCancelStreamQueryBasedOnRequestId).toHaveBeenCalledWith({
         trace_id: "trace2",
         org_id: wrapper.vm.store.state.selectedOrganization.identifier,
       });
+      // Trace IDs are cleared so a re-expand starts a clean stream.
+      expect(wrapper.vm.traceIdMapper[field]).toEqual([]);
+    });
+
+    it("should cancel the in-flight request when collapsing a loading field", async () => {
+      mockCancelStreamQueryBasedOnRequestId.mockClear();
+      const field = "level";
+      // Simulate an expanded field with a request in-flight.
+      wrapper.vm.traceIdMapper[field] = ["trace-abc"];
+      wrapper.vm.fieldValues[field] = {
+        isLoading: true,
+        values: [],
+        errMsg: "",
+      };
+
+      wrapper.vm.cancelFilterCreator({ name: field });
+
+      // The HTTP stream is aborted via the trace ID...
+      expect(mockCancelStreamQueryBasedOnRequestId).toHaveBeenCalledWith({
+        trace_id: "trace-abc",
+        org_id: wrapper.vm.store.state.selectedOrganization.identifier,
+      });
+      // ...the mapper is emptied, the loading flag is cleared, and the field
+      // is marked collapsed so the row is interactive again.
+      expect(wrapper.vm.traceIdMapper[field]).toEqual([]);
+      expect(wrapper.vm.fieldValues[field].isLoading).toBe(false);
+      expect(wrapper.vm.expandedFields[field]).toBe(false);
     });
   });
 

--- a/web/src/plugins/logs/IndexList.vue
+++ b/web/src/plugins/logs/IndexList.vue
@@ -358,13 +358,11 @@ export default defineComponent({
     const { fnParsedSQL, fnUnparsedSQL, updatedLocalLogFilterField } =
       logsUtils();
 
-    const {
-      fetchQueryDataWithWebSocket,
-      sendSearchMessageBasedOnRequestId,
-      cancelSearchQueryBasedOnRequestId,
-    } = useSearchWebSocket();
+    const { fetchQueryDataWithWebSocket, sendSearchMessageBasedOnRequestId } =
+      useSearchWebSocket();
 
-    const { fetchQueryDataWithHttpStream } = useHttpStreaming();
+    const { fetchQueryDataWithHttpStream, cancelStreamQueryBasedOnRequestId } =
+      useHttpStreaming();
 
     const traceIdMapper = ref<{ [key: string]: string[] }>({});
 
@@ -1864,10 +1862,14 @@ export default defineComponent({
     };
 
     const cancelFilterCreator = (row: any) => {
-      //if it is websocker based then cancel the trace id
-      //else cancel the further value api calls using the openedFilterFields
+      // Abort the in-flight HTTP-stream values request so collapsing actually
+      // cancels a slow fetch, then clear local state.
       expandedFields.value[row.name] = false;
+      cancelTraceId(row.name);
       cancelValueApi(row.name);
+      if (fieldValues.value[row.name]) {
+        fieldValues.value[row.name].isLoading = false;
+      }
       delete lastFieldFetchPayloads.value[row.name];
       delete cachedFieldValues.value[row.name];
       delete cachedStreamFieldValues.value[row.name];
@@ -1877,14 +1879,17 @@ export default defineComponent({
     };
 
     const cancelTraceId = (field: string) => {
+      // Field values stream over fetchQueryDataWithHttpStream, so abort via the
+      // HTTP-stream cancel (cancelStreamQueryBasedOnRequestId), not the WebSocket one.
       const traceIds = traceIdMapper.value[field];
-      if (traceIds) {
-        traceIds.forEach((traceId) => {
-          cancelSearchQueryBasedOnRequestId({
+      if (traceIds?.length) {
+        traceIds.forEach((traceId) =>
+          cancelStreamQueryBasedOnRequestId({
             trace_id: traceId,
             org_id: store?.state?.selectedOrganization?.identifier,
-          });
-        });
+          }),
+        );
+        traceIdMapper.value[field] = [];
       }
     };
 


### PR DESCRIPTION
## What changed

- **FieldValuesPanel.vue** — Added `tw:relative` to the loading wrapper so the `OInnerLoading` overlay (which is `absolute inset-0`) is contained within the expanded section instead of spilling over the entire field row.
- **IndexList.vue** — Reworked `cancelTraceId` to use `cancelStreamQueryBasedOnRequestId` (HTTP stream abort) instead of the now-removed `cancelSearchQueryBasedOnRequestId`. Updated `cancelFilterCreator` to call `cancelTraceId`, clear `isLoading`, and empty `traceIdMapper` entries.
- **FieldValuesPanel.spec.ts** — Regression test asserting the loading wrapper carries `tw:relative`.
- **IndexList.spec.ts** — Un-skipped two previously skipped cancel tests and updated them to assert on `mockCancelStreamQueryBasedOnRequestId`. Added new regression tests for the `cancelFilterCreator` → `cancelTraceId` flow on collapse.

## Why

The loading overlay (`OInnerLoading`) uses `absolute inset-0` positioning. Without a positioned ancestor, it escaped to the nearest parent (`.o-field-list__row`), covering the field row and the collapse toggle. This made it impossible for users to collapse a slow-loading field to cancel the request. The cancel logic itself was also broken — it referenced a WebSocket-based cancel function that no longer matched the actual HTTP-stream transport used for field values.