### PR TITLE
fix(stream): keep schema settings footer visible when empty

### DIFF
--- a/web/src/components/logstream/schema.vue
+++ b/web/src/components/logstream/schema.vue
@@ -789,10 +789,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- floating footer for the table -->
                 <div class="floating-buttons tw:flex-shrink-0 tw:px-2 tw:py-1">
                   <div
-                    v-if="indexData.schema.length > 0"
                     class="tw:flex tw:items-center tw:justify-between"
                   >
-                    <div class="tw:flex tw:items-center tw:gap-2">
+                    <div v-if="indexData.schema.length > 0" class="tw:flex tw:items-center tw:gap-2">
                       <span
                         v-if="activeMainTab == 'schemaSettings'"
                         class="tw:px-2 tw:py-2"


### PR DESCRIPTION
This PR resolves issue #11432 where the bottom footer (containing the Cancel and Update Settings buttons) in the stream schema settings drawer disappears if all fields are deleted or if the stream has no fields. By removing the v-if constraint from the wrapper and applying it only to the fields count and actions section, the user is always able to submit or cancel their configuration changes.