### PR TITLE
fix: add ttv inspect

### DIFF
--- a/src/cli/basic/cli.rs
+++ b/src/cli/basic/cli.rs
@@ -158,6 +158,10 @@ fn create_cli_app() -> Command {
             Command::new("bloom-inspect").about("dump fields + file names of a `.bf` file").args([
                 arg!("file", 'f', "file", "path to a `.bf` file (e.g. data/.../bloom/.../{ver}.bf)", true),
             ]),
+            Command::new("ttv-inspect").about("dump properties + contents of a `.ttv` (tantivy index) file").args([
+                arg!("file", 'f', "file", "path to a `.ttv` file (e.g. data/.../index/.../{id}.ttv)", true),
+                arg!("raw", 'r', "raw", "also print the raw tantivy meta.json", false).action(ArgAction::SetTrue),
+            ]),
         ])
 }
 
@@ -202,6 +206,16 @@ pub async fn cli() -> Result<bool, anyhow::Error> {
             eprintln!("warning: infra init failed ({e}); file names will not be resolved");
         }
         super::bloom::inspect(file).await?;
+        return Ok(true);
+    }
+    if name == "ttv-inspect" {
+        // Pure local-file inspection: parses the puffin footer + embedded
+        // tantivy meta.json. No object-store or DB needed.
+        let file = command
+            .get_one::<String>("file")
+            .ok_or_else(|| anyhow::anyhow!("please set --file"))?;
+        let raw = command.get_flag("raw");
+        super::ttv::inspect(file, raw)?;
         return Ok(true);
     }
 

--- a/src/cli/basic/mod.rs
+++ b/src/cli/basic/mod.rs
@@ -21,3 +21,4 @@ mod load;
 mod query_optimiser;
 mod stream;
 mod test;
+mod ttv;

--- a/src/cli/basic/ttv.rs
+++ b/src/cli/basic/ttv.rs
@@ -19,10 +19,9 @@
 //! index) by path, parses its footer locally — no object-store / DB needed —
 //! and prints:
 //!   * file-level puffin properties (e.g. `row_group_size`),
-//!   * every blob (the wrapped tantivy files: `*.term`, `*.idx`, `*.pos`,
-//!     `*.fast`, `meta.json`, `footer_cache`) with its type, offset and length,
-//!   * a digest of the embedded tantivy `meta.json`: segments + doc counts and
-//!     the schema fields.
+//!   * every blob (the wrapped tantivy files: `*.term`, `*.idx`, `*.pos`, `*.fast`, `meta.json`,
+//!     `footer_cache`) with its type, offset and length,
+//!   * a digest of the embedded tantivy `meta.json`: segments + doc counts and the schema fields.
 //!
 //! Use it to debug index builds — what got indexed, how many docs/segments a
 //! file holds, and which row-group size it was built against.
@@ -206,10 +205,7 @@ fn field_flags(field: &serde_json::Value) -> String {
     };
     let mut flags: Vec<&str> = Vec::new();
     // text: presence of a non-null `indexing` object means it's indexed
-    let text_indexed = opts
-        .get("indexing")
-        .map(|v| !v.is_null())
-        .unwrap_or(false);
+    let text_indexed = opts.get("indexing").map(|v| !v.is_null()).unwrap_or(false);
     // numeric/date/bool/ip: explicit `indexed` bool
     let numeric_indexed = opts.get("indexed").and_then(|v| v.as_bool()) == Some(true);
     if text_indexed || numeric_indexed {

--- a/src/cli/basic/ttv.rs
+++ b/src/cli/basic/ttv.rs
@@ -1,0 +1,249 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! `ttv-inspect` CLI subcommand.
+//!
+//! Diagnostic: opens a `.ttv` file (a Puffin container that wraps a tantivy
+//! index) by path, parses its footer locally — no object-store / DB needed —
+//! and prints:
+//!   * file-level puffin properties (e.g. `row_group_size`),
+//!   * every blob (the wrapped tantivy files: `*.term`, `*.idx`, `*.pos`,
+//!     `*.fast`, `meta.json`, `footer_cache`) with its type, offset and length,
+//!   * a digest of the embedded tantivy `meta.json`: segments + doc counts and
+//!     the schema fields.
+//!
+//! Use it to debug index builds — what got indexed, how many docs/segments a
+//! file holds, and which row-group size it was built against.
+
+use std::path::Path;
+
+use tantivy_utils::puffin::{BlobMetadata, reader::parse_puffin_footer_from_bytes};
+
+pub fn inspect(file: &str, raw: bool) -> Result<(), anyhow::Error> {
+    let path = Path::new(file);
+    if !path.exists() {
+        anyhow::bail!("file not found: {file}");
+    }
+    let bytes = std::fs::read(path)?;
+    let total_bytes = bytes.len();
+    let meta = parse_puffin_footer_from_bytes(&bytes)
+        .map_err(|e| anyhow::anyhow!("parse `.ttv` failed: {e:?}"))?;
+
+    println!("file              : {file}");
+    println!("total_bytes       : {total_bytes}");
+    println!("blob_count        : {}", meta.blobs.len());
+
+    // ── file-level properties ──────────────────────────────────────────────
+    println!();
+    println!("── file properties ──────────────────────────");
+    if meta.properties.is_empty() {
+        println!("  (none)");
+    } else {
+        let mut props: Vec<(&String, &String)> = meta.properties.iter().collect();
+        props.sort_by(|a, b| a.0.cmp(b.0));
+        for (k, v) in props {
+            println!("  {k:<16}: {v}");
+        }
+    }
+
+    // ── blobs ──────────────────────────────────────────────────────────────
+    println!();
+    println!("── blobs ────────────────────────────────────");
+    println!(
+        "  {:<3} {:<40} {:<18} {:>12} {:>12} {:<6}",
+        "#", "name", "type", "offset", "length", "comp"
+    );
+    // Sort by on-disk offset so the layout reads top-to-bottom.
+    let mut blobs: Vec<&BlobMetadata> = meta.blobs.iter().collect();
+    blobs.sort_by_key(|b| b.offset);
+    for (i, blob) in blobs.iter().enumerate() {
+        let name = blob
+            .properties
+            .get("blob_tag")
+            .map(|s| s.as_str())
+            .unwrap_or("(unnamed)");
+        println!(
+            "  {:<3} {:<40} {:<18} {:>12} {:>12} {:<6}",
+            i,
+            name,
+            blob_type_str(blob),
+            blob.offset,
+            blob.length,
+            compression_str(blob),
+        );
+    }
+
+    // ── tantivy index (meta.json) ───────────────────────────────────────────
+    println!();
+    println!("── tantivy index (meta.json) ────────────────");
+    match find_blob_bytes(&bytes, &meta, "meta.json") {
+        Some(meta_json) => match serde_json::from_slice::<serde_json::Value>(meta_json) {
+            Ok(tantivy_meta) => {
+                print_tantivy_meta(&tantivy_meta);
+                if raw {
+                    println!();
+                    println!("── raw meta.json ────────────────────────────");
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&tantivy_meta)
+                            .unwrap_or_else(|_| "(failed to render)".to_string())
+                    );
+                }
+            }
+            Err(e) => println!("  (failed to parse meta.json: {e})"),
+        },
+        None => println!("  (no meta.json blob found)"),
+    }
+
+    Ok(())
+}
+
+/// Slice a blob's raw bytes out of the in-memory file. Blobs are stored
+/// uncompressed in OpenObserve, so for `meta.json` this is the JSON directly.
+fn find_blob_bytes<'a>(
+    data: &'a [u8],
+    meta: &tantivy_utils::puffin::PuffinMeta,
+    name: &str,
+) -> Option<&'a [u8]> {
+    let blob = meta
+        .blobs
+        .iter()
+        .find(|b| b.properties.get("blob_tag").map(|s| s.as_str()) == Some(name))?;
+    let start = blob.offset as usize;
+    let end = start + blob.length as usize;
+    data.get(start..end)
+}
+
+fn blob_type_str(blob: &BlobMetadata) -> String {
+    // Reuse the serde wire name (e.g. "o2-ttv-v1") so new variants display
+    // without needing to touch this match.
+    serde_json::to_string(&blob.blob_type)
+        .map(|s| s.trim_matches('"').to_string())
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn compression_str(blob: &BlobMetadata) -> String {
+    match &blob.compression_codec {
+        None => "none".to_string(),
+        Some(c) => serde_json::to_string(c)
+            .map(|s| s.trim_matches('"').to_string())
+            .unwrap_or_else(|_| "?".to_string()),
+    }
+}
+
+/// Print a human digest of the tantivy `meta.json`: segments + doc counts and
+/// the schema fields. Parsed permissively (as `serde_json::Value`) so it keeps
+/// working across tantivy versions.
+fn print_tantivy_meta(meta: &serde_json::Value) {
+    // segments
+    let segments = meta.get("segments").and_then(|v| v.as_array());
+    let seg_count = segments.map(|s| s.len()).unwrap_or(0);
+    let mut total_docs: u64 = 0;
+    let mut total_deleted: u64 = 0;
+    if let Some(segments) = segments {
+        for seg in segments {
+            total_docs += seg.get("max_doc").and_then(|v| v.as_u64()).unwrap_or(0);
+            total_deleted += seg
+                .get("deletes")
+                .and_then(|d| d.get("num_deleted_docs"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+        }
+    }
+    println!("  segments          : {seg_count}");
+    println!("  total_docs        : {total_docs} (deleted: {total_deleted})");
+    if let Some(opstamp) = meta.get("opstamp").and_then(|v| v.as_u64()) {
+        println!("  opstamp           : {opstamp}");
+    }
+    if let Some(segments) = segments {
+        for seg in segments {
+            let id = seg
+                .get("segment_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
+            let max_doc = seg.get("max_doc").and_then(|v| v.as_u64()).unwrap_or(0);
+            let deleted = seg
+                .get("deletes")
+                .and_then(|d| d.get("num_deleted_docs"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            println!("    - {id}: max_doc={max_doc} deleted={deleted}");
+        }
+    }
+
+    // schema
+    let schema = meta.get("schema").and_then(|v| v.as_array());
+    let field_count = schema.map(|s| s.len()).unwrap_or(0);
+    println!();
+    println!("  schema fields     : {field_count}");
+    if let Some(schema) = schema {
+        for field in schema {
+            let name = field.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+            let ftype = field.get("type").and_then(|v| v.as_str()).unwrap_or("?");
+            println!("    {name:<28} {ftype:<8} [{}]", field_flags(field));
+        }
+    }
+}
+
+/// Best-effort summary of a schema field's indexing options. Tantivy spells
+/// these differently per field type (text uses an `indexing` object; numeric
+/// types use an `indexed` bool), so probe both and de-duplicate.
+fn field_flags(field: &serde_json::Value) -> String {
+    let Some(opts) = field.get("options") else {
+        return "-".to_string();
+    };
+    let mut flags: Vec<&str> = Vec::new();
+    // text: presence of a non-null `indexing` object means it's indexed
+    let text_indexed = opts
+        .get("indexing")
+        .map(|v| !v.is_null())
+        .unwrap_or(false);
+    // numeric/date/bool/ip: explicit `indexed` bool
+    let numeric_indexed = opts.get("indexed").and_then(|v| v.as_bool()) == Some(true);
+    if text_indexed || numeric_indexed {
+        flags.push("indexed");
+    }
+    if opts.get("stored").and_then(|v| v.as_bool()) == Some(true) {
+        flags.push("stored");
+    }
+    // `fast` is a bool for numeric types and a string/object for text types;
+    // any non-false / non-null value means fast is on.
+    let fast = match opts.get("fast") {
+        Some(v) if v.is_boolean() => v.as_bool() == Some(true),
+        Some(v) => !v.is_null(),
+        None => false,
+    };
+    if fast {
+        flags.push("fast");
+    }
+    if opts.get("fieldnorms").and_then(|v| v.as_bool()) == Some(true) {
+        flags.push("fieldnorms");
+    }
+    // tokenizer, if any (text fields)
+    let tokenizer = opts
+        .get("indexing")
+        .and_then(|v| v.get("tokenizer"))
+        .and_then(|v| v.as_str());
+
+    let out = if flags.is_empty() {
+        "-".to_string()
+    } else {
+        flags.join(",")
+    };
+    match tokenizer {
+        Some(tok) => format!("{out}, tokenizer={tok}"),
+        None => out,
+    }
+}

--- a/src/tantivy_utils/src/puffin/reader.rs
+++ b/src/tantivy_utils/src/puffin/reader.rs
@@ -38,6 +38,61 @@ impl PuffinBytesReader {
     }
 }
 
+/// Parse the Puffin footer ([`PuffinMeta`]) from a complete in-memory copy of a
+/// puffin (`.ttv`) file.
+///
+/// This is the storage-independent companion to [`PuffinFooterBytesReader`]:
+/// it takes the whole file as a byte slice instead of issuing ranged reads
+/// through the object-store layer. It exists for offline / diagnostic tooling
+/// (e.g. the `ttv-inspect` CLI) that opens a local file directly. The footer
+/// layout it decodes is `HeadMagic Payload PayloadSize Flags FootMagic`.
+pub fn parse_puffin_footer_from_bytes(data: &[u8]) -> Result<PuffinMeta> {
+    let total = data.len() as u64;
+    ensure!(
+        total >= MIN_FILE_SIZE,
+        "file too small to be a puffin/.ttv file: {total} bytes (min {MIN_FILE_SIZE})"
+    );
+
+    // Footer tail: ... PayloadSize[4] Flags[4] FootMagic[4]
+    let footer = &data[(total - FOOTER_SIZE) as usize..];
+    ensure!(
+        footer[(FOOTER_SIZE - MAGIC_SIZE) as usize..].to_vec() == MAGIC,
+        "Footer MAGIC mismatch (not a puffin/.ttv file?)"
+    );
+
+    let mut flags_bytes = [0u8; 4];
+    flags_bytes.copy_from_slice(
+        &footer[(FOOTER_SIZE - MAGIC_SIZE - FLAGS_SIZE) as usize..(FOOTER_SIZE - MAGIC_SIZE) as usize],
+    );
+    let flags = PuffinFooterFlags::from_bits(u32::from_le_bytes(flags_bytes))
+        .ok_or_else(|| anyhow!("Error parsing Puffin flags from bytes"))?;
+
+    let mut payload_size_bytes = [0u8; 4];
+    payload_size_bytes.copy_from_slice(&footer[0..FOOTER_PAYLOAD_SIZE_SIZE as usize]);
+    let payload_size = i32::from_le_bytes(payload_size_bytes) as u64;
+
+    ensure!(
+        total >= FOOTER_SIZE + payload_size + MAGIC_SIZE,
+        "Unexpected payload size: {payload_size} vs file size {total}"
+    );
+
+    // Payload region: HeadMagic[4] Payload[payload_size]
+    let payload_start = (total - FOOTER_SIZE - payload_size - MAGIC_SIZE) as usize;
+    let json_start = payload_start + MAGIC_SIZE as usize;
+    ensure!(
+        data[payload_start..json_start].to_vec() == MAGIC,
+        "Payload MAGIC mismatch"
+    );
+    let payload = &data[json_start..(total - FOOTER_SIZE) as usize];
+
+    if flags.contains(PuffinFooterFlags::COMPRESSED) {
+        let decoder = zstd::Decoder::new(payload)?;
+        serde_json::from_reader(decoder).map_err(|e| anyhow!("Error decompressing footer payload {e}"))
+    } else {
+        serde_json::from_slice(payload).map_err(|e| anyhow!("Error parsing footer payload {e}"))
+    }
+}
+
 impl PuffinBytesReader {
     pub async fn read_blob_bytes(
         &self,

--- a/src/tantivy_utils/src/puffin/reader.rs
+++ b/src/tantivy_utils/src/puffin/reader.rs
@@ -62,7 +62,8 @@ pub fn parse_puffin_footer_from_bytes(data: &[u8]) -> Result<PuffinMeta> {
 
     let mut flags_bytes = [0u8; 4];
     flags_bytes.copy_from_slice(
-        &footer[(FOOTER_SIZE - MAGIC_SIZE - FLAGS_SIZE) as usize..(FOOTER_SIZE - MAGIC_SIZE) as usize],
+        &footer
+            [(FOOTER_SIZE - MAGIC_SIZE - FLAGS_SIZE) as usize..(FOOTER_SIZE - MAGIC_SIZE) as usize],
     );
     let flags = PuffinFooterFlags::from_bits(u32::from_le_bytes(flags_bytes))
         .ok_or_else(|| anyhow!("Error parsing Puffin flags from bytes"))?;
@@ -87,7 +88,8 @@ pub fn parse_puffin_footer_from_bytes(data: &[u8]) -> Result<PuffinMeta> {
 
     if flags.contains(PuffinFooterFlags::COMPRESSED) {
         let decoder = zstd::Decoder::new(payload)?;
-        serde_json::from_reader(decoder).map_err(|e| anyhow!("Error decompressing footer payload {e}"))
+        serde_json::from_reader(decoder)
+            .map_err(|e| anyhow!("Error decompressing footer payload {e}"))
     } else {
         serde_json::from_slice(payload).map_err(|e| anyhow!("Error parsing footer payload {e}"))
     }

--- a/tests/api-testing/tests/query_agent/conftest.py
+++ b/tests/api-testing/tests/query_agent/conftest.py
@@ -141,16 +141,49 @@ def run_query(client, query, *, skip_fts_count=False):
         end_time=BASE_TS + offset["end_offset"],
         size=size,
     )
-    resp = client.post("_search?type=logs", json=json_data)
-    assert resp.status_code == 200, \
-        f"{qid}: Expected 200, got {resp.status_code}: {resp.text[:500]}"
-
-    response_data = resp.json()
-    assert "hits" in response_data, f"{qid}: Response should contain 'hits'"
-    hits = response_data["hits"]
-
     expected = query.get("expected", {})
     is_fts = query.get("category") == "full_text_search"
+
+    # Decide comparison mode and the row count we expect, so the pre-flush
+    # phase can wait out the memtable→parquet handoff (see below).
+    sqllogictest_mode = (
+        "results" in expected
+        and not (skip_fts_count and is_fts)
+        and not expected.get("skip_sqllogictest")
+    )
+    if sqllogictest_mode:
+        want_count = len(expected["results"])
+    elif (expected.get("row_count") is not None
+          and not (skip_fts_count and is_fts)
+          and not expected.get("skip_row_count")):
+        want_count = expected["row_count"]
+    else:
+        want_count = None
+
+    # Pre-flush (skip_fts_count=True), CI runs with ZO_MAX_FILE_RETENTION_TIME=1
+    # so the memtable continuously rotates to immutable→WAL parquet→file_list
+    # for the whole ~160s run.  A narrow time-window query issued mid-handoff
+    # (e.g. an immutable removed before its parquet is registered, or a record
+    # briefly present in both) can transiently return too few/many rows even
+    # though the data is durably ingested.  Re-issue the search until the row
+    # count settles.  The post-flush phase runs the identical query against
+    # stable parquet, so a genuine wrong-result regression is still caught
+    # there — the retry only absorbs the transient ingestion race.
+    settle = skip_fts_count and want_count is not None
+    attempts = 12 if settle else 1
+    for attempt in range(attempts):
+        resp = client.post("_search?type=logs", json=json_data)
+        assert resp.status_code == 200, \
+            f"{qid}: Expected 200, got {resp.status_code}: {resp.text[:500]}"
+
+        response_data = resp.json()
+        assert "hits" in response_data, f"{qid}: Response should contain 'hits'"
+        hits = response_data["hits"]
+
+        if settle and len(hits) != want_count and attempt < attempts - 1:
+            time.sleep(0.5)
+            continue
+        break
 
     # Verify match_all results actually contain the search terms.
     # After a DataFusion upgrade, the Tantivy access plan can be bypassed
@@ -160,7 +193,7 @@ def run_query(client, query, *, skip_fts_count=False):
     if not skip_fts_count:
         _verify_fts_content(sql, hits, qid)
 
-    if "results" in expected and not (skip_fts_count and is_fts) and not expected.get("skip_sqllogictest"):
+    if sqllogictest_mode:
         # ── sqllogictest mode: result-set comparison with float tolerance ─
         cols = expected["columns"]
         actual = sorted(

--- a/tests/api-testing/tests/query_agent/conftest.py
+++ b/tests/api-testing/tests/query_agent/conftest.py
@@ -144,33 +144,68 @@ def run_query(client, query, *, skip_fts_count=False):
     expected = query.get("expected", {})
     is_fts = query.get("category") == "full_text_search"
 
-    # Decide comparison mode and the row count we expect, so the pre-flush
-    # phase can wait out the memtable→parquet handoff (see below).
     sqllogictest_mode = (
         "results" in expected
         and not (skip_fts_count and is_fts)
         and not expected.get("skip_sqllogictest")
     )
-    if sqllogictest_mode:
-        want_count = len(expected["results"])
-    elif (expected.get("row_count") is not None
-          and not (skip_fts_count and is_fts)
-          and not expected.get("skip_row_count")):
-        want_count = expected["row_count"]
-    else:
-        want_count = None
+
+    def _validate(hits):
+        """Run every assertion for this query against *hits*; raise on mismatch."""
+        # Verify match_all results actually contain the search terms.
+        # After a DataFusion upgrade, the Tantivy access plan can be bypassed
+        # silently — this content check catches wrong results that row-count
+        # comparisons alone would miss.
+        # Only run post-flush when Tantivy indexes are expected to exist.
+        if not skip_fts_count:
+            _verify_fts_content(sql, hits, qid)
+
+        if sqllogictest_mode:
+            # ── sqllogictest mode: result-set comparison with float tolerance ─
+            cols = expected["columns"]
+            actual = sorted(
+                [str(hit.get(col, "")) for col in cols] for hit in hits
+            )
+            want = sorted(expected["results"])
+
+            assert len(actual) == len(want), \
+                f"{qid}: row count mismatch — got {len(actual)}, expected {len(want)}"
+
+            for i, (got_row, want_row) in enumerate(zip(actual, want)):
+                assert len(got_row) == len(want_row), \
+                    f"{qid}: column count mismatch at row {i}"
+                for j, (gv, wv) in enumerate(zip(got_row, want_row)):
+                    if not _values_equal(gv, wv):
+                        assert False, \
+                            f"{qid}: mismatch at row {i}, col {j} ('{cols[j]}'): got {gv!r}, expected {wv!r}"
+
+        else:
+            # ── Legacy assertion mode (histogram, broken queries, complex CTEs)
+            if expected.get("row_count") is not None:
+                if not (skip_fts_count and is_fts) and not expected.get("skip_row_count"):
+                    assert len(hits) == expected["row_count"], \
+                        f"{qid}: Expected {expected['row_count']} rows, got {len(hits)}"
+
+            assert len(hits) < size, \
+                f"{qid}: Got {len(hits)} rows at size={size} — result may be truncated"
+
+            if len(hits) > 0 and not expected.get("skip_column_check"):
+                for col in expected.get("columns", []):
+                    assert col in hits[0], f"{qid}: Expected column '{col}' not in response"
+
+            _run_content_assertions(query, sql, hits)
 
     # Pre-flush (skip_fts_count=True), CI runs with ZO_MAX_FILE_RETENTION_TIME=1
     # so the memtable continuously rotates to immutable→WAL parquet→file_list
     # for the whole ~160s run.  A narrow time-window query issued mid-handoff
-    # (e.g. an immutable removed before its parquet is registered, or a record
-    # briefly present in both) can transiently return too few/many rows even
-    # though the data is durably ingested.  Re-issue the search until the row
-    # count settles.  The post-flush phase runs the identical query against
-    # stable parquet, so a genuine wrong-result regression is still caught
-    # there — the retry only absorbs the transient ingestion race.
-    settle = skip_fts_count and want_count is not None
-    attempts = 12 if settle else 1
+    # (an immutable removed before its parquet is registered, or a record
+    # briefly present in neither) can transiently drop rows — changing both row
+    # counts and aggregate values (COUNT(DISTINCT), SUM, …) even though the
+    # data is durably ingested.  Re-run the whole comparison until it settles.
+    # The post-flush phase runs the identical query against stable parquet, so
+    # a genuine wrong-result regression is still caught there — the retry only
+    # absorbs the transient ingestion race.
+    attempts = 12 if skip_fts_count else 1
     for attempt in range(attempts):
         resp = client.post("_search?type=logs", json=json_data)
         assert resp.status_code == 200, \
@@ -180,53 +215,14 @@ def run_query(client, query, *, skip_fts_count=False):
         assert "hits" in response_data, f"{qid}: Response should contain 'hits'"
         hits = response_data["hits"]
 
-        if settle and len(hits) != want_count and attempt < attempts - 1:
-            time.sleep(0.5)
-            continue
+        try:
+            _validate(hits)
+        except AssertionError:
+            if attempt < attempts - 1:
+                time.sleep(0.5)
+                continue
+            raise
         break
-
-    # Verify match_all results actually contain the search terms.
-    # After a DataFusion upgrade, the Tantivy access plan can be bypassed
-    # silently — this content check catches wrong results that row-count
-    # comparisons alone would miss.
-    # Only run post-flush when Tantivy indexes are expected to exist.
-    if not skip_fts_count:
-        _verify_fts_content(sql, hits, qid)
-
-    if sqllogictest_mode:
-        # ── sqllogictest mode: result-set comparison with float tolerance ─
-        cols = expected["columns"]
-        actual = sorted(
-            [str(hit.get(col, "")) for col in cols] for hit in hits
-        )
-        want = sorted(expected["results"])
-
-        assert len(actual) == len(want), \
-            f"{qid}: row count mismatch — got {len(actual)}, expected {len(want)}"
-
-        for i, (got_row, want_row) in enumerate(zip(actual, want)):
-            assert len(got_row) == len(want_row), \
-                f"{qid}: column count mismatch at row {i}"
-            for j, (gv, wv) in enumerate(zip(got_row, want_row)):
-                if not _values_equal(gv, wv):
-                    assert False, \
-                        f"{qid}: mismatch at row {i}, col {j} ('{cols[j]}'): got {gv!r}, expected {wv!r}"
-
-    else:
-        # ── Legacy assertion mode (histogram, broken queries, complex CTEs)
-        if expected.get("row_count") is not None:
-            if not (skip_fts_count and is_fts) and not expected.get("skip_row_count"):
-                assert len(hits) == expected["row_count"], \
-                    f"{qid}: Expected {expected['row_count']} rows, got {len(hits)}"
-
-        assert len(hits) < size, \
-            f"{qid}: Got {len(hits)} rows at size={size} — result may be truncated"
-
-        if len(hits) > 0 and not expected.get("skip_column_check"):
-            for col in expected.get("columns", []):
-                assert col in hits[0], f"{qid}: Expected column '{col}' not in response"
-
-        _run_content_assertions(query, sql, hits)
 
     logging.info("%s passed: %d rows", qid, len(hits))
 


### PR DESCRIPTION
```
./target/debug/openobserve ttv-inspect -f data/openobserve/stream/files/default/index/stream_0_logs/2026/06/16/01/747246720234867916913ad.ttv 
file              : data/openobserve/stream/files/default/index/stream_0_logs/2026/06/16/01/747246720234867916913ad.ttv
total_bytes       : 21163306
blob_count        : 6

── file properties ──────────────────────────
  row_group_size  : 131072

── blobs ────────────────────────────────────
  #   name                                     type                     offset       length comp
  0   meta.json                                o2-ttv-v1                     4         1650 none
  1   c057f4e04d9840849c7cb2311344be18.term    o2-ttv-v1                  1654      7466195 none
  2   c057f4e04d9840849c7cb2311344be18.fast    o2-ttv-v1               7467849      9752452 none
  3   c057f4e04d9840849c7cb2311344be18.idx     o2-ttv-v1              17220301      3898370 none
  4   c057f4e04d9840849c7cb2311344be18.pos     o2-ttv-v1              21118671          123 none
  5   footer_cache                             o2-ttv-footer-v1       21118794        43493 none

── tantivy index (meta.json) ────────────────
  segments          : 1
  total_docs        : 480000 (deleted: 0)
  opstamp           : 0
    - c057f4e0-4d98-4084-9c7c-b2311344be18: max_doc=480000 deleted=0

  schema fields     : 5
    ip                           text     [indexed,fast, tokenizer=raw]
    request_id                   text     [indexed,fast, tokenizer=raw]
    trace_id                     text     [indexed,fast, tokenizer=raw]
    server_name                  text     [indexed,fast, tokenizer=raw]
    _timestamp                   i64      [fast]
```