### PR TITLE
fix: added streaming progress bar in logs explorer (#12741)

### DIFF
--- a/web/src/composables/useLogs/searchAround.ts
+++ b/web/src/composables/useLogs/searchAround.ts
@@ -68,6 +68,7 @@ export const useSearchAround = () => {
   const searchAroundData = (params: SearchAroundParams): void => {
     try {
       searchObj.loading = true;
+      searchObj.loadingProgressPercentage = 0;
       searchObj.data.errorCode = 0;
       searchObj.data.functionError = "";
       const sqlContext: string[] = [];

--- a/web/src/composables/useLogs/searchState.ts
+++ b/web/src/composables/useLogs/searchState.ts
@@ -91,6 +91,9 @@ export interface SearchObject {
   meta: any;
   data: SearchObjectData;
   runQuery: boolean;
+  // Streaming progress (0-100) for the results table and histogram bars
+  loadingProgressPercentage: number;
+  loadingHistogramProgressPercentage: number;
 }
 
 // Main search object containing all search state

--- a/web/src/composables/useLogs/useSearchBar.ts
+++ b/web/src/composables/useLogs/useSearchBar.ts
@@ -293,6 +293,7 @@ export const useSearchBar = () => {
     try {
       searchObj.loadingStream = true;
       searchObj.loading = true;
+      searchObj.loadingProgressPercentage = 0;
 
       await cancelQuery();
 
@@ -414,6 +415,7 @@ export const useSearchBar = () => {
       searchObj.data.tempFunctionName = "";
       searchObj.data.tempFunctionContent = "";
       searchObj.loading = true;
+      searchObj.loadingProgressPercentage = 0;
       await getQueryData();
     } catch (e: any) {
       console.log("Error while loading logs data");

--- a/web/src/composables/useLogs/useSearchHistogramManager.ts
+++ b/web/src/composables/useLogs/useSearchHistogramManager.ts
@@ -99,6 +99,7 @@ export const useSearchHistogramManager = () => {
         resetHistogramError();
 
         searchObj.loadingHistogram = true;
+        searchObj.loadingHistogramProgressPercentage = 0;
 
         await generateHistogramSkeleton();
 
@@ -359,6 +360,7 @@ export const useSearchHistogramManager = () => {
     }
 
     searchObj.loadingHistogram = true;
+    searchObj.loadingHistogramProgressPercentage = 0;
 
     const requestId = initializeSearchConnection(payload);
 

--- a/web/src/composables/useLogs/useSearchResponseHandler.spec.ts
+++ b/web/src/composables/useLogs/useSearchResponseHandler.spec.ts
@@ -312,6 +312,21 @@ describe("useSearchResponseHandler", () => {
       expect(mockState.searchObj.data.errorMsg).toContain("Search failed");
     });
 
+    it("should reset streaming progress to 0 on error", () => {
+      mockState.searchObj.loadingProgressPercentage = 80;
+      mockState.searchObj.loadingHistogramProgressPercentage = 60;
+
+      const request = { type: "search" };
+      const error = {
+        content: { message: "boom", trace_id: "t", code: 500 },
+      };
+
+      responseHandler.handleSearchError(request, error as any);
+
+      expect(mockState.searchObj.loadingProgressPercentage).toBe(0);
+      expect(mockState.searchObj.loadingHistogramProgressPercentage).toBe(0);
+    });
+
     it("should handle cancelled search error", () => {
       // Use mockState directly
       const notifications = useNotifications();
@@ -441,6 +456,49 @@ describe("useSearchResponseHandler", () => {
       responseHandler.handleSearchResponse(payload as any, response as any);
 
       expect(mockSearchPartitionMap["trace-1"].chunks[1]).toBe(1);
+    });
+
+    it("should set results progress on event_progress for a search payload", () => {
+      const payload = { type: "search", traceId: "trace-progress" };
+      const response = { type: "event_progress", content: { percent: 42 } };
+
+      responseHandler.handleSearchResponse(payload as any, response as any);
+
+      expect(mockState.searchObj.loadingProgressPercentage).toBe(42);
+    });
+
+    it("should route event_progress to the histogram field for a histogram payload", () => {
+      mockState.searchObj.loadingProgressPercentage = 0;
+      const payload = { type: "histogram", traceId: "trace-hist" };
+      const response = { type: "event_progress", content: { percent: 73 } };
+
+      responseHandler.handleSearchResponse(payload as any, response as any);
+
+      // Histogram progress is tracked separately; results progress is untouched.
+      expect(mockState.searchObj.loadingHistogramProgressPercentage).toBe(73);
+      expect(mockState.searchObj.loadingProgressPercentage).toBe(0);
+    });
+
+    it("should default event_progress percent to 0 when missing", () => {
+      const payload = { type: "search", traceId: "trace-progress-2" };
+      const response = { type: "event_progress", content: {} };
+
+      responseHandler.handleSearchResponse(payload as any, response as any);
+
+      expect(mockState.searchObj.loadingProgressPercentage).toBe(0);
+    });
+
+    it("should reset streaming progress to 0 on cancel_response", () => {
+      mockState.searchObj.loadingProgressPercentage = 80;
+      mockState.searchObj.loadingHistogramProgressPercentage = 45;
+
+      const payload = { type: "search", traceId: "trace-cancel" };
+      const response = { type: "cancel_response", content: {} };
+
+      responseHandler.handleSearchResponse(payload as any, response as any);
+
+      expect(mockState.searchObj.loadingProgressPercentage).toBe(0);
+      expect(mockState.searchObj.loadingHistogramProgressPercentage).toBe(0);
     });
 
     it("should handle search_response_metadata", () => {

--- a/web/src/composables/useLogs/useSearchResponseHandler.ts
+++ b/web/src/composables/useLogs/useSearchResponseHandler.ts
@@ -72,6 +72,22 @@ export const useSearchResponseHandler = () => {
     payload: WebSocketSearchPayload,
     response: WebSocketSearchResponse,
   ) => {
+    // Backend streaming progress (already mapped from "progress" to
+    // "event_progress" by useStreamingSearch). Drives the top progress bar
+    // while results stream in. Mirrors the dashboard panel handling. The
+    // histogram runs as a separate stream, so its progress is tracked on a
+    // dedicated field to avoid clobbering the results progress (they can run
+    // concurrently).
+    if (response?.type === "event_progress") {
+      const percent = response?.content?.percent ?? 0;
+      if (payload.type === "histogram" || payload.type === "pageCount") {
+        searchObj.loadingHistogramProgressPercentage = percent;
+      } else {
+        searchObj.loadingProgressPercentage = percent;
+      }
+      return;
+    }
+
     if (
       payload.type === "search" &&
       response?.type === "search_response_hits"
@@ -167,6 +183,9 @@ export const useSearchResponseHandler = () => {
     if (response.type === "cancel_response") {
       searchObj.loading = false;
       searchObj.loadingHistogram = false;
+      // Clear streaming progress so a re-run after cancel starts from 0.
+      searchObj.loadingProgressPercentage = 0;
+      searchObj.loadingHistogramProgressPercentage = 0;
       searchObj.data.isOperationCancelled = false;
 
       showCancelSearchNotification();
@@ -601,6 +620,9 @@ export const useSearchResponseHandler = () => {
   const handleSearchError = async (request: any, err: WebSocketErrorResponse) => {
     searchObj.loading = false;
     searchObj.loadingHistogram = false;
+    // Clear streaming progress so the next search starts from 0, not a stale value.
+    searchObj.loadingProgressPercentage = 0;
+    searchObj.loadingHistogramProgressPercentage = 0;
 
     const { message, trace_id, code, error_detail, error } = err.content;
 

--- a/web/src/composables/useLogs/useSearchStream.ts
+++ b/web/src/composables/useLogs/useSearchStream.ts
@@ -122,12 +122,17 @@ export const useSearchStream = () => {
       });
     }
 
-    // Update loading states
+    // Update loading states. Reset streaming progress to 0 on completion so the
+    // next search never starts from a stale percentage — the leftover value can
+    // be anything the previous search ended at (e.g. 80, 90, 100), so gating on
+    // a single magic number isn't enough.
     if (payload.type === "search") {
       searchObj.loading = false;
+      searchObj.loadingProgressPercentage = 0;
     }
     if (payload.type === "histogram" || payload.type === "pageCount") {
       searchObj.loadingHistogram = false;
+      searchObj.loadingHistogramProgressPercentage = 0;
     }
 
     //we need ot make if false

--- a/web/src/plugins/logs/SearchResult.spec.ts
+++ b/web/src/plugins/logs/SearchResult.spec.ts
@@ -304,24 +304,6 @@ describe("SearchResult Component", () => {
       expect(width).toBe("");
     });
 
-    it("should compute histogramLoader when loading", () => {
-      wrapper.vm.searchObj.meta.showHistogram = true;
-      wrapper.vm.searchObj.loadingHistogram = true;
-
-      const isLoading = wrapper.vm.histogramLoader;
-
-      expect(isLoading).toBe(true);
-    });
-
-    it("should compute histogramLoader when not loading", () => {
-      wrapper.vm.searchObj.meta.showHistogram = false;
-      wrapper.vm.searchObj.loadingHistogram = false;
-
-      const isLoading = wrapper.vm.histogramLoader;
-
-      expect(isLoading).toBe(false);
-    });
-
     it("should compute getTableWidth correctly", () => {
       Object.defineProperty(window, "innerWidth", {
         writable: true,

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -294,6 +294,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             searchObj.data.histogram.errorCode != -1
           "
         >
+          <!-- Streaming progress bar for the histogram chart: keeps the chart
+            visible while it refreshes/replaces, mirroring the results table. -->
+          <LoadingProgress
+            :loading="searchObj.loadingHistogram"
+            :loadingProgressPercentage="
+              searchObj.loadingHistogramProgressPercentage || 0
+            "
+          />
           <div
             v-if="
               searchObj.meta.showHistogram &&
@@ -373,10 +381,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 >.</span
               >
             </h5>
-          </div>
-
-          <div class="tw:pb-2 histogram-loader" v-if="histogramLoader">
-            <OSpinner size="xs" class="search-spinner" />
           </div>
         </div>
         <div
@@ -488,6 +492,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :width="getTableWidth"
             :err-msg="searchObj.data.missingStreamMessage"
             :loading="searchObj.loading"
+            :loadingProgressPercentage="searchObj.loadingProgressPercentage || 0"
             :functionErrorMsg="searchObj?.data?.functionError"
             :expandedRows="expandedLogs"
             :highlight-timestamp="searchObj.data?.searchAround?.indexTimestamp"
@@ -705,6 +710,7 @@ import OPagination from "@/lib/navigation/Pagination/OPagination.vue";
 import ODropdown from "@/lib/overlay/Dropdown/ODropdown.vue";
 import ODropdownItem from "@/lib/overlay/Dropdown/ODropdownItem.vue";
 import OBadge from "@/lib/core/Badge/OBadge.vue";
+import LoadingProgress from "@/components/common/LoadingProgress.vue";
 import { toast } from "@/lib/feedback/Toast/useToast";
 
 export default defineComponent({
@@ -717,6 +723,7 @@ export default defineComponent({
     OTooltip,
     OSelect,
     OPagination,
+    LoadingProgress,
     DetailTable: defineAsyncComponent(() => import("./DetailTable.vue")),
     ChartRenderer: defineAsyncComponent(
       () => import("@/components/dashboards/panels/ChartRenderer.vue"),
@@ -1703,10 +1710,6 @@ export default defineComponent({
       }
     });
     //this is used to show the histogram loader when the histogram is loading
-    const histogramLoader = computed(() => {
-      return searchObj.meta.showHistogram && searchObj.loadingHistogram == true;
-    });
-
     // 250 bars × 9px (7px bar + 2px gap) = 2250px — covers any viewport width.
     // Heights cycle through a realistic uneven pattern so it looks like real log data.
     const SKELETON_HEIGHTS = [45,72,58,88,62,42,78,52,73,38,68,83,48,68,44,92,62,38,72,56,32,82,48,64,38,88,68,44,78,52,40,95,55,70,30,85,65,50,75,42];
@@ -1929,7 +1932,6 @@ export default defineComponent({
       getPaginations,
       refreshPagination,
       refreshJobPagination,
-      histogramLoader,
       skeletonBarHeights,
       sendToAiChat,
       closeTable,

--- a/web/src/plugins/logs/TenstackTable.spec.ts
+++ b/web/src/plugins/logs/TenstackTable.spec.ts
@@ -16,6 +16,7 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ref } from "vue";
 import TenstackTable from "./TenstackTable.vue";
+import LoadingProgress from "@/components/common/LoadingProgress.vue";
 
 // Mock CSS.supports which is not available in jsdom
 Object.defineProperty(globalThis, "CSS", {
@@ -432,6 +433,54 @@ describe("TenstackTable", () => {
       wrapper.vm.isFunctionErrorOpen = true;
       await wrapper.vm.$nextTick();
       expect(wrapper.vm.isFunctionErrorOpen).toBe(true);
+    });
+  });
+
+  // ── Loading skeleton vs streaming progress bar ────────────────────────────────
+  describe("loading state and progress bar", () => {
+    const SKELETON = '[data-test="logs-table-skeleton-body"]';
+
+    it("shows the full skeleton when loading with no rows yet", () => {
+      const wrapper = mountComponent({ loading: true, rows: [] });
+      expect(wrapper.find(SKELETON).exists()).toBe(true);
+    });
+
+    it("hides the skeleton when loading with rows already present", () => {
+      const wrapper = mountComponent({
+        loading: true,
+        rows: [{ _timestamp: 1000, log: "test" }],
+      });
+      expect(wrapper.find(SKELETON).exists()).toBe(false);
+    });
+
+    it("does not show the skeleton when not loading", () => {
+      const wrapper = mountComponent({
+        loading: false,
+        rows: [{ _timestamp: 1000, log: "test" }],
+      });
+      expect(wrapper.find(SKELETON).exists()).toBe(false);
+    });
+
+    it("renders the LoadingProgress bar with the loading prop", () => {
+      const wrapper = mountComponent({ loading: true, rows: [] });
+      const bar = wrapper.findComponent(LoadingProgress);
+      expect(bar.exists()).toBe(true);
+      expect(bar.props("loading")).toBe(true);
+    });
+
+    it("forwards loadingProgressPercentage to the LoadingProgress bar", () => {
+      const wrapper = mountComponent({
+        loading: true,
+        rows: [{ _timestamp: 1000, log: "test" }],
+        loadingProgressPercentage: 42,
+      });
+      const bar = wrapper.findComponent(LoadingProgress);
+      expect(bar.props("loadingProgressPercentage")).toBe(42);
+    });
+
+    it("defaults loadingProgressPercentage to 0", () => {
+      const wrapper = mountComponent();
+      expect(wrapper.props("loadingProgressPercentage")).toBe(0);
     });
   });
 });

--- a/web/src/plugins/logs/TenstackTable.vue
+++ b/web/src/plugins/logs/TenstackTable.vue
@@ -23,6 +23,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     ]"
     style="color: var(--o2-log-table-text)"
   >
+    <!-- Top progress bar: keeps rows visible while a new result set streams in
+      (e.g. streaming_aggs replacing values). Same component dashboard panels
+      use; driven by backend streaming progress. The full skeleton below is
+      shown only on first load (no rows yet). -->
+    <LoadingProgress
+      :loading="loading"
+      :loadingProgressPercentage="loadingProgressPercentage"
+    />
     <table
       v-if="table"
       data-test="logs-search-result-logs-table"
@@ -207,9 +215,11 @@ class="tw:mr-1" />
         </tr>
       </thead>
 
-      <!-- Skeleton loading body — replaces the old spinner row -->
+      <!-- Skeleton loading body — shown ONLY on first load (no rows yet).
+        Once rows exist they stay visible while the top progress bar signals an
+        in-progress refresh (e.g. streaming_aggs replacing values). -->
       <tbody
-        v-if="loading"
+        v-if="loading && tableRows.length === 0"
         data-test="logs-table-skeleton-body"
         aria-busy="true"
         aria-label="Loading logs"
@@ -487,6 +497,7 @@ import { useTextHighlighter } from "@/composables/useTextHighlighter";
 import { useLogsHighlighter } from "@/composables/useLogsHighlighter";
 import OButton from "@/lib/core/Button/OButton.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
+import LoadingProgress from "@/components/common/LoadingProgress.vue";
 
 interface StreamField {
   name: string;
@@ -513,6 +524,10 @@ const props = defineProps({
   loading: {
     type: Boolean,
     default: false,
+  },
+  loadingProgressPercentage: {
+    type: Number,
+    default: 0,
   },
   errMsg: {
     type: String,

--- a/web/src/styles/logs/logs-page.scss
+++ b/web/src/styles/logs/logs-page.scss
@@ -1016,6 +1016,9 @@
 
 .histogram-container {
   border-radius: 0.5rem;
+  // Anchor the absolutely-positioned streaming progress bar (LoadingProgress)
+  // to the top of the histogram area.
+  position: relative;
 
   // Dynamic height controlled by CSS classes
   &--visible {
@@ -1045,12 +1048,6 @@
   &__message {
     min-height: 2rem; // 32px (reduced from 50px)
   }
-}
-
-.histogram-loader {
-  top: 3.125rem; // 50px
-  position: absolute;
-  left: 50%;
 }
 
 .histogram-skeleton {

--- a/web/src/ts/interfaces/query.ts
+++ b/web/src/ts/interfaces/query.ts
@@ -43,8 +43,10 @@ export interface HistogramQueryPayload {
 }
 
 export interface WebSocketSearchResponse {
-  type: "search_response" | "cancel_response" | "error" | "end" | "progress" | "search_response_metadata" | "search_response_hits";
+  type: "search_response" | "cancel_response" | "error" | "end" | "progress" | "event_progress" | "search_response_metadata" | "search_response_hits";
   content: {
+    // Present on "event_progress" responses (streaming progress percent 0-100)
+    percent?: number;
     results: {
       hits: any[];
       total: number;

--- a/web/src/utils/logs/constants.ts
+++ b/web/src/utils/logs/constants.ts
@@ -89,6 +89,8 @@ export const DEFAULT_LOGS_CONFIG = {
   loadingCounter: false,
   loadingStream: false,
   loadingSavedView: false,
+  loadingProgressPercentage: 0,
+  loadingHistogramProgressPercentage: 0,
   shouldIgnoreWatcher: false,
   communicationMethod: "streaming" as const,
   config: {


### PR DESCRIPTION
## What changed

Adds a streaming progress bar (the same `LoadingProgress.vue` used by dashboard panels) to the logs results table and histogram chart. The skeleton loader in `TenstackTable.vue` now hides once any rows exist, keeping data visible while streaming updates replace values in-place.

## Why

During `streaming_aggs`, hits arrive and replace chunk-by-chunk while `loading` stays `true` until the stream `end` signal. The full skeleton covered the table on every refresh, so users couldn't watch the incremental updates. The progress bar signals an in-progress refresh without hiding existing data.