### PR TITLE
fix(ci): query-agent run_tests job missing permissions to post PR comment

### DIFF
--- a/.github/workflows/query-agent.yml
+++ b/.github/workflows/query-agent.yml
@@ -238,6 +238,8 @@ jobs:
             mode: "true"
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Remove unused tools
         run: |


### PR DESCRIPTION
## Summary
The `run_tests` job's job-level `permissions: contents: read` was overriding the top-level `issues: write` and `pull-requests: write`, causing the "Post results comment" step to fail with `HttpError: Resource not accessible by integration`.

## Test
- Verified on [run #27815374013](https://github.com/openobserve/openobserve/actions/runs/27815374013) — both matrix configurations passed all 672 queries but failed to post results comments
- After this fix, comments will post correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)