### PR TITLE
fix: add logs and metrics to analyze time taken by pipelines

### DIFF
--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -1323,6 +1323,54 @@ pub static PIPELINE_EXPORTED_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
     .expect("Metric created")
 });
 
+// Realtime pipeline batch execution time (milliseconds). Observed by ingesters per
+// `process_batch` call so the realtime pipeline's share of ingestion latency is
+// visible. `pipeline_name` aids dashboards; cardinality is bounded by number of
+// pipelines (pipeline_id is the stable key).
+pub static PIPELINE_EXEC_TIME_MS: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
+            "pipeline_exec_time_ms",
+            "Realtime pipeline batch execution time in milliseconds".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .buckets(vec![
+            0.1, 0.25, 0.5, 1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0,
+            5000.0, 10000.0, 30000.0,
+        ])
+        .const_labels(create_const_labels()),
+        &[
+            "organization",
+            "pipeline_id",
+            "pipeline_name",
+            "stream_type",
+        ],
+    )
+    .expect("Metric created")
+});
+
+// Realtime pipeline batch size (record count per `process_batch` call).
+pub static PIPELINE_EXEC_BATCH_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
+            "pipeline_exec_batch_size",
+            "Realtime pipeline batch size (records per execution)".to_owned() + HELP_SUFFIX,
+        )
+        .namespace(NAMESPACE)
+        .buckets(vec![
+            1.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 50000.0, 100000.0,
+        ])
+        .const_labels(create_const_labels()),
+        &[
+            "organization",
+            "pipeline_id",
+            "pipeline_name",
+            "stream_type",
+        ],
+    )
+    .expect("Metric created")
+});
+
 pub static QUERY_AGGREGATION_CACHE_ITEMS: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
         Opts::new(
@@ -2140,6 +2188,12 @@ fn register_metrics(registry: &Registry) {
         .register(Box::new(PIPELINE_EXPORTED_BYTES.clone()))
         .expect("Metric registered");
     registry
+        .register(Box::new(PIPELINE_EXEC_TIME_MS.clone()))
+        .expect("Metric registered");
+    registry
+        .register(Box::new(PIPELINE_EXEC_BATCH_SIZE.clone()))
+        .expect("Metric registered");
+    registry
         .register(Box::new(QUERY_AGGREGATION_CACHE_ITEMS.clone()))
         .expect("Metric registered");
     registry
@@ -2524,6 +2578,8 @@ mod tests {
         let _ = PIPELINE_WAL_FILES.clone();
         let _ = PIPELINE_WAL_INGESTION_BYTES.clone();
         let _ = PIPELINE_EXPORTED_BYTES.clone();
+        let _ = PIPELINE_EXEC_TIME_MS.clone();
+        let _ = PIPELINE_EXEC_BATCH_SIZE.clone();
     }
 
     #[test]

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -293,10 +293,20 @@ pub async fn ingest(
     if !executable_pipelines.is_empty() {
         let records_count = pipeline_inputs.len();
         for exec_pl in &executable_pipelines {
-            match exec_pl
+            let pipeline_start = std::time::Instant::now();
+            let pl_result = exec_pl
                 .process_batch(org_id, pipeline_inputs.clone(), Some(stream_name.clone()))
-                .await
-            {
+                .await;
+            if cfg.common.print_key_event {
+                // Pipeline wall-time vs total ingest elapsed so far, to see the realtime
+                // pipeline's share of ingestion latency at the ingest layer.
+                log::info!(
+                    "[Pipeline:Timing] ingest org={org_id} stream={stream_name} records={records_count} pipeline_ms={} ingest_elapsed_ms={}",
+                    pipeline_start.elapsed().as_millis(),
+                    start.elapsed().as_millis(),
+                );
+            }
+            match pl_result {
                 Err(e) => {
                     log::error!(
                         "[Pipeline] for stream {org_id}/{stream_name}: Batch execution error: {e}.",

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -424,6 +424,9 @@ impl ExecutablePipeline {
             ));
             node_tasks.push(task);
         }
+        // Measure node task duration from when they were spawned (they start running
+        // immediately), not from when we await them below.
+        let node_tasks_start = Instant::now();
 
         // task to collect results
         let pl_name_for_results = pipeline_name.clone();
@@ -500,7 +503,6 @@ impl ExecutablePipeline {
         log::debug!(
             "[Pipeline] {pipeline_name} [inv={inv_id}]: waiting for all node tasks to complete"
         );
-        let node_tasks_start = Instant::now();
         if let Err(e) = try_join_all(node_tasks).await {
             log::error!(
                 "[Pipeline] {pipeline_name} [inv={inv_id}]: node processing jobs failed: {e}"
@@ -1636,7 +1638,7 @@ async fn process_node(
         // busy_ms under low CPU points at upstream/downstream stalls, not this node.
         let wait_ms = node_ms.saturating_sub(busy_ms);
         log::info!(
-            "[Pipeline:Timing] [inv={inv_id}] node idx={node_idx} type={node_type} label={node_label} records={count} node_ms={node_ms} busy_ms={busy_ms} wait_ms={wait_ms}"
+            "[Pipeline:Timing] [inv={inv_id}] name={pipeline_name} node idx={node_idx} type={node_type} label={node_label} records={count} node_ms={node_ms} busy_ms={busy_ms} wait_ms={wait_ms}"
         );
     }
 

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -18,6 +18,7 @@ use std::hash::{Hash, Hasher};
 use std::{
     collections::{HashMap, HashSet},
     sync::LazyLock as Lazy,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Result, anyhow};
@@ -30,6 +31,7 @@ use config::{
         self_reporting::error::{ErrorData, ErrorSource, PipelineError},
         stream::{StreamParams, StreamType},
     },
+    metrics,
     stats::MemorySize,
     utils::{
         flatten,
@@ -41,12 +43,9 @@ use futures::future::try_join_all;
 #[cfg(feature = "enterprise")]
 use o2_enterprise::enterprise::pipeline::pipeline_wal_writer::get_pipeline_wal_writer;
 use proto::cluster_rpc;
-use tokio::sync::mpsc::{Receiver, Sender, channel};
 #[cfg(feature = "enterprise")]
-use tokio::{
-    sync::Mutex,
-    time::{Duration, Instant},
-};
+use tokio::sync::Mutex;
+use tokio::sync::mpsc::{Receiver, Sender, channel};
 
 use crate::{
     common::{infra::config::QUERY_FUNCTIONS, utils::js::JSRuntimeConfig},
@@ -321,12 +320,17 @@ impl ExecutablePipeline {
         let pipeline_name = self.name.clone();
         // Unique invocation ID to correlate logs across concurrent pipeline runs
         let inv_id = &format!("{:08x}", rand::random::<u32>());
+        // Gated detailed timing logs (ZO_PRINT_KEY_EVENT). Per-batch / per-node only,
+        // never per-record, to stay safe under high ingestion rate.
+        let print_event = config::get_config().common.print_key_event;
+        let batch_start = Instant::now();
         log::info!("[Pipeline] {pipeline_name} [inv={inv_id}]: process batch of size {batch_size}");
         if batch_size == 0 {
             return Ok(HashMap::default());
         }
 
-        // Report pipeline ingestion
+        // Source size of the batch (MB). Computed before records are consumed by the
+        // pipeline. Usage is reported at the end with the real pipeline response time.
         let source_stream_params = self.get_source_stream_params();
         let source_size: f64 = records
             .iter()
@@ -334,24 +338,15 @@ impl ExecutablePipeline {
             .sum::<f64>()
             / config::SIZE_IN_MB;
 
-        if source_size > 0.0 {
-            let req_stats = config::meta::self_reporting::usage::RequestStats {
-                size: source_size,
-                records: batch_size as i64,
-                response_time: 0.0,
-                ..config::meta::self_reporting::usage::RequestStats::default()
-            };
-
-            crate::service::self_reporting::report_request_usage_stats(
-                req_stats,
-                org_id,
-                &self.id,
-                source_stream_params.stream_type,
-                config::meta::self_reporting::usage::UsageType::Pipeline,
-                0, // No functions for source stream ingestion
-                chrono::Utc::now().timestamp_micros(),
-            )
-            .await;
+        if print_event {
+            log::info!(
+                "[Pipeline:Timing] [inv={inv_id}] start id={} name={} org={org_id} stream={:?} batch_size={batch_size} source_size_mb={source_size:.4} num_nodes={} num_funcs={}",
+                self.id,
+                pipeline_name,
+                stream_name,
+                self.sorted_nodes.len(),
+                self.num_of_func(),
+            );
         }
 
         // result_channel
@@ -389,6 +384,7 @@ impl ExecutablePipeline {
                 self.function_map.get(node_id).cloned();
             let pipeline_name = pipeline_name.clone();
             let stream_name = stream_name.clone();
+            let inv_id_cp = inv_id.to_string();
 
             // WARN: Do not change. Processing node can only be done in a task, as the internals of
             // remote wal writer depends on the task id.
@@ -421,6 +417,8 @@ impl ExecutablePipeline {
                 stream_name,
                 source_stream_type,
                 _leaf_dest_stream,
+                inv_id_cp,
+                print_event,
             ));
             node_tasks.push(task);
         }
@@ -497,15 +495,18 @@ impl ExecutablePipeline {
         log::info!(
             "[Pipeline] {pipeline_name} [inv={inv_id}]: waiting for all node tasks to complete"
         );
+        let node_tasks_start = Instant::now();
         if let Err(e) = try_join_all(node_tasks).await {
             log::error!(
                 "[Pipeline] {pipeline_name} [inv={inv_id}]: node processing jobs failed: {e}"
             );
         }
+        let node_tasks_ms = node_tasks_start.elapsed().as_millis();
         log::info!("[Pipeline] {pipeline_name} [inv={inv_id}]: all node tasks completed");
 
         // Publish errors if received any
         log::info!("[Pipeline] {pipeline_name} [inv={inv_id}]: awaiting error task");
+        let error_task_start = Instant::now();
         if let Some(pipeline_errors) = error_task.await.map_err(|e| {
             log::error!(
                 "[Pipeline] {pipeline_name} [inv={inv_id}]: error collecting job failed: {e}"
@@ -527,18 +528,70 @@ impl ExecutablePipeline {
             log::debug!("[Pipeline]: execution errors occurred and published");
             publish_error(error_data).await;
         }
+        let error_collect_ms = error_task_start.elapsed().as_millis();
 
         log::info!("[Pipeline] {pipeline_name} [inv={inv_id}]: awaiting result collector");
+        let result_task_start = Instant::now();
         let results = result_task.await.map_err(|e| {
             log::error!(
                 "[Pipeline] {pipeline_name} [inv={inv_id}]: result collecting job failed: {e}"
             );
             anyhow!("[Pipeline] result collecting job failed: {}", e)
         })?;
+        let result_collect_ms = result_task_start.elapsed().as_millis();
         log::info!(
             "[Pipeline] {pipeline_name} [inv={inv_id}]: result collector returned {} stream groups",
             results.len()
         );
+
+        // Histogram metrics (always on): realtime pipeline batch execution time (ms)
+        // and batch size, labeled by pipeline so latency can be attributed per pipeline.
+        let stream_type_label = source_stream_params.stream_type.as_str();
+        let elapsed_secs = batch_start.elapsed().as_secs_f64();
+        metrics::PIPELINE_EXEC_TIME_MS
+            .with_label_values(&[org_id, &self.id, &pipeline_name, stream_type_label])
+            .observe(elapsed_secs * 1000.0);
+        metrics::PIPELINE_EXEC_BATCH_SIZE
+            .with_label_values(&[org_id, &self.id, &pipeline_name, stream_type_label])
+            .observe(batch_size as f64);
+
+        if print_event {
+            let total_ms = batch_start.elapsed().as_millis();
+            let out_records: usize = results.values().map(|v| v.len()).sum();
+            let secs = batch_start.elapsed().as_secs_f64();
+            let (records_per_sec, mb_per_sec) = if secs > 0.0 {
+                (batch_size as f64 / secs, source_size / secs)
+            } else {
+                (0.0, 0.0)
+            };
+            log::info!(
+                "[Pipeline:Timing] [inv={inv_id}] done id={} name={} batch_size={batch_size} source_size_mb={source_size:.4} out_records={out_records} total_ms={total_ms} node_tasks_ms={node_tasks_ms} result_collect_ms={result_collect_ms} error_collect_ms={error_collect_ms} records_per_sec={records_per_sec:.1} mb_per_sec={mb_per_sec:.4}",
+                self.id,
+                pipeline_name,
+            );
+        }
+
+        // Report pipeline ingestion usage LAST, with response_time set to the time
+        // spent by the pipeline processing this batch (seconds, f64).
+        if source_size > 0.0 {
+            let req_stats = config::meta::self_reporting::usage::RequestStats {
+                size: source_size,
+                records: batch_size as i64,
+                response_time: elapsed_secs,
+                ..config::meta::self_reporting::usage::RequestStats::default()
+            };
+
+            crate::service::self_reporting::report_request_usage_stats(
+                req_stats,
+                org_id,
+                &self.id,
+                source_stream_params.stream_type,
+                config::meta::self_reporting::usage::UsageType::Pipeline,
+                0, // No functions for source stream ingestion
+                chrono::Utc::now().timestamp_micros(),
+            )
+            .await;
+        }
 
         // Cross-type leaf nodes ingest directly via ingestion_service inside process_node,
         // so results here only contain same-type records for the caller to handle.
@@ -590,6 +643,20 @@ impl ExecutablePipeline {
 impl ExecutableNode {
     pub fn node_type(&self) -> String {
         self.to_string()
+    }
+
+    /// Human-readable label for timing logs, e.g. "function:my_vrl_fn" or
+    /// "stream:logs:default", so node latencies can be told apart in pipelines
+    /// with many nodes.
+    fn timing_label(&self) -> String {
+        match &self.node_data {
+            NodeData::Function(p) => format!("function:{}", p.name),
+            NodeData::Stream(p) => format!("stream:{}:{}", p.stream_type, p.stream_name),
+            NodeData::RemoteStream(p) => format!("remote_stream:{}", p.destination_name),
+            NodeData::Condition(_) => "condition".to_string(),
+            NodeData::Query(_) => "query".to_string(),
+            NodeData::LlmEvaluation(p) => format!("llm_evaluation:{}", p.name),
+        }
     }
 }
 
@@ -659,9 +726,20 @@ async fn process_node(
     stream_name: Option<String>,
     source_stream_type: StreamType,
     _leaf_dest_stream: Option<StreamParams>,
+    inv_id: String,
+    print_event: bool,
 ) -> Result<()> {
     let cfg = config::get_config();
     let mut count: usize = 0;
+    // Per-node timing (gated by ZO_PRINT_KEY_EVENT). Aggregated per batch, never
+    // per-record. `node_label` distinguishes nodes (e.g. the VRL fn name) so node
+    // latencies can be told apart in pipelines with many nodes.
+    let node_label = node.timing_label();
+    let node_type = node.node_type();
+    let node_start = Instant::now();
+    // wall time spent doing CPU work inside this node's loop (flatten + fn/eval),
+    // excluding time blocked on `recv().await` from upstream.
+    let mut busy = Duration::ZERO;
     match &node.node_data {
         NodeData::Stream(stream_params) => {
             if node.children.is_empty() {
@@ -683,10 +761,11 @@ async fn process_node(
                         flattened,
                     } = pipeline_item;
                     if !flattened && !record.is_null() && record.is_object() {
-                        record = match flatten::flatten_with_level(
-                            record,
-                            cfg.limit.ingest_flatten_level,
-                        ) {
+                        let flatten_timer = Instant::now();
+                        let flatten_res =
+                            flatten::flatten_with_level(record, cfg.limit.ingest_flatten_level);
+                        busy += flatten_timer.elapsed();
+                        record = match flatten_res {
                             Ok(flattened) => flattened,
                             Err(e) => {
                                 let err_msg = format!("LeafNode error with flattening: {e}");
@@ -827,10 +906,11 @@ async fn process_node(
                 } = pipeline_item;
                 // value must be flattened before condition params can take effect
                 if !flattened && !record.is_null() && record.is_object() {
-                    record = match flatten::flatten_with_level(
-                        record,
-                        cfg.limit.ingest_flatten_level,
-                    ) {
+                    let flatten_timer = Instant::now();
+                    let flatten_res =
+                        flatten::flatten_with_level(record, cfg.limit.ingest_flatten_level);
+                    busy += flatten_timer.elapsed();
+                    record = match flatten_res {
                         Ok(flattened) => flattened,
                         Err(e) => {
                             let err_msg = format!("ConditionNode error with flattening: {e}");
@@ -850,6 +930,7 @@ async fn process_node(
                 }
 
                 // Evaluate based on condition version
+                let eval_timer = Instant::now();
                 let passes = match condition_params {
                     config::meta::pipeline::components::ConditionParams::V1 { conditions } => {
                         // v1: Use tree-based ConditionList evaluation
@@ -860,6 +941,7 @@ async fn process_node(
                         conditions.evaluate(record.as_object().unwrap()).await
                     }
                 };
+                busy += eval_timer.elapsed();
 
                 // only send to children when passing all condition evaluations
                 if passes {
@@ -898,10 +980,11 @@ async fn process_node(
                         && !record.is_null()
                         && record.is_object()
                     {
-                        record = match flatten::flatten_with_level(
-                            record,
-                            cfg.limit.ingest_flatten_level,
-                        ) {
+                        let flatten_timer = Instant::now();
+                        let flatten_res =
+                            flatten::flatten_with_level(record, cfg.limit.ingest_flatten_level);
+                        busy += flatten_timer.elapsed();
+                        record = match flatten_res {
                             Ok(flattened) => flattened,
                             Err(e) => {
                                 let err_msg = format!("FunctionNode error with flattening: {e}");
@@ -930,13 +1013,16 @@ async fn process_node(
                         CompiledFunctionRuntime::VRL(vrl_resolver, is_result_array) => {
                             if !is_result_array {
                                 // Single record processing with VRL
-                                record = match apply_vrl_fn(
+                                let vrl_timer = Instant::now();
+                                let vrl_res = apply_vrl_fn(
                                     &mut vrl_runtime_state,
                                     vrl_resolver,
                                     record,
                                     &org_id,
                                     std::slice::from_ref(&stream_name),
-                                ) {
+                                );
+                                busy += vrl_timer.elapsed();
+                                record = match vrl_res {
                                     (res, None) => res,
                                     (res, Some(error)) => {
                                         let err_msg = format!(
@@ -979,12 +1065,15 @@ async fn process_node(
                         CompiledFunctionRuntime::JS(js_config, is_result_array) => {
                             if !is_result_array {
                                 // Single record processing with JS
-                                record = match apply_js_fn(
+                                let js_timer = Instant::now();
+                                let js_res = apply_js_fn(
                                     js_config,
                                     record,
                                     &org_id,
                                     std::slice::from_ref(&stream_name),
-                                ) {
+                                );
+                                busy += js_timer.elapsed();
+                                record = match js_res {
                                     (res, None) => res,
                                     (res, Some(error)) => {
                                         let err_msg = format!(
@@ -1036,13 +1125,16 @@ async fn process_node(
                 match runtime {
                     CompiledFunctionRuntime::VRL(vrl_resolver, true) => {
                         // VRL result array processing
-                        let result = match apply_vrl_fn(
+                        let vrl_arr_timer = Instant::now();
+                        let vrl_arr_res = apply_vrl_fn(
                             &mut vrl_runtime_state,
                             vrl_resolver,
                             json::Value::Array(result_array_records),
                             &org_id,
                             std::slice::from_ref(&stream_name),
-                        ) {
+                        );
+                        busy += vrl_arr_timer.elapsed();
+                        let result = match vrl_arr_res {
                             (res, None) => res,
                             (res, Some(error)) => {
                                 let err_msg = format!(
@@ -1083,12 +1175,15 @@ async fn process_node(
                     }
                     CompiledFunctionRuntime::JS(js_config, true) => {
                         // JS result array processing
-                        let result = match apply_js_fn(
+                        let js_arr_timer = Instant::now();
+                        let js_arr_res = apply_js_fn(
                             js_config,
                             json::Value::Array(result_array_records),
                             &org_id,
                             std::slice::from_ref(&stream_name),
-                        ) {
+                        );
+                        busy += js_arr_timer.elapsed();
+                        let result = match js_arr_res {
                             (res, None) => res,
                             (res, Some(error)) => {
                                 let err_msg = format!(
@@ -1507,6 +1602,17 @@ async fn process_node(
         "[Pipeline] {pipeline_name}: node {node_idx} ({:?}) task returning",
         node.node_data
     );
+
+    if print_event {
+        let node_ms = node_start.elapsed().as_millis();
+        let busy_ms = busy.as_millis();
+        // wait_ms ~= time blocked on upstream (channel recv). High wait_ms with low
+        // busy_ms under low CPU points at upstream/downstream stalls, not this node.
+        let wait_ms = node_ms.saturating_sub(busy_ms);
+        log::info!(
+            "[Pipeline:Timing] [inv={inv_id}] node idx={node_idx} type={node_type} label={node_label} records={count} node_ms={node_ms} busy_ms={busy_ms} wait_ms={wait_ms}"
+        );
+    }
 
     Ok(())
 }

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -451,14 +451,15 @@ impl ExecutablePipeline {
 
         // task to collect errors
         let mut pipeline_error = PipelineError::new(&self.id, &self.name);
+        let inv_id_for_errors = inv_id.clone();
         let error_task = tokio::spawn(async move {
-            log::debug!("[Pipeline]: starts error collecting job");
+            log::debug!("[Pipeline] [inv={inv_id_for_errors}]: starts error collecting job");
             let mut count = 0;
             while let Some((node_id, node_type, error, fn_name)) = error_receiver.recv().await {
                 pipeline_error.add_node_error(node_id, node_type, error, fn_name);
                 count += 1;
             }
-            log::debug!("[Pipeline]: collected {count} errors");
+            log::debug!("[Pipeline] [inv={inv_id_for_errors}]: collected {count} errors");
             if count > 0 {
                 Some(pipeline_error)
             } else {
@@ -480,7 +481,7 @@ impl ExecutablePipeline {
             };
             if let Err(send_err) = source_sender.send(pipeline_item).await {
                 log::error!(
-                    "[Pipeline]: Error sending original records into source Node for {send_err}"
+                    "[Pipeline] {pipeline_name} [inv={inv_id}]: Error sending original records into source Node for {send_err}"
                 );
                 break;
             }
@@ -489,7 +490,7 @@ impl ExecutablePipeline {
         drop(result_sender);
         drop(error_sender);
         drop(node_senders);
-        log::debug!("[Pipeline]: All records send into pipeline for processing");
+        log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: All records send into pipeline for processing");
 
         // Wait for all node tasks to complete
         log::info!(
@@ -515,7 +516,7 @@ impl ExecutablePipeline {
         })? {
             let stream_params = self.get_source_stream_params();
             log::info!(
-                "[Pipeline] id: {}, name: {}, node_errors: {:?}",
+                "[Pipeline] [inv={inv_id}] id: {}, name: {}, node_errors: {:?}",
                 pipeline_errors.pipeline_id,
                 pipeline_errors.pipeline_name,
                 pipeline_errors.node_errors
@@ -525,7 +526,7 @@ impl ExecutablePipeline {
                 stream_params,
                 error_source: ErrorSource::Pipeline(pipeline_errors),
             };
-            log::debug!("[Pipeline]: execution errors occurred and published");
+            log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: execution errors occurred and published");
             publish_error(error_data).await;
         }
         let error_collect_ms = error_task_start.elapsed().as_millis();
@@ -744,7 +745,7 @@ async fn process_node(
         NodeData::Stream(stream_params) => {
             if node.children.is_empty() {
                 log::info!(
-                    "[Pipeline] {pipeline_name} : Leaf node {node_idx} starts processing (stream={}:{})",
+                    "[Pipeline] {pipeline_name} [inv={inv_id}]: Leaf node {node_idx} starts processing (stream={}:{})",
                     stream_params.stream_type,
                     stream_params.stream_name,
                 );
@@ -774,7 +775,7 @@ async fn process_node(
                                     .await
                                 {
                                     log::error!(
-                                        "[Pipeline] {pipeline_name} : LeafNode failed sending errors for collection caused by: {send_err}"
+                                        "[Pipeline] {pipeline_name} [inv={inv_id}]: LeafNode failed sending errors for collection caused by: {send_err}"
                                     );
                                     break;
                                 }
@@ -803,13 +804,13 @@ async fn process_node(
                                     "Dynamic Stream Name resolved to empty. Record dropped"
                                         .to_string()
                                 };
-                                log::warn!("{err_msg}");
+                                log::warn!("[Pipeline] {pipeline_name} [inv={inv_id}]: {err_msg}");
                                 if let Err(send_err) = error_sender
                                     .send((node.id.to_string(), node.node_type(), err_msg, None))
                                     .await
                                 {
                                     log::error!(
-                                        "[Pipeline] {pipeline_name} : LeafNode failed sending errors for collection caused by: {send_err}"
+                                        "[Pipeline] {pipeline_name} [inv={inv_id}]: LeafNode failed sending errors for collection caused by: {send_err}"
                                     );
                                     break;
                                 }
@@ -827,7 +828,7 @@ async fn process_node(
                             result_sender.send((idx, destination_stream, record)).await
                         {
                             log::error!(
-                                "[Pipeline] {pipeline_name} : LeafNode errors sending result for collection caused by: {send_err}"
+                                "[Pipeline] {pipeline_name} [inv={inv_id}]: LeafNode errors sending result for collection caused by: {send_err}"
                             );
                             break;
                         }
@@ -843,8 +844,9 @@ async fn process_node(
                     let dest_stream_name = stream_params.stream_name.to_string();
                     let org = org_id.to_string();
                     let pl_name = pipeline_name.clone();
+                    let inv = inv_id.clone();
                     log::info!(
-                        "[Pipeline] {pl_name} : LeafNode {node_idx} spawning background ingestion for {record_count} cross-type records to {dest_stream_type}:{dest_stream_name}",
+                        "[Pipeline] {pl_name} [inv={inv}]: LeafNode {node_idx} spawning background ingestion for {record_count} cross-type records to {dest_stream_type}:{dest_stream_name}",
                     );
                     tokio::spawn(async move {
                         let req = cluster_rpc::IngestionRequest {
@@ -858,19 +860,19 @@ async fn process_node(
                         match crate::service::ingestion::ingestion_service::ingest(req).await {
                             Ok(resp) if resp.status_code == 200 => {
                                 log::info!(
-                                    "[Pipeline] {pl_name} : cross-type ingestion successful to {dest_stream_type}:{dest_stream_name}, records: {record_count}",
+                                    "[Pipeline] {pl_name} [inv={inv}]: cross-type ingestion successful to {dest_stream_type}:{dest_stream_name}, records: {record_count}",
                                 );
                             }
                             Ok(resp) => {
                                 log::error!(
-                                    "[Pipeline] {pl_name} : cross-type ingestion failed (status={}): {}",
+                                    "[Pipeline] {pl_name} [inv={inv}]: cross-type ingestion failed (status={}): {}",
                                     resp.status_code,
                                     resp.message,
                                 );
                             }
                             Err(e) => {
                                 log::error!(
-                                    "[Pipeline] {pl_name} : cross-type ingestion error: {e}"
+                                    "[Pipeline] {pl_name} [inv={inv}]: cross-type ingestion error: {e}"
                                 );
                             }
                         }
@@ -878,24 +880,24 @@ async fn process_node(
                 }
 
                 log::info!(
-                    "[Pipeline] {pipeline_name} : LeafNode {node_idx} done processing {count} records (stream={}:{})",
+                    "[Pipeline] {pipeline_name} [inv={inv_id}]: LeafNode {node_idx} done processing {count} records (stream={}:{})",
                     stream_params.stream_type,
                     stream_params.stream_name
                 );
             } else {
-                log::debug!("[Pipeline]: source node {node_idx} starts processing");
+                log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: source node {node_idx} starts processing");
                 // source stream node: send received record to all its children
                 while let Some(item) = receiver.recv().await {
                     send_to_children(&mut child_senders, item, "StreamNode").await;
                     count += 1;
                 }
                 log::debug!(
-                    "[Pipeline] {pipeline_name} : source node {node_idx} done processing {count} records"
+                    "[Pipeline] {pipeline_name} [inv={inv_id}]: source node {node_idx} done processing {count} records"
                 );
             }
         }
         NodeData::Condition(condition_params) => {
-            log::info!("[Pipeline]: cond node {node_idx} starts processing");
+            log::info!("[Pipeline] {pipeline_name} [inv={inv_id}]: cond node {node_idx} starts processing");
             let mut total_received: usize = 0;
             while let Some(pipeline_item) = receiver.recv().await {
                 total_received += 1;
@@ -919,7 +921,7 @@ async fn process_node(
                                 .await
                             {
                                 log::error!(
-                                    "[Pipeline] {pipeline_name} : ConditionNode failed sending errors for collection caused by: {send_err}"
+                                    "[Pipeline] {pipeline_name} [inv={inv_id}]: ConditionNode failed sending errors for collection caused by: {send_err}"
                                 );
                                 break;
                             }
@@ -959,11 +961,11 @@ async fn process_node(
                 }
             }
             log::info!(
-                "[Pipeline]: cond node {node_idx} done: received={total_received}, passed={count} records"
+                "[Pipeline] {pipeline_name} [inv={inv_id}]: cond node {node_idx} done: received={total_received}, passed={count} records"
             );
         }
         NodeData::Function(func_params) => {
-            log::debug!("[Pipeline]: func node {node_idx} starts processing");
+            log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: func node {node_idx} starts processing");
             let mut vrl_runtime_state = crate::service::ingestion::init_functions_runtime();
             let stream_name = stream_name.unwrap_or("pipeline".to_string());
             let mut result_array_records = Vec::new();
@@ -999,7 +1001,7 @@ async fn process_node(
                                     .await
                                 {
                                     log::error!(
-                                        "[Pipeline] {pipeline_name} : FunctionNode failed sending errors for collection caused by: {send_err}"
+                                        "[Pipeline] {pipeline_name} [inv={inv_id}]: FunctionNode failed sending errors for collection caused by: {send_err}"
                                     );
                                     break;
                                 }
@@ -1039,7 +1041,7 @@ async fn process_node(
                                             .await
                                         {
                                             log::error!(
-                                                "[Pipeline] {pipeline_name} : FunctionNode failed sending errors for collection caused by: {send_err}"
+                                                "[Pipeline] {pipeline_name} [inv={inv_id}]: FunctionNode failed sending errors for collection caused by: {send_err}"
                                             );
                                             break;
                                         }
@@ -1090,7 +1092,7 @@ async fn process_node(
                                             .await
                                         {
                                             log::error!(
-                                                "[Pipeline] {pipeline_name} : FunctionNode failed sending errors for collection caused by: {send_err}"
+                                                "[Pipeline] {pipeline_name} [inv={inv_id}]: FunctionNode failed sending errors for collection caused by: {send_err}"
                                             );
                                             break;
                                         }
@@ -1151,7 +1153,7 @@ async fn process_node(
                                     .await
                                 {
                                     log::error!(
-                                        "[Pipeline] {pipeline_name} : FunctionNode failed sending errors for collection caused by: {send_err}"
+                                        "[Pipeline] {pipeline_name} [inv={inv_id}]: FunctionNode failed sending errors for collection caused by: {send_err}"
                                     );
                                     return Ok(());
                                 }
@@ -1200,7 +1202,7 @@ async fn process_node(
                                     .await
                                 {
                                     log::error!(
-                                        "[Pipeline] {pipeline_name} : FunctionNode failed sending errors for collection caused by: {send_err}"
+                                        "[Pipeline] {pipeline_name} [inv={inv_id}]: FunctionNode failed sending errors for collection caused by: {send_err}"
                                     );
                                     return Ok(());
                                 }
@@ -1227,27 +1229,27 @@ async fn process_node(
                     _ => {
                         // Shouldn't happen (is_result_array is false)
                         log::error!(
-                            "[Pipeline] {pipeline_name} : Function node has result_array_records but runtime is not in result array mode"
+                            "[Pipeline] {pipeline_name} [inv={inv_id}]: Function node has result_array_records but runtime is not in result array mode"
                         );
                     }
                 }
             }
-            log::debug!("[Pipeline]: func node {node_idx} done processing {count} records");
+            log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: func node {node_idx} done processing {count} records");
         }
         NodeData::Query(_) => {
             // source node for Scheduled pipeline. Directly send to children nodes
-            log::debug!("[Pipeline]: query node {node_idx} starts processing");
+            log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: query node {node_idx} starts processing");
             while let Some(item) = receiver.recv().await {
                 send_to_children(&mut child_senders, item, "QueryNode").await;
                 count += 1;
             }
-            log::debug!("[Pipeline]: query node {node_idx} done processing {count} records");
+            log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: query node {node_idx} done processing {count} records");
         }
         #[cfg(feature = "enterprise")]
         NodeData::RemoteStream(remote_stream) => {
             let mut records = vec![];
             log::debug!(
-                "[Pipeline]: Destination node {node_idx} starts processing, remote_stream : {remote_stream:?}"
+                "[Pipeline] {pipeline_name} [inv={inv_id}]: Destination node {node_idx} starts processing, remote_stream : {remote_stream:?}"
             );
             let now = config::utils::time::now_micros();
             let min_ts = now - cfg.limit.ingest_allowed_upto_micro;
@@ -1272,7 +1274,7 @@ async fn process_node(
                                 .await
                             {
                                 log::error!(
-                                    "[Pipeline] {pipeline_name} : DestinationNode failed sending errors for collection caused by: {send_err}"
+                                    "[Pipeline] {pipeline_name} [inv={inv_id}]: DestinationNode failed sending errors for collection caused by: {send_err}"
                                 );
                                 break;
                             }
@@ -1290,7 +1292,7 @@ async fn process_node(
                             .await
                         {
                             log::error!(
-                                "[Pipeline] {} : DestinationNode failed sending errors for collection caused by: {send_err}",
+                                "[Pipeline] {} [inv={inv_id}]: DestinationNode failed sending errors for collection caused by: {send_err}",
                                 pipeline_name
                             );
                             break;
@@ -1304,7 +1306,7 @@ async fn process_node(
             }
 
             log::debug!(
-                "[Pipeline]: RemoteStream node processed {} records",
+                "[Pipeline] {pipeline_name} [inv={inv_id}]: RemoteStream node processed {} records",
                 records.len()
             );
             if !records.is_empty() {
@@ -1326,7 +1328,7 @@ async fn process_node(
                 }
 
                 log::debug!(
-                    "[Pipeline]: Grouped records into {} batch keys",
+                    "[Pipeline] {pipeline_name} [inv={inv_id}]: Grouped records into {} batch keys",
                     records_by_batch_key.len()
                 );
 
@@ -1352,7 +1354,7 @@ async fn process_node(
                     buffer.add_records(batch_records);
 
                     log::debug!(
-                        "[Pipeline]: Added {} records to buffer for batch_key '{batch_key}', total: {} records, {} bytes",
+                        "[Pipeline] {pipeline_name} [inv={inv_id}]: Added {} records to buffer for batch_key '{batch_key}', total: {} records, {} bytes",
                         buffer.records.len() - initial_record_count,
                         buffer.records.len(),
                         buffer.total_bytes
@@ -1364,7 +1366,7 @@ async fn process_node(
                         drop(buffers); // Release the lock before async operations
 
                         log::debug!(
-                            "[Pipeline]: Flushing buffer for batch_key '{}' - writing {} records to WAL",
+                            "[Pipeline] {pipeline_name} [inv={inv_id}]: Flushing buffer for batch_key '{}' - writing {} records to WAL",
                             batch_key,
                             records_to_write.len()
                         );
@@ -1387,7 +1389,7 @@ async fn process_node(
                                     .await
                                 {
                                     log::error!(
-                                        "[Pipeline]: DestinationNode failed sending errors for collection caused by: {send_err}"
+                                        "[Pipeline] {pipeline_name} [inv={inv_id}]: DestinationNode failed sending errors for collection caused by: {send_err}"
                                     );
                                 }
                             }
@@ -1417,24 +1419,24 @@ async fn process_node(
                         }
                     } else {
                         log::debug!(
-                            "[Pipeline]: Buffer for batch_key '{batch_key}' not ready for flush, continuing to accumulate"
+                            "[Pipeline] {pipeline_name} [inv={inv_id}]: Buffer for batch_key '{batch_key}' not ready for flush, continuing to accumulate"
                         );
                     }
                 }
             }
 
-            log::debug!("[Pipeline]: DestinationNode {node_idx} done processing {count} records");
+            log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: DestinationNode {node_idx} done processing {count} records");
         }
         #[cfg(not(feature = "enterprise"))]
         NodeData::RemoteStream(_) => {
             let err_msg = "[Pipeline]: remote destination is not supported in open source version. Records dropped".to_string();
-            log::error!("{err_msg}");
+            log::error!("[Pipeline] {pipeline_name} [inv={inv_id}]: {err_msg}");
             if let Err(send_err) = error_sender
                 .send((node.id.to_string(), node.node_type(), err_msg, None))
                 .await
             {
                 log::error!(
-                    "[Pipeline({pipeline_id})]: DestinationNode failed sending errors for collection caused by: {send_err}"
+                    "[Pipeline({pipeline_id})] {pipeline_name} [inv={inv_id}]: DestinationNode failed sending errors for collection caused by: {send_err}"
                 );
             }
         }
@@ -1445,29 +1447,29 @@ async fn process_node(
                 .online_evals_enabled
             {
                 log::warn!(
-                    "[Pipeline]: LLM evaluation node {node_idx} skipped because online evals are disabled"
+                    "[Pipeline] {pipeline_name} [inv={inv_id}]: LLM evaluation node {node_idx} skipped because online evals are disabled"
                 );
                 while receiver.recv().await.is_some() {
                     count += 1;
                 }
-                log::info!("[Pipeline]: LLM evaluation node {node_idx} skipped {count} records");
+                log::info!("[Pipeline] {pipeline_name} [inv={inv_id}]: LLM evaluation node {node_idx} skipped {count} records");
                 return Ok(());
             }
 
-            log::info!("[Pipeline]: LLM evaluation node {node_idx} starts processing");
+            log::info!("[Pipeline] {pipeline_name} [inv={inv_id}]: LLM evaluation node {node_idx} starts processing");
 
             if let Err(e) =
                 crate::service::self_reporting::ensure_llm_scores_stream_initialized(&org_id).await
             {
                 log::warn!(
-                    "[Pipeline]: LLM evaluation node {node_idx} failed to ensure _llm_scores stream initialized for {org_id}: {e}"
+                    "[Pipeline] {pipeline_name} [inv={inv_id}]: LLM evaluation node {node_idx} failed to ensure _llm_scores stream initialized for {org_id}: {e}"
                 );
             }
             if let Err(e) =
                 crate::service::self_reporting::ensure_evaluator_stream_initialized(&org_id).await
             {
                 log::warn!(
-                    "[Pipeline]: LLM evaluation node {node_idx} failed to ensure _evaluator stream initialized for {org_id}: {e}"
+                    "[Pipeline] {pipeline_name} [inv={inv_id}]: LLM evaluation node {node_idx} failed to ensure _evaluator stream initialized for {org_id}: {e}"
                 );
             }
 
@@ -1562,7 +1564,7 @@ async fn process_node(
                             .await;
                             for err in &output.errors {
                                 log::warn!(
-                                    "[Pipeline]: LLM evaluation node {node_idx} scorer '{}' error: {}",
+                                    "[Pipeline] {pipeline_name} [inv={inv_id}]: LLM evaluation node {node_idx} scorer '{}' error: {}",
                                     err.scorer_id,
                                     err.error_message
                                 );
@@ -1570,7 +1572,7 @@ async fn process_node(
                         }
                         Err(e) => {
                             log::error!(
-                                "[Pipeline]: LLM evaluation node {node_idx} execution error: {e}"
+                                "[Pipeline] {pipeline_name} [inv={inv_id}]: LLM evaluation node {node_idx} execution error: {e}"
                             );
                         }
                     }
@@ -1579,27 +1581,27 @@ async fn process_node(
             }
 
             log::info!(
-                "[Pipeline]: LLM evaluation node {node_idx} done processing {count} records"
+                "[Pipeline] {pipeline_name} [inv={inv_id}]: LLM evaluation node {node_idx} done processing {count} records"
             );
         }
         #[cfg(not(feature = "enterprise"))]
         NodeData::LlmEvaluation(_) => {
             log::warn!(
-                "[Pipeline]: LLM evaluation node {node_idx} skipped because online evals are enterprise-only"
+                "[Pipeline] {pipeline_name} [inv={inv_id}]: LLM evaluation node {node_idx} skipped because online evals are enterprise-only"
             );
             let mut skipped_count = 0usize;
             while receiver.recv().await.is_some() {
                 skipped_count += 1;
             }
             log::info!(
-                "[Pipeline]: LLM evaluation node {node_idx} skipped {skipped_count} records"
+                "[Pipeline] {pipeline_name} [inv={inv_id}]: LLM evaluation node {node_idx} skipped {skipped_count} records"
             );
         }
     }
 
     // all cloned senders dropped when function goes out of scope -> close the channel
     log::info!(
-        "[Pipeline] {pipeline_name}: node {node_idx} ({:?}) task returning",
+        "[Pipeline] {pipeline_name} [inv={inv_id}]: node {node_idx} ({:?}) task returning",
         node.node_data
     );
 


### PR DESCRIPTION
- Add logs to analyze the time taken by pipelines (can be turned on by `ZO_PRINT_KEY_EVENT=true`)
- Add pipeline processing time to the usage reporting 
- Introduce new metrics (`zo_pipeline_exec_batch_size` and `zo_pipeline_exec_time_ms`) for time taken by pipeline.