### PR TITLE
fix: bump Node heap to 8GB for web build to prevent OOM

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -18,9 +18,9 @@
     "test:coverage:check": "./coverage.sh check",
     "test:e2e": "start-server-and-test preview :4173 'cypress run --e2e'",
     "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' :4173 'cypress open --e2e'",
-    "build-only": "vite build",
-    "build-only-alpha1": "vite build --mode=alpha1",
-    "build-only-cloud-prod": "vite build --mode=production",
+    "build-only": "NODE_OPTIONS='--max-old-space-size=8192' vite build",
+    "build-only-alpha1": "NODE_OPTIONS='--max-old-space-size=8192' vite build --mode=alpha1",
+    "build-only-cloud-prod": "NODE_OPTIONS='--max-old-space-size=8192' vite build --mode=production",
     "type-check": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix",
     "lint:ci": "eslint \"src/**/*.vue\" --no-fix"


### PR DESCRIPTION
## What

Adds `NODE_OPTIONS=--max-old-space-size=8192` to all three `build-only` scripts in `web/package.json` (default, `alpha1`, `cloud-prod`).

## Why

The web production build crashes with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

The vite/rollup build hits Node's default ~4 GB old-space heap limit (the GC log shows it maxing out around 4.2 GB). When the build dies, `dist/` is never created, so the `postbuild` → `copy` step then fails with `sh: cd: dist: No such file or directory` — a confusing symptom of the real OOM.

Bumping the heap to 8 GB lets the build complete. This matches the pattern already used by `test:unit:coverage`, which sets the same option.

## Scope

Single change — only the three build script lines in `web/package.json`. No dependency or lockfile changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)