### PR TITLE
test: retry transient ingestion fetch errors in pipeline regression

### DIFF
--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -18,27 +18,24 @@ const randomNodeName = `remote-node-${Math.floor(Math.random() * 1000)}`;
  *
  * @param {string} url - Request URL
  * @param {object} options - fetch options
- * @param {number} retries - Number of additional attempts after the first (default: 3)
+ * @param {number} maxRetries - Number of additional attempts after the first (default: 3)
  * @returns {Promise<Response>} The fetch response (only network errors are retried)
  */
-async function fetchWithRetry(url, options, retries = 3) {
-    let lastError;
-    for (let attempt = 0; attempt <= retries; attempt++) {
+async function fetchWithRetry(url, options, maxRetries = 3) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
             return await fetch(url, options);
         } catch (err) {
-            lastError = err;
             const message = String(err && err.message ? err.message : err);
             const isTransient = /premature close|ECONNRESET|socket hang up|network|EPIPE|other side closed/i.test(message);
-            if (!isTransient || attempt === retries) {
+            if (!isTransient || attempt === maxRetries) {
                 throw err;
             }
             const backoffMs = 500 * (attempt + 1);
-            testLogger.warn('Transient fetch error, retrying ingestion', { url, attempt: attempt + 1, retries, error: message, backoffMs });
+            testLogger.warn('Transient fetch error, retrying ingestion', { url, attempt: attempt + 1, maxRetries, error: message, backoffMs });
             await new Promise((resolve) => setTimeout(resolve, backoffMs));
         }
     }
-    throw lastError;
 }
 
 export class PipelinesPage {

--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -7,6 +7,40 @@ import { openNavFlyoutChild } from '../commonActions.js';
 
 const randomNodeName = `remote-node-${Math.floor(Math.random() * 1000)}`;
 
+/**
+ * Perform a fetch, retrying on transient network errors.
+ *
+ * node-fetch occasionally throws "Premature close" / ECONNRESET / "socket hang up"
+ * when the server closes a keep-alive connection before the response body is fully
+ * read. These are not real ingestion failures — a retry almost always succeeds.
+ * Without this, flaky socket errors fail the ingestion in beforeEach and take the
+ * whole serial describe block down (CI: pipeline-regression metrics ingest flake).
+ *
+ * @param {string} url - Request URL
+ * @param {object} options - fetch options
+ * @param {number} retries - Number of additional attempts after the first (default: 3)
+ * @returns {Promise<Response>} The fetch response (only network errors are retried)
+ */
+async function fetchWithRetry(url, options, retries = 3) {
+    let lastError;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            return await fetch(url, options);
+        } catch (err) {
+            lastError = err;
+            const message = String(err && err.message ? err.message : err);
+            const isTransient = /premature close|ECONNRESET|socket hang up|network|EPIPE|other side closed/i.test(message);
+            if (!isTransient || attempt === retries) {
+                throw err;
+            }
+            const backoffMs = 500 * (attempt + 1);
+            testLogger.warn('Transient fetch error, retrying ingestion', { url, attempt: attempt + 1, retries, error: message, backoffMs });
+            await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        }
+    }
+    throw lastError;
+}
+
 export class PipelinesPage {
     constructor(page) {
         this.page = page;
@@ -1890,7 +1924,7 @@ export class PipelinesPage {
 
         for (const streamName of streamNames) {
             const url = `${baseUrl}/api/${orgId}/${streamName}/_json`;
-            const fetchResponse = await fetch(url, {
+            const fetchResponse = await fetchWithRetry(url, {
                 method: 'POST',
                 headers: headers,
                 body: JSON.stringify(data)
@@ -1933,7 +1967,7 @@ export class PipelinesPage {
 
         const baseUrl = (process.env.INGESTION_URL || '').replace(/\/$/, '');
         const url = `${baseUrl}/api/${orgId}/ingest/metrics/_json`;
-        const fetchResponse = await fetch(url, {
+        const fetchResponse = await fetchWithRetry(url, {
             method: 'POST',
             headers: headers,
             body: JSON.stringify(metricsData)
@@ -2045,7 +2079,7 @@ export class PipelinesPage {
         if (streamName) {
             requestHeaders["stream-name"] = streamName;
         }
-        const fetchResponse = await fetch(`${baseUrl}/api/${orgId}/v1/traces`, {
+        const fetchResponse = await fetchWithRetry(`${baseUrl}/api/${orgId}/v1/traces`, {
             method: 'POST',
             headers: requestHeaders,
             body: JSON.stringify(tracesData)


### PR DESCRIPTION
## Problem

The **Pipelines-Regression** CI job was failing on the P0 test:

> `[chromium] › RegressionSet/Pipelines/pipeline-regression.spec.js:73 › should validate scheduled pipeline SQL query with metrics stream type`

Failure (all 4 attempts):

```
FetchError: Invalid response body while trying to fetch
http://localhost:5080/api/default/ingest/metrics/_json: Premature close
```

The error originates in `beforeEach`, inside `pipelinesPage.ingestMetricsData()`. In the same setup, the global log ingestion, trace ingestion, and RUM ingestion all succeeded — only the metrics ingestion `fetch` threw.

## Root cause

`Premature close` / `ECONNRESET` / `socket hang up` are **transient** `node-fetch` errors that happen when the server closes a keep-alive socket before the response body is fully read. They are not real ingestion failures. Because the throw happens in the `beforeEach` of a **serial** describe block, a single flaky socket error fails the whole suite.

There was no retry on any of the ingestion `fetch` calls in `pipelinesPage.js`.

## Fix

Add a small `fetchWithRetry()` helper and use it for the three ingestion calls (metrics, traces, bulk). It retries (with linear backoff) **only** on transient network errors; real HTTP failures (non-2xx) are untouched and still throw immediately.

## Verification

Ran locally against `localhost:5080`:

- Failing P0 test in isolation — **passed** (36.9s)
- Full `pipeline-regression.spec.js` suite — **7 passed** (3.4m)

## Notes

- Only `tests/ui-testing/pages/pipelinesPages/pipelinesPage.js` is changed.
- The transient socket flake can't be reproduced against a healthy local server; the local runs confirm the retry wrapper is transparent on success (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)