### PR TITLE
fix(test): disable keep-alive & compression in ingest fetch

### DIFF
--- a/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
+++ b/tests/ui-testing/pages/pipelinesPages/pipelinesPage.js
@@ -1,4 +1,5 @@
 // pipelinesPage.js
+const http = require('http');
 const { expect } = require('@playwright/test')
 const testLogger = require('../../playwright-tests/utils/test-logger.js');
 const fetch = require('node-fetch');
@@ -7,14 +8,16 @@ import { openNavFlyoutChild } from '../commonActions.js';
 
 const randomNodeName = `remote-node-${Math.floor(Math.random() * 1000)}`;
 
+// HTTP agent that never pools connections. node-fetch v2 keep-alive pooling
+// is the primary cause of "Premature close" / ECONNRESET flakiness in CI.
+const noKeepAliveAgent = new http.Agent({ keepAlive: false });
+
 /**
  * Perform a fetch, retrying on transient network errors.
  *
- * node-fetch occasionally throws "Premature close" / ECONNRESET / "socket hang up"
- * when the server closes a keep-alive connection before the response body is fully
- * read. These are not real ingestion failures — a retry almost always succeeds.
- * Without this, flaky socket errors fail the ingestion in beforeEach and take the
- * whole serial describe block down (CI: pipeline-regression metrics ingest flake).
+ * Uses keepAlive: false agent + compress: false to prevent the node-fetch v2
+ * Gunzip "Premature close" / ECONNRESET flakiness that can survive retries
+ * when every connection attempt hits a pooled dead socket.
  *
  * @param {string} url - Request URL
  * @param {object} options - fetch options
@@ -22,9 +25,14 @@ const randomNodeName = `remote-node-${Math.floor(Math.random() * 1000)}`;
  * @returns {Promise<Response>} The fetch response (only network errors are retried)
  */
 async function fetchWithRetry(url, options, maxRetries = 3) {
+    const requestOpts = {
+        ...options,
+        compress: false,
+        agent: noKeepAliveAgent,
+    };
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
-            return await fetch(url, options);
+            return await fetch(url, requestOpts);
         } catch (err) {
             const message = String(err && err.message ? err.message : err);
             const isTransient = /premature close|ECONNRESET|socket hang up|network|EPIPE|other side closed/i.test(message);


### PR DESCRIPTION
## Problem

CI job **Pipelines-Regression** consistently fails on:

> `[chromium] › pipeline-regression.spec.js:73 › should validate scheduled pipeline SQL query with metrics stream type`

with `FetchError: Invalid response body … Premature close` on every attempt.

PR #12793 added `fetchWithRetry` to handle transient network errors, but the underlying cause — **node-fetch v2 keep-alive pooling + gzip decompression** — can survive retries when every connection attempt picks up the same dead socket from the pool.

## Root cause

`node-fetch` v2 defaults:
- `compress: true` → sends `Accept-Encoding: gzip` and pipes response through `Gunzip`
- Implicit HTTP agent with `keepAlive: true` → reuses connections across requests

When the server closes a pooled connection before the response body is fully read, `Gunzip` throws "Premature close." Because the bad connection stays in the pool, retries can hit the same socket and fail identically.

## Fix

- Use `keepAlive: false` agent → every fetch gets a fresh connection
- Set `compress: false` → bypass the `Gunzip` stream where the error originates
- Keep the retry wrapper as a safety net for any remaining transient faults

## Test plan

- [ ] CI: `Pipelines-Regression` job passes (especially the metrics stream type test)
- [ ] Full `pipeline-regression.spec.js` suite passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)