### PR TITLE
fix(test): extend keep-alive/compress fix to GeneralTests, Streams, Reports, SDR jobs

### DIFF
--- a/tests/ui-testing/pages/apiCleanup.js
+++ b/tests/ui-testing/pages/apiCleanup.js
@@ -1,6 +1,11 @@
+const http = require('http');
 const fetch = require('node-fetch');
 const testLogger = require('../playwright-tests/utils/test-logger.js');
 const { getAuthHeaders, getOrgIdentifier, isCloudEnvironment } = require('../playwright-tests/utils/cloud-auth.js');
+
+// node-fetch v2 keep-alive pooling + gzip decompression is the root cause of
+// "Premature close" / ECONNRESET flakiness in CI.
+const noKeepAliveAgent = new http.Agent({ keepAlive: false });
 
 class APICleanup {
     constructor(page = null) {
@@ -53,7 +58,7 @@ class APICleanup {
                 testLogger.warn('page.evaluate fetch failed, falling back to node-fetch', { url: url.substring(0, 80), error: e.message });
             }
         }
-        return fetch(url, options);
+        return fetch(url, { ...options, compress: false, agent: noKeepAliveAgent });
     }
 
     /**

--- a/tests/ui-testing/pages/generalPages/ingestionPage.js
+++ b/tests/ui-testing/pages/generalPages/ingestionPage.js
@@ -1,16 +1,27 @@
 
 import logsdata from "../../../test-data/logs_data.json";
+const http = require('http');
+const nodeFetch = require('node-fetch');
 const testLogger = require('../../playwright-tests/utils/test-logger.js');
 const { getAuthHeaders, getOrgIdentifier } = require('../../playwright-tests/utils/cloud-auth.js');
 
+// node-fetch v2 keep-alive pooling + gzip decompression is the root cause of
+// "Premature close" / ECONNRESET flakiness in CI.
+const noKeepAliveAgent = new http.Agent({ keepAlive: false });
+
 async function fetchWithRetry(url, options, maxRetries = 3) {
+  const requestOpts = { ...options, compress: false, agent: noKeepAliveAgent };
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      return await fetch(url, options);
+      return await nodeFetch(url, requestOpts);
     } catch (err) {
       const message = String(err && err.message ? err.message : err);
       const isTransient = /premature close|ECONNRESET|socket hang up|network|EPIPE|other side closed/i.test(message);
-      if (!isTransient || attempt === maxRetries) throw err;
+      if (!isTransient) {
+        testLogger.warn('Non-transient fetch error (not retrying)', { url, error: message });
+        throw err;
+      }
+      if (attempt === maxRetries) throw err;
       const backoffMs = 500 * (attempt + 1);
       testLogger.warn('Transient fetch error, retrying ingestion', { url, attempt: attempt + 1, maxRetries, error: message, backoffMs });
       await new Promise((resolve) => setTimeout(resolve, backoffMs));

--- a/tests/ui-testing/pages/generalPages/ingestionPage.js
+++ b/tests/ui-testing/pages/generalPages/ingestionPage.js
@@ -2,6 +2,22 @@
 import logsdata from "../../../test-data/logs_data.json";
 const testLogger = require('../../playwright-tests/utils/test-logger.js');
 const { getAuthHeaders, getOrgIdentifier } = require('../../playwright-tests/utils/cloud-auth.js');
+
+async function fetchWithRetry(url, options, maxRetries = 3) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fetch(url, options);
+    } catch (err) {
+      const message = String(err && err.message ? err.message : err);
+      const isTransient = /premature close|ECONNRESET|socket hang up|network|EPIPE|other side closed/i.test(message);
+      if (!isTransient || attempt === maxRetries) throw err;
+      const backoffMs = 500 * (attempt + 1);
+      testLogger.warn('Transient fetch error, retrying ingestion', { url, attempt: attempt + 1, maxRetries, error: message, backoffMs });
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    }
+  }
+}
+
 export class IngestionPage {
   constructor(page) {
     this.page = page;
@@ -10,7 +26,7 @@ export class IngestionPage {
     const orgId = getOrgIdentifier();
     const streamName = "e2e_automate";
     const headers = getAuthHeaders();
-    const fetchResponse = await fetch(
+    const fetchResponse = await fetchWithRetry(
       `${process.env.INGESTION_URL}/api/${orgId}/${streamName}/_json`,
       {
         method: "POST",
@@ -70,7 +86,7 @@ export class IngestionPage {
   async ingestionMultiOrg(orgId) {
     const streamName = "e2e_automate";
     const headers = getAuthHeaders();
-    const fetchResponse = await fetch(
+    const fetchResponse = await fetchWithRetry(
       `${process.env.INGESTION_URL}/api/${orgId}/${streamName}/_json`,
       {
         method: "POST",
@@ -96,7 +112,7 @@ export class IngestionPage {
 
   async ingestionMultiOrgStream(orgId, streamName) {
     const headers = getAuthHeaders();
-    const fetchResponse = await fetch(
+    const fetchResponse = await fetchWithRetry(
       `${process.env.INGESTION_URL}/api/${orgId}/${streamName}/_json`,
       {
         method: "POST",
@@ -158,7 +174,7 @@ export class IngestionPage {
       testLogger.debug(`ingestionJoinUnion: Ingesting to stream '${streamName}' at ${url}`);
 
       try {
-        const response = await fetch(url, {
+        const response = await fetchWithRetry(url, {
           method: "POST",
           headers: headers,
           body: JSON.stringify(logsdata),

--- a/tests/ui-testing/pages/streamsPages/streamsPage.js
+++ b/tests/ui-testing/pages/streamsPages/streamsPage.js
@@ -5,7 +5,16 @@ import { IngestionPage } from '../generalPages/ingestionPage.js';
 import { ManagementPage } from '../generalPages/managementPage.js';
 
 import { getHeaders, getIngestionUrl, sendRequest } from '../../utils/apiUtils.js';
+const http = require('http');
 const testLogger = require('../../playwright-tests/utils/test-logger.js');
+
+// node-fetch v2 keep-alive pooling + gzip decompression is the root cause of
+// "Premature close" / ECONNRESET flakiness in CI.
+const _noKeepAliveAgent = new http.Agent({ keepAlive: false });
+async function _nodeFetchSafe(url, opts = {}) {
+    const fetch = (await import('node-fetch')).default;
+    return fetch(url, { ...opts, compress: false, agent: _noKeepAliveAgent });
+}
 
 export class StreamsPage {
     constructor(page) {
@@ -559,9 +568,8 @@ export class StreamsPage {
             }
 
             // Self-hosted: use node-fetch with Basic Auth
-            const fetch = (await import('node-fetch')).default;
             const headers = getHeaders();
-            const response = await fetch(`${process.env.INGESTION_URL}/api/${orgId}/streams/${streamName}?type=${streamType}`, {
+            const response = await _nodeFetchSafe(`${process.env.INGESTION_URL}/api/${orgId}/streams/${streamName}?type=${streamType}`, {
                 method: 'POST',
                 headers: headers,
                 body: JSON.stringify(payload)
@@ -610,9 +618,8 @@ export class StreamsPage {
             }
 
             // Self-hosted: use node-fetch with Basic Auth
-            const fetch = (await import('node-fetch')).default;
             const headers = getHeaders();
-            const response = await fetch(`${process.env.INGESTION_URL}/api/${orgId}/streams`, {
+            const response = await _nodeFetchSafe(`${process.env.INGESTION_URL}/api/${orgId}/streams`, {
                 method: 'GET',
                 headers: headers
             });
@@ -674,9 +681,8 @@ export class StreamsPage {
                 data = result;
             } else {
                 // Self-hosted: use node-fetch with Basic Auth
-                const fetch = (await import('node-fetch')).default;
                 const headers = getHeaders();
-                const response = await fetch(`${process.env.INGESTION_URL}/api/${orgId}/_search?type=logs`, {
+                const response = await _nodeFetchSafe(`${process.env.INGESTION_URL}/api/${orgId}/_search?type=logs`, {
                     method: 'POST',
                     headers: headers,
                     body: JSON.stringify(query)
@@ -907,9 +913,8 @@ export class StreamsPage {
             }
 
             // Self-hosted: use node-fetch with Basic Auth
-            const fetch = (await import('node-fetch')).default;
             const headers = getHeaders();
-            const response = await fetch(`${process.env.INGESTION_URL}/api/${orgId}/streams/${streamName}?type=${streamType}`, {
+            const response = await _nodeFetchSafe(`${process.env.INGESTION_URL}/api/${orgId}/streams/${streamName}?type=${streamType}`, {
                 method: 'DELETE',
                 headers: headers
             });

--- a/tests/ui-testing/pages/streamsPages/streamsPage.js
+++ b/tests/ui-testing/pages/streamsPages/streamsPage.js
@@ -6,14 +6,14 @@ import { ManagementPage } from '../generalPages/managementPage.js';
 
 import { getHeaders, getIngestionUrl, sendRequest } from '../../utils/apiUtils.js';
 const http = require('http');
+const nodeFetch = require('node-fetch');
 const testLogger = require('../../playwright-tests/utils/test-logger.js');
 
 // node-fetch v2 keep-alive pooling + gzip decompression is the root cause of
 // "Premature close" / ECONNRESET flakiness in CI.
 const _noKeepAliveAgent = new http.Agent({ keepAlive: false });
-async function _nodeFetchSafe(url, opts = {}) {
-    const fetch = (await import('node-fetch')).default;
-    return fetch(url, { ...opts, compress: false, agent: _noKeepAliveAgent });
+function _nodeFetchSafe(url, opts = {}) {
+    return nodeFetch(url, { ...opts, compress: false, agent: _noKeepAliveAgent });
 }
 
 export class StreamsPage {

--- a/tests/ui-testing/playwright-tests/GeneralTests/model-pricing.spec.js
+++ b/tests/ui-testing/playwright-tests/GeneralTests/model-pricing.spec.js
@@ -1,10 +1,16 @@
 const { test, expect, navigateToBase } = require('../utils/enhanced-baseFixtures.js');
 const PageManager = require('../../pages/page-manager.js');
 const testLogger = require('../utils/test-logger.js');
-const fetch = require('node-fetch');
+const http = require('http');
+const nodeFetch = require('node-fetch');
 const { getAuthHeaders, getOrgIdentifier } = require('../utils/cloud-auth.js');
 const { generateHexId } = require('../utils/trace-ingestion.js');
 const fs = require('fs');
+
+// node-fetch v2 keep-alive pooling + gzip decompression is the root cause of
+// "Premature close" / ECONNRESET flakiness in CI.
+const noKeepAliveAgent = new http.Agent({ keepAlive: false });
+const fetch = (url, opts = {}) => nodeFetch(url, { ...opts, compress: false, agent: noKeepAliveAgent });
 
 test.describe.configure({ mode: 'parallel' });
 

--- a/tests/ui-testing/playwright-tests/SDR/regexPatternManagement.spec.js
+++ b/tests/ui-testing/playwright-tests/SDR/regexPatternManagement.spec.js
@@ -37,9 +37,8 @@ test.describe("Regex Pattern Management Tests", { tag: '@enterprise' }, () => {
     // OForm validates on submit (not field-disabled); clicking save triggers
     // Zod validation which keeps the drawer open on error.
     await pm.sdrPatternsPage.saveButton.click();
-    await page.waitForTimeout(300);
     testLogger.info('Verifying drawer stays open after save with empty name');
-    await expect(pm.sdrPatternsPage.saveButton).toBeVisible({ timeout: 5000 });
+    await expect(pm.sdrPatternsPage.addPatternTitle).toBeVisible({ timeout: 5000 });
 
     await pm.sdrPatternsPage.cancelButton.click();
     await page.waitForTimeout(500);
@@ -51,9 +50,8 @@ test.describe("Regex Pattern Management Tests", { tag: '@enterprise' }, () => {
     await pm.sdrPatternsPage.patternDescriptionInput.fill('Test description');
 
     await pm.sdrPatternsPage.saveButton.click();
-    await page.waitForTimeout(300);
     testLogger.info('Verifying drawer stays open after save with empty pattern');
-    await expect(pm.sdrPatternsPage.saveButton).toBeVisible({ timeout: 5000 });
+    await expect(pm.sdrPatternsPage.addPatternTitle).toBeVisible({ timeout: 5000 });
   });
 
   // ===== ERROR HANDLING TESTS =====

--- a/tests/ui-testing/playwright-tests/SDR/regexPatternManagement.spec.js
+++ b/tests/ui-testing/playwright-tests/SDR/regexPatternManagement.spec.js
@@ -21,37 +21,39 @@ test.describe("Regex Pattern Management Tests", { tag: '@enterprise' }, () => {
 
   // ===== VALIDATION TESTS =====
 
-  test("should disable save button when required fields are empty", {
+  test("should reject save when required fields are empty", {
     tag: ['@sdr', '@regexPatterns', '@negative', '@validation', '@P2']
   }, async ({ page }) => {
-    testLogger.info('Testing that save button is disabled when required fields are empty');
+    testLogger.info('Testing that form rejects save when required fields are empty');
 
     await pm.sdrPatternsPage.navigateToRegexPatterns();
 
-    // Test 1: Empty pattern name
+    // Test 1: Empty pattern name — form should not close
     testLogger.info('Testing empty pattern name');
     await pm.sdrPatternsPage.clickAddPattern();
     await pm.sdrPatternsPage.patternDescriptionInput.fill('Test description');
     await pm.sdrPatternsPage.patternInput.fill('^[A-Z]{5}[0-9]{4}[A-Z]$');
 
-    let saveButton = pm.sdrPatternsPage.saveButton;
-    let isDisabled = await saveButton.isDisabled();
-    testLogger.info(`Save button disabled (empty name): ${isDisabled}`);
-    expect(isDisabled).toBeTruthy();
+    // OForm validates on submit (not field-disabled); clicking save triggers
+    // Zod validation which keeps the drawer open on error.
+    await pm.sdrPatternsPage.saveButton.click();
+    await page.waitForTimeout(300);
+    testLogger.info('Verifying drawer stays open after save with empty name');
+    await expect(pm.sdrPatternsPage.saveButton).toBeVisible({ timeout: 5000 });
 
     await pm.sdrPatternsPage.cancelButton.click();
     await page.waitForTimeout(500);
 
-    // Test 2: Empty regex pattern
+    // Test 2: Empty regex pattern — form should not close
     testLogger.info('Testing empty regex pattern');
     await pm.sdrPatternsPage.clickAddPattern();
     await pm.sdrPatternsPage.patternNameInput.fill('empty_pattern');
     await pm.sdrPatternsPage.patternDescriptionInput.fill('Test description');
 
-    saveButton = pm.sdrPatternsPage.saveButton;
-    isDisabled = await saveButton.isDisabled();
-    testLogger.info(`Save button disabled (empty pattern): ${isDisabled}`);
-    expect(isDisabled).toBeTruthy();
+    await pm.sdrPatternsPage.saveButton.click();
+    await page.waitForTimeout(300);
+    testLogger.info('Verifying drawer stays open after save with empty pattern');
+    await expect(pm.sdrPatternsPage.saveButton).toBeVisible({ timeout: 5000 });
   });
 
   // ===== ERROR HANDLING TESTS =====

--- a/tests/ui-testing/utils/apiUtils.js
+++ b/tests/ui-testing/utils/apiUtils.js
@@ -1,8 +1,15 @@
 import fs from 'fs';
 import path from 'path';
+import http from 'http';
 
 // Cache cloud config to avoid re-reading on every call
 let _cachedCloudConfig = null;
+
+// node-fetch v2 keep-alive pooling + gzip decompression is the root cause of
+// "Premature close" / ECONNRESET flakiness in CI. A fresh connection per
+// request (keepAlive: false) + skipping the Gunzip stream (compress: false)
+// eliminates both failure modes.
+const noKeepAliveAgent = new http.Agent({ keepAlive: false });
 
 export const getHeaders = () => {
   // On cloud, use email:passcode from cloud-config.json (written by global-setup-alpha1.js)
@@ -48,6 +55,8 @@ export const sendRequest = async (page, url, payload, headers) => {
     method: "POST",
     headers: headers,
     body: JSON.stringify(payload),
+    compress: false,
+    agent: noKeepAliveAgent,
   });
 
   return await response.json();


### PR DESCRIPTION
## Summary

Applies the same node-fetch v2 fix from PR #12799 (pipelines) to all remaining CI jobs that show \"Premature close\" / ECONNRESET failures:

- **apiUtils.js** (`sendRequest`): adds `compress:false` + `noKeepAliveAgent` — fixes **Streams** job (`multiselect-stream.spec.js`, `streamname.spec.js`)
- **apiCleanup.js** (`_fetch`): same fix on the node-fetch fallback path — fixes **Reports** job (dashboard/report API calls)
- **model-pricing.spec.js**: wraps `node-fetch` with a local safe-fetch shim — fixes **GeneralTests** job (`/llm/models` premature close)
- **streamsPage.js**: replaces four dynamic `node-fetch` imports with a shared `_nodeFetchSafe` helper
- **ingestionPage.js**: adds `fetchWithRetry` around native fetch to handle transient `ECONNRESET`/premature close in `beforeEach` ingestion

**SDR fix:** `regexPatternManagement.spec.js` — `AddRegexPattern.vue` migrated to `OForm` with submit-time Zod validation (`AddRegexPattern.schema.ts`). The `ODrawer` primary button is no longer disabled for empty fields; validation triggers on click and keeps the drawer open on error. Replaces stale `expect(isDisabled).toBeTruthy()` checks with click-then-expect-drawer-still-visible assertions.

## Root cause (same as #12799)

`node-fetch` v2 defaults to `keepAlive: true` (connection pooling) and `compress: true` (Gunzip stream). When the server closes a pooled connection early, the Gunzip stream throws \"Premature close\". Because the dead socket stays in the pool, retries hit the same socket. `keepAlive: false` + `compress: false` eliminates both failure modes.

## Test plan

- [ ] GeneralTests / `model-pricing.spec.js` — no more premature close on `/llm/models`
- [ ] Streams / `multiselect-stream.spec.js` + `streamname.spec.js` — no more premature close on ingestion
- [ ] Reports / `reportsScheduleNow.spec.js` — no more premature close during beforeEach ingestion
- [ ] SDR / `regexPatternManagement.spec.js` — validation test passes with updated assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)