### PR TITLE
feat: dashboard `locale format` support as unit

### DIFF
--- a/web/src/components/dashboards/OverrideConfigPopup.vue
+++ b/web/src/components/dashboards/OverrideConfigPopup.vue
@@ -148,6 +148,10 @@ export default defineComponent({
         value: "numbers",
       },
       {
+        label: t("dashboard.localeFormat"),
+        value: "locale",
+      },
+      {
         label: t("dashboard.bytes"),
         value: "bytes",
       },

--- a/web/src/components/dashboards/PanelSchemaRenderer.spec.ts
+++ b/web/src/components/dashboards/PanelSchemaRenderer.spec.ts
@@ -60,6 +60,10 @@ vi.mock("@/utils/dashboard/convertPanelData", () => ({
   }),
 }));
 
+vi.mock("@/utils/clipboard", () => ({
+  copyToClipboard: vi.fn(() => Promise.resolve(true)),
+}));
+
 vi.mock("@/utils/commons", () => ({
   getAllDashboardsByFolderId: vi.fn(),
   getDashboard: vi.fn(),
@@ -160,6 +164,7 @@ import PanelSchemaRenderer from "@/components/dashboards/PanelSchemaRenderer.vue
 import i18n from "@/locales";
 import store from "@/test/unit/helpers/store";
 import { usePanelDataLoader } from "@/composables/dashboard/usePanelDataLoader";
+import { copyToClipboard } from "@/utils/clipboard";
 
 
 describe("PanelSchemaRenderer", () => {
@@ -2279,6 +2284,96 @@ describe("PanelSchemaRenderer", () => {
       expect(wrapper.vm.metadata).toBeDefined();
       expect(wrapper.vm.panelSchema.queries).toBeDefined();
       expect(wrapper.vm.panelSchema.queries.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("metric copy button", () => {
+    const metricSeries = () => [
+      {
+        _metricText: "1.50KB",
+        _metricLayout: {
+          left: 0,
+          top: 0,
+          width: 200,
+          height: 100,
+          cx: 100,
+          cy: 50,
+          fontSize: 24,
+        },
+      },
+      {
+        _metricText: "2.00MB",
+        _metricLayout: {
+          left: 200,
+          top: 0,
+          width: 200,
+          height: 100,
+          cx: 300,
+          cy: 50,
+          fontSize: 24,
+        },
+      },
+    ];
+
+    const mountMetric = async (series = metricSeries()) => {
+      const w = createWrapper({
+        panelSchema: { ...defaultProps.panelSchema, type: "metric" },
+      });
+      await flushPromises();
+      w.vm.panelData = { chartType: "metric", options: { series } };
+      await nextTick();
+      return w;
+    };
+
+    it("builds one copy item per metric value", async () => {
+      wrapper = await mountMetric();
+      expect(wrapper.vm.metricItems).toHaveLength(2);
+      expect(wrapper.vm.metricItems[0]).toMatchObject({ idx: 0, text: "1.50KB" });
+      expect(wrapper.vm.metricItems[1]).toMatchObject({ idx: 1, text: "2.00MB" });
+    });
+
+    it("skips series without a value or layout", async () => {
+      wrapper = await mountMetric([
+        { _metricText: "", _metricLayout: { left: 0, width: 100 } },
+        { _metricText: "5", _metricLayout: null },
+      ]);
+      expect(wrapper.vm.metricItems).toHaveLength(0);
+    });
+
+    it("returns no items for non-metric panels", async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+      wrapper.vm.panelData = { options: { series: metricSeries() } };
+      await nextTick();
+      expect(wrapper.vm.metricItems).toEqual([]);
+    });
+
+    it("zone style spans the value's grid cell", async () => {
+      wrapper = await mountMetric();
+      expect(wrapper.vm.metricZoneStyle(wrapper.vm.metricItems[1])).toEqual({
+        left: "200px",
+        top: "0px",
+        width: "200px",
+        height: "100px",
+      });
+    });
+
+    it("positions the icon beside the number, clamped inside the cell", async () => {
+      wrapper = await mountMetric();
+      const style = wrapper.vm.metricIconStyle(wrapper.vm.metricItems[0]);
+      // halfWidth = 6 * 24 * 0.55 / 2 = 39.6; left = (100-0) + 39.6 + 2 = 141.6;
+      // maxLeft = 200 - 28 - 2 = 170 → 141.6 wins.
+      expect(style.left).toBe("141.6px");
+      expect(style.top).toBe("50px");
+      expect(style.transform).toBe("translateY(-50%)");
+    });
+
+    it("copies the displayed value and flags the copied state", async () => {
+      wrapper = await mountMetric();
+      wrapper.vm.copyMetricItem(wrapper.vm.metricItems[1]);
+      expect(copyToClipboard).toHaveBeenCalledWith("2.00MB", { silent: true });
+      await flushPromises();
+      expect(wrapper.vm.metricCopiedIdx).toBe(1);
     });
   });
 });

--- a/web/src/components/dashboards/PanelSchemaRenderer.spec.ts
+++ b/web/src/components/dashboards/PanelSchemaRenderer.spec.ts
@@ -2361,9 +2361,9 @@ describe("PanelSchemaRenderer", () => {
     it("positions the icon beside the number, clamped inside the cell", async () => {
       wrapper = await mountMetric();
       const style = wrapper.vm.metricIconStyle(wrapper.vm.metricItems[0]);
-      // halfWidth = 6 * 24 * 0.55 / 2 = 39.6; left = (100-0) + 39.6 + 2 = 141.6;
-      // maxLeft = 200 - 28 - 2 = 170 → 141.6 wins.
-      expect(style.left).toBe("141.6px");
+      // jsdom has no layout so calculateWidthText returns 0:
+      // left = (cx 100 - left 0) + 0/2 + 2 = 102; maxLeft = 200 - 28 - 2 = 170.
+      expect(style.left).toBe("102px");
       expect(style.top).toBe("50px");
       expect(style.transform).toBe("translateY(-50%)");
     });

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -114,6 +114,37 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           @domcontextmenu="onChartDomContextMenu"
         />
       </div>
+      <!-- Metric chart: per-value copy icon, revealed on hover of each number -->
+      <div
+        v-if="metricItems.length"
+        style="position: absolute; inset: 0; pointer-events: none; z-index: 8"
+        data-test="dashboard-metric-copy-overlay"
+      >
+        <div
+          v-for="m in metricItems"
+          :key="m.idx"
+          style="position: absolute; pointer-events: auto"
+          :style="metricZoneStyle(m)"
+          @mouseenter="hoveredMetricIdx = m.idx"
+          @mouseleave="hoveredMetricIdx = null"
+        >
+          <OButton
+            v-show="hoveredMetricIdx === m.idx || metricCopiedIdx === m.idx"
+            variant="ghost"
+            size="icon-xs-sq"
+            style="position: absolute"
+            :style="metricIconStyle(m)"
+            @click="copyMetricItem(m)"
+            data-test="dashboard-metric-copy-btn"
+            :data-copied="metricCopiedIdx === m.idx ? 'true' : undefined"
+          >
+            <OIcon
+              :name="metricCopiedIdx === m.idx ? 'check' : 'content-copy'"
+              size="sm"
+            />
+          </OButton>
+        </div>
+      </div>
       <div
         v-if="
           !errorDetail?.message &&
@@ -393,6 +424,7 @@ import OButton from "@/lib/core/Button/OButton.vue";
 import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
 import OSeparator from '@/lib/core/Separator/OSeparator.vue';
+import { copyToClipboard } from "@/utils/clipboard";
 
 export default defineComponent({
   name: "PanelSchemaRenderer",
@@ -596,6 +628,57 @@ export default defineComponent({
     const isCursorOverPanel = ref(false);
     const showPopupsAndOverlays = () => {
       isCursorOverPanel.value = true;
+    };
+
+    // Metric chart: one copy icon per rendered value (multi-SQL renders many).
+    // Values are already unit/decimal/timestamp formatted at the metric level;
+    // _metricLayout gives the canvas pixel position so the icon sits beside it.
+    const metricItems = computed(() => {
+      if (props.panelSchema?.type !== "metric") return [];
+      const series = panelData.value?.options?.series ?? [];
+      return series
+        .map((s: any, idx: number) => ({
+          idx,
+          text: s?._metricText,
+          layout: s?._metricLayout,
+        }))
+        .filter(
+          (m: any) =>
+            m.layout && m.text != null && String(m.text).trim() !== "",
+        );
+    });
+    // Hover zone = each value's grid cell.
+    const metricZoneStyle = (m: any) => ({
+      left: `${m.layout.left}px`,
+      top: `${m.layout.top}px`,
+      width: `${m.layout.width}px`,
+      height: `${m.layout.height}px`,
+    });
+    // Fixed copy-button width (icon-xs-sq), matching the table chart.
+    const COPY_BTN_PX = 28;
+    // Sit just past the number's right edge (estimated a touch wide so it never
+    // overlaps), clamped inside the cell. The font-size reserve guarantees room.
+    const metricIconStyle = (m: any) => {
+      const fs = m.layout?.fontSize || 24;
+      const halfWidth = (String(m.text).length * fs * 0.55) / 2;
+      const left = m.layout.cx - m.layout.left + halfWidth + 2;
+      const maxLeft = m.layout.width - COPY_BTN_PX - 2;
+      return {
+        left: `${Math.min(left, maxLeft)}px`,
+        top: `${m.layout.cy - m.layout.top}px`,
+        transform: "translateY(-50%)",
+      };
+    };
+    const hoveredMetricIdx = ref<number | null>(null);
+    const metricCopiedIdx = ref<number | null>(null);
+    const copyMetricItem = (m: any) => {
+      if (m.text == null) return;
+      copyToClipboard(String(m.text), { silent: true }).then(() => {
+        metricCopiedIdx.value = m.idx;
+        setTimeout(() => {
+          if (metricCopiedIdx.value === m.idx) metricCopiedIdx.value = null;
+        }, 3000);
+      });
     };
 
     // get refs from props
@@ -1616,6 +1699,12 @@ export default defineComponent({
       panelsList,
       isCursorOverPanel,
       showPopupsAndOverlays,
+      metricItems,
+      metricZoneStyle,
+      metricIconStyle,
+      hoveredMetricIdx,
+      metricCopiedIdx,
+      copyMetricItem,
       downloadDataAsCSV,
       downloadDataAsJSON,
       getPanelCsvData: (title: string) => {

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -425,6 +425,7 @@ import OIcon from "@/lib/core/Icon/OIcon.vue";
 import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
 import OSeparator from '@/lib/core/Separator/OSeparator.vue';
 import { copyToClipboard } from "@/utils/clipboard";
+import { calculateWidthText } from "@/utils/dashboard/chartDimensionUtils";
 
 export default defineComponent({
   name: "PanelSchemaRenderer",
@@ -656,12 +657,12 @@ export default defineComponent({
     });
     // Fixed copy-button width (icon-xs-sq), matching the table chart.
     const COPY_BTN_PX = 28;
-    // Sit just past the number's right edge (estimated a touch wide so it never
-    // overlaps), clamped inside the cell. The font-size reserve guarantees room.
+    // Sit just past the number's measured right edge, clamped inside the cell.
+    // Measuring (vs estimating) keeps the icon off the digits for any value.
     const metricIconStyle = (m: any) => {
       const fs = m.layout?.fontSize || 24;
-      const halfWidth = (String(m.text).length * fs * 0.55) / 2;
-      const left = m.layout.cx - m.layout.left + halfWidth + 2;
+      const textWidth = calculateWidthText(String(m.text), `${fs}px`);
+      const left = m.layout.cx - m.layout.left + textWidth / 2 + 2;
       const maxLeft = m.layout.width - COPY_BTN_PX - 2;
       return {
         left: `${Math.min(left, maxLeft)}px`,

--- a/web/src/components/dashboards/addPanel/ConfigPanel.vue
+++ b/web/src/components/dashboards/addPanel/ConfigPanel.vue
@@ -2224,6 +2224,10 @@ export default defineComponent({
         value: "numbers",
       },
       {
+        label: t("dashboard.localeFormat"),
+        value: "locale",
+      },
+      {
         label: t("dashboard.bytes"),
         value: "bytes",
       },

--- a/web/src/locales/index.spec.ts
+++ b/web/src/locales/index.spec.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getLanguage } from "@/utils/cookies";
+
+vi.mock("@/utils/cookies", () => ({
+  getLanguage: vi.fn(),
+  setLanguage: vi.fn(),
+}));
+
+import { getNumberLocale } from "@/locales";
+
+describe("getNumberLocale (locale format unit)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps app language codes to valid BCP-47 tags", () => {
+    const cases: Array<[string, string]> = [
+      ["en-gb", "en-GB"],
+      ["tr-turk", "tr-TR"],
+      ["zh-cn", "zh-CN"],
+      ["zh-tw", "zh-TW"],
+      ["fr", "fr-FR"],
+      ["es", "es-ES"],
+      ["de", "de-DE"],
+      ["it", "it-IT"],
+      ["ja", "ja-JP"],
+      ["ko", "ko-KR"],
+      ["nl", "nl-NL"],
+      ["pt", "pt-PT"],
+    ];
+    for (const [appCode, bcp47] of cases) {
+      (getLanguage as any).mockReturnValue(appCode);
+      expect(getNumberLocale()).toBe(bcp47);
+    }
+  });
+
+  it("falls back to en-GB for an unmapped language", () => {
+    (getLanguage as any).mockReturnValue("xx-unknown");
+    expect(getNumberLocale()).toBe("en-GB");
+  });
+
+  it("produces Intl-formatted separators per locale", () => {
+    (getLanguage as any).mockReturnValue("de");
+    const de = new Intl.NumberFormat(getNumberLocale(), {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(1234567.89);
+    expect(de).toBe("1.234.567,89");
+
+    (getLanguage as any).mockReturnValue("en-gb");
+    const en = new Intl.NumberFormat(getNumberLocale(), {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(1234567.89);
+    expect(en).toBe("1,234,567.89");
+  });
+});

--- a/web/src/locales/index.spec.ts
+++ b/web/src/locales/index.spec.ts
@@ -21,7 +21,7 @@ vi.mock("@/utils/cookies", () => ({
   setLanguage: vi.fn(),
 }));
 
-import { getNumberLocale } from "@/locales";
+import { getNumberLocale } from "@/locales/numberFormat";
 
 describe("getNumberLocale (locale format unit)", () => {
   beforeEach(() => {

--- a/web/src/locales/index.ts
+++ b/web/src/locales/index.ts
@@ -86,6 +86,25 @@ export const getLocale = () => {
   return "en-gb";
 };
 
+// App language codes are not all valid BCP-47, so map them for Intl.NumberFormat.
+const APP_LOCALE_TO_BCP47: Record<string, string> = {
+  "en-gb": "en-GB",
+  "tr-turk": "tr-TR",
+  "zh-cn": "zh-CN",
+  "zh-tw": "zh-TW",
+  fr: "fr-FR",
+  es: "es-ES",
+  de: "de-DE",
+  it: "it-IT",
+  ja: "ja-JP",
+  ko: "ko-KR",
+  nl: "nl-NL",
+  pt: "pt-PT",
+};
+
+export const getNumberLocale = (): string =>
+  APP_LOCALE_TO_BCP47[getLocale()] ?? "en-GB";
+
 const i18n = createI18n({
   locale: getLocale(),
   fallbackLocale: "en-gb",

--- a/web/src/locales/index.ts
+++ b/web/src/locales/index.ts
@@ -86,24 +86,9 @@ export const getLocale = () => {
   return "en-gb";
 };
 
-// App language codes are not all valid BCP-47, so map them for Intl.NumberFormat.
-const APP_LOCALE_TO_BCP47: Record<string, string> = {
-  "en-gb": "en-GB",
-  "tr-turk": "tr-TR",
-  "zh-cn": "zh-CN",
-  "zh-tw": "zh-TW",
-  fr: "fr-FR",
-  es: "es-ES",
-  de: "de-DE",
-  it: "it-IT",
-  ja: "ja-JP",
-  ko: "ko-KR",
-  nl: "nl-NL",
-  pt: "pt-PT",
-};
-
-export const getNumberLocale = (): string =>
-  APP_LOCALE_TO_BCP47[getLocale()] ?? "en-GB";
+// Re-exported for consumers that import from "@/locales"; defined in a
+// standalone module so utils don't pull createI18n into their import graph.
+export { getNumberLocale } from "./numberFormat";
 
 const i18n = createI18n({
   locale: getLocale(),

--- a/web/src/locales/index.ts
+++ b/web/src/locales/index.ts
@@ -86,10 +86,6 @@ export const getLocale = () => {
   return "en-gb";
 };
 
-// Re-exported for consumers that import from "@/locales"; defined in a
-// standalone module so utils don't pull createI18n into their import graph.
-export { getNumberLocale } from "./numberFormat";
-
 const i18n = createI18n({
   locale: getLocale(),
   fallbackLocale: "en-gb",

--- a/web/src/locales/languages/de.json
+++ b/web/src/locales/languages/de.json
@@ -1386,6 +1386,7 @@
     "selectDashboardLabel": "Wählen Sie Dashboard",
     "selectTabLabel": "Wählen Sie Tab",
     "numbers": "Zahlen",
+    "localeFormat": "Gebietsschema-Format",
     "nanoseconds": "Nanosekunden (ns)",
     "currency": "Währung",
     "p99": "P99",

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -2009,6 +2009,7 @@
     "bottom": "Bottom",
     "default": "Default",
     "numbers": "Numbers",
+    "localeFormat": "Locale Format",
     "bytes": "Bytes",
     "kilobytes": "Kilobytes (KB)",
     "megabytes": "Megabytes (MB)",

--- a/web/src/locales/languages/es.json
+++ b/web/src/locales/languages/es.json
@@ -1385,6 +1385,7 @@
     "selectDashboardLabel": "Seleccione panel",
     "selectTabLabel": "Seleccione pestaña",
     "numbers": "Números",
+    "localeFormat": "Formato regional",
     "nanoseconds": "Nanosegundos (ns)",
     "currency": "Moneda",
     "p99": "P99",

--- a/web/src/locales/languages/fr.json
+++ b/web/src/locales/languages/fr.json
@@ -1386,6 +1386,7 @@
     "selectDashboardLabel": "Sélectionnez le tableau de bord",
     "selectTabLabel": "Sélectionnez un onglet",
     "numbers": "Nombres",
+    "localeFormat": "Format régional",
     "nanoseconds": "Nanosecondes (ns)",
     "currency": "Devise",
     "p99": "P99",

--- a/web/src/locales/languages/hi.json
+++ b/web/src/locales/languages/hi.json
@@ -1205,6 +1205,7 @@
     "selectDashboardLabel": "Select Dashboard",
     "selectTabLabel": "Select Tab",
     "numbers": "Numbers",
+    "localeFormat": "Locale Format",
     "nanoseconds": "Nanoseconds (ns)",
     "currency": "Currency",
     "p99": "P99",

--- a/web/src/locales/languages/it.json
+++ b/web/src/locales/languages/it.json
@@ -1386,6 +1386,7 @@
     "selectDashboardLabel": "Seleziona Dashboard",
     "selectTabLabel": "Seleziona scheda",
     "numbers": "Numeri",
+    "localeFormat": "Formato locale",
     "nanoseconds": "Nanosecondi (ns)",
     "currency": "Valuta",
     "p99": "P99",

--- a/web/src/locales/languages/ja.json
+++ b/web/src/locales/languages/ja.json
@@ -1403,6 +1403,7 @@
     "selectDashboardLabel": "ダッシュボードを選択",
     "selectTabLabel": "タブを選択",
     "numbers": "数字",
+    "localeFormat": "ロケール形式",
     "nanoseconds": "ナノ秒 (ns)",
     "currency": "通貨",
     "p99": "99",

--- a/web/src/locales/languages/ko.json
+++ b/web/src/locales/languages/ko.json
@@ -1386,6 +1386,7 @@
     "selectDashboardLabel": "대시보드 선택",
     "selectTabLabel": "탭 선택",
     "numbers": "숫자",
+    "localeFormat": "로캘 형식",
     "nanoseconds": "나노세컨드 (ns)",
     "currency": "화폐",
     "p99": "P99",

--- a/web/src/locales/languages/nl.json
+++ b/web/src/locales/languages/nl.json
@@ -1386,6 +1386,7 @@
     "selectDashboardLabel": "Selecteer Dashboard",
     "selectTabLabel": "Tabblad selecteren",
     "numbers": "Getallen",
+    "localeFormat": "Landnotatie",
     "nanoseconds": "Nanoseconden (ns)",
     "currency": "Valuta",
     "p99": "P99",

--- a/web/src/locales/languages/pt.json
+++ b/web/src/locales/languages/pt.json
@@ -1386,6 +1386,7 @@
     "selectDashboardLabel": "Selecione o painel",
     "selectTabLabel": "Selecione a guia",
     "numbers": "Números",
+    "localeFormat": "Formato Regional",
     "nanoseconds": "Nanossegundos (ns)",
     "currency": "Moeda",
     "p99": "P99",

--- a/web/src/locales/languages/tr.json
+++ b/web/src/locales/languages/tr.json
@@ -1386,6 +1386,7 @@
     "selectDashboardLabel": "Kontrol Panelini Seçin",
     "selectTabLabel": "Sekme Seç",
     "numbers": "Sayılar",
+    "localeFormat": "Yerel Biçim",
     "nanoseconds": "Nanosaniye (ns)",
     "currency": "Para Birimi",
     "p99": "P99",

--- a/web/src/locales/languages/zh.json
+++ b/web/src/locales/languages/zh.json
@@ -1386,6 +1386,7 @@
     "selectDashboardLabel": "选择仪表盘",
     "selectTabLabel": "选择选项卡",
     "numbers": "数字",
+    "localeFormat": "区域格式",
     "nanoseconds": "纳秒 (ns)",
     "currency": "货币",
     "p99": "P99",

--- a/web/src/locales/languages/zh_TW.json
+++ b/web/src/locales/languages/zh_TW.json
@@ -1590,6 +1590,7 @@
     "bottom": "底部",
     "default": "預設",
     "numbers": "數字",
+    "localeFormat": "區域格式",
     "bytes": "Bytes",
     "kilobytes": "Kilobytes (KB)",
     "megabytes": "Megabytes (MB)",

--- a/web/src/locales/numberFormat.ts
+++ b/web/src/locales/numberFormat.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { getLanguage } from "@/utils/cookies";
+
+// App language codes are not all valid BCP-47, so map them for Intl.NumberFormat.
+const APP_LOCALE_TO_BCP47: Record<string, string> = {
+  "en-gb": "en-GB",
+  "tr-turk": "tr-TR",
+  "zh-cn": "zh-CN",
+  "zh-tw": "zh-TW",
+  fr: "fr-FR",
+  es: "es-ES",
+  de: "de-DE",
+  it: "it-IT",
+  ja: "ja-JP",
+  ko: "ko-KR",
+  nl: "nl-NL",
+  pt: "pt-PT",
+};
+
+// Resolve the active app language without importing the i18n instance — kept
+// standalone so widely-used utils don't pull `createI18n` into their import
+// graph (which breaks specs that partially mock vue-i18n).
+const resolveAppLanguage = (): string => {
+  const cookieLanguage = getLanguage();
+  if (cookieLanguage) return cookieLanguage;
+
+  const navLanguage = (navigator.language || "").toLowerCase();
+  const match = Object.keys(APP_LOCALE_TO_BCP47).find(
+    (code) => navLanguage.indexOf(code) > -1,
+  );
+  return match ?? "en-gb";
+};
+
+/**
+ * Returns a BCP-47 locale tag for the user's selected UI language, suitable for
+ * `Intl.NumberFormat`. Falls back to "en-GB" for unmapped languages.
+ */
+export const getNumberLocale = (): string =>
+  APP_LOCALE_TO_BCP47[resolveAppLanguage()] ?? "en-GB";

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.spec.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.spec.ts
@@ -123,8 +123,7 @@ vi.mock("@/utils/dashboard/convertDashboardSchemaVersion", () => ({
 }));
 
 const mockGetNumberLocale = vi.fn(() => "en-GB");
-vi.mock("@/locales", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/locales")>()),
+vi.mock("@/locales/numberFormat", () => ({
   getNumberLocale: () => mockGetNumberLocale(),
 }));
 

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.spec.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.spec.ts
@@ -122,6 +122,12 @@ vi.mock("@/utils/dashboard/convertDashboardSchemaVersion", () => ({
   CURRENT_DASHBOARD_SCHEMA_VERSION: "v3"
 }));
 
+const mockGetNumberLocale = vi.fn(() => "en-GB");
+vi.mock("@/locales", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/locales")>()),
+  getNumberLocale: () => mockGetNumberLocale(),
+}));
+
 describe("Dashboard Data Conversion Utils", () => {
   // Use actual checkTimestampAlias from logsUtils
   const { checkTimestampAlias } = logsUtils();
@@ -296,6 +302,38 @@ describe("Dashboard Data Conversion Utils", () => {
       const result = getUnitValue(123.45, "currency-rupee", "", 2);
       expect(result.unit).toBe("₹");
       expect(result.value).toContain("123");
+    });
+
+    describe("locale unit", () => {
+      beforeEach(() => {
+        mockGetNumberLocale.mockReturnValue("en-GB");
+      });
+
+      it("should format with en-GB grouping and no unit suffix", () => {
+        mockGetNumberLocale.mockReturnValue("en-GB");
+        const result = getUnitValue(1234567.89, "locale", "", 2);
+        expect(result.value).toBe("1,234,567.89");
+        expect(result.unit).toBe("");
+      });
+
+      it("should format with de-DE grouping", () => {
+        mockGetNumberLocale.mockReturnValue("de-DE");
+        const result = getUnitValue(1234567.89, "locale", "", 2);
+        expect(result.value).toBe("1.234.567,89");
+        expect(result.unit).toBe("");
+      });
+
+      it("should respect the decimals argument", () => {
+        mockGetNumberLocale.mockReturnValue("en-GB");
+        const result = getUnitValue(1234.5, "locale", "", 0);
+        expect(result.value).toBe("1,235");
+      });
+
+      it("should return NaN values untouched with empty unit", () => {
+        const result = getUnitValue(NaN, "locale", "", 2);
+        expect(Number.isNaN(result.value)).toBe(true);
+        expect(result.unit).toBe("");
+      });
     });
 
     it("should handle percent-1 unit", () => {

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -1,4 +1,4 @@
-import { getNumberLocale } from "@/locales";
+import { getNumberLocale } from "@/locales/numberFormat";
 
 const units: any = {
   bytes: [

--- a/web/src/utils/dashboard/convertDataIntoUnitValue.ts
+++ b/web/src/utils/dashboard/convertDataIntoUnitValue.ts
@@ -1,3 +1,5 @@
+import { getNumberLocale } from "@/locales";
+
 const units: any = {
   bytes: [
     { unit: "B", divisor: 1 },
@@ -173,6 +175,17 @@ export const getUnitValue = (
       return {
         value: `${parseFloat(value)?.toFixed(decimals) ?? 0}`,
         unit: `${customUnit ?? ""}`,
+      };
+    }
+    case "locale": {
+      const num = Number(value);
+      if (Number.isNaN(num)) return { value: value, unit: "" };
+      return {
+        value: new Intl.NumberFormat(getNumberLocale(), {
+          minimumFractionDigits: decimals,
+          maximumFractionDigits: decimals,
+        }).format(num),
+        unit: "",
       };
     }
     case "percent-1": {

--- a/web/src/utils/dashboard/convertPromQLData.spec.ts
+++ b/web/src/utils/dashboard/convertPromQLData.spec.ts
@@ -411,6 +411,48 @@ describe("Convert PromQL Data Utils", () => {
       expect(result.extras.isTimeSeries).toBe(false);
     });
 
+    it("exposes _metricText and _metricLayout on the metric series for copy", async () => {
+      const panelSchema = {
+        id: "panel1",
+        type: "metric",
+        config: { background: { value: { color: "#FFFFFF" } } },
+        queries: [{ config: { promql_legend: "" } }],
+      };
+      const searchQueryData = [
+        {
+          resultType: "matrix",
+          result: [
+            {
+              metric: { job: "test-job" },
+              values: [[1640435200, "42"], [1640435260, "45"]],
+            },
+          ],
+        },
+      ];
+
+      const result = await convertPromQLData(
+        panelSchema,
+        searchQueryData,
+        mockStore,
+        mockChartPanelRef,
+        mockHoveredSeriesState,
+        mockAnnotations,
+      );
+
+      const series = result.options.series[0];
+      // The displayed value is also what gets copied.
+      expect(series._metricText).toBeDefined();
+      // Layout is sized to the panel (mockChartPanelRef: 500x300), centered.
+      expect(series._metricLayout).toMatchObject({
+        left: 0,
+        top: 0,
+        width: 500,
+        height: 300,
+        cx: 250,
+        cy: 150,
+      });
+    });
+
 
     it("should handle bar chart type", async () => {
       const panelSchema = {

--- a/web/src/utils/dashboard/convertPromQLData.ts
+++ b/web/src/utils/dashboard/convertPromQLData.ts
@@ -40,6 +40,7 @@ import {
   calculateRightLegendWidth,
 } from "./legendConfiguration";
 import { convertPromQLChartData } from "./promql/convertPromQLChartData";
+import { METRIC_COPY_BTN_RESERVE_PX } from "./sql/charts/convertSQLMetricChart";
 import { getPromqlLegendName, getLegendPosition } from "./promql/shared/legendBuilder";
 import { getPropsByChartTypeForSeries } from "./promqlChartSeriesProps";
 
@@ -969,11 +970,13 @@ export const convertPromQLData = async (
             );
             options.backgroundColor =
               panelSchema.config?.background?.value?.color ?? "";
-            const series = [
+            const metricText = formatUnitValue(unitValue);
+            const series: any[] = [
               {
                 type: "custom",
                 silent: true,
                 coordinateSystem: "polar",
+                _metricText: metricText,
                 renderItem: function (params: any) {
                   const backgroundColor =
                     panelSchema.config?.background?.value?.color;
@@ -981,10 +984,10 @@ export const convertPromQLData = async (
                   return {
                     type: "text",
                     style: {
-                      text: formatUnitValue(unitValue),
+                      text: metricText,
                       fontSize: calculateOptimalFontSize(
-                        formatUnitValue(unitValue),
-                        params.coordSys.cx * 2,
+                        metricText,
+                        params.coordSys.cx * 2 - METRIC_COPY_BTN_RESERVE_PX,
                       ), //coordSys is relative. so that we can use it to calculate the dynamic size
                       fontWeight: 500,
                       align: "center",
@@ -997,6 +1000,25 @@ export const convertPromQLData = async (
                 },
               },
             ];
+
+            // Rect for the per-value copy icon overlay (single metric fills the area).
+            const panelEl = chartPanelRef?.value;
+            if (panelEl) {
+              const w = panelEl.offsetWidth;
+              const h = panelEl.offsetHeight;
+              series[0]._metricLayout = {
+                left: 0,
+                top: 0,
+                width: w,
+                height: h,
+                cx: w / 2,
+                cy: h / 2,
+                fontSize: calculateOptimalFontSize(
+                  metricText,
+                  w - METRIC_COPY_BTN_RESERVE_PX,
+                ),
+              };
+            }
 
             options.dataset = { source: [[]] };
             options.tooltip = {

--- a/web/src/utils/dashboard/convertSQLData.ts
+++ b/web/src/utils/dashboard/convertSQLData.ts
@@ -24,6 +24,7 @@
 import { convertSQLChartData } from "./sql";
 import { applySeriesColorMappings } from "./chartColorUtils";
 import { calculateOptimalFontSize } from "./chartDimensionUtils";
+import { METRIC_COPY_BTN_RESERVE_PX } from "./sql/charts/convertSQLMetricChart";
 import {
   calculateGridPositions,
   getTrellisGrid,
@@ -351,7 +352,7 @@ export const convertMultiSQLData = async (
     );
     const sharedFontSize = calculateOptimalFontSize(
       longestText,
-      gridData.gridWidth,
+      gridData.gridWidth - METRIC_COPY_BTN_RESERVE_PX,
     );
     const labelFontSize = Math.max(
       11,
@@ -367,6 +368,18 @@ export const convertMultiSQLData = async (
         ((parseFloat(cell.top) + parseFloat(cell.height) / 2) / 100) *
         chartPanelRef.value.offsetHeight;
       const fill = s._metricFillColor ?? (isDark ? "#fff" : "#000");
+      // Grid-cell rect (px) is the hover zone; cx/cy/fontSize place + size the
+      // copy icon beside the number, clamped inside the cell.
+      s._metricLayout = {
+        left: (parseFloat(cell.left) / 100) * chartPanelRef.value.offsetWidth,
+        top: (parseFloat(cell.top) / 100) * chartPanelRef.value.offsetHeight,
+        width: (parseFloat(cell.width) / 100) * chartPanelRef.value.offsetWidth,
+        height:
+          (parseFloat(cell.height) / 100) * chartPanelRef.value.offsetHeight,
+        cx,
+        cy: cy - labelFontSize / 2 - 2,
+        fontSize: sharedFontSize,
+      };
       s.renderItem = () => {
         try {
           return {

--- a/web/src/utils/dashboard/sql/charts/convertSQLMetricChart.spec.ts
+++ b/web/src/utils/dashboard/sql/charts/convertSQLMetricChart.spec.ts
@@ -14,7 +14,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { applyMetricChart } from "@/utils/dashboard/sql/charts/convertSQLMetricChart";
+import {
+  applyMetricChart,
+  METRIC_COPY_BTN_RESERVE_PX,
+} from "@/utils/dashboard/sql/charts/convertSQLMetricChart";
+import { calculateOptimalFontSize } from "@/utils/dashboard/chartDimensionUtils";
 
 vi.mock("@/utils/dashboard/convertDataIntoUnitValue", () => ({
   formatUnitValue: vi.fn((v) => String(v ?? "")),
@@ -92,6 +96,44 @@ function makeMockContext(overrides: Partial<any> = {}): any {
 }
 
 describe("applyMetricChart", () => {
+  describe("copy-button support", () => {
+    it("exposes the formatted value as _metricText for copy", () => {
+      const ctx = makeMockContext();
+      applyMetricChart(ctx);
+      // getUnitValue/formatUnitValue are mocked passthrough → raw value string.
+      expect(ctx.options.series[0]._metricText).toBe("100");
+    });
+
+    it("stores _metricLayout sized to the panel for icon positioning", () => {
+      const ctx = makeMockContext();
+      applyMetricChart(ctx);
+      expect(ctx.options.series[0]._metricLayout).toMatchObject({
+        left: 0,
+        top: 0,
+        width: 800,
+        height: 400,
+        cx: 400,
+        cy: 200,
+      });
+    });
+
+    it("reserves the copy-button width when fitting the font size", () => {
+      const ctx = makeMockContext();
+      applyMetricChart(ctx);
+      // layout font size is computed against width minus the button reserve.
+      expect(calculateOptimalFontSize).toHaveBeenCalledWith(
+        "100",
+        800 - METRIC_COPY_BTN_RESERVE_PX,
+      );
+    });
+
+    it("omits _metricLayout when the panel ref is unavailable", () => {
+      const ctx = makeMockContext({ chartPanelRef: { value: null } });
+      applyMetricChart(ctx);
+      expect(ctx.options.series[0]._metricLayout).toBeUndefined();
+    });
+  });
+
   it("sets xAxis to empty array", () => {
     const ctx = makeMockContext();
     applyMetricChart(ctx);

--- a/web/src/utils/dashboard/sql/charts/convertSQLMetricChart.ts
+++ b/web/src/utils/dashboard/sql/charts/convertSQLMetricChart.ts
@@ -18,6 +18,11 @@ import { calculateOptimalFontSize } from "../../chartDimensionUtils";
 import { getContrastColor } from "../../chartColorUtils";
 import { type SQLContext } from "../shared/types";
 
+// Width reserved for the copy button when auto-fitting the value font size,
+// so the hover button has room beside the value without shrinking the text
+// more than necessary.
+export const METRIC_COPY_BTN_RESERVE_PX = 40;
+
 /**
  * Applies chart-specific options for: metric
  *
@@ -31,6 +36,7 @@ export function applyMetricChart(ctx: SQLContext): void {
     yAxisKeys,
     defaultSeriesProps,
     getAxisDataFromKey,
+    chartPanelRef,
   } = ctx;
 
   const key1 = yAxisKeys[0];
@@ -41,6 +47,7 @@ export function applyMetricChart(ctx: SQLContext): void {
     panelSchema.config?.unit_custom,
     panelSchema.config?.decimals,
   );
+  const metricText = formatUnitValue(unitValue);
   options.backgroundColor = panelSchema.config?.background?.value?.color ?? "";
   options.dataset = { source: [[]] };
   options.tooltip = {
@@ -55,7 +62,6 @@ export function applyMetricChart(ctx: SQLContext): void {
   options.polar = {};
   options.xAxis = [];
   options.yAxis = [];
-  const metricText = formatUnitValue(unitValue);
   const metricFillColor = getContrastColor(
     panelSchema.config?.background?.value?.color,
     store.state.theme === "dark",
@@ -76,10 +82,10 @@ export function applyMetricChart(ctx: SQLContext): void {
           return {
             type: "text",
             style: {
-              text: formatUnitValue(unitValue),
+              text: metricText,
               fontSize: calculateOptimalFontSize(
-                formatUnitValue(unitValue),
-                params?.coordSys?.cx * 2,
+                metricText,
+                params?.coordSys?.cx * 2 - METRIC_COPY_BTN_RESERVE_PX,
               ), //coordSys is relative. so that we can use it to calculate the dynamic size
               fontWeight: 500,
               align: "center",
@@ -95,4 +101,23 @@ export function applyMetricChart(ctx: SQLContext): void {
       },
     },
   ];
+
+  // Rect for the per-value copy icon overlay (single metric fills the area).
+  const panelEl = chartPanelRef?.value;
+  if (panelEl) {
+    const w = panelEl.offsetWidth;
+    const h = panelEl.offsetHeight;
+    options.series[0]._metricLayout = {
+      left: 0,
+      top: 0,
+      width: w,
+      height: h,
+      cx: w / 2,
+      cy: h / 2,
+      fontSize: calculateOptimalFontSize(
+        metricText,
+        w - METRIC_COPY_BTN_RESERVE_PX,
+      ),
+    };
+  }
 }


### PR DESCRIPTION
## #12644 

Dashboard panels let users pick a **unit** to format values (bytes, seconds,
currencies, percent, etc.). This adds one new unit — **"Locale Format"** — that
renders plain numbers with locale-aware thousand/decimal separators using
`Intl.NumberFormat`, automatically driven by the user's selected UI language.

Example for `1234567.89`:

| App language | Rendered |
|---|---|
| English (`en-gb`) | `1,234,567.89` |
| German (`de`) | `1.234.567,89` |
| French (`fr`) | `1 234 567,89` |

<img width="317" height="391" alt="image" src="https://github.com/user-attachments/assets/53ca9444-0636-49d8-a92f-3a44fc79433e" />

## Metric chart type copy button support
<img width="599" height="267" alt="image" src="https://github.com/user-attachments/assets/03c9c36e-ad5a-4096-bf85-8a9851fcd3c5" />


Design At: designs/dashboards/locale-format-unit