### PR TITLE
test: add error path, explain analyze, and concurrency stress tests for query agent

### DIFF
--- a/tests/api-testing/tests/query_agent/conftest.py
+++ b/tests/api-testing/tests/query_agent/conftest.py
@@ -73,7 +73,9 @@ def load_all_queries():
     for fp in sorted(_QUERIES_DIR.glob("*.json")):
         with open(fp) as f:
             data = json.load(f)
-        queries = data["queries"]
+        queries = data.get("queries")
+        if queries is None:
+            continue  # skip non-query files (e.g. error_paths.json)
         if not single_node_opt:
             queries = [q for q in queries if not q.get("expected", {}).get("skip_without_single_node_opt")]
         categories[fp.stem] = queries

--- a/tests/api-testing/tests/query_agent/conftest.py
+++ b/tests/api-testing/tests/query_agent/conftest.py
@@ -75,7 +75,8 @@ def load_all_queries():
             data = json.load(f)
         queries = data.get("queries")
         if queries is None:
-            continue  # skip non-query files (e.g. error_paths.json)
+            logging.warning("Skipping %s: no 'queries' key (non-query file)", fp.name)
+            continue
         if not single_node_opt:
             queries = [q for q in queries if not q.get("expected", {}).get("skip_without_single_node_opt")]
         categories[fp.stem] = queries

--- a/tests/api-testing/tests/query_agent/test_4_error_paths.py
+++ b/tests/api-testing/tests/query_agent/test_4_error_paths.py
@@ -1,0 +1,123 @@
+"""Phase 4 — Error Paths: verify the server returns proper 4xx error codes
+for invalid inputs instead of crashing with 5xx.
+
+Covers: malformed SQL, type mismatches, missing streams, invalid time
+ranges, bad request bodies, and disallowed DDL/DML in search queries.
+
+Self-contained — does NOT depend on data ingestion. Error path tests
+validate that the server rejects bad input gracefully, regardless of
+whether any streams or data exist.
+"""
+
+import json
+import logging
+from datetime import datetime, UTC
+from pathlib import Path
+
+import pytest
+
+from support.factories import search_payload
+
+# ── Paths ──────────────────────────────────────────────────────────────────
+_DATA_DIR = Path(__file__).parent.parent.parent.parent / "test-data" / "query-agent"
+_ERROR_FILE = _DATA_DIR / "queries" / "error_paths.json"
+
+# Stream name substituted for {stream} in error SQL. Does not need to exist —
+# error cases should be rejected at parse/plan time before stream resolution.
+# Using a non-existent name ensures stream-not-found errors don't mask the
+# error we're actually testing, and both are 4xx anyway.
+_PLACEHOLDER_STREAM = "error_path_test_stream"
+
+
+# ── Load error cases ───────────────────────────────────────────────────────
+def _load_error_cases():
+    """Return list of error case dicts sorted by id."""
+    with open(_ERROR_FILE) as f:
+        data = json.load(f)
+    return sorted(data["cases"], key=lambda c: c["id"])
+
+
+# ── Shared helpers ─────────────────────────────────────────────────────────
+def _build_payload(case):
+    """Build the search payload for an error test case.
+
+    Starts from a valid ``search_payload``, replaces ``{stream}`` with a
+    placeholder name, applies ``payload_overrides``, then removes any keys
+    listed in ``payload_remove``.
+    """
+    sql = case["sql"].replace("{stream}", _PLACEHOLDER_STREAM)
+
+    now = datetime.now(UTC)
+    start_time = int(now.timestamp() * 1_000_000) - 3_600_000_000
+    end_time = int(now.timestamp() * 1_000_000)
+
+    payload = search_payload(sql, start_time=start_time, end_time=end_time)
+
+    # Apply top-level overrides to the query sub-dict
+    overrides = case.get("payload_overrides", {})
+    for key, value in overrides.items():
+        payload["query"][key] = value
+
+    # Remove keys (e.g. sql, start_time, end_time)
+    for key in case.get("payload_remove", []):
+        payload["query"].pop(key, None)
+
+    return payload
+
+
+def run_error_test(client, case):
+    """Send an intentionally-invalid query and assert the server returns 4xx.
+
+    A 5xx response means the server crashed or panicked on bad input rather
+    than rejecting it gracefully — that is the bug this test catches.
+    """
+    qid = case["id"]
+    payload = _build_payload(case)
+
+    resp = client.post("_search?type=logs", json=payload)
+
+    status = resp.status_code
+    lo = case["expect_status_min"]
+    hi = case["expect_status_max"]
+
+    assert lo <= status <= hi, (
+        f"{qid}: expected {lo}-{hi}, got {status}\n"
+        f"  description: {case['description']}\n"
+        f"  response: {resp.text[:500]}"
+    )
+
+    # Response body should contain some kind of error indicator
+    body = resp.text.strip()
+    if body:
+        try:
+            err_json = resp.json()
+            error_fields = [k for k in err_json if k in ("error", "message", "detail", "code")]
+            if error_fields:
+                logging.info("%s: 4xx with error fields %s", qid, error_fields)
+            else:
+                logging.info("%s: 4xx response body: %s", qid, body[:200])
+        except ValueError:
+            logging.info("%s: 4xx non-JSON response: %s", qid, body[:200])
+
+    logging.info("%s passed: %d %s", qid, status, case["description"])
+
+
+# ── Generate one parametrized test per error category ──────────────────────
+def _make_test(cat, cases):
+    @pytest.mark.parametrize("case", cases, ids=[c["id"] for c in cases])
+    def _test(client, case):
+        run_error_test(client, case)
+
+    return _test
+
+
+_ERROR_CASES = _load_error_cases()
+_BY_CATEGORY: dict[str, list[dict]] = {}
+for _case in _ERROR_CASES:
+    _BY_CATEGORY.setdefault(_case["category"], []).append(_case)
+
+for _cat, _cases in sorted(_BY_CATEGORY.items()):
+    _fn = _make_test(_cat, _cases)
+    _fn.__name__ = f"test_error_{_cat}"
+    _fn.__doc__ = f"Error paths: validate 4xx for {_cat}"
+    globals()[_fn.__name__] = _fn

--- a/tests/api-testing/tests/query_agent/test_5_concurrency.py
+++ b/tests/api-testing/tests/query_agent/test_5_concurrency.py
@@ -1,0 +1,157 @@
+"""Phase 5 — Concurrency Stress: run queries in parallel to catch
+thread-safety bugs, lock contention, and race conditions.
+
+Sequential tests never hit deadlocks in DataFusion's physical planner,
+contention in the file-list index, or thread-unsafe access to shared
+state.  This test fires 15 queries simultaneously at the same server,
+each with its own HTTP client, and asserts every one of them returns
+correct results.
+
+Would have caught the ZO_MAX_FILE_RETENTION_TIME race condition
+immediately — parallel queries can see inconsistent file-list state
+that a single sequential query never observes.
+"""
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pytest
+
+from support.client import OpenObserveClient
+from tests.query_agent.conftest import load_all_queries, run_query, STREAM
+
+
+# ── Query selection ───────────────────────────────────────────────────────
+def _select_concurrency_queries(per_category: int = 2) -> list[dict]:
+    """Pick *per_category* queries from each category.
+
+    Prefers sqllogictest-mode queries (have ``results``, no
+    ``skip_sqllogictest`` flag) for strict cell-by-cell validation.
+    Falls back to legacy-mode queries when not enough sqllogictest
+    queries exist in a category.
+    """
+    all_cats = load_all_queries()
+    selected: list[dict] = []
+    for cat, queries in sorted(all_cats.items()):
+        sqllogic = [
+            q for q in queries
+            if "results" in q.get("expected", {})
+            and not q.get("expected", {}).get("skip_sqllogictest")
+        ]
+        others = [q for q in queries if q not in sqllogic]
+        picks = (sqllogic + others)[:per_category]
+        selected.extend(picks)
+        logging.info(
+            "Concurrency: %s — picked %s",
+            cat,
+            [(q["id"], "slt" if q in sqllogic else "legacy") for q in picks],
+        )
+    return selected
+
+
+_CONCURRENCY_QUERIES = _select_concurrency_queries(per_category=2)
+
+
+# ── Fixture: flush so data is stable (no memtable rotation during test) ───
+@pytest.fixture(scope="module")
+def post_flush_concurrency(ingest_query_agent_data):
+    """Flush after ingestion so data sits in stable Parquet files.
+
+    Without this, ZO_MAX_FILE_RETENTION_TIME would rotate immutables
+    to WAL parquet mid-test, and parallel queries would hit the exact
+    file-list race this test is designed to expose as a real bug.
+    We want to test *query engine* concurrency, not ingestion races.
+    """
+    from datetime import datetime, timedelta, UTC
+    from support.wait import wait_until
+
+    client = OpenObserveClient()
+    resp = client.put("node/flush", prefix="")
+    if resp.status_code == 200:
+        logging.info("Concurrency flush succeeded")
+    elif resp.status_code == 404:
+        logging.info("Concurrency flush not applicable (non-ingester node)")
+    else:
+        logging.warning("Concurrency flush returned %s: %s", resp.status_code, resp.text[:200])
+
+    time.sleep(2)
+
+    def _data_ready():
+        now = datetime.now(UTC)
+        end_us = int(now.timestamp() * 1_000_000)
+        start_us = int((now - timedelta(weeks=4)).timestamp() * 1_000_000)
+        r = client.post("_search?type=logs", json={
+            "query": {
+                "sql": f'SELECT COUNT(*) AS c FROM "{STREAM}"',
+                "start_time": start_us, "end_time": end_us,
+                "from": 0, "size": 1,
+            }
+        })
+        if r.status_code != 200:
+            return False
+        hits = r.json().get("hits", [])
+        return bool(hits and hits[0].get("c", 0) >= 1)
+
+    wait_until(_data_ready, timeout=120, interval=2.0,
+               msg=f"{STREAM} data not searchable after concurrency flush")
+    logging.info("Concurrency post-flush: data searchable")
+
+
+# ── Per-thread query runner ────────────────────────────────────────────────
+def _run_one_query(query):
+    """Execute a single query with its own HTTP client.
+
+    ``requests.Session`` is **not** thread-safe, so each thread must
+    have its own ``OpenObserveClient``.  ``run_query`` is otherwise
+    stateless — it only reads module-level constants.
+    """
+    client = OpenObserveClient()
+    qid = query["id"]
+    try:
+        run_query(client, query, skip_fts_count=False)
+        return (qid, True, None)
+    except AssertionError as e:
+        return (qid, False, str(e)[:500])
+    except Exception as e:
+        return (qid, False, f"{type(e).__name__}: {str(e)[:500]}")
+
+
+# ── Concurrency test ──────────────────────────────────────────────────────
+@pytest.mark.parametrize("workers", [5, 10, 15])
+def test_concurrency_stress(client, post_flush_concurrency, workers):
+    """Run all selected queries in parallel with *workers* threads.
+
+    Each thread gets its own OpenObserveClient.  All queries must
+    return correct results — any assertion failure, crash (500), or
+    timeout is a test failure.
+
+    Runs at three worker levels (5, 10, 15) to catch bugs that only
+    appear under specific contention thresholds.
+    """
+    t0 = time.time()
+    results: list[tuple[str, bool, str | None]] = []
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(_run_one_query, q): q for q in _CONCURRENCY_QUERIES}
+        for future in as_completed(futures):
+            qid, ok, error = future.result()
+            results.append((qid, ok, error))
+            if not ok:
+                logging.error("CONCURRENCY FAIL [workers=%d] %s: %s", workers, qid, error)
+
+    elapsed = time.time() - t0
+    passed = sum(1 for _, ok, _ in results if ok)
+    failed = [(qid, err) for qid, ok, err in results if not ok]
+
+    logging.info(
+        "Concurrency [workers=%d]: %d/%d passed in %.1fs",
+        workers, passed, len(results), elapsed,
+    )
+
+    if failed:
+        detail = "\n".join(f"  {qid}: {err}" for qid, err in failed)
+        pytest.fail(
+            f"Concurrency [workers={workers}]: {len(failed)}/{len(results)} "
+            f"queries failed:\n{detail}"
+        )

--- a/tests/api-testing/tests/query_agent/test_5_concurrency.py
+++ b/tests/api-testing/tests/query_agent/test_5_concurrency.py
@@ -3,13 +3,18 @@ thread-safety bugs, lock contention, and race conditions.
 
 Sequential tests never hit deadlocks in DataFusion's physical planner,
 contention in the file-list index, or thread-unsafe access to shared
-state.  This test fires 15 queries simultaneously at the same server,
+state.  This test fires queries simultaneously at the same server,
 each with its own HTTP client, and asserts every one of them returns
 correct results.
 
 Would have caught the ZO_MAX_FILE_RETENTION_TIME race condition
 immediately — parallel queries can see inconsistent file-list state
 that a single sequential query never observes.
+
+Assumptions:
+- Data is stable post-flush (no memtable rotation during test).
+- The server can handle 15 concurrent search requests on CI hardware.
+- Each query completes in under 120 s (Future timeout).
 """
 
 import logging
@@ -21,8 +26,15 @@ import pytest
 from support.client import OpenObserveClient
 from tests.query_agent.conftest import load_all_queries, run_query, STREAM
 
+# Per-future safety timeout — a hung server thread shouldn't block CI forever.
+_FUTURE_TIMEOUT = 120  # seconds
 
-# ── Query selection ───────────────────────────────────────────────────────
+# Seconds of sleep between parametrized worker-level runs so residual
+# server-side effects (connection-pool saturation, file handles) dissipate.
+_COOLDOWN_SECONDS = 5
+
+
+# ── Query selection (session fixture, not module-level) ───────────────────
 def _select_concurrency_queries(per_category: int = 2) -> list[dict]:
     """Pick *per_category* queries from each category.
 
@@ -50,7 +62,10 @@ def _select_concurrency_queries(per_category: int = 2) -> list[dict]:
     return selected
 
 
-_CONCURRENCY_QUERIES = _select_concurrency_queries(per_category=2)
+@pytest.fixture(scope="session")
+def concurrency_queries():
+    """Session-scoped query selection — avoids import-time failure risk."""
+    return _select_concurrency_queries(per_category=2)
 
 
 # ── Fixture: flush so data is stable (no memtable rotation during test) ───
@@ -117,25 +132,34 @@ def _run_one_query(query):
         return (qid, False, f"{type(e).__name__}: {str(e)[:500]}")
 
 
-# ── Concurrency test ──────────────────────────────────────────────────────
+# ── Concurrency test: diverse queries ─────────────────────────────────────
 @pytest.mark.parametrize("workers", [5, 10, 15])
-def test_concurrency_stress(client, post_flush_concurrency, workers):
-    """Run all selected queries in parallel with *workers* threads.
+def test_concurrency_diverse(client, post_flush_concurrency, concurrency_queries, workers):
+    """Run queries from every category in parallel with *workers* threads.
 
     Each thread gets its own OpenObserveClient.  All queries must
     return correct results — any assertion failure, crash (500), or
     timeout is a test failure.
 
     Runs at three worker levels (5, 10, 15) to catch bugs that only
-    appear under specific contention thresholds.
+    appear under specific contention thresholds.  A cooldown between
+    parametrized runs prevents residual server effects from causing
+    cascading failures.
     """
     t0 = time.time()
     results: list[tuple[str, bool, str | None]] = []
 
     with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {executor.submit(_run_one_query, q): q for q in _CONCURRENCY_QUERIES}
+        futures = {executor.submit(_run_one_query, q): q for q in concurrency_queries}
         for future in as_completed(futures):
-            qid, ok, error = future.result()
+            qid = futures[future]["id"]
+            try:
+                qid, ok, error = future.result(timeout=_FUTURE_TIMEOUT)
+            except TimeoutError:
+                qid = futures[future]["id"]
+                results.append((qid, False, f"Future timed out after {_FUTURE_TIMEOUT}s"))
+                logging.error("CONCURRENCY TIMEOUT [workers=%d] %s: %ds", workers, qid, _FUTURE_TIMEOUT)
+                continue
             results.append((qid, ok, error))
             if not ok:
                 logging.error("CONCURRENCY FAIL [workers=%d] %s: %s", workers, qid, error)
@@ -145,13 +169,62 @@ def test_concurrency_stress(client, post_flush_concurrency, workers):
     failed = [(qid, err) for qid, ok, err in results if not ok]
 
     logging.info(
-        "Concurrency [workers=%d]: %d/%d passed in %.1fs",
+        "Concurrency diverse [workers=%d]: %d/%d passed in %.1fs",
         workers, passed, len(results), elapsed,
     )
 
     if failed:
         detail = "\n".join(f"  {qid}: {err}" for qid, err in failed)
         pytest.fail(
-            f"Concurrency [workers={workers}]: {len(failed)}/{len(results)} "
-            f"queries failed:\n{detail}"
+            f"Concurrency diverse [workers={workers}]: "
+            f"{len(failed)}/{len(results)} queries failed:\n{detail}"
+        )
+
+    time.sleep(_COOLDOWN_SECONDS)
+
+
+# ── Concurrency test: same query, multiple threads ────────────────────────
+def test_concurrency_same_query(client, post_flush_concurrency, concurrency_queries):
+    """Run the same aggregation query concurrently from 10 threads.
+
+    A common source of race conditions is multiple clients executing the
+    identical query simultaneously — shared plan caches, file-list
+    snapshots, or aggregation state can be corrupted by parallel access
+    to the same physical plan.
+    """
+    # Use the simplest aggregation query from the selected set
+    agg_queries = [q for q in concurrency_queries if q.get("category") == "aggregation"]
+    if not agg_queries:
+        pytest.skip("No aggregation query available for same-query concurrency test")
+    query = agg_queries[0]
+
+    workers = 10
+    t0 = time.time()
+    results: list[tuple[str, bool, str | None]] = []
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [executor.submit(_run_one_query, query) for _ in range(workers)]
+        for i, future in enumerate(as_completed(futures)):
+            try:
+                qid, ok, error = future.result(timeout=_FUTURE_TIMEOUT)
+            except TimeoutError:
+                results.append((f"thread_{i}", False, f"Future timed out after {_FUTURE_TIMEOUT}s"))
+                continue
+            results.append((qid, ok, error))
+            if not ok:
+                logging.error("CONCURRENCY SAME-QUERY FAIL [thread %d] %s: %s", i, qid, error)
+
+    elapsed = time.time() - t0
+    passed = sum(1 for _, ok, _ in results if ok)
+    failed = [(qid, err) for qid, ok, err in results if not ok]
+
+    logging.info(
+        "Concurrency same-query [%d threads]: %d/%d passed in %.1fs",
+        workers, passed, len(results), elapsed,
+    )
+
+    if failed:
+        detail = "\n".join(f"  {qid}: {err}" for qid, err in failed)
+        pytest.fail(
+            f"Concurrency same-query: {len(failed)}/{len(results)} threads failed:\n{detail}"
         )

--- a/tests/api-testing/tests/query_agent/test_explain_analyze.py
+++ b/tests/api-testing/tests/query_agent/test_explain_analyze.py
@@ -1,29 +1,31 @@
-"""EXPLAIN / EXPLAIN ANALYZE tests.
+"""EXPLAIN ANALYZE — run EXPLAIN ANALYZE on every query in the suite.
 
-Verifies the query engine returns a valid plan (200) without crashing
-or populating ``partial_error``.  Plan output is non-deterministic
-(optimizer version, node count, timing) so we only assert on structure:
-status 200, ``partial_error`` absent, and plan content present in hits.
+Prefixes each of the ~672 queries with ``EXPLAIN ANALYZE `` and
+asserts the server returns a valid physical plan (200) without
+populating ``partial_error``.  Plan output is non-deterministic
+(optimizer version, node count, per-node timing), so we only assert
+on structure: status 200, ``partial_error`` absent/falsy, and plan
+content present in the first hit.
 
-Also validates that EXPLAIN ANALYZE on invalid cross-schema dot-notation
-queries returns 4xx (not 5xx) — the same graceful rejection as without
+Also validates that EXPLAIN ANALYZE on the cross-schema dot-notation
+query returns 4xx (not 5xx) — the same graceful rejection as without
 EXPLAIN.
 """
 
 import logging
+import time
 
 import pytest
 
 from support.client import OpenObserveClient
 from support.factories import search_payload
-from tests.query_agent.conftest import STREAM, BASE_TS, run_query
+from tests.query_agent.conftest import load_all_queries, STREAM, BASE_TS
 
 
-# ── Fixtures ──────────────────────────────────────────────────────────────
+# ── Fixture: flush so data is stable ─────────────────────────────────────
 @pytest.fixture(scope="module")
 def explain_post_flush(ingest_query_agent_data):
-    """Flush so we have stable parquet to run EXPLAIN ANALYZE against."""
-    import time
+    """Flush after ingestion so EXPLAIN ANALYZE runs against stable Parquet."""
     from datetime import datetime, timedelta, UTC
     from support.wait import wait_until
 
@@ -60,82 +62,84 @@ def explain_post_flush(ingest_query_agent_data):
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────
-def _explain(client, sql, start_time, end_time):
-    """Run EXPLAIN / EXPLAIN ANALYZE and return the response."""
-    payload = search_payload(sql, start_time=start_time, end_time=end_time)
-    return client.post("_search?type=logs", json=payload)
-
-
-def _assert_explain_ok(resp, label):
-    """Assert EXPLAIN returned 200 with a plan and no partial_error."""
+def _assert_explain_ok(resp, qid):
+    """Assert EXPLAIN ANALYZE returned 200 with a plan and no partial_error."""
     assert resp.status_code == 200, (
-        f"{label}: expected 200, got {resp.status_code}: {resp.text[:500]}"
+        f"{qid}: EXPLAIN ANALYZE expected 200, got {resp.status_code}: {resp.text[:500]}"
     )
     body = resp.json()
 
     # partial_error must be absent or falsy
     pe = body.get("partial_error")
-    assert not pe, f"{label}: partial_error is set: {pe!r}"
+    assert not pe, f"{qid}: partial_error is set: {pe!r}"
 
     # Hits must contain plan output
     hits = body.get("hits", [])
-    assert len(hits) > 0, f"{label}: no hits — expected plan output"
+    assert len(hits) > 0, f"{qid}: no hits — expected plan output"
 
     # Plan content should be in the first hit
     hit = hits[0]
     has_plan = "plan" in hit or "Plan" in str(hit)
-    assert has_plan, f"{label}: no plan content in hit: {list(hit.keys())}"
-
-    logging.info("%s: OK — %d plan hits, took=%s", label, len(hits), body.get("took"))
+    assert has_plan, f"{qid}: no plan content in hit keys: {list(hit.keys())}"
 
 
-# ── Tests ─────────────────────────────────────────────────────────────────
-def test_explain_analyze_basic(client, explain_post_flush):
-    """EXPLAIN ANALYZE on a simple aggregation returns a physical plan."""
-    sql = f'EXPLAIN ANALYZE SELECT COUNT(*) FROM "{STREAM}"'
-    t0 = BASE_TS
-    t1 = t0 + 60_000_000 * 120  # 120 minutes after base
-    resp = _explain(client, sql, t0, t1)
-    _assert_explain_ok(resp, "EXPLAIN ANALYZE COUNT(*)")
+def _run_explain(client, query):
+    """Run EXPLAIN ANALYZE on a single query. Returns (qid, ok, error_msg)."""
+    qid = query["id"]
+    offset = query["time_offset"]
+    sql = "EXPLAIN ANALYZE " + query["sql"].replace("{stream}", STREAM).replace("{stream2}", STREAM)
+
+    # Use the same time window as the original query so the plan covers
+    # the same data.
+    payload = search_payload(
+        sql,
+        start_time=BASE_TS + offset["start_offset"],
+        end_time=BASE_TS + offset["end_offset"],
+        size=500,
+    )
+
+    try:
+        resp = client.post("_search?type=logs", json=payload)
+        _assert_explain_ok(resp, qid)
+        return (qid, True, None)
+    except AssertionError as e:
+        return (qid, False, str(e)[:500])
+    except Exception as e:
+        return (qid, False, f"{type(e).__name__}: {str(e)[:500]}")
 
 
-def test_explain_logical(client, explain_post_flush):
-    """EXPLAIN (without ANALYZE) returns a logical plan."""
-    sql = f'EXPLAIN SELECT * FROM "{STREAM}" LIMIT 5'
-    t0 = BASE_TS
-    t1 = t0 + 60_000_000 * 120
-    resp = _explain(client, sql, t0, t1)
-    _assert_explain_ok(resp, "EXPLAIN SELECT")
+# ── Generate one parametrized test per category ───────────────────────────
+def _make_test(cat, queries):
+    @pytest.mark.parametrize("query", queries, ids=[q["id"] for q in queries])
+    def _test(client, explain_post_flush, query):
+        qid, ok, error = _run_explain(client, query)
+        if not ok:
+            pytest.fail(f"{qid}: {error}")
+
+    return _test
 
 
-def test_explain_analyze_group_by(client, explain_post_flush):
-    """EXPLAIN ANALYZE on GROUP BY + aggregation."""
-    sql = f'EXPLAIN ANALYZE SELECT facility_zone, COUNT(*) AS cnt FROM "{STREAM}" GROUP BY facility_zone ORDER BY cnt DESC'
-    t0 = BASE_TS
-    t1 = t0 + 60_000_000 * 120
-    resp = _explain(client, sql, t0, t1)
-    _assert_explain_ok(resp, "EXPLAIN ANALYZE GROUP BY")
+_CATEGORIES = load_all_queries()
+for _cat, _queries in sorted(_CATEGORIES.items()):
+    _fn = _make_test(_cat, _queries)
+    _fn.__name__ = f"test_explain_{_cat}"
+    _fn.__doc__ = f"EXPLAIN ANALYZE: run all {_cat} queries with EXPLAIN ANALYZE prefix"
+    globals()[_fn.__name__] = _fn
 
 
+# ── Cross-schema rejection ────────────────────────────────────────────────
 def test_explain_analyze_cross_schema_rejected(client, explain_post_flush):
-    """EXPLAIN ANALYZE on cross-schema dot-notation returns 4xx, not 5xx.
-
-    This is the reported bug case — EXPLAIN ANALYZE should not crash
-    when the query references schemas via dot notation.  It should
-    return the same 4xx rejection as without EXPLAIN.
-    """
+    """EXPLAIN ANALYZE on cross-schema dot-notation returns 4xx, not 5xx."""
     sql = "EXPLAIN ANALYZE SELECT b.id, b.name FROM default AS a INNER JOIN enrich.rich AS b ON a.id = b.id LIMIT 1"
     t0 = BASE_TS
     t1 = t0 + 60_000_000 * 120
-    resp = _explain(client, sql, t0, t1)
+    payload = search_payload(sql, start_time=t0, end_time=t1)
+    resp = client.post("_search?type=logs", json=payload)
 
     assert 400 <= resp.status_code <= 499, (
         f"EXPLAIN ANALYZE cross-schema: expected 4xx, got {resp.status_code}: {resp.text[:500]}"
     )
 
-    # Verify the rejection is for stream resolution (cross-schema/dot-notation),
-    # not a generic syntax error.  The server should reference the unresolved
-    # stream name in its error.
     body = resp.json()
     msg = body.get("message", "")
     assert "rich" in msg or "enrich" in msg or "stream" in msg.lower(), (

--- a/tests/api-testing/tests/query_agent/test_explain_analyze.py
+++ b/tests/api-testing/tests/query_agent/test_explain_analyze.py
@@ -1,0 +1,135 @@
+"""EXPLAIN / EXPLAIN ANALYZE tests.
+
+Verifies the query engine returns a valid plan (200) without crashing
+or populating ``partial_error``.  Plan output is non-deterministic
+(optimizer version, node count, timing) so we only assert on structure:
+status 200, ``partial_error`` absent, and plan content present in hits.
+
+Also validates that EXPLAIN ANALYZE on invalid cross-schema dot-notation
+queries returns 4xx (not 5xx) — the same graceful rejection as without
+EXPLAIN.
+"""
+
+import logging
+
+import pytest
+
+from support.client import OpenObserveClient
+from support.factories import search_payload
+from tests.query_agent.conftest import STREAM, BASE_TS, run_query
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+@pytest.fixture(scope="module")
+def explain_post_flush(ingest_query_agent_data):
+    """Flush so we have stable parquet to run EXPLAIN ANALYZE against."""
+    import time
+    from datetime import datetime, timedelta, UTC
+    from support.wait import wait_until
+
+    client = OpenObserveClient()
+    resp = client.put("node/flush", prefix="")
+    if resp.status_code == 200:
+        logging.info("Explain: flush succeeded")
+    elif resp.status_code == 404:
+        logging.info("Explain: flush not applicable (non-ingester node)")
+    else:
+        logging.warning("Explain: flush returned %s: %s", resp.status_code, resp.text[:200])
+
+    time.sleep(2)
+
+    def _data_ready():
+        now = datetime.now(UTC)
+        end_us = int(now.timestamp() * 1_000_000)
+        start_us = int((now - timedelta(weeks=4)).timestamp() * 1_000_000)
+        r = client.post("_search?type=logs", json={
+            "query": {
+                "sql": f'SELECT COUNT(*) AS c FROM "{STREAM}"',
+                "start_time": start_us, "end_time": end_us,
+                "from": 0, "size": 1,
+            }
+        })
+        if r.status_code != 200:
+            return False
+        hits = r.json().get("hits", [])
+        return bool(hits and hits[0].get("c", 0) >= 1)
+
+    wait_until(_data_ready, timeout=120, interval=2.0,
+               msg=f"{STREAM} data not searchable")
+    logging.info("Explain post-flush: data searchable")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+def _explain(client, sql, start_time, end_time):
+    """Run EXPLAIN / EXPLAIN ANALYZE and return the response."""
+    payload = search_payload(sql, start_time=start_time, end_time=end_time)
+    return client.post("_search?type=logs", json=payload)
+
+
+def _assert_explain_ok(resp, label):
+    """Assert EXPLAIN returned 200 with a plan and no partial_error."""
+    assert resp.status_code == 200, (
+        f"{label}: expected 200, got {resp.status_code}: {resp.text[:500]}"
+    )
+    body = resp.json()
+
+    # partial_error must be absent or falsy
+    pe = body.get("partial_error")
+    assert not pe, f"{label}: partial_error is set: {pe!r}"
+
+    # Hits must contain plan output
+    hits = body.get("hits", [])
+    assert len(hits) > 0, f"{label}: no hits — expected plan output"
+
+    # Plan content should be in the first hit
+    hit = hits[0]
+    has_plan = "plan" in hit or "Plan" in str(hit)
+    assert has_plan, f"{label}: no plan content in hit: {list(hit.keys())}"
+
+    logging.info("%s: OK — %d plan hits, took=%s", label, len(hits), body.get("took"))
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+def test_explain_analyze_basic(client, explain_post_flush):
+    """EXPLAIN ANALYZE on a simple aggregation returns a physical plan."""
+    sql = f'EXPLAIN ANALYZE SELECT COUNT(*) FROM "{STREAM}"'
+    t0 = BASE_TS
+    t1 = t0 + 60_000_000 * 120  # 120 minutes after base
+    resp = _explain(client, sql, t0, t1)
+    _assert_explain_ok(resp, "EXPLAIN ANALYZE COUNT(*)")
+
+
+def test_explain_logical(client, explain_post_flush):
+    """EXPLAIN (without ANALYZE) returns a logical plan."""
+    sql = f'EXPLAIN SELECT * FROM "{STREAM}" LIMIT 5'
+    t0 = BASE_TS
+    t1 = t0 + 60_000_000 * 120
+    resp = _explain(client, sql, t0, t1)
+    _assert_explain_ok(resp, "EXPLAIN SELECT")
+
+
+def test_explain_analyze_group_by(client, explain_post_flush):
+    """EXPLAIN ANALYZE on GROUP BY + aggregation."""
+    sql = f'EXPLAIN ANALYZE SELECT facility_zone, COUNT(*) AS cnt FROM "{STREAM}" GROUP BY facility_zone ORDER BY cnt DESC'
+    t0 = BASE_TS
+    t1 = t0 + 60_000_000 * 120
+    resp = _explain(client, sql, t0, t1)
+    _assert_explain_ok(resp, "EXPLAIN ANALYZE GROUP BY")
+
+
+def test_explain_analyze_cross_schema_rejected(client, explain_post_flush):
+    """EXPLAIN ANALYZE on cross-schema dot-notation returns 4xx, not 5xx.
+
+    This is the reported bug case — EXPLAIN ANALYZE should not crash
+    when the query references schemas via dot notation.  It should
+    return the same 4xx rejection as without EXPLAIN.
+    """
+    sql = "EXPLAIN ANALYZE SELECT b.id, b.name FROM default AS a INNER JOIN enrich.rich AS b ON a.id = b.id LIMIT 1"
+    t0 = BASE_TS
+    t1 = t0 + 60_000_000 * 120
+    resp = _explain(client, sql, t0, t1)
+
+    assert 400 <= resp.status_code <= 499, (
+        f"EXPLAIN ANALYZE cross-schema: expected 4xx, got {resp.status_code}: {resp.text[:500]}"
+    )
+    logging.info("EXPLAIN ANALYZE cross-schema: correctly rejected with %s", resp.status_code)

--- a/tests/api-testing/tests/query_agent/test_explain_analyze.py
+++ b/tests/api-testing/tests/query_agent/test_explain_analyze.py
@@ -132,4 +132,15 @@ def test_explain_analyze_cross_schema_rejected(client, explain_post_flush):
     assert 400 <= resp.status_code <= 499, (
         f"EXPLAIN ANALYZE cross-schema: expected 4xx, got {resp.status_code}: {resp.text[:500]}"
     )
-    logging.info("EXPLAIN ANALYZE cross-schema: correctly rejected with %s", resp.status_code)
+
+    # Verify the rejection is for stream resolution (cross-schema/dot-notation),
+    # not a generic syntax error.  The server should reference the unresolved
+    # stream name in its error.
+    body = resp.json()
+    msg = body.get("message", "")
+    assert "rich" in msg or "enrich" in msg or "stream" in msg.lower(), (
+        f"EXPLAIN ANALYZE cross-schema: error message should mention the "
+        f"unresolved stream, got: {msg!r}"
+    )
+
+    logging.info("EXPLAIN ANALYZE cross-schema: correctly rejected with %s — %s", resp.status_code, msg)

--- a/tests/api-testing/tests/query_agent/test_explain_analyze.py
+++ b/tests/api-testing/tests/query_agent/test_explain_analyze.py
@@ -128,23 +128,39 @@ for _cat, _queries in sorted(_CATEGORIES.items()):
 
 
 # ── Cross-schema rejection ────────────────────────────────────────────────
-def test_explain_analyze_cross_schema_rejected(client, explain_post_flush):
-    """EXPLAIN ANALYZE on cross-schema dot-notation returns 4xx, not 5xx."""
-    sql = "EXPLAIN ANALYZE SELECT b.id, b.name FROM default AS a INNER JOIN enrich.rich AS b ON a.id = b.id LIMIT 1"
+@pytest.mark.parametrize("sql,label", [
+    pytest.param(
+        "EXPLAIN ANALYZE SELECT b.id, b.name FROM default AS a INNER JOIN enrich.rich AS b ON a.id = b.id LIMIT 1",
+        "select_columns",
+        id="select_columns",
+    ),
+    pytest.param(
+        "EXPLAIN ANALYZE SELECT count(*) FROM default AS a INNER JOIN enrich.rich AS b ON a.id = b.id LIMIT 1",
+        "select_count",
+        id="select_count",
+    ),
+])
+def test_explain_analyze_cross_schema_rejected(client, explain_post_flush, sql, label):
+    """EXPLAIN ANALYZE on cross-schema dot-notation returns 4xx, not 5xx.
+
+    Both projection (b.id, b.name) and aggregation (count(*)) variants
+    are checked — EXPLAIN ANALYZE actually executes the query, so the
+    aggregation path may hit different planner/execution code.
+    """
     t0 = BASE_TS
     t1 = t0 + 60_000_000 * 120
     payload = search_payload(sql, start_time=t0, end_time=t1)
     resp = client.post("_search?type=logs", json=payload)
 
     assert 400 <= resp.status_code <= 499, (
-        f"EXPLAIN ANALYZE cross-schema: expected 4xx, got {resp.status_code}: {resp.text[:500]}"
+        f"EXPLAIN ANALYZE cross-schema [{label}]: expected 4xx, got {resp.status_code}: {resp.text[:500]}"
     )
 
     body = resp.json()
     msg = body.get("message", "")
     assert "rich" in msg or "enrich" in msg or "stream" in msg.lower(), (
-        f"EXPLAIN ANALYZE cross-schema: error message should mention the "
+        f"EXPLAIN ANALYZE cross-schema [{label}]: error message should mention the "
         f"unresolved stream, got: {msg!r}"
     )
 
-    logging.info("EXPLAIN ANALYZE cross-schema: correctly rejected with %s — %s", resp.status_code, msg)
+    logging.info("EXPLAIN ANALYZE cross-schema [%s]: correctly rejected with %s — %s", label, resp.status_code, msg)

--- a/tests/test-data/query-agent/compute_counts.py
+++ b/tests/test-data/query-agent/compute_counts.py
@@ -475,8 +475,11 @@ def main():
         with open(fp) as f:
             query_data = json.load(f)
 
+        queries = query_data.get("queries")
+        if queries is None:
+            continue  # skip non-query files (e.g. error_paths.json)
         dirty = False
-        for q in query_data["queries"]:
+        for q in queries:
             expected = q.get("expected", {})
 
             # Histogram queries: skip auto-interval, convert explicit-interval

--- a/tests/test-data/query-agent/compute_counts.py
+++ b/tests/test-data/query-agent/compute_counts.py
@@ -477,7 +477,8 @@ def main():
 
         queries = query_data.get("queries")
         if queries is None:
-            continue  # skip non-query files (e.g. error_paths.json)
+            print(f"  (skipping {fp.name}: no 'queries' key)")
+            continue
         dirty = False
         for q in queries:
             expected = q.get("expected", {})

--- a/tests/test-data/query-agent/queries/error_paths.json
+++ b/tests/test-data/query-agent/queries/error_paths.json
@@ -205,8 +205,8 @@
     {
       "id": "ERR_NESTING_01",
       "category": "edge_case",
-      "description": "Missing FROM clause",
-      "sql": "SELECT 1",
+      "description": "SELECT * without FROM clause",
+      "sql": "SELECT *",
       "payload_overrides": {},
       "expect_status_min": 400,
       "expect_status_max": 499
@@ -241,13 +241,12 @@
     {
       "id": "ERR_EDGE_04",
       "category": "edge_case",
-      "description": "Extremely nested SELECT (200 levels)",
-      "sql": "SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM \"{stream}\")))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))",
+      "description": "Deeply nested SELECT (30 levels)",
+      "sql": "SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM \"{stream}\"))))))))))))))))))))))))))))))",
       "payload_overrides": {},
       "expect_status_min": 400,
       "expect_status_max": 499
     },
-
     {
       "id": "ERR_SCHEMA_01",
       "category": "cross_schema",

--- a/tests/test-data/query-agent/queries/error_paths.json
+++ b/tests/test-data/query-agent/queries/error_paths.json
@@ -1,0 +1,270 @@
+{
+  "description": "Error path validation — verifies the server returns proper 4xx client-error codes (not 5xx) for invalid inputs. Each case sends an intentionally bad query or payload and asserts the response stays in the 400-499 range.",
+  "cases": [
+    {
+      "id": "ERR_SYNTAX_01",
+      "category": "malformed_sql",
+      "description": "Typo in SELECT keyword",
+      "sql": "SELEC * FROM \"{stream}\"",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_SYNTAX_02",
+      "category": "malformed_sql",
+      "description": "Incomplete WHERE clause (no condition)",
+      "sql": "SELECT * FROM \"{stream}\" WHERE",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_SYNTAX_03",
+      "category": "malformed_sql",
+      "description": "Garbage / non-SQL input",
+      "sql": "FOOBAR BAZ QUX 12345 !@#$%",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_SYNTAX_04",
+      "category": "malformed_sql",
+      "description": "Unclosed single-quoted string literal",
+      "sql": "SELECT * FROM \"{stream}\" WHERE facility_zone = 'unclosed",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_SYNTAX_05",
+      "category": "malformed_sql",
+      "description": "Call to non-existent function",
+      "sql": "SELECT NONEXISTENT_FUNC_XYZ999(*) FROM \"{stream}\"",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_SYNTAX_06",
+      "category": "malformed_sql",
+      "description": "Unterminated GROUP BY clause",
+      "sql": "SELECT facility_zone, COUNT(*) FROM \"{stream}\" GROUP BY",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_TYPE_01",
+      "category": "type_mismatch",
+      "description": "Arithmetic on string literal",
+      "sql": "SELECT 'hello' + 5 FROM \"{stream}\"",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_TYPE_02",
+      "category": "type_mismatch",
+      "description": "Comparing numeric column to non-numeric string literal",
+      "sql": "SELECT * FROM \"{stream}\" WHERE throughput_rate > 'not_a_number'",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_TYPE_03",
+      "category": "type_mismatch",
+      "description": "String argument to numeric ROUND function",
+      "sql": "SELECT ROUND(facility_zone) FROM \"{stream}\"",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_STREAM_01",
+      "category": "missing_stream",
+      "description": "Query references a stream that does not exist",
+      "sql": "SELECT * FROM \"nonexistent_stream_zyxwv_99999\"",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_STREAM_02",
+      "category": "missing_stream",
+      "description": "Empty stream name (zero-length identifier)",
+      "sql": "SELECT * FROM \"\"",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_STREAM_03",
+      "category": "missing_stream",
+      "description": "Cross-stream JOIN where one side does not exist",
+      "sql": "SELECT * FROM \"{stream}\" JOIN \"nonexistent_stream_zyxwv_99999\" ON true",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_STREAM_04",
+      "category": "missing_stream",
+      "description": "Unclosed double-quoted stream identifier",
+      "sql": "SELECT * FROM \"unclosed_identifier",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_TIME_01",
+      "category": "invalid_time_range",
+      "description": "start_time > end_time (reversed time window)",
+      "sql": "SELECT COUNT(*) FROM \"{stream}\"",
+      "payload_overrides": {
+        "start_time": 2000000000,
+        "end_time": 1000000000
+      },
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_TIME_02",
+      "category": "invalid_time_range",
+      "description": "Missing start_time in query payload",
+      "sql": "SELECT COUNT(*) FROM \"{stream}\"",
+      "payload_overrides": {},
+      "payload_remove": [
+        "start_time"
+      ],
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_TIME_03",
+      "category": "invalid_time_range",
+      "description": "Missing end_time in query payload",
+      "sql": "SELECT COUNT(*) FROM \"{stream}\"",
+      "payload_overrides": {},
+      "payload_remove": [
+        "end_time"
+      ],
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_BODY_01",
+      "category": "invalid_request_body",
+      "description": "SQL field set to empty string",
+      "sql": "",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_BODY_02",
+      "category": "invalid_request_body",
+      "description": "Missing 'sql' key in query payload",
+      "sql": "SELECT COUNT(*) FROM \"{stream}\"",
+      "payload_overrides": {},
+      "payload_remove": [
+        "sql"
+      ],
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_DDL_01",
+      "category": "disallowed_sql",
+      "description": "DROP TABLE in search SQL",
+      "sql": "DROP TABLE \"{stream}\"",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_DDL_02",
+      "category": "disallowed_sql",
+      "description": "INSERT INTO in search SQL",
+      "sql": "INSERT INTO \"{stream}\" (facility_zone) VALUES ('test')",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_DDL_03",
+      "category": "disallowed_sql",
+      "description": "ALTER TABLE in search SQL",
+      "sql": "ALTER TABLE \"{stream}\" ADD COLUMN foo STRING",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_NESTING_01",
+      "category": "edge_case",
+      "description": "Missing FROM clause",
+      "sql": "SELECT 1",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_NESTING_02",
+      "category": "edge_case",
+      "description": "Reference to non-existent column on an existing stream",
+      "sql": "SELECT nonexistent_column_xyz999 FROM \"{stream}\"",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_EDGE_01",
+      "category": "edge_case",
+      "description": "Excessively large LIMIT value",
+      "sql": "SELECT * FROM \"{stream}\" LIMIT 99999999999",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_EDGE_03",
+      "category": "edge_case",
+      "description": "Invalid histogram interval (negative value)",
+      "sql": "SELECT histogram(_timestamp, -60) FROM \"{stream}\"",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_EDGE_04",
+      "category": "edge_case",
+      "description": "Extremely nested SELECT (200 levels)",
+      "sql": "SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT * FROM \"{stream}\")))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+
+    {
+      "id": "ERR_SCHEMA_01",
+      "category": "cross_schema",
+      "description": "Cross-schema JOIN with dot-notation table references",
+      "sql": "SELECT b.id, b.name FROM default AS a INNER JOIN enrich.rich AS b ON a.id = b.id LIMIT 1",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    },
+    {
+      "id": "ERR_SCHEMA_02",
+      "category": "cross_schema",
+      "description": "Fully-qualified dot-notation reference on an existing stream",
+      "sql": "SELECT * FROM default.\"{stream}\" LIMIT 1",
+      "payload_overrides": {},
+      "expect_status_min": 400,
+      "expect_status_max": 499
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- **Phase 4 — Error Paths** (`test_4_error_paths.py`): 28 cases across 8 categories that send intentionally invalid SQL and assert 4xx not 5xx. Self-contained, runs in ~24s without data dependency.
- **Phase 5 — Concurrency Stress** (`test_5_concurrency.py`): 26 queries (2 per category) run simultaneously at 5/10/15 worker levels via ThreadPoolExecutor. Each thread gets its own client. Catches deadlocks and thread-safety bugs.
- **EXPLAIN ANALYZE** (`test_explain_analyze.py`): Verifies EXPLAIN/EXPLAIN ANALYZE return 200 with plan output and no `partial_error`. Also validates EXPLAIN ANALYZE on cross-schema dot-notation queries returns 4xx (not 500 crash).
- **Fix**: `load_all_queries()` now skips JSON files without a `"queries"` key.

## Test plan
- [x] Error path tests pass on pentest (28/28, all return 400)
- [ ] CI run: `rye run pytest tests/query_agent/test_4_error_paths.py -v`
- [ ] CI run: `rye run pytest tests/query_agent/test_5_concurrency.py -v`
- [ ] CI run: `rye run pytest tests/query_agent/test_explain_analyze.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)