### PR TITLE
fix: repoint formatLargeNumber import to @/utils/zincutils (unblocks v0.91.0 release build)

### DIFF
--- a/web/src/composables/useLogs/useHistogram.ts
+++ b/web/src/composables/useLogs/useHistogram.ts
@@ -31,8 +31,7 @@ const SEVERITY_ORDER: Record<string, number> = {
   error: 9, critical: 10, fatal: 11,
 };
 
-import { formatSizeFromMB, histogramDateTimezone } from "@/utils/zincutils";
-import { formatLargeNumber } from "@/utils/formatters";
+import { formatSizeFromMB, histogramDateTimezone, formatLargeNumber } from "@/utils/zincutils";
 
 import { logsUtils } from "@/composables/useLogs/logsUtils";
 

--- a/web/src/plugins/logs/SearchResult.vue
+++ b/web/src/plugins/logs/SearchResult.vue
@@ -672,8 +672,7 @@ import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
 
 import { byString } from "../../utils/json";
-import { getImageURL, useLocalWrapContent } from "../../utils/zincutils";
-import { formatLargeNumber } from "@/utils/formatters";
+import { getImageURL, useLocalWrapContent, formatLargeNumber } from "../../utils/zincutils";
 import useLogs from "../../composables/useLogs";
 import { useSearchStream } from "@/composables/useLogs/useSearchStream";
 import usePatterns from "@/composables/useLogs/usePatterns";


### PR DESCRIPTION
## Problem

The v0.91.0 release builds (**both OSS and Enterprise**) fail in the frontend `vite build` step with:

```
[vite:load-fallback] Could not load .../web/src/utils/formatters
  (imported by src/composables/useLogs/useHistogram.ts): ENOENT: no such file or directory
ERROR: "build-only" exited with 1.
```

## Root cause

The zincutils-split PR #12689 (which creates `web/src/utils/formatters.ts` and makes `zincutils.ts` re-export it) was **not** included in `branch-v0.91.0`. However, PR #12817 ("Logs page UI fixes 0.91.0") **was** included, and it added imports from `@/utils/formatters` — a module that does not exist on this branch. The result is an unresolvable import that aborts the production build.

`formatLargeNumber` still lives in `@/utils/zincutils` on this branch.

## Fix

Repoint both broken imports back to `@/utils/zincutils` (folded into the existing zincutils import in each file to avoid duplicate imports):

- `web/src/composables/useLogs/useHistogram.ts`
- `web/src/plugins/logs/SearchResult.vue`

## Scope check

- These were the **only** two `@/utils/formatters` references on the branch.
- Verified none of the other modules introduced by the split PR (`queryUtils`, `storage`, `timezone`, `uuid`, `auth`) are imported on this branch, so this is the complete fix.
- The Enterprise repo has no formatters references; it consumes the OSS `web/` frontend, so this single fix unblocks both release builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)