### PR TITLE
fix: if record is null in pipeline, ignore it

### DIFF
--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -792,6 +792,14 @@ async fn process_node(
                         };
                     }
 
+                    // A null / non-object record means an upstream function filtered it
+                    // out (e.g. VRL `. = null`). Drop it instead of forwarding to the
+                    // destination, where it would fail at handle_timestamp with
+                    // "Value is not an object" and inflate the failed count.
+                    if record.is_null() || !record.is_object() {
+                        continue;
+                    }
+
                     let mut destination_stream = stream_params.clone();
                     if destination_stream.stream_name.contains("{") {
                         match resolve_stream_name(&destination_stream.stream_name, &record) {
@@ -941,6 +949,13 @@ async fn process_node(
                         }
                     };
                     flattened = true;
+                }
+
+                // A null / non-object record means an upstream function filtered it out
+                // (e.g. VRL `. = null`). Skip it: it can't satisfy any condition and
+                // `as_object().unwrap()` below would panic on a null.
+                if record.is_null() || !record.is_object() {
+                    continue;
                 }
 
                 // Evaluate based on condition version

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -796,7 +796,7 @@ async fn process_node(
                     // out (e.g. VRL `. = null`). Drop it instead of forwarding to the
                     // destination, where it would fail at handle_timestamp with
                     // "Value is not an object" and inflate the failed count.
-                    if record.is_null() || !record.is_object() {
+                    if !record.is_object() {
                         continue;
                     }
 
@@ -954,7 +954,7 @@ async fn process_node(
                 // A null / non-object record means an upstream function filtered it out
                 // (e.g. VRL `. = null`). Skip it: it can't satisfy any condition and
                 // `as_object().unwrap()` below would panic on a null.
-                if record.is_null() || !record.is_object() {
+                if !record.is_object() {
                     continue;
                 }
 


### PR DESCRIPTION
Currently in pipeline execution, if any null record is encountered, it results in errors. Instead it should just ignore the null records and continue. It is very common in pipeline vrls to use -`. = null` when certain condition matches.