### PR TITLE
fix: Removed native scrollIntoView from SpanBlock onMounted as it was blocking scroll

### DIFF
--- a/web/src/plugins/traces/SpanBlock.spec.ts
+++ b/web/src/plugins/traces/SpanBlock.spec.ts
@@ -539,4 +539,54 @@ describe("SpanBlock", () => {
       expect(hasHex || hasRgb).toBe(true);
     });
   });
+
+  describe("pre-selected span_id scroll behavior", () => {
+    let scrollSpy: ReturnType<typeof vi.fn>;
+    let originalScrollIntoView: any;
+
+    beforeEach(() => {
+      scrollSpy = vi.fn();
+      // jsdom does not implement scrollIntoView — install a spy.
+      originalScrollIntoView = (Element.prototype as any).scrollIntoView;
+      (Element.prototype as any).scrollIntoView = scrollSpy;
+    });
+
+    afterEach(async () => {
+      (Element.prototype as any).scrollIntoView = originalScrollIntoView;
+      await router.push({ query: {} });
+    });
+
+    // Regression: with virtualized rows, a SpanBlock remounts every time it
+    // scrolls into the viewport. It must NOT scroll the URL's span_id back into
+    // view on each mount (that fought the user's scroll). Centering the
+    // pre-selected span is owned by TraceTree via the virtualizer.
+    it("should not scroll the span into view on mount when span_id is in the route query", async () => {
+      await router.push({ query: { span_id: mockSpan.spanId } });
+
+      const localWrapper = mount(SpanBlock, {
+        attachTo: document.body,
+        props: {
+          span: mockSpan,
+          baseTracePosition: mockBaseTracePosition,
+          depth: 0,
+          styleObj: mockStyle,
+          showCollapse: true,
+          isCollapsed: false,
+          spanDimensions: mockSpanDimensions,
+          spanData: mockSpanData,
+        },
+        global: {
+          plugins: [i18n, router],
+          provide: { store: mockStore },
+          stubs: { "q-resize-observer": true },
+        },
+      });
+
+      await flushPromises();
+
+      expect(scrollSpy).not.toHaveBeenCalled();
+
+      localWrapper.unmount();
+    });
+  });
 });

--- a/web/src/plugins/traces/SpanBlock.vue
+++ b/web/src/plugins/traces/SpanBlock.vue
@@ -105,7 +105,6 @@ import { getImageURL, formatTimeWithSuffix } from "@/utils/zincutils";
 import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
 import { b64EncodeStandard } from "@/utils/zincutils";
-import { useRouter } from "vue-router";
 
 export default defineComponent({
   name: "SpanBlock",
@@ -158,7 +157,6 @@ export default defineComponent({
     });
 
     const durationStyle = ref({});
-    const router = useRouter();
     const { t } = useI18n();
 
     const leftPosition = ref(0);
@@ -189,21 +187,12 @@ export default defineComponent({
 
     onMounted(async () => {
       durationStyle.value = getDurationStyle();
-      const params = router.currentRoute.value.query;
-      const spanId = Array.isArray(params.span_id)
-        ? params.span_id[0]
-        : params.span_id; // Ensure it's a single string
 
-      if (spanId) {
-        const element = document.getElementById(spanId);
-        if (element) {
-          element.scrollIntoView({
-            behavior: "smooth", // Smooth scrolling
-            block: "center", // Attempt to align the element at the center of the screen
-            inline: "nearest", // Keep horizontal alignment as close as possible
-          });
-        }
-      }
+      // NOTE: do NOT scroll the pre-selected span into view here. Rows are
+      // virtualized, so a SpanBlock remounts every time it scrolls into the
+      // viewport — doing scrollIntoView on each mount snapped the view back to
+      // the URL's span_id and fought the user's scroll. Centering the
+      // pre-selected span is owned by TraceTree (virtualizer scrollToIndex).
 
       if (spanBlock.value) {
         _resizeObserver = new ResizeObserver(() => {

--- a/web/src/plugins/traces/TraceDetails.spec.ts
+++ b/web/src/plugins/traces/TraceDetails.spec.ts
@@ -471,6 +471,22 @@ describe("TraceDetails", () => {
       expect(wrapper.vm.searchObj.data.traceDetails.selectedSpanId).toBe(null);
     });
 
+    it("should cancel any in-flight span scroll when sidebar closes", () => {
+      const cancelScroll = vi.fn();
+      wrapper.vm.traceTreeRef = { cancelScroll };
+
+      wrapper.vm.closeSidebar();
+
+      expect(cancelScroll).toHaveBeenCalledTimes(1);
+      expect(wrapper.vm.searchObj.data.traceDetails.selectedSpanId).toBe(null);
+    });
+
+    it("should not throw on close when the trace tree ref is absent", () => {
+      wrapper.vm.traceTreeRef = null;
+
+      expect(() => wrapper.vm.closeSidebar()).not.toThrow();
+    });
+
     it("should render trace tree component", () => {
       const traceTree = wrapper.find('[data-test="trace-details-tree"]');
       expect(traceTree.exists()).toBe(true);

--- a/web/src/plugins/traces/TraceDetails.vue
+++ b/web/src/plugins/traces/TraceDetails.vue
@@ -1525,6 +1525,8 @@ export default defineComponent({
     const resetTraceDetails = () => {
       searchObj.data.traceDetails.showSpanDetails = false;
       searchObj.data.traceDetails.selectedSpanId = "";
+      // Selection is being cleared — cancel any live scroll targeting it.
+      traceTreeRef.value?.cancelScroll?.();
       searchObj.data.traceDetails.selectedTrace = {
         trace_id: "",
         trace_start_time: 0,
@@ -1589,6 +1591,8 @@ export default defineComponent({
       showTraceDetails.value = false;
       searchObj.data.traceDetails.showSpanDetails = false;
       searchObj.data.traceDetails.selectedSpanId = "";
+      // Cancel any scroll left over from a previous trace before (re)loading.
+      traceTreeRef.value?.cancelScroll?.();
 
       // If embedded mode with span list provided, skip fetching
       if (props.mode === "embedded" && props.spanListProp.length > 0) {
@@ -2290,6 +2294,9 @@ export default defineComponent({
       hoveredSpanId.value = "";
       searchObj.data.traceDetails.showSpanDetails = false;
       searchObj.data.traceDetails.selectedSpanId = null;
+      // Stop any pending/in-flight programmatic scroll so the closed span no
+      // longer snaps back into view while the user scrolls the tree.
+      traceTreeRef.value?.cancelScroll?.();
     };
     const toggleSpanCollapse = (spanId: number | string) => {
       collapseMapping.value[spanId] = !collapseMapping.value[spanId];

--- a/web/src/plugins/traces/TraceTree.spec.ts
+++ b/web/src/plugins/traces/TraceTree.spec.ts
@@ -13,6 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// Shared, stable spy so call assertions survive the virtualizer computed being
+// re-evaluated on every read (the mock recreates its object each access).
+const { mockScrollToIndex } = vi.hoisted(() => ({
+  mockScrollToIndex: vi.fn(),
+}));
+
 // Mock @tanstack/vue-virtual BEFORE any imports so the virtualizer returns
 // synthetic virtual rows even when scrollContainer is null (as in jsdom).
 vi.mock("@tanstack/vue-virtual", () => ({
@@ -22,7 +28,6 @@ vi.mock("@tanstack/vue-virtual", () => ({
       const options = optionsComputed.value;
       const count = options.count;
       const estimateSize = options.estimateSize?.() ?? 30;
-      const scrollToIndex = vi.fn();
       const items = Array.from({ length: count }, (_, i) => ({
         key: i,
         index: i,
@@ -34,7 +39,8 @@ vi.mock("@tanstack/vue-virtual", () => ({
       return {
         getVirtualItems: () => items,
         getTotalSize: () => count * estimateSize,
-        scrollToIndex,
+        scrollToIndex: mockScrollToIndex,
+        currentScrollToIndex: null,
       };
     });
   }),
@@ -597,6 +603,61 @@ describe("TraceTree", () => {
 
         // scrollToSpan returns early when spanIndex === -1
         expect(() => wrapper.vm.scrollToMatch()).not.toThrow();
+      });
+    });
+
+    describe("cancelScroll function", () => {
+      const validSpanId = "d9603ec7f76eb499";
+
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it("should expose cancelScroll", () => {
+        expect(wrapper.vm.cancelScroll).toBeTypeOf("function");
+      });
+
+      it("should clear a pending scroll so scrollToIndex never fires", () => {
+        wrapper.vm.scrollToSpan(validSpanId, 300);
+        wrapper.vm.cancelScroll();
+        vi.advanceTimersByTime(300);
+
+        expect(mockScrollToIndex).not.toHaveBeenCalled();
+      });
+
+      it("should let a pending scroll fire when not cancelled", () => {
+        wrapper.vm.scrollToSpan(validSpanId, 300);
+        vi.advanceTimersByTime(300);
+
+        expect(mockScrollToIndex).toHaveBeenCalledTimes(1);
+      });
+
+      it("should supersede an earlier pending scroll with the latest one", () => {
+        wrapper.vm.scrollToSpan(validSpanId, 300);
+        wrapper.vm.scrollToSpan(validSpanId, 300);
+        vi.advanceTimersByTime(300);
+
+        // The first timeout was cleared by the second call.
+        expect(mockScrollToIndex).toHaveBeenCalledTimes(1);
+      });
+
+      it("should not throw when nothing is pending", () => {
+        expect(() => wrapper.vm.cancelScroll()).not.toThrow();
+      });
+
+      it("should drop a pending scroll on unmount", () => {
+        wrapper.vm.scrollToSpan(validSpanId, 300);
+        wrapper.unmount();
+        vi.advanceTimersByTime(300);
+
+        expect(mockScrollToIndex).not.toHaveBeenCalled();
+
+        // Re-mount so the suite-level afterEach unmounts a live wrapper.
+        wrapper = mountTraceTree();
       });
     });
   });

--- a/web/src/plugins/traces/TraceTree.vue
+++ b/web/src/plugins/traces/TraceTree.vue
@@ -401,6 +401,7 @@ import {
   watch,
   computed,
   onMounted,
+  onBeforeUnmount,
 } from "vue";
 import useTraces from "@/composables/useTraces";
 import { useStore } from "vuex";
@@ -523,6 +524,12 @@ export default defineComponent({
       }
     });
 
+    onBeforeUnmount(() => {
+      // Drop any queued scroll so it can't fire against a torn-down virtualizer
+      // (the tree can remount since searchObj is a module-level singleton).
+      cancelScroll();
+    });
+
     // ── CSS connector helpers (pre-computed, O(n) total) ────────────────────
     // nextSiblingMap[i] = true when spans[i] has a next sibling at the same
     // depth with no shallower span in between. Built in a single RTL scan so
@@ -641,15 +648,47 @@ export default defineComponent({
         .filter((index: any) => index !== -1);
     };
 
+    // Tracks the pending scrollToSpan setTimeout so a newer scroll or an
+    // explicit cancel can clear an in-flight one. Non-reactive — never used in
+    // the template.
+    let pendingScrollTimeout: ReturnType<typeof setTimeout> | null = null;
+
     const scrollToSpan = (spanId: string, delay: number = 0) => {
       const spanIndex = (props.spans as any[]).findIndex(
         (s: any) => s.spanId === spanId || s.span_id === spanId,
       );
 
       if (spanIndex !== -1) {
-        setTimeout(() => {
+        // Clear any previously queued scroll so only the latest one runs.
+        if (pendingScrollTimeout !== null) {
+          clearTimeout(pendingScrollTimeout);
+        }
+        pendingScrollTimeout = setTimeout(() => {
+          pendingScrollTimeout = null;
           rowVirtualizer.value.scrollToIndex(spanIndex, { align: "center" });
         }, delay);
+      }
+    };
+
+    // Cancels any pending and in-flight programmatic scroll. Called when the
+    // selection is cleared (e.g. sidebar close) so the virtualizer stops
+    // forcing the previously-selected span back into view while the user
+    // scrolls manually.
+    const cancelScroll = () => {
+      if (pendingScrollTimeout !== null) {
+        clearTimeout(pendingScrollTimeout);
+        pendingScrollTimeout = null;
+      }
+      // TanStack's scrollToIndex runs a requestAnimationFrame retry loop that
+      // keeps re-scrolling until the target offset is reached; the loop only
+      // bails when its captured `currentScrollToIndex` no longer matches the
+      // instance's. Resetting it to null (the value the library inits it to)
+      // makes the next frame bail. There is no public API for this, so guard
+      // the access in case the internal field is renamed in a future
+      // @tanstack/virtual-core release.
+      const virtualizer = rowVirtualizer.value as any;
+      if (virtualizer && "currentScrollToIndex" in virtualizer) {
+        virtualizer.currentScrollToIndex = null;
       }
     };
 
@@ -815,6 +854,7 @@ export default defineComponent({
       isHighlighted,
       currentSelectedValue,
       scrollToSpan,
+      cancelScroll,
       scrollToMatch,
       findMatches,
       getChildCount,


### PR DESCRIPTION
## What changed

- **Removed** the native `scrollIntoView()` call from `SpanBlock.vue`'s `onMounted` hook, which was fighting the user's manual scroll in a virtualized list.
- **Added** `cancelScroll()` to `TraceTree.vue` — clears pending timeouts and aborts the TanStack virtualizer retry loop by resetting `currentScrollToIndex`.
- **Wired cancellations** in `TraceDetails.vue` — calls `traceTreeRef.value?.cancelScroll?.()` when the sidebar closes, trace details reset, or a new trace is loaded.
- **Added `onBeforeUnmount`** cleanup in `TraceTree.vue` so a queued scroll can't fire against a torn-down virtualizer.
- **Added regression tests** in `SpanBlock.spec.ts`, `TraceTree.spec.ts`, and `TraceDetails.spec.ts` covering all scroll-cancellation paths.

## Why

When `TraceDetails.vue` is opened with a `span_id` query parameter, `SpanBlock.vue` called `element.scrollIntoView()` on mount. Because rows are virtualized via `@tanstack/vue-virtual`, a `SpanBlock` remounts every time it scrolls into the viewport — so each remount snapped the viewport back to the pre-selected span, fighting the user's manual scroll. The issue only manifested when a `span_id` was pre-selected at page load.