### PR TITLE
ci(docgen): OSS caller — forward /docgen to the ENT DocGen engine

### DIFF
--- a/.github/workflows/docgen-caller.yml
+++ b/.github/workflows/docgen-caller.yml
@@ -22,6 +22,9 @@ name: DocGen Caller (openobserve)
 # We use DeepSeek precisely because DEEPSEEK_API_KEY already exists here (e2e-council.yml +
 # ai-code-review.yml) — no Anthropic secret needed. E2E_DEV_CI_TOKEN is only used by the engine
 # for cross-repo diff reads + Phase B docs pushes (comments post as github-actions[bot]).
+#
+# KILL SWITCH: the engine honors a DOCGEN_DISABLED repo/org variable — set it to 'true' to
+# disable all DocGen runs without removing these files.
 
 on:
   issue_comment:
@@ -34,6 +37,10 @@ on:
       dry_run:
         description: "Triage only (no generation)"
         type: boolean
+        # Intentional SAFE default: a manual dispatch previews (triage only) unless you opt
+        # into generation by unchecking this. (Comment path is explicit: /docgen = full run,
+        # /docgen-dryrun = triage.) In Phase A dry_run has no effect yet — everything is
+        # triage-only — so this only matters once Phase B (doc generation) lands.
         default: true
 
 permissions:

--- a/.github/workflows/docgen-caller.yml
+++ b/.github/workflows/docgen-caller.yml
@@ -1,0 +1,65 @@
+name: DocGen Caller (openobserve)
+
+# Thin caller: watches openobserve (OSS) PRs and forwards to the reusable DocGen engine that
+# lives in o2-enterprise. All real logic lives in the engine; this file only decides WHETHER
+# to run (command detection + org-member gate) and WHICH PR, then forwards.
+#
+# WHY A CALLER (not dispatch the engine directly): a reusable workflow runs in the CALLER's
+# context, so triggering from here makes the run use openobserve's own GITHUB_TOKEN /
+# github-actions[bot] — which can comment on OSS PRs. Dispatching the engine from o2-enterprise
+# would run in ENT's context (ENT bot) and could NOT comment on an OSS PR.
+#
+# TWO WAYS TO TRIGGER:
+#   - issue_comment    → an org member comments `/docgen` or `/docgen-dryrun` on an OSS PR.
+#   - workflow_dispatch → manual "Run workflow" button (Actions UI / gh) against a PR number.
+#                         Dispatch is inherently restricted to users with repo write access.
+#
+# ORG-MEMBER GATE (comment path, no API call): gate on the comment author_association —
+# OWNER / MEMBER (org member) or COLLABORATOR. On this PUBLIC repo this blocks random external
+# commenters from firing paid model runs.
+#
+# SECRETS CONTEXT: a cross-repo reusable runs in THIS (openobserve) repo's secrets context.
+# We use DeepSeek precisely because DEEPSEEK_API_KEY already exists here (e2e-council.yml +
+# ai-code-review.yml) — no Anthropic secret needed. E2E_DEV_CI_TOKEN is only used by the engine
+# for cross-repo diff reads + Phase B docs pushes (comments post as github-actions[bot]).
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "OSS PR number to run DocGen triage on"
+        required: true
+      dry_run:
+        description: "Triage only (no generation)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  call-docgen:
+    # Run on a manual dispatch, OR on an exact `/docgen[-dryrun]` comment from an org member.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+       (github.event.comment.body == '/docgen' || github.event.comment.body == '/docgen-dryrun') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    uses: openobserve/o2-enterprise/.github/workflows/docgen.yml@main
+    with:
+      source_repo: openobserve
+      # dispatch supplies pr_number directly (inputs.* is the typed dispatch context, empty on
+      # the comment path); comment path uses the commented PR.
+      pr_number: ${{ inputs.pr_number || github.event.issue.number }}
+      # dispatch: honor the (typed boolean) dry_run input; comment path: dry-run only for
+      # /docgen-dryrun. Use inputs.dry_run (typed bool), NOT github.event.inputs (a string).
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || github.event.comment.body == '/docgen-dryrun' }}
+      actor: ${{ github.event_name == 'workflow_dispatch' && github.actor || github.event.comment.user.login }}
+    secrets:
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      CROSS_REPO_TOKEN: ${{ secrets.E2E_DEV_CI_TOKEN }}

--- a/.github/workflows/docgen-caller.yml
+++ b/.github/workflows/docgen-caller.yml
@@ -47,7 +47,6 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  id-token: write
 
 jobs:
   call-docgen:


### PR DESCRIPTION
Brings the **OSS side** of DocGen-on-CI online. This is the thin "caller" that lets `/docgen` work on `openobserve` PRs; all real logic lives in the reusable engine in `o2-enterprise`.

## What it does
- Triggers on a `/docgen` or `/docgen-dryrun` **comment** on an OSS PR (org-member gated via `author_association`), or a manual **`workflow_dispatch`** (write-access gated by GitHub).
- Forwards to `openobserve/o2-enterprise/.github/workflows/docgen.yml@main` via `workflow_call`.

## Why this is just a thin caller
GitHub only delivers a repo's PR/comment events to workflows **in that repo**, so OSS needs its own listener. Crucially, a **reusable workflow runs in the caller's context** — so an OSS-triggered run executes *as openobserve* (OSS runner + OSS `GITHUB_TOKEN`) and comments on the OSS PR with OSS's own `github-actions[bot]`. No cross-repo token needed for comments.

## Runtime
OpenCode + DeepSeek (`deepseek-v4-pro`). `DEEPSEEK_API_KEY` already exists in OSS (used by `e2e-council.yml` + `ai-code-review.yml`), so no new secret is required.

## ⚠️ Merge order
**Merge this AFTER `o2-enterprise#1977`** lands on ENT `main`. This caller runs the engine at `@main`; the `github-actions[bot]` comment-identity fix is in #1977. Merging earlier would make OSS triage comments post as the PAT owner instead of the bot. Opening now so it's review-ready.

## Phase A only
Triage only — generates nothing. Inert until a `/docgen[-dryrun]` comment or manual dispatch. `DOCGEN_DISABLED` repo/org variable is a global kill switch (in the engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)