### PR TITLE
chore: service catalog progress bars + alert history flapping timeline

### DIFF
--- a/web/src/components/alerts/AlertHistoryDrawer.spec.ts
+++ b/web/src/components/alerts/AlertHistoryDrawer.spec.ts
@@ -584,12 +584,18 @@ describe("AlertHistoryDrawer.vue", () => {
   });
 
   describe("Helper Functions", () => {
-    it("formatStatus should capitalize first letter", async () => {
+    it("formatStatus should normalize status to display labels", async () => {
       await mountComponent();
       const vm = wrapper.vm as any;
       expect(vm.formatStatus("firing")).toBe("Firing");
       expect(vm.formatStatus("ok")).toBe("Ok");
-      expect(vm.formatStatus("error")).toBe("Error");
+      // error/anomaly/completed are all firing states
+      expect(vm.formatStatus("error")).toBe("Firing");
+      expect(vm.formatStatus("anomaly")).toBe("Firing");
+      expect(vm.formatStatus("completed")).toBe("Firing");
+      // condition_not_satisfied is an ok state
+      expect(vm.formatStatus("condition_not_satisfied")).toBe("Ok");
+      expect(vm.formatStatus("skipped")).toBe("Skipped");
     });
 
     it("formatStatus should return Unknown for empty/null input", async () => {

--- a/web/src/components/alerts/AlertHistoryDrawer.vue
+++ b/web/src/components/alerts/AlertHistoryDrawer.vue
@@ -193,111 +193,114 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <!-- History Table -->
             <div
               v-else
-              class="code-block tw:flex tw:flex-col tw:flex-1 tw:overflow-hidden"
-              :class="
-                store.state.theme === 'dark'
-                  ? 'code-block-dark'
-                  : 'code-block-light'
-              "
+              class="tw:flex tw:flex-col tw:flex-1 tw:overflow-hidden tw:gap-2"
             >
-              <OTable
-                :data="alertHistory"
-                :columns="historyTableColumns"
-                row-key="timestamp"
-                pagination="server"
-                v-model:current-page="currentPage"
-                v-model:page-size="selectedPerPage"
-                :total-count="resultTotal"
-                :loading="isLoadingHistory"
-                :row-class="getRowClass"
-                :default-columns="false"
-                :show-global-filter="false"
-                class="history-table tw:flex-1 tw:overflow-hidden"
-                data-test="alert-details-history-table"
-                @pagination-change="onPaginationChange"
-              >
-                <template #[`cell-#`]="{ row }">
-                  <span
-                    class="tw:text-[13px] tw:tabular-nums"
-                    :class="
-                      store.state.theme === 'dark'
-                        ? 'tw:text-gray-500'
-                        : 'tw:text-gray-400'
-                    "
-                  >
-                    {{
-                      (currentPage - 1) * selectedPerPage +
-                      alertHistory.findIndex((r: any) => r.timestamp === row.timestamp) +
-                      1
-                    }}
-                  </span>
-                </template>
-                <template #cell-status="{ row }">
-                  <OBadge
-                    size="sm"
-                    :icon="getStatusChipIcon(row.status)"
-                    :variant="getStatusChipVariant(row.status)"
-                    class="tw:cursor-default"
-                    data-test="alert-history-status-chip"
-                  >
-                    {{ formatStatus(row.status) }}
-                    <OTooltip
-                      v-if="row.error"
-                      :max-width="'300px'"
-                      :content="row.error"
-                    />
-                  </OBadge>
-                </template>
-                <template #cell-timestamp="{ row }">
-                  <span class="tw:text-[13px]">{{
-                    formatTimestamp(row.timestamp)
-                  }}</span>
-                  <OTooltip :content="formatTimestampFull(row.timestamp)" />
-                </template>
-                <template #cell-evaluation_time="{ row }">
-                  <span class="tw:text-[13px] tw:tabular-nums">
-                    {{
-                      row.evaluation_took_in_secs
-                        ? row.evaluation_took_in_secs.toFixed(3) + "s"
-                        : "—"
-                    }}
-                  </span>
-                </template>
-                <template #cell-query_time="{ row }">
-                  <span class="tw:text-[13px] tw:tabular-nums">
-                    {{
-                      row.query_took ? row.query_took + "ms" : "—"
-                    }}
-                  </span>
-                </template>
-                <template #cell-anomaly_count="{ row }">
-                  <span
-                    class="tw:text-[13px] tw:tabular-nums"
-                    :class="
-                      row.anomaly_count > 0
-                        ? 'tw:text-red-500 tw:font-medium'
-                        : ''
-                    "
-                  >
-                    {{
-                      row.anomaly_count != null ? row.anomaly_count : "—"
-                    }}
-                  </span>
-                </template>
-                <template #cell-error="{ row }">
-                  <span class="tw:text-[13px]">{{ row.error || "—" }}</span>
-                </template>
+              <!-- Firing frequency timeline -->
+              <AlertHistoryTimeline
+                v-if="alertHistory.length > 0"
+                :history="alertHistory"
+              />
 
-                <template #bottom="scope">
-                  <div class="tw:flex tw:items-center tw:w-full tw:h-[48px]">
-                    <div
-                      class="o2-table-footer-title tw:flex tw:items-center tw:w-[220px]"
+              <div
+                class="code-block tw:flex tw:flex-col tw:flex-1 tw:overflow-hidden"
+                :class="store.state.theme === 'dark' ? 'code-block-dark' : 'code-block-light'"
+              >
+                <OTable
+                  :data="groupedHistory"
+                  :columns="historyTableColumns"
+                  row-key="timestamp"
+                  pagination="server"
+                  v-model:current-page="currentPage"
+                  v-model:page-size="selectedPerPage"
+                  :total-count="resultTotal"
+                  :loading="isLoadingHistory"
+                  :row-class="getRowClass"
+                  :default-columns="false"
+                  :show-global-filter="false"
+                  class="history-table tw:flex-1 tw:overflow-hidden"
+                  data-test="alert-details-history-table"
+                  @pagination-change="onPaginationChange"
+                >
+                  <template #[`cell-#`]="{ row }">
+                    <span
+                      class="tw:text-[13px] tw:tabular-nums"
+                      :class="store.state.theme === 'dark' ? 'tw:text-gray-500' : 'tw:text-gray-400'"
                     >
-                      {{ resultTotal }} {{ t("alerts.alertDetails.results") }}
+                      {{ row._displayIndex ?? '—' }}
+                    </span>
+                  </template>
+
+                  <template #cell-status="{ row }">
+                    <!-- Flapping group row -->
+                    <div v-if="row._flappingGroup" class="tw:flex tw:items-center tw:gap-1.5">
+                      <OIcon
+                        :name="expandedGroups.has(row.timestamp) ? 'expand-less' : 'expand-more'"
+                        size="sm"
+                        class="tw:cursor-pointer tw:opacity-50 tw:shrink-0"
+                        @click="toggleFlappingGroup(row.timestamp)"
+                      />
+                      <OBadge size="sm" variant="warning-soft" class="tw:cursor-pointer tw:shrink-0" @click="toggleFlappingGroup(row.timestamp)">
+                        ⚡ Flapping
+                      </OBadge>
+                      <span class="tw:text-[11px] tw:truncate" style="color: var(--color-text-secondary)">
+                        {{ row._children.length }} rows · {{ row._duration }}
+                      </span>
                     </div>
-                  </div>
-                </template>
-              </OTable>
+                    <!-- Normal row -->
+                    <OBadge
+                      v-else
+                      size="sm"
+                      :icon="getStatusChipIcon(row.status)"
+                      :variant="getStatusChipVariant(row.status)"
+                      class="tw:cursor-default"
+                      data-test="alert-history-status-chip"
+                    >
+                      {{ formatStatus(row.status) }}
+                      <OTooltip v-if="row.error" :max-width="'300px'" :content="row.error" />
+                    </OBadge>
+                  </template>
+
+                  <template #cell-timestamp="{ row }">
+                    <span class="tw:text-[13px]" :class="row._child ? 'tw:pl-5 tw:opacity-70' : ''">
+                      {{ formatTimestamp(row.timestamp) }}
+                    </span>
+                    <OTooltip :content="formatTimestampFull(row.timestamp)" />
+                  </template>
+
+                  <template #cell-evaluation_time="{ row }">
+                    <span class="tw:text-[13px] tw:tabular-nums">
+                      {{ row.evaluation_took_in_secs ? row.evaluation_took_in_secs.toFixed(3) + "s" : "—" }}
+                    </span>
+                  </template>
+
+                  <template #cell-query_time="{ row }">
+                    <span class="tw:text-[13px] tw:tabular-nums">
+                      {{ row.query_took ? row.query_took + "ms" : "—" }}
+                    </span>
+                  </template>
+
+                  <template #cell-anomaly_count="{ row }">
+                    <span
+                      class="tw:text-[13px] tw:tabular-nums"
+                      :class="row.anomaly_count > 0 ? 'tw:text-red-500 tw:font-medium' : ''"
+                    >
+                      {{ row.anomaly_count != null ? row.anomaly_count : "—" }}
+                    </span>
+                  </template>
+
+                  <template #cell-error="{ row }">
+                    <span class="tw:text-[13px]">{{ row.error || "—" }}</span>
+                  </template>
+
+                  <template #bottom>
+                    <div class="tw:flex tw:items-center tw:w-full tw:h-[48px]">
+                      <div class="o2-table-footer-title tw:flex tw:items-center tw:w-[220px]">
+                        {{ resultTotal }} {{ t("alerts.alertDetails.results") }}
+                      </div>
+                    </div>
+                  </template>
+                </OTable>
+              </div>
             </div>
           </div>
         </OTabPanel>
@@ -494,6 +497,7 @@ import type { Ref } from "vue";
 import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
 import { toast } from "@/lib/feedback/Toast/useToast";
 import { copyToClipboard } from "@/utils/clipboard";
+import AlertHistoryTimeline from "./AlertHistoryTimeline.vue";
 
 // Composables
 const { t } = useI18n();
@@ -533,6 +537,157 @@ const activeTab = ref("history");
 // Refs
 const alertHistory: Ref<any[]> = ref([]);
 const isLoadingHistory = ref(false);
+
+// ── Flapping group helpers ──────────────────────────────────────────────────
+const MIN_FLAP_TRANSITIONS = 3; // firing↔ok flips within a run to call it flapping
+const MIN_FLAP_WINDOW = 4;      // minimum consecutive rows needed
+
+function rowIsFiring(s: string) {
+  const v = s?.toLowerCase();
+  return v === "firing" || v === "error" || v === "anomaly" || v === "completed";
+}
+function rowIsOk(s: string) {
+  const v = s?.toLowerCase();
+  return v === "ok" || v === "success" || v === "normal" || v === "condition_not_satisfied";
+}
+
+// Build a boolean mask: true = row is inside a flapping run.
+// Strategy:
+//  1. Scan forward to find the first window of MIN_FLAP_WINDOW rows that
+//     contains >= MIN_FLAP_TRANSITIONS firing↔ok flips — this is a zone start.
+//  2. Once inside a zone, keep extending as long as each new row causes a
+//     flip relative to the previous non-skipped state.
+//  3. Stop extending when we see MAX_STABLE_TAIL consecutive rows with no
+//     flip, then trim those trailing stable rows off the end of the zone.
+function buildFlappingMask(rows: any[]): boolean[] {
+  const n = rows.length;
+  const mask = new Array(n).fill(false);
+  const MAX_STABLE_TAIL = 2; // consecutive non-flipping rows that end a zone
+
+  function stateOf(s: string): "firing" | "ok" | "other" {
+    if (rowIsFiring(s)) return "firing";
+    if (rowIsOk(s))    return "ok";
+    return "other";
+  }
+
+  let i = 0;
+  while (i < n) {
+    // Count transitions in the next MIN_FLAP_WINDOW rows
+    let transitions = 0;
+    let prev = stateOf(rows[i].status);
+    let windowEnd = -1;
+    for (let j = i + 1; j < Math.min(i + MIN_FLAP_WINDOW + 10, n); j++) {
+      const cur = stateOf(rows[j].status);
+      if (cur !== "other" && prev !== "other" && cur !== prev) transitions++;
+      if (cur !== "other") prev = cur;
+      if (transitions >= MIN_FLAP_TRANSITIONS) { windowEnd = j; break; }
+    }
+
+    if (windowEnd === -1) { i++; continue; } // no flapping here
+
+    // Found a flapping zone starting at i — now extend it forward
+    let zoneEnd = windowEnd;
+    let stableTail = 0;
+    let lastState = stateOf(rows[zoneEnd].status);
+
+    for (let j = zoneEnd + 1; j < n; j++) {
+      const cur = stateOf(rows[j].status);
+      if (cur === "other") { zoneEnd = j; stableTail = 0; continue; }
+      if (cur !== lastState) {
+        // flip — still flapping
+        lastState = cur;
+        zoneEnd = j;
+        stableTail = 0;
+      } else {
+        // same state — stable tail growing
+        stableTail++;
+        if (stableTail >= MAX_STABLE_TAIL) break;
+        zoneEnd = j;
+      }
+    }
+
+    // Trim stable tail off the end
+    while (zoneEnd > windowEnd && stateOf(rows[zoneEnd].status) === stateOf(rows[zoneEnd - 1].status)) {
+      zoneEnd--;
+    }
+
+    for (let k = i; k <= zoneEnd; k++) mask[k] = true;
+    i = zoneEnd + 1; // skip past this zone
+  }
+  return mask;
+}
+
+function durationLabel(startTs: number, endTs: number): string {
+  // timestamps are in microseconds — convert to ms
+  const startMs = startTs > 1e12 ? startTs / 1000 : startTs;
+  const endMs   = endTs   > 1e12 ? endTs   / 1000 : endTs;
+  const ms = Math.abs(endMs - startMs);
+  const mins = Math.round(ms / 60000);
+  if (mins < 1) return "< 1 min";
+  if (mins < 60) return `${mins} min`;
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+// Tracks which flapping group rows are expanded (key = group timestamp)
+const expandedGroups = ref<Set<number>>(new Set());
+
+function toggleFlappingGroup(ts: number) {
+  const s = new Set(expandedGroups.value);
+  s.has(ts) ? s.delete(ts) : s.add(ts);
+  expandedGroups.value = s;
+}
+
+// Produce the display list: normal rows pass through, flapping runs become one
+// header row (+ children shown when expanded)
+const groupedHistory = computed(() => {
+  const rows = [...alertHistory.value].sort((a, b) => b.timestamp - a.timestamp); // newest first for table
+  if (!rows.length) return rows;
+
+  // mask is on sorted-asc; re-sort for mask then flip back
+  const asc = [...rows].sort((a, b) => a.timestamp - b.timestamp);
+  const mask = buildFlappingMask(asc);
+  // map back to desc order by timestamp
+  const maskByTs = new Map(asc.map((r, i) => [r.timestamp, mask[i]]));
+
+  const result: any[] = [];
+  let i = 0;
+  let displayNum = (currentPage.value - 1) * selectedPerPage.value + 1;
+  while (i < rows.length) {
+    const row = rows[i];
+    if (!maskByTs.get(row.timestamp)) {
+      result.push({ ...row, _displayIndex: displayNum++ });
+      i++;
+    } else {
+      // collect all consecutive flapping rows
+      const children: any[] = [];
+      while (i < rows.length && maskByTs.get(rows[i].timestamp)) {
+        children.push(rows[i]);
+        i++;
+      }
+      const timestamps = children.map((r) => r.timestamp);
+      const minTs = Math.min(...timestamps);
+      const maxTs = Math.max(...timestamps);
+      const groupTs = maxTs;
+      result.push({
+        timestamp: groupTs,
+        status: "flapping",
+        _flappingGroup: true,
+        _children: children,
+        _duration: durationLabel(minTs, maxTs),
+        _displayIndex: null,
+      });
+      displayNum += children.length;
+      if (expandedGroups.value.has(groupTs)) {
+        children.forEach((c, ci) =>
+          result.push({ ...c, _child: true, _displayIndex: displayNum - children.length + ci }),
+        );
+      }
+    }
+  }
+  return result;
+});
 
 // Date time - default to last 15 minutes (relative)
 const dateTimeRef = ref<any>(null);
@@ -586,7 +741,7 @@ const alertHistoryColumns = [
     header: t("alerts.historyTable.status"),
     accessorKey: "status",
     sortable: true,
-    size: 200,
+    size: 280,
     meta: { align: "left" as const },
   },
   {
@@ -665,31 +820,40 @@ const historyTableColumns = computed(() =>
 // Helper Functions
 
 const getRowClass = (row: any) => {
-  const status = row?.status;
-  if (store.state.theme === "dark") {
-    switch (status?.toLowerCase()) {
-      case "firing":
-      case "error":
-      case "anomaly":
-        return "row-error-dark";
-      default:
-        return "";
-    }
-  } else {
-    switch (status?.toLowerCase()) {
-      case "firing":
-      case "error":
-      case "anomaly":
-        return "row-error-light";
-      default:
-        return "";
-    }
+  if (row?._flappingGroup) {
+    return store.state.theme === "dark" ? "row-flapping-dark" : "row-flapping-light";
   }
+  if (row?._child) {
+    return store.state.theme === "dark" ? "row-child-dark" : "row-child-light";
+  }
+  const status = row?.status?.toLowerCase();
+  const isFiringStatus = status === "firing" || status === "error" || status === "anomaly" || status === "completed";
+  if (isFiringStatus) {
+    return store.state.theme === "dark" ? "row-error-dark" : "row-error-light";
+  }
+  return "";
 };
 
 const formatStatus = (status: string) => {
   if (!status) return "Unknown";
-  return status.charAt(0).toUpperCase() + status.slice(1);
+  switch (status.toLowerCase()) {
+    case "firing":
+    case "completed":
+    case "error":
+    case "anomaly":
+      return "Firing";
+    case "ok":
+    case "success":
+    case "normal":
+    case "condition_not_satisfied":
+      return "Ok";
+    case "skipped":
+      return "Skipped";
+    case "pending":
+      return "Pending";
+    default:
+      return status.charAt(0).toUpperCase() + status.slice(1).replace(/_/g, " ");
+  }
 };
 
 const getStatusChipIcon = (status: string) => {
@@ -698,9 +862,12 @@ const getStatusChipIcon = (status: string) => {
     case "error":
     case "anomaly":
       return "error-outline";
+    case "completed":
+      return "notifications-active";
     case "ok":
     case "success":
     case "normal":
+    case "condition_not_satisfied":
       return "check-circle-outline";
     case "skipped":
       return "block";
@@ -716,10 +883,12 @@ const getStatusChipVariant = (status: string) => {
     case "firing":
     case "error":
     case "anomaly":
+    case "completed":
       return "error-soft";
     case "ok":
     case "success":
     case "normal":
+    case "condition_not_satisfied":
       return "success-soft";
     case "skipped":
       return "warning-soft";
@@ -891,12 +1060,12 @@ watch(
 }
 
 /* ── Row tints ── */
-.row-error-light {
-  background: #fff5f5 !important;
-}
-.row-error-dark {
-  background: #2d1b1b !important;
-}
+.row-error-light   { background: #fff5f5 !important; }
+.row-error-dark    { background: #2d1b1b !important; }
+.row-flapping-light { background: #f5f3ff !important; }
+.row-flapping-dark  { background: #1e1a2e !important; }
+.row-child-light   { background: #fafafa !important; }
+.row-child-dark    { background: #1a1a1a !important; }
 
 /* ── Table layout ── */
 .history-table {

--- a/web/src/components/alerts/AlertHistoryDrawer.vue
+++ b/web/src/components/alerts/AlertHistoryDrawer.vue
@@ -849,6 +849,8 @@ const formatStatus = (status: string) => {
       return "Ok";
     case "skipped":
       return "Skipped";
+    case "failed":
+      return "Failed";
     case "pending":
       return "Pending";
     default:
@@ -871,6 +873,8 @@ const getStatusChipIcon = (status: string) => {
       return "check-circle-outline";
     case "skipped":
       return "block";
+    case "failed":
+      return "cancel";
     case "pending":
       return "schedule";
     default:
@@ -892,6 +896,8 @@ const getStatusChipVariant = (status: string) => {
       return "success-soft";
     case "skipped":
       return "warning-soft";
+    case "failed":
+      return "error-soft";
     case "pending":
       return "primary-soft";
     default:

--- a/web/src/components/alerts/AlertHistoryTimeline.vue
+++ b/web/src/components/alerts/AlertHistoryTimeline.vue
@@ -1,0 +1,332 @@
+<!-- Copyright 2026 OpenObserve Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+  <div class="tw:flex tw:flex-col tw:gap-1.5 tw:w-full tw:shrink-0 tw:px-1 tw:py-2">
+    <!-- Header row: oldest … legend … newest -->
+    <div class="tw:flex tw:items-center tw:justify-between tw:px-1">
+      <span class="tw:text-[11px] tw:tabular-nums" style="color: var(--color-text-caption)">
+        {{ oldestLabel }}
+      </span>
+
+      <div class="tw:flex tw:items-center tw:gap-3">
+        <span v-if="firingCount > 0" class="tw:flex tw:items-center tw:gap-1 tw:text-[11px]">
+          <span class="tw:inline-block tw:w-2 tw:h-2 tw:rounded-sm" style="background: var(--color-badge-error-solid-bg)" />
+          <span class="tw:font-medium" style="color: var(--color-badge-error-soft-text)">{{ firingCount }} Firing</span>
+        </span>
+        <span class="tw:flex tw:items-center tw:gap-1 tw:text-[11px]" style="color: var(--color-text-secondary)">
+          <span class="tw:inline-block tw:w-2 tw:h-2 tw:rounded-sm" style="background: var(--color-badge-success-solid-bg)" />
+          {{ okCount }} Ok
+        </span>
+        <span v-if="skippedCount > 0" class="tw:flex tw:items-center tw:gap-1 tw:text-[11px]" style="color: var(--color-text-muted)">
+          <span class="tw:inline-block tw:w-2 tw:h-2 tw:rounded-sm" style="background: var(--color-border-default)" />
+          {{ skippedCount }} Skipped
+        </span>
+        <span v-if="hasFlappingZone" class="tw:flex tw:items-center tw:gap-1 tw:text-[11px] tw:font-semibold" style="color: #7c3aed; filter: brightness(0.9)">
+          <span class="tw:inline-block tw:w-2 tw:h-2 tw:rounded-sm" style="background: #7c3aed" />
+          Flapping
+        </span>
+      </div>
+
+      <span class="tw:text-[11px] tw:tabular-nums" style="color: var(--color-text-caption)">
+        {{ newestLabel }}
+      </span>
+    </div>
+
+    <!-- Timeline strip + transition labels -->
+    <div class="tw:flex tw:flex-col tw:gap-[3px] tw:w-full tw:px-1">
+
+    <!-- Strip -->
+    <div class="tw:flex tw:gap-[2px] tw:w-full tw:h-6 tw:items-stretch">
+      <template v-for="(seg, i) in segments" :key="i">
+        <!-- Flapping zone segment -->
+        <div
+          v-if="seg.type === 'flapping'"
+          class="tw:flex tw:items-center tw:justify-center tw:rounded-sm tw:cursor-default tw:relative tw:transition-opacity tw:duration-100 hover:tw:opacity-80 tw:overflow-clip"
+          :style="{ flex: seg.weight, minWidth: '12px', background: '#7c3aed' }"
+          @mouseenter="hoveredIndex = i"
+          @mouseleave="hoveredIndex = null"
+        >
+          <span class="tw:text-[11px] tw:select-none tw:font-semibold tw:leading-none tw:tracking-wide tw:px-1 tw:truncate" style="color: #fff">⚡ Flapping</span>
+          <div v-if="hoveredIndex === i" class="o2-timeline-tooltip">
+            <div class="tw:font-semibold tw:flex tw:items-center tw:gap-1">
+              <span>⚡ Flapping Zone</span>
+            </div>
+            <div class="tw:opacity-70 tw:mt-0.5">{{ seg.startLabel }} – {{ seg.endLabel }}</div>
+            <div class="tw:opacity-60 tw:text-[10px] tw:mt-0.5">{{ seg.count }} transitions</div>
+          </div>
+        </div>
+
+        <!-- Normal block -->
+        <div
+          v-else
+          class="tw:flex-1 tw:rounded-sm tw:min-w-[4px] tw:cursor-default tw:relative tw:transition-opacity tw:duration-100 hover:tw:opacity-75"
+          :style="{ flex: seg.weight, background: blockColor(seg.status) }"
+          @mouseenter="hoveredIndex = i"
+          @mouseleave="hoveredIndex = null"
+        >
+          <div v-if="hoveredIndex === i" class="o2-timeline-tooltip">
+            <div class="tw:font-semibold tw:capitalize tw:flex tw:items-center tw:gap-1.5">
+              <span
+                class="tw:inline-block tw:w-2 tw:h-2 tw:rounded-sm tw:shrink-0"
+                :style="{ background: blockColor(seg.status) }"
+              />
+              {{ normalizeStatus(seg.status) }}
+            </div>
+            <div class="tw:opacity-60 tw:mt-0.5">{{ seg.startLabel }}</div>
+            <div v-if="seg.count > 1" class="tw:opacity-50 tw:text-[10px]">{{ seg.count }} evaluations</div>
+          </div>
+        </div>
+      </template>
+    </div><!-- /strip -->
+
+    <!-- Transition tick labels — one label per segment boundary (skip first = oldestLabel) -->
+    <div class="tw:flex tw:w-full tw:relative tw:h-[14px]">
+      <template v-for="(seg, i) in segments" :key="i">
+        <div :style="{ flex: seg.weight, minWidth: 0, position: 'relative' }">
+          <!-- Show label at the left edge of every segment except the first -->
+          <span
+            v-if="i > 0"
+            class="tw:absolute tw:left-0 tw:top-0 tw:text-[10px] tw:tabular-nums tw:whitespace-nowrap tw:translate-x-[-50%]"
+            style="color: var(--color-text-caption)"
+          >
+            {{ seg.startLabel }}
+          </span>
+        </div>
+      </template>
+    </div><!-- /tick labels -->
+
+    </div><!-- /strip + labels wrapper -->
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from "vue";
+
+const props = defineProps<{
+  history: Array<{ status: string; timestamp: number }>;
+}>();
+
+const hoveredIndex = ref<number | null>(null);
+
+// ── Status helpers ──────────────────────────────────────────────────────────
+
+function isFiring(s: string) {
+  const v = s?.toLowerCase();
+  return v === "firing" || v === "error" || v === "anomaly" || v === "completed";
+}
+
+function isOk(s: string) {
+  const v = s?.toLowerCase();
+  return v === "ok" || v === "success" || v === "normal" || v === "condition_not_satisfied";
+}
+
+function normalizeStatus(s: string): string {
+  const v = s?.toLowerCase();
+  if (isFiring(v)) return "Firing";
+  if (isOk(v)) return "Ok";
+  if (v === "skipped") return "Skipped";
+  return s?.replace(/_/g, " ") ?? "Unknown";
+}
+
+function blockColor(status: string): string {
+  if (isFiring(status)) return "var(--color-badge-error-solid-bg)";
+  if (isOk(status)) return "var(--color-badge-success-solid-bg)";
+  return "var(--color-border-default)";
+}
+
+// ── Sorted rows ─────────────────────────────────────────────────────────────
+
+const sorted = computed(() =>
+  [...props.history].sort((a, b) => a.timestamp - b.timestamp),
+);
+
+// ── Stats ───────────────────────────────────────────────────────────────────
+
+const firingCount = computed(() => props.history.filter((r) => isFiring(r.status)).length);
+const okCount     = computed(() => props.history.filter((r) => isOk(r.status)).length);
+const skippedCount = computed(() =>
+  props.history.filter((r) => !isFiring(r.status) && !isOk(r.status)).length,
+);
+
+// ── Flapping detection ───────────────────────────────────────────────────────
+const MIN_WINDOW      = 4;
+const MIN_TRANSITIONS = 3;
+const MAX_STABLE_TAIL = 2;
+
+type RowState = "firing" | "ok" | "other";
+function rowState(s: string): RowState {
+  if (isFiring(s)) return "firing";
+  if (isOk(s)) return "ok";
+  return "other";
+}
+
+const flappingMask = computed<boolean[]>(() => {
+  const rows = sorted.value;
+  const n = rows.length;
+  const mask = new Array(n).fill(false);
+
+  let i = 0;
+  while (i < n) {
+    let transitions = 0;
+    let prev = rowState(rows[i].status);
+    let windowEnd = -1;
+    for (let j = i + 1; j < Math.min(i + MIN_WINDOW + 10, n); j++) {
+      const cur = rowState(rows[j].status);
+      if (cur !== "other" && prev !== "other" && cur !== prev) transitions++;
+      if (cur !== "other") prev = cur;
+      if (transitions >= MIN_TRANSITIONS) { windowEnd = j; break; }
+    }
+    if (windowEnd === -1) { i++; continue; }
+
+    let zoneEnd = windowEnd;
+    let stableTail = 0;
+    let lastState = rowState(rows[zoneEnd].status);
+    for (let j = zoneEnd + 1; j < n; j++) {
+      const cur = rowState(rows[j].status);
+      if (cur === "other") { zoneEnd = j; stableTail = 0; continue; }
+      if (cur !== lastState) {
+        lastState = cur; zoneEnd = j; stableTail = 0;
+      } else {
+        stableTail++;
+        if (stableTail >= MAX_STABLE_TAIL) break;
+        zoneEnd = j;
+      }
+    }
+    // trim stable tail
+    while (zoneEnd > windowEnd && rowState(rows[zoneEnd].status) === rowState(rows[zoneEnd - 1].status)) {
+      zoneEnd--;
+    }
+
+    for (let k = i; k <= zoneEnd; k++) mask[k] = true;
+    i = zoneEnd + 1;
+  }
+  return mask;
+});
+
+const hasFlappingZone = computed(() => flappingMask.value.some(Boolean));
+
+// ── Build display segments ───────────────────────────────────────────────────
+// Merge consecutive rows of same type (flapping / normal-status) into one segment.
+// Weight = number of rows in segment (proportional width).
+
+type Segment =
+  | { type: "flapping"; weight: number; count: number; startLabel: string; endLabel: string }
+  | { type: "normal";   weight: number; count: number; status: string; startLabel: string };
+
+const MAX_BLOCKS = 60;
+
+const segments = computed<Segment[]>(() => {
+  const rows = sorted.value;
+  if (!rows.length) return [];
+
+  // If too many rows, bucket first (preserving flapping mask per bucket)
+  let displayRows: Array<{ status: string; timestamp: number; flapping: boolean }>;
+
+  if (rows.length <= MAX_BLOCKS) {
+    displayRows = rows.map((r, i) => ({
+      status: r.status,
+      timestamp: r.timestamp,
+      flapping: flappingMask.value[i],
+    }));
+  } else {
+    const bucketSize = rows.length / MAX_BLOCKS;
+    displayRows = Array.from({ length: MAX_BLOCKS }, (_, b) => {
+      const start = Math.floor(b * bucketSize);
+      const end   = Math.min(Math.floor((b + 1) * bucketSize), rows.length);
+      const bucket = rows.slice(start, end);
+      const bucketFlapping = flappingMask.value.slice(start, end).some(Boolean);
+      // worst status in bucket
+      const status = bucket.some((r) => isFiring(r.status))
+        ? "firing"
+        : bucket.some((r) => isOk(r.status))
+          ? "ok"
+          : "skipped";
+      return { status, timestamp: bucket[0].timestamp, flapping: bucketFlapping };
+    });
+  }
+
+  // Merge consecutive same-type runs
+  const segs: Segment[] = [];
+  let i = 0;
+  while (i < displayRows.length) {
+    const cur = displayRows[i];
+    if (cur.flapping) {
+      let j = i;
+      while (j < displayRows.length && displayRows[j].flapping) j++;
+      segs.push({
+        type: "flapping",
+        weight: j - i,
+        count: j - i,
+        startLabel: formatTimestamp(displayRows[i].timestamp),
+        endLabel: formatTimestamp(displayRows[j - 1].timestamp),
+      });
+      i = j;
+    } else {
+      const status = cur.status;
+      let j = i;
+      while (j < displayRows.length && !displayRows[j].flapping && displayRows[j].status === status) j++;
+      segs.push({
+        type: "normal",
+        weight: j - i,
+        count: j - i,
+        status,
+        startLabel: formatTimestamp(displayRows[i].timestamp),
+      });
+      i = j;
+    }
+  }
+  return segs;
+});
+
+// ── Labels ───────────────────────────────────────────────────────────────────
+
+const oldestLabel = computed(() =>
+  sorted.value.length ? formatTimestamp(sorted.value[0].timestamp) : "",
+);
+const newestLabel = computed(() =>
+  sorted.value.length ? formatTimestamp(sorted.value[sorted.value.length - 1].timestamp) : "",
+);
+
+function formatTimestamp(ts: number): string {
+  if (!ts) return "";
+  const ms = ts > 1e12 ? ts / 1000 : ts;
+  return new Date(ms).toLocaleString([], {
+    month: "short", day: "numeric",
+    hour: "2-digit", minute: "2-digit",
+  });
+}
+</script>
+
+<style scoped>
+.o2-timeline-tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  white-space: nowrap;
+  border-radius: var(--radius-md);
+  padding: 6px 10px;
+  font-size: 11px;
+  line-height: 1.4;
+  box-shadow: var(--shadow-md);
+  pointer-events: none;
+  background: var(--color-surface-overlay);
+  border: 1px solid var(--color-border-default);
+  color: var(--color-text-body);
+}
+</style>

--- a/web/src/components/alerts/AlertHistoryTimeline.vue
+++ b/web/src/components/alerts/AlertHistoryTimeline.vue
@@ -36,7 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           {{ skippedCount }} Skipped
         </span>
         <span v-if="hasFlappingZone" class="tw:flex tw:items-center tw:gap-1 tw:text-[11px] tw:font-semibold" style="color: #7c3aed; filter: brightness(0.9)">
-          <span class="tw:inline-block tw:w-2 tw:h-2 tw:rounded-sm" style="background: #7c3aed" />
+          <span class="tw:inline-block tw:w-2 tw:h-2 tw:rounded-sm o2-flap-swatch" />
           Flapping
         </span>
       </div>
@@ -50,24 +50,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <div class="tw:flex tw:flex-col tw:gap-[3px] tw:w-full tw:px-1">
 
     <!-- Strip -->
-    <div class="tw:flex tw:gap-[2px] tw:w-full tw:h-6 tw:items-stretch">
+    <div class="tw:flex tw:gap-[2px] tw:w-full tw:h-6 tw:items-stretch" style="overflow: visible">
       <template v-for="(seg, i) in segments" :key="i">
-        <!-- Flapping zone segment -->
+        <!-- Flapping zone — alternating hatched red/green cells + callout pill -->
         <div
           v-if="seg.type === 'flapping'"
-          class="tw:flex tw:items-center tw:justify-center tw:rounded-sm tw:cursor-default tw:relative tw:transition-opacity tw:duration-100 hover:tw:opacity-80"
-          :style="{ flex: seg.weight, minWidth: '12px', background: '#7c3aed' }"
+          class="tw:flex tw:gap-[2px] tw:items-stretch tw:relative"
+          :style="{ flex: seg.weight, minWidth: '12px' }"
           @mouseenter="hoveredIndex = i"
           @mouseleave="hoveredIndex = null"
         >
-          <span class="tw:text-[11px] tw:select-none tw:font-semibold tw:leading-none tw:tracking-wide tw:px-1 tw:truncate tw:overflow-clip" style="color: #fff">⚡ Flapping</span>
-          <div v-if="hoveredIndex === i" class="o2-timeline-tooltip">
-            <div class="tw:font-semibold tw:flex tw:items-center tw:gap-1">
-              <span>⚡ Flapping Zone</span>
-            </div>
-            <div class="tw:opacity-70 tw:mt-0.5">{{ seg.startLabel }} – {{ seg.endLabel }}</div>
-            <div class="tw:opacity-60 tw:text-[10px] tw:mt-0.5">{{ seg.count }} transitions</div>
+          <!-- Persistent callout pill above the zone -->
+          <div class="o2-flap-pill">
+            <span class="tw:font-semibold">⚡ Flapping</span>
+            <span class="o2-flap-pill-dot">•</span>{{ seg.flips }} flips
+            <span class="o2-flap-pill-dot">•</span>{{ seg.durationLabel }}
           </div>
+          <div
+            v-for="(cell, c) in seg.cells"
+            :key="c"
+            class="tw:flex-1 tw:rounded-sm tw:min-w-[6px]"
+            :style="flapCellStyle(cell.status)"
+          />
         </div>
 
         <!-- Normal block -->
@@ -93,20 +97,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </template>
     </div><!-- /strip -->
 
-    <!-- Transition tick labels — one label per segment boundary (skip first = oldestLabel) -->
-    <div class="tw:flex tw:w-full tw:relative tw:h-[14px]">
-      <template v-for="(seg, i) in segments" :key="i">
-        <div :style="{ flex: seg.weight, minWidth: 0, position: 'relative' }">
-          <!-- Show label at the left edge of every segment except the first -->
-          <span
-            v-if="i > 0"
-            class="tw:absolute tw:left-0 tw:top-0 tw:text-[10px] tw:tabular-nums tw:whitespace-nowrap tw:translate-x-[-50%]"
-            style="color: var(--color-text-caption)"
-          >
-            {{ seg.startLabel }}
-          </span>
-        </div>
-      </template>
+    <!-- Transition tick labels — placed by cumulative width; labels that would
+         overlap the previously shown one are skipped to keep them readable. -->
+    <div class="tw:w-full tw:relative tw:h-[14px]">
+      <span
+        v-for="(tick, i) in tickLabels"
+        :key="i"
+        class="tw:absolute tw:top-0 tw:text-[10px] tw:tabular-nums tw:whitespace-nowrap tw:translate-x-[-50%]"
+        :style="{ left: tick.leftPct + '%', color: 'var(--color-text-caption)' }"
+      >
+        {{ tick.label }}
+      </span>
     </div><!-- /tick labels -->
 
     </div><!-- /strip + labels wrapper -->
@@ -224,7 +225,16 @@ const hasFlappingZone = computed(() => flappingMask.value.some(Boolean));
 // Weight = number of rows in segment (proportional width).
 
 type Segment =
-  | { type: "flapping"; weight: number; count: number; startLabel: string; endLabel: string }
+  | {
+      type: "flapping";
+      weight: number;
+      count: number;
+      cells: Array<{ status: string }>;
+      flips: number;
+      durationLabel: string;
+      startLabel: string;
+      endLabel: string;
+    }
   | { type: "normal";   weight: number; count: number; status: string; startLabel: string };
 
 const MAX_BLOCKS = 60;
@@ -267,10 +277,26 @@ const segments = computed<Segment[]>(() => {
     if (cur.flapping) {
       let j = i;
       while (j < displayRows.length && displayRows[j].flapping) j++;
+      const cells = displayRows.slice(i, j).map((r) => ({ status: r.status }));
+      // flips = number of firing<->ok state changes within the zone
+      let flips = 0;
+      let prevState = rowState(cells[0].status);
+      for (let k = 1; k < cells.length; k++) {
+        const s = rowState(cells[k].status);
+        if (s !== "other" && prevState !== "other" && s !== prevState) flips++;
+        if (s !== "other") prevState = s;
+      }
+      // duration spans from the zone start to the row just after the zone
+      // (or the last zone row if the flapping zone ends the timeline).
+      const startTs = displayRows[i].timestamp;
+      const endTs = displayRows[j]?.timestamp ?? displayRows[j - 1].timestamp;
       segs.push({
         type: "flapping",
         weight: j - i,
         count: j - i,
+        cells,
+        flips,
+        durationLabel: formatDuration(toMs(endTs) - toMs(startTs)),
         startLabel: formatTimestamp(displayRows[i].timestamp),
         endLabel: formatTimestamp(displayRows[j - 1].timestamp),
       });
@@ -292,6 +318,31 @@ const segments = computed<Segment[]>(() => {
   return segs;
 });
 
+// ── Tick labels ──────────────────────────────────────────────────────────────
+// Position each boundary label by cumulative segment weight (% of total) and
+// drop any that would sit too close to the previously shown label so they
+// never overlap. Endpoints are already shown as oldest/newest in the header.
+const MIN_TICK_GAP_PCT = 7;
+
+const tickLabels = computed<Array<{ leftPct: number; label: string }>>(() => {
+  const segs = segments.value;
+  const total = segs.reduce((sum, s) => sum + s.weight, 0) || 1;
+  const out: Array<{ leftPct: number; label: string }> = [];
+  let cum = 0;
+  let lastShownPct = -Infinity;
+  segs.forEach((seg, i) => {
+    if (i > 0) {
+      const pct = (cum / total) * 100;
+      if (pct - lastShownPct >= MIN_TICK_GAP_PCT && pct <= 100 - MIN_TICK_GAP_PCT) {
+        out.push({ leftPct: pct, label: seg.startLabel });
+        lastShownPct = pct;
+      }
+    }
+    cum += seg.weight;
+  });
+  return out;
+});
+
 // ── Labels ───────────────────────────────────────────────────────────────────
 
 const oldestLabel = computed(() =>
@@ -301,17 +352,87 @@ const newestLabel = computed(() =>
   sorted.value.length ? formatTimestamp(sorted.value[sorted.value.length - 1].timestamp) : "",
 );
 
+function toMs(ts: number): number {
+  // Timestamps may arrive in microseconds; normalize to milliseconds.
+  return ts > 1e12 ? ts / 1000 : ts;
+}
+
 function formatTimestamp(ts: number): string {
   if (!ts) return "";
-  const ms = ts > 1e12 ? ts / 1000 : ts;
-  return new Date(ms).toLocaleString([], {
+  return new Date(toMs(ts)).toLocaleString([], {
     month: "short", day: "numeric",
     hour: "2-digit", minute: "2-digit",
   });
 }
+
+function formatDuration(ms: number): string {
+  const totalMin = Math.max(0, Math.round(ms / 60000));
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h) return `${h}h`;
+  return `${m}m`;
+}
+
+// Diagonal-hatch fill for a flapping cell, tinted by its real status colour.
+function flapCellStyle(status: string) {
+  return {
+    background:
+      "repeating-linear-gradient(45deg, rgba(255,255,255,0.32) 0, rgba(255,255,255,0.32) 2px, transparent 2px, transparent 6px), " +
+      blockColor(status),
+    boxShadow: "inset 0 0 0 1px rgba(124, 58, 237, 0.55)",
+  };
+}
 </script>
 
 <style scoped>
+/* Hatched purple swatch used in the legend for the flapping key */
+.o2-flap-swatch {
+  background:
+    repeating-linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.4) 0,
+      rgba(255, 255, 255, 0.4) 1px,
+      transparent 1px,
+      transparent 3px
+    ),
+    #7c3aed;
+}
+
+/* Persistent purple callout pill above a flapping zone */
+.o2-flap-pill {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 30;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #fff;
+  background: #7c3aed;
+  box-shadow: var(--shadow-md);
+  pointer-events: none;
+}
+.o2-flap-pill-dot {
+  opacity: 0.6;
+  font-weight: 400;
+}
+.o2-flap-pill::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: #7c3aed;
+}
+
 .o2-timeline-tooltip {
   position: absolute;
   top: calc(100% + 6px);

--- a/web/src/components/alerts/AlertHistoryTimeline.vue
+++ b/web/src/components/alerts/AlertHistoryTimeline.vue
@@ -55,12 +55,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <!-- Flapping zone segment -->
         <div
           v-if="seg.type === 'flapping'"
-          class="tw:flex tw:items-center tw:justify-center tw:rounded-sm tw:cursor-default tw:relative tw:transition-opacity tw:duration-100 hover:tw:opacity-80 tw:overflow-clip"
+          class="tw:flex tw:items-center tw:justify-center tw:rounded-sm tw:cursor-default tw:relative tw:transition-opacity tw:duration-100 hover:tw:opacity-80"
           :style="{ flex: seg.weight, minWidth: '12px', background: '#7c3aed' }"
           @mouseenter="hoveredIndex = i"
           @mouseleave="hoveredIndex = null"
         >
-          <span class="tw:text-[11px] tw:select-none tw:font-semibold tw:leading-none tw:tracking-wide tw:px-1 tw:truncate" style="color: #fff">⚡ Flapping</span>
+          <span class="tw:text-[11px] tw:select-none tw:font-semibold tw:leading-none tw:tracking-wide tw:px-1 tw:truncate tw:overflow-clip" style="color: #fff">⚡ Flapping</span>
           <div v-if="hoveredIndex === i" class="o2-timeline-tooltip">
             <div class="tw:font-semibold tw:flex tw:items-center tw:gap-1">
               <span>⚡ Flapping Zone</span>
@@ -314,7 +314,7 @@ function formatTimestamp(ts: number): string {
 <style scoped>
 .o2-timeline-tooltip {
   position: absolute;
-  bottom: calc(100% + 6px);
+  top: calc(100% + 6px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 50;

--- a/web/src/components/dashboards/PanelSchemaRenderer.vue
+++ b/web/src/components/dashboards/PanelSchemaRenderer.vue
@@ -1768,6 +1768,21 @@ export default defineComponent({
   inset: 0;
   width: 100%;
   height: 100%;
+  // Override the inline empty-state's intrinsic min-height/padding so the
+  // content centers within the actual panel box (top/bottom/left/right)
+  // instead of being pushed down by a fixed 160px min-height.
+  min-height: 0 !important;
+  padding: 0.5rem !important;
+  // Establish a size container so we can react to very short panels.
+  container-type: size;
+}
+
+// When the panel is too short to comfortably fit the icon, hide it and
+// show just the centered "No Data" message.
+@container (max-height: 5rem) {
+  .noData :deep(.o2-empty-state__inline-icon) {
+    display: none;
+  }
 }
 
 .annotation-popup-bg {

--- a/web/src/lib/core/EmptyState/OEmptyState.vue
+++ b/web/src/lib/core/EmptyState/OEmptyState.vue
@@ -64,7 +64,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <!-- inline size shows a compact icon instead of a full illustration -->
       <span
         v-else-if="inlineIcon"
-        :class="['tw:inline-flex tw:items-center tw:justify-center tw:rounded-full', sizeClass.iconWrap]"
+        :class="['o2-empty-state__inline-icon tw:inline-flex tw:items-center tw:justify-center tw:rounded-full', sizeClass.iconWrap]"
       >
         <OIcon :name="inlineIcon" :size="size === 'inline' ? 'lg' : 'xl'" />
       </span>

--- a/web/src/locales/languages/en.json
+++ b/web/src/locales/languages/en.json
@@ -4364,7 +4364,7 @@
   },
   "alert_list": {
     "alert_details": "Alert Details",
-    "alert_history": "Alert History"
+    "alert_history": "History"
   },
   "sreChat": {
     "emptyMessage": "Ask me anything about your alerts and incidents",

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -3079,6 +3079,17 @@ export default defineComponent({
       padding: 0 0.0625rem !important;
     }
   }
+
+  :deep(.render-dashboard-charts-container) {
+    padding: 0 !important;
+  }
+
+  :deep(.render-dashboard-charts-container > *:first-child) {
+    background: transparent !important;
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+  }
 }
 
 :deep(

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -266,7 +266,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     :enable-text-highlight="false"
                     :enable-status-bar="false"
                     :enable-ai-context-button="false"
-                    :row-height="28"
+                    :row-height="38"
                     @sort-change="handleSortChange"
                     @click:data-row="
                       (row: any) =>
@@ -287,34 +287,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       >
                     </template>
                     <template #cell-p99="{ item }">
-                      <span
-                        :class="
-                          item.p99 > 0
-                            ? 'tw:text-[var(--o2-latency-p99)]'
-                            : ''
-                        "
-                        >{{ formatOperationLatency(item.p99) }}</span
-                      >
+                      <ServiceCatalogBarCell
+                        :value="item.p99"
+                        :max="rowMaxes(sortedOperationsTableRows, ['p99']).p99"
+                        :label="formatOperationLatency(item.p99)"
+                        variant="warning"
+                      />
                     </template>
                     <template #cell-p95="{ item }">
-                      <span
-                        :class="
-                          item.p95 > 0
-                            ? 'tw:text-[var(--o2-latency-p95)]'
-                            : ''
-                        "
-                        >{{ formatOperationLatency(item.p95) }}</span
-                      >
+                      <ServiceCatalogBarCell
+                        :value="item.p95"
+                        :max="rowMaxes(sortedOperationsTableRows, ['p95']).p95"
+                        :label="formatOperationLatency(item.p95)"
+                      />
                     </template>
                     <template #cell-p75="{ item }">
-                      <span
-                        :class="
-                          item.p75 > 0
-                            ? 'tw:text-[var(--o2-latency-p75)]'
-                            : ''
-                        "
-                        >{{ formatOperationLatency(item.p75) }}</span
-                      >
+                      <ServiceCatalogBarCell
+                        :value="item.p75"
+                        :max="rowMaxes(sortedOperationsTableRows, ['p75']).p75"
+                        :label="formatOperationLatency(item.p75)"
+                      />
                     </template>
                     <template #cell-actions="{ row, column, active }">
                       <OButton
@@ -381,7 +373,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   :enable-text-highlight="false"
                   :enable-status-bar="false"
                   :enable-ai-context-button="false"
-                  :row-height="28"
+                  :row-height="38"
                   @sort-change="handleSortChange"
                   @click:data-row="
                     (row: any) =>
@@ -424,34 +416,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     >
                   </template>
                   <template #cell-p99="{ item }">
-                    <span
-                      :class="
-                        item.p99 > 0
-                          ? 'tw:text-[var(--o2-latency-p99)]'
-                          : ''
-                      "
-                      >{{ formatOperationLatency(item.p99) }}</span
-                    >
+                    <ServiceCatalogBarCell
+                      :value="item.p99"
+                      :max="rowMaxes(sortResourceRows(buildResourceTableRows(cfg)), ['p99']).p99"
+                      :label="formatOperationLatency(item.p99)"
+                      variant="warning"
+                    />
                   </template>
                   <template #cell-p95="{ item }">
-                    <span
-                      :class="
-                        item.p95 > 0
-                          ? 'tw:text-[var(--o2-latency-p95)]'
-                          : ''
-                      "
-                      >{{ formatOperationLatency(item.p95) }}</span
-                    >
+                    <ServiceCatalogBarCell
+                      :value="item.p95"
+                      :max="rowMaxes(sortResourceRows(buildResourceTableRows(cfg)), ['p95']).p95"
+                      :label="formatOperationLatency(item.p95)"
+                    />
                   </template>
                   <template #cell-p75="{ item }">
-                    <span
-                      :class="
-                        item.p75 > 0
-                          ? 'tw:text-[var(--o2-latency-p75)]'
-                          : ''
-                      "
-                      >{{ formatOperationLatency(item.p75) }}</span
-                    >
+                    <ServiceCatalogBarCell
+                      :value="item.p75"
+                      :max="rowMaxes(sortResourceRows(buildResourceTableRows(cfg)), ['p75']).p75"
+                      :label="formatOperationLatency(item.p75)"
+                    />
                   </template>
                   <template #empty>
                     <div
@@ -611,6 +595,7 @@ import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
 import OCheckbox from "@/lib/forms/Checkbox/OCheckbox.vue";
 import OSeparator from '@/lib/core/Separator/OSeparator.vue';
 import { toast } from "@/lib/feedback/Toast/useToast";
+import ServiceCatalogBarCell from "./components/ServiceCatalogBarCell.vue";
 
 const TelemetryCorrelationDashboard = defineAsyncComponent(
   () => import("@/plugins/correlation/TelemetryCorrelationDashboard.vue"),
@@ -857,6 +842,7 @@ export default defineComponent({
     OTooltip,
     OCheckbox,
     OIcon,
+    ServiceCatalogBarCell,
 },
   props: {
     selectedNode: {
@@ -2342,6 +2328,14 @@ export default defineComponent({
      return ['p99','p95','p75'].includes(column);
     }
 
+    function rowMaxes(rows: any[], fields: string[]): Record<string, number> {
+      const result: Record<string, number> = {};
+      for (const f of fields) {
+        result[f] = rows.reduce((m, r) => Math.max(m, r[f] ?? 0), 0) || 1;
+      }
+      return result;
+    }
+
     return {
       t,
       serviceMetrics,
@@ -2403,7 +2397,8 @@ export default defineComponent({
       handleSortChange,
       sortResourceRows,
       formatOperationLatency,
-      isDurationColumn
+      isDurationColumn,
+      rowMaxes,
     };
   },
 });
@@ -3088,5 +3083,10 @@ export default defineComponent({
   .metrics-correlation-dashboard .q-splitter--vertical > .q-splitter__separator
 ) {
   height: 100% !important;
+}
+
+:deep([data-o2-drawer]) {
+  border-top-left-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
 }
 </style>

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -134,6 +134,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <RenderDashboardCharts
                 ref="dashboardChartsRef"
                 :viewOnly="true"
+                :frame="false"
                 :dashboardData="dashboardData || {}"
                 :currentTimeObj="currentTimeObj"
                 :allowAlertCreation="false"
@@ -3082,13 +3083,6 @@ export default defineComponent({
 
   :deep(.render-dashboard-charts-container) {
     padding: 0 !important;
-  }
-
-  :deep(.render-dashboard-charts-container > *:first-child) {
-    background: transparent !important;
-    border: none !important;
-    border-radius: 0 !important;
-    box-shadow: none !important;
   }
 }
 

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -3072,6 +3072,8 @@ export default defineComponent({
 .red-charts-section {
   :deep(.card-container) {
     box-shadow: none;
+    background: transparent;
+    border: none;
 
     :first-child {
       padding: 0 0.0625rem !important;

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -59,7 +59,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <!-- RED Charts Section -->
         <div
           v-if="streamFilter !== 'all' && dashboardData"
-          class="red-charts-section tw:flex tw:flex-col tw:mb-0!"
+          class="panel-section red-charts-section tw:flex tw:flex-col tw:mb-0!"
           data-test="service-graph-side-panel-red-charts"
         >
           <!-- DataZoom filter chips + View in Traces button -->
@@ -3073,16 +3073,10 @@ export default defineComponent({
 .red-charts-section {
   :deep(.card-container) {
     box-shadow: none;
-    background: transparent;
-    border: none;
 
     :first-child {
       padding: 0 0.0625rem !important;
     }
-  }
-
-  :deep(.render-dashboard-charts-container) {
-    padding: 0 !important;
   }
 }
 
@@ -3092,8 +3086,4 @@ export default defineComponent({
   height: 100% !important;
 }
 
-:deep([data-o2-drawer]) {
-  border-top-left-radius: 0.75rem;
-  border-bottom-left-radius: 0.75rem;
-}
 </style>

--- a/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
+++ b/web/src/plugins/traces/ServiceGraphNodeSidePanel.vue
@@ -59,7 +59,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <!-- RED Charts Section -->
         <div
           v-if="streamFilter !== 'all' && dashboardData"
-          class="panel-section red-charts-section tw:flex tw:flex-col tw:mb-0!"
+          class="red-charts-section tw:flex tw:flex-col tw:mb-0!"
           data-test="service-graph-side-panel-red-charts"
         >
           <!-- DataZoom filter chips + View in Traces button -->
@@ -144,7 +144,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
         </div>
 
-        <OSeparator class="tw:my-[1rem]!" />
+        <OSeparator v-if="streamFilter !== 'all' && dashboardData" class="tw:my-[1rem]!" />
         <!-- Tabs: Operations / Nodes / Pods -->
         <template v-if="streamFilter !== 'all'">
           <div

--- a/web/src/plugins/traces/ServicesCatalog.vue
+++ b/web/src/plugins/traces/ServicesCatalog.vue
@@ -272,24 +272,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <!-- Request / error count columns -->
         <template #cell-total_requests="{ item }">
-          <ServiceCatalogBarCell
-            :value="item.total_requests"
-            :max="columnMaxes.total_requests"
-            :label="formatLargeNumber(item.total_requests)"
-            :tooltip="item.total_requests.toLocaleString()"
-            :data-test="`services-catalog-requests-${item.service_name}`"
-          />
+          <span :data-test="`services-catalog-requests-${item.service_name}`">
+            {{ formatLargeNumber(item.total_requests) }}
+            <OTooltip :content="item.total_requests.toLocaleString()" />
+          </span>
         </template>
 
         <template #cell-error_count="{ item }">
-          <ServiceCatalogBarCell
-            :value="item.error_count"
-            :max="columnMaxes.error_count"
-            :label="formatLargeNumber(item.error_count)"
-            :tooltip="item.error_count.toLocaleString()"
-            :variant="item.error_count > 0 ? 'danger' : 'default'"
-            :data-test="`services-catalog-errors-${item.service_name}`"
-          />
+          <span :data-test="`services-catalog-errors-${item.service_name}`">
+            {{ formatLargeNumber(item.error_count) }}
+            <OTooltip :content="item.error_count.toLocaleString()" />
+          </span>
         </template>
 
         <!-- Latency / duration columns -->
@@ -550,18 +543,18 @@ const tableColumns = computed(() => [
     meta: { slot: true, align: "right", sortable: true },
   },
   {
-    id: "error_rate",
-    header: t("traces.servicesCatalog.columns.errorRate"),
-    accessorKey: "error_rate",
-    size: 110,
-    enableSorting: true,
-    meta: { slot: true, align: "right", sortable: true },
-  },
-  {
     id: "error_count",
     header: t("traces.servicesCatalog.columns.errors"),
     accessorKey: "error_count",
     size: 90,
+    enableSorting: true,
+    meta: { slot: true, align: "right", sortable: true },
+  },
+  {
+    id: "error_rate",
+    header: t("traces.servicesCatalog.columns.errorRate"),
+    accessorKey: "error_rate",
+    size: 110,
     enableSorting: true,
     meta: { slot: true, align: "right", sortable: true },
   },
@@ -619,8 +612,6 @@ function colMax(key: keyof ServiceRow): number {
 }
 
 const columnMaxes = computed(() => ({
-  total_requests: colMax("total_requests"),
-  error_count: colMax("error_count"),
   error_rate: colMax("error_rate"),
   p50_latency_ns: colMax("p50_latency_ns"),
   p95_latency_ns: colMax("p95_latency_ns"),

--- a/web/src/plugins/traces/ServicesCatalog.vue
+++ b/web/src/plugins/traces/ServicesCatalog.vue
@@ -511,7 +511,7 @@ const tableColumns = computed(() => [
     header: t("traces.servicesCatalog.columns.serviceName"),
     accessorKey: "service_name",
     enableSorting: true,
-    size: 200,
+    size: 260,
     meta: { slot: true, align: "left", sortable: true },
   },
   {

--- a/web/src/plugins/traces/ServicesCatalog.vue
+++ b/web/src/plugins/traces/ServicesCatalog.vue
@@ -228,7 +228,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :loading="isLoading"
         :sort-by="sortBy"
         :sort-order="sortOrder"
-        :row-height="28"
+        :row-height="38"
         :enable-column-reorder="true"
         :enable-row-expand="false"
         :enable-text-highlight="false"
@@ -259,69 +259,84 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           />
         </template>
 
-        <!-- Error rate with color coding -->
+        <!-- Error rate with progress bar -->
         <template #cell-error_rate="{ item }">
-          <span
-            :class="errorRateClass(item.error_rate)"
+          <ServiceCatalogBarCell
+            :value="item.error_rate"
+            :max="columnMaxes.error_rate"
+            :label="formatPercent(item.error_rate)"
+            :variant="item.error_rate > 10 ? 'danger' : item.error_rate > 5 ? 'warning' : 'default'"
             :data-test="`services-catalog-error-rate-${item.service_name}`"
-          >
-            {{ formatPercent(item.error_rate) }}
-          </span>
+          />
         </template>
 
         <!-- Request / error count columns -->
         <template #cell-total_requests="{ item }">
-          <span :data-test="`services-catalog-requests-${item.service_name}`">
-            {{ formatLargeNumber(item.total_requests) }}
-            <OTooltip :content="item.total_requests.toLocaleString()" />
-          </span>
+          <ServiceCatalogBarCell
+            :value="item.total_requests"
+            :max="columnMaxes.total_requests"
+            :label="formatLargeNumber(item.total_requests)"
+            :tooltip="item.total_requests.toLocaleString()"
+            :data-test="`services-catalog-requests-${item.service_name}`"
+          />
         </template>
 
         <template #cell-error_count="{ item }">
-          <span :data-test="`services-catalog-errors-${item.service_name}`">
-            {{ formatLargeNumber(item.error_count) }}
-            <OTooltip :content="item.error_count.toLocaleString()" />
-          </span>
+          <ServiceCatalogBarCell
+            :value="item.error_count"
+            :max="columnMaxes.error_count"
+            :label="formatLargeNumber(item.error_count)"
+            :tooltip="item.error_count.toLocaleString()"
+            :variant="item.error_count > 0 ? 'danger' : 'default'"
+            :data-test="`services-catalog-errors-${item.service_name}`"
+          />
         </template>
 
         <!-- Latency / duration columns -->
         <template #cell-p50_latency_ns="{ item }">
-          <span>
-            {{ formatLat(item.p50_latency_ns) }}
-            <OTooltip :content="item.p50_latency_ns.toLocaleString() + ' ns'" />
-          </span>
+          <ServiceCatalogBarCell
+            :value="item.p50_latency_ns"
+            :max="columnMaxes.p50_latency_ns"
+            :label="formatLat(item.p50_latency_ns)"
+            :tooltip="item.p50_latency_ns.toLocaleString() + ' ns'"
+          />
         </template>
 
         <template #cell-p95_latency_ns="{ item }">
-          <span>
-            {{ formatLat(item.p95_latency_ns) }}
-            <OTooltip :content="item.p95_latency_ns.toLocaleString() + ' ns'" />
-          </span>
+          <ServiceCatalogBarCell
+            :value="item.p95_latency_ns"
+            :max="columnMaxes.p95_latency_ns"
+            :label="formatLat(item.p95_latency_ns)"
+            :tooltip="item.p95_latency_ns.toLocaleString() + ' ns'"
+          />
         </template>
 
         <template #cell-p99_latency_ns="{ item }">
-          <span
-            :class="
-              item.p99_latency_ns > P99_WARN_NS ? 'tw:text-orange-500' : ''
-            "
-          >
-            {{ formatLat(item.p99_latency_ns) }}
-            <OTooltip :content="item.p99_latency_ns.toLocaleString() + ' ns'" />
-          </span>
+          <ServiceCatalogBarCell
+            :value="item.p99_latency_ns"
+            :max="columnMaxes.p99_latency_ns"
+            :label="formatLat(item.p99_latency_ns)"
+            :tooltip="item.p99_latency_ns.toLocaleString() + ' ns'"
+            :variant="item.p99_latency_ns > P99_WARN_NS ? 'warning' : 'default'"
+          />
         </template>
 
         <template #cell-avg_duration_ns="{ item }">
-          <span>
-            {{ formatLat(item.avg_duration_ns) }}
-            <OTooltip :content="item.avg_duration_ns.toLocaleString() + ' ns'" />
-          </span>
+          <ServiceCatalogBarCell
+            :value="item.avg_duration_ns"
+            :max="columnMaxes.avg_duration_ns"
+            :label="formatLat(item.avg_duration_ns)"
+            :tooltip="item.avg_duration_ns.toLocaleString() + ' ns'"
+          />
         </template>
 
         <template #cell-max_duration_ns="{ item }">
-          <span>
-            {{ formatLat(item.max_duration_ns) }}
-            <OTooltip :content="item.max_duration_ns.toLocaleString() + ' ns'" />
-          </span>
+          <ServiceCatalogBarCell
+            :value="item.max_duration_ns"
+            :max="columnMaxes.max_duration_ns"
+            :label="formatLat(item.max_duration_ns)"
+            :tooltip="item.max_duration_ns.toLocaleString() + ' ns'"
+          />
         </template>
 
         <!-- Cell actions overlay -->
@@ -366,6 +381,7 @@ import { copyToClipboard as qCopyToClipboard } from "@/utils/clipboard";
 import TenstackTable from "@/components/TenstackTable.vue";
 import CellActions from "@/plugins/logs/data-table/CellActions.vue";
 import TraceServiceCell from "./components/TraceServiceCell.vue";
+import ServiceCatalogBarCell from "./components/ServiceCatalogBarCell.vue";
 import ServiceGraphNodeSidePanel from "./ServiceGraphNodeSidePanel.vue";
 import useTraces from "@/composables/useTraces";
 import useStreams from "@/composables/useStreams";
@@ -595,6 +611,22 @@ const statusCounts = computed(() => ({
   critical: services.value.filter((s) => s.status === "critical").length,
   warning: services.value.filter((s) => s.status === "warning").length,
   degraded: services.value.filter((s) => s.status === "degraded").length,
+}));
+
+function colMax(key: keyof ServiceRow): number {
+  const vals = filteredServices.value.map((s) => (s[key] as number) ?? 0);
+  return vals.length ? Math.max(...vals) : 1;
+}
+
+const columnMaxes = computed(() => ({
+  total_requests: colMax("total_requests"),
+  error_count: colMax("error_count"),
+  error_rate: colMax("error_rate"),
+  p50_latency_ns: colMax("p50_latency_ns"),
+  p95_latency_ns: colMax("p95_latency_ns"),
+  p99_latency_ns: colMax("p99_latency_ns"),
+  avg_duration_ns: colMax("avg_duration_ns"),
+  max_duration_ns: colMax("max_duration_ns"),
 }));
 
 const filteredServices = computed(() => {

--- a/web/src/plugins/traces/components/ServiceCatalogBarCell.vue
+++ b/web/src/plugins/traces/components/ServiceCatalogBarCell.vue
@@ -1,0 +1,44 @@
+<!-- Copyright 2026 OpenObserve Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<template>
+  <div class="tw:flex tw:flex-col tw:gap-[0.15rem] tw:w-full tw:min-w-0">
+    <span class="tw:text-[0.75rem] tw:leading-none tw:tabular-nums tw:truncate">
+      {{ label }}
+      <OTooltip v-if="tooltip" :content="tooltip" />
+    </span>
+    <OProgressBar :value="ratio" :variant="variant" size="xs" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import OProgressBar from "@/lib/data/ProgressBar/OProgressBar.vue";
+import OTooltip from "@/lib/overlay/Tooltip/OTooltip.vue";
+import type { ProgressBarVariant } from "@/lib/data/ProgressBar/OProgressBar.types";
+
+const props = defineProps<{
+  value: number;
+  max: number;
+  label: string;
+  variant?: ProgressBarVariant;
+  tooltip?: string;
+}>();
+
+const ratio = computed(() =>
+  props.max > 0 ? Math.min(1, props.value / props.max) : 0,
+);
+</script>


### PR DESCRIPTION
## Summary

- **Service Catalog**: Add progress bars to latency and error rate columns (P50, P95, P99, Avg Duration, Max Duration, Error Rate), scaled relative to the column maximum across all filtered services. Raw count columns (Requests, Errors) kept as plain text to avoid misleading comparisons.
- **Service Graph Side Panel**: Extend the same progress bar treatment to the Operations tab and K8s/resource tabs. Remove the outer border box from RED charts using `:frame="false"` on `RenderDashboardCharts`.
- **Alert History Timeline**: Add a colored strip visualization above the history table showing firing (red), ok (green), and flapping (purple) zones across the selected time range. Flapping zones are detected automatically based on rapid state alternation and shown as a single collapsed row in the table with transition count and duration. Status labels normalized — `completed` → Firing, `condition_not_satisfied` → Ok.

## Changes

### New files
- `web/src/plugins/traces/components/ServiceCatalogBarCell.vue` — reusable bar cell (label + OProgressBar, scaled to column max)
- `web/src/components/alerts/AlertHistoryTimeline.vue` — state strip with flapping zone detection, hover tooltips, transition timestamps

### Modified files
- `web/src/plugins/traces/ServicesCatalog.vue` — column maxes computed, bar cells wired up, column order adjusted
- `web/src/plugins/traces/ServiceGraphNodeSidePanel.vue` — progress bars on ops/resource tabs, `:frame="false"` on RED charts
- `web/src/components/alerts/AlertHistoryDrawer.vue` — timeline integrated, flapping row grouping, status label normalization

## Test plan

- [ ] Service Catalog: verify progress bars scale correctly when filtering services, bars absent on Requests/Errors columns
- [ ] Service Graph side panel: progress bars visible on Operations tab P95/P99/P75; RED charts have no outer border box
- [ ] Alert History: open an alert with mixed firing/ok history — timeline strip appears above table
- [ ] Alert History: open an alert with rapid firing↔ok alternation — purple Flapping zone visible in strip, flapping rows collapsed in table with expand chevron
- [ ] Alert History: status badges show "Firing" for completed/error/anomaly, "Ok" for condition_not_satisfied
- [ ] Dark mode: all components render correctly with theme tokens