### PR TITLE
fix: pass org_id to short_urls::add in super-cluster queue

### DIFF
--- a/src/super_cluster_queue/short_urls.rs
+++ b/src/super_cluster_queue/short_urls.rs
@@ -30,7 +30,11 @@ pub(crate) async fn process(msg: Message) -> Result<()> {
             if infra::table::short_urls::contains(&short_id).await? {
                 return Ok(());
             }
-            infra::table::short_urls::add(&short_id, &original_url).await?;
+            // The super-cluster queue only carries the original_url, not the
+            // org_id, so store an empty org_id. This matches the legacy
+            // semantics in `short_urls::get`, where empty-org rows are accepted
+            // from any org.
+            infra::table::short_urls::add(&short_id, &original_url, "").await?;
         }
         MessageType::ShortUrlDelete => {
             let short_id = parse_key(&msg.key)?;


### PR DESCRIPTION
## Problem

The enterprise build is broken on `main` (`error[E0061]`):

```
error[E0061]: this function takes 3 arguments but 2 arguments were supplied
  --> src/super_cluster_queue/short_urls.rs:33:13
33 | infra::table::short_urls::add(&short_id, &original_url).await?;
   |                                          argument #3 of type `&str` is missing
```

#12829 ("fix: org id as mandatory check") made `org_id` a mandatory third argument of `infra::table::short_urls::add`, but the **enterprise-gated** super-cluster queue handler `super_cluster_queue::short_urls::process` was not updated. This module is `#[cfg(feature = "enterprise")]`, so OSS-only CI compiled fine while the enterprise build (and every downstream Playwright shard) failed.

## Fix

The super-cluster queue message (`emit_put_event` → `short_url_put`) only carries the `original_url` over the wire — `org_id` is never published to the queue. So the receiver passes an empty `org_id`.

This matches the legacy semantics introduced in #12829, where `short_urls::get` accepts empty-org rows from any org:

```rust
infra::table::short_urls::add(&short_id, &original_url, "").await?;
```

## Note / possible follow-up

With an empty `org_id`, short URLs replicated **across a super cluster** are stored org-agnostic (accepted from any org on lookup), the same as pre-existing legacy rows. If org-scoped short URLs need to survive super-cluster replication, a follow-up should thread `org_id` through the queue message value (producer `emit_put_event` and the `short_url_put` payload) — a larger change touching the wire format. This PR only unblocks the build with behavior consistent with #12829's design.