### PR TITLE
fix: restore dark-mode backgrounds for traces field panel and span status chips (#12843)

### DIFF
--- a/web/src/components/common/FieldExpansion.vue
+++ b/web/src/components/common/FieldExpansion.vue
@@ -255,10 +255,15 @@ defineExpose({ reset: () => fieldValuesPanelRef.value?.reset() });
 
 .field-expansion-item .o-collapsible-content {
   width: 100%;
+  /* Themed background for the expanded value panel. Without this the panel is
+     transparent and falls back to a near-white surface in dark mode. Uses the
+     purpose-built token so it stays dark in dark mode / light gray in light mode. */
+  background-color: var(--color-field-list-expansion-bg);
 }
 
 .field-expansion-item[data-state="open"] {
   margin-bottom: 0.375rem;
+  border: 1px solid var(--color-field-list-expansion-border);
 }
 
 </style>

--- a/web/src/plugins/traces/components/SpanStatusPill.vue
+++ b/web/src/plugins/traces/components/SpanStatusPill.vue
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
         ? 'o2-status-pill--error tw:text-(--o2-status-error-text) tw:bg-(--o2-status-error-bg)'
         : isOk
           ? 'o2-status-pill--success tw:text-(--o2-status-success-text) tw:bg-(--o2-status-success-bg)'
-          : 'o2-status-pill--unset tw:text-[var(--o2-status-unset-text,#888888)] tw:bg-[var(--o2-status-unset-bg,#f0f0f0)]'
+          : 'o2-status-pill--unset tw:text-[var(--o2-status-neutral-text)] tw:bg-[var(--o2-status-neutral-bg)]'
     "
   >
     <span
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
           ? 'tw:bg-[var(--o2-status-error-text)]'
           : isOk
             ? 'tw:bg-[var(--o2-status-success-text)]'
-            : 'tw:bg-[var(--o2-status-unset-text,#888888)]'
+            : 'tw:bg-[var(--o2-status-neutral-text)]'
       "
     />
     <span


### PR DESCRIPTION
## What
Fixes the two dark-mode regressions reported in openobserve/o2-enterprise#1990 (introduced by the scoped-SCSS removal on this branch):

1. **Field dropdown shows white in dark mode** — `FieldExpansion.vue`
   The expanded field-values panel (`.o-collapsible-content`) lost its `background-color` during the scoped-CSS cleanup, so it fell back to a near-white surface in dark mode. Restored using the purpose-built (and previously orphaned) `--color-field-list-expansion-bg` / `--color-field-list-expansion-border` tokens, which are defined for both themes. This also fixes the same bug in the shared logs field list.

2. **Span status chips show white** — `SpanStatusPill.vue`
   The `UNSET` case referenced `--o2-status-unset-text` / `--o2-status-unset-bg`, which are not defined anywhere, so they fell through to literal `#888888` / `#f0f0f0` fallbacks regardless of theme. Since most spans are `UNSET`, the Span Status column rendered as white chips. Switched to the defined `--o2-status-neutral-*` tokens, matching `SpanStatusCodeBadge`.

## Testing
- `SpanStatusPill.spec.ts`: 15/15 pass.
- No new unit-test failures introduced (the 2 pre-existing `FieldExpansion` failures exist on the branch independently of this change).
- Verified against both screenshots in the issue.

Closes openobserve/o2-enterprise#1990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
