### PR TITLE
test: fix Sankey 'No Data' edge test starved by textContent auto-wait

### DIFF
--- a/tests/ui-testing/playwright-tests/Dashboards/dashboard-sankey.spec.js
+++ b/tests/ui-testing/playwright-tests/Dashboards/dashboard-sankey.spec.js
@@ -421,20 +421,33 @@ test.describe("Sankey chart testcases", () => {
       await pm.dashboardPanelActions.waitForChartToRender();
 
       // Verify no data or error is shown (incomplete Sankey config).
-      // Use expect.poll to handle the async gap between the apply button
-      // re-enabling and Vue committing the no-data text to the DOM.
-      // Checking textContent (not just isVisible) avoids false-positives
-      // from the empty zero-height no-data div that exists when noData === "".
+      // With only a Source field, the Sankey config is incomplete, so applying
+      // surfaces panel validation errors ("Add one field for the target/value")
+      // instead of running the query — the "No Data" empty state never renders.
+      // Accept EITHER the dashboard validation errors OR a "No Data" state.
+      //
+      // IMPORTANT: check the error locator FIRST and use count()/isVisible()
+      // (instant, no auto-wait). locator.textContent() auto-waits for the
+      // element to attach, so calling it on [data-test="no-data"] — which never
+      // renders here — blocks the whole poll for its full timeout and starves
+      // the error check that would otherwise pass on the first iteration.
       const noDataLocator = pm.dashboardPanelActions.getNoDataLocator();
       const dashErrorLocator = pm.dashboardPanelActions.getDashboardErrorLocator();
 
       await expect.poll(async () => {
-        const noDataText = (await noDataLocator.textContent().catch(() => '')).trim();
-        const dashErrorVisible = await dashErrorLocator.isVisible().catch(() => false);
-        return noDataText.length > 0 || dashErrorVisible;
+        // Validation errors are the expected outcome for an incomplete Sankey.
+        if (await dashErrorLocator.isVisible().catch(() => false)) return true;
+        // Only read text once the no-data element exists (count() never waits),
+        // avoiding the textContent auto-wait that blocked the poll previously.
+        if ((await noDataLocator.count()) === 0) return false;
+        const noDataText = (
+          await noDataLocator.first().textContent().catch(() => "")
+        ).trim();
+        return noDataText.length > 0;
       }, {
         timeout: 12000,
-        message: 'Expected "No Data" or dashboard error when only Source field is configured',
+        message:
+          'Expected dashboard validation errors or "No Data" when only Source field is configured',
       }).toBeTruthy();
 
       testLogger.info("Sankey no data state verified");


### PR DESCRIPTION
## What

Fixes the consistently-failing E2E test `Dashboards/dashboard-sankey.spec.js:400 › should show No Data when only Source field is configured` (surfaced by o2-enterprise run [28041876852](https://github.com/openobserve/o2-enterprise/actions/runs/28041876852/job/83025088903), `e2e / Dashboards-Charts`).

## Root cause

With **only a Source field**, the Sankey config is incomplete, so clicking Apply triggers panel **validation errors** (`DashboardErrors`: "Add one field for the target / value") and never runs the query — the `[data-test="no-data"]` element is never rendered.

The poll predicate called `noDataLocator.textContent()` **first**. `locator.textContent()` auto-waits for its element to attach, so it blocked for the full 12s timeout and the predicate **never reached** the `dashErrorLocator.isVisible()` fallback that would have passed. The failure trace confirms it: `textContent` on `no-data` called 1×, `isVisible` on `dashboard-error` called 0×. Deterministic, not flaky (failed all 4 CI attempts × 4 retries).

## Fix

- Check the non-blocking `dashErrorLocator.isVisible()` **first**.
- Guard the no-data text read with `count()` (instant, no auto-wait); only call `textContent()` once the element exists.
- Comments/message updated to reflect that validation errors are the expected outcome for an incomplete Sankey config.

No page-object changes needed.

## Verification

Ran locally against `http://localhost:5080` **3× — all passed** (16.4s / 15.5s / 15.8s), with the validation error detected on the first poll iteration each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)