### PR TITLE
fix: only use pipeline id and org id for pipeline metrics

### DIFF
--- a/src/config/src/metrics.rs
+++ b/src/config/src/metrics.rs
@@ -1325,8 +1325,7 @@ pub static PIPELINE_EXPORTED_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
 
 // Realtime pipeline batch execution time (milliseconds). Observed by ingesters per
 // `process_batch` call so the realtime pipeline's share of ingestion latency is
-// visible. `pipeline_name` aids dashboards; cardinality is bounded by number of
-// pipelines (pipeline_id is the stable key).
+// visible. Cardinality is bounded by number of pipelines.
 pub static PIPELINE_EXEC_TIME_MS: Lazy<HistogramVec> = Lazy::new(|| {
     HistogramVec::new(
         HistogramOpts::new(
@@ -1339,12 +1338,7 @@ pub static PIPELINE_EXEC_TIME_MS: Lazy<HistogramVec> = Lazy::new(|| {
             5000.0, 10000.0, 30000.0,
         ])
         .const_labels(create_const_labels()),
-        &[
-            "organization",
-            "pipeline_id",
-            "pipeline_name",
-            "stream_type",
-        ],
+        &["organization", "pipeline_id"],
     )
     .expect("Metric created")
 });
@@ -1361,12 +1355,7 @@ pub static PIPELINE_EXEC_BATCH_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
             1.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 50000.0, 100000.0,
         ])
         .const_labels(create_const_labels()),
-        &[
-            "organization",
-            "pipeline_id",
-            "pipeline_name",
-            "stream_type",
-        ],
+        &["organization", "pipeline_id"],
     )
     .expect("Metric created")
 });

--- a/src/service/logs/ingest.rs
+++ b/src/service/logs/ingest.rs
@@ -301,7 +301,8 @@ pub async fn ingest(
                 // Pipeline wall-time vs total ingest elapsed so far, to see the realtime
                 // pipeline's share of ingestion latency at the ingest layer.
                 log::info!(
-                    "[Pipeline:Timing] ingest org={org_id} stream={stream_name} records={records_count} pipeline_ms={} ingest_elapsed_ms={}",
+                    "[Pipeline:Timing] ingest org={org_id} stream={stream_name} pipeline={} records={records_count} pipeline_ms={} ingest_elapsed_ms={}",
+                    exec_pl.get_pipeline_name(),
                     pipeline_start.elapsed().as_millis(),
                     start.elapsed().as_millis(),
                 );

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -522,7 +522,7 @@ impl ExecutablePipeline {
         })? {
             let stream_params = self.get_source_stream_params();
             log::error!(
-                "[Pipeline] id: {}, name: {}, node_errors: {:?}",
+                "[Pipeline] [inv={inv_id}] id: {}, name: {}, node_errors: {:?}",
                 pipeline_errors.pipeline_id,
                 pipeline_errors.pipeline_name,
                 pipeline_errors.node_errors

--- a/src/service/pipeline/batch_execution.rs
+++ b/src/service/pipeline/batch_execution.rs
@@ -195,6 +195,7 @@ impl PipelineExt for Pipeline {
 pub struct ExecutablePipeline {
     pub id: String,
     name: String,
+    is_realtime: bool,
     source_node_id: String,
     sorted_nodes: Vec<String>,
     function_map: HashMap<String, CompiledFunctionRuntime>,
@@ -207,6 +208,7 @@ impl MemorySize for ExecutablePipeline {
         std::mem::size_of::<ExecutablePipeline>()
             + self.id.mem_size()
             + self.name.mem_size()
+            + self.is_realtime.mem_size()
             + self.source_node_id.mem_size()
             + self.sorted_nodes.mem_size()
             + self.function_map.mem_size()
@@ -302,6 +304,7 @@ impl ExecutablePipeline {
         Ok(Self {
             id: pipeline.id.to_string(),
             name: pipeline.name.to_string(),
+            is_realtime: pipeline.source.is_realtime(),
             source_node_id,
             node_map,
             sorted_nodes,
@@ -502,19 +505,14 @@ impl ExecutablePipeline {
         );
 
         // Wait for all node tasks to complete
-        log::debug!(
-            "[Pipeline] {pipeline_name} [inv={inv_id}]: waiting for all node tasks to complete"
-        );
         if let Err(e) = try_join_all(node_tasks).await {
             log::error!(
                 "[Pipeline] {pipeline_name} [inv={inv_id}]: node processing jobs failed: {e}"
             );
         }
         let node_tasks_ms = node_tasks_start.elapsed().as_millis();
-        log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: all node tasks completed");
 
         // Publish errors if received any
-        log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: awaiting error task");
         let error_task_start = Instant::now();
         if let Some(pipeline_errors) = error_task.await.map_err(|e| {
             log::error!(
@@ -524,7 +522,7 @@ impl ExecutablePipeline {
         })? {
             let stream_params = self.get_source_stream_params();
             log::error!(
-                "[Pipeline] [inv={inv_id}] id: {}, name: {}, node_errors: {:?}",
+                "[Pipeline] id: {}, name: {}, node_errors: {:?}",
                 pipeline_errors.pipeline_id,
                 pipeline_errors.pipeline_name,
                 pipeline_errors.node_errors
@@ -541,7 +539,6 @@ impl ExecutablePipeline {
         }
         let error_collect_ms = error_task_start.elapsed().as_millis();
 
-        log::debug!("[Pipeline] {pipeline_name} [inv={inv_id}]: awaiting result collector");
         let result_task_start = Instant::now();
         let results = result_task.await.map_err(|e| {
             log::error!(
@@ -550,21 +547,18 @@ impl ExecutablePipeline {
             anyhow!("[Pipeline] result collecting job failed: {}", e)
         })?;
         let result_collect_ms = result_task_start.elapsed().as_millis();
-        log::debug!(
-            "[Pipeline] {pipeline_name} [inv={inv_id}]: result collector returned {} stream groups",
-            results.len()
-        );
 
         // Histogram metrics (always on): realtime pipeline batch execution time (ms)
         // and batch size, labeled by pipeline so latency can be attributed per pipeline.
-        let stream_type_label = source_stream_params.stream_type.as_str();
         let elapsed_secs = batch_start.elapsed().as_secs_f64();
-        metrics::PIPELINE_EXEC_TIME_MS
-            .with_label_values(&[org_id, &self.id, &pipeline_name, stream_type_label])
-            .observe(elapsed_secs * 1000.0);
-        metrics::PIPELINE_EXEC_BATCH_SIZE
-            .with_label_values(&[org_id, &self.id, &pipeline_name, stream_type_label])
-            .observe(batch_size as f64);
+        if self.is_realtime {
+            metrics::PIPELINE_EXEC_TIME_MS
+                .with_label_values(&[org_id, &self.id])
+                .observe(elapsed_secs * 1000.0);
+            metrics::PIPELINE_EXEC_BATCH_SIZE
+                .with_label_values(&[org_id, &self.id])
+                .observe(batch_size as f64);
+        }
 
         if print_event {
             let total_ms = batch_start.elapsed().as_millis();
@@ -576,9 +570,10 @@ impl ExecutablePipeline {
                 (0.0, 0.0)
             };
             log::info!(
-                "[Pipeline:Timing] [inv={inv_id}] done id={} name={} batch_size={batch_size} source_size_mb={source_size:.4} out_records={out_records} total_ms={total_ms} node_tasks_ms={node_tasks_ms} result_collect_ms={result_collect_ms} error_collect_ms={error_collect_ms} records_per_sec={records_per_sec:.1} mb_per_sec={mb_per_sec:.4}",
+                "[Pipeline:Timing] [inv={inv_id}] done id={} name={} stream_groups={} batch_size={batch_size} source_size_mb={source_size:.4} out_records={out_records} total_ms={total_ms} node_tasks_ms={node_tasks_ms} result_collect_ms={result_collect_ms} error_collect_ms={error_collect_ms} records_per_sec={records_per_sec:.1} mb_per_sec={mb_per_sec:.4}",
                 self.id,
                 pipeline_name,
+                results.len()
             );
         }
 
@@ -635,6 +630,10 @@ impl ExecutablePipeline {
 
     pub fn get_pipeline_id(&self) -> &str {
         &self.id
+    }
+
+    pub fn get_pipeline_name(&self) -> &str {
+        &self.name
     }
 
     fn get_source_stream_params(&self) -> StreamParams {


### PR DESCRIPTION
- Should emit metrics only for realtime pipelines
- Only use org id and pipeline id for metric labels.
- Improve the logs