### PR TITLE
ci(docgen): OSS caller forwards DEEPSEEK_API_KEY_E2E (pairs with ENT 1999)

### DIFF
--- a/.github/workflows/docgen-caller.yml
+++ b/.github/workflows/docgen-caller.yml
@@ -67,5 +67,7 @@ jobs:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || github.event.comment.body == '/docgen-dryrun' }}
       actor: ${{ github.event_name == 'workflow_dispatch' && github.actor || github.event.comment.user.login }}
     secrets:
-      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      # OSS holds the DeepSeek key as DEEPSEEK_API_KEY_E2E; forward it under the engine's
+      # (renamed) DEEPSEEK_API_KEY_E2E input. Both repos now standardize on this name.
+      DEEPSEEK_API_KEY_E2E: ${{ secrets.DEEPSEEK_API_KEY_E2E }}
       CROSS_REPO_TOKEN: ${{ secrets.E2E_DEV_CI_TOKEN }}


### PR DESCRIPTION
The OSS caller forwarded `DEEPSEEK_API_KEY` (which doesn't exist on OSS — the secret is `DEEPSEEK_API_KEY_E2E`), so an OSS `/docgen` would get an empty DeepSeek key. This forwards `DEEPSEEK_API_KEY_E2E` under the engine's matching (renamed) input.

**Merge order: merge ENT o2-enterprise#1999 FIRST**, then this. Until #1999 is on `main`, the engine still expects the old `DEEPSEEK_API_KEY` input name, so editors/actionlint will flag this as a mismatch — that's expected and resolves once #1999 merges.

Part of enabling the OSS `/docgen` path end-to-end (with o2-enterprise#1999, which also fixes the private-ENT checkout for the screenshots build).