### PR TITLE
fix: sync local node cache on NATS updates

### DIFF
--- a/src/common/infra/cluster/nats.rs
+++ b/src/common/infra/cluster/nats.rs
@@ -260,6 +260,7 @@ pub(crate) async fn set_status(status: NodeStatus) -> Result<()> {
     if let Err(e) = client.put(&key, val.into(), NEED_WATCH, None).await {
         return Err(Error::Message(format!("online node error: {e}")));
     }
+    add_node_to_cache(node).await;
 
     Ok(())
 }
@@ -282,6 +283,7 @@ pub(crate) async fn update_local_node(node: &Node) -> Result<()> {
     if let Err(e) = client.put(&key, val.into(), NEED_WATCH, None).await {
         return Err(Error::Message(format!("update node error: {e}")));
     }
+    add_node_to_cache(node.clone()).await;
     Ok(())
 }
 

--- a/src/common/infra/cluster/nats.rs
+++ b/src/common/infra/cluster/nats.rs
@@ -329,4 +329,35 @@ mod tests {
         println!("[CLUSTER::TEST] test_nats_register: {ret:?}");
         assert!(ret.is_ok());
     }
+
+    #[tokio::test]
+    async fn test_nats_update_local_node_updates_cache() {
+        config::cache_instance_id("instance");
+        infra::db_init().await.unwrap();
+        register().await.unwrap();
+
+        let mut node = get_node_by_uuid(&LOCAL_NODE.uuid).await.unwrap();
+        node.scheduled = true;
+        update_local_node(&node).await.unwrap();
+
+        let cached = get_node_by_uuid(&LOCAL_NODE.uuid).await.unwrap();
+        assert!(cached.scheduled);
+    }
+
+    #[tokio::test]
+    async fn test_nats_set_status_preserves_cached_scheduled() {
+        config::cache_instance_id("instance");
+        infra::db_init().await.unwrap();
+        register().await.unwrap();
+
+        let mut node = get_node_by_uuid(&LOCAL_NODE.uuid).await.unwrap();
+        node.scheduled = true;
+        update_local_node(&node).await.unwrap();
+
+        set_status(NodeStatus::Online).await.unwrap();
+
+        let cached = get_node_by_uuid(&LOCAL_NODE.uuid).await.unwrap();
+        assert!(cached.scheduled);
+        assert_eq!(cached.status, NodeStatus::Online);
+    }
 }


### PR DESCRIPTION
Fixes #12870

## Summary
- write successful NATS local node status updates through to the in-memory node cache
- write successful NATS local node mutations through to the in-memory node cache
- add regression coverage for preserving cached `scheduled` state across status updates

This prevents the heartbeat path from re-publishing stale local cache state, such as `scheduled=false`, after `set_schedulable()` has already written `scheduled=true` to NATS.

## Validation
- `git diff --check`
- attempted `PROTOC=/tmp/protoc-25.3/bin/protoc cargo test test_nats_`
  - local environment progressed past missing `protoc`, then failed because this checkout is using stable `rustc 1.93.1` while the repo pins `nightly-2026-05-20` and uses `#![feature(macro_metavar_expr_concat)]`