### PR TITLE
ci: UI house-style check (no emoji, i18n) on changed .vue files

### DIFF
--- a/.github/workflows/ui-style-check.yml
+++ b/.github/workflows/ui-style-check.yml
@@ -1,0 +1,42 @@
+name: UI Style Check
+
+# Enforces OpenObserve UI house style on the CHANGED .vue files in a PR ONLY:
+#   - no emojis
+#   - no raw user-facing text (strings must use i18n t('key') with the key in en.json)
+#
+# Scoped to changed files so it never trips on the existing backlog (~142 files / ~544 strings) and
+# never blocks unrelated PRs. The main `lint:ci` is unchanged. This is the all-contributors backstop
+# that mirrors the codegen pipeline's own deterministic style gate (kept in sync intentionally).
+
+on:
+  pull_request:
+    paths:
+      - "web/src/**/*.vue"
+
+permissions:
+  contents: read
+
+jobs:
+  ui-style:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need the base ref to diff against
+
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+
+      - name: Check changed .vue files for emoji + raw text
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Only the .vue files changed in this PR (Added/Copied/Modified/Renamed).
+          mapfile -t CHANGED < <(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- 'web/src/**/*.vue')
+          if [ "${#CHANGED[@]}" -eq 0 ]; then
+            echo "No changed .vue files — nothing to check."; exit 0
+          fi
+          printf 'Checking %d changed .vue file(s):\n' "${#CHANGED[@]}"; printf '  %s\n' "${CHANGED[@]}"
+          node web/scripts/check-ui-style.mjs "${CHANGED[@]}"

--- a/web/scripts/check-ui-style.mjs
+++ b/web/scripts/check-ui-style.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * OpenObserve UI house-style check (changed-files only).
+ *
+ * Enforces two rules on the .vue files passed as args:
+ *   1. NO emojis anywhere.
+ *   2. NO raw user-facing text in templates — visible strings must go through i18n
+ *      (`{{ t('key') }}` / `{{ $t('key') }}`), with the key in locales/languages/en.json.
+ *
+ * Intentionally dependency-free (no new eslint plugin) and scoped to the files it's given, so it
+ * NEVER touches the existing backlog — CI passes only the PR's changed files. A line may opt out
+ * with a trailing `<!-- codegen-style-exempt: reason -->` or `// codegen-style-exempt: reason`.
+ *
+ * Usage: node web/scripts/check-ui-style.mjs <file1.vue> <file2.vue> ...
+ * Exits 1 (with a report) if any file violates; 0 if clean / no files.
+ */
+import fs from "fs";
+
+const EMOJI =
+  /[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{2190}-\u{21FF}\u{FE0F}\u{200D}]/u;
+// Visible text node between tags: >Some Words< that isn't a {{ ... }} interpolation.
+const RAW_TEXT = />\s*[A-Za-z][A-Za-z ,.'’\-!?]{2,}\s*</;
+const EXEMPT = /codegen-style-exempt/;
+
+const files = process.argv.slice(2).filter((f) => f.endsWith(".vue"));
+let violations = 0;
+
+for (const file of files) {
+  let src;
+  try {
+    src = fs.readFileSync(file, "utf8");
+  } catch {
+    continue; // deleted/renamed file in the diff — skip
+  }
+  // Only scan the <template> block for raw text; scan the whole file for emojis.
+  const lines = src.split("\n");
+  let inTemplate = false;
+  lines.forEach((line, i) => {
+    if (/<template[\s>]/.test(line)) inTemplate = true;
+    if (/<\/template>/.test(line)) inTemplate = false;
+    if (EXEMPT.test(line)) return;
+
+    // Strip a same-line comment (HTML <!-- --> or JS // …) before checking — comments aren't
+    // user-facing, so a stray glyph there isn't a violation.
+    const code = line.replace(/<!--.*?-->/g, "").replace(/\/\/.*$/, "");
+
+    if (EMOJI.test(code)) {
+      console.error(`${file}:${i + 1}  emoji not allowed — use a q-icon/SVG if an icon is needed`);
+      console.error(`    ${line.trim()}`);
+      violations++;
+    }
+    if (inTemplate && RAW_TEXT.test(code) && !/\{\{[^}]*\}\}/.test(code)) {
+      console.error(`${file}:${i + 1}  raw user-facing text — use t('key') + add the key to en.json`);
+      console.error(`    ${line.trim()}`);
+      violations++;
+    }
+  });
+}
+
+if (violations > 0) {
+  console.error(`\n✗ UI house-style check: ${violations} violation(s) in changed files.`);
+  console.error(
+    "  Rules: no emojis; user-facing strings via i18n t('key') with the key in locales/languages/en.json.",
+  );
+  console.error("  (False positive? add `codegen-style-exempt: <reason>` to the line.)");
+  process.exit(1);
+}
+console.log(`UI house-style check: clean (${files.length} changed .vue file(s)).`);


### PR DESCRIPTION
## What

A PR check enforcing two long-standing OpenObserve UI conventions on **changed `.vue` files only**:
- **No emojis** in template/script (use a `q-icon`/SVG icon if an icon is needed).
- **No raw user-facing text** — visible strings must use i18n `t('key')` with the key added to `locales/languages/en.json`.

## Why scoped to changed files

The repo has a large existing backlog (~142 files with raw text, ~56 with emojis). A global eslint error rule would break `lint:ci` everywhere and require a mass migration. This check runs **only on the files a PR changes** (`git diff base..head`), so it enforces the convention going forward without touching the backlog or blocking unrelated PRs. `lint:ci` is unchanged.

## How

- `web/scripts/check-ui-style.mjs` — a small dependency-free scanner (no new eslint plugin). Skips comments; a genuine edge case can opt a line out with `codegen-style-exempt: <reason>`.
- `.github/workflows/ui-style-check.yml` — runs the scanner on the PR's changed `web/src/**/*.vue`.

This mirrors the deterministic style gate in the code-gen pipeline (so AI-generated and human PRs are held to the same bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
