### PR TITLE
fix(test): harden SDR + Logs regression tests against CI render/index lag

### DIFF
--- a/tests/ui-testing/pages/logsPages/logsPage.js
+++ b/tests/ui-testing/pages/logsPages/logsPage.js
@@ -3216,7 +3216,18 @@ export class LogsPage {
      * @returns {Promise<void>}
      */
     async openLogDetailSidebar() {
-        await this.page.locator(this.logTableColumnSource).click();
+        const sourceCell = this.page.locator(this.logTableColumnSource).first();
+        // Under CI load the row can resolve in the DOM while the results table is still
+        // streaming/re-rendering, so a plain click waits out its timeout on "element is not
+        // stable". Wait for the cell to be visible, bring it into view, then click with a
+        // force fallback to push past any transient instability or overlay.
+        await sourceCell.waitFor({ state: 'visible', timeout: 30000 });
+        await sourceCell.scrollIntoViewIfNeeded().catch(() => {});
+        try {
+            await sourceCell.click({ timeout: 15000 });
+        } catch {
+            await sourceCell.click({ force: true });
+        }
         await this.page.locator(this.logDetailDialog).waitFor({ state: 'visible', timeout: 10000 });
         testLogger.info('Log detail sidebar opened');
     }
@@ -5167,7 +5178,15 @@ export class LogsPage {
 
     async clickAddFieldToTableButton(fieldName) {
         const addBtn = this.page.locator(`[data-test="log-search-index-list-add-${fieldName}-field-btn"]`);
-        await addBtn.waitFor({ state: 'visible', timeout: 5000 });
+        try {
+            await addBtn.waitFor({ state: 'visible', timeout: 5000 });
+        } catch {
+            // The add button is only revealed while the field row is hovered. Under CI load
+            // the hover state can be lost (or never settled) before the click — re-hover the
+            // field row and wait again before giving up.
+            await this.page.locator(`[data-test="log-search-expand-${fieldName}-field-btn"]`).hover().catch(() => {});
+            await addBtn.waitFor({ state: 'visible', timeout: 10000 });
+        }
         await addBtn.click();
         // The add operation commits when both (a) the toggle inverts to a remove
         // button in the sidebar, and (b) the field column header appears in the

--- a/tests/ui-testing/pages/sdrPages/sdrVerificationPage.js
+++ b/tests/ui-testing/pages/sdrPages/sdrVerificationPage.js
@@ -88,6 +88,15 @@ export class SDRVerificationPage {
     await this.navigateToLogsQuick();
     await logsPage.selectStream(streamName);
 
+    // The field key is expected to be present unless it is being dropped (redacted/visible
+    // both keep the key). Use that to gate the retry on content rather than mere presence
+    // of a row — under CI load the latest row can render before the freshly-ingested field
+    // is searchable, so breaking on the first non-null row asserts against stale data.
+    const fieldAsJsonKey = `"${fieldName}":`;
+    const fieldAsKey = `${fieldName}:`;
+    const expectFieldPresent = !shouldBeDropped;
+    const hasField = (text) => text.includes(fieldAsJsonKey) || text.includes(fieldAsKey);
+
     // Retry loop: wait for logs to appear after ingestion (CI can be slow to index)
     const maxRetries = 5;
     let logText = null;
@@ -100,15 +109,16 @@ export class SDRVerificationPage {
 
       logText = await this.getLatestLogText();
 
-      testLogger.info(`Attempt ${attempt}/${maxRetries}: ${logText ? 'Log entry found' : 'No logs found'}`);
+      const fieldReady = logText !== null && (!expectFieldPresent || hasField(logText));
+      testLogger.info(`Attempt ${attempt}/${maxRetries}: ${logText ? (fieldReady ? 'Log entry ready' : 'Log entry found but field not yet indexed') : 'No logs found'}`);
 
-      if (logText) {
+      if (fieldReady) {
         break;
       }
 
       if (attempt < maxRetries) {
         const waitTime = attempt * 3000;
-        testLogger.info(`No logs found yet, waiting ${waitTime / 1000}s before retry...`);
+        testLogger.info(`Log not ready yet, waiting ${waitTime / 1000}s before retry...`);
         await this.page.waitForTimeout(waitTime);
       }
     }
@@ -118,9 +128,7 @@ export class SDRVerificationPage {
     testLogger.info(`Latest log text (first 300 chars): ${logText?.substring(0, 300)}...`);
 
     // Check if field exists in the log
-    const fieldAsJsonKey = `"${fieldName}":`;
-    const fieldAsKey = `${fieldName}:`;
-    const fieldFound = logText.includes(fieldAsJsonKey) || logText.includes(fieldAsKey);
+    const fieldFound = hasField(logText);
 
     if (shouldBeDropped) {
       // Field should NOT be present at all
@@ -142,12 +150,24 @@ export class SDRVerificationPage {
   /**
    * Fetch all log entry texts with full retry and 3-tier locator fallback.
    * Navigates to Logs, selects stream, waits until at least minCount entries appear.
+   *
+   * Row count alone is an unreliable readiness signal: under CI load the search can
+   * return a partial/stale result set (or the loose `tbody tr` fallback can count
+   * non-data rows) where the row count is satisfied but freshly-ingested fields are
+   * not yet searchable. When `requiredFields` is supplied, the fetch additionally
+   * waits until every one of those field names actually appears in the fetched logs,
+   * making readiness content-aware rather than purely count-based.
+   *
+   * @param {string[]} requiredFields - Field names that must appear before returning.
    * @returns {string[]} Array of log text strings (may be fewer than minCount on timeout).
    */
-  async fetchAllLogTexts(logsPage, streamName, minCount = 1) {
+  async fetchAllLogTexts(logsPage, streamName, minCount = 1, requiredFields = []) {
     await this.closeStreamDetailSidebarIfOpen();
     await this.navigateToLogsQuick();
     await logsPage.selectStream(streamName);
+
+    const hasField = (text, field) =>
+      text.includes(`"${field}":`) || text.includes(`${field}:`);
 
     const maxRetries = 5;
     let logTexts = [];
@@ -176,7 +196,19 @@ export class SDRVerificationPage {
           const text = await locator.nth(i).textContent();
           logTexts.push(text);
         }
-        if (logTexts.length >= minCount) break;
+
+        // Content gate: only treat the result set as "ready" once every required
+        // field is actually present. Otherwise the freshly-ingested data is still
+        // indexing — keep retrying so we don't assert against a partial result set.
+        const missingFields = requiredFields.filter(
+          (field) => !logTexts.some((text) => hasField(text, field))
+        );
+
+        if (logTexts.length >= minCount && missingFields.length === 0) break;
+
+        if (missingFields.length > 0) {
+          testLogger.info(`fetchAllLogTexts attempt ${attempt}/${maxRetries}: ${logTexts.length} entries found but fields not yet indexed: ${missingFields.join(', ')}`);
+        }
       }
 
       testLogger.info(`fetchAllLogTexts attempt ${attempt}/${maxRetries}: found ${logTexts.length} entries (need ${minCount})`);
@@ -198,7 +230,13 @@ export class SDRVerificationPage {
   async verifyMultipleFields(logsPage, streamName, fieldsToVerify) {
     testLogger.info(`Verifying ${fieldsToVerify.length} fields in stream: ${streamName}`);
 
-    const logTexts = await this.fetchAllLogTexts(logsPage, streamName, fieldsToVerify.length);
+    // Fields that must be present (everything except dropped fields) gate the fetch so we
+    // wait for them to be searchable instead of asserting against a partially-indexed result.
+    const requiredFields = fieldsToVerify
+      .filter(({ shouldBeDropped }) => !shouldBeDropped)
+      .map(({ fieldName }) => fieldName);
+
+    const logTexts = await this.fetchAllLogTexts(logsPage, streamName, fieldsToVerify.length, requiredFields);
     expect(logTexts.length, 'No logs found in the stream after multiple retries').toBeGreaterThan(0);
 
     for (const { fieldName, shouldBeDropped, shouldBeRedacted, shouldBeHashed } of fieldsToVerify) {

--- a/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-9754.spec.js
+++ b/tests/ui-testing/playwright-tests/RegressionSet/Logs/logs-9754.spec.js
@@ -11,7 +11,7 @@
 const { test, expect, navigateToBase } = require('../../utils/enhanced-baseFixtures.js');
 const testLogger = require('../../utils/test-logger.js');
 const PageManager = require('../../../pages/page-manager.js');
-const { getHeaders, getIngestionUrl, sendRequest } = require('../../utils/data-ingestion.js');
+const { getHeaders, getIngestionUrl, sendRequest, waitForStreamData } = require('../../utils/data-ingestion.js');
 const { getOrgIdentifier } = require('../../utils/cloud-auth.js');
 
 // Test data containing edge cases for bug #9754
@@ -181,6 +181,13 @@ test.describe("Logs Highlighting Regression Bug Fixes", () => {
     await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
     const streamAvailable = await pm.logsPage.waitForStreamAvailable(STREAM_NAME, 90000, 3000);
     testLogger.info(`Stream "${STREAM_NAME}" available: ${streamAvailable}`);
+
+    // waitForStreamAvailable only confirms the stream exists in the list — it does not
+    // guarantee the ingested rows are searchable yet. Under CI load that gap left the
+    // later queries hitting an empty table (expectLogsTableVisible / selectStream flakes).
+    // Poll the search API until the rows are actually queryable before the tests run.
+    const dataReady = await waitForStreamData(page, STREAM_NAME, BUG_9754_TEST_LOGS.length, 60000);
+    testLogger.info(`Stream "${STREAM_NAME}" searchable data ready: ${dataReady}`);
 
     testLogger.info('Test data ingested successfully');
   });


### PR DESCRIPTION
Two clusters of CI-only flakes — **every affected spec passes locally**; all failures reproduce only under CI load (slow indexing / re-rendering). All fixes are in test page-objects / setup — no product or assertion changes.

## 1. SDR verification (o2-enterprise#2022, `e2e / SDR` — 7 failed)

`ingestionTime{Drop,Hash,Redaction}`, `queryTime{Drop,Hash,Redaction}`, `multipleSDRPatterns` all died with `Field <name> should be visible but was not found` (`foundLog === null`).

**Cause:** the verification helpers used **row count** as the readiness signal for freshly-ingested logs. `fetchAllLogTexts` returned the moment `minCount` rows rendered (the loose `tbody tr` fallback could even count non-data rows), and `verifySingleFieldInLatestLog` broke on the first non-null row — so under load they asserted against a partial/stale result set before the fields were searchable. The per-field loop throws on the first field, so the error always named the first field (`website_url`/`user_email`/`multi_data`), masking the real cause.

**Fix (`sdrVerificationPage.js`):** make readiness content-aware — `fetchAllLogTexts` takes `requiredFields` and retries until every required field actually appears; `verifyMultipleFields` passes all non-dropped fields; `verifySingleFieldInLatestLog` gates its retry loop on field presence when expected.

## 2. Logs regression (scheduled Logs-Regression on `main` — [OSS](https://github.com/openobserve/openobserve/actions/runs/28208045315) / [ENT](https://github.com/openobserve/o2-enterprise/actions/runs/28207989646), 3 failed + 1 flaky)

- **logs-9754** (`detail sidebar` / `unclosed brackets`): empty/late table & `selectStream` not finding the stream — the setup only waited for the stream to *exist*, not for its rows to be searchable. Gate the setup on `waitForStreamData` (polls the search API).
- **#9724** (`detail sidebar JSON tab`): row resolved but the table was still re-rendering → plain click timed out on "element not stable". Harden `openLogDetailSidebar`: wait for a visible row, scroll into view, click with a force fallback.
- **#9388** (`saved views stream switching`): the hover-revealed add-field button was lost before the click. `clickAddFieldToTableButton` now re-hovers the field row and waits again before failing.

## Verification (local, enterprise build `localhost:5080`)

| Suite | Result |
|-------|--------|
| 7 SDR specs | 14 passed |
| logs-9754.spec.js | 6 passed |
| logs-regression #9388 + #9724 | 2 passed |

```
npx playwright test playwright-tests/SDR/<spec>.spec.js --project=chromium
npx playwright test playwright-tests/RegressionSet/Logs/logs-9754.spec.js --project=chromium
npx playwright test playwright-tests/RegressionSet/Logs/logs-regression.spec.js -g "9388|9724" --project=chromium
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)